### PR TITLE
Replace --no-quarantine flag with postflight command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,7 +246,7 @@ jobs:
           ### Homebrew (recommended)
           \`\`\`bash
           brew tap sozercan/kaset https://github.com/sozercan/kaset
-          brew install --cask kaset --no-quarantine
+          brew install --cask kaset
           \`\`\`
 
           ### Manual Download

--- a/Casks/kaset.rb
+++ b/Casks/kaset.rb
@@ -11,6 +11,10 @@ cask "kaset" do
 
   app "Kaset.app"
 
+  postflight do
+    system_command "/usr/bin/xattr", args: ["-cr", "#{appdir}/Kaset.app"], sudo: false
+  end
+
   zap trash: [
     "~/Library/Application Support/Kaset",
     "~/Library/Caches/com.sertacozercan.Kaset",

--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ Download the latest release from the [Releases](https://github.com/sozercan/kase
 
 ```bash
 brew tap sozercan/kaset https://github.com/sozercan/kaset
-brew install --cask kaset --no-quarantine
+brew install --cask kaset
 ```
 
-> **Note:** The `--no-quarantine` flag is required because the app is not signed.
-> If you downloaded the app manually, you can remove the quarantine attribute with:
+> **Note:** The app is not signed.
+> If you downloaded the app manually, you can clear extended attributes (including quarantine) with:
 > ```bash
-> xattr -d com.apple.quarantine /Applications/Kaset.app
+> xattr -cr /Applications/Kaset.app
 > ```
 
 ## Keyboard Shortcuts


### PR DESCRIPTION
Running `brew install --cask kaset` should be enough. This will also fix the warning from Brew side:

```
Warning: Calling the `--[no-]quarantine` switch is deprecated! There is no replacement.
```