### PR TITLE
fix(release): sign release builds with Apple Development cert

### DIFF
--- a/.github/workflows/api-explorer.yml
+++ b/.github/workflows/api-explorer.yml
@@ -1,0 +1,96 @@
+name: API Explorer
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "Sources/APIExplorer/**"
+      - "Package.swift"
+      - "Package.resolved"
+      - ".github/workflows/api-explorer.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "Sources/APIExplorer/**"
+      - "Package.swift"
+      - "Package.resolved"
+      - ".github/workflows/api-explorer.yml"
+  workflow_dispatch:
+
+jobs:
+  build_and_smoke_test:
+    name: Build and smoke-test API Explorer
+    timeout-minutes: 15
+    runs-on: macos-26
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+
+      - name: Select Xcode version
+        run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
+
+      - name: Show Swift version
+        run: swift --version
+
+      - name: Cache SPM dependencies
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/Library/Caches/org.swift.swiftpm/spm-repositories
+            .build
+          key: ${{ runner.os }}-spm-api-explorer-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-api-explorer-
+
+      - name: Build api-explorer
+        run: swift build -c release --product api-explorer
+
+      - name: Smoke-test - list endpoints (offline)
+        run: |
+          set -euo pipefail
+          OUT=$(swift run -c release -q api-explorer list)
+          echo "$OUT"
+          # Sanity: list output should mention at least one well-known browseId.
+          echo "$OUT" | grep -q "FEmusic_home" \
+            || { echo "ERROR: 'list' output missing FEmusic_home"; exit 1; }
+
+      - name: Smoke-test - auth status (offline, expect 'not authenticated')
+        run: |
+          set -euo pipefail
+          # CI has no Kaset cookie backup, so this should report no auth and exit 0.
+          OUT=$(swift run -c release -q api-explorer auth)
+          echo "$OUT"
+
+      - name: Smoke-test - browse FEmusic_home (unauthenticated)
+        run: |
+          set -euo pipefail
+          # Hits real YouTube Music API. Network flakiness is possible; retry once.
+          run_browse() {
+            swift run -c release -q api-explorer browse FEmusic_home
+          }
+          OUT=$(run_browse) || { sleep 5; OUT=$(run_browse); }
+          echo "$OUT"
+
+          # Validate basic response shape so we catch silent API drift.
+          echo "$OUT" | grep -q "HTTP 200" \
+            || { echo "ERROR: expected 'HTTP 200' from FEmusic_home"; exit 1; }
+          echo "$OUT" | grep -q "singleColumnBrowseResultsRenderer" \
+            || { echo "ERROR: expected 'singleColumnBrowseResultsRenderer' in response"; exit 1; }
+          echo "$OUT" | grep -q "Tab 0:" \
+            || { echo "ERROR: expected at least one tab in FEmusic_home response"; exit 1; }
+
+      - name: Smoke-test - browse FEmusic_charts (unauthenticated)
+        run: |
+          set -euo pipefail
+          run_browse() {
+            swift run -c release -q api-explorer browse FEmusic_charts
+          }
+          OUT=$(run_browse) || { sleep 5; OUT=$(run_browse); }
+          echo "$OUT"
+          echo "$OUT" | grep -q "HTTP 200" \
+            || { echo "ERROR: expected 'HTTP 200' from FEmusic_charts"; exit 1; }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,9 +71,55 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Using version: $VERSION"
 
+      - name: Import Apple Development certificate
+        id: import_cert
+        env:
+          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+          MACOS_KEYCHAIN_PWD: ${{ secrets.MACOS_KEYCHAIN_PWD }}
+        run: |
+          if [ -z "$MACOS_CERTIFICATE" ]; then
+            echo "No MACOS_CERTIFICATE secret set; falling back to ad-hoc signing."
+            echo "identity=" >> "$GITHUB_OUTPUT"
+            echo "signing_mode=adhoc" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          KEYCHAIN_PATH="$RUNNER_TEMP/kaset-signing.keychain-db"
+          CERT_PATH="$RUNNER_TEMP/cert.p12"
+
+          echo "$MACOS_CERTIFICATE" | base64 --decode > "$CERT_PATH"
+
+          security create-keychain -p "$MACOS_KEYCHAIN_PWD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$MACOS_KEYCHAIN_PWD" "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" -P "$MACOS_CERTIFICATE_PWD" \
+            -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k "$MACOS_KEYCHAIN_PWD" "$KEYCHAIN_PATH" >/dev/null
+
+          # Prepend our keychain to the search list so codesign can find the cert.
+          security list-keychains -d user -s "$KEYCHAIN_PATH" \
+            $(security list-keychains -d user | tr -d '"')
+
+          rm -f "$CERT_PATH"
+
+          IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" \
+            | grep "Apple Development" | head -1 | sed -E 's/.*"(.+)".*/\1/')
+          if [ -z "$IDENTITY" ]; then
+            echo "ERROR: Imported keychain has no Apple Development identity"
+            security find-identity -v -p codesigning "$KEYCHAIN_PATH"
+            exit 1
+          fi
+
+          echo "Using signing identity: $IDENTITY"
+          echo "identity=$IDENTITY" >> "$GITHUB_OUTPUT"
+          echo "signing_mode=dev" >> "$GITHUB_OUTPUT"
+
       - name: Build release app
         env:
-          KASET_SIGNING: adhoc
+          KASET_SIGNING: ${{ steps.import_cert.outputs.signing_mode }}
+          APP_IDENTITY: ${{ steps.import_cert.outputs.identity }}
           ARCHES: "arm64 x86_64"
         run: |
           # Set version from tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,8 +78,15 @@ jobs:
           MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
           MACOS_KEYCHAIN_PWD: ${{ secrets.MACOS_KEYCHAIN_PWD }}
         run: |
-          if [ -z "$MACOS_CERTIFICATE" ]; then
-            echo "No MACOS_CERTIFICATE secret set; falling back to ad-hoc signing."
+          # All three secrets must be present; otherwise fall back to ad-hoc.
+          # Failing partway through import would leave the workflow in a worse
+          # state than ad-hoc, so validate up front.
+          if [ -z "$MACOS_CERTIFICATE" ] || [ -z "$MACOS_CERTIFICATE_PWD" ] || [ -z "$MACOS_KEYCHAIN_PWD" ]; then
+            if [ -n "$MACOS_CERTIFICATE" ]; then
+              echo "WARN: MACOS_CERTIFICATE is set but MACOS_CERTIFICATE_PWD or MACOS_KEYCHAIN_PWD is missing; falling back to ad-hoc signing."
+            else
+              echo "No MACOS_CERTIFICATE secret set; falling back to ad-hoc signing."
+            fi
             echo "identity=" >> "$GITHUB_OUTPUT"
             echo "signing_mode=adhoc" >> "$GITHUB_OUTPUT"
             exit 0
@@ -93,8 +100,10 @@ jobs:
           security create-keychain -p "$MACOS_KEYCHAIN_PWD" "$KEYCHAIN_PATH"
           security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
           security unlock-keychain -p "$MACOS_KEYCHAIN_PWD" "$KEYCHAIN_PATH"
+          # Restrict private-key access to codesign rather than -A (all apps).
           security import "$CERT_PATH" -P "$MACOS_CERTIFICATE_PWD" \
-            -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+            -t cert -f pkcs12 -k "$KEYCHAIN_PATH" \
+            -T /usr/bin/codesign -T /usr/bin/security
           security set-key-partition-list -S apple-tool:,apple:,codesign: \
             -s -k "$MACOS_KEYCHAIN_PWD" "$KEYCHAIN_PATH" >/dev/null
 

--- a/Scripts/build-app.sh
+++ b/Scripts/build-app.sh
@@ -328,13 +328,20 @@ echo "🔏 Signing app..."
 if [[ "$SIGNING_MODE" == "adhoc" ]]; then
   CODESIGN_ARGS=(--force --sign -)
 elif [[ "$SIGNING_MODE" == "dev" ]]; then
-  # Use Apple Development certificate
-  CODESIGN_HASH=$(security find-identity -v -p codesigning | grep "Apple Development" | head -1 | awk '{print $2}')
-  if [[ -z "$CODESIGN_HASH" ]]; then
+  # Use Apple Development certificate. Allow callers (e.g. CI) to pin the
+  # exact identity via APP_IDENTITY; otherwise pick the first one available.
+  if [[ -n "${APP_IDENTITY:-}" ]]; then
+    CODESIGN_ID="$APP_IDENTITY"
+  else
+    CODESIGN_ID=$(security find-identity -v -p codesigning | grep "Apple Development" | head -1 | awk '{print $2}')
+  fi
+  if [[ -z "$CODESIGN_ID" ]]; then
     echo "WARN: No Apple Development certificate found. Falling back to ad-hoc signing."
     CODESIGN_ARGS=(--force --sign -)
   else
-    CODESIGN_ARGS=(--force --sign "$CODESIGN_HASH")
+    # --options runtime + a stable Team ID signature keeps Keychain ACLs
+    # stable across launches (issue #238).
+    CODESIGN_ARGS=(--force --options runtime --sign "$CODESIGN_ID")
   fi
 else
   CODESIGN_ID="${APP_IDENTITY:-Developer ID Application}"

--- a/Scripts/build-app.sh
+++ b/Scripts/build-app.sh
@@ -39,7 +39,8 @@ mkdir -p "$BUILD_DIR"
 # Build for each architecture
 for ARCH in "${ARCH_LIST[@]}"; do
   echo "  → Building for $ARCH..."
-  swift build -c "$CONF" --arch "$ARCH"
+  # Only build the app product; APIExplorer compiles separately in CI / `swift test`.
+  swift build -c "$CONF" --arch "$ARCH" --product "$APP_NAME"
 done
 
 # Create app bundle structure


### PR DESCRIPTION
## Summary
- Switch CI release builds from ad-hoc signing to a stable Apple Development (Team ID) signature so Keychain ACLs persist across launches, fixing the repeated-prompt / stuck-loading-screen issue reported in #238.
- `Scripts/build-app.sh` `dev` mode now honors `APP_IDENTITY` and signs with `--options runtime` (hardened runtime).
- `.github/workflows/release.yml` imports a `.p12` from `MACOS_CERTIFICATE` / `MACOS_CERTIFICATE_PWD` / `MACOS_KEYCHAIN_PWD` into a temp keychain before the build, then sets `KASET_SIGNING=dev` and `APP_IDENTITY=...`. Falls back to ad-hoc if the secret is unset so the workflow keeps working pre-rollout.

## Why this fixes #238
Ad-hoc signed sandboxed apps have no stable code-signing identity. macOS Keychain ACLs are bound to the signature, so every launch looks like a new app → repeated "allow access" prompts → app never finishes loading. Signing with a free Apple Development cert produces a stable Team ID signature, which is enough to make ACLs sticky after the first "Always Allow."

## Required repo secrets (add before tagging next release)
- `MACOS_CERTIFICATE` — base64 of the exported `.p12` (cert + private key)
- `MACOS_CERTIFICATE_PWD` — password set during `.p12` export
- `MACOS_KEYCHAIN_PWD` — random string for the temp keychain

If any are missing, the workflow gracefully falls back to ad-hoc signing.

## Test plan
- [ ] Local: `KASET_SIGNING=dev APP_IDENTITY="Apple Development: ... (TEAMID)" Scripts/build-app.sh release` produces a bundle whose `codesign -dv` shows the Team ID and `--options runtime`.
- [ ] Launch the local bundle twice — confirm Keychain prompt appears at most once and the loading screen completes.
- [ ] Push a test tag (or run release workflow via `workflow_dispatch`) with secrets configured; verify the produced DMG is signed with the dev cert and is universal (arm64 + x86_64).
- [ ] Without secrets configured, re-run the workflow and verify it still completes via ad-hoc fallback.

Refs #238