### PR TITLE
fix: restore MainActor context for notification observation task

### DIFF
--- a/Core/Services/Notification/NotificationService.swift
+++ b/Core/Services/Notification/NotificationService.swift
@@ -42,7 +42,7 @@ final class NotificationService {
     // MARK: - Observation
 
     private func startObserving() {
-        self.observationTask = Task { [weak self] in
+        self.observationTask = Task { @MainActor [weak self] in
             guard let self else { return }
             var previousTrack: Song?
 


### PR DESCRIPTION
## Summary
- Adds `@MainActor` annotation to the Task closure in `NotificationService.startObserving()`
- Fixes notification observation that broke when `nonisolated(unsafe)` was added in commit 6f0602d

## Root Cause
When `nonisolated(unsafe)` was added to `observationTask` to fix Swift 6 deinit warnings, the Task lost its implicit `@MainActor` context inheritance. This caused the polling loop to not properly observe changes to the `@MainActor`-isolated `playerService.currentTrack` property.

## Fix
Adding `@MainActor` to the Task closure ensures proper actor isolation, matching the pattern already used in `NetworkMonitor`.

```swift
// Before (broken):
self.observationTask = Task { [weak self] in

// After (fixed):
self.observationTask = Task { @MainActor [weak self] in
```

## Test plan
- [ ] Play a track and verify notification appears
- [ ] Skip to next track and verify new notification appears
- [ ] Toggle "Show Now Playing Notifications" setting and verify it's respected

🤖 Generated with [Claude Code](https://claude.ai/code)