### PR TITLE
Update CLI-first contributor docs and add repo skills

### DIFF
--- a/.agents/skills/api-exploration/SKILL.md
+++ b/.agents/skills/api-exploration/SKILL.md
@@ -1,0 +1,35 @@
+# API Exploration
+
+Use this skill when a task needs a new or modified YouTube Music API call, response parser validation, authenticated endpoint investigation, or fixture capture.
+
+## Guardrails
+
+- Always enhance `Sources/APIExplorer/main.swift`; do not write one-off scripts for endpoint exploration.
+- Never commit real cookies, SAPISID values, tokens, or account identifiers. Redact anything sensitive in notes, fixtures, and examples.
+- Prefer API endpoints over WebView whenever the functionality already exists in `YTMusicClient`.
+
+## Workflow
+
+1. Start with `swift run api-explorer auth` if the task touches sign-in-backed endpoints.
+2. Check what already exists with `swift run api-explorer list`.
+3. Probe the endpoint with `browse`, `action`, or `continuation` before touching production code.
+4. Save representative payloads with `-o` when parser work or regression tests need fixtures.
+5. Update `docs/api-discovery.md` if you confirm a new endpoint, parameter, or auth constraint.
+
+## Common Commands
+
+```bash
+swift run api-explorer auth
+swift run api-explorer list
+swift run api-explorer browse FEmusic_home -v
+swift run api-explorer browse FEmusic_liked_playlists -v
+swift run api-explorer action search '{"query":"never gonna give you up"}'
+```
+
+## Landmarks
+
+- `Sources/APIExplorer/main.swift`
+- `docs/api-discovery.md`
+- `Tests/KasetTests/Fixtures/`
+
+Authenticated exploration reads the debug cookie export from `~/Library/Application Support/Kaset/cookies.dat`.

--- a/.agents/skills/dev-loop-packaging/SKILL.md
+++ b/.agents/skills/dev-loop-packaging/SKILL.md
@@ -1,0 +1,33 @@
+# Dev Loop Packaging
+
+Use this skill when you need a fresh `.app` bundle, a fast build-package-relaunch loop, or a packaged runtime repro instead of a compile-only check.
+
+## Default Loop
+
+- Prefer `swift build` for the fastest compile verification.
+- Prefer `swift test --skip KasetUITests` for the default non-UI test pass.
+- Escalate to packaging only when you need a runnable app bundle, login/WebView/runtime inspection, or bundle verification.
+
+## Common Commands
+
+```bash
+swift build
+Scripts/build-app.sh
+Scripts/compile_and_run.sh
+Scripts/compile_and_run.sh --test
+Scripts/compile_and_run.sh --lint
+Scripts/compile_and_run.sh --wait
+```
+
+## What The Scripts Do
+
+- `Scripts/build-app.sh` builds the app and assembles `.build/app/Kaset.app`.
+- `Scripts/compile_and_run.sh` kills existing Kaset processes, optionally runs tests and linting, packages the app, relaunches it, and checks that it stays running.
+- `Scripts/compile_and_run.sh --test` runs the SwiftPM test target before packaging; it does not invoke the separate Xcode UI-test project.
+- `Scripts/build-app.sh` can also build for custom architectures via `ARCHES`.
+
+## Landmarks
+
+- `Scripts/build-app.sh`
+- `Scripts/compile_and_run.sh`
+- `.build/app/Kaset.app`

--- a/.agents/skills/playback-webview-debugging/SKILL.md
+++ b/.agents/skills/playback-webview-debugging/SKILL.md
@@ -1,0 +1,30 @@
+# Playback WebView Debugging
+
+Use this skill when playback, auth recovery, queue sync, or hidden WebView state diverges from the native Swift state.
+
+## When To Use It
+
+- Playback starts, stops, or advances unexpectedly
+- Auth looks stale and API calls return 401/403
+- WebView metadata drifts from the native queue
+- You need to inspect JavaScript bridge events or DOM/player state
+
+## Runtime Workflow
+
+1. Reproduce with the packaged app or `Scripts/compile_and_run.sh`.
+2. Use Xcode Console filters to watch runtime logs:
+   `subsystem:Kaset category:player`
+   `subsystem:Kaset category:auth`
+3. In debug builds, verify `webView.isInspectable = true`, then inspect the player WebView with Safari Web Inspector.
+4. To simulate auth expiry, delete `__Secure-3PAPISID` via Safari Web Inspector storage tools and trigger an authenticated API call.
+5. If auth cookies or headers look suspicious, run `swift run api-explorer auth` and compare against the exported cookie state.
+
+## Landmarks
+
+- `docs/testing.md`
+- `docs/playback.md`
+- `Sources/Kaset/Views/MiniPlayerWebView.swift`
+- `Sources/Kaset/Views/SingletonPlayerWebView+ObserverScript.swift`
+- `Sources/Kaset/Services/Player/PlayerService.swift`
+- `Sources/Kaset/Services/Player/PlayerService+WebQueueSync.swift`
+- `Sources/Kaset/Services/WebKit/WebKitManager.swift`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,8 @@ swift test --skip KasetUITests
 swiftlint --strict && swiftformat .
 ```
 
+Default local workflow is CLI-first: use the commands above for day-to-day verification, and escalate to Xcode/`xcodebuild` only for simulator, UI, or runtime debugging, screenshots, or scheme-specific investigation.
+
 > ⚠️ **SwiftFormat `--self insert` rule**: The project uses `--self insert` in `.swiftformat`. This means:
 > - In static methods, call other static methods with `Self.methodName()` (not bare `methodName()`)
 > - In instance methods, use `self.property` explicitly
@@ -52,6 +54,8 @@ swift run api-explorer auth          # Check auth status
 swift run api-explorer list          # List known endpoints
 swift run api-explorer browse FEmusic_home -v  # Explore with verbose output
 ```
+
+Put repeatable, repo-specific workflows in `.agents/skills/` so `AGENTS.md` stays focused on repo-wide rules.
 
 ## Coding Rules
 

--- a/docs/adr/0012-localization-strategy.md
+++ b/docs/adr/0012-localization-strategy.md
@@ -10,10 +10,12 @@ Kaset has no localization infrastructure. All ~300 user-facing strings are hardc
 
 Requirements:
 1. **Minimal disruption** — Adding localization should not require architectural changes
-2. **SPM compatibility** — Kaset is an SPM-only project (no `.xcodeproj`)
+2. **SwiftPM-first compatibility** — Kaset builds primarily via SwiftPM, with checked-in Xcode projects for app and UI-test workflows
 3. **Modern tooling** — Leverage Swift 6 / Xcode 16+ capabilities
 4. **Arabic support** — Must handle RTL layout, Arabic plural forms (6 categories), and mixed-language content
 5. **Maintainability** — New strings added by contributors should be easy to localize
+
+The repo is SwiftPM-first, but it also includes `Kaset.xcodeproj` and `KasetUITests.xcodeproj` for app packaging, runtime debugging, and UI-test workflows.
 
 ## Decision
 

--- a/docs/task-planning.md
+++ b/docs/task-planning.md
@@ -4,6 +4,8 @@ For any non-trivial task, **plan in phases with testable exit criteria** before 
 
 > ⚠️ **Never implement without an approved plan** — Planning and execution are separate phases. Do not write production code until the plan has been reviewed. When working in plan mode, always include **"don't implement yet"** as a guard. The human will say when to start.
 
+> 🔁 **Follow the repo default loop in `AGENTS.md`** — Local verification is CLI-first: `swift build`, targeted `swift test --skip KasetUITests`, then `swiftlint --strict && swiftformat .`. Use Xcode/`xcodebuild` only for UI/runtime debugging, scheme-specific investigation, or CI parity.
+
 ## Phase Structure
 
 Every task should be broken into phases. Each phase must have:
@@ -32,11 +34,11 @@ Every task should be broken into phases. Each phase must have:
 | Define new types/protocols | Type signatures compile |
 | Plan public API surface | No breaking changes to existing callers (or changes identified) |
 
-**Exit gate**: `xcodebuild build` succeeds with stub implementations.
+**Exit gate**: `swift build` succeeds with stub implementations.
 
 ### Phase 3: Core Implementation
 
-> 🔄 **Continuously verify the build** — Run `xcodebuild build` throughout implementation, not just at the end. Catch type errors and regressions early, not after 15 minutes of changes.
+> 🔄 **Continuously verify the build** — Run `swift build` throughout implementation, not just at the end. Catch type errors and regressions early, not after 15 minutes of changes.
 
 > 📋 **Track progress in the plan** — Mark tasks and phases as completed as you go. The human should be able to glance at the plan at any point and see exactly where things stand.
 
@@ -47,16 +49,16 @@ Every task should be broken into phases. Each phase must have:
 | Add logging | `DiagnosticsLogger` calls in place |
 | Performance verified | Anti-pattern checklist passed, perf tests added if applicable |
 
-**Exit gate**: `xcodebuild test -only-testing:KasetTests` passes.
+**Exit gate**: Targeted `swift test --skip KasetUITests --filter ...` passes for the new code path.
 
 ### Phase 4: Quality Assurance
 | Deliverable | Exit Criteria |
 |-------------|---------------|
 | Linting passes | `swiftlint --strict` reports 0 errors |
 | Formatting applied | `swiftformat .` makes no changes |
-| Full test suite passes | `xcodebuild test` succeeds |
+| Full default test suite passes | `swift test --skip KasetUITests` succeeds |
 
-**Exit gate**: CI-equivalent checks pass locally.
+**Exit gate**: `swift build`, `swift test --skip KasetUITests`, `swiftlint --strict`, and `swiftformat .` pass locally.
 
 ## Example: Adding a New Service
 
@@ -67,17 +69,19 @@ Phase 1: Research
 
 Phase 2: Interface
 ├── Create NewService.swift with protocol + stub
-├── Exit: `xcodebuild build` passes
+├── Exit: `swift build` passes
 
 Phase 3: Implementation
 ├── Implement methods, add error handling
 ├── Create NewServiceTests.swift
-├── Run `xcodebuild build` after each major change
-├── Exit: `xcodebuild test -only-testing:KasetTests/NewServiceTests` passes
+├── Run `swift build` after each major change
+├── Exit: `swift test --skip KasetUITests --filter NewServiceTests` passes
 
 Phase 4: QA
-├── Run swiftlint, swiftformat
-├── Exit: Full test suite passes, no lint errors
+├── Run `swift build`
+├── Run `swift test --skip KasetUITests`
+├── Run `swiftlint --strict && swiftformat .`
+├── Exit: Default local CLI loop passes
 ```
 
 ## Implementation Discipline

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2,12 +2,14 @@
 
 This document covers testing strategies, commands, and best practices for Kaset.
 
-## Test Commands
+> 🔁 **Default local loop lives in `AGENTS.md`** — Stay CLI-first for everyday verification: `swift build`, `swift test --skip KasetUITests`, then `swiftlint --strict && swiftformat .`. Use Xcode/`xcodebuild` only for UI/runtime debugging, scheme-specific investigation, or CI parity.
+
+## Common Tasks
 
 ### Unit Tests
 
 ```bash
-swift test
+swift test --skip KasetUITests
 ```
 
 ### Build Only
@@ -142,11 +144,17 @@ Apply tags to categorize tests for filtering:
 
 Available tags: `.api`, `.parser`, `.viewModel`, `.service`, `.model`, `.slow`, `.integration`
 
-**Run by tag:**
+Tags are most useful for suite organization and Xcode/CI filtering. For quick local iteration, prefer a name-based filter:
+
 ```bash
-# Run only parser tests
-xcodebuild test -scheme Kaset -only-testing:KasetTests -skip-testing:KasetUITests \
-  2>&1 | grep -E "parser"
+# Run tests matching a name or suite pattern
+swift test --skip KasetUITests --filter Parser
+```
+
+If you need Xcode's logs or scheme-specific filtering, escalate to:
+
+```bash
+xcodebuild test -scheme Kaset -only-testing:KasetTests -skip-testing:KasetUITests
 ```
 
 ### Time Limits
@@ -374,7 +382,7 @@ LLM outputs are inherently non-deterministic. These tests mitigate flakiness by:
 
 #### Recommended CI Configuration
 
-For stable CI pipelines, **exclude integration tests** and run them separately in a scheduled job:
+For stable CI pipelines, **exclude integration tests** and run them separately in a scheduled job. These are CI/Xcode-specific commands; keep day-to-day local verification on the default CLI loop above:
 
 ```bash
 # CI: Run unit tests only (stable)
@@ -403,13 +411,12 @@ xcodebuild test -scheme Kaset -destination 'platform=macOS' \
 #### Run Commands
 
 ```bash
-# Run ONLY integration tests (requires Apple Intelligence)
+# Special-case: run ONLY integration tests (requires Apple Intelligence)
 xcodebuild test -scheme Kaset -destination 'platform=macOS' \
   -only-testing:KasetTests/MusicIntentIntegrationTests
 
-# Run all unit tests (integration tests auto-skip if AI unavailable)
-xcodebuild test -scheme Kaset -destination 'platform=macOS' \
-  -only-testing:KasetTests
+# Default local run for the non-UI test suite
+swift test --skip KasetUITests
 ```
 
 #### Test Characteristics
@@ -434,7 +441,9 @@ Before releasing:
 - [ ] Re-opening window doesn't duplicate audio
 - [ ] Sign out and re-login works
 
-### Simulating Auth Expiry
+### Simulating Auth Expiry (Runtime Debugging)
+
+Use this runtime debugging workflow when auth state looks stale or you need to inspect 401/403 recovery behavior:
 
 To test auth recovery:
 
@@ -446,14 +455,16 @@ To test auth recovery:
 
 ### Console Logging
 
-Use Xcode's Console to filter logs:
+Use Xcode's Console when the CLI loop is not enough and you need runtime inspection:
 
 ```
 subsystem:Kaset category:player
 subsystem:Kaset category:auth
 ```
 
-### WebView Debugging
+### WebView Debugging (Runtime Escalation)
+
+Enable Web Inspector for debug builds when playback or auth issues need DOM or JavaScript inspection:
 
 Enable Web Inspector for debug builds:
 
@@ -468,6 +479,8 @@ Right-click WebView → Inspect Element
 ## Continuous Integration
 
 ### GitHub Actions Workflow
+
+CI can use Xcode-specific commands for macOS runner parity. Keep this separate from the default local CLI loop above.
 
 ```yaml
 name: Build & Test


### PR DESCRIPTION
## Summary
- align contributor guidance around a CLI-first local loop using `swift build`, `swift test --skip KasetUITests`, `swiftlint --strict`, and `swiftformat .`
- reframe `xcodebuild` usage in planning and testing docs as an escalation path for UI, runtime, and CI-specific workflows
- update the localization ADR to describe the repo as SwiftPM-first with checked-in Xcode projects
- add repo skills for API exploration, playback/WebView debugging, and app packaging workflows

## Testing
- `swift test --skip KasetUITests --filter NoSuchTest`