### PR TITLE
docs: add maintainer demo checklist to contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -199,6 +199,15 @@ final class MyServiceTests: XCTestCase {
 5. **Small PRs** — Keep changes focused and reviewable
 6. **Share AI Prompts** — If you used AI assistance, include the prompt in your PR (see below)
 
+### Maintainer Demo Checklist
+
+- [ ] Use test-only credentials for every demo workflow.
+- [ ] Work on a dedicated demo branch before sharing changes.
+- [ ] Inspect the diff before push.
+- [ ] Open a PR only after validation is complete.
+
+Demo workflows are for maintainers, not end-user product features.
+
 ## AI-Assisted Contributions & Prompt Requests
 
 We embrace AI-assisted development! Whether you use GitHub Copilot, Claude, Cursor, or other AI tools, we welcome contributions that leverage these capabilities.


### PR DESCRIPTION
## Summary
- add a short `Maintainer Demo Checklist` subsection to `CONTRIBUTING.md`
- include four one-line checklist items for safe demo workflow habits
- clarify that demo workflows are for maintainers, not end-user product features

## Validation
- documentation-only change; no code or runtime changes
- reviewed by security and quality reviewers