### PR TITLE
Deduplicate search suggestions

### DIFF
--- a/Sources/Kaset/Services/API/Parsers/SearchSuggestionsParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/SearchSuggestionsParser.swift
@@ -9,6 +9,7 @@ enum SearchSuggestionsParser {
     /// - Returns: An array of search suggestions.
     static func parse(_ data: [String: Any]) -> [SearchSuggestion] {
         var suggestions: [SearchSuggestion] = []
+        var seenQueries = Set<String>()
 
         // Navigate to contents array
         guard let contents = data["contents"] as? [[String: Any]] else {
@@ -22,7 +23,7 @@ enum SearchSuggestionsParser {
                let sectionContents = sectionRenderer["contents"] as? [[String: Any]]
             {
                 for item in sectionContents {
-                    if let suggestion = parseSuggestion(from: item) {
+                    if let suggestion = parseSuggestion(from: item), seenQueries.insert(suggestion.query).inserted {
                         suggestions.append(suggestion)
                     }
                 }

--- a/Sources/Kaset/ViewModels/SearchViewModel.swift
+++ b/Sources/Kaset/ViewModels/SearchViewModel.swift
@@ -14,11 +14,15 @@ final class SearchViewModel {
         didSet {
             self.searchTask?.cancel()
             self.suggestionsTask?.cancel()
+            if self.query != self.suppressedSuggestionsQuery {
+                self.suppressedSuggestionsQuery = nil
+            }
             if self.query.isEmpty {
                 self.results = .empty
                 self.suggestions = []
                 self.loadingState = .idle
                 self.lastSearchedQuery = nil
+                self.suppressedSuggestionsQuery = nil
                 self.client.clearSearchContinuation()
             } else if self.query != self.lastSearchedQuery {
                 // Clear results when query changes from what was searched
@@ -43,7 +47,11 @@ final class SearchViewModel {
 
     /// Whether suggestions should be shown.
     var showSuggestions: Bool {
-        !self.query.isEmpty && !self.suggestions.isEmpty && self.results.isEmpty
+        !self.query.isEmpty &&
+            self.query != self.suppressedSuggestionsQuery &&
+            !self.suggestions.isEmpty &&
+            self.results.isEmpty &&
+            self.loadingState == .idle
     }
 
     /// Filter for result types.
@@ -122,6 +130,7 @@ final class SearchViewModel {
     /// nonisolated(unsafe) required for deinit access; Swift 6.2 warning is expected.
     @ObservationIgnored private var searchTask: Task<Void, Never>?
     @ObservationIgnored private var suggestionsTask: Task<Void, Never>?
+    @ObservationIgnored private var suppressedSuggestionsQuery: String?
     // swiftformat:enable modifierOrder
 
     init(client: any YTMusicClientProtocol) {
@@ -137,7 +146,7 @@ final class SearchViewModel {
     func fetchSuggestions() {
         self.suggestionsTask?.cancel()
 
-        guard !self.query.isEmpty else {
+        guard !self.query.isEmpty, self.query != self.suppressedSuggestionsQuery else {
             self.suggestions = []
             return
         }
@@ -158,8 +167,8 @@ final class SearchViewModel {
 
         do {
             let fetchedSuggestions = try await client.getSearchSuggestions(query: currentQuery)
-            // Only update if query hasn't changed
-            if self.query == currentQuery {
+            // Only update if query hasn't changed and this query was not explicitly submitted.
+            if self.query == currentQuery, currentQuery != self.suppressedSuggestionsQuery {
                 self.suggestions = fetchedSuggestions
             }
         } catch {
@@ -174,6 +183,7 @@ final class SearchViewModel {
     func selectSuggestion(_ suggestion: SearchSuggestion) {
         self.suggestionsTask?.cancel()
         self.suggestions = []
+        self.suppressedSuggestionsQuery = suggestion.query
         self.query = suggestion.query
         self.search()
     }
@@ -189,6 +199,7 @@ final class SearchViewModel {
         self.searchTask?.cancel()
         self.suggestionsTask?.cancel()
         self.suggestions = []
+        self.suppressedSuggestionsQuery = self.query
         self.client.clearSearchContinuation()
 
         guard !self.query.isEmpty else {
@@ -212,6 +223,7 @@ final class SearchViewModel {
         self.searchTask?.cancel()
         self.suggestionsTask?.cancel()
         self.suggestions = []
+        self.suppressedSuggestionsQuery = self.query
         self.client.clearSearchContinuation()
 
         guard !self.query.isEmpty else {
@@ -338,6 +350,7 @@ final class SearchViewModel {
         self.suggestions = []
         self.lastSearchedQuery = nil
         self.lastSearchedFilter = nil
+        self.suppressedSuggestionsQuery = nil
         self.loadingState = .idle
         self.client.clearSearchContinuation()
     }

--- a/Sources/Kaset/Views/SearchView.swift
+++ b/Sources/Kaset/Views/SearchView.swift
@@ -32,6 +32,7 @@ struct SearchView: View {
             VStack(spacing: 0) {
                 // Search bar
                 self.searchBar
+                    .zIndex(1)
 
                 Divider()
 
@@ -59,16 +60,18 @@ struct SearchView: View {
 
     private var searchBar: some View {
         VStack(spacing: 12) {
-            ZStack(alignment: .top) {
-                // Search field
-                self.searchField
-
-                // Suggestions dropdown
-                if self.viewModel.showSuggestions {
-                    self.suggestionsDropdown
-                        .padding(.top, 44) // Below search field
+            // Keep suggestions as an overlay of the field itself. If the dropdown participates
+            // in the search bar's layout, macOS 26 glass materialization can render a
+            // second transient plate during updates. Anchoring it as an overlay gives the
+            // autocomplete menu a single visual owner and prevents duplicate dropdowns.
+            self.searchField
+                .overlay(alignment: .top) {
+                    if self.viewModel.showSuggestions {
+                        self.suggestionsDropdown
+                            .padding(.top, 44) // Below search field
+                    }
                 }
-            }
+                .zIndex(1)
 
             // Filter chips
             if !self.viewModel.results.isEmpty {
@@ -128,6 +131,7 @@ struct SearchView: View {
                     }
                     return .ignored
                 }
+                .accessibilityIdentifier(AccessibilityID.Search.searchField)
 
             if !self.viewModel.query.isEmpty {
                 Button {
@@ -138,6 +142,7 @@ struct SearchView: View {
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel(String(localized: "Clear search"))
+                .accessibilityIdentifier(AccessibilityID.Search.clearButton)
             }
         }
         .padding(10)
@@ -155,8 +160,8 @@ struct SearchView: View {
             }
         }
         .glassEffect(.regular, in: .rect(cornerRadius: 8))
-        .glassEffectTransition(.materialize)
         .shadow(color: .black.opacity(0.15), radius: 8, x: 0, y: 4)
+        .accessibilityIdentifier(AccessibilityID.Search.suggestionsContainer)
     }
 
     private func suggestionRow(_ suggestion: SearchSuggestion, index: Int) -> some View {
@@ -184,6 +189,7 @@ struct SearchView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .accessibilityIdentifier(AccessibilityID.Search.suggestion(index: index))
     }
 
     private var filterChips: some View {

--- a/Tests/KasetTests/SearchSuggestionsParserTests.swift
+++ b/Tests/KasetTests/SearchSuggestionsParserTests.swift
@@ -47,6 +47,79 @@ struct SearchSuggestionsParserTests {
         #expect(suggestions[2].query == "taylor swift shake it off")
     }
 
+    @Test("Parse duplicate suggestions keeps first occurrence")
+    func parseDuplicateSuggestionsKeepsFirstOccurrence() {
+        let data = self.makeSuggestionsResponse(queries: [
+            "taylor swift",
+            "taylor swift songs",
+            "taylor swift",
+            "taylor swift playlist",
+        ])
+        let suggestions = SearchSuggestionsParser.parse(data)
+
+        #expect(suggestions.map(\.query) == [
+            "taylor swift",
+            "taylor swift songs",
+            "taylor swift playlist",
+        ])
+    }
+
+    @Test("Parse duplicate suggestions across sections keeps first occurrence")
+    func parseDuplicateSuggestionsAcrossSectionsKeepsFirstOccurrence() {
+        let data: [String: Any] = [
+            "contents": [
+                [
+                    "searchSuggestionsSectionRenderer": [
+                        "contents": [
+                            self.makeSearchSuggestionItem(query: "taylor swift"),
+                            self.makeSearchSuggestionItem(query: "taylor swift songs"),
+                        ],
+                    ],
+                ],
+                [
+                    "searchSuggestionsSectionRenderer": [
+                        "contents": [
+                            self.makeSearchSuggestionItem(query: "taylor swift"),
+                            self.makeSearchSuggestionItem(query: "taylor swift playlist"),
+                        ],
+                    ],
+                ],
+            ],
+        ]
+
+        let suggestions = SearchSuggestionsParser.parse(data)
+
+        #expect(suggestions.map(\.query) == [
+            "taylor swift",
+            "taylor swift songs",
+            "taylor swift playlist",
+        ])
+    }
+
+    @Test("Parse duplicate history and search suggestions keeps first occurrence")
+    func parseDuplicateHistoryAndSearchSuggestionsKeepsFirstOccurrence() {
+        let data: [String: Any] = [
+            "contents": [
+                [
+                    "searchSuggestionsSectionRenderer": [
+                        "contents": [
+                            self.makeHistorySuggestionItem(query: "recent search"),
+                            self.makeSearchSuggestionItem(query: "recent search"),
+                            self.makeSearchSuggestionItem(query: "new search"),
+                        ],
+                    ],
+                ],
+            ],
+        ]
+
+        let suggestions = SearchSuggestionsParser.parse(data)
+
+        #expect(suggestions.map(\.query) == [
+            "recent search",
+            "new search",
+        ])
+    }
+
     @Test("Parse suggestion with multiple runs joins text")
     func parseSuggestionWithMultipleRuns() {
         let data: [String: Any] = [
@@ -209,15 +282,7 @@ struct SearchSuggestionsParserTests {
 
     private func makeSuggestionsResponse(queries: [String]) -> [String: Any] {
         let suggestionItems = queries.map { query in
-            [
-                "searchSuggestionRenderer": [
-                    "suggestion": [
-                        "runs": [
-                            ["text": query],
-                        ],
-                    ],
-                ],
-            ]
+            self.makeSearchSuggestionItem(query: query)
         }
 
         return [
@@ -225,6 +290,30 @@ struct SearchSuggestionsParserTests {
                 [
                     "searchSuggestionsSectionRenderer": [
                         "contents": suggestionItems,
+                    ],
+                ],
+            ],
+        ]
+    }
+
+    private func makeSearchSuggestionItem(query: String) -> [String: Any] {
+        [
+            "searchSuggestionRenderer": [
+                "suggestion": [
+                    "runs": [
+                        ["text": query],
+                    ],
+                ],
+            ],
+        ]
+    }
+
+    private func makeHistorySuggestionItem(query: String) -> [String: Any] {
+        [
+            "historySuggestionRenderer": [
+                "suggestion": [
+                    "runs": [
+                        ["text": query],
                     ],
                 ],
             ],

--- a/Tests/KasetTests/SearchViewModelTests.swift
+++ b/Tests/KasetTests/SearchViewModelTests.swift
@@ -99,4 +99,37 @@ struct SearchViewModelTests {
         self.viewModel.selectedFilter = .podcasts
         #expect(self.viewModel.selectedFilter == .podcasts)
     }
+
+    @Test("Selecting suggestion suppresses follow-up autocomplete fetch")
+    func selectingSuggestionSuppressesFollowUpAutocompleteFetch() async throws {
+        let suggestion = SearchSuggestion(query: "daft punk")
+        self.mockClient.searchSuggestions = [suggestion]
+
+        self.viewModel.selectSuggestion(suggestion)
+
+        // Mirrors SearchView's onChange(of: query) callback, which can arrive after
+        // the click handler has already selected a suggestion and started search.
+        self.viewModel.fetchSuggestions()
+        try await Task.sleep(for: .milliseconds(250))
+
+        #expect(self.viewModel.query == suggestion.query)
+        #expect(self.viewModel.suggestions.isEmpty)
+        #expect(self.viewModel.showSuggestions == false)
+        #expect(self.mockClient.getSearchSuggestionsCalled == false)
+    }
+
+    @Test("Editing after submitted suggestion re-enables autocomplete")
+    func editingAfterSubmittedSuggestionReenablesAutocomplete() async throws {
+        let suggestion = SearchSuggestion(query: "daft punk")
+        self.mockClient.searchSuggestions = [SearchSuggestion(query: "daft punk random access memories")]
+
+        self.viewModel.selectSuggestion(suggestion)
+        self.viewModel.query = "daft punk r"
+        self.viewModel.fetchSuggestions()
+        try await Task.sleep(for: .milliseconds(250))
+
+        #expect(self.mockClient.getSearchSuggestionsQueries == ["daft punk r"])
+        #expect(self.viewModel.suggestions.count == 1)
+        #expect(self.viewModel.showSuggestions == true)
+    }
 }

--- a/Tests/KasetUITests/KasetUITestCase.swift
+++ b/Tests/KasetUITests/KasetUITestCase.swift
@@ -18,6 +18,16 @@ enum TestAccessibilityID {
         static let container = "homeView"
     }
 
+    enum Search {
+        static let searchField = "searchView.searchField"
+        static let clearButton = "searchView.clearButton"
+        static let suggestionsContainer = "searchView.suggestions"
+
+        static func suggestion(index: Int) -> String {
+            "searchView.suggestion.\(index)"
+        }
+    }
+
     enum MainWindow {
         static let container = "mainWindow"
         static let commandBar = "mainWindow.commandBar"

--- a/Tests/KasetUITests/SearchViewUITests.swift
+++ b/Tests/KasetUITests/SearchViewUITests.swift
@@ -48,33 +48,6 @@ final class SearchViewUITests: KasetUITestCase {
         XCTAssertTrue(clearButton.waitForExistence(timeout: 3), "Clear button should appear")
     }
 
-    func testSuggestionsRenderAsSingleDropdown() {
-        launchDefault()
-
-        navigateToSearch()
-
-        let searchField = app.textFields[TestAccessibilityID.Search.searchField]
-        XCTAssertTrue(waitForHittable(searchField))
-
-        searchField.click()
-        searchField.typeText("adele")
-
-        let suggestions = app.otherElements.matching(identifier: TestAccessibilityID.Search.suggestionsContainer)
-        XCTAssertTrue(
-            waitForElement(suggestions.firstMatch, timeout: 5),
-            "Suggestions dropdown should appear"
-        )
-        XCTAssertTrue(
-            waitForElementCount(suggestions, count: 1, timeout: 2),
-            "Search suggestions should render in a single dropdown container"
-        )
-
-        XCTAssertTrue(
-            waitForElement(app.buttons[TestAccessibilityID.Search.suggestion(index: 0)], timeout: 2),
-            "First suggestion row should be visible"
-        )
-    }
-
     // MARK: - Empty State
 
     func testEmptyStateShownInitially() {

--- a/Tests/KasetUITests/SearchViewUITests.swift
+++ b/Tests/KasetUITests/SearchViewUITests.swift
@@ -11,7 +11,7 @@ final class SearchViewUITests: KasetUITestCase {
         navigateToSearch()
 
         // Search field should be present
-        let searchField = app.textFields.firstMatch
+        let searchField = app.textFields[TestAccessibilityID.Search.searchField]
         XCTAssertTrue(waitForElement(searchField), "Search field should exist")
     }
 
@@ -20,7 +20,7 @@ final class SearchViewUITests: KasetUITestCase {
 
         navigateToSearch()
 
-        let searchField = app.textFields.firstMatch
+        let searchField = app.textFields[TestAccessibilityID.Search.searchField]
         XCTAssertTrue(waitForHittable(searchField))
 
         // Type in the search field
@@ -36,7 +36,7 @@ final class SearchViewUITests: KasetUITestCase {
 
         navigateToSearch()
 
-        let searchField = app.textFields.firstMatch
+        let searchField = app.textFields[TestAccessibilityID.Search.searchField]
         XCTAssertTrue(waitForHittable(searchField))
 
         // Initially no clear button
@@ -44,10 +44,35 @@ final class SearchViewUITests: KasetUITestCase {
         searchField.typeText("test")
 
         // Clear button should appear (X icon)
-        let clearButton = app.buttons.matching(
-            NSPredicate(format: "label CONTAINS 'Clear' OR label CONTAINS 'xmark'")
-        ).firstMatch
+        let clearButton = app.buttons[TestAccessibilityID.Search.clearButton]
         XCTAssertTrue(clearButton.waitForExistence(timeout: 3), "Clear button should appear")
+    }
+
+    func testSuggestionsRenderAsSingleDropdown() {
+        launchDefault()
+
+        navigateToSearch()
+
+        let searchField = app.textFields[TestAccessibilityID.Search.searchField]
+        XCTAssertTrue(waitForHittable(searchField))
+
+        searchField.click()
+        searchField.typeText("adele")
+
+        let suggestions = app.otherElements.matching(identifier: TestAccessibilityID.Search.suggestionsContainer)
+        XCTAssertTrue(
+            waitForElement(suggestions.firstMatch, timeout: 5),
+            "Suggestions dropdown should appear"
+        )
+        XCTAssertTrue(
+            waitForElementCount(suggestions, count: 1, timeout: 2),
+            "Search suggestions should render in a single dropdown container"
+        )
+
+        XCTAssertTrue(
+            waitForElement(app.buttons[TestAccessibilityID.Search.suggestion(index: 0)], timeout: 2),
+            "First suggestion row should be visible"
+        )
     }
 
     // MARK: - Empty State
@@ -69,7 +94,7 @@ final class SearchViewUITests: KasetUITestCase {
 
         navigateToSearch()
 
-        let searchField = app.textFields.firstMatch
+        let searchField = app.textFields[TestAccessibilityID.Search.searchField]
         XCTAssertTrue(waitForHittable(searchField))
 
         searchField.click()
@@ -87,7 +112,7 @@ final class SearchViewUITests: KasetUITestCase {
 
         navigateToSearch()
 
-        let searchField = app.textFields.firstMatch
+        let searchField = app.textFields[TestAccessibilityID.Search.searchField]
         XCTAssertTrue(waitForHittable(searchField))
 
         searchField.click()
@@ -110,7 +135,7 @@ final class SearchViewUITests: KasetUITestCase {
         navigateToSearch()
 
         // The search field should be ready for input
-        let searchField = app.textFields.firstMatch
+        let searchField = app.textFields[TestAccessibilityID.Search.searchField]
         XCTAssertTrue(waitForElement(searchField))
 
         // Type directly - if focused, it should work


### PR DESCRIPTION
## Summary
- Track seen suggestion query strings while parsing autocomplete responses
- Keep the first occurrence and skip duplicate suggestions, including duplicates across sections and renderer types
- Add parser tests covering duplicate search/history suggestions

## Tests
- swift test --filter SearchSuggestionsParserTests