### PR TITLE
docs: add maintainer demo workflow examples to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,16 +51,16 @@ brew install sozercan/repo/kaset
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, architecture, and coding guidelines.
 
-### Maintainer Demo Workflow Examples
+### Demo-Only Maintainer Workflow Examples
 
-These are demo workflow examples for maintainers, not end-user product features.
+This subsection is included only to document internal maintainer demo scenarios in README; the items below are not Kaset product features or end-user capabilities.
 
 - chat orchestration
 - parallel review
 - scheduled workflows
 - security scanning
 
-Demos must use placeholder or sample data only, never real secrets, tokens, or cookies, and require human approval for privileged actions.
+Any demo of these maintainer-only workflows must use placeholder or sample data only, never real secrets, tokens, or cookies, and must have human approval for privileged actions.
 
 We welcome AI-assisted contributions! You can submit traditional PRs or **prompt requests** — share the AI prompt that generates your changes, and maintainers can review the intent before running the code. See the [AI-Assisted Contributions](CONTRIBUTING.md#ai-assisted-contributions--prompt-requests) section for details.
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,17 @@ brew install sozercan/repo/kaset
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, architecture, and coding guidelines.
 
+### Maintainer Demo Workflow Examples
+
+These are demo workflow examples for maintainers, not end-user product features.
+
+- chat orchestration
+- parallel review
+- scheduled workflows
+- security scanning
+
+Demos must use placeholder or sample data only, never real secrets, tokens, or cookies, and require human approval for privileged actions.
+
 We welcome AI-assisted contributions! You can submit traditional PRs or **prompt requests** — share the AI prompt that generates your changes, and maintainers can review the intent before running the code. See the [AI-Assisted Contributions](CONTRIBUTING.md#ai-assisted-contributions--prompt-requests) section for details.
 
 ## Disclaimer


### PR DESCRIPTION
## Summary
- add a maintainer-facing demo workflow subsection to `README.md`
- keep the change documentation-only and easy to review
- clarify demo guardrails around sample data, secrets, and human approval for privileged actions

## Validation
- security review approved
- quality review approved