### PR TITLE
fix: restore currentTrack when restoring queue on app launch

### DIFF
--- a/Sources/Kaset/Services/Player/PlayerService+Queue.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+Queue.swift
@@ -399,6 +399,7 @@ extension PlayerService {
 
             self.queue = savedQueue
             self.currentIndex = min(savedIndex, savedQueue.count - 1)
+            self.currentTrack = savedQueue[self.currentIndex]
             self.logger.info("Restored queue with \(savedQueue.count) songs at index \(self.currentIndex)")
             return true
         } catch {

--- a/Tests/KasetTests/PlayerServiceQueueTests.swift
+++ b/Tests/KasetTests/PlayerServiceQueueTests.swift
@@ -230,6 +230,7 @@ struct PlayerServiceQueueTests {
         #expect(newService.queue.count == 3)
         #expect(newService.currentIndex == 1)
         #expect(newService.queue[0].title == "Song 0")
+        #expect(newService.currentTrack?.title == newService.queue[1].title)
     }
 
     @Test("Clear saved queue removes persistence data")


### PR DESCRIPTION
## Description

Fixes a bug where `restoreQueueFromPersistence()` restored the `queue` array and `currentIndex` on app launch but failed to set `currentTrack`. This caused the mini-player to show no current song after relaunch even though the queue was populated, making it impossible to resume playback from where you left off.

## AI Prompt (Optional)

<details>
<summary>AI Prompt Used</summary>

```
Fix GitHub issue #120: restore last playing queue and song on app relaunch
```

**AI Tool:** GitHub Copilot

</details>

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test update

## Related Issues

Fixes #120

## Changes Made

- `PlayerService+Queue.swift`: added `self.currentTrack = savedQueue[self.currentIndex]` in `restoreQueueFromPersistence()` so the current song is set when the queue is restored on launch
- `PlayerServiceQueueTests.swift`: added assertion that `currentTrack` is correctly set after queue restoration

## Testing

- [x] Unit tests updated with assertion for `currentTrack` after restoration

## Checklist

- [x] My code follows the project style guidelines
- [x] I have added tests that prove my fix works
- [x] My changes generate no new warnings