### PR TITLE
fix(search/sidebar/playback): improve fallback search, sidebar playback, and resume recovery

### DIFF
--- a/Sources/Kaset/Services/Player/PlayerService+PlaybackControls.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+PlaybackControls.swift
@@ -52,7 +52,7 @@ extension PlayerService {
         // create it from `pendingPlayVideoId` and autoload in `PersistentPlayerView`.
         self.showMiniPlayer = false
         if SingletonPlayerWebView.shared.webView != nil {
-            SingletonPlayerWebView.shared.loadVideo(videoId: videoId)
+            SingletonPlayerWebView.shared.loadVideo(videoId: videoId, strategy: .resumeWhenSameVideoId)
         }
 
         // Fetch full song metadata in the background to get feedbackTokens
@@ -61,7 +61,7 @@ extension PlayerService {
 
     /// Plays a song.
     func play(song: Song) async {
-        await self.play(song: song, webLoadStrategy: .standard)
+        await self.play(song: song, webLoadStrategy: .resumeWhenSameVideoId)
     }
 
     /// Plays a song.

--- a/Sources/Kaset/ViewModels/SearchViewModel.swift
+++ b/Sources/Kaset/ViewModels/SearchViewModel.swift
@@ -417,7 +417,6 @@ final class SearchViewModel {
                         firstError = error
                     }
                     self.logger.warning("Filtered fallback search failed: \(error.localizedDescription)")
-                }
             }
         }
 

--- a/Sources/Kaset/ViewModels/SearchViewModel.swift
+++ b/Sources/Kaset/ViewModels/SearchViewModel.swift
@@ -80,7 +80,8 @@ final class SearchViewModel {
 
     /// Whether more results are available to load.
     var hasMoreResults: Bool {
-        // For "All" filter, we don't support pagination (mixed results)
+        // The "All" fallback merges independent filtered endpoints, so there is
+        // no single continuation route that can load the next mixed page safely.
         guard self.selectedFilter != .all else { return false }
         return self.client.hasMoreSearchResults
     }
@@ -278,11 +279,8 @@ final class SearchViewModel {
         self.logger.info("Searching for: \(currentQuery) with filter: \(currentFilter.rawValue)")
 
         do {
-            let searchResults: SearchResponse
-
-                // Use filtered search for specific filters to get more results
-                = switch currentFilter
-            {
+            // Use filtered search for specific filters to get more results.
+            let searchResults: SearchResponse = switch currentFilter {
             case .all:
                 try await self.searchAllResults(query: currentQuery)
             case .songs:
@@ -366,23 +364,60 @@ final class SearchViewModel {
         var firstError: Error?
         var fallbackResponses: [SearchResponse] = []
 
-        for search in [
-            self.client.searchSongsWithPagination,
-            self.client.searchAlbums,
-            self.client.searchArtists,
-            self.client.searchFeaturedPlaylists,
-            self.client.searchCommunityPlaylists,
-            self.client.searchPodcasts,
-        ] {
-            guard !Task.isCancelled else { break }
-
-            do {
-                fallbackResponses.append(try await search(query))
-            } catch {
-                if firstError == nil {
-                    firstError = error
+        await withTaskGroup(of: Result<SearchResponse, Error>.self) { group in
+            group.addTask { [client = self.client] in
+                do {
+                    return try await .success(client.searchSongsWithPagination(query: query))
+                } catch {
+                    return .failure(error)
                 }
-                self.logger.warning("Filtered fallback search failed: \(error.localizedDescription)")
+            }
+            group.addTask { [client = self.client] in
+                do {
+                    return try await .success(client.searchAlbums(query: query))
+                } catch {
+                    return .failure(error)
+                }
+            }
+            group.addTask { [client = self.client] in
+                do {
+                    return try await .success(client.searchArtists(query: query))
+                } catch {
+                    return .failure(error)
+                }
+            }
+            group.addTask { [client = self.client] in
+                do {
+                    return try await .success(client.searchFeaturedPlaylists(query: query))
+                } catch {
+                    return .failure(error)
+                }
+            }
+            group.addTask { [client = self.client] in
+                do {
+                    return try await .success(client.searchCommunityPlaylists(query: query))
+                } catch {
+                    return .failure(error)
+                }
+            }
+            group.addTask { [client = self.client] in
+                do {
+                    return try await .success(client.searchPodcasts(query: query))
+                } catch {
+                    return .failure(error)
+                }
+            }
+
+            for await result in group {
+                switch result {
+                case let .success(response):
+                    fallbackResponses.append(response)
+                case let .failure(error):
+                    if firstError == nil {
+                        firstError = error
+                    }
+                    self.logger.warning("Filtered fallback search failed: \(error.localizedDescription)")
+                }
             }
         }
 
@@ -421,6 +456,8 @@ final class SearchViewModel {
             artists: artists,
             playlists: playlists,
             podcastShows: podcastShows,
+            // Mixed fallback results deliberately do not expose a continuation:
+            // each source category has its own token and continuation endpoint.
             continuationToken: nil
         )
     }

--- a/Sources/Kaset/ViewModels/SearchViewModel.swift
+++ b/Sources/Kaset/ViewModels/SearchViewModel.swift
@@ -284,7 +284,7 @@ final class SearchViewModel {
                 = switch currentFilter
             {
             case .all:
-                try await self.client.search(query: currentQuery)
+                try await self.searchAllResults(query: currentQuery)
             case .songs:
                 try await self.client.searchSongsWithPagination(query: currentQuery)
             case .albums:
@@ -353,6 +353,76 @@ final class SearchViewModel {
             self.logger.error("Failed to load more: \(error.localizedDescription)")
             self.loadingState = .loaded // Revert to loaded state to allow retry
         }
+    }
+
+    private func searchAllResults(query: String) async throws -> SearchResponse {
+        let generalResults = try await self.client.search(query: query)
+        guard generalResults.isEmpty else {
+            return generalResults
+        }
+
+        self.logger.info("General search returned no results; loading filtered fallback results")
+
+        var firstError: Error?
+        var fallbackResponses: [SearchResponse] = []
+
+        for search in [
+            self.client.searchSongsWithPagination,
+            self.client.searchAlbums,
+            self.client.searchArtists,
+            self.client.searchFeaturedPlaylists,
+            self.client.searchCommunityPlaylists,
+            self.client.searchPodcasts,
+        ] {
+            guard !Task.isCancelled else { break }
+
+            do {
+                fallbackResponses.append(try await search(query))
+            } catch {
+                if firstError == nil {
+                    firstError = error
+                }
+                self.logger.warning("Filtered fallback search failed: \(error.localizedDescription)")
+            }
+        }
+
+        let fallbackResults = Self.mergedSearchResults(fallbackResponses)
+        if fallbackResults.isEmpty, let firstError {
+            throw firstError
+        }
+
+        return fallbackResults
+    }
+
+    private static func mergedSearchResults(_ responses: [SearchResponse]) -> SearchResponse {
+        var seenSongIds: Set<String> = []
+        var seenAlbumIds: Set<String> = []
+        var seenArtistIds: Set<String> = []
+        var seenPlaylistIds: Set<String> = []
+        var seenPodcastShowIds: Set<String> = []
+
+        var songs: [Song] = []
+        var albums: [Album] = []
+        var artists: [Artist] = []
+        var playlists: [Playlist] = []
+        var podcastShows: [PodcastShow] = []
+
+        for response in responses {
+            songs.append(contentsOf: response.songs.filter { seenSongIds.insert($0.id).inserted })
+            albums.append(contentsOf: response.albums.filter { seenAlbumIds.insert($0.id).inserted })
+            artists.append(contentsOf: response.artists.filter { seenArtistIds.insert($0.id).inserted })
+            playlists.append(contentsOf: response.playlists.filter { seenPlaylistIds.insert($0.id).inserted })
+            podcastShows.append(contentsOf: response.podcastShows.filter { seenPodcastShowIds.insert($0.id).inserted })
+        }
+
+        return SearchResponse(
+            songs: songs,
+            albums: albums,
+            artists: artists,
+            playlists: playlists,
+            podcastShows: podcastShows,
+            continuationToken: nil
+        )
     }
 
     /// Clears search results.

--- a/Sources/Kaset/ViewModels/SearchViewModel.swift
+++ b/Sources/Kaset/ViewModels/SearchViewModel.swift
@@ -417,6 +417,7 @@ final class SearchViewModel {
                         firstError = error
                     }
                     self.logger.warning("Filtered fallback search failed: \(error.localizedDescription)")
+                }
             }
         }
 

--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -334,6 +334,7 @@ struct MainWindow: View {
                 selection: self.$navigationSelection,
                 pinnedSelection: self.$selectedSidebarPinnedItem
             )
+            .environment(self.libraryViewModel)
         } detail: {
             ZStack(alignment: .trailing) {
                 self.detailView(

--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -346,7 +346,6 @@ struct MainWindow: View {
                 // Right sidebar overlay - either lyrics or queue (mutually exclusive)
                 self.rightSidebarOverlay(client: self.client)
             }
-            .clipped()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)) { _ in

--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -329,30 +329,30 @@ struct MainWindow: View {
     // MARK: - Main Content
 
     private var mainContent: some View {
-        ZStack(alignment: .trailing) {
-            // Main navigation content
-            NavigationSplitView(columnVisibility: self.$columnVisibility) {
-                Sidebar(
-                    selection: self.$navigationSelection,
-                    pinnedSelection: self.$selectedSidebarPinnedItem
-                )
-            } detail: {
+        NavigationSplitView(columnVisibility: self.$columnVisibility) {
+            Sidebar(
+                selection: self.$navigationSelection,
+                pinnedSelection: self.$selectedSidebarPinnedItem
+            )
+        } detail: {
+            ZStack(alignment: .trailing) {
                 self.detailView(
                     for: self.navigationSelection,
                     pinnedItem: self.selectedSidebarPinnedItem,
                     client: self.client
                 )
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)) { _ in
-                // Ensure the sidebar returns when the app is re-activated from the Dock or app switcher.
-                if self.columnVisibility != .all {
-                    self.columnVisibility = .all
-                }
-            }
 
-            // Right sidebar overlay - either lyrics or queue (mutually exclusive)
-            self.rightSidebarOverlay(client: self.client)
+                // Right sidebar overlay - either lyrics or queue (mutually exclusive)
+                self.rightSidebarOverlay(client: self.client)
+            }
+            .clipped()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)) { _ in
+            // Ensure the sidebar returns when the app is re-activated from the Dock or app switcher.
+            if self.columnVisibility != .all {
+                self.columnVisibility = .all
+            }
         }
         .animation(.easeInOut(duration: 0.25), value: self.playerService.showLyrics)
         .animation(.easeInOut(duration: 0.25), value: self.playerService.showQueue)

--- a/Sources/Kaset/Views/MiniPlayerWebView.swift
+++ b/Sources/Kaset/Views/MiniPlayerWebView.swift
@@ -339,7 +339,8 @@ final class SingletonPlayerWebView {
         switch strategy {
         case .standard:
             if videoId == previousVideoId {
-                self.logger.debug("Video \(videoId) already loaded, skipping")
+                self.logger.debug("Video \(videoId) already loaded, resuming playback")
+                self.play()
                 return
             }
         case .preferInPlaceWhenSameVideoId:

--- a/Sources/Kaset/Views/MiniPlayerWebView.swift
+++ b/Sources/Kaset/Views/MiniPlayerWebView.swift
@@ -237,6 +237,8 @@ final class SingletonPlayerWebView {
     enum VideoLoadStrategy: Equatable {
         /// Skip navigation when `videoId` matches `currentVideoId`.
         case standard
+        /// Same `videoId` as tracked: resume playback for an explicit user play intent.
+        case resumeWhenSameVideoId
         /// Same `videoId` as tracked: `seek(0)` + play only (fast). Different id: full watch URL load.
         case preferInPlaceWhenSameVideoId
         /// Same `videoId` as tracked: full `webView.load` (DOM out of sync with Swift). Different id: full load.
@@ -339,7 +341,12 @@ final class SingletonPlayerWebView {
         switch strategy {
         case .standard:
             if videoId == previousVideoId {
-                self.logger.debug("Video \(videoId) already loaded, resuming playback")
+                self.logger.debug("Video \(videoId) already loaded, skipping duplicate load")
+                return
+            }
+        case .resumeWhenSameVideoId:
+            if videoId == previousVideoId {
+                self.logger.debug("Video \(videoId) already loaded, resuming from explicit play intent")
                 self.play()
                 return
             }

--- a/Sources/Kaset/Views/Sidebar.swift
+++ b/Sources/Kaset/Views/Sidebar.swift
@@ -10,6 +10,8 @@ struct Sidebar: View {
 
     @Binding var selection: NavigationItem?
     @Binding var pinnedSelection: SidebarPinnedItem?
+    @Environment(PlayerService.self) private var playerService
+    @Environment(LibraryViewModel.self) private var libraryViewModel: LibraryViewModel?
     @Environment(SidebarPinnedItemsManager.self) private var sidebarPinnedItemsManager
     @Environment(PodcastsAvailabilityService.self) private var podcastsAvailability
 
@@ -63,6 +65,14 @@ struct Sidebar: View {
                         }
                     }
 
+                    if !self.topPlaylists.isEmpty {
+                        Section(String(localized: "Top Playlists")) {
+                            ForEach(self.topPlaylists) { playlist in
+                                self.topPlaylistRow(playlist)
+                            }
+                        }
+                    }
+
                     // Collection section
                     Section(String(localized: "Collection")) {
                         NavigationLink(value: SidebarSelection.navigation(.library)) {
@@ -103,6 +113,17 @@ struct Sidebar: View {
             SidebarProfileView()
         }
         .navigationSplitViewColumnWidth(min: 200, ideal: 220, max: 300)
+        .task {
+            guard let libraryViewModel = self.libraryViewModel,
+                  libraryViewModel.loadingState == .idle
+            else { return }
+
+            await libraryViewModel.load()
+        }
+    }
+
+    private var topPlaylists: [Playlist] {
+        Array((self.libraryViewModel?.playlists ?? []).prefix(10))
     }
 
     private var currentSidebarSelection: SidebarSelection? {
@@ -184,6 +205,66 @@ struct Sidebar: View {
                 self.sidebarPinnedItemsManager.remove(contentId: item.contentId)
             } label: {
                 Label("Remove from Sidebar", systemImage: "sidebar.left")
+            }
+        }
+    }
+
+    private func topPlaylistRow(_ playlist: Playlist) -> some View {
+        let item = SidebarPinnedItem.from(playlist)
+
+        return HStack(spacing: 6) {
+            Button {
+                self.selectPlaylist(item)
+            } label: {
+                Label {
+                    Text(playlist.title)
+                        .lineLimit(1)
+                } icon: {
+                    Image(systemName: "music.note.list")
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            Button {
+                self.playPlaylist(playlist)
+            } label: {
+                Image(systemName: "play.fill")
+                    .font(.system(size: 11, weight: .semibold))
+            }
+            .buttonStyle(.borderless)
+            .controlSize(.small)
+            .help(String(localized: "Play"))
+            .accessibilityLabel(
+                Text(
+                    "Play \(playlist.title)",
+                    comment: "Accessibility label for playing a playlist from the sidebar"
+                )
+            )
+        }
+    }
+
+    private func selectPlaylist(_ item: SidebarPinnedItem) {
+        guard self.currentSidebarSelection != .pinned(item) else { return }
+
+        self.selection = nil
+        self.pinnedSelection = item
+        HapticService.navigation()
+    }
+
+    private func playPlaylist(_ playlist: Playlist) {
+        guard let libraryViewModel = self.libraryViewModel else { return }
+
+        Task {
+            do {
+                let response = try await libraryViewModel.client.getPlaylist(id: playlist.id)
+                let tracks = response.detail.tracks.filter(\.isPlayable)
+                guard !tracks.isEmpty else { return }
+
+                await self.playerService.playQueue(tracks, startingAt: 0)
+            } catch {
+                DiagnosticsLogger.ui.error("Failed to play sidebar playlist: \(error.localizedDescription)")
             }
         }
     }

--- a/Sources/Kaset/Views/Sidebar.swift
+++ b/Sources/Kaset/Views/Sidebar.swift
@@ -18,6 +18,9 @@ struct Sidebar: View {
     /// Namespace for glass effect morphing.
     @Namespace private var sidebarNamespace
 
+    @State private var playingTopPlaylistId: String?
+    @State private var topPlaylistPlaybackTask: Task<Void, Never>?
+
     var body: some View {
         VStack(spacing: 0) {
             GlassEffectContainer(spacing: 0) {
@@ -119,6 +122,11 @@ struct Sidebar: View {
             else { return }
 
             await libraryViewModel.load()
+        }
+        .onDisappear {
+            self.topPlaylistPlaybackTask?.cancel()
+            self.topPlaylistPlaybackTask = nil
+            self.playingTopPlaylistId = nil
         }
     }
 
@@ -230,11 +238,18 @@ struct Sidebar: View {
             Button {
                 self.playPlaylist(playlist)
             } label: {
-                Image(systemName: "play.fill")
-                    .font(.system(size: 11, weight: .semibold))
+                if self.playingTopPlaylistId == playlist.id {
+                    ProgressView()
+                        .controlSize(.small)
+                        .scaleEffect(0.55)
+                } else {
+                    Image(systemName: "play.fill")
+                        .font(.system(size: 11, weight: .semibold))
+                }
             }
             .buttonStyle(.borderless)
             .controlSize(.small)
+            .disabled(self.playingTopPlaylistId != nil)
             .help(String(localized: "Play"))
             .accessibilityLabel(
                 Text(
@@ -256,9 +271,23 @@ struct Sidebar: View {
     private func playPlaylist(_ playlist: Playlist) {
         guard let libraryViewModel = self.libraryViewModel else { return }
 
-        Task {
+        self.topPlaylistPlaybackTask?.cancel()
+        self.playingTopPlaylistId = playlist.id
+
+        self.topPlaylistPlaybackTask = Task {
+            defer {
+                Task { @MainActor in
+                    if self.playingTopPlaylistId == playlist.id {
+                        self.playingTopPlaylistId = nil
+                    }
+                    self.topPlaylistPlaybackTask = nil
+                }
+            }
+
             do {
                 let response = try await libraryViewModel.client.getPlaylist(id: playlist.id)
+                guard !Task.isCancelled else { return }
+
                 let tracks = response.detail.tracks.filter(\.isPlayable)
                 guard !tracks.isEmpty else { return }
 

--- a/Sources/Kaset/Views/SingletonPlayerWebView+ObserverScript.swift
+++ b/Sources/Kaset/Views/SingletonPlayerWebView+ObserverScript.swift
@@ -9,7 +9,6 @@ extension SingletonPlayerWebView {
         function __kasetAttemptAutoplayRecovery(video, playBtn) {
             if (!window.__kasetAutoplayPending) return 'noop';
             if (!video.paused) { window.__kasetAutoplayPending = false; return 'noop'; }
-            window.__kasetAutoplayPending = false;
             if (playBtn) { playBtn.click(); return 'clicked'; }
             try { video.play(); return 'played'; } catch (e) { return 'error'; }
         }
@@ -180,6 +179,7 @@ extension SingletonPlayerWebView {
                     // there may not be another `canplay` event to drive recovery.
                     if (video.readyState >= 3) {
                         recoverAutoplayIfNeeded();
+                        scheduleAutoplayRecoveryBurst();
                     }
 
                     // Startup enforcement burst: YouTube may reset volume up to ~2s after

--- a/Sources/Kaset/Views/SingletonPlayerWebView+ObserverScript.swift
+++ b/Sources/Kaset/Views/SingletonPlayerWebView+ObserverScript.swift
@@ -31,6 +31,10 @@ extension SingletonPlayerWebView {
             let lastUpdateTime = 0;
             const UPDATE_THROTTLE_MS = 500; // Throttle updates to max 2/sec
             const POLL_INTERVAL_MS = 1000; // Poll at 1Hz during playback (reduced from 250ms)
+            // Retry autoplay for ~6s after a fresh navigation; slow player
+            // bootstraps can miss the first canplay recovery attempt.
+            const AUTOPLAY_RECOVERY_INTERVAL_MS = 250;
+            const MAX_AUTOPLAY_RECOVERY_ATTEMPTS = 24;
 
             // Volume enforcement: track target volume set by Swift
             // Don't set a default - only enforce when explicitly set by Swift
@@ -145,7 +149,29 @@ extension SingletonPlayerWebView {
                         __kasetAttemptAutoplayRecovery(video, btn);
                     }
 
+                    function scheduleAutoplayRecoveryBurst() {
+                        if (video.__kasetAutoplayRecoveryInterval) return;
+
+                        let recoveryCount = 0;
+                        video.__kasetAutoplayRecoveryInterval = setInterval(() => {
+                            if (!window.__kasetAutoplayPending || !video.paused) {
+                                window.__kasetAutoplayPending = false;
+                                clearInterval(video.__kasetAutoplayRecoveryInterval);
+                                video.__kasetAutoplayRecoveryInterval = null;
+                                return;
+                            }
+
+                            recoverAutoplayIfNeeded();
+                            if (++recoveryCount >= MAX_AUTOPLAY_RECOVERY_ATTEMPTS) {
+                                window.__kasetAutoplayPending = false;
+                                clearInterval(video.__kasetAutoplayRecoveryInterval);
+                                video.__kasetAutoplayRecoveryInterval = null;
+                            }
+                        }, AUTOPLAY_RECOVERY_INTERVAL_MS);
+                    }
+
                     video.addEventListener('canplay', recoverAutoplayIfNeeded);
+                    video.addEventListener('canplay', scheduleAutoplayRecoveryBurst);
 
                     // Apply target volume immediately when video element is first detected
                     enforceVolumeNow();

--- a/Tests/KasetTests/AutoplayRecoveryTests.swift
+++ b/Tests/KasetTests/AutoplayRecoveryTests.swift
@@ -31,7 +31,7 @@ struct AutoplayRecoveryJSTests {
         #expect(ctx.evaluateScript("clicked").toBool() == true)
         #expect(ctx.evaluateScript("played").toBool() == false)
         #expect(ctx.evaluateScript("result").toString() == "clicked")
-        #expect(ctx.evaluateScript("window.__kasetAutoplayPending").toBool() == false)
+        #expect(ctx.evaluateScript("window.__kasetAutoplayPending").toBool() == true)
     }
 
     @Test("Falls back to video.play() when the player-bar button is not mounted")
@@ -47,7 +47,7 @@ struct AutoplayRecoveryJSTests {
         )
         #expect(ctx.evaluateScript("played").toBool() == true)
         #expect(ctx.evaluateScript("result").toString() == "played")
-        #expect(ctx.evaluateScript("window.__kasetAutoplayPending").toBool() == false)
+        #expect(ctx.evaluateScript("window.__kasetAutoplayPending").toBool() == true)
     }
 
     @Test("Does nothing and clears the flag when the video is already playing")
@@ -99,7 +99,7 @@ struct AutoplayRecoveryJSTests {
             """
         )
         #expect(ctx.evaluateScript("result").toString() == "error")
-        #expect(ctx.evaluateScript("window.__kasetAutoplayPending").toBool() == false)
+        #expect(ctx.evaluateScript("window.__kasetAutoplayPending").toBool() == true)
     }
 
     @Test("Observer script embeds the recovery function")
@@ -124,7 +124,7 @@ struct AutoplayRecoveryJSTests {
         #expect(SingletonPlayerWebView.observerScript.contains("AUTOPLAY_RECOVERY_INTERVAL_MS"))
         #expect(SingletonPlayerWebView.observerScript.contains("MAX_AUTOPLAY_RECOVERY_ATTEMPTS"))
     }
-  }
+}
 
 // MARK: - AutoplayIntentScriptTests
 

--- a/Tests/KasetTests/AutoplayRecoveryTests.swift
+++ b/Tests/KasetTests/AutoplayRecoveryTests.swift
@@ -116,7 +116,15 @@ struct AutoplayRecoveryJSTests {
     func observerScriptRetriesRecoveryWhenMediaAlreadyReady() {
         #expect(SingletonPlayerWebView.observerScript.contains("video.readyState >= 3"))
     }
-}
+
+    @Test("Observer script retries autoplay recovery while playback is pending")
+    func observerScriptRetriesWhilePending() {
+        #expect(SingletonPlayerWebView.observerScript.contains("scheduleAutoplayRecoveryBurst"))
+        #expect(SingletonPlayerWebView.observerScript.contains("!window.__kasetAutoplayPending || !video.paused"))
+        #expect(SingletonPlayerWebView.observerScript.contains("AUTOPLAY_RECOVERY_INTERVAL_MS"))
+        #expect(SingletonPlayerWebView.observerScript.contains("MAX_AUTOPLAY_RECOVERY_ATTEMPTS"))
+    }
+  }
 
 // MARK: - AutoplayIntentScriptTests
 

--- a/Tests/KasetTests/Helpers/MockYTMusicClient.swift
+++ b/Tests/KasetTests/Helpers/MockYTMusicClient.swift
@@ -49,6 +49,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     var podcastsSections: [PodcastSection] = []
     var podcastsContinuationSections: [[PodcastSection]] = []
     var searchResponse: SearchResponse = .empty
+    var generalSearchResponse: SearchResponse?
     var searchContinuationResponses: [SearchResponse] = []
     var searchSuggestions: [SearchSuggestion] = []
     var libraryPlaylists: [Playlist] = []
@@ -394,7 +395,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.searchQueries.append(query)
         self._searchContinuationIndex = 0
         if let error = shouldThrowError { throw error }
-        return self.searchResponse
+        return self.generalSearchResponse ?? self.searchResponse
     }
 
     func searchSongs(query: String) async throws -> [Song] {

--- a/Tests/KasetTests/SearchViewModelTests.swift
+++ b/Tests/KasetTests/SearchViewModelTests.swift
@@ -151,4 +151,24 @@ struct SearchViewModelTests {
         #expect(self.viewModel.filteredItems.isEmpty)
         #expect(self.viewModel.shouldShowFilters)
     }
+
+    @Test("All search falls back to filtered results when general search is empty")
+    func allSearchFallsBackToFilteredResultsWhenGeneralSearchIsEmpty() async {
+        self.mockClient.generalSearchResponse = .empty
+        self.mockClient.searchResponse = TestFixtures.makeSearchResponse(
+            songCount: 2,
+            albumCount: 1,
+            artistCount: 1,
+            playlistCount: 1
+        )
+        self.viewModel.query = "lofi"
+        self.viewModel.selectedFilter = .all
+
+        self.viewModel.searchImmediately()
+        try? await Task.sleep(for: .milliseconds(25))
+
+        #expect(self.viewModel.loadingState == .loaded)
+        #expect(self.viewModel.filteredItems.count == 5)
+        #expect(self.mockClient.searchQueries.count == 7)
+    }
 }

--- a/Tests/KasetTests/SearchViewModelTests.swift
+++ b/Tests/KasetTests/SearchViewModelTests.swift
@@ -161,6 +161,9 @@ struct SearchViewModelTests {
             artistCount: 1,
             playlistCount: 1
         )
+        self.mockClient.searchContinuationResponses = [
+            TestFixtures.makeSearchResponse(songCount: 1),
+        ]
         self.viewModel.query = "lofi"
         self.viewModel.selectedFilter = .all
 
@@ -169,6 +172,8 @@ struct SearchViewModelTests {
 
         #expect(self.viewModel.loadingState == .loaded)
         #expect(self.viewModel.filteredItems.count == 5)
+        #expect(self.viewModel.results.continuationToken == nil)
+        #expect(self.viewModel.hasMoreResults == false)
         #expect(self.mockClient.searchQueries.count == 7)
     }
 }


### PR DESCRIPTION
## Description

  Improves search fallback behavior, adds top playlists to the sidebar, and fixes several playback recovery edge cases around resume intent handling and autoplay recovery.

  ## AI Prompt (Optional)

  <details>
  <summary>🤖 AI Prompt Used</summary>


  N/A - Manual implementation


  **AI Tool:** OpenAI Codex

  </details>

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [x] ✨ New feature (non-breaking change that adds functionality)
  - [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] 📚 Documentation update
  - [ ] 🎨 UI/UX improvement
  - [ ] ♻️ Refactoring (no functional changes)
  - [x] 🧪 Test update
  - [ ] 🔧 Build/CI configuration

  ## Related Issues

  ## Changes Made

  - Fixed fallback search so filtered results close out correctly and all fallback results are considered in parallel.
  - Added top playlists to the sidebar.
  - Serialized sidebar playlist playback to avoid overlapping requests.
  - Clipped the right sidebar overlay correctly in the main window layout.
  - Fixed playback recovery so already loaded songs can resume properly.
  - Prevented same-video resume intents from retriggering playback incorrectly.
  - Retried autoplay after selecting a home card.
  - Updated and added tests for search, sidebar playback, and autoplay recovery behavior.

  ## Testing

  - [x] Unit tests pass (`xcodebuild test -only-testing:KasetTests`)
  - [x] Manual testing performed
  - [ ] UI tested on macOS 26+

  ## Checklist

  - [x] My code follows the project's style guidelines
  - [x] I have run `swiftlint --strict && swiftformat .`
  - [x] I have added tests that prove my fix/feature works
  - [x] New and existing unit tests pass locally
  - [ ] I have updated documentation if needed
  - [x] I have checked for any performance implications
  - [x] My changes generate no new warnings

  ## Screenshots

  ## Additional Notes