### PR TITLE
test(library): drop wall-clock race in refresh-while-loading test

### DIFF
--- a/Tests/KasetTests/LibraryViewModelTests.swift
+++ b/Tests/KasetTests/LibraryViewModelTests.swift
@@ -140,7 +140,7 @@ struct LibraryViewModelTests {
     }
 
     @Test("Refresh keeps existing library content visible while background load runs")
-    func refreshKeepsExistingContentVisibleWhileLoading() async throws {
+    func refreshKeepsExistingContentVisibleWhileLoading() async {
         self.mockClient.libraryPlaylists = [TestFixtures.makePlaylist(id: "VL1", title: "Playlist 1")]
         await self.viewModel.load()
 
@@ -153,11 +153,22 @@ struct LibraryViewModelTests {
         ]
         self.mockClient.libraryContentResponseDelays = [.milliseconds(200)]
 
+        // Deterministic handshake: yield once from the mock's getLibraryContent
+        // hook when the refresh's call enters. This replaces a wall-clock
+        // Task.sleep(50ms) that could flake under CI runner load — the previous
+        // version could resume after the entire 200ms mock delay had already
+        // completed, so the in-flight assertions raced the final state.
+        // By the time the hook fires, refresh() has synchronously set
+        // loadingState = .loadingMore (before its first await).
+        let (signalStream, signalContinuation) = AsyncStream<Void>.makeStream()
+        self.mockClient.onGetLibraryContent = { signalContinuation.yield() }
+
         let refreshTask = Task {
             await self.viewModel.refresh()
         }
 
-        try await Task.sleep(for: .milliseconds(50))
+        var iterator = signalStream.makeAsyncIterator()
+        _ = await iterator.next()
 
         #expect(self.viewModel.loadingState == .loadingMore)
         #expect(self.viewModel.playlists.map(\.id) == ["VL1"])
@@ -166,6 +177,8 @@ struct LibraryViewModelTests {
 
         #expect(self.viewModel.loadingState == .loaded)
         #expect(self.viewModel.playlists.map(\.id) == ["VL2"])
+
+        signalContinuation.finish()
     }
 
     @Test("Refresh failure keeps existing library content visible")


### PR DESCRIPTION
## Description

Hardens the flaky \`LibraryViewModelTests.refreshKeepsExistingContentVisibleWhileLoading\` test so it stops tripping CI under loaded macOS runners.

The previous version raced a \`Task.sleep(50ms)\` intermediate checkpoint against the mock's \`200ms\` \`getLibraryContent\` delay. On a loaded runner the 50ms checkpoint could resume after the entire refresh had already completed, so the intermediate assertions (\`loadingState == .loadingMore\`, \`playlists == [\"VL1\"]\`) raced the final state and the test failed at the *post-refresh* assertion (line 168) with \`playlists == [\"VL1\"]\` instead of \`[\"VL2\"]\`.

This PR replaces the sleep with a one-shot \`AsyncStream<Void>\` handshake driven by the existing \`MockYTMusicClient.onGetLibraryContent\` hook — no mock changes needed. The test now suspends until the mock's \`getLibraryContent\` actually enters; by then \`LibraryViewModel.refresh()\` has synchronously set \`loadingState = .loadingMore\` (before its first \`await\`), so the in-flight assertions are deterministic.

## AI Prompt (Optional)

<details>
<summary>🤖 AI Prompt Used</summary>

\`\`\`
The LibraryViewModelTests.refreshKeepsExistingContentVisibleWhileLoading
test is flaky on macOS CI: a Task.sleep(50ms) intermediate checkpoint
races a 200ms mock delay. Replace the wall-clock sleep with a
deterministic handshake driven by the existing
MockYTMusicClient.onGetLibraryContent hook (no mock changes). Verify by
running the test 5x locally.
\`\`\`

**AI Tool:** Claude Code

</details>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🧪 Test update

## Related Issues

Stable fix for the flake observed on https://github.com/sozercan/kaset/pull/231 and likely elsewhere on macOS Unit Tests jobs.

## Changes Made

- \`Tests/KasetTests/LibraryViewModelTests.swift\`:
  - Replace \`try await Task.sleep(for: .milliseconds(50))\` with \`await iterator.next()\` on an \`AsyncStream<Void>\` yielded from \`mockClient.onGetLibraryContent\`.
  - Function loses \`throws\` (no awaited throwing call remains).
  - Comment explains the why so future readers don't reintroduce a sleep.

No production code, no mock code, no other tests touched.

## Testing

- [x] \`swift test --filter refreshKeepsExistingContentVisibleWhileLoading\` × 5 — all pass, ~200ms each (matches the mock delay; no extra slack).
- [x] Full suite: \`swift test --skip KasetUITests\` reports \`1314 tests, 0 issues\`.
- [x] \`swiftlint --strict\` clean.
- [x] \`swiftformat .\` clean (formatter trimmed the now-unused \`throws\` automatically).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run \`swiftlint --strict && swiftformat .\`
- [x] New and existing unit tests pass locally
- [ ] I have updated documentation if needed (no docs change required)
- [x] My changes generate no new warnings

## Additional Notes

The \`onGetLibraryContent\` hook already existed in \`MockYTMusicClient\` — this just wires it up with an \`AsyncStream\`-based one-shot signal in the one test that needed it. If we ever add other tests that need to observe the in-flight \`getLibraryContent\` state, the same pattern works.