### PR TITLE
fix: restore currentTrack when restoring queue from persistence

### DIFF
--- a/Sources/Kaset/Services/Player/PlayerService+Queue.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+Queue.swift
@@ -399,7 +399,8 @@ extension PlayerService {
 
             self.queue = savedQueue
             self.currentIndex = min(savedIndex, savedQueue.count - 1)
-            self.logger.info("Restored queue with \(savedQueue.count) songs at index \(self.currentIndex)")
+            self.currentTrack = savedQueue[self.currentIndex]
+            self.logger.info("Restored queue with \(savedQueue.count) songs at index \(self.currentIndex), current track: \(savedQueue[self.currentIndex].title)")
             return true
         } catch {
             self.logger.error("Failed to restore queue: \(error.localizedDescription)")

--- a/Tests/KasetTests/PlayerServiceQueueTests.swift
+++ b/Tests/KasetTests/PlayerServiceQueueTests.swift
@@ -230,6 +230,7 @@ struct PlayerServiceQueueTests {
         #expect(newService.queue.count == 3)
         #expect(newService.currentIndex == 1)
         #expect(newService.queue[0].title == "Song 0")
+        #expect(newService.currentTrack?.videoId == songs[1].videoId)
     }
 
     @Test("Clear saved queue removes persistence data")


### PR DESCRIPTION
## Description

When the app launches and restores the saved queue from UserDefaults, `currentTrack` was not being set. This left the player bar empty even though the queue was correctly populated.

Fixes #120

## AI Prompt (Optional)

<details>
<summary>🤖 AI Prompt Used</summary>

```
Implement fix for GitHub issue #120
```

**AI Tool:** GitHub Copilot CLI

</details>

## Type of Change

- [x] 🐛 Bug fix
- [x] 🧪 Test update

## Related Issues

Fixes #120

## Changes Made

- `PlayerService+Queue.swift`: set `self.currentTrack` when restoring queue so player bar shows correct track.
- `PlayerServiceQueueTests.swift`: added assertion verifying `currentTrack` is restored.

## Testing

- [x] Unit tests pass (`swift test --skip KasetUITests`)

## Checklist

- [x] Code follows style guidelines
- [x] Tests added
- [x] No new warnings