### PR TITLE
feat: redesign player bar and fix metadata sync

### DIFF
--- a/Sources/Kaset/Services/Player/PlayerService+WebQueueSync.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+WebQueueSync.swift
@@ -541,19 +541,87 @@ extension PlayerService {
             return
         }
 
-        self.currentTrack = Song(
-            id: resolvedVideoId,
+        let priorTrack = self.currentTrack
+        let priorVideoId = priorTrack?.videoId
+        // Reuse rich metadata (album, navigable artists, library state) from the prior
+        // track when the videoId matches, otherwise fall back to a queue entry so
+        // autoplay-driven track changes don't drop the album/artist links until the
+        // async `fetchSongMetadata` finishes.
+        let metadataSource: Song? = if priorVideoId == resolvedVideoId {
+            priorTrack
+        } else {
+            self.queue.first(where: { $0.videoId == resolvedVideoId })
+        }
+
+        self.currentTrack = self.mergedTrackForWebMetadata(
+            resolvedVideoId: resolvedVideoId,
             title: title,
-            artists: [artistObj],
-            album: nil,
-            duration: self.duration > 0 ? self.duration : nil,
+            artistObj: artistObj,
             thumbnailURL: thumbnailURL,
-            videoId: resolvedVideoId
+            metadataSource: metadataSource
         )
 
+        // Only fetch on YouTube-driven track changes; Kaset-initiated playback
+        // already triggers `fetchSongMetadata` from `play(videoId:)`.
+        if priorVideoId != nil, priorVideoId != resolvedVideoId, resolvedVideoId != "unknown" {
+            Task {
+                await self.fetchSongMetadata(videoId: resolvedVideoId)
+            }
+        }
+
         if trackChanged {
+            self.applyTrackStatusAfterMetadataMerge(
+                resolvedVideoId: resolvedVideoId,
+                hasMetadataSource: metadataSource != nil
+            )
+        }
+    }
+
+    private func mergedTrackForWebMetadata(
+        resolvedVideoId: String,
+        title: String,
+        artistObj: Artist,
+        thumbnailURL: URL?,
+        metadataSource: Song?
+    ) -> Song {
+        let mergedArtists: [Artist] = if let source = metadataSource,
+                                         source.artists.contains(where: \.hasNavigableId)
+        {
+            source.artists
+        } else {
+            [artistObj]
+        }
+        let mergedThumbnail = thumbnailURL ?? metadataSource?.thumbnailURL
+        let mergedDuration = self.duration > 0 ? self.duration : metadataSource?.duration
+
+        return Song(
+            id: resolvedVideoId,
+            title: title,
+            artists: mergedArtists,
+            album: metadataSource?.album,
+            duration: mergedDuration,
+            thumbnailURL: mergedThumbnail,
+            videoId: resolvedVideoId,
+            hasVideo: metadataSource?.hasVideo,
+            musicVideoType: metadataSource?.musicVideoType,
+            likeStatus: metadataSource?.likeStatus,
+            isInLibrary: metadataSource?.isInLibrary,
+            feedbackTokens: metadataSource?.feedbackTokens,
+            isExplicit: metadataSource?.isExplicit
+        )
+    }
+
+    private func applyTrackStatusAfterMetadataMerge(resolvedVideoId: String, hasMetadataSource: Bool) {
+        if hasMetadataSource {
+            if let cachedStatus = SongLikeStatusManager.shared.status(for: resolvedVideoId) {
+                self.currentTrackLikeStatus = cachedStatus
+            }
+            if let track = self.currentTrack {
+                self.currentTrackInLibrary = track.isInLibrary ?? false
+                self.currentTrackFeedbackTokens = track.feedbackTokens
+            }
+        } else {
             self.resetTrackStatus()
-            // Immediately restore like status from SongLikeStatusManager cache
             if let cachedStatus = SongLikeStatusManager.shared.status(for: resolvedVideoId) {
                 self.currentTrackLikeStatus = cachedStatus
             }

--- a/Sources/Kaset/Views/ChartsView.swift
+++ b/Sources/Kaset/Views/ChartsView.swift
@@ -34,9 +34,9 @@ struct ChartsView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .localizedNavigationTitle("Charts")
             .navigationDestinations(client: self.viewModel.client)
-        }
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            PlayerBar()
+            .safeAreaInset(edge: .bottom, spacing: 0) {
+                PlayerBar()
+            }
         }
         .onAppear {
             if self.viewModel.loadingState == .idle {

--- a/Sources/Kaset/Views/ExploreView.swift
+++ b/Sources/Kaset/Views/ExploreView.swift
@@ -34,9 +34,9 @@ struct ExploreView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .localizedNavigationTitle("Explore")
             .navigationDestinations(client: self.viewModel.client)
-        }
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            PlayerBar()
+            .safeAreaInset(edge: .bottom, spacing: 0) {
+                PlayerBar()
+            }
         }
         .onAppear {
             if self.viewModel.loadingState == .idle {

--- a/Sources/Kaset/Views/HistoryView.swift
+++ b/Sources/Kaset/Views/HistoryView.swift
@@ -53,9 +53,9 @@ struct HistoryView: View {
                 }
             }
             .navigationDestinations(client: self.viewModel.client)
-        }
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            PlayerBar()
+            .safeAreaInset(edge: .bottom, spacing: 0) {
+                PlayerBar()
+            }
         }
         .task {
             if self.viewModel.loadingState == .idle {

--- a/Sources/Kaset/Views/HomeView.swift
+++ b/Sources/Kaset/Views/HomeView.swift
@@ -36,9 +36,9 @@ struct HomeView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .localizedNavigationTitle("Home")
             .navigationDestinations(client: self.viewModel.client)
-        }
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            PlayerBar()
+            .safeAreaInset(edge: .bottom, spacing: 0) {
+                PlayerBar()
+            }
         }
         .onAppear {
             if self.viewModel.loadingState == .idle {

--- a/Sources/Kaset/Views/LibraryView.swift
+++ b/Sources/Kaset/Views/LibraryView.swift
@@ -104,11 +104,11 @@ struct LibraryView: View {
             .navigationDestination(for: PodcastShow.self) { show in
                 PodcastShowView(show: show, client: self.viewModel.client)
             }
+            .safeAreaInset(edge: .bottom, spacing: 0) {
+                PlayerBar()
+            }
         }
         .environment(self.viewModel)
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            PlayerBar()
-        }
         .task {
             if self.viewModel.loadingState == .idle {
                 await self.viewModel.load()

--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -302,7 +302,7 @@ struct MainWindow: View {
                 }
                 .frame(maxHeight: .infinity)
                 .padding(.top, 12)
-                .padding(.bottom, 76) // Space for PlayerBar
+                .padding(.bottom, 92) // Space for PlayerBar (metadata + seek row)
                 .transition(.move(edge: .trailing).combined(with: .opacity))
 
                 Spacer()

--- a/Sources/Kaset/Views/MoodsAndGenresView.swift
+++ b/Sources/Kaset/Views/MoodsAndGenresView.swift
@@ -34,9 +34,9 @@ struct MoodsAndGenresView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .localizedNavigationTitle("Moods & Genres")
             .navigationDestinations(client: self.viewModel.client)
-        }
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            PlayerBar()
+            .safeAreaInset(edge: .bottom, spacing: 0) {
+                PlayerBar()
+            }
         }
         .onAppear {
             if self.viewModel.loadingState == .idle {

--- a/Sources/Kaset/Views/NewReleasesView.swift
+++ b/Sources/Kaset/Views/NewReleasesView.swift
@@ -34,9 +34,9 @@ struct NewReleasesView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .localizedNavigationTitle("New Releases")
             .navigationDestinations(client: self.viewModel.client)
-        }
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            PlayerBar()
+            .safeAreaInset(edge: .bottom, spacing: 0) {
+                PlayerBar()
+            }
         }
         .onAppear {
             if self.viewModel.loadingState == .idle {

--- a/Sources/Kaset/Views/PlayerBar.swift
+++ b/Sources/Kaset/Views/PlayerBar.swift
@@ -8,12 +8,9 @@ struct PlayerBar: View {
     private static let brandAccent = PackageResourceLookup.brandAccent
 
     @Environment(PlayerService.self) private var playerService
-    @Environment(WebKitManager.self) private var webKitManager
 
     /// Namespace for glass effect morphing and unioning.
     @Namespace private var playerNamespace
-
-    @State private var isHovering = false
 
     /// Local seek value for smooth slider dragging without network calls on every change.
     @State private var seekValue: Double = 0
@@ -32,32 +29,23 @@ struct PlayerBar: View {
     var body: some View {
         GlassEffectContainer(spacing: 0) {
             HStack(spacing: 0) {
-                // Left section: Playback controls
-                self.playbackControls
+                self.trackInfoSection
+                    .frame(maxWidth: .infinity, alignment: .leading)
 
-                Spacer()
+                self.controlsSection
+                    .frame(maxWidth: .infinity)
 
-                // Center section: Track info OR seek bar (on hover)
-                self.centerSection
-
-                Spacer()
-
-                // Right section: Volume control
                 self.volumeControl
+                    .frame(maxWidth: .infinity, alignment: .trailing)
             }
-            .padding(.horizontal, 20)
+            .padding(.horizontal, 24)
             .padding(.vertical, 8)
-            .frame(height: 52)
+            .frame(minHeight: 64)
             .glassEffect(.regular.interactive(), in: .capsule)
             .glassEffectID("playerBar", in: self.playerNamespace)
         }
         .padding(.horizontal, 16)
         .padding(.bottom, 12)
-        .onHover { hovering in
-            withAnimation(.easeInOut(duration: 0.15)) {
-                self.isHovering = hovering
-            }
-        }
         .background {
             // Keyboard shortcuts for media controls
             Group {
@@ -124,35 +112,35 @@ struct PlayerBar: View {
         }
     }
 
-    // MARK: - Center Section (track info blurs, seek bar appears on hover)
+    // MARK: - Left Column: track info
 
-    private var centerSection: some View {
-        ZStack {
-            // Error state display with retry option
-            if case let .error(message) = playerService.state {
-                self.errorView(message: message)
+    private var trackInfoSection: some View {
+        Group {
+            if let track = playerService.currentTrack {
+                self.trackLeadingBlock(track: track)
             } else {
-                // Track info (blurred when hovering and track is playing)
-                self.trackInfoView
-                    .blur(radius: self.isHovering && self.playerService.currentTrack != nil ? 8 : 0)
-                    .opacity(self.isHovering && self.playerService.currentTrack != nil ? 0 : 1)
-
-                // On hover: seek bar for normal tracks, LIVE indicator for live streams.
-                if self.isHovering, self.playerService.currentTrack != nil {
-                    if self.playerService.isCurrentItemLive {
-                        self.liveIndicatorView
-                            .transition(.opacity)
-                    } else {
-                        self.seekBarView
-                            .transition(.opacity)
-                    }
-                }
+                self.noTrackPlaceholderView
             }
         }
-        .frame(maxWidth: 400)
     }
 
-    // MARK: - Live Indicator View (replaces seek bar for live streams)
+    // MARK: - Center Column: controls + seek bar
+
+    private var controlsSection: some View {
+        VStack(spacing: 6) {
+            self.playbackControls
+
+            if case let .error(message) = playerService.state {
+                self.errorView(message: message)
+            } else if self.playerService.isCurrentItemLive {
+                self.liveIndicatorView
+            } else {
+                self.seekBarView
+            }
+        }
+    }
+
+    // MARK: - Live Indicator View (shown instead of seek bar for live streams)
 
     private var liveIndicatorView: some View {
         HStack(spacing: 8) {
@@ -165,8 +153,21 @@ struct PlayerBar: View {
                 .foregroundStyle(.red)
                 .tracking(0.5)
         }
+        .frame(maxWidth: .infinity, alignment: .center)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(String(localized: "Live stream"))
+    }
+
+    // MARK: - No Track Placeholder
+
+    private var noTrackPlaceholderView: some View {
+        RoundedRectangle(cornerRadius: 4)
+            .fill(.quaternary)
+            .overlay {
+                CassetteIcon(size: 20)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(width: 36, height: 36)
     }
 
     // MARK: - Error View
@@ -200,42 +201,95 @@ struct PlayerBar: View {
         }
     }
 
-    // MARK: - Track Info View
+    // MARK: - Track leading block (artwork + titles)
 
-    private var trackInfoView: some View {
-        HStack(spacing: 10) {
-            // Thumbnail
-            if let track = self.playerService.currentTrack {
-                SongThumbnailView(song: track, size: 36, cornerRadius: 4)
-            } else {
-                RoundedRectangle(cornerRadius: 4)
-                    .fill(.quaternary)
-                    .overlay {
-                        CassetteIcon(size: 20)
-                            .foregroundStyle(.secondary)
-                    }
-                    .frame(width: 36, height: 36)
-            }
-
-            // Track info
-            if let track = playerService.currentTrack {
-                VStack(alignment: .leading, spacing: 1) {
-                    Text(track.title)
-                        .font(.system(size: 12, weight: .medium))
-                        .lineLimit(1)
-                        .foregroundStyle(.primary)
-
-                    Text(track.artistsDisplay.isEmpty ? String(localized: "Unknown Artist") : track.artistsDisplay)
-                        .font(.system(size: 10))
-                        .lineLimit(1)
-                        .foregroundStyle(.secondary)
+    private func trackLeadingBlock(track: Song) -> some View {
+        HStack(alignment: .center, spacing: 10) {
+            if let album = track.album, album.hasNavigableId {
+                NavigationLink(value: Self.playlistForAlbum(album, track: track)) {
+                    SongThumbnailView(song: track, size: 40, cornerRadius: 4)
                 }
-                .frame(maxWidth: 200, alignment: .leading)
+                .buttonStyle(.plain)
+                .help(String(localized: "Open album for this song"))
+            } else {
+                SongThumbnailView(song: track, size: 40, cornerRadius: 4)
             }
+
+            VStack(alignment: .leading, spacing: 3) {
+                self.trackTitleLabel(for: track)
+                self.trackArtistLabel(for: track)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 
-    // MARK: - Seek Bar View (replaces track info on hover)
+    @ViewBuilder
+    private func trackTitleLabel(for track: Song) -> some View {
+        if let album = track.album, album.hasNavigableId {
+            NavigationLink(value: Self.playlistForAlbum(album, track: track)) {
+                Text(track.title)
+                    .font(.system(size: 14, weight: .semibold))
+                    .lineLimit(1)
+                    .foregroundStyle(.primary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.vertical, 3)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier(AccessibilityID.PlayerBar.trackTitle)
+            .accessibilityHint(String(localized: "Open album for this song"))
+            .help(String(localized: "Open album for this song"))
+        } else {
+            Text(track.title)
+                .font(.system(size: 14, weight: .semibold))
+                .lineLimit(1)
+                .foregroundStyle(.primary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.vertical, 3)
+                .accessibilityIdentifier(AccessibilityID.PlayerBar.trackTitle)
+        }
+    }
+
+    @ViewBuilder
+    private func trackArtistLabel(for track: Song) -> some View {
+        let display = track.artistsDisplay.isEmpty ? String(localized: "Unknown Artist") : track.artistsDisplay
+        if let artist = track.artists.first(where: { $0.hasNavigableId }) {
+            NavigationLink(value: artist) {
+                Text(display)
+                    .font(.system(size: 12))
+                    .lineLimit(1)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.vertical, 3)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier(AccessibilityID.PlayerBar.trackArtist)
+            .accessibilityHint(String(localized: "Open artist page"))
+            .help(String(localized: "Open artist page"))
+        } else {
+            Text(display)
+                .font(.system(size: 12))
+                .lineLimit(1)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.vertical, 3)
+                .accessibilityIdentifier(AccessibilityID.PlayerBar.trackArtist)
+        }
+    }
+
+    private static func playlistForAlbum(_ album: Album, track: Song) -> Playlist {
+        Playlist(
+            id: album.id,
+            title: album.title,
+            description: nil,
+            thumbnailURL: album.thumbnailURL ?? track.thumbnailURL,
+            trackCount: album.trackCount,
+            author: Artist.inline(name: album.artistsDisplay, namespace: "album-artist")
+        )
+    }
+
+    // MARK: - Seek Bar View
 
     private var seekBarView: some View {
         HStack(spacing: 10) {
@@ -258,6 +312,8 @@ struct PlayerBar: View {
             }
             .controlSize(.small)
             .tint(Self.brandAccent)
+            .disabled(self.playerService.duration <= 0)
+            .frame(maxWidth: .infinity)
 
             // Remaining time - use cached formatted string when not seeking
             Text(self.isSeeking ? "-\(self.formatTime(self.playerService.duration - self.seekValue * self.playerService.duration))" : self.formattedRemaining)
@@ -573,7 +629,6 @@ struct PlayerBar: View {
 #Preview {
     PlayerBar()
         .environment(PlayerService())
-        .environment(WebKitManager.shared)
         .frame(width: 600)
         .padding()
         .background(Color(nsColor: .windowBackgroundColor))

--- a/Sources/Kaset/Views/PodcastsView.swift
+++ b/Sources/Kaset/Views/PodcastsView.swift
@@ -40,9 +40,9 @@ struct PodcastsView: View {
                 PodcastShowView(show: show, client: self.viewModel.client)
             }
             .navigationDestinations(client: self.viewModel.client)
-        }
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            PlayerBar()
+            .safeAreaInset(edge: .bottom, spacing: 0) {
+                PlayerBar()
+            }
         }
         .onAppear {
             if self.viewModel.loadingState == .idle {

--- a/Sources/Kaset/Views/SearchView.swift
+++ b/Sources/Kaset/Views/SearchView.swift
@@ -41,9 +41,9 @@ struct SearchView: View {
             }
             .localizedNavigationTitle("Search")
             .navigationDestinations(client: self.viewModel.client)
-        }
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            PlayerBar()
+            .safeAreaInset(edge: .bottom, spacing: 0) {
+                PlayerBar()
+            }
         }
         .onAppear {
             self.isSearchFieldFocused = true

--- a/Tests/KasetTests/PlayerServiceTests.swift
+++ b/Tests/KasetTests/PlayerServiceTests.swift
@@ -124,6 +124,92 @@ struct PlayerServiceTests {
         #expect(self.playerService.currentTrack?.thumbnailURL == nil)
     }
 
+    @Test("Web metadata refresh preserves album and navigable artists for same video")
+    func updateTrackMetadataPreservesNavigableMetadataWhenSameVideo() {
+        let album = Album(
+            id: "MPREb_preservetest",
+            title: "Preserved Album",
+            artists: nil,
+            thumbnailURL: nil,
+            year: nil,
+            trackCount: nil
+        )
+        let channelArtist = Artist(
+            id: "UCpreservetestchannelid0",
+            name: "Tony Iommi",
+            thumbnailURL: nil,
+            subtitle: nil,
+            profileKind: .artist
+        )
+        let richSong = Song(
+            id: "v-rich",
+            title: "Original Title",
+            artists: [channelArtist],
+            album: album,
+            duration: 200,
+            thumbnailURL: URL(string: "https://example.com/a.jpg"),
+            videoId: "v-rich"
+        )
+        self.playerService.currentTrack = richSong
+
+        self.playerService.updateTrackMetadata(
+            title: "Title From WebView",
+            artist: "Tony Iommi",
+            thumbnailUrl: "",
+            videoId: "v-rich"
+        )
+
+        #expect(self.playerService.currentTrack?.videoId == "v-rich")
+        #expect(self.playerService.currentTrack?.title == "Title From WebView")
+        #expect(self.playerService.currentTrack?.album?.id == album.id)
+        #expect(self.playerService.currentTrack?.artists.first?.id == channelArtist.id)
+        #expect(self.playerService.currentTrack?.artists.first?.hasNavigableId == true)
+    }
+
+    @Test("Web metadata refresh hydrates album and navigable artists from queue on track change")
+    func updateTrackMetadataPullsAlbumFromQueueOnTrackChange() {
+        let album = Album(
+            id: "MPREb_queuetest",
+            title: "Queue Album",
+            artists: nil,
+            thumbnailURL: nil,
+            year: nil,
+            trackCount: nil
+        )
+        let channelArtist = Artist(
+            id: "UCqueuetestchannelid0",
+            name: "Geezer Butler",
+            thumbnailURL: nil,
+            subtitle: nil,
+            profileKind: .artist
+        )
+        let priorSong = Song(id: "v-prior", title: "Prior", artists: [], album: nil, videoId: "v-prior")
+        let queuedSong = Song(
+            id: "v-next",
+            title: "Queued Title",
+            artists: [channelArtist],
+            album: album,
+            duration: 180,
+            thumbnailURL: URL(string: "https://example.com/q.jpg"),
+            videoId: "v-next"
+        )
+        self.playerService.currentTrack = priorSong
+        self.playerService.setQueue([queuedSong])
+
+        // Simulate WebView reporting an autoplay-driven advance to v-next.
+        self.playerService.updateTrackMetadata(
+            title: "Title From WebView",
+            artist: "Geezer Butler",
+            thumbnailUrl: "",
+            videoId: "v-next"
+        )
+
+        #expect(self.playerService.currentTrack?.videoId == "v-next")
+        #expect(self.playerService.currentTrack?.album?.id == album.id)
+        #expect(self.playerService.currentTrack?.artists.first?.id == channelArtist.id)
+        #expect(self.playerService.currentTrack?.artists.first?.hasNavigableId == true)
+    }
+
     @Test("Confirm playback started")
     func confirmPlaybackStarted() {
         self.playerService.showMiniPlayer = true

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1065,11 +1065,10 @@ A floating capsule-shaped player bar at the bottom of the content area:
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
-│  ◀◀  ▶  ▶▶  │  🎵 [Thumbnail] Song Title - Artist  │  🔊━━━ │
+│  ◀◀  ▶  ▶▶  │  🎵 [Thumb] Song Title (→ album if navigable) │  🔊━━━ │
+│               │           Artist line (→ artist if navigable) │        │
+│               │  0:00 ━━━━━━━━━━━━━━━━━━━━━━━━━━ -3:45        │        │
 └─────────────────────────────────────────────────────────────┘
-         ↑                      ↑                        ↑
-    Playback              Now Playing              Volume
-    Controls               Info                   Control
 ```
 
 **Implementation**:
@@ -1078,7 +1077,7 @@ GlassEffectContainer(spacing: 0) {
     HStack {
         playbackControls
         Spacer()
-        centerSection  // thumbnail + track info
+        centerSection  // metadata row + always-visible seek (or LIVE)
         Spacer()
         volumeControl
     }
@@ -1089,15 +1088,26 @@ GlassEffectContainer(spacing: 0) {
 **Key Points**:
 - Uses `GlassEffectContainer` to wrap glass elements
 - `.glassEffect(.regular.interactive(), in: .capsule)` for the liquid glass look
+- Center column is a `VStack`: track title and artist (`NavigationLink` when `hasNavigableId`; song title opens the album as a `Playlist` destination), then seek bar or LIVE indicator—no hover-to-reveal progress
 - Only shows functional buttons (no placeholder buttons)
-- Thumbnail and track info in center section
 
 ### PlayerBar Integration
 
-The `PlayerBar` must be added to **every navigable view** via `safeAreaInset`:
+The `PlayerBar` must be added to **every navigable view** via `safeAreaInset`. For views that define a `NavigationStack` (Home, Library, Search, etc.), attach the inset **inside** the stack’s root content (chained after `navigationDestinations`) so `NavigationLink` in the bar targets the same stack and path as the rest of the screen.
 
 ```swift
-// In HomeView, LibraryView, SearchView, PlaylistDetailView
+// Tab roots: inset inside NavigationStack
+NavigationStack(path: $navigationPath) {
+    Group { /* content */ }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .localizedNavigationTitle("Home")
+        .navigationDestinations(client: client)
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            PlayerBar()
+        }
+}
+
+// Pushed views (e.g. PlaylistDetailView): inset on the view still works — already under the stack
 .safeAreaInset(edge: .bottom, spacing: 0) {
     PlayerBar()
 }
@@ -1105,7 +1115,7 @@ The `PlayerBar` must be added to **every navigable view** via `safeAreaInset`:
 
 **Why not in MainWindow?**
 - `NavigationSplitView` detail views have their own navigation stacks
-- Views pushed onto a `NavigationStack` don't inherit parent's `safeAreaInset`
+- Tab roots that placed `safeAreaInset` *outside* the `NavigationStack` broke `NavigationLink` from the bar; keeping the inset inside the stack fixes that
 - Each view must explicitly include the `PlayerBar`
 
 ### Sidebar


### PR DESCRIPTION
### Visual Changes
| Before (Hover-to-reveal) | After (3-column layout with Seek Bar and clickable links) |
| :--- | :--- |
| ![Before](https://github.com/user-attachments/assets/3b9aa3bb-5bb5-4834-af04-7619a8dd3b9f) | ![After](https://github.com/user-attachments/assets/f90c1ad2-ad48-4411-9c60-2d25660143a3) |

# Description
This PR introduces a significant redesign of the **PlayerBar** and fixes metadata synchronization issues during autoplay transitions.

### Key Changes:
* **PlayerBar Redesign:** 
    * Implemented a permanent 3-column layout: `[Track Info] | [Controls + Seek] | [Volume]`.
    * The seek bar is now always visible, improving feature discoverability.
    * Track title, artist, and album art are now interactive `NavigationLinks`, allowing direct navigation to their respective pages (when available).
* **Bug Fixes:**
    * Fixed a race condition in `PlayerService+WebQueueSync` where autoplay transitions would briefly drop metadata while waiting for the background fetch.
    * Moved `safeAreaInset` inside the `NavigationStack` on all tab roots to ensure navigation from the bar works correctly.

### Why?
* **UX/Accessibility:** The previous hover-to-reveal seek bar was not discoverable.
* **Consistency:** Making track information tappable aligns the app with modern media player expectations.
* **Data Integrity:** The metadata "flicker" during autoplay advances affected the overall polish of the app.

### Tests Performed
* **Unit Tests:** Added 2 new tests to validate the `metadata-merge` logic.
* **Verification:** 
    * Ran `swift build` and `swift test --skip KasetUITests`.
    * Validated code style with `swiftlint --strict` and `swiftformat .`.
    * All local checks passed successfully.

---
### AI Assistance
Used **Claude Code** to assist with layout refactoring and metadata logic.
> **Prompt:** *Redesign PlayerBar with a 3-column layout (track info left, controls + seek center, volume right) and make the seek bar always visible. Make track title, artist, and album art NavigationLinks. Fix PlayerService+WebQueueSync metadata preservation. Move safeAreaInset inside NavigationStack.*