### PR TITLE
fix: restore currentTrack when restoring queue from persistence

### DIFF
--- a/Sources/Kaset/Services/Player/PlayerService+Queue.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+Queue.swift
@@ -399,6 +399,7 @@ extension PlayerService {
 
             self.queue = savedQueue
             self.currentIndex = min(savedIndex, savedQueue.count - 1)
+            self.currentTrack = savedQueue[self.currentIndex]
             self.logger.info("Restored queue with \(savedQueue.count) songs at index \(self.currentIndex)")
             return true
         } catch {

--- a/Tests/KasetTests/PlayerServiceQueueTests.swift
+++ b/Tests/KasetTests/PlayerServiceQueueTests.swift
@@ -230,6 +230,7 @@ struct PlayerServiceQueueTests {
         #expect(newService.queue.count == 3)
         #expect(newService.currentIndex == 1)
         #expect(newService.queue[0].title == "Song 0")
+        #expect(newService.currentTrack?.title == "Song 1")
     }
 
     @Test("Clear saved queue removes persistence data")


### PR DESCRIPTION
## Description

Fixes #120.

Previously, `restoreQueueFromPersistence()` restored `queue` and `currentIndex` from UserDefaults, but did **not** set `currentTrack`. The player bar showed no track after restarting the app.

## Type of Change

- [x] Bug fix
- [x] Test update

## Related Issues

Fixes #120

## Changes Made

- Set `self.currentTrack = savedQueue[self.currentIndex]` in `restoreQueueFromPersistence()`
- Added assertion in `queuePersistence` test to verify `currentTrack` is set after restoration

## Checklist

- [x] Code follows project style guidelines
- [x] Added tests proving the fix works