### PR TITLE
fix: restore currentTrack when resuming queue on launch

### DIFF
--- a/Sources/Kaset/Services/Player/PlayerService+Queue.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+Queue.swift
@@ -399,6 +399,17 @@ extension PlayerService {
 
             self.queue = savedQueue
             self.currentIndex = min(savedIndex, savedQueue.count - 1)
+            self.currentTrack = savedQueue[safe: self.currentIndex]
+
+            // Synchronize track metadata so the UI (like/library status) reflects the restored song
+            if let song = self.currentTrack, let tokens = song.feedbackTokens {
+                self.currentTrackFeedbackTokens = tokens
+                self.currentTrackInLibrary = song.isInLibrary ?? false
+                if let likeStatus = song.likeStatus {
+                    self.currentTrackLikeStatus = likeStatus
+                }
+            }
+
             self.logger.info("Restored queue with \(savedQueue.count) songs at index \(self.currentIndex)")
             return true
         } catch {

--- a/Tests/KasetTests/PlayerServiceQueueTests.swift
+++ b/Tests/KasetTests/PlayerServiceQueueTests.swift
@@ -230,6 +230,7 @@ struct PlayerServiceQueueTests {
         #expect(newService.queue.count == 3)
         #expect(newService.currentIndex == 1)
         #expect(newService.queue[0].title == "Song 0")
+        #expect(newService.currentTrack?.title == "Song 1")
     }
 
     @Test("Clear saved queue removes persistence data")


### PR DESCRIPTION
## Summary

Fixes #120 — When Kaset restarted, the saved queue was loaded into memory but `currentTrack` was left as `nil`. This caused the player bar and Now Playing UI to appear empty, preventing users from seeing which track was last playing and resuming playback.

## Root Cause

`restoreQueueFromPersistence()` correctly restored `self.queue` and `self.currentIndex` from UserDefaults, but never set `self.currentTrack`. Every other code path that modifies the queue (e.g. `playQueue`, `playWithRadio`, `playWithMix`) also sets `currentTrack` — this one did not.

## Changes

- **`Sources/Kaset/Services/Player/PlayerService+Queue.swift`**: After restoring `queue` and `currentIndex`, now also sets `currentTrack = savedQueue[safe: currentIndex]` and synchronises `currentTrackFeedbackTokens`, `currentTrackInLibrary`, and `currentTrackLikeStatus` from the persisted song so the like/library status UI is correct on launch.

- **`Tests/KasetTests/PlayerServiceQueueTests.swift`**: Extended the `queuePersistence` test to assert `currentTrack` is populated after restoration (was previously unchecked, allowing the bug to exist silently).