### PR TITLE
Fix auditing issues for the Cask

### DIFF
--- a/Casks/kaset.rb
+++ b/Casks/kaset.rb
@@ -2,9 +2,9 @@ cask "kaset" do
   version "0.3.0"
   sha256 "e2eced2a4c356f7f9622c18ae772c961de9e55f270df9a2de66c51c442d50424"
 
-  url "https://github.com/sozercan/kaset/releases/download/v0.3.0/kaset-v0.3.0.dmg"
+  url "https://github.com/sozercan/kaset/releases/download/v#{version}/kaset-v#{version}.dmg"
   name "Kaset"
-  desc "Native macOS YouTube Music client"
+  desc "Native YouTube Music client"
   homepage "https://github.com/sozercan/kaset"
 
   depends_on macos: ">= :tahoe"


### PR DESCRIPTION
Running `brew audit --strict kaset` and `brew style kaset`, you'll see issues like

```
 - Use `sha256 :no_check` when URL is unversioned.
goooler/repo/kaset
  * Use `sha256 :no_check` when URL is unversioned.
Error: 1 problem in 1 cask detected.
Error: Use `sha256 :no_check` when URL is unversioned.
Error: Process completed with exit code 1.
```

and

```
Taps/goooler/homebrew-repo/Casks/kaset.rb:7:16: C: Cask/Desc: Description shouldn't contain the platform.
  desc "Native macos YouTube Music client"
               ^^^^^

9 files inspected, 1 offense detected
```

Copied the fixed stuff from https://github.com/Goooler/homebrew-repo/pull/120.