### PR TITLE
fix: eliminate volume spikes on song transitions

### DIFF
--- a/Views/macOS/MiniPlayerWebView.swift
+++ b/Views/macOS/MiniPlayerWebView.swift
@@ -438,6 +438,17 @@ final class SingletonPlayerWebView {
                         video.volume = \(savedVolume);
                     }
 
+                    // Sync YouTube's internal player APIs to prevent overrides
+                    const ytVolume = Math.round(\(savedVolume) * 100);
+                    const player = document.querySelector('ytmusic-player');
+                    if (player && player.playerApi) {
+                        player.playerApi.setVolume(ytVolume);
+                    }
+                    const moviePlayer = document.getElementById('movie_player');
+                    if (moviePlayer && moviePlayer.setVolume) {
+                        moviePlayer.setVolume(ytVolume);
+                    }
+
                     // Clear flag after a moment
                     setTimeout(() => { window.__kasetIsSettingVolume = false; }, 100);
 

--- a/Views/macOS/SingletonPlayerWebView+ObserverScript.swift
+++ b/Views/macOS/SingletonPlayerWebView+ObserverScript.swift
@@ -58,6 +58,9 @@ extension SingletonPlayerWebView {
 
                     video.addEventListener('play', startPolling);
                     video.addEventListener('playing', startPolling);
+                    // Enforce volume on playing event to catch all track changes
+                    // (auto-advance, SPA navigation, button clicks)
+                    video.addEventListener('playing', () => enforceVolumeNow());
                     video.addEventListener('pause', stopPolling);
                     video.addEventListener('ended', stopPolling);
                     video.addEventListener('waiting', () => sendUpdate()); // Buffer state


### PR DESCRIPTION
## Summary

Fixes #108 (Related: #29)

Users hear brief but loud volume spikes (~100ms at full volume) whenever a new song starts, even though the app volume is set low. This was reported as a regression of #29, but investigation shows the original fix was incomplete.

## Root Causes

1. **Trailing debounce on `volumechange` listener** — delayed enforcement by 100ms, audio played at YouTube's default volume during that window
2. **`didFinish` missing 3-way sync** — only set `video.volume`, not YouTube's internal APIs (`playerApi`/`moviePlayer`), allowing YouTube to override
3. **No volume enforcement on track changes via SPA navigation** — `playing` event not used as enforcement trigger
4. **Duplicate listener attachment** — `attachVideoListeners()` didn't set `__kasetListenersAttached` on first call, causing MutationObserver to re-attach all listeners

## Changes

| Fix | Description |
|-----|-------------|
| **A** | Replace trailing debounce with immediate enforcement + 100ms cooldown |
| **B** | Enforce volume on `playing` event + 500ms delayed reapply for late YouTube resets |
| **C** | Guard `attachVideoListeners()` with `__kasetListenersAttached` flag; remove duplicate flag-set from MutationObserver |
| **D** | Add `playerApi.setVolume()` and `moviePlayer.setVolume()` to `didFinish` handler |

## Files Changed

- `Views/macOS/SingletonPlayerWebView+ObserverScript.swift` — Fixes A, B, C
- `Views/macOS/MiniPlayerWebView.swift` — Fix D

## Testing

- `xcodebuild build` ✅
- `xcodebuild test -only-testing:KasetTests` ✅
- Code reviewed by GPT-5.3 Codex and Claude Opus 4.6 (no issues found after fix iteration)