### PR TITLE
fix: do not animate waveform when song is paused

### DIFF
--- a/Views/macOS/QueueView.swift
+++ b/Views/macOS/QueueView.swift
@@ -212,7 +212,7 @@ private struct QueueRowView: View {
         if self.isCurrentTrack {
             Image(systemName: "waveform")
                 .font(.system(size: 12, weight: .medium))
-                .foregroundStyle(.red)
+                .foregroundStyle(self.playerService.isPlaying ? AnyShapeStyle(.red) : AnyShapeStyle(.tertiary))
                 .symbolEffect(
                     .variableColor.iterative,
                     options: .repeating,


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🧪 Test update
- [ ] 🔧 Build/CI configuration

## Related Issues

<!-- Link any related issues using "Fixes #123" or "Relates to #123" -->

## Changes Made

<!-- List the key changes made in this PR -->

- 

## Testing

<!-- Describe how you tested these changes -->

- [ ] Unit tests pass (`xcodebuild test -only-testing:KasetTests`)
- [ ] Manual testing performed
- [ ] UI tested on macOS 26+

## Checklist

<!-- Mark completed items with an 'x' -->

- [ ] My code follows the project's style guidelines
- [ ] I have run `swiftlint --strict && swiftformat .`
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing unit tests pass locally
- [ ] I have updated documentation if needed
- [ ] I have checked for any performance implications
- [ ] My changes generate no new warnings

## Screenshots

<!-- If applicable, add screenshots or recordings to demonstrate the changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->
