### PR TITLE
Add playback session persistence across app restarts

### DIFF
--- a/Sources/Kaset/Services/Player/PlayerService+Queue.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+Queue.swift
@@ -399,6 +399,7 @@ extension PlayerService {
 
             self.queue = savedQueue
             self.currentIndex = min(savedIndex, savedQueue.count - 1)
+            self.currentTrack = savedQueue[safe: self.currentIndex]
             self.logger.info("Restored queue with \(savedQueue.count) songs at index \(self.currentIndex)")
             return true
         } catch {

--- a/Tests/KasetTests/PlayerServiceQueueTests.swift
+++ b/Tests/KasetTests/PlayerServiceQueueTests.swift
@@ -230,6 +230,7 @@ struct PlayerServiceQueueTests {
         #expect(newService.queue.count == 3)
         #expect(newService.currentIndex == 1)
         #expect(newService.queue[0].title == "Song 0")
+        #expect(newService.currentTrack?.videoId == songs[1].videoId)
     }
 
     @Test("Clear saved queue removes persistence data")


### PR DESCRIPTION
## Summary
- persist the current playback queue, active track, elapsed position, repeat mode, and shuffle state
- restore the saved playback session on startup when the queue is empty
- add coverage for playback state persistence and restoration behavior

Closes #120