### PR TITLE
fix: use video.paused for play/pause state detection

### DIFF
--- a/Views/macOS/MiniPlayerWebView.swift
+++ b/Views/macOS/MiniPlayerWebView.swift
@@ -120,17 +120,16 @@ struct MiniPlayerWebView: NSViewRepresentable {
                     const titleEl = document.querySelector('.ytmusic-player-bar.title');
                     const artistEl = document.querySelector('.ytmusic-player-bar.byline');
                     const progressBar = document.querySelector('#progress-bar');
-                    const playPauseBtn = document.querySelector('.play-pause-button.ytmusic-player-bar');
 
                     const title = titleEl ? titleEl.textContent : '';
                     const artist = artistEl ? artistEl.textContent : '';
                     const progress = progressBar ? parseInt(progressBar.getAttribute('value') || '0') : 0;
                     const duration = progressBar ? parseInt(progressBar.getAttribute('aria-valuemax') || '0') : 0;
 
-                    // Check if playing by looking at the button title
-                    const isPlaying = playPauseBtn ?
-                        playPauseBtn.getAttribute('title') === 'Pause' ||
-                        playPauseBtn.getAttribute('aria-label') === 'Pause' : false;
+                    // Use video element's paused property for language-agnostic detection
+                    // Previously checked button title/aria-label which fails for non-English locales
+                    const video = document.querySelector('video');
+                    const isPlaying = video ? !video.paused : false;
 
                     bridge.postMessage({
                         type: 'STATE_UPDATE',

--- a/Views/macOS/SingletonPlayerWebView+ObserverScript.swift
+++ b/Views/macOS/SingletonPlayerWebView+ObserverScript.swift
@@ -211,10 +211,10 @@ extension SingletonPlayerWebView {
                 lastUpdateTime = now;
 
                 try {
-                    const playPauseBtn = document.querySelector('.play-pause-button.ytmusic-player-bar');
-                    const isPlaying = playPauseBtn ?
-                        (playPauseBtn.getAttribute('title') === 'Pause' ||
-                         playPauseBtn.getAttribute('aria-label') === 'Pause') : false;
+                    // Use video element's paused property for language-agnostic detection
+                    // Previously checked button title/aria-label which fails for non-English locales
+                    const video = document.querySelector('video');
+                    const isPlaying = video ? !video.paused : false;
 
                     const progressBar = document.querySelector('#progress-bar');
 


### PR DESCRIPTION
## Summary
- Fix play/pause icon not updating when music is playing
- Replace localized button attribute check (`title === 'Pause'`) with video element's `paused` property
- This change is language-agnostic and works regardless of YouTube Music's display language

## Root Cause
The JavaScript observer scripts checked for hardcoded English text in the play/pause button's `title` and `aria-label` attributes. When YouTube Music is displayed in a non-English language (e.g., German, Spanish), these attributes contain localized text, causing `isPlaying` to always return `false`.

## Fix
Use `video.paused` property directly instead of checking button text:
```javascript
// Before (fails for non-English locales)
const playPauseBtn = document.querySelector('.play-pause-button.ytmusic-player-bar');
const isPlaying = playPauseBtn?.getAttribute('title') === 'Pause';

// After (language-agnostic)
const video = document.querySelector('video');
const isPlaying = video ? !video.paused : false;
```

## Test plan
- [ ] Verify play/pause icon updates correctly when music starts/stops
- [ ] Test with YouTube Music set to a non-English language
- [ ] Verify keyboard shortcuts (Space) still toggle play/pause correctly
- [ ] Verify media keys still work correctly

Fixes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)