### PR TITLE
fix(skills): add missing YAML frontmatter

### DIFF
--- a/.agents/skills/api-exploration/SKILL.md
+++ b/.agents/skills/api-exploration/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: api-exploration
+description: Use when a task needs a new or modified YouTube Music API call, response parser validation, authenticated endpoint investigation, or fixture capture; explore endpoints with `swift run api-explorer` before changing production code.
+metadata:
+  short-description: Explore YouTube Music APIs
+---
+
 # API Exploration
 
 Use this skill when a task needs a new or modified YouTube Music API call, response parser validation, authenticated endpoint investigation, or fixture capture.

--- a/.agents/skills/dev-loop-packaging/SKILL.md
+++ b/.agents/skills/dev-loop-packaging/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: dev-loop-packaging
+description: Use when you need a fresh packaged `.app` bundle, a fast build-package-relaunch loop, or a packaged runtime repro for Kaset instead of a compile-only verification.
+metadata:
+  short-description: Package and relaunch Kaset
+---
+
 # Dev Loop Packaging
 
 Use this skill when you need a fresh `.app` bundle, a fast build-package-relaunch loop, or a packaged runtime repro instead of a compile-only check.

--- a/.agents/skills/playback-webview-debugging/SKILL.md
+++ b/.agents/skills/playback-webview-debugging/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: playback-webview-debugging
+description: Use when playback, auth recovery, queue sync, or hidden WebView state diverges from native Swift state and you need to debug the DRM playback WebView, bridge events, or cookie/auth behavior.
+metadata:
+  short-description: Debug playback WebView state
+---
+
 # Playback WebView Debugging
 
 Use this skill when playback, auth recovery, queue sync, or hidden WebView state diverges from the native Swift state.


### PR DESCRIPTION
## Summary
- add required YAML frontmatter to the repo-local skill definitions
- restore loading for dev-loop-packaging, api-exploration, and playback-webview-debugging
- keep the skill bodies unchanged beyond metadata

## Testing
- parsed each SKILL.md frontmatter locally to confirm required fields are present
- not run (metadata-only Markdown change)