### PR TITLE
fix(player): block YouTube seek handlers at document start to stop Control Center flicker

### DIFF
--- a/Sources/Kaset/Views/MiniPlayerWebView.swift
+++ b/Sources/Kaset/Views/MiniPlayerWebView.swift
@@ -689,6 +689,23 @@ extension SingletonPlayerWebView {
                     localStorage.setItem('kasetUseNextPrev', '\(jsBoolean)');
                 } catch (e) {}
                 window.__kasetUseNextPrev = \(jsBoolean);
+                // Wrap setActionHandler at document start so YouTube's seekforward/seekbackward
+                // registrations are blocked before Control Center can reflect them. Without this
+                // the existing RAF override only clears them on the next frame, leaving a window
+                // where the macOS Now Playing widget briefly shows the 15s skip buttons.
+                try {
+                    var ms = navigator.mediaSession;
+                    if (ms && !ms.__kasetSetActionHandlerWrapped) {
+                        var orig = ms.setActionHandler.bind(ms);
+                        ms.setActionHandler = function(type, handler) {
+                            if (window.__kasetUseNextPrev && (type === 'seekforward' || type === 'seekbackward')) {
+                                return orig(type, null);
+                            }
+                            return orig(type, handler);
+                        };
+                        ms.__kasetSetActionHandlerWrapped = true;
+                    }
+                } catch (e) {}
             })();
         """
     }

--- a/Tests/KasetTests/MediaControlScriptTests.swift
+++ b/Tests/KasetTests/MediaControlScriptTests.swift
@@ -27,6 +27,73 @@ struct MediaControlScriptTests {
         #expect(windowPreference == "true")
     }
 
+    @Test("Bootstrap wrapper blocks seekforward/seekbackward registrations when nextPrev is enabled")
+    func bootstrapWrapperBlocksSeekHandlersInNextPrevMode() throws {
+        let context = try #require(self.makeBootstrapWrapperContext())
+
+        self.evaluate(SingletonPlayerWebView.mediaControlStyleBootstrapScript(useNextPrev: true), in: context)
+        self.evaluate(
+            """
+            navigator.mediaSession.setActionHandler('seekforward', function() {});
+            navigator.mediaSession.setActionHandler('seekbackward', function() {});
+            navigator.mediaSession.setActionHandler('nexttrack', function() {});
+            """,
+            in: context
+        )
+
+        let calls = context.evaluateScript("mediaSessionCalls.join(',')")?.toString() ?? ""
+        #expect(calls.contains("seekforward:clear"))
+        #expect(calls.contains("seekbackward:clear"))
+        #expect(calls.contains("nexttrack:set"))
+    }
+
+    @Test("Bootstrap wrapper passes seekforward/seekbackward through when nextPrev is disabled")
+    func bootstrapWrapperPassesSeekHandlersInSkipMode() throws {
+        let context = try #require(self.makeBootstrapWrapperContext())
+
+        self.evaluate(SingletonPlayerWebView.mediaControlStyleBootstrapScript(useNextPrev: false), in: context)
+        self.evaluate(
+            """
+            navigator.mediaSession.setActionHandler('seekforward', function() {});
+            navigator.mediaSession.setActionHandler('seekbackward', function() {});
+            """,
+            in: context
+        )
+
+        let calls = context.evaluateScript("mediaSessionCalls.join(',')")?.toString() ?? ""
+        #expect(calls.contains("seekforward:set"))
+        #expect(calls.contains("seekbackward:set"))
+    }
+
+    @Test("Bootstrap wrapper honors runtime toggle of __kasetUseNextPrev")
+    func bootstrapWrapperHonorsRuntimeToggle() throws {
+        let context = try #require(self.makeBootstrapWrapperContext())
+
+        self.evaluate(SingletonPlayerWebView.mediaControlStyleBootstrapScript(useNextPrev: false), in: context)
+        self.evaluate("navigator.mediaSession.setActionHandler('seekforward', function() {});", in: context)
+        self.evaluate("window.__kasetUseNextPrev = true;", in: context)
+        self.evaluate("navigator.mediaSession.setActionHandler('seekforward', function() {});", in: context)
+
+        let calls = context.evaluateScript("mediaSessionCalls.join(',')")?.toString() ?? ""
+        // First call (skip mode): set; second call (nextPrev mode): cleared by wrapper.
+        #expect(calls == "seekforward:set,seekforward:clear")
+    }
+
+    @Test("Bootstrap wrapper installs only once per page even on repeat injection")
+    func bootstrapWrapperInstallsOnlyOnce() throws {
+        let context = try #require(self.makeBootstrapWrapperContext())
+
+        self.evaluate(SingletonPlayerWebView.mediaControlStyleBootstrapScript(useNextPrev: true), in: context)
+        self.evaluate(SingletonPlayerWebView.mediaControlStyleBootstrapScript(useNextPrev: true), in: context)
+        self.evaluate("navigator.mediaSession.setActionHandler('seekforward', function() {});", in: context)
+
+        let clearCount = context.evaluateScript("""
+            mediaSessionCalls.filter(function(c) { return c === 'seekforward:clear'; }).length
+        """)?.toInt32() ?? -1
+        // Single wrapper layer means a single original-call passthrough per registration.
+        #expect(clearCount == 1)
+    }
+
     @Test("Override script keeps a single animation-frame loop active")
     func overrideScriptKeepsSingleAnimationFrameLoop() throws {
         let context = try #require(self.makeOverrideScriptContext(useNextPrev: true))
@@ -57,6 +124,40 @@ struct MediaControlScriptTests {
         self.evaluate("runNextAnimationFrame();", in: context)
         let callbacksAfterFrameDrain = context.evaluateScript("pendingRafCallbacks.length")?.toInt32() ?? -1
         #expect(callbacksAfterFrameDrain == 1)
+    }
+
+    private func makeBootstrapWrapperContext() -> JSContext? {
+        guard let context = JSContext() else { return nil }
+
+        self.evaluate(
+            """
+            var localStorageValues = {};
+            var localStorage = {
+                getItem: function(key) {
+                    return Object.prototype.hasOwnProperty.call(localStorageValues, key)
+                        ? localStorageValues[key]
+                        : null;
+                },
+                setItem: function(key, value) {
+                    localStorageValues[key] = value;
+                }
+            };
+            var window = {};
+            var mediaSessionCalls = [];
+            var mediaSessionHandlers = {};
+            var navigator = {
+                mediaSession: {
+                    setActionHandler: function(name, handler) {
+                        mediaSessionCalls.push(name + ':' + (handler ? 'set' : 'clear'));
+                        mediaSessionHandlers[name] = handler;
+                    }
+                }
+            };
+            """,
+            in: context
+        )
+
+        return context
     }
 
     private func evaluateBootstrapStateScript(in context: JSContext) {

--- a/Tests/KasetTests/MediaControlScriptTests.swift
+++ b/Tests/KasetTests/MediaControlScriptTests.swift
@@ -42,9 +42,7 @@ struct MediaControlScriptTests {
         )
 
         let calls = context.evaluateScript("mediaSessionCalls.join(',')")?.toString() ?? ""
-        #expect(calls.contains("seekforward:clear"))
-        #expect(calls.contains("seekbackward:clear"))
-        #expect(calls.contains("nexttrack:set"))
+        #expect(calls == "seekforward:clear,seekbackward:clear,nexttrack:set")
     }
 
     @Test("Bootstrap wrapper passes seekforward/seekbackward through when nextPrev is disabled")
@@ -61,12 +59,11 @@ struct MediaControlScriptTests {
         )
 
         let calls = context.evaluateScript("mediaSessionCalls.join(',')")?.toString() ?? ""
-        #expect(calls.contains("seekforward:set"))
-        #expect(calls.contains("seekbackward:set"))
+        #expect(calls == "seekforward:set,seekbackward:set")
     }
 
-    @Test("Bootstrap wrapper honors runtime toggle of __kasetUseNextPrev")
-    func bootstrapWrapperHonorsRuntimeToggle() throws {
+    @Test("Bootstrap wrapper honors runtime toggle skip → nextPrev")
+    func bootstrapWrapperHonorsRuntimeToggleToNextPrev() throws {
         let context = try #require(self.makeBootstrapWrapperContext())
 
         self.evaluate(SingletonPlayerWebView.mediaControlStyleBootstrapScript(useNextPrev: false), in: context)
@@ -75,8 +72,20 @@ struct MediaControlScriptTests {
         self.evaluate("navigator.mediaSession.setActionHandler('seekforward', function() {});", in: context)
 
         let calls = context.evaluateScript("mediaSessionCalls.join(',')")?.toString() ?? ""
-        // First call (skip mode): set; second call (nextPrev mode): cleared by wrapper.
         #expect(calls == "seekforward:set,seekforward:clear")
+    }
+
+    @Test("Bootstrap wrapper honors runtime toggle nextPrev → skip")
+    func bootstrapWrapperHonorsRuntimeToggleToSkip() throws {
+        let context = try #require(self.makeBootstrapWrapperContext())
+
+        self.evaluate(SingletonPlayerWebView.mediaControlStyleBootstrapScript(useNextPrev: true), in: context)
+        self.evaluate("navigator.mediaSession.setActionHandler('seekforward', function() {});", in: context)
+        self.evaluate("window.__kasetUseNextPrev = false;", in: context)
+        self.evaluate("navigator.mediaSession.setActionHandler('seekforward', function() {});", in: context)
+
+        let calls = context.evaluateScript("mediaSessionCalls.join(',')")?.toString() ?? ""
+        #expect(calls == "seekforward:clear,seekforward:set")
     }
 
     @Test("Bootstrap wrapper installs only once per page even on repeat injection")
@@ -90,8 +99,52 @@ struct MediaControlScriptTests {
         let clearCount = context.evaluateScript("""
             mediaSessionCalls.filter(function(c) { return c === 'seekforward:clear'; }).length
         """)?.toInt32() ?? -1
-        // Single wrapper layer means a single original-call passthrough per registration.
         #expect(clearCount == 1)
+    }
+
+    @Test("Bootstrap wrapper preserves passed-through handler reference for nexttrack")
+    func bootstrapWrapperPreservesHandlerReference() throws {
+        let context = try #require(self.makeBootstrapWrapperContext())
+
+        self.evaluate(SingletonPlayerWebView.mediaControlStyleBootstrapScript(useNextPrev: true), in: context)
+        self.evaluate(
+            """
+            window.__handlerInvoked = false;
+            navigator.mediaSession.setActionHandler('nexttrack', function() {
+                window.__handlerInvoked = true;
+            });
+            mediaSessionHandlers.nexttrack();
+            """,
+            in: context
+        )
+
+        let invoked = context.evaluateScript("String(window.__handlerInvoked)")?.toString()
+        #expect(invoked == "true")
+    }
+
+    @Test("Bootstrap wrapper coexists with the override script's seek-handler clearing")
+    func bootstrapWrapperCoexistsWithOverrideScript() throws {
+        let context = try #require(self.makeOverrideScriptContext(useNextPrev: true))
+
+        self.evaluate(SingletonPlayerWebView.mediaControlStyleBootstrapScript(useNextPrev: true), in: context)
+        self.evaluate(SingletonPlayerWebView.mediaControlOverrideScript, in: context)
+        self.evaluate("runNextAnimationFrame();", in: context)
+        self.evaluate(
+            """
+            navigator.mediaSession.setActionHandler('seekforward', function() {});
+            navigator.mediaSession.setActionHandler('seekbackward', function() {});
+            """,
+            in: context
+        )
+
+        let seekForwardClearCount = context.evaluateScript("""
+            mediaSessionCalls.filter(function(c) { return c === 'seekforward:clear'; }).length
+        """)?.toInt32() ?? 0
+        let seekForwardSetCount = context.evaluateScript("""
+            mediaSessionCalls.filter(function(c) { return c === 'seekforward:set'; }).length
+        """)?.toInt32() ?? -1
+        #expect(seekForwardClearCount > 0)
+        #expect(seekForwardSetCount == 0)
     }
 
     @Test("Override script keeps a single animation-frame loop active")


### PR DESCRIPTION
## Description
<img width="307" height="145" alt="스크린샷 2026-04-26 오후 5 13 17" src="https://github.com/user-attachments/assets/6848c3ef-c69f-497f-b0e5-4f34eab0417c" />

Fix the macOS Now Playing widget (Control Center) briefly showing the 15-second skip-forward / skip-backward buttons even when the user has the **Next/Previous Track** media-control style selected.

The existing `mediaControlOverrideScript` clears `seekforward` / `seekbackward` `mediaSession` action handlers via a `requestAnimationFrame` loop injected at document end. YouTube Music's own scripts run between document start and that override and register the seek handlers themselves. Control Center reflects the registered handlers in real time, so there is a frame-or-two window where the 15s skip buttons are visible before the RAF loop catches up — perceived by the user as a brief flash.

The fix wraps `navigator.mediaSession.setActionHandler` at document start, alongside the existing `__kasetUseNextPrev` flag setup. While the flag is `true`, any `seekforward` / `seekbackward` registration is intercepted at the source and forwarded as `null`, so the registration never reaches Control Center. The wrapper reads the flag dynamically, so toggling to *Skip Forward/Backward* mode at runtime passes seek registrations through unchanged. The existing RAF override stays in place to own `nexttrack` / `previoustrack` handler ownership against late re-registrations from YouTube.

<details>
<summary>🤖 AI Prompt Used</summary>

```
Iterative session with Claude (Opus 4.7). Summary of the prompt trajectory:

1. Reproduce the flicker — trace `mediaControlOverrideScript`'s RAF loop and YouTube's setActionHandler timing to confirm the visible window between YouTube registering and Kaset clearing.
2. Considered three approaches: (a) shorten override interval to microtask, (b) install the override before YouTube via document-start injection, (c) intercept setActionHandler. Picked (c) — handler-time interception is the only one that closes the window deterministically.
3. Located the wrapper inside `mediaControlStyleBootstrapScript` because that helper already runs at document start and already owns `__kasetUseNextPrev` flag setup; co-locating avoided adding a third script to install.
4. Verified the wrapper does not break the runtime style toggle: `mediaControlStyleSyncScript`'s seek-handler restoration path runs after `__kasetUseNextPrev` is set to `false`, so the wrapper passes those calls through.
5. /simplify pass surfaced three test gaps and one assertion-tightness gap. Added: reverse-direction toggle (nextPrev → skip), handler-reference preservation, bootstrap+override coexistence; tightened block / passthrough tests from `.contains` to exact-sequence assertions.
```

**AI Tool:** Claude (Opus 4.7)

</details>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🧪 Test update

## Related Issues

User-reported regression; no tracking issue filed.

## Changes Made

- Wrap `navigator.mediaSession.setActionHandler` inside `mediaControlStyleBootstrapScript` (`MiniPlayerWebView.swift`) — installed at document start, idempotent via `__kasetSetActionHandlerWrapped` sentinel
- Seven new JSContext tests in `MediaControlScriptTests.swift` covering: nextPrev block, skip passthrough, both runtime toggle directions, repeat-injection idempotency, handler-reference preservation, bootstrap+override coexistence
- Tightened the two pre-existing block / passthrough assertions from substring matches to exact-sequence equality so reordering or extra `setActionHandler` calls fail loudly

| Mode (`__kasetUseNextPrev`) | `seekforward` / `seekbackward` registration | `nexttrack` / `previoustrack` registration |
|---|---|---|
| `true` (Next/Previous Track) | Forwarded as `null` (blocked) | Passes through (RAF loop owns them) |
| `false` (Skip Forward/Backward) | Passes through (YouTube's handlers active) | Passes through |

## Testing

- [x] `swift build`
- [x] `swift test --skip KasetUITests` — 1261/1261 pass (7 new in `MediaControlScriptTests`, 2 existing tightened)
- [x] `swiftlint --strict && swiftformat .` — 0 violations, no diffs
- [x] Manual: built via `Scripts/compile_and_run.sh`, started playback, opened Control Center, confirmed 15s skip buttons no longer flash with Next/Previous Track selected
- [x] Manual: toggled setting to Skip Forward/Backward and back, verified buttons swap cleanly with no flicker in either direction

## Checklist

- [x] Follows project style (`--self insert`, WHY-only doc comments)
- [x] `swiftlint --strict && swiftformat .`
- [x] Tests added for the fix
- [x] New and existing unit tests pass locally
- [x] No docs/ADR change needed — same domain as #146 / #211 / `mediaControlOverrideScript`, not a new architectural decision
- [x] No new warnings

## Commit history

- `73dd4d7` — wrapper itself plus the initial four block / passthrough / toggle / idempotency tests
- `6b5a4c0` — assertion tightening + reverse-toggle / handler-reference / coexistence tests added after the /simplify review pass

## Additional Notes

The wrapper is installed unconditionally (regardless of the initial `useNextPrev` value) so that switching to nextPrev mode at runtime is also covered without re-injecting scripts. The runtime check inside the wrapper makes it a no-op when the flag is `false`. The `__kasetSetActionHandlerWrapped` sentinel matches the existing `__kasetListenersAttached` / `__kasetOverrideAttached` install-once convention used elsewhere in the WebView scripts.