### PR TITLE
feat(api): use configured language for YouTube Music API requests

### DIFF
--- a/Sources/Kaset/Services/API/YTMusicClient.swift
+++ b/Sources/Kaset/Services/API/YTMusicClient.swift
@@ -1373,7 +1373,7 @@ final class YTMusicClient: YTMusicClientProtocol {
             "client": [
                 "clientName": "WEB_REMIX",
                 "clientVersion": Self.clientVersion,
-                "hl": "en",
+                "hl": SettingsManager.shared.contentLanguage.apiLanguageCode,
                 "gl": "US",
                 "experimentIds": [],
                 "experimentsToken": "",

--- a/Sources/Kaset/Services/SettingsManager.swift
+++ b/Sources/Kaset/Services/SettingsManager.swift
@@ -107,6 +107,13 @@ final class SettingsManager {
             }
         }
 
+        /// The language code for YouTube Music API requests (`hl` parameter).
+        /// Returns the explicit language code or derives one from the system locale,
+        /// falling back to `"en"`.
+        var apiLanguageCode: String {
+            self.languageCode ?? Locale.current.language.languageCode?.identifier ?? "en"
+        }
+
         /// The locale matching this language selection.
         var locale: Locale {
             if let code = self.languageCode {
@@ -232,11 +239,12 @@ final class SettingsManager {
         }
     }
 
-    /// The language used for the app interface.
+    /// The language used for the app interface and API content.
     var contentLanguage: ContentLanguage {
         didSet {
             UserDefaults.standard.set(self.contentLanguage.rawValue, forKey: Keys.contentLanguage)
             AppLocalization.setLanguage(self.contentLanguage.languageCode)
+            APICache.shared.invalidateAll()
         }
     }
 

--- a/Tests/KasetTests/APICacheTests.swift
+++ b/Tests/KasetTests/APICacheTests.swift
@@ -88,6 +88,33 @@ struct APICacheTests {
         #expect(APICache.TTL.songMetadata == 30 * 60) // 30 minutes
     }
 
+    @Test("Cache keys change when API request language changes")
+    func stableCacheKeyChangesWhenRequestLanguageChanges() {
+        let englishBody: [String: Any] = [
+            "browseId": "FEmusic_home",
+            "context": [
+                "client": [
+                    "hl": "en",
+                    "gl": "US",
+                ],
+            ],
+        ]
+        let koreanBody: [String: Any] = [
+            "browseId": "FEmusic_home",
+            "context": [
+                "client": [
+                    "hl": "ko",
+                    "gl": "US",
+                ],
+            ],
+        ]
+
+        let englishKey = APICache.stableCacheKey(endpoint: "browse", body: englishBody)
+        let koreanKey = APICache.stableCacheKey(endpoint: "browse", body: koreanBody)
+
+        #expect(englishKey != koreanKey)
+    }
+
     @Test("Lyrics cache not invalidated by mutations")
     func lyricsCacheNotInvalidatedByMutations() {
         self.cache.set(key: "browse:lyrics_abc123", data: ["text": "lyrics content"], ttl: APICache.TTL.lyrics)

--- a/Tests/KasetTests/SettingsManagerTests.swift
+++ b/Tests/KasetTests/SettingsManagerTests.swift
@@ -91,6 +91,48 @@ struct SettingsManagerTests {
         #expect(UserDefaults.standard.object(forKey: repeatKey) == nil)
     }
 
+    @Test("Explicit content languages expose stable API language codes")
+    func explicitContentLanguagesExposeAPILanguageCodes() {
+        let expectedCodes: [(SettingsManager.ContentLanguage, String)] = [
+            (.english, "en"),
+            (.korean, "ko"),
+            (.arabic, "ar"),
+            (.turkish, "tr"),
+            (.indonesian, "id"),
+        ]
+
+        for (language, expectedCode) in expectedCodes {
+            #expect(language.apiLanguageCode == expectedCode)
+        }
+    }
+
+    @Test("System content language uses the current locale language code fallback")
+    func systemContentLanguageUsesCurrentLocaleLanguageCode() {
+        let expectedCode = Locale.current.language.languageCode?.identifier ?? "en"
+        #expect(SettingsManager.ContentLanguage.system.apiLanguageCode == expectedCode)
+    }
+
+    @Test("Changing content language invalidates API cache and updates localization bundle")
+    func changingContentLanguageInvalidatesCacheAndUpdatesLocalizationBundle() {
+        let manager = SettingsManager.shared
+        let originalLanguage = manager.contentLanguage
+
+        defer {
+            APICache.shared.invalidateAll()
+            manager.contentLanguage = originalLanguage
+        }
+
+        manager.contentLanguage = .english
+        APICache.shared.set(key: "browse:test-home", data: ["title": "Home"], ttl: 60)
+
+        #expect(APICache.shared.get(key: "browse:test-home") != nil)
+
+        manager.contentLanguage = .korean
+
+        #expect(APICache.shared.get(key: "browse:test-home") == nil)
+        #expect(AppLocalization.bundle.localizedString(forKey: "Home", value: nil, table: nil) == "홈")
+    }
+
     // MARK: - launchPage Computed Property Tests
 
     @Test("launchPage returns defaultLaunchPage for non-lastUsed")


### PR DESCRIPTION
## Summary

<img width="1160" height="589" alt="image" src="https://github.com/user-attachments/assets/74dec5b1-6a4b-42cb-b5d6-c01b6aecb2ab" />


The `hl` parameter in `YTMusicClient.buildContext()` was hardcoded to `"en"`, causing the YouTube Music API to always return English content regardless of the user's language setting. This change makes the API respect the app's content language preference so that section titles, descriptions, and other API-driven content are returned in the user's selected language.

### Before
- App UI language changes worked (via String Catalogs), but API content always came back in English
- Home, Explore, Charts, and other API-driven screens showed English section titles/descriptions even when the user selected Korean, Arabic, Turkish, or Indonesian

### After
- API requests use the configured language (`hl` parameter matches the content language setting)
- Changing language in Settings immediately invalidates the API cache, so fresh content is fetched in the new language on the next request
- System language option derives the language code from the user's macOS locale, falling back to `"en"`

## Changes

- **`SettingsManager.swift`**: Add `apiLanguageCode` computed property to `ContentLanguage` enum that always returns a valid language code string. Invalidate `APICache` when `contentLanguage` changes to clear stale responses.
- **`YTMusicClient.swift`**: Replace hardcoded `"hl": "en"` with `SettingsManager.shared.contentLanguage.apiLanguageCode` in `buildContext()`.

## Note on ADR-0012

ADR-0012 lists "API request parameters" under "What Is NOT Localized". That refers to not wrapping API parameter strings in `String(localized:)` for String Catalog translation — it does not apply here, where we are dynamically setting the `hl` value based on user preference.

## Test plan

- [x] `swift build` passes
- [x] `swiftlint --strict` — 0 violations
- [x] `swiftformat .` — 0 files changed
- [x] `swift test --skip KasetUITests` — 1123 tests passed
- [x] Manual: Change language in Settings → verify API-driven content (Home, Explore, Charts) reflects the selected language
- [x] Manual: Select "System Default" → verify it uses the macOS system language

🤖 Generated with [Claude Code](https://claude.com/claude-code)