### PR TITLE
Fix packaged app accent color lookup

### DIFF
--- a/Scripts/build-app.sh
+++ b/Scripts/build-app.sh
@@ -71,6 +71,17 @@ verify_binary_arches() {
   done
 }
 
+compile_asset_catalog() {
+  local source_catalog="$1"
+  local output_dir="$2"
+  if [[ -d "$source_catalog" ]] && command -v actool &>/dev/null; then
+    actool --compile "$output_dir" \
+      --platform macosx \
+      --minimum-deployment-target 26.0 \
+      "$source_catalog" 2>/dev/null || true
+  fi
+}
+
 # Install binary (handles universal builds)
 install_binary() {
   local name="$1"
@@ -114,6 +125,8 @@ cat > "$APP_BUNDLE/Contents/Info.plist" <<PLIST
     <string>kaset</string>
     <key>CFBundleIconName</key>
     <string>kaset</string>
+    <key>NSAccentColorName</key>
+    <string>AccentColor</string>
     <key>CFBundleIdentifier</key>
     <string>${BUNDLE_ID}</string>
     <key>CFBundleInfoDictionaryVersion</key>
@@ -206,10 +219,7 @@ fi
 XCASSETS_PATH="$ROOT/Sources/Kaset/Resources/Assets.xcassets"
 if [[ -d "$XCASSETS_PATH" ]] && command -v actool &>/dev/null; then
   echo "🎨 Compiling asset catalog..."
-  actool --compile "$APP_BUNDLE/Contents/Resources" \
-    --platform macosx \
-    --minimum-deployment-target 26.0 \
-    "$XCASSETS_PATH" 2>/dev/null || true
+  compile_asset_catalog "$XCASSETS_PATH" "$APP_BUNDLE/Contents/Resources"
 fi
 
 # Embed Sparkle.framework
@@ -247,8 +257,13 @@ shopt -u nullglob
 if [[ ${#SWIFTPM_BUNDLES[@]} -gt 0 ]]; then
   for bundle in "${SWIFTPM_BUNDLES[@]}"; do
     bundle_name=$(basename "$bundle")
+    bundle_dest="$APP_BUNDLE/Contents/Resources/$bundle_name"
     echo "  → Copying resource bundle: $bundle_name"
     cp -R "$bundle" "$APP_BUNDLE/Contents/Resources/"
+    if [[ -d "$bundle_dest/Assets.xcassets" ]] && command -v actool &>/dev/null; then
+      echo "    ↳ Compiling bundle asset catalog"
+      compile_asset_catalog "$bundle_dest/Assets.xcassets" "$bundle_dest"
+    fi
   done
 fi
 

--- a/Sources/Kaset/Utilities/PackageResourceLookup.swift
+++ b/Sources/Kaset/Utilities/PackageResourceLookup.swift
@@ -1,0 +1,39 @@
+import AppKit
+import SwiftUI
+
+enum PackageResourceLookup {
+    private static let resourceBundleName = "Kaset_Kaset.bundle"
+    private static let accentColorName = NSColor.Name("AccentColor")
+
+    static let brandAccent: Color = {
+        if let color = NSColor(named: accentColorName, bundle: Bundle.main) {
+            return Color(nsColor: color)
+        }
+
+        for bundle in candidateBundles {
+            if let color = NSColor(named: accentColorName, bundle: bundle) {
+                return Color(nsColor: color)
+            }
+        }
+
+        return Color(red: 1.0, green: 0.0, blue: 0.337)
+    }()
+
+    private static let candidateBundles: [Bundle] = {
+        var bundles: [Bundle] = []
+        var seenPaths = Set<String>()
+
+        let candidateURLs = [
+            Bundle.main.resourceURL?.appendingPathComponent(resourceBundleName),
+            Bundle.main.executableURL?.deletingLastPathComponent().appendingPathComponent(resourceBundleName),
+        ]
+
+        for url in candidateURLs.compactMap(\.self) {
+            guard seenPaths.insert(url.path).inserted else { continue }
+            guard let bundle = Bundle(url: url) else { continue }
+            bundles.append(bundle)
+        }
+
+        return bundles
+    }()
+}

--- a/Sources/Kaset/Views/PlayerBar.swift
+++ b/Sources/Kaset/Views/PlayerBar.swift
@@ -5,6 +5,8 @@ import SwiftUI
 /// Player bar shown at the bottom of the content area, styled like Apple Music with Liquid Glass.
 @available(macOS 26.0, *)
 struct PlayerBar: View {
+    private static let brandAccent = PackageResourceLookup.brandAccent
+
     @Environment(PlayerService.self) private var playerService
     @Environment(WebKitManager.self) private var webKitManager
 
@@ -234,6 +236,7 @@ struct PlayerBar: View {
                 }
             }
             .controlSize(.small)
+            .tint(Self.brandAccent)
 
             // Remaining time - use cached formatted string when not seeking
             Text(self.isSeeking ? "-\(self.formatTime(self.playerService.duration - self.seekValue * self.playerService.duration))" : self.formattedRemaining)
@@ -413,6 +416,7 @@ struct PlayerBar: View {
             }
             .frame(width: 80)
             .controlSize(.small)
+            .tint(Self.brandAccent)
             .onChange(of: self.volumeValue) { oldValue, newValue in
                 // Apply volume changes in real-time during dragging for immediate feedback
                 if self.isAdjustingVolume {


### PR DESCRIPTION
## Summary
- fix packaged app resource lookup so the accent color asset can be found outside SwiftPM test/runtime layouts
- update the player bar accent color loading to use the packaged app lookup path
- keep the app build script aligned with the packaged resource layout used by the app bundle

## Testing
- bash -n Scripts/build-app.sh
- swift test
