### PR TITLE
docs: add maintainer demo checklist to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -199,6 +199,15 @@ final class MyServiceTests: XCTestCase {
 5. **Small PRs** — Keep changes focused and reviewable
 6. **Share AI Prompts** — If you used AI assistance, include the prompt in your PR (see below)
 
+### Maintainer Demo Checklist
+
+- [ ] Use test-only credentials.
+- [ ] Work on a dedicated demo branch.
+- [ ] Inspect the diff before push.
+- [ ] Open a PR only after validation.
+
+Demo workflows are for maintainers, not end-user product features.
+
 ## AI-Assisted Contributions & Prompt Requests
 
 We embrace AI-assisted development! Whether you use GitHub Copilot, Claude, Cursor, or other AI tools, we welcome contributions that leverage these capabilities.


### PR DESCRIPTION
## Summary
- add a short `Maintainer Demo Checklist` subsection to `CONTRIBUTING.md`
- include four one-line checklist bullets for maintainer demo workflow hygiene
- clarify that demo workflows are for maintainers, not end-user product features

## Validation
- reviewed by security reviewer
- reviewed by quality reviewer
- documentation-only diff