### PR TITLE
Add play video command to AppleScript documentation

### DIFF
--- a/docs/applescript.md
+++ b/docs/applescript.md
@@ -7,6 +7,7 @@ Kaset supports AppleScript for automation with tools like Raycast, Alfred, and S
 | Command | Description |
 | ------- | ----------- |
 | `play` | Start or resume playback |
+| `play video` | Play a YouTube video by its video ID
 | `pause` | Pause playback |
 | `playpause` | Toggle play/pause |
 | `next track` | Skip to next track |
@@ -29,6 +30,12 @@ tell application "Kaset"
     set volume 50
     toggle shuffle
 end tell
+```
+
+### Play a video
+
+```applescript
+tell application "Kaset" to play video "dQw4w9WgXcQ"
 ```
 
 ### Get Player State


### PR DESCRIPTION

## Description

<!-- Provide a brief description of the changes in this PR -->
Added command to play YouTube videos by video ID and included example usage.

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📚 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🧪 Test update
- [ ] 🔧 Build/CI configuration