### PR TITLE
docs: add maintainer demo workflow notes to CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,6 +203,12 @@ final class MyServiceTests: XCTestCase {
 
 We embrace AI-assisted development! Whether you use GitHub Copilot, Claude, Cursor, or other AI tools, we welcome contributions that leverage these capabilities.
 
+### Maintainer Demo Workflow Examples
+
+For repository maintainers, this repo may also include **demo workflow examples** for repository automation such as **chat orchestration**, **parallel review**, **scheduled workflows**, and **security scanning**.
+
+These are examples for maintainers evaluating automation in the repository, **not end-user product features** in Kaset itself.
+
 ### What is a Prompt Request?
 
 A **prompt request** is a contribution where you share the AI prompt that generates code, rather than (or in addition to) the code itself. This approach:


### PR DESCRIPTION
## Summary
- add a short maintainer-facing subsection to `CONTRIBUTING.md`
- describe four repository automation demo workflows: chat orchestration, parallel review, scheduled workflows, and security scanning
- clarify that these are demo workflow examples for maintainers, not end-user product features

## Validation
- documentation-only change
- no tests run