### PR TITLE
fix(player): advance queue when manually seeking to end of track

### DIFF
--- a/Sources/Kaset/Services/Player/PlayerService+WebQueueSync.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+WebQueueSync.swift
@@ -4,6 +4,20 @@ import Foundation
 
 @MainActor
 extension PlayerService {
+    /// Distance from `duration` at which a manual seek is treated as the end of the track.
+    /// `video.currentTime = duration` does not reliably fire `ended` in WebKit, and a subsequent
+    /// play call would restart the same song from 0 instead of advancing.
+    static let seekToEndThreshold: TimeInterval = 0.5
+
+    /// Routes a manual seek that landed at the end of the track through the track-ended path so
+    /// repeat / queue / autoplay-suppression rules apply consistently with a natural end.
+    func handleManualSeekToEnd() async {
+        self.logger.info("Manual seek reached end of track; routing through track-ended path")
+        self.clearRestoredPlaybackSessionState()
+        self.progress = self.duration
+        await self.handleTrackEnded(observedVideoId: self.currentTrack?.videoId)
+    }
+
     private func normalizedObservedVideoId(_ videoId: String?) -> String? {
         guard let videoId, !videoId.isEmpty else { return nil }
         return videoId

--- a/Sources/Kaset/Services/Player/PlayerService+WebQueueSync.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+WebQueueSync.swift
@@ -15,7 +15,20 @@ extension PlayerService {
         self.logger.info("Manual seek reached end of track; routing through track-ended path")
         self.clearRestoredPlaybackSessionState()
         self.progress = self.duration
+
+        if self.shouldSynchronizeWebViewForTerminalManualSeekToEnd {
+            SingletonPlayerWebView.shared.seekAndPause(to: self.duration)
+        }
+
         await self.handleTrackEnded(observedVideoId: self.currentTrack?.videoId)
+    }
+
+    private var shouldSynchronizeWebViewForTerminalManualSeekToEnd: Bool {
+        if self.queue.isEmpty {
+            return !(self.repeatMode == .one && (self.currentTrack != nil || self.pendingPlayVideoId != nil))
+        }
+
+        return !self.canAdvanceNativeQueueAfterTrackEnd
     }
 
     private func normalizedObservedVideoId(_ videoId: String?) -> String? {

--- a/Sources/Kaset/Services/Player/PlayerService.swift
+++ b/Sources/Kaset/Services/Player/PlayerService.swift
@@ -757,13 +757,15 @@ final class PlayerService: NSObject, PlayerServiceProtocol {
     func seek(to time: TimeInterval) async {
         let clampedTime = self.duration > 0 ? min(max(time, 0), self.duration) : max(time, 0)
         self.logger.debug("Seeking to \(clampedTime)")
-
         if self.isPendingRestoredLoadDeferred {
             self.progress = clampedTime
             self.pendingRestoredSeek = clampedTime
             return
         }
-
+        if self.duration > 0, clampedTime >= self.duration - Self.seekToEndThreshold {
+            await self.handleManualSeekToEnd()
+            return
+        }
         self.clearRestoredPlaybackSessionState()
         if self.pendingPlayVideoId != nil {
             SingletonPlayerWebView.shared.seek(to: clampedTime)

--- a/Sources/Kaset/Views/SingletonPlayerWebView+PlaybackControls.swift
+++ b/Sources/Kaset/Views/SingletonPlayerWebView+PlaybackControls.swift
@@ -104,6 +104,24 @@ extension SingletonPlayerWebView {
         webView.evaluateJavaScript(script, completionHandler: nil)
     }
 
+    /// Atomically pause and seek the underlying video.
+    func seekAndPause(to time: Double) {
+        guard let webView else { return }
+
+        let safeTime = time.isFinite ? max(time, 0) : 0
+        let script = """
+            (function() {
+                const video = document.querySelector('video');
+                if (!video) { return 'no-video'; }
+                video.pause();
+                video.currentTime = \(safeTime);
+                video.pause();
+                return 'seeked-paused';
+            })();
+        """
+        webView.evaluateJavaScript(script, completionHandler: nil)
+    }
+
     /// Seeks to the start and resumes playback without a full page load (repeat-one, same-URL recovery).
     func restartInPlaceFromBeginning() {
         self.seek(to: 0)

--- a/Tests/KasetTests/PlayerServiceWebQueueSyncTests.swift
+++ b/Tests/KasetTests/PlayerServiceWebQueueSyncTests.swift
@@ -740,4 +740,132 @@ struct PlayerServiceWebQueueSyncTests {
         #expect(self.playerService.queue.count == 1)
         #expect(self.playerService.queue.first?.videoId == "lonely-video")
     }
+
+    // MARK: - Manual Seek to End Tests
+
+    @Test("Manual seek to end of track advances to next queue song")
+    func manualSeekToEndAdvancesQueue() async {
+        let songs = [
+            Song(id: "1", title: "Song 1", artists: [], album: nil, duration: 180, thumbnailURL: nil, videoId: "v1"),
+            Song(id: "2", title: "Song 2", artists: [], album: nil, duration: 200, thumbnailURL: nil, videoId: "v2"),
+        ]
+
+        await self.playerService.playQueue(songs, startingAt: 0)
+        self.playerService.duration = 180
+
+        await self.playerService.seek(to: 180)
+
+        #expect(self.playerService.currentIndex == 1)
+        #expect(self.playerService.pendingPlayVideoId == "v2")
+    }
+
+    @Test("Manual seek within end-threshold still advances queue")
+    func manualSeekWithinEndThresholdAdvancesQueue() async {
+        let songs = [
+            Song(id: "1", title: "Song 1", artists: [], album: nil, duration: 180, thumbnailURL: nil, videoId: "v1"),
+            Song(id: "2", title: "Song 2", artists: [], album: nil, duration: 200, thumbnailURL: nil, videoId: "v2"),
+        ]
+
+        await self.playerService.playQueue(songs, startingAt: 0)
+        self.playerService.duration = 180
+
+        await self.playerService.seek(to: 180 - PlayerService.seekToEndThreshold + 0.01)
+
+        #expect(self.playerService.currentIndex == 1)
+        #expect(self.playerService.pendingPlayVideoId == "v2")
+    }
+
+    @Test("Manual seek to mid-track does not advance queue")
+    func manualSeekToMidTrackDoesNotAdvanceQueue() async {
+        let songs = [
+            Song(id: "1", title: "Song 1", artists: [], album: nil, duration: 180, thumbnailURL: nil, videoId: "v1"),
+            Song(id: "2", title: "Song 2", artists: [], album: nil, duration: 200, thumbnailURL: nil, videoId: "v2"),
+        ]
+
+        await self.playerService.playQueue(songs, startingAt: 0)
+        self.playerService.duration = 180
+
+        await self.playerService.seek(to: 90)
+
+        #expect(self.playerService.currentIndex == 0)
+        #expect(self.playerService.pendingPlayVideoId == "v1")
+        #expect(self.playerService.progress == 90)
+    }
+
+    @Test("Manual seek to end with repeat one replays the same song")
+    func manualSeekToEndWithRepeatOneReplaysSameSong() async {
+        let songs = [
+            Song(id: "1", title: "Song 1", artists: [], album: nil, duration: 180, thumbnailURL: nil, videoId: "v1"),
+            Song(id: "2", title: "Song 2", artists: [], album: nil, duration: 200, thumbnailURL: nil, videoId: "v2"),
+        ]
+
+        await self.playerService.playQueue(songs, startingAt: 0)
+        self.playerService.cycleRepeatMode()
+        self.playerService.cycleRepeatMode()
+        #expect(self.playerService.repeatMode == .one)
+        self.playerService.duration = 180
+
+        await self.playerService.seek(to: 180)
+
+        #expect(self.playerService.currentIndex == 0)
+        #expect(self.playerService.pendingPlayVideoId == "v1")
+    }
+
+    @Test("Manual seek to end of last queue song with repeat off pauses at end")
+    func manualSeekToEndOfLastQueueSongPausesPlayback() async {
+        let songs = [
+            Song(id: "1", title: "Song 1", artists: [], album: nil, duration: 180, thumbnailURL: nil, videoId: "v1"),
+            Song(id: "2", title: "Song 2", artists: [], album: nil, duration: 200, thumbnailURL: nil, videoId: "v2"),
+        ]
+
+        await self.playerService.playQueue(songs, startingAt: 1)
+        self.playerService.duration = 200
+
+        await self.playerService.seek(to: 200)
+
+        #expect(self.playerService.state == .ended)
+        #expect(self.playerService.currentIndex == 1)
+        #expect(self.playerService.shouldSuppressAutoplayAfterQueueEnd == true)
+    }
+
+    @Test("Manual seek to end with repeat all wraps from last song to first")
+    func manualSeekToEndWithRepeatAllWrapsToFirst() async {
+        let songs = [
+            Song(id: "1", title: "Song 1", artists: [], album: nil, duration: 180, thumbnailURL: nil, videoId: "v1"),
+            Song(id: "2", title: "Song 2", artists: [], album: nil, duration: 200, thumbnailURL: nil, videoId: "v2"),
+        ]
+
+        await self.playerService.playQueue(songs, startingAt: 1)
+        self.playerService.cycleRepeatMode()
+        #expect(self.playerService.repeatMode == .all)
+        self.playerService.duration = 200
+
+        await self.playerService.seek(to: 200)
+
+        #expect(self.playerService.currentIndex == 0)
+        #expect(self.playerService.pendingPlayVideoId == "v1")
+    }
+
+    @Test("Restored seek before load is not treated as seek-to-end")
+    func manualSeekToEndDuringRestorationIsDeferred() async {
+        let songs = [
+            Song(id: "1", title: "Song 1", artists: [], album: nil, duration: 180, thumbnailURL: nil, videoId: "v1"),
+            Song(id: "2", title: "Song 2", artists: [], album: nil, duration: 200, thumbnailURL: nil, videoId: "v2"),
+        ]
+
+        self.playerService.applyRestoredPlaybackSession(
+            queue: songs,
+            currentIndex: 0,
+            progress: 60,
+            duration: 180
+        )
+
+        #expect(self.playerService.isPendingRestoredLoadDeferred == true)
+
+        await self.playerService.seek(to: 180)
+
+        #expect(self.playerService.currentIndex == 0)
+        #expect(self.playerService.pendingPlayVideoId == "v1")
+        #expect(self.playerService.pendingRestoredSeek == 180)
+    }
 }


### PR DESCRIPTION
## Description

https://github.com/user-attachments/assets/3673ef86-daf5-4e0b-a0e5-ddb675b9f28d


Fix a bug where dragging the seek slider to the very end of a track caused the same song to replay from the beginning instead of advancing to the next queue item.

WebKit's HTML5 `<video>` does not reliably fire the `ended` event when `currentTime` is assigned exactly to `duration`. Without `ended`, `handleTrackEnded()` is never invoked and the video is left at duration; a subsequent `play()` call (e.g. autoplay recovery, NowPlaying resume) restarts from `0` per HTML5 spec, which the user perceives as the same song replaying.

The fix detects manual seeks landing within `seekToEndThreshold` (0.5s) of `duration` in `PlayerService.seek(to:)` and routes them through the existing track-ended path so repeat / queue / autoplay-suppression rules apply consistently with a natural end. Stale-event protection in `handleTrackEnded` (`expectedCurrentVideoId != observedVideoId`) already prevents double-advance if WebKit later does fire `ended` for the same track.

<details>
<summary>🤖 AI Prompt Used</summary>

```
Iterative session with Claude (Opus 4.7). Summary of the prompt trajectory:

1. Investigate the regression — trace seek() → SingletonPlayerWebView.seek → JS `video.currentTime = duration` and confirm WebKit's `ended` event is the missing link.
2. Considered three thresholds (0.001 / 0.05 / 0.5s); landed on 0.5s as a balance between catching imprecise slider releases and preserving lyrics-tap intent for near-end timestamps.
3. Co-located the threshold + helper alongside `handleTrackEnded` in `PlayerService+WebQueueSync.swift` to keep track-ended orchestration in one place; the `seek(to:)` branch in `PlayerService.swift` only calls into the helper.
4. Reviewed call graph (slider, NowPlaying scrubber, lyrics tap, previous() seek-to-0, restoration) for regressions; restoration deferred-load takes precedence.
5. Trimmed comments to WHY-only per AGENTS.md and kept `PlayerService.swift` exactly at the 900-line cap by extracting the helper rather than inlining.
```

**AI Tool:** Claude (Opus 4.7)

</details>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🧪 Test update

## Related Issues

User-reported regression; no tracking issue filed.

## Changes Made

- `seekToEndThreshold` static constant + `handleManualSeekToEnd()` helper in `PlayerService+WebQueueSync.swift`
- New early-return branch in `PlayerService.seek(to:)` that runs after the restoration-deferred check and before the normal seek path
- 7 new unit tests in `PlayerServiceWebQueueSyncTests.swift` covering: basic advance, threshold boundary, mid-track no-op, repeat one replay, last-song pause, repeat all wrap, deferred restoration

| Scenario | Behavior |
|---|---|
| Seek to end with queue (repeat off) | Advance to next song |
| Seek to end with repeat one | Replay current song |
| Seek to end of last queue song (repeat off) | Pause at end (`shouldSuppressAutoplayAfterQueueEnd = true`) |
| Seek to end with repeat all (last song) | Wrap to first song |
| Seek to end during deferred restoration | Defer (preserve `pendingRestoredSeek`) |
| Seek to mid-track | Normal seek (unchanged) |

## Testing

- [x] `swift build`
- [x] `swift test --skip KasetUITests` — 1261/1261 pass (7 new)
- [x] `swiftlint --strict && swiftformat .` — 0 violations, no diffs
- [x] Manual: built via `Scripts/compile_and_run.sh`, verified slider drag-to-end advances queue
- [x] Manual: verified mid-track seek and `Previous` button (`seek(to: 0)`) unaffected
- [x] UI tested on macOS 26+ (local build, arm64)

## Checklist

- [x] Follows project style (`--self insert`, WHY-only doc comments)
- [x] `swiftlint --strict && swiftformat .`
- [x] Tests added for the fix
- [x] New and existing unit tests pass locally
- [x] No docs/ADR change needed — extension of the existing `handleTrackEnded` orchestration, not a new architectural decision
- [x] No new warnings
- [x] `PlayerService.swift` kept at the 900-line `file_length` cap by extracting the helper into the existing `+WebQueueSync` extension

## Additional Notes

The 0.5s threshold also catches a NowPlaying scrubber drag-to-end (matches the slider's UX). It does intercept a hypothetical lyrics-tap at a timestamp within 0.5s of `duration`, but the practical impact is at most ~0.5s of song-ending audio that would have advanced via the natural `ended` path anyway.