### PR TITLE
Keep playback WebView hidden

### DIFF
--- a/Sources/Kaset/Services/Player/PlayerService+PlaybackControls.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+PlaybackControls.swift
@@ -46,16 +46,13 @@ extension PlayerService {
 
         self.pendingPlayVideoId = videoId
 
-        // If user has already interacted this session, auto-play without popup
-        if self.hasUserInteractedThisSession {
-            self.logger.info("User has interacted before, auto-playing without popup")
-            self.showMiniPlayer = false
-            // Load the video directly - WebView session should allow autoplay
+        // Hidden-first playback: keep the persistent WebView anchored at 1×1 and
+        // let its observer confirm playback once YouTube actually starts. If the
+        // singleton already exists, navigate immediately; otherwise SwiftUI will
+        // create it from `pendingPlayVideoId` and autoload in `PersistentPlayerView`.
+        self.showMiniPlayer = false
+        if SingletonPlayerWebView.shared.webView != nil {
             SingletonPlayerWebView.shared.loadVideo(videoId: videoId)
-        } else {
-            // First time: show the mini player for user interaction
-            self.showMiniPlayer = true
-            self.logger.info("Showing mini player for first-time user interaction")
         }
 
         // Fetch full song metadata in the background to get feedbackTokens
@@ -106,15 +103,13 @@ extension PlayerService {
 
         self.pendingPlayVideoId = song.videoId
 
-        // If user has already interacted this session, auto-play without popup
-        if self.hasUserInteractedThisSession {
-            self.logger.info("User has interacted before, auto-playing without popup")
-            self.showMiniPlayer = false
+        // Hidden-first playback: keep the persistent WebView anchored at 1×1 and
+        // let its observer confirm playback once YouTube actually starts. If the
+        // singleton already exists, navigate immediately; otherwise SwiftUI will
+        // create it from `pendingPlayVideoId` and autoload in `PersistentPlayerView`.
+        self.showMiniPlayer = false
+        if SingletonPlayerWebView.shared.webView != nil {
             SingletonPlayerWebView.shared.loadVideo(videoId: song.videoId, strategy: webLoadStrategy)
-        } else {
-            // First time: show the mini player for user interaction
-            self.showMiniPlayer = true
-            self.logger.info("Showing mini player for first-time user interaction")
         }
 
         // Fetch full song metadata if we don't have feedbackTokens
@@ -123,13 +118,13 @@ extension PlayerService {
         }
     }
 
-    /// Called when the mini player confirms playback has started.
-    /// This is the only place that should open the session autoplay gate.
+    /// Records that the WebView observer has confirmed playback actually started.
+    /// Confirmation is intentionally independent of mini-player visibility.
     func confirmPlaybackStarted() {
         self.showMiniPlayer = false
         self.state = .playing
         self.markUserInteractedThisSession()
-        self.logger.info("Playback confirmed started, user interaction recorded")
+        self.logger.info("Playback confirmed started")
     }
 
     /// Called when the mini player is dismissed.
@@ -225,19 +220,16 @@ extension PlayerService {
 
         let shouldLoadPendingVideo = self.shouldLoadPendingVideoBeforePlayback
         if self.isPendingRestoredLoadDeferred {
-            self.beginRestoredPlaybackLoad(autoResumeAfterSeek: self.hasUserInteractedThisSession)
+            self.beginRestoredPlaybackLoad(autoResumeAfterSeek: true)
         } else {
             self.clearRestoredPlaybackSessionState()
         }
 
         if shouldLoadPendingVideo {
-            if self.hasUserInteractedThisSession {
-                self.showMiniPlayer = false
-                self.state = .loading
+            self.showMiniPlayer = false
+            self.state = self.shouldAutoResumeAfterRestoredLoad ? .loading : self.state
+            if SingletonPlayerWebView.shared.webView != nil {
                 SingletonPlayerWebView.shared.loadVideo(videoId: pendingPlayVideoId)
-            } else {
-                self.showMiniPlayer = true
-                self.logger.info("Showing mini player so the user can resume playback")
             }
             return
         }

--- a/Sources/Kaset/Services/Player/PlayerService+PlaybackControls.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+PlaybackControls.swift
@@ -121,10 +121,22 @@ extension PlayerService {
     /// Records that the WebView observer has confirmed playback actually started.
     /// Confirmation is intentionally independent of mini-player visibility.
     func confirmPlaybackStarted() {
+        let shouldHideMiniPlayer = self.showMiniPlayer
+        let didStartPlayback = self.state != .playing
+        let shouldRecordInteraction = !self.hasUserInteractedThisSession
+
+        guard shouldHideMiniPlayer || didStartPlayback || shouldRecordInteraction else { return }
+
         self.showMiniPlayer = false
         self.state = .playing
-        self.markUserInteractedThisSession()
-        self.logger.info("Playback confirmed started")
+
+        if shouldRecordInteraction {
+            self.markUserInteractedThisSession()
+        }
+
+        if didStartPlayback {
+            self.logger.info("Playback confirmed started")
+        }
     }
 
     /// Called when the mini player is dismissed.
@@ -227,7 +239,7 @@ extension PlayerService {
 
         if shouldLoadPendingVideo {
             self.showMiniPlayer = false
-            self.state = self.shouldAutoResumeAfterRestoredLoad ? .loading : self.state
+            self.state = .loading
             if SingletonPlayerWebView.shared.webView != nil {
                 SingletonPlayerWebView.shared.loadVideo(videoId: pendingPlayVideoId)
             }

--- a/Sources/Kaset/Services/Player/PlayerService+PlaybackRestoration.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+PlaybackRestoration.swift
@@ -119,7 +119,7 @@ private extension PlayerService {
         self.duration = duration
 
         if isPlaying {
-            self.state = .playing
+            self.confirmPlaybackStarted()
         } else if self.state == .playing {
             self.state = .paused
         }

--- a/Sources/Kaset/Services/Protocols.swift
+++ b/Sources/Kaset/Services/Protocols.swift
@@ -407,7 +407,7 @@ protocol PlayerServiceProtocol: AnyObject, Sendable {
 
     // MARK: - State Updates
 
-    /// Called when the mini player confirms playback has started.
+    /// Records that the WebView observer has confirmed playback has started.
     func confirmPlaybackStarted()
 
     /// Called when the mini player is dismissed.

--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -182,11 +182,6 @@ struct MainWindow: View {
                 self.showLoginSheet = true
             }
         }
-        .onChange(of: self.playerService.isPlaying) { _, isPlaying in
-            if isPlaying {
-                self.playerService.confirmPlaybackStarted()
-            }
-        }
         .onChange(of: self.playerService.showVideo) { _, showVideo in
             DiagnosticsLogger.player.debug("showVideo onChange triggered: \(showVideo)")
             if showVideo {

--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -104,45 +104,17 @@ struct MainWindow: View {
                 DiagnosticsLogger.app.info("MainWindow: Login check complete")
             }
 
-            // Persistent WebView - always present once a video has been requested
-            // Uses a SINGLETON WebView instance that persists for the app lifetime
-            // Compact size (120x68) for first-time interaction, then hidden (1x1)
+            // Persistent WebView - always present once a video has been requested.
+            // Uses a SINGLETON WebView instance that persists for the app lifetime.
+            // Keep it as a hidden 1×1 anchor for audio playback; do not reveal a mini overlay.
             if let videoId = playerService.pendingPlayVideoId {
-                ZStack(alignment: .topTrailing) {
-                    PersistentPlayerView(videoId: videoId, isExpanded: self.playerService.showMiniPlayer)
-                        .frame(
-                            width: self.playerService.showMiniPlayer ? 120 : 1,
-                            height: self.playerService.showMiniPlayer ? 68 : 1
-                        )
-                        .clipShape(RoundedRectangle(cornerRadius: 6))
-                        .opacity(self.playerService.showMiniPlayer ? 0.95 : 0)
-
-                    if self.playerService.showMiniPlayer {
-                        Button {
-                            self.playerService.confirmPlaybackStarted()
-                        } label: {
-                            Image(systemName: "xmark.circle.fill")
-                                .font(.system(size: 14))
-                                .foregroundStyle(.white.opacity(0.8))
-                                .shadow(radius: 1)
-                        }
-                        .buttonStyle(.plain)
-                        .accessibilityLabel(String(localized: "Close"))
-                        .padding(3)
-                    }
-                }
-                .shadow(color: self.playerService.showMiniPlayer ? .black.opacity(0.2) : .clear, radius: 6, y: 3)
-                .padding(.trailing, self.playerService.showMiniPlayer ? 12 : 0)
-                .padding(.bottom, self.playerService.showMiniPlayer ? 76 : 0)
-                .allowsHitTesting(self.playerService.showMiniPlayer)
-                // Hiding must not interpolate frame/opacity (no “shrink”); showing can ease in.
-                .transaction { transaction in
-                    if !self.playerService.showMiniPlayer {
+                PersistentPlayerView(videoId: videoId, isExpanded: false)
+                    .frame(width: 1, height: 1)
+                    .opacity(0)
+                    .allowsHitTesting(false)
+                    .transaction { transaction in
                         transaction.animation = nil
-                    } else {
-                        transaction.animation = .easeInOut(duration: 0.2)
                     }
-                }
             }
         }
         .sheet(isPresented: self.$showLoginSheet) {
@@ -211,8 +183,7 @@ struct MainWindow: View {
             }
         }
         .onChange(of: self.playerService.isPlaying) { _, isPlaying in
-            // Auto-hide the WebView once playback starts
-            if isPlaying, self.playerService.showMiniPlayer {
+            if isPlaying {
                 self.playerService.confirmPlaybackStarted()
             }
         }

--- a/Sources/Kaset/Views/MiniPlayerViews.swift
+++ b/Sources/Kaset/Views/MiniPlayerViews.swift
@@ -2,14 +2,15 @@ import SwiftUI
 
 // MARK: - PersistentPlayerView
 
-/// A SwiftUI view that displays the singleton WebView.
-/// The WebView is created once and reused for all playback.
+/// A SwiftUI anchor for the singleton WebView.
+/// The WebView is created once, kept attached while audio playback is pending,
+/// and normally rendered as a hidden 1×1 view.
 struct PersistentPlayerView: NSViewRepresentable {
     @Environment(WebKitManager.self) private var webKitManager
     @Environment(PlayerService.self) private var playerService
 
     let videoId: String
-    let isExpanded: Bool
+    let isExpanded: Bool // Retained for compatibility; audio playback keeps this hidden.
 
     private let logger = DiagnosticsLogger.player
 
@@ -35,7 +36,7 @@ struct PersistentPlayerView: NSViewRepresentable {
         if self.playerService.shouldAutoloadPendingVideo,
            SingletonPlayerWebView.shared.currentVideoId != self.videoId
         {
-            self.logger.info("Initial load for videoId: \(self.videoId)")
+            self.logger.info("Initial hidden load for videoId: \(self.videoId)")
             SingletonPlayerWebView.shared.loadVideo(videoId: self.videoId)
         }
 
@@ -59,7 +60,9 @@ struct PersistentPlayerView: NSViewRepresentable {
 
         webView.frame = container.bounds
 
-        if self.playerService.shouldAutoloadPendingVideo {
+        if self.playerService.shouldAutoloadPendingVideo,
+           SingletonPlayerWebView.shared.currentVideoId != self.videoId
+        {
             SingletonPlayerWebView.shared.loadVideo(videoId: self.videoId)
         }
     }

--- a/Tests/KasetTests/PlayerServiceQueueTests.swift
+++ b/Tests/KasetTests/PlayerServiceQueueTests.swift
@@ -328,7 +328,7 @@ struct PlayerServiceQueueTests {
         #expect(newService.pendingPlayVideoId == duplicateSong.videoId)
     }
 
-    @Test("Resume on a restored session reveals the mini player before loading playback")
+    @Test("Resume on a restored session loads through the hidden persistent player")
     func resumeDeferredRestoredSession() async {
         // Arrange
         let songs = TestFixtures.makeSongs(count: 2)
@@ -345,8 +345,8 @@ struct PlayerServiceQueueTests {
         // Assert
         #expect(self.playerService.pendingPlayVideoId == songs[1].videoId)
         #expect(self.playerService.progress == 42)
-        #expect(self.playerService.state == .paused)
-        #expect(self.playerService.showMiniPlayer == true)
+        #expect(self.playerService.state == .loading)
+        #expect(self.playerService.showMiniPlayer == false)
         #expect(self.playerService.shouldAutoloadPendingVideo == true)
     }
 

--- a/Tests/KasetTests/PlayerServiceTests.swift
+++ b/Tests/KasetTests/PlayerServiceTests.swift
@@ -240,6 +240,18 @@ struct PlayerServiceTests {
         #expect(self.playerService.hasUserInteractedThisSession == true)
     }
 
+    @Test("Observed playback confirms session while mini player is hidden")
+    func observedPlaybackConfirmsHiddenSession() {
+        #expect(self.playerService.hasUserInteractedThisSession == false)
+        #expect(self.playerService.showMiniPlayer == false)
+
+        self.playerService.updatePlaybackState(isPlaying: true, progress: 3, duration: 180)
+
+        #expect(self.playerService.hasUserInteractedThisSession == true)
+        #expect(self.playerService.showMiniPlayer == false)
+        #expect(self.playerService.state == .playing)
+    }
+
     // MARK: - Pending Play Video Tests
 
     @Test("pendingPlayVideoId initially nil")

--- a/Tests/KasetTests/ScriptCommandsTests.swift
+++ b/Tests/KasetTests/ScriptCommandsTests.swift
@@ -249,7 +249,7 @@ struct ScriptCommandsTests {
 
     // MARK: - PlayVideoCommand Tests
 
-    @Test("PlayVideo keeps the first-session gate closed until playback is confirmed")
+    @Test("PlayVideo stays hidden while keeping the first-session gate closed until playback is confirmed")
     func playVideoKeepsFirstSessionGateClosedUntilPlaybackIsConfirmed() async {
         let playerService = PlayerService()
         let mockClient = MockYTMusicClient()
@@ -265,7 +265,7 @@ struct ScriptCommandsTests {
                 playerService.currentTrack?.videoId == "first-video-id" &&
                 playerService.queue.count == 1 &&
                 playerService.queue.first?.videoId == "first-video-id" &&
-                playerService.showMiniPlayer == true &&
+                playerService.showMiniPlayer == false &&
                 mockClient.getRadioQueueVideoIds == ["first-video-id"]
         }
 
@@ -274,7 +274,7 @@ struct ScriptCommandsTests {
         #expect(playerService.currentTrack?.videoId == "first-video-id")
         #expect(playerService.queue.count == 1)
         #expect(playerService.queue.first?.videoId == "first-video-id")
-        #expect(playerService.showMiniPlayer == true)
+        #expect(playerService.showMiniPlayer == false)
 
         playerService.miniPlayerDismissed()
         #expect(playerService.showMiniPlayer == false)
@@ -288,7 +288,7 @@ struct ScriptCommandsTests {
                 playerService.currentTrack?.videoId == "second-video-id" &&
                 playerService.queue.count == 1 &&
                 playerService.queue.first?.videoId == "second-video-id" &&
-                playerService.showMiniPlayer == true &&
+                playerService.showMiniPlayer == false &&
                 mockClient.getRadioQueueVideoIds == ["first-video-id", "second-video-id"]
         }
 
@@ -297,7 +297,7 @@ struct ScriptCommandsTests {
         #expect(playerService.currentTrack?.videoId == "second-video-id")
         #expect(playerService.queue.count == 1)
         #expect(playerService.queue.first?.videoId == "second-video-id")
-        #expect(playerService.showMiniPlayer == true)
+        #expect(playerService.showMiniPlayer == false)
 
         playerService.confirmPlaybackStarted()
         #expect(playerService.showMiniPlayer == false)


### PR DESCRIPTION
## Summary
- keep the persistent playback WebView mounted as a hidden 1×1 anchor instead of showing a mini overlay
- start initial and restored playback hidden-first, with observer state confirming playback
- update playback tests for hidden-first behavior and WebView confirmation semantics

## Tests
- swift test --filter 'PlayerServiceTests|PlayerServiceQueueTests|ScriptCommandsTests'