### PR TITLE
Add playback audio quality setting

### DIFF
--- a/Sources/Kaset/Services/Player/NowPlayingManager.swift
+++ b/Sources/Kaset/Services/Player/NowPlayingManager.swift
@@ -30,6 +30,7 @@ final class NowPlayingManager {
         self.playerService = playerService
         self.setupRemoteCommands()
         self.syncMediaControlSetting()
+        self.syncPlaybackAudioQualitySetting()
         self.logger.info("NowPlayingManager configured (remote commands only)")
 
         self.observeSettingsChanges()
@@ -38,9 +39,11 @@ final class NowPlayingManager {
     private func observeSettingsChanges() {
         withObservationTracking {
             _ = self.settings.mediaControlStyle
+            _ = self.settings.playbackAudioQuality
         } onChange: {
             Task { @MainActor [weak self] in
                 self?.syncMediaControlSetting()
+                self?.syncPlaybackAudioQualitySetting()
                 self?.observeSettingsChanges()
             }
         }
@@ -50,6 +53,11 @@ final class NowPlayingManager {
     private func syncMediaControlSetting() {
         let useNextPrev = self.settings.mediaControlStyle == .nextPreviousTrack
         SingletonPlayerWebView.shared.setMediaControlStyle(useNextPrev: useNextPrev)
+    }
+
+    /// Syncs the preferred playback audio quality setting to the singleton WebView and its bootstrap state.
+    private func syncPlaybackAudioQualitySetting() {
+        SingletonPlayerWebView.shared.setPlaybackAudioQuality(self.settings.playbackAudioQuality)
     }
 
     // MARK: - Remote Commands

--- a/Sources/Kaset/Services/SettingsManager.swift
+++ b/Sources/Kaset/Services/SettingsManager.swift
@@ -19,6 +19,7 @@ final class SettingsManager {
         static let scrobblePercentThreshold = "settings.scrobblePercentThreshold"
         static let scrobbleMinSeconds = "settings.scrobbleMinSeconds"
         static let mediaControlStyle = "settings.mediaControlStyle"
+        static let playbackAudioQuality = "settings.playbackAudioQuality"
         static let syncedLyricsEnabled = "settings.syncedLyricsEnabled"
         static let romanizationEnabled = "settings.romanizationEnabled"
         static let contentLanguage = "settings.contentLanguage"
@@ -146,6 +147,29 @@ final class SettingsManager {
         }
     }
 
+    // MARK: - Playback Audio Quality
+
+    /// Preferred audio quality for playback through the YouTube Music WebView.
+    enum PlaybackAudioQuality: String, CaseIterable, Identifiable {
+        case auto
+        case low
+        case normal
+        case high
+
+        var id: String {
+            rawValue
+        }
+
+        var displayName: String {
+            switch self {
+            case .auto: "Auto"
+            case .low: "Low"
+            case .normal: "Normal"
+            case .high: "High"
+            }
+        }
+    }
+
     // MARK: - Settings Properties
 
     /// Whether to show system notifications when the track changes.
@@ -185,6 +209,13 @@ final class SettingsManager {
     var mediaControlStyle: MediaControlStyle {
         didSet {
             UserDefaults.standard.set(self.mediaControlStyle.rawValue, forKey: Keys.mediaControlStyle)
+        }
+    }
+
+    /// Preferred audio quality for playback through the YouTube Music WebView.
+    var playbackAudioQuality: PlaybackAudioQuality {
+        didSet {
+            UserDefaults.standard.set(self.playbackAudioQuality.rawValue, forKey: Keys.playbackAudioQuality)
         }
     }
 
@@ -279,6 +310,14 @@ final class SettingsManager {
             self.mediaControlStyle = style
         } else {
             self.mediaControlStyle = .nextPreviousTrack
+        }
+
+        if let rawValue = UserDefaults.standard.string(forKey: Keys.playbackAudioQuality),
+           let quality = PlaybackAudioQuality(rawValue: rawValue)
+        {
+            self.playbackAudioQuality = quality
+        } else {
+            self.playbackAudioQuality = .auto
         }
 
         if let rawValue = UserDefaults.standard.string(forKey: Keys.defaultLaunchPage),

--- a/Sources/Kaset/Views/GeneralSettingsView.swift
+++ b/Sources/Kaset/Views/GeneralSettingsView.swift
@@ -57,6 +57,14 @@ struct GeneralSettingsView: View {
                 Toggle("Remember Shuffle & Repeat", isOn: self.$settings.rememberPlaybackSettings)
                     .help("Save shuffle and repeat settings across app restarts")
 
+                // Playback Audio Quality
+                Picker("Playback Audio Quality", selection: self.$settings.playbackAudioQuality) {
+                    ForEach(SettingsManager.PlaybackAudioQuality.allCases) { quality in
+                        Text(quality.displayName).tag(quality)
+                    }
+                }
+                .help("Choose the preferred audio quality for YouTube Music playback")
+
                 // Now Playing Controls
                 Picker("Now Playing Controls", selection: self.$settings.mediaControlStyle) {
                     ForEach(SettingsManager.MediaControlStyle.allCases) { style in

--- a/Sources/Kaset/Views/MiniPlayerWebView.swift
+++ b/Sources/Kaset/Views/MiniPlayerWebView.swift
@@ -244,6 +244,7 @@ final class SingletonPlayerWebView {
 
     var displayMode: DisplayMode = .hidden
     private var mediaControlUsesNextPrev: Bool
+    private var playbackAudioQuality: SettingsManager.PlaybackAudioQuality
 
     /// Tracks if lyrics high-frequency polling should be active
     /// Used to restore polling after full-page navigation
@@ -251,6 +252,7 @@ final class SingletonPlayerWebView {
 
     private init() {
         self.mediaControlUsesNextPrev = SettingsManager.shared.mediaControlStyle == .nextPreviousTrack
+        self.playbackAudioQuality = SettingsManager.shared.playbackAudioQuality
     }
 
     /// Get or create the singleton WebView.
@@ -433,6 +435,13 @@ final class SingletonPlayerWebView {
         )
         contentController.addUserScript(mediaControlBootstrapScript)
 
+        let playbackAudioQualityBootstrapScript = WKUserScript(
+            source: self.playbackAudioQualityBootstrapScript(),
+            injectionTime: .atDocumentStart,
+            forMainFrameOnly: true
+        )
+        contentController.addUserScript(playbackAudioQualityBootstrapScript)
+
         // Inject mediaSession override at document end without allowing duplicate RAF loops.
         let mediaOverrideScript = WKUserScript(
             source: Self.mediaControlOverrideScript,
@@ -440,6 +449,14 @@ final class SingletonPlayerWebView {
             forMainFrameOnly: true
         )
         contentController.addUserScript(mediaOverrideScript)
+
+        // Apply preferred playback audio quality at document end and after player recreation.
+        let playbackAudioQualityOverrideScript = WKUserScript(
+            source: Self.playbackAudioQualityOverrideScript,
+            injectionTime: .atDocumentEnd,
+            forMainFrameOnly: true
+        )
+        contentController.addUserScript(playbackAudioQualityOverrideScript)
 
         // Inject observer script (at document end)
         let script = WKUserScript(
@@ -817,5 +834,20 @@ extension SingletonPlayerWebView {
                 .observe(document.documentElement, {childList:true, subtree:true});
         })();
         """
+    }
+
+    // MARK: - Playback Audio Quality
+
+    /// Updates the current page and the bootstrap state used by future page loads.
+    func setPlaybackAudioQuality(_ quality: SettingsManager.PlaybackAudioQuality) {
+        self.playbackAudioQuality = quality
+
+        guard let webView = self.webView else { return }
+        let script = Self.playbackAudioQualitySyncScript(quality: quality)
+        webView.evaluateJavaScript(script, completionHandler: nil)
+    }
+
+    func playbackAudioQualityBootstrapScript() -> String {
+        Self.playbackAudioQualityBootstrapScript(quality: self.playbackAudioQuality)
     }
 }

--- a/Sources/Kaset/Views/MiniPlayerWebView.swift
+++ b/Sources/Kaset/Views/MiniPlayerWebView.swift
@@ -612,21 +612,58 @@ final class SingletonPlayerWebView {
             }
         }
 
+        private static let allowedAudioQualityStatsKeys: Set<String> = [
+            "afmt",
+            "audioBitrate",
+            "audioCodec",
+            "audioCodecs",
+            "audioFormat",
+            "audioItag",
+            "audioMimeType",
+            "audioQuality",
+            "audio_format",
+            "bitrate",
+            "codec",
+            "codecs",
+            "debug_audioFormat",
+            "debug_audioQuality",
+            "debug_playbackQuality",
+            "itag",
+            "mimeType",
+            "quality",
+        ]
+
+        private static let allowedAudioQualityStatsFragments: Set<String> = [
+            "bitrate",
+            "codec",
+            "format",
+            "itag",
+            "mime",
+            "quality",
+        ]
+
         private static func logAudioQualityStats(body: [String: Any], observedVideoId: String?) {
+            let message = Self.audioQualityStatsLogMessage(body: body, observedVideoId: observedVideoId)
+            DiagnosticsLogger.player.info("Audio quality stats: \(message, privacy: .private)")
+        }
+
+        static func audioQualityStatsLogMessage(body: [String: Any], observedVideoId: String?) -> String {
             let preferred = Self.sanitizedLogString(body["preferred"])
             let desired = Self.sanitizedLogString(body["desired"])
             let applied = (body["applied"] as? Bool) == true ? "true" : "false"
             let observed = Self.sanitizedLogString(body["observed"])
             let source = Self.sanitizedLogString(body["source"])
             let videoId = Self.sanitizedLogString(observedVideoId, fallback: "unknown")
-            let available = Self.compactJSONText(body["available"], fallback: "[]")
-            let stats = Self.compactJSONText(body["stats"], fallback: "{}")
+            let available = Self.compactJSONText(
+                Self.sanitizedPrimitiveArray(body["available"]) ?? [],
+                fallback: "[]"
+            )
+            let stats = Self.compactJSONText(Self.sanitizedStatsForNerds(body["stats"]), fallback: "{}")
 
-            let message = """
+            return """
             preferred=\(preferred) desired=\(desired) applied=\(applied) observed=\(observed) \
             source=\(source) videoId=\(videoId) available=\(available) stats=\(stats)
             """
-            DiagnosticsLogger.player.info("Audio quality stats: \(message, privacy: .public)")
         }
 
         private static func sanitizedLogString(_ value: Any?, fallback: String = "unknown") -> String {
@@ -638,14 +675,18 @@ final class SingletonPlayerWebView {
                 String(describing: value)
             }
 
-            guard !string.isEmpty else { return fallback }
-            return String(string.prefix(200))
+            let flattened = string
+                .replacingOccurrences(of: "\n", with: " ")
+                .replacingOccurrences(of: "\r", with: " ")
+                .replacingOccurrences(of: "\t", with: " ")
+
+            guard !flattened.isEmpty else { return fallback }
+            return String(flattened.prefix(200))
         }
 
-        private static func compactJSONText(_ value: Any?, fallback: String) -> String {
-            guard let sanitized = sanitizedJSONValue(value, depth: 0),
-                  JSONSerialization.isValidJSONObject(sanitized),
-                  let data = try? JSONSerialization.data(withJSONObject: sanitized, options: [.sortedKeys]),
+        private static func compactJSONText(_ value: Any, fallback: String) -> String {
+            guard JSONSerialization.isValidJSONObject(value),
+                  let data = try? JSONSerialization.data(withJSONObject: value, options: [.sortedKeys]),
                   let text = String(data: data, encoding: .utf8)
             else {
                 return fallback
@@ -654,37 +695,109 @@ final class SingletonPlayerWebView {
             return text
         }
 
-        private static func sanitizedJSONValue(_ value: Any?, depth: Int) -> Any? {
-            guard let value, depth < 3 else { return nil }
+        private static func sanitizedStatsForNerds(_ value: Any?) -> [String: Any] {
+            guard let value = value as? [String: Any] else { return [:] }
+
+            var sanitized: [String: Any] = [:]
+            for key in value.keys.sorted() where sanitized.count < 12 {
+                guard Self.isAllowedAudioQualityStatsKey(key) else { continue }
+
+                let sanitizedKey = String(key.prefix(80))
+                if let primitive = Self.sanitizedPrimitive(value[key]) {
+                    sanitized[sanitizedKey] = primitive
+                    continue
+                }
+
+                if let primitiveArray = Self.sanitizedPrimitiveArray(value[key]) {
+                    sanitized[sanitizedKey] = primitiveArray
+                }
+            }
+
+            return sanitized
+        }
+
+        private static func isAllowedAudioQualityStatsKey(_ key: String) -> Bool {
+            if self.allowedAudioQualityStatsKeys.contains(key) {
+                return true
+            }
+
+            let lowercasedKey = key.lowercased()
+            return lowercasedKey.contains("audio")
+                && Self.allowedAudioQualityStatsFragments.contains { lowercasedKey.contains($0) }
+        }
+
+        private static func sanitizedPrimitiveArray(_ value: Any?) -> [Any]? {
+            guard let values = value as? [Any] else { return nil }
+
+            let sanitized = values.prefix(12).compactMap { Self.sanitizedPrimitive($0) }
+            return sanitized.isEmpty ? nil : sanitized
+        }
+
+        private static func sanitizedPrimitive(_ value: Any?) -> Any? {
+            guard let value else { return nil }
 
             if let value = value as? String {
-                return String(value.prefix(200))
+                return String(value.prefix(160))
             }
 
             if let value = value as? Bool {
                 return value
             }
 
-            if let value = value as? NSNumber {
+            return Self.sanitizedNumericPrimitive(value)
+        }
+
+        private static func sanitizedNumericPrimitive(_ value: Any) -> Any? {
+            if let value = value as? Int {
                 return value
             }
 
-            if let value = value as? [String: Any] {
-                var sanitized: [String: Any] = [:]
-                for key in value.keys.sorted().prefix(20) {
-                    guard !key.isEmpty,
-                          let sanitizedValue = Self.sanitizedJSONValue(value[key], depth: depth + 1)
-                    else {
-                        continue
-                    }
-
-                    sanitized[String(key.prefix(80))] = sanitizedValue
-                }
-                return sanitized
+            if let value = value as? Int8 {
+                return value
             }
 
-            if let value = value as? [Any] {
-                return value.prefix(20).compactMap { Self.sanitizedJSONValue($0, depth: depth + 1) }
+            if let value = value as? Int16 {
+                return value
+            }
+
+            if let value = value as? Int32 {
+                return value
+            }
+
+            if let value = value as? Int64 {
+                return value
+            }
+
+            if let value = value as? UInt {
+                return value
+            }
+
+            if let value = value as? UInt8 {
+                return value
+            }
+
+            if let value = value as? UInt16 {
+                return value
+            }
+
+            if let value = value as? UInt32 {
+                return value
+            }
+
+            if let value = value as? UInt64 {
+                return value
+            }
+
+            if let value = value as? Double {
+                return value.isFinite ? value : nil
+            }
+
+            if let value = value as? Float {
+                return value.isFinite ? Double(value) : nil
+            }
+
+            if let value = value as? NSNumber {
+                return value.doubleValue.isFinite ? value : nil
             }
 
             return nil

--- a/Sources/Kaset/Views/MiniPlayerWebView.swift
+++ b/Sources/Kaset/Views/MiniPlayerWebView.swift
@@ -1,3 +1,4 @@
+import os
 import SwiftUI
 import WebKit
 
@@ -243,8 +244,8 @@ final class SingletonPlayerWebView {
     }
 
     var displayMode: DisplayMode = .hidden
-    private var mediaControlUsesNextPrev: Bool
-    private var playbackAudioQuality: SettingsManager.PlaybackAudioQuality
+    var mediaControlUsesNextPrev: Bool
+    var playbackAudioQuality: SettingsManager.PlaybackAudioQuality
 
     /// Tracks if lyrics high-frequency polling should be active
     /// Used to restore polling after full-page navigation
@@ -467,6 +468,18 @@ final class SingletonPlayerWebView {
         contentController.addUserScript(script)
     }
 
+    func refreshInstalledUserScripts() {
+        guard let webView else { return }
+
+        let currentVolume = self.coordinator?.playerService.volume ?? 1.0
+        let isRestoringPlaybackSession = self.coordinator?.playerService.isRestoringPlaybackSession ?? false
+        self.installUserScripts(
+            on: webView.configuration.userContentController,
+            isRestoringPlaybackSession: isRestoringPlaybackSession,
+            targetVolume: currentVolume
+        )
+    }
+
     // MARK: - Coordinator
 
     final class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler {
@@ -481,59 +494,60 @@ final class SingletonPlayerWebView {
                   let type = body["type"] as? String
             else { return }
 
-            let observedVideoId: String? = if let videoId = body["videoId"] as? String, !videoId.isEmpty {
-                videoId
-            } else {
-                nil
-            }
+            let observedVideoId = Self.observedVideoId(from: body)
 
-            if type == "TRACK_ENDED" {
+            switch type {
+            case "TRACK_ENDED":
                 Task { @MainActor in
                     await self.playerService.handleTrackEnded(observedVideoId: observedVideoId)
                 }
-                return
-            }
-
-            if type == "REMOTE_NEXT" {
+            case "REMOTE_NEXT":
                 Task { @MainActor in
                     await self.playerService.next()
                 }
-                return
-            }
-
-            if type == "REMOTE_PREVIOUS" {
+            case "REMOTE_PREVIOUS":
                 Task { @MainActor in
                     await self.playerService.previous()
                 }
+            case "AIRPLAY_STATUS":
+                self.handleAirPlayStatusUpdate(body: body)
+            case "LYRICS_TIME":
+                self.handleLyricsTimeUpdate(body: body)
+            case "PLAYBACK_AUDIO_QUALITY_STATS":
+                Self.logAudioQualityStats(body: body, observedVideoId: observedVideoId)
+            case "STATE_UPDATE":
+                self.handleStateUpdate(body: body, observedVideoId: observedVideoId)
+            default:
                 return
             }
+        }
 
-            // Handle AirPlay status updates
-            if type == "AIRPLAY_STATUS" {
-                let isConnected = body["isConnected"] as? Bool ?? false
-                let wasRequested = body["wasRequested"] as? Bool ?? false
+        private static func observedVideoId(from body: [String: Any]) -> String? {
+            guard let videoId = body["videoId"] as? String, !videoId.isEmpty else { return nil }
+            return videoId
+        }
 
-                Task { @MainActor in
-                    self.playerService.updateAirPlayStatus(
-                        isConnected: isConnected,
-                        wasRequested: wasRequested
-                    )
-                }
-                return
+        private func handleAirPlayStatusUpdate(body: [String: Any]) {
+            let isConnected = body["isConnected"] as? Bool ?? false
+            let wasRequested = body["wasRequested"] as? Bool ?? false
+
+            Task { @MainActor in
+                self.playerService.updateAirPlayStatus(
+                    isConnected: isConnected,
+                    wasRequested: wasRequested
+                )
             }
+        }
 
-            // Handle high frequency lyrics time updates
-            if type == "LYRICS_TIME" {
-                if let time = body["time"] as? Double {
-                    Task { @MainActor in
-                        self.playerService.currentTimeMs = Int(time * 1000)
-                    }
-                }
-                return
+        private func handleLyricsTimeUpdate(body: [String: Any]) {
+            guard let time = body["time"] as? Double else { return }
+
+            Task { @MainActor in
+                self.playerService.currentTimeMs = Int(time * 1000)
             }
+        }
 
-            guard type == "STATE_UPDATE" else { return }
-
+        private func handleStateUpdate(body: [String: Any], observedVideoId: String?) {
             let isPlaying = body["isPlaying"] as? Bool ?? false
             let progress = body["progress"] as? Int ?? 0
             let duration = body["duration"] as? Int ?? 0
@@ -541,18 +555,8 @@ final class SingletonPlayerWebView {
             let artist = body["artist"] as? String ?? ""
             let thumbnailUrl = body["thumbnailUrl"] as? String ?? ""
             let trackChanged = body["trackChanged"] as? Bool ?? false
-            let likeStatusString = body["likeStatus"] as? String ?? "INDIFFERENT"
+            let likeStatus = Self.likeStatus(from: body["likeStatus"] as? String)
             let hasVideo = body["hasVideo"] as? Bool ?? false
-
-            // Parse like status
-            let likeStatus: LikeStatus = switch likeStatusString {
-            case "LIKE":
-                .like
-            case "DISLIKE":
-                .dislike
-            default:
-                .indifferent
-            }
 
             Task { @MainActor in
                 self.playerService.updatePlaybackState(
@@ -595,6 +599,95 @@ final class SingletonPlayerWebView {
                     }
                 }
             }
+        }
+
+        private static func likeStatus(from rawValue: String?) -> LikeStatus {
+            switch rawValue {
+            case "LIKE":
+                .like
+            case "DISLIKE":
+                .dislike
+            default:
+                .indifferent
+            }
+        }
+
+        private static func logAudioQualityStats(body: [String: Any], observedVideoId: String?) {
+            let preferred = Self.sanitizedLogString(body["preferred"])
+            let desired = Self.sanitizedLogString(body["desired"])
+            let applied = (body["applied"] as? Bool) == true ? "true" : "false"
+            let observed = Self.sanitizedLogString(body["observed"])
+            let source = Self.sanitizedLogString(body["source"])
+            let videoId = Self.sanitizedLogString(observedVideoId, fallback: "unknown")
+            let available = Self.compactJSONText(body["available"], fallback: "[]")
+            let stats = Self.compactJSONText(body["stats"], fallback: "{}")
+
+            let message = """
+            preferred=\(preferred) desired=\(desired) applied=\(applied) observed=\(observed) \
+            source=\(source) videoId=\(videoId) available=\(available) stats=\(stats)
+            """
+            DiagnosticsLogger.player.info("Audio quality stats: \(message, privacy: .public)")
+        }
+
+        private static func sanitizedLogString(_ value: Any?, fallback: String = "unknown") -> String {
+            guard let value else { return fallback }
+
+            let string: String = if let stringValue = value as? String {
+                stringValue
+            } else {
+                String(describing: value)
+            }
+
+            guard !string.isEmpty else { return fallback }
+            return String(string.prefix(200))
+        }
+
+        private static func compactJSONText(_ value: Any?, fallback: String) -> String {
+            guard let sanitized = sanitizedJSONValue(value, depth: 0),
+                  JSONSerialization.isValidJSONObject(sanitized),
+                  let data = try? JSONSerialization.data(withJSONObject: sanitized, options: [.sortedKeys]),
+                  let text = String(data: data, encoding: .utf8)
+            else {
+                return fallback
+            }
+
+            return text
+        }
+
+        private static func sanitizedJSONValue(_ value: Any?, depth: Int) -> Any? {
+            guard let value, depth < 3 else { return nil }
+
+            if let value = value as? String {
+                return String(value.prefix(200))
+            }
+
+            if let value = value as? Bool {
+                return value
+            }
+
+            if let value = value as? NSNumber {
+                return value
+            }
+
+            if let value = value as? [String: Any] {
+                var sanitized: [String: Any] = [:]
+                for key in value.keys.sorted().prefix(20) {
+                    guard !key.isEmpty,
+                          let sanitizedValue = Self.sanitizedJSONValue(value[key], depth: depth + 1)
+                    else {
+                        continue
+                    }
+
+                    sanitized[String(key.prefix(80))] = sanitizedValue
+                }
+                return sanitized
+            }
+
+            if let value = value as? [Any] {
+                return value.prefix(20).compactMap { Self.sanitizedJSONValue($0, depth: depth + 1) }
+            }
+
+            return nil
         }
 
         func webView(_ webView: WKWebView, didFinish _: WKNavigation!) {
@@ -679,175 +772,5 @@ final class SingletonPlayerWebView {
                 }
             }
         }
-    }
-}
-
-// MARK: - SingletonPlayerWebView Media Controls
-
-extension SingletonPlayerWebView {
-    /// Updates the current page and the bootstrap state used by future page loads.
-    func setMediaControlStyle(useNextPrev: Bool) {
-        self.mediaControlUsesNextPrev = useNextPrev
-
-        guard let webView = self.webView else { return }
-        let script = Self.mediaControlStyleSyncScript(useNextPrev: useNextPrev)
-        webView.evaluateJavaScript(script, completionHandler: nil)
-    }
-
-    func mediaControlBootstrapScript() -> String {
-        Self.mediaControlStyleBootstrapScript(useNextPrev: self.mediaControlUsesNextPrev)
-    }
-
-    static func mediaControlStyleBootstrapScript(useNextPrev: Bool) -> String {
-        let jsBoolean = useNextPrev ? "true" : "false"
-        return """
-            (function() {
-                try {
-                    localStorage.setItem('kasetUseNextPrev', '\(jsBoolean)');
-                } catch (e) {}
-                window.__kasetUseNextPrev = \(jsBoolean);
-                // Wrap setActionHandler at document start so YouTube's seekforward/seekbackward
-                // registrations are blocked before Control Center can reflect them. Without this
-                // the existing RAF override only clears them on the next frame, leaving a window
-                // where the macOS Now Playing widget briefly shows the 15s skip buttons.
-                try {
-                    var ms = navigator.mediaSession;
-                    if (ms && !ms.__kasetSetActionHandlerWrapped) {
-                        var orig = ms.setActionHandler.bind(ms);
-                        ms.setActionHandler = function(type, handler) {
-                            if (window.__kasetUseNextPrev && (type === 'seekforward' || type === 'seekbackward')) {
-                                return orig(type, null);
-                            }
-                            return orig(type, handler);
-                        };
-                        ms.__kasetSetActionHandlerWrapped = true;
-                    }
-                } catch (e) {}
-            })();
-        """
-    }
-
-    static func mediaControlStyleSyncScript(useNextPrev: Bool) -> String {
-        let jsBoolean = useNextPrev ? "true" : "false"
-        let restoreSeekHandlers = if useNextPrev {
-            ""
-        } else {
-            """
-                try {
-                    var ms = navigator.mediaSession;
-                    ms.setActionHandler('nexttrack', null);
-                    ms.setActionHandler('previoustrack', null);
-                    ms.setActionHandler('seekforward', function(d) {
-                        var v = document.querySelector('video');
-                        if (v) v.currentTime = Math.min(v.duration,
-                            v.currentTime + ((d && d.seekOffset) || 15));
-                    });
-                    ms.setActionHandler('seekbackward', function(d) {
-                        var v = document.querySelector('video');
-                        if (v) v.currentTime = Math.max(0,
-                            v.currentTime - ((d && d.seekOffset) || 15));
-                    });
-                } catch (e) {}
-            """
-        }
-
-        return """
-            (function() {
-                try {
-                    localStorage.setItem('kasetUseNextPrev', '\(jsBoolean)');
-                } catch (e) {}
-                window.__kasetUseNextPrev = \(jsBoolean);
-                if (typeof window.__kasetRefreshMediaControlStyle === 'function') {
-                    window.__kasetRefreshMediaControlStyle();
-                }
-                \(restoreSeekHandlers)
-            })();
-        """
-    }
-
-    static var mediaControlOverrideScript: String {
-        """
-        (function() {
-            if (typeof window.__kasetUseNextPrev !== 'boolean') {
-                try {
-                    window.__kasetUseNextPrev =
-                        localStorage.getItem('kasetUseNextPrev') === 'true';
-                } catch (e) {
-                    window.__kasetUseNextPrev = false;
-                }
-            }
-
-            var overrideFrameId = null;
-
-            function applyOverride() {
-                if (!window.__kasetUseNextPrev) {
-                    return;
-                }
-                try {
-                    var ms = navigator.mediaSession;
-                    ms.setActionHandler('seekforward', null);
-                    ms.setActionHandler('seekbackward', null);
-                    ms.setActionHandler('nexttrack', function() {
-                        window.webkit.messageHandlers.singletonPlayer
-                            .postMessage({ type: 'REMOTE_NEXT' });
-                    });
-                    ms.setActionHandler('previoustrack', function() {
-                        window.webkit.messageHandlers.singletonPlayer
-                            .postMessage({ type: 'REMOTE_PREVIOUS' });
-                    });
-                } catch (e) {}
-            }
-
-            function scheduleOverrideLoop() {
-                if (overrideFrameId !== null || !window.__kasetUseNextPrev) {
-                    return;
-                }
-
-                overrideFrameId = requestAnimationFrame(function() {
-                    overrideFrameId = null;
-                    if (!window.__kasetUseNextPrev) {
-                        return;
-                    }
-                    applyOverride();
-                    scheduleOverrideLoop();
-                });
-            }
-
-            window.__kasetRefreshMediaControlStyle = function() {
-                applyOverride();
-                scheduleOverrideLoop();
-            };
-
-            window.__kasetRefreshMediaControlStyle();
-
-            // Re-apply on video events where YouTube re-registers handlers.
-            function attachVideoOverride() {
-                var v = document.querySelector('video');
-                if (!v || v.__kasetOverrideAttached) return;
-                v.__kasetOverrideAttached = true;
-                ['playing','loadedmetadata','loadeddata','canplay','seeked']
-                    .forEach(function(e) { v.addEventListener(e, applyOverride); });
-            }
-
-            attachVideoOverride();
-            new MutationObserver(attachVideoOverride)
-                .observe(document.documentElement, {childList:true, subtree:true});
-        })();
-        """
-    }
-
-    // MARK: - Playback Audio Quality
-
-    /// Updates the current page and the bootstrap state used by future page loads.
-    func setPlaybackAudioQuality(_ quality: SettingsManager.PlaybackAudioQuality) {
-        self.playbackAudioQuality = quality
-
-        guard let webView = self.webView else { return }
-        let script = Self.playbackAudioQualitySyncScript(quality: quality)
-        webView.evaluateJavaScript(script, completionHandler: nil)
-    }
-
-    func playbackAudioQualityBootstrapScript() -> String {
-        Self.playbackAudioQualityBootstrapScript(quality: self.playbackAudioQuality)
     }
 }

--- a/Sources/Kaset/Views/SingletonPlayerWebView+PlaybackAudioQuality.swift
+++ b/Sources/Kaset/Views/SingletonPlayerWebView+PlaybackAudioQuality.swift
@@ -80,6 +80,238 @@ extension SingletonPlayerWebView {
                 return false;
             }
 
+            var lastAudioQualityStatsKey = '';
+            var lastAudioQualityStatsTime = 0;
+            var AUDIO_QUALITY_STATS_MIN_INTERVAL_MS = 30000;
+
+            function safePrimitive(value) {
+                if (value === null || typeof value === 'undefined') return null;
+
+                var type = typeof value;
+                if (type === 'string') {
+                    return value.length > 160 ? value.substring(0, 160) : value;
+                }
+                if (type === 'number') {
+                    return isFinite(value) ? value : null;
+                }
+                if (type === 'boolean') {
+                    return value;
+                }
+
+                return null;
+            }
+
+            function safePrimitiveArray(value) {
+                if (!value || !Array.isArray(value)) return null;
+
+                var result = [];
+                for (var i = 0; i < value.length && result.length < 12; i += 1) {
+                    var safe = safePrimitive(value[i]);
+                    if (safe !== null) {
+                        result.push(safe);
+                    }
+                }
+
+                return result.length > 0 ? result : null;
+            }
+
+            function readFunctionValue(target, names) {
+                for (var i = 0; i < names.length; i += 1) {
+                    var name = names[i];
+                    try {
+                        if (target && typeof target[name] === 'function') {
+                            var value = target[name]();
+                            if (value !== null && typeof value !== 'undefined') {
+                                return {
+                                    name: name,
+                                    value: value
+                                };
+                            }
+                        }
+                    } catch (e) {}
+                }
+
+                return null;
+            }
+
+            function readObjectProperty(target, names) {
+                for (var i = 0; i < names.length; i += 1) {
+                    var name = names[i];
+                    try {
+                        if (target && target[name] !== null && typeof target[name] !== 'undefined') {
+                            return {
+                                name: name,
+                                value: target[name]
+                            };
+                        }
+                    } catch (e) {}
+                }
+
+                return null;
+            }
+
+            function isAllowedStatsKey(key) {
+                if (!key || typeof key !== 'string') return false;
+
+                var exact = {
+                    afmt: true,
+                    audioFormat: true,
+                    audio_format: true,
+                    audioCodec: true,
+                    audioCodecs: true,
+                    audioItag: true,
+                    audioMimeType: true,
+                    audioQuality: true,
+                    audioBitrate: true,
+                    bitrate: true,
+                    codec: true,
+                    codecs: true,
+                    debug_audioFormat: true,
+                    debug_audioQuality: true,
+                    debug_playbackQuality: true,
+                    itag: true,
+                    mimeType: true,
+                    quality: true
+                };
+
+                if (exact[key]) return true;
+
+                var lower = key.toLowerCase();
+                return lower.indexOf('audio') >= 0
+                    && (
+                        lower.indexOf('bitrate') >= 0
+                        || lower.indexOf('codec') >= 0
+                        || lower.indexOf('format') >= 0
+                        || lower.indexOf('itag') >= 0
+                        || lower.indexOf('mime') >= 0
+                        || lower.indexOf('quality') >= 0
+                    );
+            }
+
+            function sanitizedStatsForNerds(rawStats) {
+                var stats = {};
+                if (!rawStats || typeof rawStats !== 'object') return stats;
+
+                try {
+                    var keys = Object.keys(rawStats);
+                    for (var i = 0; i < keys.length && Object.keys(stats).length < 12; i += 1) {
+                        var key = keys[i];
+                        if (!isAllowedStatsKey(key)) continue;
+
+                        var value = rawStats[key];
+                        var safe = safePrimitive(value);
+                        if (safe !== null) {
+                            stats[key] = safe;
+                            continue;
+                        }
+
+                        var safeArray = safePrimitiveArray(value);
+                        if (safeArray !== null) {
+                            stats[key] = safeArray;
+                        }
+                    }
+                } catch (e) {}
+
+                return stats;
+            }
+
+            function audioQualityFromItag(itag) {
+                switch (String(itag)) {
+                case '139':
+                case '249':
+                case '250':
+                    return 'AUDIO_QUALITY_LOW';
+                case '140':
+                case '251':
+                    return 'AUDIO_QUALITY_MEDIUM';
+                case '141':
+                    return 'AUDIO_QUALITY_HIGH';
+                default:
+                    return null;
+                }
+            }
+
+            function inferredAudioQualityFromPrimitive(value) {
+                var text = String(value);
+                var token = '';
+
+                function observedQualityFromToken(candidate) {
+                    if (candidate.length < 2 || candidate.length > 3) return null;
+
+                    var quality = audioQualityFromItag(candidate);
+                    if (!quality) return null;
+
+                    return {
+                        quality: quality,
+                        itag: candidate
+                    };
+                }
+
+                for (var i = 0; i <= text.length; i += 1) {
+                    var character = i < text.length ? text.charAt(i) : '';
+                    if (character >= '0' && character <= '9') {
+                        token += character;
+                        continue;
+                    }
+
+                    if (token.length > 0) {
+                        var inferred = observedQualityFromToken(token);
+                        if (inferred) return inferred;
+                        token = '';
+                    }
+                }
+
+                return null;
+            }
+
+            function inferredAudioQualityFromValue(value) {
+                var safe = safePrimitive(value);
+                if (safe !== null) {
+                    return inferredAudioQualityFromPrimitive(safe);
+                }
+
+                var safeArray = safePrimitiveArray(value);
+                if (safeArray !== null) {
+                    for (var i = 0; i < safeArray.length; i += 1) {
+                        var inferred = inferredAudioQualityFromPrimitive(safeArray[i]);
+                        if (inferred) return inferred;
+                    }
+                }
+
+                return null;
+            }
+
+            function inferredAudioQualityFromStats(stats) {
+                var keys = [
+                    'itag',
+                    'audioItag',
+                    'afmt',
+                    'audioFormat',
+                    'audio_format',
+                    'debug_audioFormat',
+                    'codec',
+                    'codecs',
+                    'audioCodec',
+                    'audioCodecs'
+                ];
+
+                for (var i = 0; i < keys.length; i += 1) {
+                    var key = keys[i];
+                    if (!stats || stats[key] === null || typeof stats[key] === 'undefined') continue;
+
+                    var inferred = inferredAudioQualityFromValue(stats[key]);
+                    if (inferred) {
+                        return {
+                            quality: inferred.quality,
+                            itag: inferred.itag,
+                            source: 'statsForNerds.' + key + '.itag'
+                        };
+                    }
+                }
+
+                return null;
+            }
+
             function applyToPlayerApi(playerApi, quality) {
                 var applied = false;
                 var audioQuality = youtubeAudioQualityValue(quality);
@@ -109,12 +341,21 @@ extension SingletonPlayerWebView {
             function candidatePlayers() {
                 var players = [];
 
+                function addPlayer(target, source) {
+                    if (target) {
+                        players.push({
+                            target: target,
+                            source: source
+                        });
+                    }
+                }
+
                 try {
                     var ytmusicPlayer = document.querySelector('ytmusic-player');
                     if (ytmusicPlayer) {
-                        players.push(ytmusicPlayer);
+                        addPlayer(ytmusicPlayer, 'ytmusic-player');
                         if (ytmusicPlayer.playerApi) {
-                            players.push(ytmusicPlayer.playerApi);
+                            addPlayer(ytmusicPlayer.playerApi, 'ytmusic-player.playerApi');
                         }
                     }
                 } catch (e) {}
@@ -122,17 +363,163 @@ extension SingletonPlayerWebView {
                 try {
                     var moviePlayer = document.getElementById('movie_player');
                     if (moviePlayer) {
-                        players.push(moviePlayer);
+                        addPlayer(moviePlayer, 'movie_player');
                     }
                 } catch (e) {}
 
                 try {
                     if (window.yt && window.yt.player) {
-                        players.push(window.yt.player);
+                        addPlayer(window.yt.player, 'window.yt.player');
                     }
                 } catch (e) {}
 
                 return players;
+            }
+
+            function videoIdFromPlayers(players) {
+                for (var i = 0; i < players.length; i += 1) {
+                    var entry = players[i];
+                    var dataResult = readFunctionValue(entry.target, ['getVideoData']);
+                    if (!dataResult || !dataResult.value || typeof dataResult.value !== 'object') continue;
+
+                    var videoId = safePrimitive(
+                        dataResult.value.video_id
+                        || dataResult.value.videoId
+                        || dataResult.value.videoID
+                    );
+                    if (videoId) return videoId;
+                }
+
+                try {
+                    if (window.location && window.location.href && typeof URL === 'function') {
+                        var url = new URL(window.location.href);
+                        return safePrimitive(url.searchParams.get('v')) || '';
+                    }
+                } catch (e) {}
+
+                return '';
+            }
+
+            function collectAudioQualitySnapshot(quality, desired, applied, players) {
+                var snapshot = {
+                    type: 'PLAYBACK_AUDIO_QUALITY_STATS',
+                    preferred: quality,
+                    desired: desired,
+                    applied: !!applied,
+                    observed: 'unknown',
+                    source: 'unavailable',
+                    videoId: videoIdFromPlayers(players),
+                    available: [],
+                    stats: {}
+                };
+
+                for (var i = 0; i < players.length; i += 1) {
+                    var entry = players[i];
+
+                    if (snapshot.observed === 'unknown') {
+                        var observed = readFunctionValue(entry.target, [
+                            'getAudioQuality',
+                            'getPlaybackAudioQuality',
+                            'getPreferredAudioQuality'
+                        ]) || readObjectProperty(entry.target, [
+                            'audioQuality',
+                            'playbackAudioQuality',
+                            'preferredAudioQuality'
+                        ]);
+
+                        if (observed) {
+                            var safeObserved = safePrimitive(observed.value);
+                            if (safeObserved !== null) {
+                                snapshot.observed = safeObserved;
+                                snapshot.source = entry.source + '.' + observed.name;
+                            }
+                        }
+                    }
+
+                    if (snapshot.available.length === 0) {
+                        var available = readFunctionValue(entry.target, [
+                            'getAvailableAudioQualityLevels',
+                            'getAvailableAudioQualities',
+                            'getAudioQualityLevels'
+                        ]);
+
+                        if (available) {
+                            var safeAvailable = safePrimitiveArray(available.value);
+                            if (safeAvailable !== null) {
+                                snapshot.available = safeAvailable;
+                            }
+                        }
+                    }
+
+                    if (Object.keys(snapshot.stats).length === 0) {
+                        var statsResult = readFunctionValue(entry.target, ['getStatsForNerds']);
+                        if (statsResult) {
+                            snapshot.stats = sanitizedStatsForNerds(statsResult.value);
+                        }
+                    }
+                }
+
+                if (snapshot.observed === 'unknown') {
+                    var statsObserved = readObjectProperty(snapshot.stats, [
+                        'audioQuality',
+                        'debug_audioQuality',
+                        'quality',
+                        'debug_playbackQuality'
+                    ]);
+                    if (statsObserved) {
+                        var safeStatsObserved = safePrimitive(statsObserved.value);
+                        if (safeStatsObserved !== null) {
+                            snapshot.observed = safeStatsObserved;
+                            snapshot.source = 'statsForNerds.' + statsObserved.name;
+                        }
+                    }
+                }
+
+                if (snapshot.observed === 'unknown') {
+                    var inferredStatsObserved = inferredAudioQualityFromStats(snapshot.stats);
+                    if (inferredStatsObserved) {
+                        snapshot.observed = inferredStatsObserved.quality;
+                        snapshot.source = inferredStatsObserved.source;
+                        snapshot.observedItag = inferredStatsObserved.itag;
+                    }
+                }
+
+                return snapshot;
+            }
+
+            function postAudioQualityStats(snapshot) {
+                try {
+                    var handler = window.webkit
+                        && window.webkit.messageHandlers
+                        && window.webkit.messageHandlers.singletonPlayer;
+
+                    if (!handler || typeof handler.postMessage !== 'function') return;
+
+                    var now = (typeof Date !== 'undefined' && typeof Date.now === 'function')
+                        ? Date.now()
+                        : 0;
+                    var statsKey = [
+                        snapshot.preferred,
+                        snapshot.desired,
+                        snapshot.applied ? 'applied' : 'not-applied',
+                        snapshot.observed,
+                        snapshot.source,
+                        snapshot.videoId,
+                        JSON.stringify(snapshot.available || []),
+                        JSON.stringify(snapshot.stats || {})
+                    ].join('|');
+
+                    if (
+                        statsKey === lastAudioQualityStatsKey
+                        && now - lastAudioQualityStatsTime < AUDIO_QUALITY_STATS_MIN_INTERVAL_MS
+                    ) {
+                        return;
+                    }
+
+                    handler.postMessage(snapshot);
+                    lastAudioQualityStatsKey = statsKey;
+                    lastAudioQualityStatsTime = now;
+                } catch (e) {}
             }
 
             window.__kasetApplyPlaybackAudioQuality = function() {
@@ -140,9 +527,19 @@ extension SingletonPlayerWebView {
                 window.__kasetPlaybackAudioQuality = quality;
 
                 var applied = false;
-                candidatePlayers().forEach(function(player) {
-                    applied = applyToPlayerApi(player, quality) || applied;
+                var players = candidatePlayers();
+                players.forEach(function(entry) {
+                    applied = applyToPlayerApi(entry.target, quality) || applied;
                 });
+
+                postAudioQualityStats(
+                    collectAudioQualitySnapshot(
+                        quality,
+                        youtubeAudioQualityValue(quality),
+                        applied,
+                        players
+                    )
+                );
 
                 return applied;
             };

--- a/Sources/Kaset/Views/SingletonPlayerWebView+PlaybackAudioQuality.swift
+++ b/Sources/Kaset/Views/SingletonPlayerWebView+PlaybackAudioQuality.swift
@@ -70,21 +70,6 @@ extension SingletonPlayerWebView {
                     return 'AUDIO_QUALITY_AUTO';
                 }
             }
-
-            function youtubePlaybackQualityValue(quality) {
-                switch (quality) {
-                case 'low':
-                    return 'small';
-                case 'normal':
-                    return 'medium';
-                case 'high':
-                    return 'hd720';
-                case 'auto':
-                default:
-                    return 'auto';
-                }
-            }
-
             function callIfFunction(target, name, args) {
                 try {
                     if (target && typeof target[name] === 'function') {
@@ -98,20 +83,7 @@ extension SingletonPlayerWebView {
             function applyToPlayerApi(playerApi, quality) {
                 var applied = false;
                 var audioQuality = youtubeAudioQualityValue(quality);
-                var playbackQuality = youtubePlaybackQualityValue(quality);
-
                 applied = callIfFunction(playerApi, 'setAudioQuality', [audioQuality]) || applied;
-                applied = callIfFunction(playerApi, 'setPlaybackQuality', [playbackQuality]) || applied;
-
-                if (quality === 'auto') {
-                    applied = callIfFunction(playerApi, 'setPlaybackQualityRange', []) || applied;
-                } else {
-                    applied = callIfFunction(
-                        playerApi,
-                        'setPlaybackQualityRange',
-                        [playbackQuality, playbackQuality]
-                    ) || applied;
-                }
 
                 try {
                     if (playerApi && typeof playerApi.setOption === 'function') {

--- a/Sources/Kaset/Views/SingletonPlayerWebView+PlaybackAudioQuality.swift
+++ b/Sources/Kaset/Views/SingletonPlayerWebView+PlaybackAudioQuality.swift
@@ -1,0 +1,230 @@
+// MARK: - Playback Audio Quality Scripts
+
+extension SingletonPlayerWebView {
+    static func playbackAudioQualityBootstrapScript(
+        quality: SettingsManager.PlaybackAudioQuality
+    ) -> String {
+        """
+        (function() {
+            try {
+                localStorage.setItem('kasetPlaybackAudioQuality', '\(quality.rawValue)');
+            } catch (e) {}
+            window.__kasetPlaybackAudioQuality = '\(quality.rawValue)';
+        })();
+        """
+    }
+
+    static func playbackAudioQualitySyncScript(
+        quality: SettingsManager.PlaybackAudioQuality
+    ) -> String {
+        """
+        (function() {
+            try {
+                localStorage.setItem('kasetPlaybackAudioQuality', '\(quality.rawValue)');
+            } catch (e) {}
+            window.__kasetPlaybackAudioQuality = '\(quality.rawValue)';
+            if (typeof window.__kasetApplyPlaybackAudioQuality === 'function') {
+                window.__kasetApplyPlaybackAudioQuality();
+            }
+        })();
+        """
+    }
+
+    static var playbackAudioQualityOverrideScript: String {
+        """
+        (function() {
+            function normalizedQuality(value) {
+                switch (value) {
+                case 'low':
+                case 'normal':
+                case 'high':
+                case 'auto':
+                    return value;
+                default:
+                    return 'auto';
+                }
+            }
+
+            function currentQuality() {
+                if (typeof window.__kasetPlaybackAudioQuality === 'string') {
+                    return normalizedQuality(window.__kasetPlaybackAudioQuality);
+                }
+
+                try {
+                    return normalizedQuality(localStorage.getItem('kasetPlaybackAudioQuality'));
+                } catch (e) {
+                    return 'auto';
+                }
+            }
+
+            function youtubeAudioQualityValue(quality) {
+                switch (quality) {
+                case 'low':
+                    return 'AUDIO_QUALITY_LOW';
+                case 'normal':
+                    return 'AUDIO_QUALITY_MEDIUM';
+                case 'high':
+                    return 'AUDIO_QUALITY_HIGH';
+                case 'auto':
+                default:
+                    return 'AUDIO_QUALITY_AUTO';
+                }
+            }
+
+            function youtubePlaybackQualityValue(quality) {
+                switch (quality) {
+                case 'low':
+                    return 'small';
+                case 'normal':
+                    return 'medium';
+                case 'high':
+                    return 'hd720';
+                case 'auto':
+                default:
+                    return 'auto';
+                }
+            }
+
+            function callIfFunction(target, name, args) {
+                try {
+                    if (target && typeof target[name] === 'function') {
+                        target[name].apply(target, args);
+                        return true;
+                    }
+                } catch (e) {}
+                return false;
+            }
+
+            function applyToPlayerApi(playerApi, quality) {
+                var applied = false;
+                var audioQuality = youtubeAudioQualityValue(quality);
+                var playbackQuality = youtubePlaybackQualityValue(quality);
+
+                applied = callIfFunction(playerApi, 'setAudioQuality', [audioQuality]) || applied;
+                applied = callIfFunction(playerApi, 'setPlaybackQuality', [playbackQuality]) || applied;
+
+                if (quality === 'auto') {
+                    applied = callIfFunction(playerApi, 'setPlaybackQualityRange', []) || applied;
+                } else {
+                    applied = callIfFunction(
+                        playerApi,
+                        'setPlaybackQualityRange',
+                        [playbackQuality, playbackQuality]
+                    ) || applied;
+                }
+
+                try {
+                    if (playerApi && typeof playerApi.setOption === 'function') {
+                        [
+                            ['audio', 'quality', audioQuality],
+                            ['audio', 'audioQuality', audioQuality],
+                            ['player', 'audioQuality', audioQuality],
+                            ['player', 'audio_quality', audioQuality],
+                            ['playback', 'audioQuality', audioQuality],
+                            ['playback', 'audio_quality', audioQuality]
+                        ].forEach(function(args) {
+                            try {
+                                playerApi.setOption(args[0], args[1], args[2]);
+                                applied = true;
+                            } catch (e) {}
+                        });
+                    }
+                } catch (e) {}
+
+                return applied;
+            }
+
+            function candidatePlayers() {
+                var players = [];
+
+                try {
+                    var ytmusicPlayer = document.querySelector('ytmusic-player');
+                    if (ytmusicPlayer) {
+                        players.push(ytmusicPlayer);
+                        if (ytmusicPlayer.playerApi) {
+                            players.push(ytmusicPlayer.playerApi);
+                        }
+                    }
+                } catch (e) {}
+
+                try {
+                    var moviePlayer = document.getElementById('movie_player');
+                    if (moviePlayer) {
+                        players.push(moviePlayer);
+                    }
+                } catch (e) {}
+
+                try {
+                    if (window.yt && window.yt.player) {
+                        players.push(window.yt.player);
+                    }
+                } catch (e) {}
+
+                return players;
+            }
+
+            window.__kasetApplyPlaybackAudioQuality = function() {
+                var quality = currentQuality();
+                window.__kasetPlaybackAudioQuality = quality;
+
+                var applied = false;
+                candidatePlayers().forEach(function(player) {
+                    applied = applyToPlayerApi(player, quality) || applied;
+                });
+
+                return applied;
+            };
+
+            var applyScheduled = false;
+
+            function applyNow() {
+                applyScheduled = false;
+                try {
+                    window.__kasetApplyPlaybackAudioQuality();
+                } catch (e) {}
+            }
+
+            function scheduleApply() {
+                if (applyScheduled) {
+                    return;
+                }
+
+                applyScheduled = true;
+
+                try {
+                    if (typeof requestAnimationFrame === 'function') {
+                        requestAnimationFrame(applyNow);
+                    } else if (typeof setTimeout === 'function') {
+                        setTimeout(applyNow, 0);
+                    } else {
+                        applyNow();
+                    }
+                } catch (e) {
+                    applyNow();
+                }
+            }
+
+            applyNow();
+
+            function attachVideoListeners() {
+                var v = document.querySelector('video');
+                if (!v || v.__kasetAudioQualityAttached) return;
+                v.__kasetAudioQualityAttached = true;
+                ['loadedmetadata', 'loadeddata', 'canplay', 'playing', 'emptied']
+                    .forEach(function(eventName) {
+                        v.addEventListener(eventName, scheduleApply);
+                    });
+            }
+
+            attachVideoListeners();
+
+            try {
+                new MutationObserver(function() {
+                    attachVideoListeners();
+                    scheduleApply();
+                }).observe(document.documentElement, { childList: true, subtree: true });
+            } catch (e) {}
+        })();
+        """
+    }
+}

--- a/Sources/Kaset/Views/SingletonPlayerWebView+PlaybackPreferences.swift
+++ b/Sources/Kaset/Views/SingletonPlayerWebView+PlaybackPreferences.swift
@@ -1,0 +1,171 @@
+// MARK: - SingletonPlayerWebView Media Controls
+
+extension SingletonPlayerWebView {
+    /// Updates the current page and the bootstrap state used by future page loads.
+    func setMediaControlStyle(useNextPrev: Bool) {
+        self.mediaControlUsesNextPrev = useNextPrev
+        self.refreshInstalledUserScripts()
+
+        guard let webView = self.webView else { return }
+        let script = Self.mediaControlStyleSyncScript(useNextPrev: useNextPrev)
+        webView.evaluateJavaScript(script, completionHandler: nil)
+    }
+
+    func mediaControlBootstrapScript() -> String {
+        Self.mediaControlStyleBootstrapScript(useNextPrev: self.mediaControlUsesNextPrev)
+    }
+
+    static func mediaControlStyleBootstrapScript(useNextPrev: Bool) -> String {
+        let jsBoolean = useNextPrev ? "true" : "false"
+        return """
+            (function() {
+                try {
+                    localStorage.setItem('kasetUseNextPrev', '\(jsBoolean)');
+                } catch (e) {}
+                window.__kasetUseNextPrev = \(jsBoolean);
+                // Wrap setActionHandler at document start so YouTube's seekforward/seekbackward
+                // registrations are blocked before Control Center can reflect them. Without this
+                // the existing RAF override only clears them on the next frame, leaving a window
+                // where the macOS Now Playing widget briefly shows the 15s skip buttons.
+                try {
+                    var ms = navigator.mediaSession;
+                    if (ms && !ms.__kasetSetActionHandlerWrapped) {
+                        var orig = ms.setActionHandler.bind(ms);
+                        ms.setActionHandler = function(type, handler) {
+                            if (window.__kasetUseNextPrev && (type === 'seekforward' || type === 'seekbackward')) {
+                                return orig(type, null);
+                            }
+                            return orig(type, handler);
+                        };
+                        ms.__kasetSetActionHandlerWrapped = true;
+                    }
+                } catch (e) {}
+            })();
+        """
+    }
+
+    static func mediaControlStyleSyncScript(useNextPrev: Bool) -> String {
+        let jsBoolean = useNextPrev ? "true" : "false"
+        let restoreSeekHandlers = if useNextPrev {
+            ""
+        } else {
+            """
+                try {
+                    var ms = navigator.mediaSession;
+                    ms.setActionHandler('nexttrack', null);
+                    ms.setActionHandler('previoustrack', null);
+                    ms.setActionHandler('seekforward', function(d) {
+                        var v = document.querySelector('video');
+                        if (v) v.currentTime = Math.min(v.duration,
+                            v.currentTime + ((d && d.seekOffset) || 15));
+                    });
+                    ms.setActionHandler('seekbackward', function(d) {
+                        var v = document.querySelector('video');
+                        if (v) v.currentTime = Math.max(0,
+                            v.currentTime - ((d && d.seekOffset) || 15));
+                    });
+                } catch (e) {}
+            """
+        }
+
+        return """
+            (function() {
+                try {
+                    localStorage.setItem('kasetUseNextPrev', '\(jsBoolean)');
+                } catch (e) {}
+                window.__kasetUseNextPrev = \(jsBoolean);
+                if (typeof window.__kasetRefreshMediaControlStyle === 'function') {
+                    window.__kasetRefreshMediaControlStyle();
+                }
+                \(restoreSeekHandlers)
+            })();
+        """
+    }
+
+    static var mediaControlOverrideScript: String {
+        """
+        (function() {
+            if (typeof window.__kasetUseNextPrev !== 'boolean') {
+                try {
+                    window.__kasetUseNextPrev =
+                        localStorage.getItem('kasetUseNextPrev') === 'true';
+                } catch (e) {
+                    window.__kasetUseNextPrev = false;
+                }
+            }
+
+            var overrideFrameId = null;
+
+            function applyOverride() {
+                if (!window.__kasetUseNextPrev) {
+                    return;
+                }
+                try {
+                    var ms = navigator.mediaSession;
+                    ms.setActionHandler('seekforward', null);
+                    ms.setActionHandler('seekbackward', null);
+                    ms.setActionHandler('nexttrack', function() {
+                        window.webkit.messageHandlers.singletonPlayer
+                            .postMessage({ type: 'REMOTE_NEXT' });
+                    });
+                    ms.setActionHandler('previoustrack', function() {
+                        window.webkit.messageHandlers.singletonPlayer
+                            .postMessage({ type: 'REMOTE_PREVIOUS' });
+                    });
+                } catch (e) {}
+            }
+
+            function scheduleOverrideLoop() {
+                if (overrideFrameId !== null || !window.__kasetUseNextPrev) {
+                    return;
+                }
+
+                overrideFrameId = requestAnimationFrame(function() {
+                    overrideFrameId = null;
+                    if (!window.__kasetUseNextPrev) {
+                        return;
+                    }
+                    applyOverride();
+                    scheduleOverrideLoop();
+                });
+            }
+
+            window.__kasetRefreshMediaControlStyle = function() {
+                applyOverride();
+                scheduleOverrideLoop();
+            };
+
+            window.__kasetRefreshMediaControlStyle();
+
+            // Re-apply on video events where YouTube re-registers handlers.
+            function attachVideoOverride() {
+                var v = document.querySelector('video');
+                if (!v || v.__kasetOverrideAttached) return;
+                v.__kasetOverrideAttached = true;
+                ['playing','loadedmetadata','loadeddata','canplay','seeked']
+                    .forEach(function(e) { v.addEventListener(e, applyOverride); });
+            }
+
+            attachVideoOverride();
+            new MutationObserver(attachVideoOverride)
+                .observe(document.documentElement, {childList:true, subtree:true});
+        })();
+        """
+    }
+
+    // MARK: - Playback Audio Quality
+
+    /// Updates the current page and the bootstrap state used by future page loads.
+    func setPlaybackAudioQuality(_ quality: SettingsManager.PlaybackAudioQuality) {
+        self.playbackAudioQuality = quality
+        self.refreshInstalledUserScripts()
+
+        guard let webView = self.webView else { return }
+        let script = Self.playbackAudioQualitySyncScript(quality: quality)
+        webView.evaluateJavaScript(script, completionHandler: nil)
+    }
+
+    func playbackAudioQualityBootstrapScript() -> String {
+        Self.playbackAudioQualityBootstrapScript(quality: self.playbackAudioQuality)
+    }
+}

--- a/Tests/KasetTests/MediaControlScriptTests.swift
+++ b/Tests/KasetTests/MediaControlScriptTests.swift
@@ -179,6 +179,205 @@ struct MediaControlScriptTests {
         #expect(callbacksAfterFrameDrain == 1)
     }
 
+    @Test("Playback audio quality bootstrap script stores selected quality")
+    func playbackAudioQualityBootstrapStoresSelectedQuality() throws {
+        let context = try #require(JSContext())
+        self.evaluateBootstrapStateScript(in: context)
+
+        self.evaluate(
+            SingletonPlayerWebView.playbackAudioQualityBootstrapScript(quality: .high),
+            in: context
+        )
+
+        let storedQuality = context.evaluateScript("localStorageValues.kasetPlaybackAudioQuality")?.toString()
+        let windowQuality = context.evaluateScript("window.__kasetPlaybackAudioQuality")?.toString()
+
+        #expect(storedQuality == "high")
+        #expect(windowQuality == "high")
+    }
+
+    @Test("Playback audio quality sync script updates state and applies when available")
+    func playbackAudioQualitySyncUpdatesStateAndApplies() throws {
+        let context = try #require(JSContext())
+        self.evaluateBootstrapStateScript(in: context)
+        self.evaluate(
+            """
+            var applyCallCount = 0;
+            window.__kasetApplyPlaybackAudioQuality = function() {
+                applyCallCount += 1;
+            };
+            """,
+            in: context
+        )
+
+        self.evaluate(
+            SingletonPlayerWebView.playbackAudioQualitySyncScript(quality: .low),
+            in: context
+        )
+
+        let storedQuality = context.evaluateScript("localStorageValues.kasetPlaybackAudioQuality")?.toString()
+        let windowQuality = context.evaluateScript("window.__kasetPlaybackAudioQuality")?.toString()
+        let applyCallCount = context.evaluateScript("applyCallCount")?.toInt32() ?? -1
+
+        #expect(storedQuality == "low")
+        #expect(windowQuality == "low")
+        #expect(applyCallCount == 1)
+    }
+
+    @Test("Playback audio quality override script does not throw without YouTube APIs")
+    func playbackAudioQualityOverrideDoesNotThrowWithoutYouTubeApis() throws {
+        let context = try #require(JSContext())
+        self.evaluate(
+            """
+            var localStorageValues = { kasetPlaybackAudioQuality: 'high' };
+            var localStorage = {
+                getItem: function(key) { return localStorageValues[key] || null; },
+                setItem: function(key, value) { localStorageValues[key] = value; }
+            };
+            var window = {};
+            var document = {
+                documentElement: {},
+                querySelector: function() { return null; },
+                getElementById: function() { return null; }
+            };
+            function MutationObserver(callback) { this.callback = callback; }
+            MutationObserver.prototype.observe = function() {};
+            """,
+            in: context
+        )
+
+        self.evaluate(SingletonPlayerWebView.playbackAudioQualityOverrideScript, in: context)
+
+        let hasApplyFunction = context.evaluateScript(
+            "typeof window.__kasetApplyPlaybackAudioQuality === 'function'"
+        )?.toBool() ?? false
+
+        #expect(hasApplyFunction)
+    }
+
+    @Test("Playback audio quality override applies mocked player API quality")
+    func playbackAudioQualityOverrideAppliesMockedPlayerApiQuality() throws {
+        let context = try #require(JSContext())
+        self.evaluate(
+            """
+            var localStorageValues = { kasetPlaybackAudioQuality: 'high' };
+            var localStorage = {
+                getItem: function(key) { return localStorageValues[key] || null; },
+                setItem: function(key, value) { localStorageValues[key] = value; }
+            };
+            var audioQualityCalls = [];
+            var playbackQualityCalls = [];
+            var optionCalls = [];
+            var playerApi = {
+                setAudioQuality: function(value) { audioQualityCalls.push(value); },
+                setPlaybackQuality: function(value) { playbackQualityCalls.push(value); },
+                setOption: function(module, option, value) {
+                    optionCalls.push(module + ':' + option + ':' + value);
+                }
+            };
+            var ytmusicPlayer = { playerApi: playerApi };
+            var video = {
+                addEventListener: function() {}
+            };
+            var document = {
+                documentElement: {},
+                querySelector: function(selector) {
+                    if (selector === 'ytmusic-player') return ytmusicPlayer;
+                    if (selector === 'video') return video;
+                    return null;
+                },
+                getElementById: function() { return null; }
+            };
+            var window = {};
+            function MutationObserver(callback) { this.callback = callback; }
+            MutationObserver.prototype.observe = function() {};
+            """,
+            in: context
+        )
+
+        self.evaluate(SingletonPlayerWebView.playbackAudioQualityOverrideScript, in: context)
+
+        let audioQuality = context.evaluateScript("audioQualityCalls[0]")?.toString()
+        let playbackQuality = context.evaluateScript("playbackQualityCalls[0]")?.toString()
+        let optionCount = context.evaluateScript("optionCalls.length")?.toInt32() ?? -1
+
+        #expect(audioQuality == "AUDIO_QUALITY_HIGH")
+        #expect(playbackQuality == "hd720")
+        #expect(optionCount > 0)
+    }
+
+    @Test("Playback audio quality override coalesces repeated reapply scheduling")
+    func playbackAudioQualityOverrideCoalescesRepeatedReapplyScheduling() throws {
+        let context = try #require(JSContext())
+        self.evaluate(
+            """
+            var pendingRafCallbacks = [];
+            function requestAnimationFrame(callback) {
+                pendingRafCallbacks.push(callback);
+                return pendingRafCallbacks.length;
+            }
+            function runNextAnimationFrame() {
+                var callback = pendingRafCallbacks.shift();
+                if (callback) {
+                    callback();
+                }
+            }
+            var localStorageValues = { kasetPlaybackAudioQuality: 'normal' };
+            var localStorage = {
+                getItem: function(key) { return localStorageValues[key] || null; },
+                setItem: function(key, value) { localStorageValues[key] = value; }
+            };
+            var audioQualityCalls = [];
+            var playerApi = {
+                setAudioQuality: function(value) { audioQualityCalls.push(value); }
+            };
+            var ytmusicPlayer = { playerApi: playerApi };
+            var videoListeners = {};
+            var video = {
+                addEventListener: function(name, handler) {
+                    videoListeners[name] = handler;
+                }
+            };
+            var document = {
+                documentElement: {},
+                querySelector: function(selector) {
+                    if (selector === 'ytmusic-player') return ytmusicPlayer;
+                    if (selector === 'video') return video;
+                    return null;
+                },
+                getElementById: function() { return null; }
+            };
+            var window = {};
+            var mutationCallback = null;
+            function MutationObserver(callback) { mutationCallback = callback; }
+            MutationObserver.prototype.observe = function() {};
+            """,
+            in: context
+        )
+
+        self.evaluate(SingletonPlayerWebView.playbackAudioQualityOverrideScript, in: context)
+        self.evaluate(
+            """
+            videoListeners.loadedmetadata();
+            videoListeners.loadeddata();
+            videoListeners.canplay();
+            mutationCallback();
+            """,
+            in: context
+        )
+
+        let pendingBeforeDrain = context.evaluateScript("pendingRafCallbacks.length")?.toInt32() ?? -1
+        #expect(pendingBeforeDrain == 1)
+
+        self.evaluate("runNextAnimationFrame();", in: context)
+
+        let pendingAfterDrain = context.evaluateScript("pendingRafCallbacks.length")?.toInt32() ?? -1
+        let audioQualityCallCount = context.evaluateScript("audioQualityCalls.length")?.toInt32() ?? -1
+
+        #expect(pendingAfterDrain == 0)
+        #expect(audioQualityCallCount == 2)
+    }
+
     private func makeBootstrapWrapperContext() -> JSContext? {
         guard let context = JSContext() else { return nil }
 

--- a/Tests/KasetTests/MediaControlScriptTests.swift
+++ b/Tests/KasetTests/MediaControlScriptTests.swift
@@ -267,10 +267,14 @@ struct MediaControlScriptTests {
             };
             var audioQualityCalls = [];
             var playbackQualityCalls = [];
+            var playbackQualityRangeCalls = [];
             var optionCalls = [];
             var playerApi = {
                 setAudioQuality: function(value) { audioQualityCalls.push(value); },
                 setPlaybackQuality: function(value) { playbackQualityCalls.push(value); },
+                setPlaybackQualityRange: function() {
+                    playbackQualityRangeCalls.push(Array.prototype.slice.call(arguments));
+                },
                 setOption: function(module, option, value) {
                     optionCalls.push(module + ':' + option + ':' + value);
                 }
@@ -298,11 +302,13 @@ struct MediaControlScriptTests {
         self.evaluate(SingletonPlayerWebView.playbackAudioQualityOverrideScript, in: context)
 
         let audioQuality = context.evaluateScript("audioQualityCalls[0]")?.toString()
-        let playbackQuality = context.evaluateScript("playbackQualityCalls[0]")?.toString()
+        let playbackQualityCallCount = context.evaluateScript("playbackQualityCalls.length")?.toInt32() ?? -1
+        let playbackQualityRangeCallCount = context.evaluateScript("playbackQualityRangeCalls.length")?.toInt32() ?? -1
         let optionCount = context.evaluateScript("optionCalls.length")?.toInt32() ?? -1
 
         #expect(audioQuality == "AUDIO_QUALITY_HIGH")
-        #expect(playbackQuality == "hd720")
+        #expect(playbackQualityCallCount == 0)
+        #expect(playbackQualityRangeCallCount == 0)
         #expect(optionCount > 0)
     }
 

--- a/Tests/KasetTests/MediaControlScriptTests.swift
+++ b/Tests/KasetTests/MediaControlScriptTests.swift
@@ -312,6 +312,231 @@ struct MediaControlScriptTests {
         #expect(optionCount > 0)
     }
 
+    @Test("Playback audio quality override posts sanitized stats through bridge")
+    func playbackAudioQualityOverridePostsSanitizedStatsThroughBridge() throws {
+        let context = try #require(JSContext())
+        self.evaluate(
+            """
+            var localStorageValues = { kasetPlaybackAudioQuality: 'high' };
+            var localStorage = {
+                getItem: function(key) { return localStorageValues[key] || null; },
+                setItem: function(key, value) { localStorageValues[key] = value; }
+            };
+            var postedMessages = [];
+            var window = {
+                webkit: {
+                    messageHandlers: {
+                        singletonPlayer: {
+                            postMessage: function(message) {
+                                postedMessages.push(message);
+                            }
+                        }
+                    }
+                }
+            };
+            var playerApi = {
+                setAudioQuality: function() {},
+                setOption: function() {},
+                getAudioQuality: function() { return 'AUDIO_QUALITY_HIGH'; },
+                getAvailableAudioQualityLevels: function() {
+                    return ['AUDIO_QUALITY_LOW', 'AUDIO_QUALITY_HIGH'];
+                },
+                getVideoData: function() {
+                    return { video_id: 'abc123' };
+                },
+                getStatsForNerds: function() {
+                    return {
+                        debug_audioFormat: '251 opus',
+                        debug_audioQuality: 'AUDIO_QUALITY_HIGH',
+                        cpn: 'sensitive-cpn'
+                    };
+                }
+            };
+            var ytmusicPlayer = { playerApi: playerApi };
+            var video = {
+                addEventListener: function() {}
+            };
+            var document = {
+                documentElement: {},
+                querySelector: function(selector) {
+                    if (selector === 'ytmusic-player') return ytmusicPlayer;
+                    if (selector === 'video') return video;
+                    return null;
+                },
+                getElementById: function() { return null; }
+            };
+            function MutationObserver(callback) { this.callback = callback; }
+            MutationObserver.prototype.observe = function() {};
+            """,
+            in: context
+        )
+
+        self.evaluate(SingletonPlayerWebView.playbackAudioQualityOverrideScript, in: context)
+
+        let messageCount = context.evaluateScript("postedMessages.length")?.toInt32() ?? -1
+        let type = context.evaluateScript("postedMessages[0].type")?.toString()
+        let preferred = context.evaluateScript("postedMessages[0].preferred")?.toString()
+        let desired = context.evaluateScript("postedMessages[0].desired")?.toString()
+        let observed = context.evaluateScript("postedMessages[0].observed")?.toString()
+        let videoId = context.evaluateScript("postedMessages[0].videoId")?.toString()
+        let audioFormat = context.evaluateScript("postedMessages[0].stats.debug_audioFormat")?.toString()
+        let cpnWasOmitted = context.evaluateScript(
+            "typeof postedMessages[0].stats.cpn === 'undefined'"
+        )?.toBool() ?? false
+
+        #expect(messageCount == 1)
+        #expect(type == "PLAYBACK_AUDIO_QUALITY_STATS")
+        #expect(preferred == "high")
+        #expect(desired == "AUDIO_QUALITY_HIGH")
+        #expect(observed == "AUDIO_QUALITY_HIGH")
+        #expect(videoId == "abc123")
+        #expect(audioFormat == "251 opus")
+        #expect(cpnWasOmitted)
+
+        self.evaluate("window.__kasetApplyPlaybackAudioQuality();", in: context)
+
+        let messageCountAfterDuplicate = context.evaluateScript("postedMessages.length")?.toInt32() ?? -1
+        #expect(messageCountAfterDuplicate == 1)
+    }
+
+    @Test("Playback audio quality override infers observed quality from Stats for Nerds itag")
+    func playbackAudioQualityOverrideInfersObservedQualityFromStatsItag() throws {
+        let context = try #require(JSContext())
+        self.evaluate(
+            """
+            var localStorageValues = { kasetPlaybackAudioQuality: 'low' };
+            var localStorage = {
+                getItem: function(key) { return localStorageValues[key] || null; },
+                setItem: function(key, value) { localStorageValues[key] = value; }
+            };
+            var postedMessages = [];
+            var window = {
+                webkit: {
+                    messageHandlers: {
+                        singletonPlayer: {
+                            postMessage: function(message) {
+                                postedMessages.push(message);
+                            }
+                        }
+                    }
+                }
+            };
+            var playerApi = {
+                setAudioQuality: function() {},
+                setOption: function() {},
+                getVideoData: function() {
+                    return { video_id: 'itag-video' };
+                },
+                getStatsForNerds: function() {
+                    return {
+                        codecs: '0 / mp4a.40.2 (141)',
+                        cpn: 'sensitive-cpn'
+                    };
+                }
+            };
+            var ytmusicPlayer = { playerApi: playerApi };
+            var video = {
+                addEventListener: function() {}
+            };
+            var document = {
+                documentElement: {},
+                querySelector: function(selector) {
+                    if (selector === 'ytmusic-player') return ytmusicPlayer;
+                    if (selector === 'video') return video;
+                    return null;
+                },
+                getElementById: function() { return null; }
+            };
+            function MutationObserver(callback) { this.callback = callback; }
+            MutationObserver.prototype.observe = function() {};
+            """,
+            in: context
+        )
+
+        self.evaluate(SingletonPlayerWebView.playbackAudioQualityOverrideScript, in: context)
+
+        let messageCount = context.evaluateScript("postedMessages.length")?.toInt32() ?? -1
+        let preferred = context.evaluateScript("postedMessages[0].preferred")?.toString()
+        let desired = context.evaluateScript("postedMessages[0].desired")?.toString()
+        let observed = context.evaluateScript("postedMessages[0].observed")?.toString()
+        let source = context.evaluateScript("postedMessages[0].source")?.toString()
+        let observedItag = context.evaluateScript("postedMessages[0].observedItag")?.toString()
+        let codecs = context.evaluateScript("postedMessages[0].stats.codecs")?.toString()
+        let cpnWasOmitted = context.evaluateScript(
+            "typeof postedMessages[0].stats.cpn === 'undefined'"
+        )?.toBool() ?? false
+
+        #expect(messageCount == 1)
+        #expect(preferred == "low")
+        #expect(desired == "AUDIO_QUALITY_LOW")
+        #expect(observed == "AUDIO_QUALITY_HIGH")
+        #expect(source == "statsForNerds.codecs.itag")
+        #expect(observedItag == "141")
+        #expect(codecs == "0 / mp4a.40.2 (141)")
+        #expect(cpnWasOmitted)
+    }
+
+    @Test("Playback audio quality override maps Opus 251 Stats for Nerds itag to medium quality")
+    func playbackAudioQualityOverrideMapsOpus251StatsItagToMediumQuality() throws {
+        let context = try #require(JSContext())
+        self.evaluate(
+            """
+            var localStorageValues = { kasetPlaybackAudioQuality: 'normal' };
+            var localStorage = {
+                getItem: function(key) { return localStorageValues[key] || null; },
+                setItem: function(key, value) { localStorageValues[key] = value; }
+            };
+            var postedMessages = [];
+            var window = {
+                webkit: {
+                    messageHandlers: {
+                        singletonPlayer: {
+                            postMessage: function(message) {
+                                postedMessages.push(message);
+                            }
+                        }
+                    }
+                }
+            };
+            var playerApi = {
+                setAudioQuality: function() {},
+                setOption: function() {},
+                getStatsForNerds: function() {
+                    return {
+                        debug_audioFormat: 'opus (251)'
+                    };
+                }
+            };
+            var ytmusicPlayer = { playerApi: playerApi };
+            var video = {
+                addEventListener: function() {}
+            };
+            var document = {
+                documentElement: {},
+                querySelector: function(selector) {
+                    if (selector === 'ytmusic-player') return ytmusicPlayer;
+                    if (selector === 'video') return video;
+                    return null;
+                },
+                getElementById: function() { return null; }
+            };
+            function MutationObserver(callback) { this.callback = callback; }
+            MutationObserver.prototype.observe = function() {};
+            """,
+            in: context
+        )
+
+        self.evaluate(SingletonPlayerWebView.playbackAudioQualityOverrideScript, in: context)
+
+        let observed = context.evaluateScript("postedMessages[0].observed")?.toString()
+        let source = context.evaluateScript("postedMessages[0].source")?.toString()
+        let observedItag = context.evaluateScript("postedMessages[0].observedItag")?.toString()
+
+        #expect(observed == "AUDIO_QUALITY_MEDIUM")
+        #expect(source == "statsForNerds.debug_audioFormat.itag")
+        #expect(observedItag == "251")
+    }
+
     @Test("Playback audio quality override coalesces repeated reapply scheduling")
     func playbackAudioQualityOverrideCoalescesRepeatedReapplyScheduling() throws {
         let context = try #require(JSContext())

--- a/Tests/KasetTests/PlaybackAudioQualityStatsLoggingTests.swift
+++ b/Tests/KasetTests/PlaybackAudioQualityStatsLoggingTests.swift
@@ -1,0 +1,54 @@
+import Testing
+@testable import Kaset
+
+@Suite(.serialized, .tags(.service))
+@MainActor
+struct PlaybackAudioQualityStatsLoggingTests {
+    @Test("Audio quality stats log message keeps only native-allowlisted stats")
+    func audioQualityStatsLogMessageSanitizesUntrustedBridgePayload() {
+        let body: [String: Any] = [
+            "preferred": "high",
+            "desired": "AUDIO_QUALITY_HIGH",
+            "applied": true,
+            "observed": "AUDIO_QUALITY_MEDIUM",
+            "source": "stats",
+            "available": [
+                "AUDIO_QUALITY_HIGH",
+                ["mock": "mock-token"],
+                Double.infinity,
+                true,
+            ],
+            "stats": [
+                "audioBitrate": "256kbps",
+                "audioCodec": [
+                    "opus",
+                    ["mock": "mock-token"],
+                    251,
+                    false,
+                    Double.nan,
+                ],
+                "audioSecret": "mock-token",
+                "debug_audioQuality": "AUDIO_QUALITY_HIGH",
+                "trackingCookie": "mock-cookie",
+                "unrelated": ["mock": "mock-token"],
+            ],
+        ]
+
+        let message = SingletonPlayerWebView.Coordinator.audioQualityStatsLogMessage(
+            body: body,
+            observedVideoId: "video-id"
+        )
+
+        #expect(message.contains("available=[\"AUDIO_QUALITY_HIGH\",true]"))
+        #expect(message.contains("\"audioBitrate\":\"256kbps\""))
+        #expect(message.contains("\"audioCodec\":[\"opus\",251,false]"))
+        #expect(message.contains("\"debug_audioQuality\":\"AUDIO_QUALITY_HIGH\""))
+        #expect(!message.contains("trackingCookie"))
+        #expect(!message.contains("audioSecret"))
+        #expect(!message.contains("unrelated"))
+        #expect(!message.contains("mock-token"))
+        #expect(!message.contains("mock-cookie"))
+        #expect(!message.contains("Infinity"))
+        #expect(!message.contains("NaN"))
+    }
+}

--- a/Tests/KasetTests/SettingsManagerTests.swift
+++ b/Tests/KasetTests/SettingsManagerTests.swift
@@ -208,6 +208,36 @@ struct SettingsManagerTests {
         #expect(manager.mediaControlStyle == .nextPreviousTrack)
     }
 
+    // MARK: - PlaybackAudioQuality Tests
+
+    @Test("PlaybackAudioQuality has correct display names")
+    func playbackAudioQualityDisplayNames() {
+        #expect(SettingsManager.PlaybackAudioQuality.auto.displayName == "Auto")
+        #expect(SettingsManager.PlaybackAudioQuality.low.displayName == "Low")
+        #expect(SettingsManager.PlaybackAudioQuality.normal.displayName == "Normal")
+        #expect(SettingsManager.PlaybackAudioQuality.high.displayName == "High")
+    }
+
+    @Test("PlaybackAudioQuality rawValues roundtrip correctly")
+    func playbackAudioQualityRawValues() {
+        for quality in SettingsManager.PlaybackAudioQuality.allCases {
+            let restored = SettingsManager.PlaybackAudioQuality(rawValue: quality.rawValue)
+            #expect(restored == quality)
+        }
+    }
+
+    @Test("PlaybackAudioQuality identifiers are unique")
+    func playbackAudioQualityIdentifiersUnique() {
+        let ids = SettingsManager.PlaybackAudioQuality.allCases.map(\.id)
+        let uniqueIds = Set(ids)
+        #expect(ids.count == uniqueIds.count)
+    }
+
+    @Test("PlaybackAudioQuality has all expected cases")
+    func playbackAudioQualityAllCasesCovered() {
+        #expect(SettingsManager.PlaybackAudioQuality.allCases.count == 4)
+    }
+
     // MARK: - All Cases Coverage
 
     @Test("All LaunchPage cases are covered")

--- a/docs/playback.md
+++ b/docs/playback.md
@@ -19,6 +19,8 @@ Our solution: A **singleton WebView** that loads YouTube Music watch pages and p
 | Component | File | Purpose |
 |-----------|------|---------|
 | `SingletonPlayerWebView` | `MiniPlayerWebView.swift` | Manages the one-and-only WebView |
+| `SingletonPlayerWebView+PlaybackPreferences` | `SingletonPlayerWebView+PlaybackPreferences.swift` | Installs and refreshes playback preference user scripts |
+| `SingletonPlayerWebView+PlaybackAudioQuality` | `SingletonPlayerWebView+PlaybackAudioQuality.swift` | Applies preferred YouTube audio quality and reports diagnostics |
 | `PersistentPlayerView` | `MiniPlayerWebView.swift` | SwiftUI wrapper for the WebView |
 | `PlayerService` | `PlayerService.swift` | Playback state and control |
 | `PlayerService+WebQueueSync` | `PlayerService+WebQueueSync.swift` | Keeps native queue state authoritative when WebView events drift |
@@ -96,6 +98,7 @@ The observer script continuously reports:
 - The observed `videoId`
 - Whether the observer thinks the track changed
 - Like status and lightweight video availability
+- Sanitized audio-quality diagnostics via `PLAYBACK_AUDIO_QUALITY_STATS`
 
 Swift updates `PlayerService` from every `STATE_UPDATE`, then uses
 `PlayerService+WebQueueSync` to decide whether the reported track matches
@@ -143,6 +146,158 @@ func loadVideo(videoId: String) {
 When the WebView reports a new `videoId`, Kaset treats that as authoritative
 even if the DOM title/artist are still stale. This avoids a race where YouTube
 switches tracks before the player bar text catches up.
+
+## Playback Preferences and Audio Quality
+
+Kaset injects a small set of playback preference scripts into the singleton
+player WebView from `SingletonPlayerWebView+PlaybackPreferences.swift` and
+`SingletonPlayerWebView+PlaybackAudioQuality.swift`.
+
+### Script responsibilities
+
+| Script | Injection timing | Purpose |
+|--------|------------------|---------|
+| Media control bootstrap | document start | Wraps `navigator.mediaSession.setActionHandler` so the macOS media keys can use either seek-forward/back or next/previous behavior. |
+| Playback audio-quality bootstrap | document start | Stores the preferred `SettingsManager.PlaybackAudioQuality` value on `window.__kasetPlaybackAudioQuality` before YouTube's player finishes booting. |
+| Playback audio-quality override | document end | Finds candidate YouTube player APIs, asks them to use the preferred audio quality, and reports sanitized diagnostics back to Swift. |
+| Playback audio-quality sync | runtime preference changes | Updates `window.__kasetPlaybackAudioQuality` and immediately reapplies the preference if the override script is already installed. |
+
+When either the media-control mode or playback audio-quality setting changes,
+`refreshInstalledUserScripts()` rebuilds the WebView user scripts and also sends
+runtime sync JavaScript to the already-loaded page. This matters because WebKit
+user scripts only affect future document loads; the explicit sync path keeps the
+currently playing song aligned with the new setting.
+
+### Applying the preferred audio quality
+
+The override script probes several YouTube Music player surfaces, currently
+including:
+
+- `document.querySelector('ytmusic-player')`
+- `ytmusic-player.playerApi`
+- `document.getElementById('movie_player')`
+- `window.yt.player`
+
+For each candidate it tries best-effort YouTube player APIs:
+
+```javascript
+playerApi.setAudioQuality(desiredQuality)
+playerApi.setOption('audio', 'quality', desiredQuality)
+playerApi.setOption('audio', 'audioQuality', desiredQuality)
+playerApi.setOption('player', 'audioQuality', desiredQuality)
+playerApi.setOption('player', 'audio_quality', desiredQuality)
+playerApi.setOption('playback', 'audioQuality', desiredQuality)
+playerApi.setOption('playback', 'audio_quality', desiredQuality)
+```
+
+The YouTube-facing values are:
+
+| Kaset setting | YouTube value |
+|---------------|---------------|
+| `.low` | `small` |
+| `.medium` | `medium` |
+| `.high` | `highres` |
+
+YouTube may still choose the final stream based on account entitlement,
+availability, network conditions, or player policy. Treat this path as a
+preference request plus instrumentation, not as a guarantee that YouTube will
+serve a specific stream.
+
+### How to get playback quality info
+
+The audio-quality override script posts a dedicated WebKit bridge message when
+it has a new diagnostic snapshot:
+
+```javascript
+window.webkit.messageHandlers.singletonPlayer.postMessage({
+    type: 'PLAYBACK_AUDIO_QUALITY_STATS',
+    preferred: 'AUDIO_QUALITY_HIGH',
+    desired: 'highres',
+    applied: true,
+    observed: 'AUDIO_QUALITY_HIGH',
+    source: 'statsForNerds.codecs.itag',
+    observedItag: '141',
+    videoId: 's5oSscNIyIs',
+    available: [],
+    stats: { codecs: '0 / mp4a.40.2 (141)' }
+});
+```
+
+Swift handles this in `MiniPlayerWebView.swift` and logs it through
+`DiagnosticsLogger.player` as `Audio quality stats: ...`.
+
+To inspect the latest quality diagnostics while a song is playing, run:
+
+```bash
+/usr/bin/log show --process Kaset --last 10m --style compact --info --debug \
+  | grep 'Audio quality stats'
+```
+
+For a narrower query against Kaset's unified logging subsystem:
+
+```bash
+/usr/bin/log show --process Kaset --last 10m --style compact --info --debug \
+  --predicate 'subsystem == "com.sertacozercan.Kaset"' \
+  | grep 'Audio quality stats'
+```
+
+Example log line:
+
+```text
+Audio quality stats: preferred=AUDIO_QUALITY_HIGH desired=highres applied=true observed=AUDIO_QUALITY_HIGH source=statsForNerds.codecs.itag videoId=s5oSscNIyIs available=[] stats={"codecs":"0 / mp4a.40.2 (141)"}
+```
+
+The most useful fields are:
+
+| Field | Meaning |
+|-------|---------|
+| `preferred` | Kaset's selected playback audio-quality setting. |
+| `desired` | The string Kaset sent to YouTube player APIs. |
+| `applied` | Whether at least one known setter call appeared to succeed. This does not prove YouTube selected that stream. |
+| `observed` | Best available observed quality from player APIs or Stats for Nerds inference. |
+| `source` | Where `observed` came from, for example `movie_player.getAudioQuality` or `statsForNerds.codecs.itag`. |
+| `observedItag` | Inferred audio itag when one was found. This is included in the bridge payload; the compact Swift log focuses on sanitized summary fields. |
+| `videoId` | The current YouTube video id, if available. |
+| `available` | Sanitized result from available-audio-quality player APIs, when exposed. |
+| `stats` | Allowlisted, sanitized Stats for Nerds fields. |
+
+### Stats for Nerds and itag inference
+
+YouTube Music does not expose a stable public API for the selected audio stream.
+The diagnostic path therefore combines several best-effort sources:
+
+1. Direct player getters such as `getAudioQuality()`,
+   `getPlaybackAudioQuality()`, and `getPreferredAudioQuality()`.
+2. Available-quality getters such as `getAvailableAudioQualityLevels()`.
+3. Allowlisted Stats for Nerds fields from `getStatsForNerds()`.
+4. Itag inference from primitive values found in those allowlisted fields.
+
+Current audio itag mapping:
+
+| Itag | Inferred quality |
+|------|------------------|
+| `139`, `249`, `250` | `AUDIO_QUALITY_LOW` |
+| `140`, `251` | `AUDIO_QUALITY_MEDIUM` |
+| `141` | `AUDIO_QUALITY_HIGH` |
+
+Only primitive values and primitive arrays are inspected. The bridge payload is
+throttled and sanitized before logging so that noisy or sensitive player objects
+are not emitted to unified logging.
+
+### Troubleshooting quality diagnostics
+
+- No `Audio quality stats` line: confirm the app was built with the latest
+  `SingletonPlayerWebView+PlaybackAudioQuality.swift`, start a fresh song, and
+  query at least the last 10 minutes of logs.
+- `applied=false`: none of the probed player APIs exposed a usable setter at
+  that moment. The observer will retry on video lifecycle and DOM mutation
+  events.
+- `observed=unknown`: YouTube did not expose a known getter or allowlisted Stats
+  for Nerds value yet. Wait for playback to start or seek/change tracks to cause
+  another snapshot.
+- `preferred` and `observed` differ: YouTube may have ignored the preference,
+  the stream may not be available for that account/video, or the observed value
+  may have been captured before the player settled.
 
 ## Background Audio
 


### PR DESCRIPTION
## Summary
- Add a playback audio quality setting with Auto, Low, Normal, and High options
- Persist the selected quality in SettingsManager and expose it in General Settings
- Sync quality changes through NowPlayingManager to the singleton WebView
- Inject WebKit scripts to apply the preferred quality to YouTube Music player APIs
- Add unit coverage for settings and playback audio quality scripts

## Tests
- swift test --filter MediaControlScriptTests --parallel
- swift test --filter SettingsManagerTests --parallel