### PR TITLE
fix(search): keep filters visible for empty results

### DIFF
--- a/Sources/Kaset/ViewModels/SearchViewModel.swift
+++ b/Sources/Kaset/ViewModels/SearchViewModel.swift
@@ -41,6 +41,20 @@ final class SearchViewModel {
     /// Search suggestions for autocomplete.
     private(set) var suggestions: [SearchSuggestion] = []
 
+    /// Whether filters should be shown for the current search.
+    var shouldShowFilters: Bool {
+        guard !self.query.isEmpty, self.lastSearchedQuery == self.query else {
+            return false
+        }
+
+        switch self.loadingState {
+        case .loading, .loaded, .loadingMore:
+            return true
+        case .idle, .error:
+            return false
+        }
+    }
+
     /// Whether suggestions should be shown.
     var showSuggestions: Bool {
         !self.query.isEmpty && !self.suggestions.isEmpty && self.results.isEmpty

--- a/Sources/Kaset/Views/SearchView.swift
+++ b/Sources/Kaset/Views/SearchView.swift
@@ -71,7 +71,7 @@ struct SearchView: View {
             }
 
             // Filter chips
-            if !self.viewModel.results.isEmpty {
+            if self.viewModel.shouldShowFilters {
                 self.filterChips
             }
         }

--- a/Tests/KasetTests/SearchViewModelTests.swift
+++ b/Tests/KasetTests/SearchViewModelTests.swift
@@ -99,4 +99,23 @@ struct SearchViewModelTests {
         self.viewModel.selectedFilter = .podcasts
         #expect(self.viewModel.selectedFilter == .podcasts)
     }
+
+    @Test("Filter chips remain visible after empty filtered search")
+    func filterChipsRemainVisibleAfterEmptyFilteredSearch() async {
+        self.mockClient.searchResponse = SearchResponse(
+            songs: [],
+            albums: [],
+            artists: [],
+            playlists: []
+        )
+        self.viewModel.query = "Versus Music Official"
+        self.viewModel.selectedFilter = .artists
+
+        self.viewModel.searchImmediately()
+        try? await Task.sleep(for: .milliseconds(25))
+
+        #expect(self.viewModel.loadingState == .loaded)
+        #expect(self.viewModel.filteredItems.isEmpty)
+        #expect(self.viewModel.shouldShowFilters)
+    }
 }


### PR DESCRIPTION
## Description

The search view hid the filter chips whenever the selected filter returned no visible rows. That made an empty Artists search look like search was completely broken, because the user could no longer see or change the active filter. This adds a view-model state for showing filters after a search has run, even when the filtered result set is empty. Fixes #200.

## AI Prompt (Optional)

<details>
<summary>🤖 AI Prompt Used</summary>

```
Fix issue sozercan/kaset#200: [Bug]: Search Artists Breaks Search Completely. Investigate the search artists functionality, write a failing test, implement a bug fix, verify with the repository test and lint workflow, and submit a PR.
```

**AI Tool:** OpenClaw

</details>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Refactoring (no functional changes)
- [x] 🧪 Test update
- [ ] 🔧 Build/CI configuration

## Related Issues

Fixes #200

## Changes Made

- Added search view-model state for showing filter chips after a search has run.
- Updated the search view to keep filter chips visible for empty filtered results.
- Added a regression test for an empty Artists search result.

## Testing

- [x] Unit tests pass (`swift test --skip KasetUITests`)
- [ ] Manual testing performed
- [ ] UI tested on macOS 26+

Additional local checks:
- `swift test --skip KasetUITests`
- `swift build`
- `swiftlint lint --strict`
- `swiftformat --lint .`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `swiftlint --strict && swiftformat .`
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally
- [ ] I have updated documentation if needed
- [x] I have checked for any performance implications
- [x] My changes generate no new warnings

## Screenshots

N/A

## Additional Notes

UI tests were not run because the repository guidance requires confirmation before launching them.
