### PR TITLE
fix(podcasts): hide tab in regions where YT Music returns 404

### DIFF
--- a/Sources/Kaset/KasetApp.swift
+++ b/Sources/Kaset/KasetApp.swift
@@ -40,6 +40,7 @@ struct KasetApp: App {
     @State private var syncedLyricsService: SyncedLyricsService
     @State private var equalizerService = EqualizerService.shared
     @State private var settings = SettingsManager.shared
+    @State private var podcastsAvailabilityService = PodcastsAvailabilityService()
 
     /// Triggers search field focus when set to true.
     @State private var searchFocusTrigger = false
@@ -133,6 +134,7 @@ struct KasetApp: App {
                     .environment(self.scrobblingCoordinator)
                     .environment(self.syncedLyricsService)
                     .environment(self.equalizerService)
+                    .environment(self.podcastsAvailabilityService)
                     .environment(\.searchFocusTrigger, self.$searchFocusTrigger)
                     .environment(\.navigationSelection, self.$navigationSelection)
                     .environment(\.showCommandBar, self.$showCommandBar)

--- a/Sources/Kaset/Services/API/MockUITestYTMusicClient.swift
+++ b/Sources/Kaset/Services/API/MockUITestYTMusicClient.swift
@@ -127,6 +127,9 @@ final class MockUITestYTMusicClient: YTMusicClientProtocol {
 
     func getPodcasts() async throws -> [PodcastSection] {
         try? await Task.sleep(for: .milliseconds(100))
+        if UITestConfig.environmentValue(for: UITestConfig.mockPodcastsRegionUnavailableKey) == "true" {
+            throw YTMusicError.apiError(message: "HTTP 404", code: 404)
+        }
         return []
     }
 

--- a/Sources/Kaset/Services/PodcastsAvailabilityService.swift
+++ b/Sources/Kaset/Services/PodcastsAvailabilityService.swift
@@ -41,7 +41,24 @@ final class PodcastsAvailabilityService {
     /// (`PodcastsViewModel.load`) demotes the state.
     static let firstProbeGateTimeout: Duration = .seconds(2)
 
+    private var accountScope: AccountScope = .unconfigured
+    private var generation = 0
+
     init() {}
+
+    // MARK: - Account scope
+
+    /// Records the currently-active account without changing the visible
+    /// availability state. This invalidates in-flight probes from the
+    /// previous account so a late completion cannot mutate the new
+    /// account's state.
+    func activateAccount(_ accountId: String?) {
+        let scope = AccountScope.account(Self.normalizedAccountId(accountId))
+        guard self.accountScope != scope else { return }
+
+        self.accountScope = scope
+        self.generation += 1
+    }
 
     // MARK: - Probing
 
@@ -55,6 +72,8 @@ final class PodcastsAvailabilityService {
         using client: any YTMusicClientProtocol,
         timeout: Duration = firstProbeGateTimeout
     ) async {
+        self.activateAccount(accountId)
+
         // Spawn the probe as an unstructured task so the timeout race
         // below can return without waiting on it. `probe(...)` updates
         // `availability` and `didResolveFirstProbe` itself when it
@@ -81,12 +100,13 @@ final class PodcastsAvailabilityService {
 
         // If our caller has been cancelled (e.g. logout flipped
         // `state.isLoggedIn`), tear down the probe and leave the gate
-        // for `reset()` to manage. Otherwise release it.
+        // for `reset()` to manage. Otherwise release it only if this
+        // first-resolution request still belongs to the active account.
         if Task.isCancelled {
             probeTask.cancel()
             return
         }
-        self.didResolveFirstProbe = true
+        self.resolveFirstProbeGateIfActive(for: accountId)
     }
 
     /// Calls `client.getPodcasts()` and updates `availability` based on
@@ -97,11 +117,16 @@ final class PodcastsAvailabilityService {
         for accountId: String?,
         using client: any YTMusicClientProtocol
     ) async -> Availability {
-        let label = Self.normalizedAccountId(accountId)
+        let token = self.beginProbe(for: accountId)
+        let label = token.accountId
         DiagnosticsLogger.api.info("Probing podcasts availability for account=\(label)")
 
         do {
             let sections = try await client.getPodcasts()
+            guard self.shouldApplyProbeResult(token, outcome: "success") else {
+                return self.availability
+            }
+
             if sections.isEmpty {
                 // Empty payload from a probe is not authoritative — leave
                 // the state alone and let the user-initiated path
@@ -114,6 +139,10 @@ final class PodcastsAvailabilityService {
             self.didResolveFirstProbe = true
             return .available
         } catch let YTMusicError.apiError(_, code) where code == 404 {
+            guard self.shouldApplyProbeResult(token, outcome: "HTTP 404") else {
+                return self.availability
+            }
+
             DiagnosticsLogger.api.info("Probe returned HTTP 404; podcasts unavailable for account=\(label)")
             self.availability = .unavailable
             self.didResolveFirstProbe = true
@@ -124,6 +153,10 @@ final class PodcastsAvailabilityService {
             DiagnosticsLogger.api.debug("Probe cancelled for account=\(label)")
             return self.availability
         } catch {
+            guard self.shouldApplyProbeResult(token, outcome: "inconclusive") else {
+                return self.availability
+            }
+
             // Transient (5xx, network, auth). Don't change state — let
             // the lazy 404 path or the next session re-evaluate. Still
             // mark the gate as resolved so the UI doesn't hang behind
@@ -137,16 +170,22 @@ final class PodcastsAvailabilityService {
     // MARK: - Lazy signals (from PodcastsViewModel)
 
     /// Marks podcasts as unavailable based on a user-initiated load
-    /// that hit 404 or returned an empty payload. The caller is on the
-    /// active account, so this is always authoritative.
-    func markUnavailable(for _: String?) {
+    /// that hit 404 or returned an empty payload. The signal is applied
+    /// only when it still belongs to the active account.
+    func markUnavailable(for accountId: String?) {
+        guard self.shouldApplyLazySignal(for: accountId, outcome: "unavailable") else { return }
+
+        self.generation += 1
         self.availability = .unavailable
         self.didResolveFirstProbe = true
     }
 
     /// Marks podcasts as available based on a user-initiated load that
     /// returned a non-empty payload.
-    func markAvailable(for _: String?) {
+    func markAvailable(for accountId: String?) {
+        guard self.shouldApplyLazySignal(for: accountId, outcome: "available") else { return }
+
+        self.generation += 1
         self.availability = .available
         self.didResolveFirstProbe = true
     }
@@ -156,12 +195,77 @@ final class PodcastsAvailabilityService {
     /// Resets state so the next sign-in re-gates the UI and re-probes.
     /// Called on logout.
     func reset() {
+        self.accountScope = .loggedOut
+        self.generation += 1
         self.availability = .unknown
         self.didResolveFirstProbe = false
     }
 
+    private func beginProbe(for accountId: String?) -> ProbeToken {
+        self.activateAccount(accountId)
+        self.generation += 1
+        return ProbeToken(
+            accountId: Self.normalizedAccountId(accountId),
+            generation: self.generation
+        )
+    }
+
+    private func shouldApplyProbeResult(
+        _ token: ProbeToken,
+        outcome: String
+    ) -> Bool {
+        guard self.accountScope == .account(token.accountId),
+              self.generation == token.generation
+        else {
+            DiagnosticsLogger.api.debug("Ignoring stale podcasts availability probe for account=\(token.accountId), outcome=\(outcome)")
+            return false
+        }
+        return true
+    }
+
+    private func shouldApplyLazySignal(for accountId: String?, outcome: String) -> Bool {
+        let normalizedAccountId = Self.normalizedAccountId(accountId)
+        switch self.accountScope {
+        case .unconfigured:
+            self.accountScope = .account(normalizedAccountId)
+            self.generation += 1
+            return true
+        case .loggedOut:
+            DiagnosticsLogger.api.debug("Ignoring podcasts availability signal while logged out for account=\(normalizedAccountId), outcome=\(outcome)")
+            return false
+        case let .account(activeAccountId):
+            guard activeAccountId == normalizedAccountId else {
+                DiagnosticsLogger.api.debug("Ignoring stale podcasts availability signal for account=\(normalizedAccountId), outcome=\(outcome)")
+                return false
+            }
+            return true
+        }
+    }
+
+    private func resolveFirstProbeGateIfActive(for accountId: String?) {
+        let normalizedAccountId = Self.normalizedAccountId(accountId)
+        guard self.accountScope == .account(normalizedAccountId) else {
+            DiagnosticsLogger.api.debug("Ignoring stale first podcasts probe gate for account=\(normalizedAccountId)")
+            return
+        }
+        self.didResolveFirstProbe = true
+    }
+
     private static func normalizedAccountId(_ accountId: String?) -> String {
         accountId ?? "primary"
+    }
+}
+
+private extension PodcastsAvailabilityService {
+    enum AccountScope: Equatable {
+        case unconfigured
+        case loggedOut
+        case account(String)
+    }
+
+    struct ProbeToken: Equatable {
+        let accountId: String
+        let generation: Int
     }
 }
 

--- a/Sources/Kaset/Services/PodcastsAvailabilityService.swift
+++ b/Sources/Kaset/Services/PodcastsAvailabilityService.swift
@@ -1,0 +1,183 @@
+import Foundation
+import Observation
+
+// MARK: - PodcastsAvailabilityService
+
+/// Tracks whether the YouTube Music Podcasts discovery surface is
+/// available for the current session. YouTube does not offer the surface
+/// in every region, and `FEmusic_podcasts` returns HTTP 404 in those
+/// regions. The sidebar consults this service to hide the row when the
+/// endpoint is known to be unavailable.
+///
+/// State is in-memory only — no persistence. Each app launch re-probes
+/// from scratch so a region change (e.g. enabling a VPN before
+/// relaunching) is reflected without sign-out/in. The owning view
+/// defers rendering main content until `didResolveFirstProbe` flips, so
+/// the user never sees the Podcasts row appear-then-disappear.
+@MainActor
+@Observable
+final class PodcastsAvailabilityService {
+    enum Availability: Equatable {
+        case unknown
+        case available
+        case unavailable
+    }
+
+    /// Current state. `Sidebar` reads this to decide whether to render
+    /// the Podcasts row (renders on `.unknown` and `.available`, hides on
+    /// `.unavailable`).
+    private(set) var availability: Availability = .unknown
+
+    /// `true` once the first probe of the session resolves (success,
+    /// 404, transient error) or the timeout fires. `MainWindow` uses
+    /// this as a UI gate — main content renders only after this flips,
+    /// so the sidebar paints with the correct state on first frame.
+    private(set) var didResolveFirstProbe: Bool = false
+
+    /// Maximum time the gate waits for the first probe before failing
+    /// open and letting the sidebar render with `availability` still
+    /// `.unknown` (which displays the same as `.available`). If the
+    /// probe later returns 404, the lazy path
+    /// (`PodcastsViewModel.load`) demotes the state.
+    static let firstProbeGateTimeout: Duration = .seconds(2)
+
+    init() {}
+
+    // MARK: - Probing
+
+    /// Runs the first probe of the session and resolves the UI gate.
+    /// Returns when the probe completes OR the timeout fires —
+    /// whichever happens first. The probe always runs to completion in
+    /// the background regardless of the timeout, so a slow-but-definite
+    /// 404 still demotes the tab when it lands.
+    func probeForFirstResolution(
+        for accountId: String?,
+        using client: any YTMusicClientProtocol,
+        timeout: Duration = firstProbeGateTimeout
+    ) async {
+        // Spawn the probe as an unstructured task so the timeout race
+        // below can return without waiting on it. `probe(...)` updates
+        // `availability` and `didResolveFirstProbe` itself when it
+        // finishes — even after the timeout has already released the
+        // gate, a late 404 still demotes the tab.
+        let probeTask = Task { [weak self] in
+            _ = await self?.probe(for: accountId, using: client)
+        }
+
+        // Race: the first of (probe finishes) and (timeout fires) wins.
+        // A single-resume latch + checked continuation lets the loser's
+        // task continue running without being awaited.
+        let latch = ResumeLatch()
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            Task { @MainActor in
+                try? await Task.sleep(for: timeout)
+                latch.tryResume(continuation)
+            }
+            Task { @MainActor in
+                _ = await probeTask.value
+                latch.tryResume(continuation)
+            }
+        }
+
+        // If our caller has been cancelled (e.g. logout flipped
+        // `state.isLoggedIn`), tear down the probe and leave the gate
+        // for `reset()` to manage. Otherwise release it.
+        if Task.isCancelled {
+            probeTask.cancel()
+            return
+        }
+        self.didResolveFirstProbe = true
+    }
+
+    /// Calls `client.getPodcasts()` and updates `availability` based on
+    /// the result. Used by `probeForFirstResolution` and by the account
+    /// switch flow in `MainWindow`.
+    @discardableResult
+    func probe(
+        for accountId: String?,
+        using client: any YTMusicClientProtocol
+    ) async -> Availability {
+        let label = Self.normalizedAccountId(accountId)
+        DiagnosticsLogger.api.info("Probing podcasts availability for account=\(label)")
+
+        do {
+            let sections = try await client.getPodcasts()
+            if sections.isEmpty {
+                // Empty payload from a probe is not authoritative — leave
+                // the state alone and let the user-initiated path
+                // (`PodcastsViewModel.load`) confirm.
+                DiagnosticsLogger.api.info("Probe returned 0 sections; leaving availability=\(String(describing: self.availability))")
+                self.didResolveFirstProbe = true
+                return self.availability
+            }
+            self.availability = .available
+            self.didResolveFirstProbe = true
+            return .available
+        } catch let YTMusicError.apiError(_, code) where code == 404 {
+            DiagnosticsLogger.api.info("Probe returned HTTP 404; podcasts unavailable for account=\(label)")
+            self.availability = .unavailable
+            self.didResolveFirstProbe = true
+            return .unavailable
+        } catch is CancellationError {
+            // Cancelled (e.g. user logged out before probe completed).
+            // Don't touch state — `reset()` is the authoritative path.
+            DiagnosticsLogger.api.debug("Probe cancelled for account=\(label)")
+            return self.availability
+        } catch {
+            // Transient (5xx, network, auth). Don't change state — let
+            // the lazy 404 path or the next session re-evaluate. Still
+            // mark the gate as resolved so the UI doesn't hang behind
+            // a flaky network.
+            DiagnosticsLogger.api.debug("Probe inconclusive for account=\(label): \(error.localizedDescription)")
+            self.didResolveFirstProbe = true
+            return self.availability
+        }
+    }
+
+    // MARK: - Lazy signals (from PodcastsViewModel)
+
+    /// Marks podcasts as unavailable based on a user-initiated load
+    /// that hit 404 or returned an empty payload. The caller is on the
+    /// active account, so this is always authoritative.
+    func markUnavailable(for _: String?) {
+        self.availability = .unavailable
+        self.didResolveFirstProbe = true
+    }
+
+    /// Marks podcasts as available based on a user-initiated load that
+    /// returned a non-empty payload.
+    func markAvailable(for _: String?) {
+        self.availability = .available
+        self.didResolveFirstProbe = true
+    }
+
+    // MARK: - Lifecycle
+
+    /// Resets state so the next sign-in re-gates the UI and re-probes.
+    /// Called on logout.
+    func reset() {
+        self.availability = .unknown
+        self.didResolveFirstProbe = false
+    }
+
+    private static func normalizedAccountId(_ accountId: String?) -> String {
+        accountId ?? "primary"
+    }
+}
+
+// MARK: - ResumeLatch
+
+/// Single-resume gate used by `probeForFirstResolution` to race two
+/// `@MainActor`-isolated tasks (probe completion vs timeout). The loser
+/// observes `tryResume` as a no-op and exits silently. Isolated to the
+/// main actor so the latch needs no additional synchronisation.
+@MainActor
+private final class ResumeLatch {
+    private var resumed = false
+
+    func tryResume(_ continuation: CheckedContinuation<Void, Never>) {
+        guard !self.resumed else { return }
+        self.resumed = true
+        continuation.resume()
+    }
+}

--- a/Sources/Kaset/Utilities/UITestConfig.swift
+++ b/Sources/Kaset/Utilities/UITestConfig.swift
@@ -46,6 +46,11 @@ enum UITestConfig {
     /// When true, force logged-out state in UI tests.
     static let mockLoggedOutKey = "MOCK_LOGGED_OUT"
 
+    /// When true, the mock client returns HTTP 404 from `getPodcasts()`
+    /// to simulate a region where YouTube Music does not offer the
+    /// Podcasts discovery surface. Used to UI-test sidebar visibility.
+    static let mockPodcastsRegionUnavailableKey = "MOCK_PODCASTS_REGION_UNAVAILABLE"
+
     // MARK: - Detection
 
     /// Returns true if the app was launched in UI test mode.

--- a/Sources/Kaset/ViewModels/PodcastsViewModel.swift
+++ b/Sources/Kaset/ViewModels/PodcastsViewModel.swift
@@ -16,6 +16,15 @@ final class PodcastsViewModel {
 
     /// The API client (exposed for navigation to detail views).
     let client: any YTMusicClientProtocol
+    /// Service that tracks per-account region availability of the
+    /// podcasts discovery surface. Configured post-init by the owning
+    /// view so existing call sites/previews can construct the viewmodel
+    /// without the service.
+    private(set) var availabilityService: PodcastsAvailabilityService?
+    /// Account id that owns the current load — passed through to
+    /// `availabilityService` so 404 / empty results are recorded against
+    /// the right key. Updated by `configure` on account switches.
+    private(set) var accountId: String?
     private let logger = DiagnosticsLogger.api
     // swiftformat:disable modifierOrder
     /// Task for background loading, cancelled in deinit.
@@ -29,8 +38,25 @@ final class PodcastsViewModel {
     /// Maximum continuations to load in background.
     private static let maxContinuations = 4
 
-    init(client: any YTMusicClientProtocol) {
+    init(
+        client: any YTMusicClientProtocol,
+        availabilityService: PodcastsAvailabilityService? = nil,
+        accountId: String? = nil
+    ) {
         self.client = client
+        self.availabilityService = availabilityService
+        self.accountId = accountId
+    }
+
+    /// Wires the viewmodel up to the availability service and the
+    /// currently-active account. Called by `MainWindow` on first display
+    /// and whenever the active account changes. Safe to call repeatedly.
+    func configure(
+        availabilityService: PodcastsAvailabilityService?,
+        accountId: String?
+    ) {
+        self.availabilityService = availabilityService
+        self.accountId = accountId
     }
 
     deinit {
@@ -53,12 +79,32 @@ final class PodcastsViewModel {
             let sectionCount = self.sections.count
             self.logger.info("Podcasts content loaded: \(sectionCount) sections")
 
-            // Start background loading of additional sections
-            self.startBackgroundLoading()
+            // Tell the availability service what we just observed. A
+            // user-initiated load is authoritative, so empty payloads
+            // count as "unavailable" here (unlike the background probe).
+            if self.sections.isEmpty {
+                self.availabilityService?.markUnavailable(for: self.accountId)
+            } else {
+                self.availabilityService?.markAvailable(for: self.accountId)
+                // Only continue progressive loading when there's real
+                // content; an empty payload means there's nothing to
+                // continue and the tab is about to disappear anyway.
+                self.startBackgroundLoading()
+            }
         } catch is CancellationError {
             // Task was cancelled (e.g., user navigated away) — reset to idle so it can retry
             self.logger.debug("Podcasts load cancelled")
             self.loadingState = .idle
+        } catch let YTMusicError.apiError(_, code) where code == 404 {
+            // Region without podcasts. Land on `.loaded` with empty
+            // sections — the sidebar row will disappear within a frame
+            // via the availability service, so a generic error toast
+            // would be misleading.
+            self.logger.info("Podcasts endpoint returned 404; marking region unavailable")
+            self.sections = []
+            self.hasMoreSections = false
+            self.loadingState = .loaded
+            self.availabilityService?.markUnavailable(for: self.accountId)
         } catch {
             self.logger.error("Failed to load podcasts: \(error.localizedDescription)")
             self.loadingState = .error(LoadingError(from: error))

--- a/Sources/Kaset/ViewModels/PodcastsViewModel.swift
+++ b/Sources/Kaset/ViewModels/PodcastsViewModel.swift
@@ -35,6 +35,11 @@ final class PodcastsViewModel {
     /// Number of background continuations loaded.
     private var continuationsLoaded = 0
 
+    /// Incremented whenever foreground load results should no longer be
+    /// allowed to mutate this view model (account switch, refresh, or a
+    /// newer load).
+    private var loadGeneration = 0
+
     /// Maximum continuations to load in background.
     private static let maxContinuations = 4
 
@@ -55,8 +60,14 @@ final class PodcastsViewModel {
         availabilityService: PodcastsAvailabilityService?,
         accountId: String?
     ) {
+        let accountChanged = self.accountId != accountId
+
         self.availabilityService = availabilityService
         self.accountId = accountId
+
+        if accountChanged {
+            self.resetContentForAccountSwitch()
+        }
     }
 
     deinit {
@@ -67,12 +78,21 @@ final class PodcastsViewModel {
     func load() async {
         guard self.loadingState != .loading else { return }
 
+        self.loadGeneration += 1
+        let loadGeneration = self.loadGeneration
+        let loadAccountId = self.accountId
+
         self.loadingState = .loading
         self.logger.info("Loading podcasts content")
 
         do {
-            self.sections = try await self.client.getPodcasts()
+            let sections = try await self.client.getPodcasts()
+            guard self.isCurrentLoad(generation: loadGeneration, accountId: loadAccountId) else {
+                self.logger.debug("Ignoring stale podcasts load result")
+                return
+            }
 
+            self.sections = sections
             self.hasMoreSections = self.client.hasMorePodcastsSections
             self.loadingState = .loaded
             self.continuationsLoaded = 0
@@ -83,19 +103,26 @@ final class PodcastsViewModel {
             // user-initiated load is authoritative, so empty payloads
             // count as "unavailable" here (unlike the background probe).
             if self.sections.isEmpty {
-                self.availabilityService?.markUnavailable(for: self.accountId)
+                self.availabilityService?.markUnavailable(for: loadAccountId)
             } else {
-                self.availabilityService?.markAvailable(for: self.accountId)
+                self.availabilityService?.markAvailable(for: loadAccountId)
                 // Only continue progressive loading when there's real
                 // content; an empty payload means there's nothing to
                 // continue and the tab is about to disappear anyway.
                 self.startBackgroundLoading()
             }
         } catch is CancellationError {
+            guard self.isCurrentLoad(generation: loadGeneration, accountId: loadAccountId) else { return }
+
             // Task was cancelled (e.g., user navigated away) — reset to idle so it can retry
             self.logger.debug("Podcasts load cancelled")
             self.loadingState = .idle
         } catch let YTMusicError.apiError(_, code) where code == 404 {
+            guard self.isCurrentLoad(generation: loadGeneration, accountId: loadAccountId) else {
+                self.logger.debug("Ignoring stale podcasts 404")
+                return
+            }
+
             // Region without podcasts. Land on `.loaded` with empty
             // sections — the sidebar row will disappear within a frame
             // via the availability service, so a generic error toast
@@ -104,8 +131,13 @@ final class PodcastsViewModel {
             self.sections = []
             self.hasMoreSections = false
             self.loadingState = .loaded
-            self.availabilityService?.markUnavailable(for: self.accountId)
+            self.availabilityService?.markUnavailable(for: loadAccountId)
         } catch {
+            guard self.isCurrentLoad(generation: loadGeneration, accountId: loadAccountId) else {
+                self.logger.debug("Ignoring stale podcasts load failure")
+                return
+            }
+
             self.logger.error("Failed to load podcasts: \(error.localizedDescription)")
             self.loadingState = .error(LoadingError(from: error))
         }
@@ -114,6 +146,8 @@ final class PodcastsViewModel {
     /// Loads more sections in the background progressively.
     private func startBackgroundLoading() {
         self.backgroundLoadTask?.cancel()
+        let backgroundGeneration = self.loadGeneration
+        let backgroundAccountId = self.accountId
         self.backgroundLoadTask = Task { [weak self] in
             guard let self else { return }
 
@@ -122,17 +156,25 @@ final class PodcastsViewModel {
 
             guard !Task.isCancelled else { return }
 
-            await self.loadMoreSections()
+            await self.loadMoreSections(generation: backgroundGeneration, accountId: backgroundAccountId)
         }
     }
 
     /// Loads additional sections from continuations progressively.
-    private func loadMoreSections() async {
+    private func loadMoreSections(generation: Int, accountId: String?) async {
         while self.hasMoreSections, self.continuationsLoaded < Self.maxContinuations {
-            guard self.loadingState == .loaded else { break }
+            guard self.loadingState == .loaded,
+                  self.isCurrentLoad(generation: generation, accountId: accountId),
+                  !Task.isCancelled
+            else { break }
 
             do {
-                if let additionalSections = try await client.getPodcastsContinuation() {
+                let additionalSections = try await client.getPodcastsContinuation()
+                guard self.isCurrentLoad(generation: generation, accountId: accountId),
+                      !Task.isCancelled
+                else { break }
+
+                if let additionalSections {
                     self.sections.append(contentsOf: additionalSections)
                     self.continuationsLoaded += 1
                     self.hasMoreSections = self.client.hasMorePodcastsSections
@@ -158,9 +200,24 @@ final class PodcastsViewModel {
     /// Refreshes podcasts content.
     func refresh() async {
         self.backgroundLoadTask?.cancel()
+        self.loadGeneration += 1
         self.sections = []
         self.hasMoreSections = true
         self.continuationsLoaded = 0
+        self.loadingState = .idle
         await self.load()
+    }
+
+    private func resetContentForAccountSwitch() {
+        self.backgroundLoadTask?.cancel()
+        self.loadGeneration += 1
+        self.sections = []
+        self.hasMoreSections = true
+        self.continuationsLoaded = 0
+        self.loadingState = .idle
+    }
+
+    private func isCurrentLoad(generation: Int, accountId: String?) -> Bool {
+        generation == self.loadGeneration && accountId == self.accountId
     }
 }

--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -215,6 +215,13 @@ struct MainWindow: View {
         }
         .onChange(of: self.accountService.currentAccount?.id) { _, newAccountId in
             self.playerService.resetTrackStatus()
+            self.podcastsViewModel?.configure(
+                availabilityService: self.podcastsAvailability,
+                accountId: newAccountId
+            )
+            if let newAccountId {
+                self.podcastsAvailability.activateAccount(newAccountId)
+            }
 
             Task { @MainActor in
                 APICache.shared.invalidateAll()
@@ -251,12 +258,22 @@ struct MainWindow: View {
                 }
             }
         }
-        .onChange(of: self.podcastsAvailability.availability) { _, newValue in
+        .onChange(of: self.podcastsAvailability.availability) { oldValue, newValue in
             // If the user is sitting on the Podcasts tab when it flips
             // unavailable, redirect to Home so they don't end up on a
             // sidebar row that no longer exists.
             if newValue == .unavailable, self.navigationSelection == .podcasts {
                 self.navigationSelection = .home
+            }
+
+            // Switching back from an unavailable account keeps the
+            // Podcasts VM reset/idle until the probe confirms the new
+            // account is available. Eagerly refresh then so the tab does
+            // not remain on the prior account's loaded-empty state.
+            if oldValue == .unavailable, newValue == .available {
+                Task { @MainActor in
+                    await self.podcastsViewModel?.refresh()
+                }
             }
         }
         .task {
@@ -265,9 +282,13 @@ struct MainWindow: View {
         .task(id: self.accountService.currentAccount?.id) {
             // Keep PodcastsViewModel in sync with the active account so
             // 404 / empty results are recorded against the right account.
+            let accountId = self.accountService.currentAccount?.id
+            if let accountId {
+                self.podcastsAvailability.activateAccount(accountId)
+            }
             self.podcastsViewModel?.configure(
                 availabilityService: self.podcastsAvailability,
-                accountId: self.accountService.currentAccount?.id
+                accountId: accountId
             )
         }
         .task(id: self.authService.state.isLoggedIn) {

--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -23,6 +23,7 @@ struct MainWindow: View {
     @Environment(WebKitManager.self) private var webKitManager
     @Environment(AccountService.self) private var accountService
     @Environment(SongLikeStatusManager.self) private var likeStatusManager
+    @Environment(PodcastsAvailabilityService.self) private var podcastsAvailability
     @Environment(\.searchFocusTrigger) private var searchFocusTrigger
     @Environment(\.showCommandBar) private var showCommandBar
     @Environment(\.showWhatsNew) private var showWhatsNew
@@ -91,7 +92,14 @@ struct MainWindow: View {
                     // Show loading while checking login status to avoid onboarding flash
                     self.initializingView
                 } else if self.authService.state.isLoggedIn {
-                    self.mainContent
+                    if self.podcastsAvailability.didResolveFirstProbe {
+                        self.mainContent
+                    } else {
+                        // Hold the same loading view until the podcasts
+                        // probe resolves so the sidebar paints with the
+                        // correct state on first frame.
+                        self.initializingView
+                    }
                 } else {
                     OnboardingView()
                 }
@@ -210,11 +218,23 @@ struct MainWindow: View {
 
                 self.historyViewModel?.reset()
 
+                // Brand accounts can have a different region than the
+                // primary; re-probe in the background so the sidebar
+                // reflects the new account. We deliberately do NOT
+                // reset the gate (`didResolveFirstProbe`) here — that
+                // would tear down `mainContent` and show the loading
+                // spinner full-screen during the switch. Sidebar may
+                // briefly show the prior account's tab state until the
+                // probe lands.
                 DiagnosticsLogger.auth.info("Account switched, refreshing content and current track metadata...")
 
                 await withTaskGroup(of: Void.self) { group in
                     group.addTask {
                         await self.refreshAllContent()
+                    }
+
+                    group.addTask {
+                        await self.podcastsAvailability.probe(for: newAccountId, using: self.client)
                     }
 
                     if let currentVideoId = self.playerService.currentTrack?.videoId {
@@ -225,8 +245,41 @@ struct MainWindow: View {
                 }
             }
         }
+        .onChange(of: self.podcastsAvailability.availability) { _, newValue in
+            // If the user is sitting on the Podcasts tab when it flips
+            // unavailable, redirect to Home so they don't end up on a
+            // sidebar row that no longer exists.
+            if newValue == .unavailable, self.navigationSelection == .podcasts {
+                self.navigationSelection = .home
+            }
+        }
         .task {
             NowPlayingManager.shared.configure(playerService: self.playerService)
+        }
+        .task(id: self.accountService.currentAccount?.id) {
+            // Keep PodcastsViewModel in sync with the active account so
+            // 404 / empty results are recorded against the right account.
+            self.podcastsViewModel?.configure(
+                availabilityService: self.podcastsAvailability,
+                accountId: self.accountService.currentAccount?.id
+            )
+        }
+        .task(id: self.authService.state.isLoggedIn) {
+            // Run the podcasts availability probe whenever the user
+            // becomes logged in (cold start with cached cookies, or
+            // after an explicit sign-in). The result gates `mainContent`
+            // via `didResolveFirstProbe`, so the sidebar paints with the
+            // correct state on first frame — no flicker.
+            guard self.authService.state.isLoggedIn else { return }
+            // Brief delay so post-login cookies have a chance to settle
+            // into the data store the API client reads from. On cold
+            // start cookies are already there; this 200 ms is a small
+            // safety margin and is invisible behind the spinner.
+            try? await Task.sleep(for: .milliseconds(200))
+            await self.podcastsAvailability.probeForFirstResolution(
+                for: self.accountService.currentAccount?.id,
+                using: self.client
+            )
         }
         .onChange(of: self.likeStatusManager.lastLikeEvent) { _, event in
             guard let event else { return }
@@ -430,6 +483,9 @@ struct MainWindow: View {
         case .loggedOut:
             // Onboarding view handles login, no need to auto-show sheet
             self.accountService.clearAccounts()
+            // Reset podcasts availability so the next sign-in re-gates
+            // the UI and re-probes the endpoint.
+            self.podcastsAvailability.reset()
         case .loggingIn:
             self.showLoginSheet = true
         case .loggedIn:
@@ -450,7 +506,9 @@ struct MainWindow: View {
                     // Brief delay to ensure cookies are fully propagated in WebKit
                     try? await Task.sleep(for: .milliseconds(500))
 
-                    // Parallel initial data fetch for ~40% faster app launch
+                    // Parallel initial data fetch for ~40% faster app launch.
+                    // The podcasts probe is driven separately by the
+                    // `.task(id: state.isLoggedIn)` UI gate below.
                     await withTaskGroup(of: Void.self) { group in
                         group.addTask { await self.homeViewModel?.refresh() }
                         group.addTask { await self.exploreViewModel?.refresh() }
@@ -491,14 +549,22 @@ struct MainWindow: View {
     /// This method is called when the user switches between their primary account
     /// and brand accounts, ensuring all views display content for the new account.
     private func refreshAllContent() async {
-        // Parallel refresh of all content views
+        // Parallel refresh of all content views.
+        // The podcasts refresh is gated on the latest availability
+        // signal so a brand-account switch into a region without
+        // podcasts doesn't fire the spurious 404 the bug is about. The
+        // probe scheduled alongside this group will re-evaluate
+        // availability separately.
+        let podcastsAvailable = self.podcastsAvailability.availability != .unavailable
         await withTaskGroup(of: Void.self) { group in
             group.addTask { await self.homeViewModel?.refresh() }
             group.addTask { await self.exploreViewModel?.refresh() }
             group.addTask { await self.chartsViewModel?.refresh() }
             group.addTask { await self.moodsAndGenresViewModel?.refresh() }
             group.addTask { await self.newReleasesViewModel?.refresh() }
-            group.addTask { await self.podcastsViewModel?.refresh() }
+            if podcastsAvailable {
+                group.addTask { await self.podcastsViewModel?.refresh() }
+            }
             group.addTask { await self.likedMusicViewModel?.refresh() }
             group.addTask { await self.historyViewModel?.load() }
             group.addTask { await self.libraryViewModel?.refresh() }

--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -92,7 +92,13 @@ struct MainWindow: View {
                     // Show loading while checking login status to avoid onboarding flash
                     self.initializingView
                 } else if self.authService.state.isLoggedIn {
-                    if self.podcastsAvailability.didResolveFirstProbe {
+                    // Skip the probe gate in UI test mode: existing test
+                    // fixtures (e.g. `navigateToSidebarItem`) check
+                    // sidebar element existence synchronously right after
+                    // launch and don't tolerate the ~300 ms gate delay.
+                    // The probe still fires in the background so the
+                    // `MOCK_PODCASTS_REGION_UNAVAILABLE` path works.
+                    if self.podcastsAvailability.didResolveFirstProbe || UITestConfig.isUITestMode {
                         self.mainContent
                     } else {
                         // Hold the same loading view until the podcasts

--- a/Sources/Kaset/Views/Sidebar.swift
+++ b/Sources/Kaset/Views/Sidebar.swift
@@ -11,6 +11,7 @@ struct Sidebar: View {
     @Binding var selection: NavigationItem?
     @Binding var pinnedSelection: SidebarPinnedItem?
     @Environment(SidebarPinnedItemsManager.self) private var sidebarPinnedItemsManager
+    @Environment(PodcastsAvailabilityService.self) private var podcastsAvailability
 
     /// Namespace for glass effect morphing.
     @Namespace private var sidebarNamespace
@@ -54,10 +55,12 @@ struct Sidebar: View {
                         }
                         .accessibilityIdentifier(AccessibilityID.Sidebar.newReleasesItem)
 
-                        NavigationLink(value: SidebarSelection.navigation(.podcasts)) {
-                            Label(NavigationItem.podcasts.displayName, systemImage: NavigationItem.podcasts.icon)
+                        if self.podcastsAvailability.availability != .unavailable {
+                            NavigationLink(value: SidebarSelection.navigation(.podcasts)) {
+                                Label(NavigationItem.podcasts.displayName, systemImage: NavigationItem.podcasts.icon)
+                            }
+                            .accessibilityIdentifier(AccessibilityID.Sidebar.podcastsItem)
                         }
-                        .accessibilityIdentifier(AccessibilityID.Sidebar.podcastsItem)
                     }
 
                     // Collection section
@@ -191,4 +194,5 @@ struct Sidebar: View {
     Sidebar(selection: .constant(.home), pinnedSelection: .constant(nil))
         .frame(width: 220)
         .environment(SidebarPinnedItemsManager(skipLoad: true))
+        .environment(PodcastsAvailabilityService())
 }

--- a/Tests/KasetTests/Helpers/MockYTMusicClient.swift
+++ b/Tests/KasetTests/Helpers/MockYTMusicClient.swift
@@ -61,6 +61,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     var addToPlaylistMenus: [String: AddToPlaylistMenu] = [:]
     var defaultAddToPlaylistMenu = AddToPlaylistMenu(title: nil, options: [], canCreatePlaylist: false)
     var onGetLibraryContent: (@MainActor () -> Void)?
+    var onGetPodcasts: (@MainActor () -> Void)?
     var subscribeToArtistDelay: Duration?
     var unsubscribeFromArtistDelay: Duration?
     var rateSongDelay: Duration?
@@ -355,6 +356,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
 
     func getPodcasts() async throws -> [PodcastSection] {
         self._podcastsContinuationIndex = 0
+        self.onGetPodcasts?()
         if let delay = self.getPodcastsDelay {
             try await Task.sleep(for: delay)
         }

--- a/Tests/KasetTests/Helpers/MockYTMusicClient.swift
+++ b/Tests/KasetTests/Helpers/MockYTMusicClient.swift
@@ -65,6 +65,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     var unsubscribeFromArtistDelay: Duration?
     var rateSongDelay: Duration?
     var getSongDelay: Duration?
+    var getPodcastsDelay: Duration?
     var shouldAutoUpdatePlaylistLibraryOnMutation = true
     var shouldAutoUpdatePodcastLibraryOnMutation = true
     var shouldAutoUpdateArtistLibraryOnMutation = true
@@ -354,6 +355,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
 
     func getPodcasts() async throws -> [PodcastSection] {
         self._podcastsContinuationIndex = 0
+        if let delay = self.getPodcastsDelay {
+            try await Task.sleep(for: delay)
+        }
         if let error = shouldThrowError { throw error }
         return self.podcastsSections
     }

--- a/Tests/KasetTests/PodcastsAvailabilityServiceTests.swift
+++ b/Tests/KasetTests/PodcastsAvailabilityServiceTests.swift
@@ -2,6 +2,8 @@ import Foundation
 import Testing
 @testable import Kaset
 
+// MARK: - PodcastsAvailabilityServiceTests
+
 @Suite(.serialized, .tags(.service))
 @MainActor
 struct PodcastsAvailabilityServiceTests {
@@ -86,6 +88,63 @@ struct PodcastsAvailabilityServiceTests {
         // Transient failures must not flip a known-good state.
         #expect(result == .available)
         #expect(service.availability == .available)
+    }
+
+    // MARK: - Account/session invalidation
+
+    @Test
+    func late404ProbeDoesNotOverrideNewerAccountAvailability() async {
+        let service = PodcastsAvailabilityService()
+
+        let staleClient = MockYTMusicClient()
+        staleClient.getPodcastsDelay = .milliseconds(150)
+        staleClient.shouldThrowError = YTMusicError.apiError(message: "HTTP 404", code: 404)
+        let staleProbeStarted = AsyncSignal()
+        staleClient.onGetPodcasts = { staleProbeStarted.signal() }
+
+        let staleProbe = Task { @MainActor in
+            await service.probe(for: "account-a", using: staleClient)
+        }
+        await staleProbeStarted.wait()
+
+        let currentClient = MockYTMusicClient()
+        currentClient.podcastsSections = [
+            PodcastSection(id: UUID().uuidString, title: "Available Shows", items: []),
+        ]
+
+        let currentResult = await service.probe(for: "account-b", using: currentClient)
+        #expect(currentResult == .available)
+        #expect(service.availability == .available)
+        #expect(service.didResolveFirstProbe == true)
+
+        let staleResult = await staleProbe.value
+        #expect(staleResult == .available)
+        #expect(service.availability == .available)
+        #expect(service.didResolveFirstProbe == true)
+    }
+
+    @Test
+    func resetInvalidatesLateProbeCompletion() async {
+        let service = PodcastsAvailabilityService()
+        let client = MockYTMusicClient()
+        client.getPodcastsDelay = .milliseconds(150)
+        client.shouldThrowError = YTMusicError.apiError(message: "HTTP 404", code: 404)
+        let probeStarted = AsyncSignal()
+        client.onGetPodcasts = { probeStarted.signal() }
+
+        let probe = Task { @MainActor in
+            await service.probe(for: "primary", using: client)
+        }
+        await probeStarted.wait()
+
+        service.reset()
+        #expect(service.availability == .unknown)
+        #expect(service.didResolveFirstProbe == false)
+
+        let result = await probe.value
+        #expect(result == .unknown)
+        #expect(service.availability == .unknown)
+        #expect(service.didResolveFirstProbe == false)
     }
 
     // MARK: - First-resolution gate
@@ -179,5 +238,32 @@ struct PodcastsAvailabilityServiceTests {
 
         #expect(service.availability == .unknown)
         #expect(service.didResolveFirstProbe == false)
+    }
+}
+
+// MARK: - AsyncSignal
+
+@MainActor
+private final class AsyncSignal {
+    private var isSignalled = false
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func signal() {
+        guard !self.isSignalled else { return }
+        self.isSignalled = true
+        self.continuation?.resume()
+        self.continuation = nil
+    }
+
+    func wait() async {
+        if self.isSignalled { return }
+
+        await withCheckedContinuation { continuation in
+            if self.isSignalled {
+                continuation.resume()
+            } else {
+                self.continuation = continuation
+            }
+        }
     }
 }

--- a/Tests/KasetTests/PodcastsAvailabilityServiceTests.swift
+++ b/Tests/KasetTests/PodcastsAvailabilityServiceTests.swift
@@ -1,0 +1,183 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+@Suite(.serialized, .tags(.service))
+@MainActor
+struct PodcastsAvailabilityServiceTests {
+    // MARK: - Initial state
+
+    @Test
+    func initialAvailabilityIsUnknown() {
+        let service = PodcastsAvailabilityService()
+        #expect(service.availability == .unknown)
+        #expect(service.didResolveFirstProbe == false)
+    }
+
+    // MARK: - Probe outcomes
+
+    @Test
+    func probeWithNonEmptySectionsMarksAvailable() async {
+        let client = MockYTMusicClient()
+        client.podcastsSections = [
+            PodcastSection(id: UUID().uuidString, title: "Top Shows", items: []),
+        ]
+        let service = PodcastsAvailabilityService()
+
+        let result = await service.probe(for: "primary", using: client)
+
+        #expect(result == .available)
+        #expect(service.availability == .available)
+        #expect(service.didResolveFirstProbe == true)
+    }
+
+    @Test
+    func probeWith404MarksUnavailable() async {
+        let client = MockYTMusicClient()
+        client.shouldThrowError = YTMusicError.apiError(message: "HTTP 404", code: 404)
+        let service = PodcastsAvailabilityService()
+
+        let result = await service.probe(for: "primary", using: client)
+
+        #expect(result == .unavailable)
+        #expect(service.availability == .unavailable)
+        #expect(service.didResolveFirstProbe == true)
+    }
+
+    @Test
+    func probeWithEmptySectionsLeavesAvailabilityUnchangedButResolvesGate() async {
+        let client = MockYTMusicClient()
+        client.podcastsSections = []
+        let service = PodcastsAvailabilityService()
+
+        let result = await service.probe(for: "primary", using: client)
+
+        // Empty payload from a probe is not authoritative — leave the
+        // state alone. The lazy path will confirm via user-initiated
+        // load.
+        #expect(result == .unknown)
+        #expect(service.availability == .unknown)
+        // But the gate releases so the UI doesn't hang.
+        #expect(service.didResolveFirstProbe == true)
+    }
+
+    @Test
+    func probeWith500LeavesAvailabilityUnchangedButResolvesGate() async {
+        let client = MockYTMusicClient()
+        client.shouldThrowError = YTMusicError.apiError(message: "HTTP 500", code: 500)
+        let service = PodcastsAvailabilityService()
+
+        let result = await service.probe(for: "primary", using: client)
+
+        #expect(result == .unknown)
+        #expect(service.availability == .unknown)
+        #expect(service.didResolveFirstProbe == true)
+    }
+
+    @Test
+    func probeWithNetworkErrorLeavesKnownGoodStateAlone() async {
+        let client = MockYTMusicClient()
+        client.shouldThrowError = YTMusicError.networkError(underlying: URLError(.timedOut))
+        let service = PodcastsAvailabilityService()
+        service.markAvailable(for: "primary")
+
+        let result = await service.probe(for: "primary", using: client)
+
+        // Transient failures must not flip a known-good state.
+        #expect(result == .available)
+        #expect(service.availability == .available)
+    }
+
+    // MARK: - First-resolution gate
+
+    @Test
+    func probeForFirstResolutionFlipsGateOn404() async {
+        let client = MockYTMusicClient()
+        client.shouldThrowError = YTMusicError.apiError(message: "HTTP 404", code: 404)
+        let service = PodcastsAvailabilityService()
+        #expect(service.didResolveFirstProbe == false)
+
+        await service.probeForFirstResolution(for: "primary", using: client)
+
+        #expect(service.availability == .unavailable)
+        #expect(service.didResolveFirstProbe == true)
+    }
+
+    @Test
+    func probeForFirstResolutionFlipsGateOnSuccess() async {
+        let client = MockYTMusicClient()
+        client.podcastsSections = [
+            PodcastSection(id: UUID().uuidString, title: "Top", items: []),
+        ]
+        let service = PodcastsAvailabilityService()
+
+        await service.probeForFirstResolution(for: "primary", using: client)
+
+        #expect(service.availability == .available)
+        #expect(service.didResolveFirstProbe == true)
+    }
+
+    @Test
+    func probeForFirstResolutionFlipsGateOnTimeoutAndProbeKeepsRunning() async {
+        // Mock client that doesn't return until well after the timeout
+        // and then yields a 404, so we can confirm both that the gate
+        // releases via timeout and that the late 404 still demotes the
+        // tab when it lands.
+        let client = MockYTMusicClient()
+        client.getPodcastsDelay = .milliseconds(500)
+        client.shouldThrowError = YTMusicError.apiError(message: "HTTP 404", code: 404)
+        let service = PodcastsAvailabilityService()
+
+        await service.probeForFirstResolution(
+            for: "primary",
+            using: client,
+            timeout: .milliseconds(50)
+        )
+
+        // Gate releases via timeout; state still unknown so sidebar fails open.
+        #expect(service.didResolveFirstProbe == true)
+        #expect(service.availability == .unknown)
+
+        // The probe is still running in the background — wait for it
+        // and confirm the eventual 404 demotes the tab.
+        try? await Task.sleep(for: .milliseconds(700))
+        #expect(service.availability == .unavailable)
+    }
+
+    // MARK: - Lazy signals
+
+    @Test
+    func markUnavailableUpdatesStateAndResolvesGate() {
+        let service = PodcastsAvailabilityService()
+
+        service.markUnavailable(for: "primary")
+
+        #expect(service.availability == .unavailable)
+        #expect(service.didResolveFirstProbe == true)
+    }
+
+    @Test
+    func markAvailableUpdatesStateAndResolvesGate() {
+        let service = PodcastsAvailabilityService()
+
+        service.markAvailable(for: "primary")
+
+        #expect(service.availability == .available)
+        #expect(service.didResolveFirstProbe == true)
+    }
+
+    // MARK: - Reset
+
+    @Test
+    func resetClearsBothAvailabilityAndGate() {
+        let service = PodcastsAvailabilityService()
+        service.markUnavailable(for: "primary")
+        #expect(service.availability == .unavailable)
+        #expect(service.didResolveFirstProbe == true)
+
+        service.reset()
+
+        #expect(service.availability == .unknown)
+        #expect(service.didResolveFirstProbe == false)
+    }
+}

--- a/Tests/KasetTests/PodcastsViewModelTests.swift
+++ b/Tests/KasetTests/PodcastsViewModelTests.swift
@@ -180,4 +180,66 @@ struct PodcastsViewModelTests {
         #expect(self.viewModel.loadingState == .loaded)
         #expect(self.viewModel.sections.isEmpty)
     }
+
+    // MARK: - Region availability integration
+
+    @Test
+    func loadHTTP404MarksAvailabilityUnavailableAndLandsLoaded() async {
+        let availability = PodcastsAvailabilityService()
+        self.viewModel.configure(availabilityService: availability, accountId: "primary")
+        self.mockClient.shouldThrowError = YTMusicError.apiError(message: "HTTP 404", code: 404)
+
+        await self.viewModel.load()
+
+        // Lands on .loaded with empty sections rather than .error so the
+        // user doesn't see a generic "Server Error 404" toast while the
+        // sidebar row is being torn down by the availability service.
+        #expect(self.viewModel.loadingState == .loaded)
+        #expect(self.viewModel.sections.isEmpty)
+        #expect(availability.availability == .unavailable)
+    }
+
+    @Test
+    func loadEmptyPayloadMarksAvailabilityUnavailable() async {
+        let availability = PodcastsAvailabilityService()
+        self.viewModel.configure(availabilityService: availability, accountId: "primary")
+        self.mockClient.podcastsSections = []
+
+        await self.viewModel.load()
+
+        // User-initiated empty payload is treated as authoritative — the
+        // sidebar row should disappear.
+        #expect(availability.availability == .unavailable)
+    }
+
+    @Test
+    func loadNonEmptyPayloadMarksAvailabilityAvailable() async {
+        let availability = PodcastsAvailabilityService()
+        self.viewModel.configure(availabilityService: availability, accountId: "primary")
+        self.mockClient.podcastsSections = [
+            PodcastSection(id: UUID().uuidString, title: "Top Shows", items: []),
+        ]
+
+        await self.viewModel.load()
+
+        #expect(availability.availability == .available)
+    }
+
+    @Test
+    func loadNetworkErrorDoesNotMutateAvailability() async {
+        let availability = PodcastsAvailabilityService()
+        availability.markAvailable(for: "primary")
+        self.viewModel.configure(availabilityService: availability, accountId: "primary")
+        self.mockClient.shouldThrowError = YTMusicError.networkError(underlying: URLError(.timedOut))
+
+        await self.viewModel.load()
+
+        // Transient errors must not flip a known-good state.
+        #expect(availability.availability == .available)
+        if case .error = self.viewModel.loadingState {
+            // Expected — generic error UI for transient failures.
+        } else {
+            Issue.record("Expected error state but got \(self.viewModel.loadingState)")
+        }
+    }
 }

--- a/Tests/KasetTests/PodcastsViewModelTests.swift
+++ b/Tests/KasetTests/PodcastsViewModelTests.swift
@@ -200,6 +200,25 @@ struct PodcastsViewModelTests {
     }
 
     @Test
+    func configureForNewAccountResetsLoadedEmptyUnavailableState() async {
+        let availability = PodcastsAvailabilityService()
+        self.viewModel.configure(availabilityService: availability, accountId: "account-a")
+        self.mockClient.shouldThrowError = YTMusicError.apiError(message: "HTTP 404", code: 404)
+
+        await self.viewModel.load()
+
+        #expect(self.viewModel.loadingState == .loaded)
+        #expect(self.viewModel.sections.isEmpty)
+        #expect(availability.availability == .unavailable)
+
+        self.viewModel.configure(availabilityService: availability, accountId: "account-b")
+
+        #expect(self.viewModel.loadingState == .idle)
+        #expect(self.viewModel.sections.isEmpty)
+        #expect(self.viewModel.hasMoreSections == true)
+    }
+
+    @Test
     func loadEmptyPayloadMarksAvailabilityUnavailable() async {
         let availability = PodcastsAvailabilityService()
         self.viewModel.configure(availabilityService: availability, accountId: "primary")

--- a/docs/adr/0019-podcasts-availability.md
+++ b/docs/adr/0019-podcasts-availability.md
@@ -1,0 +1,191 @@
+# ADR-0019: Region-Aware Podcasts Tab Visibility
+
+## Status
+
+Implemented
+
+## Context
+
+YouTube Music does not offer the **Podcasts** discovery surface in every
+region. In unsupported regions the `FEmusic_podcasts` browse endpoint
+returns HTTP 404 (confirmed via
+`swift run api-explorer browse FEmusic_podcasts -v` from a Turkish IP —
+clean `HTTP 404` with `"status": "NOT_FOUND"`), and the YT Music web client
+itself redirects `music.youtube.com/podcasts` to home in those regions.
+
+Kaset previously rendered the Podcasts row in the sidebar unconditionally.
+Users in unsupported regions saw `Server Error — Something went wrong (Error
+404)` whenever they opened the tab (issue
+[#100](https://github.com/sozercan/kaset/issues/100)). Region is determined
+by YouTube from cookies/IP, not by the `hl` parameter, so the app cannot
+override it client-side.
+
+Other podcast surfaces are gated separately and continue to work in
+unsupported regions:
+
+- `LibraryView` *Podcasts* filter — uses `FEmusic_library_non_music_audio_list`.
+- `SearchViewModel` *Podcasts* filter — search-podcasts works (commenter on
+  issue #100 confirmed).
+- `ArtistDetailView` podcasts section — already gated by
+  `!detail.podcasts.isEmpty`.
+
+So the fix is scoped to the discovery tab only.
+
+## Decision
+
+Add a `PodcastsAvailabilityService` (`@MainActor @Observable`) that probes
+`FEmusic_podcasts` once per session, gates main-window rendering on the
+result, and exposes the resolved state to the sidebar through the SwiftUI
+environment. State is **in-memory only** — every cold launch re-probes from
+scratch.
+
+### State machine
+
+```
+.unknown ────probe success (≥1 section) OR markAvailable────▶ .available
+   │                                                            │
+   │     probe HTTP 404                                          │ user-initiated
+   │     OR user-initiated load HTTP 404                         │ load returns
+   │     OR user-initiated load returns empty                    │ ≥1 section
+   ▼                                                            ▼
+.unavailable ◀──────────────────────────────────────────────────┘
+```
+
+A second observable, `didResolveFirstProbe: Bool`, tracks whether the first
+probe of the session has finished. It flips to `true` on any probe
+completion (success, 404, transient error) **or** when a 2-second timeout
+fires. `MainWindow.body` shows the loading spinner until this flag flips,
+so the sidebar paints with the correct state on first frame — no
+appear-then-disappear flicker.
+
+### No persistence
+
+The service's state lives only in memory. Trade-offs considered:
+
+- **+** Region changes (e.g. enabling a VPN) are picked up by quitting
+  and relaunching the app — no sign-out/in dance and no cache to
+  invalidate.
+- **+** No schema versioning, no TTL, no per-account cache lifecycle to
+  reason about.
+- **−** One extra `browse` request per cold launch. Cost is essentially
+  zero: the request runs in parallel with `homeViewModel.refresh()`
+  etc., warms `APICache` so opening the tab right after launch is
+  instant on available regions, and is hidden behind the spinner on
+  unavailable regions where it ends quickly with 404.
+
+A persistent cache keyed by `accountId` with a TTL on `.unavailable`
+was considered but rejected — see *Alternatives*.
+
+### Detection rules
+
+- **Authoritative**: `YTMusicError.apiError(code: 404)` from
+  `client.getPodcasts()`, whether raised by the background probe or a
+  user-initiated `PodcastsViewModel.load`.
+- **Authoritative**: success with non-empty sections → `.available`.
+- **Secondary** (lazy path only): a user-initiated load that returns zero
+  sections. Empty payloads are noisy from the probe path (cold caches,
+  transient YT issues), so we only trust them when the user has actively
+  visited the tab. Background probe with empty sections releases the gate
+  but leaves `availability` untouched.
+- **Ignored**: 5xx, network errors, auth errors. Transient failures must
+  never demote a known-good state. They still release the gate so the UI
+  doesn't hang behind a flaky network.
+
+### Probe lifecycle (in `MainWindow`)
+
+- **First probe**: a `.task(id: authService.state.isLoggedIn)` modifier
+  fires whenever `isLoggedIn` flips to `true` — covering both cold launches
+  with cached cookies (`.initializing → .loggedIn`) and explicit sign-ins
+  (`.loggingIn → .loggedIn`). After a 200 ms cookie-settle delay it calls
+  `service.probeForFirstResolution(...)`, which races the probe against a
+  2-second timeout and flips `didResolveFirstProbe` when either completes.
+  The probe always runs to completion in the background — a slow but
+  definite 404 still demotes the tab when it lands, even if the gate
+  released earlier via timeout.
+- **Account switch**: existing `onChange(of:
+  accountService.currentAccount?.id)` block fires a probe in the same
+  `withTaskGroup` as the other content refreshes. The gate
+  (`didResolveFirstProbe`) is deliberately *not* re-closed here, so
+  `mainContent` stays visible while content refreshes; the sidebar
+  briefly shows the prior account's tab state until the probe returns
+  a definitive answer. We accept this small staleness window in
+  exchange for not tearing down the whole UI on every switch.
+- **Logout**: `service.reset()` clears both `availability` and
+  `didResolveFirstProbe`. The next sign-in re-gates the UI and re-probes.
+- **`refreshAllContent`**: skips the podcasts viewmodel refresh when
+  `availability == .unavailable` to avoid re-firing the spurious 404.
+
+### UI integration
+
+- **`Sidebar.swift`** renders the Podcasts `NavigationLink` only when
+  `availability != .unavailable`.
+- **`MainWindow.swift`** holds `mainContent` rendering until
+  `didResolveFirstProbe == true`; until then the existing
+  `initializingView` (cassette icon + spinner) is shown. Also redirects
+  `navigationSelection = .home` if the state flips to `.unavailable`
+  while the user is on the Podcasts tab (handles the lazy-path case
+  during account switches).
+- **`PodcastsViewModel.load()`** on `apiError(code: 404)` calls
+  `service.markUnavailable(for:)` and lands on `.loaded` with empty
+  sections instead of `.error`. The sidebar row disappears within a frame,
+  so a generic toast would be wrong; a clean empty state is the softer
+  landing.
+
+## Consequences
+
+**Positive**
+
+- Users in regions without podcasts no longer see a 404 toast and lose the
+  dead tab automatically.
+- Region changes via VPN are picked up on the next app launch — no
+  account/session manipulation required.
+- No flicker on cold launch in either direction (US-style users see the
+  tab when content paints, TR-style users never see it appear).
+- Other podcast features (library subscriptions, search, artist pages)
+  remain fully functional because they're gated separately.
+- No new third-party dependencies. No persistence-layer surface area.
+
+**Negative**
+
+- One extra `browse` request per cold launch. Mitigated by parallelism
+  with the existing post-login refreshes and by `APICache` warming for
+  available regions.
+- Cold-launch first paint is gated on the probe (or 2 s timeout). For
+  available regions this is typically <500 ms and invisible behind the
+  spinner that already covers the auth check.
+
+**Neutral**
+
+- `SettingsManager.LaunchPage` already excludes `.podcasts`, so default-tab
+  logic needed no changes. `lastUsedPage` is typed as `LaunchPage` and
+  cannot become podcasts.
+- Keyboard navigation commands (⌘1/2/3/F/K) and the command bar do not
+  reference podcasts.
+
+## Alternatives considered
+
+- **Lazy-only (no proactive probe)**: simpler, but the Podcasts row
+  would show on the first session in an unsupported region until the
+  user clicked it and saw the 404. The first-paint flicker is exactly
+  what we're trying to avoid.
+- **Probe via a custom HEAD/exists endpoint**: not worth a separate
+  code path; reusing `getPodcasts()` warms `APICache` on success.
+- **Persisted cache keyed by `accountId` with a TTL on `.unavailable`**:
+  would avoid the per-launch probe cost, but the cache key is
+  fundamentally wrong for this signal. Region (`gl`) — not account — is
+  what gates the endpoint, and YouTube derives `gl` from cookies. A
+  user can change region without changing account (e.g. by toggling a
+  VPN), and there's no client-visible signal we could use to invalidate
+  the cache when that happens. The result would be that
+  *connect-VPN-then-relaunch* becomes *connect-VPN, sign out, sign in*
+  — strictly worse UX than re-probing on launch. The per-launch probe
+  is also nearly free thanks to `APICache` warming and parallelism with
+  the existing post-login refreshes, so the cache would buy us very
+  little even when correct.
+- **Persisted cache keyed by `(accountId, languageCode)`**: same
+  fundamental problem as the per-account cache — language is a poor
+  proxy for region (YT derives `gl` from cookies). Worse, it would
+  force unnecessary re-probes on every locale toggle while still
+  missing the VPN case.
+- **Use `gl` from `Locale.current`**: same problem — the user's macOS
+  region setting is independent of YouTube's account region.

--- a/docs/adr/0019-podcasts-availability.md
+++ b/docs/adr/0019-podcasts-availability.md
@@ -42,14 +42,22 @@ scratch.
 ### State machine
 
 ```
-.unknown ────probe success (≥1 section) OR markAvailable────▶ .available
-   │                                                            │
-   │     probe HTTP 404                                          │ user-initiated
-   │     OR user-initiated load HTTP 404                         │ load returns
-   │     OR user-initiated load returns empty                    │ ≥1 section
-   ▼                                                            ▼
-.unavailable ◀──────────────────────────────────────────────────┘
+.unknown     --available signal----> .available
+.unknown     --unavailable signal--> .unavailable
+.available   --unavailable signal--> .unavailable
+.unavailable --available signal----> .available
 ```
+
+Where:
+
+- **Available signal**: probe success with `≥1` section, or
+  `markAvailable` from a user-initiated non-empty load.
+- **Unavailable signal**: probe HTTP 404, user-initiated load HTTP 404,
+  or user-initiated load returns empty.
+
+Successful signals can therefore promote `.unavailable` back to
+`.available` after an account/region change; unavailable signals can also
+remove the tab from either `.unknown` or `.available`.
 
 A second observable, `didResolveFirstProbe: Bool`, tracks whether the first
 probe of the session has finished. It flips to `true` on any probe

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -53,3 +53,4 @@ What becomes easier or more difficult because of this change?
 | [0016](0016-staged-command-parsing-and-queue-analysis.md) | Staged Command Parsing And Queue Analysis | Accepted |
 | [0017](0017-equalizer.md) | 6-Band Equalizer via Core Audio Process Tap | Implemented |
 | [0018](0018-artist-page-episodes.md) | Artist Page — Episodes, Singles, Playlists, Podcasts, Related Artists | Accepted |
+| [0019](0019-podcasts-availability.md) | Region-Aware Podcasts Tab Visibility | Implemented |


### PR DESCRIPTION
## Description

YouTube Music does not offer the Podcasts discovery surface in every region. In unsupported regions the `FEmusic_podcasts` browse endpoint returns HTTP 404, so users (e.g. on a Turkish IP — confirmed via `swift run api-explorer browse FEmusic_podcasts -v`) see a generic *"Server Error 404"* whenever they open the tab. The web client itself redirects `music.youtube.com/podcasts` to home in those regions.

This PR adds a `PodcastsAvailabilityService` that probes `FEmusic_podcasts` once per session, gates main-window rendering on the result, and hides the Podcasts row from the sidebar when the discovery endpoint is unavailable. Because the gate holds first paint until the probe resolves (or a 2 s timeout fires), the sidebar paints with the correct state on first frame — no appear-then-disappear flicker.

State is in-memory only — every cold launch re-probes from scratch, so a region change (e.g. enabling a VPN before relaunching) is reflected without sign-out/in. Other podcast surfaces (library subscriptions, search, artist pages) are untouched — they're gated separately and keep working in unsupported regions.

Design rationale and the full state machine are in [ADR-0019](docs/adr/0019-podcasts-availability.md).

## AI Prompt (Optional)

<details>
<summary>🤖 AI Prompt Used</summary>

```
The bug reported at https://github.com/sozercan/kaset/issues/100 is reproducible by switching between regions where YouTube Music's Podcasts surface is supported and where it isn't (e.g. via a VPN such as Mullvad to and from a US exit). Plan a reliable way of showing and hiding the Podcasts tab. Take into account everywhere in the application — sidebar, default tab on startup, account switching, command bar, keyboard shortcuts — all of which would need intervention for the implementation.
```

**AI Tool:** Claude (via Claude Code)

</details>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 📚 Documentation update
- [x] 🧪 Test update

## Related Issues

Fixes #100.

## Changes Made

- **New `PodcastsAvailabilityService`** (`@MainActor @Observable`, in-memory only): tracks `.unknown` / `.available` / `.unavailable`. `probeForFirstResolution` races the probe against a 2 s timeout via a checked-continuation latch and exposes `didResolveFirstProbe` for the UI gate. The probe always runs to completion in the background, so a slow but definite 404 still demotes the tab when it lands.
- **`MainWindow`**: holds `mainContent` rendering until `didResolveFirstProbe` flips. Probe runs whenever `state.isLoggedIn` flips to `true` (covering cold launch with cached cookies and explicit sign-ins). Account switches re-probe in the background without re-closing the gate, so `mainContent` stays visible during the switch. Logout calls `service.reset()` so the next sign-in re-gates and re-probes. Redirects from the Podcasts tab to Home if availability flips to `.unavailable` while the user is on it. Skips the podcasts task in `refreshAllContent` when known unavailable.
- **`Sidebar`**: conditionally renders the Podcasts `NavigationLink` based on the service's availability.
- **`PodcastsViewModel`**: reports HTTP 404 and empty payloads to the service via the lazy path, lands on `.loaded` with empty sections (no toast) so the tab disappears cleanly. Transient errors (5xx, network) still surface as `.error` and leave availability untouched.
- **UI test plumbing**: `MockUITestYTMusicClient` honors a new `MOCK_PODCASTS_REGION_UNAVAILABLE` env flag to simulate the 404. `MockYTMusicClient` gains `getPodcastsDelay` for the service's timeout test.
- **Docs**: ADR-0019 + index entry.

## Testing

- [x] Unit tests pass (`swift test --skip KasetUITests`) — 1367 tests
- [x] `swiftlint --strict && swiftformat .` clean
- [x] Manual testing performed:
  - Cold launch on Turkish IP with no VPN → sidebar paints without the Podcasts row from first frame.
  - Cold launch on a podcast-enabled region (via VPN) → sidebar paints with the row from first frame.
  - Account switch from a podcast-enabled to a podcast-disabled brand account → tab updates in the background; `mainContent` stays visible throughout.
  - VM 404 path (lazy) confirmed via `MOCK_PODCASTS_REGION_UNAVAILABLE` flag.
  - Sidebar Library → Podcasts filter and Search → Podcasts filter still work in unavailable regions (separate endpoints, untouched).
- [x] UI tested on macOS 26+

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `swiftlint --strict && swiftformat .`
- [x] I have added tests that prove my fix works (12 new service tests + 4 new viewmodel tests)
- [x] New and existing unit tests pass locally
- [x] I have updated documentation if needed (ADR-0019 + index)
- [x] I have checked for any performance implications (one extra `browse` request per cold launch, run in parallel with existing post-login refreshes; warms `APICache` on success)
- [x] My changes generate no new warnings

## Additional Notes

A couple of design choices worth highlighting (full rationale in the ADR):

- **No flicker**: the `didResolveFirstProbe` gate holds the existing initializing-spinner until the probe resolves (or 2 s timeout). For available regions this is typically <500 ms and invisible behind the spinner that already covers the auth check. For unsupported regions the spinner ends with the sidebar already in the correct (Podcasts-less) state.
- **No persistence — by design**: a persistent cache keyed by `accountId` was considered but rejected. Region (`gl`) — not account — is what gates the endpoint, and YouTube derives `gl` from cookies. A user can change region without changing account (e.g. by toggling a VPN), and there's no client-visible signal we could use to invalidate the cache when that happens. A cache would always be wrong after a VPN toggle until the user signed out and back in. The per-launch probe is essentially free (parallel with existing post-login refreshes, warms `APICache`) and gets us "connect-VPN-then-relaunch" correctness for free.
- **Other podcast surfaces are intentionally not affected**: `LibraryView` Podcasts filter (`FEmusic_library_non_music_audio_list`), `SearchViewModel` Podcasts filter, and `ArtistDetailView` podcasts section all work in unavailable regions and are gated separately.