### PR TITLE
refactor: optimize AGENTS.md — 67% reduction via doc extraction

### DIFF
--- a/docs/common-bug-patterns.md
+++ b/docs/common-bug-patterns.md
@@ -1,0 +1,170 @@
+# Common Bug Patterns to Avoid
+
+These patterns have caused bugs in this codebase. **Always check for these during code review.**
+
+## ❌ Fire-and-Forget Tasks
+
+```swift
+// ❌ BAD: Task not tracked, errors lost, can't cancel
+func likeTrack() {
+    Task { await api.like(trackId) }
+}
+
+// ✅ GOOD: Track task, handle errors, support cancellation
+private var likeTask: Task<Void, Error>?
+
+func likeTrack() async throws {
+    likeTask?.cancel()
+    likeTask = Task {
+        try await api.like(trackId)
+    }
+    try await likeTask?.value
+}
+```
+
+## ❌ Optimistic Updates Without Proper Rollback
+
+```swift
+// ❌ BAD: CancellationError not handled, cache permanently wrong
+func rate(_ song: Song, status: LikeStatus) async {
+    let previous = cache[song.id]
+    cache[song.id] = status  // Optimistic update
+    do {
+        try await api.rate(song.id, status)
+    } catch {
+        cache[song.id] = previous  // Doesn't run on cancellation!
+    }
+}
+
+// ✅ GOOD: Handle ALL errors including cancellation
+func rate(_ song: Song, status: LikeStatus) async {
+    let previous = cache[song.id]
+    cache[song.id] = status
+    do {
+        try await api.rate(song.id, status)
+    } catch let error as CancellationError {
+        cache[song.id] = previous  // Rollback on cancel
+        throw error  // Propagate original cancellation
+    } catch {
+        cache[song.id] = previous  // Rollback on error
+        throw error
+    }
+}
+```
+
+## ❌ Static Shared Singletons with Mutable Assignment
+
+```swift
+// ❌ BAD: Race condition if multiple instances created
+class LibraryViewModel {
+    static var shared: LibraryViewModel?
+    init() { Self.shared = self }  // Overwrites previous!
+}
+
+// ✅ GOOD: Use SwiftUI Environment for dependency injection
+@Observable @MainActor
+class LibraryViewModel { /* ... */ }
+
+// In parent view:
+.environment(libraryViewModel)
+
+// In child view:
+@Environment(LibraryViewModel.self) var viewModel
+```
+
+## ❌ `.onAppear` Instead of `.task` for Async Work
+
+```swift
+// ❌ BAD: Task not cancelled on disappear, can update stale view
+.onAppear {
+    Task { await viewModel.load() }
+}
+
+// ✅ GOOD: Lifecycle-managed, auto-cancelled on disappear
+.task {
+    await viewModel.load()
+}
+
+// ✅ GOOD: With ID for re-execution on change
+.task(id: playlistId) {
+    await viewModel.load(playlistId)
+}
+```
+
+## ❌ ForEach with Unstable Identity
+
+```swift
+// ❌ BAD: Index-based identity causes wrong views during mutations
+ForEach(tracks.indices, id: \.self) { index in
+    TrackRow(track: tracks[index])
+}
+
+// ❌ BAD: Array enumeration recreates identity on every change
+ForEach(Array(tracks.enumerated()), id: \.offset) { index, track in
+    TrackRow(track: track, rank: index + 1)
+}
+
+// ✅ GOOD: Use stable model identity
+ForEach(tracks) { track in
+    TrackRow(track: track)
+}
+
+// ✅ GOOD: If you need index for display (charts), use element ID
+ForEach(Array(tracks.enumerated()), id: \.element.id) { index, track in
+    TrackRow(track: track, rank: index + 1)
+}
+```
+
+## ❌ Background Tasks Not Cancelled on Deinit
+
+```swift
+// ❌ BAD: Task continues after ViewModel is deallocated
+@Observable @MainActor
+class HomeViewModel {
+    private var backgroundTask: Task<Void, Never>?
+    
+    func startLoading() {
+        backgroundTask = Task { /* ... */ }
+    }
+    // Missing deinit cleanup!
+}
+
+// ✅ GOOD: Cancel tasks in deinit
+@Observable @MainActor
+class HomeViewModel {
+    private var backgroundTask: Task<Void, Never>?
+    
+    func startLoading() {
+        backgroundTask?.cancel()
+        backgroundTask = Task { [weak self] in
+            guard !Task.isCancelled else { return }
+            // ...
+        }
+    }
+    
+    deinit {
+        backgroundTask?.cancel()
+    }
+}
+```
+
+## ❌ Shared Continuation Tokens Across Different Requests
+
+```swift
+// ❌ BAD: Single token for all search types causes conflicts
+class YTMusicClient {
+    private var searchContinuationToken: String?  // Shared!
+    
+    func searchSongs() { /* sets token */ }
+    func searchAlbums() { /* overwrites token! */ }
+}
+
+// ✅ GOOD: Scope tokens by request type or return in response
+class YTMusicClient {
+    private var continuationTokens: [String: String] = [:]
+    
+    func searchSongs() -> (songs: [Song], continuation: String?) {
+        // Return token with response, let caller manage
+    }
+}
+```

--- a/docs/task-planning.md
+++ b/docs/task-planning.md
@@ -1,0 +1,96 @@
+# Task Planning: Phases with Exit Criteria
+
+For any non-trivial task, **plan in phases with testable exit criteria** before writing code. This ensures incremental progress and early detection of issues.
+
+> ⚠️ **Never implement without an approved plan** — Planning and execution are separate phases. Do not write production code until the plan has been reviewed. When working in plan mode, always include **"don't implement yet"** as a guard. The human will say when to start.
+
+## Phase Structure
+
+Every task should be broken into phases. Each phase must have:
+1. **Clear deliverable** — What artifact or change is produced
+2. **Testable exit criteria** — How to verify the phase is complete
+3. **Rollback point** — The phase should leave the codebase in a working state
+
+## Standard Phases
+
+### Phase 1: Research & Understanding
+
+> 📝 **Write research findings to a persistent file** — Don't just summarize verbally. Write a structured research document (in the session workspace, not the repo) with findings about affected files, existing patterns, edge cases, and dependencies. This is the review surface — if the research is wrong, the plan will be wrong.
+
+| Deliverable | Exit Criteria |
+|-------------|---------------|
+| Written research artifact | Findings documented in a persistent file |
+| Identify affected files and dependencies | List all files to modify/create |
+| Understand existing patterns | Can explain how similar features work |
+| Read relevant docs | Confirmed patterns in `docs/` apply |
+
+**Exit gate**: Can articulate the implementation plan without ambiguity.
+
+### Phase 2: Interface Design
+| Deliverable | Exit Criteria |
+|-------------|---------------|
+| Define new types/protocols | Type signatures compile |
+| Plan public API surface | No breaking changes to existing callers (or changes identified) |
+
+**Exit gate**: `xcodebuild build` succeeds with stub implementations.
+
+### Phase 3: Core Implementation
+
+> 🔄 **Continuously verify the build** — Run `xcodebuild build` throughout implementation, not just at the end. Catch type errors and regressions early, not after 15 minutes of changes.
+
+> 📋 **Track progress in the plan** — Mark tasks and phases as completed as you go. The human should be able to glance at the plan at any point and see exactly where things stand.
+
+| Deliverable | Exit Criteria |
+|-------------|---------------|
+| Implement business logic | Unit tests pass for new code |
+| Handle error cases | Error paths have test coverage |
+| Add logging | `DiagnosticsLogger` calls in place |
+| Performance verified | Anti-pattern checklist passed, perf tests added if applicable |
+
+**Exit gate**: `xcodebuild test -only-testing:KasetTests` passes.
+
+### Phase 4: Quality Assurance
+| Deliverable | Exit Criteria |
+|-------------|---------------|
+| Linting passes | `swiftlint --strict` reports 0 errors |
+| Formatting applied | `swiftformat .` makes no changes |
+| Full test suite passes | `xcodebuild test` succeeds |
+
+**Exit gate**: CI-equivalent checks pass locally.
+
+## Example: Adding a New Service
+
+```
+Phase 1: Research
+├── Write findings to session workspace
+├── Exit: Understand YTMusicClient pattern, confirm no existing solution
+
+Phase 2: Interface
+├── Create NewService.swift with protocol + stub
+├── Exit: `xcodebuild build` passes
+
+Phase 3: Implementation
+├── Implement methods, add error handling
+├── Create NewServiceTests.swift
+├── Run `xcodebuild build` after each major change
+├── Exit: `xcodebuild test -only-testing:KasetTests/NewServiceTests` passes
+
+Phase 4: QA
+├── Run swiftlint, swiftformat
+├── Exit: Full test suite passes, no lint errors
+```
+
+## Implementation Discipline
+
+- **Reference existing code for consistency** — When building features similar to existing ones, explicitly find and match existing implementations. A new detail view should match the patterns in existing detail views. A new parser should follow the structure in `Core/Services/API/Parsers/`. Point to the reference file and replicate its patterns rather than designing from scratch.
+- **Revert and re-scope on wrong direction** — If implementation goes wrong, don't try to incrementally patch a bad approach. Revert git changes and narrow the scope. A clean restart with tighter scope almost always produces better results than fixing a broken chain of changes.
+- **Protect existing interfaces** — Do not change public function signatures, protocols, or model types unless the plan explicitly calls for it. When in doubt, make the new code adapt to existing interfaces, not the other way around.
+
+## Checkpoint Communication
+
+After each phase, briefly report:
+- ✅ What was completed
+- 🧪 Test/verification results
+- ➡️ Next phase plan
+
+This keeps the human informed and provides natural points to course-correct.


### PR DESCRIPTION
## Summary

Slims AGENTS.md from **608 → 202 lines** (67% reduction) by extracting verbose content to dedicated docs and removing duplication.

## What changed

### Extracted to new docs files
- **`docs/common-bug-patterns.md`** — 169 lines of concurrency/SwiftUI anti-patterns with code examples
- **`docs/task-planning.md`** — 160 lines of phase-based planning workflow with exit criteria

### Removed (already covered elsewhere)
- Build/test commands → already in `docs/testing.md`
- Liquid Glass quick rules → already in `docs/architecture.md`
- Swift Testing quick reference → already in `docs/testing.md`
- WebKit patterns → already in `docs/playback.md`
- Performance checklist details → already in `docs/architecture.md`
- Subagent workflow section → tool-specific, not broadly applicable

### Added (from [blog research](https://boristane.com/blog/how-i-use-claude-code/))
- "Never implement without an approved plan" guard
- Write research findings to persistent files
- Continuous build verification during implementation
- Revert and re-scope on wrong direction
- Reference existing code for consistency
- Protect existing interfaces

### Condensed
- API Discovery Workflow: 50 lines → 6 lines + link to `docs/api-discovery.md`
- Checklists kept inline but with links to detailed docs

## Result
AGENTS.md is now focused on **rules, quick-reference tables, and checklists** — detailed patterns and examples live in docs/ where they can be maintained independently.