### PR TITLE
Fix PlayerBar layout at narrow widths

### DIFF
--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -356,7 +356,7 @@ struct MainWindow: View {
         }
         .animation(.easeInOut(duration: 0.25), value: self.playerService.showLyrics)
         .animation(.easeInOut(duration: 0.25), value: self.playerService.showQueue)
-        .frame(minWidth: 900, minHeight: 600)
+        .frame(minWidth: 980, minHeight: 600)
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
                 Button {
@@ -499,7 +499,7 @@ struct MainWindow: View {
                 .controlSize(.regular)
                 .frame(width: 20, height: 20)
         }
-        .frame(minWidth: 900, minHeight: 600)
+        .frame(minWidth: 980, minHeight: 600)
     }
 
     private func handleAuthStateChange(oldState: AuthService.State, newState: AuthService.State) {

--- a/Sources/Kaset/Views/PlayerBar.swift
+++ b/Sources/Kaset/Views/PlayerBar.swift
@@ -536,6 +536,7 @@ struct PlayerBar: View {
     private var volumeControl: some View {
         HStack(spacing: 8) {
             if self.isCompactLayout {
+                CompactVisibleActionButtons(playerNamespace: self.playerNamespace)
                 self.compactActionsMenu
             } else {
                 // Like/Dislike/Library actions
@@ -622,43 +623,6 @@ struct PlayerBar: View {
 
             Button {
                 HapticService.toggle()
-                self.playerService.dislikeCurrentTrack()
-            } label: {
-                Label(
-                    self.playerService.currentTrackLikeStatus == .dislike ? String(localized: "Disliked") : String(localized: "Dislike"),
-                    systemImage: self.playerService.currentTrackLikeStatus == .dislike
-                        ? "hand.thumbsdown.fill"
-                        : "hand.thumbsdown"
-                )
-            }
-            .disabled(self.playerService.currentTrack == nil)
-
-            Button {
-                HapticService.toggle()
-                self.playerService.likeCurrentTrack()
-            } label: {
-                Label(
-                    self.playerService.currentTrackLikeStatus == .like ? String(localized: "Liked") : String(localized: "Like"),
-                    systemImage: self.playerService.currentTrackLikeStatus == .like
-                        ? "hand.thumbsup.fill"
-                        : "hand.thumbsup"
-                )
-            }
-            .disabled(self.playerService.currentTrack == nil)
-
-            Divider()
-
-            Button {
-                HapticService.toggle()
-                withAnimation(AppAnimation.standard) {
-                    player.showLyrics.toggle()
-                }
-            } label: {
-                Label(String(localized: "Lyrics"), systemImage: "quote.bubble")
-            }
-
-            Button {
-                HapticService.toggle()
                 withAnimation(AppAnimation.standard) {
                     player.showQueue.toggle()
                 }
@@ -679,23 +643,6 @@ struct PlayerBar: View {
                         : "rectangle.inset.bottomright.filled"
                 )
             }
-
-            Divider()
-
-            Button {
-                guard self.playerService.currentTrackHasVideo else { return }
-                HapticService.toggle()
-                DiagnosticsLogger.player.debug(
-                    "Video button clicked, toggling showVideo from \(self.playerService.showVideo)"
-                )
-                withAnimation(AppAnimation.standard) {
-                    player.showVideo.toggle()
-                }
-            } label: {
-                Label(String(localized: "Video"), systemImage: self.playerService.showVideo ? "tv.fill" : "tv")
-            }
-            .keyboardShortcut("v", modifiers: [.command, .shift])
-            .disabled(self.playerService.currentTrack == nil || !self.playerService.currentTrackHasVideo)
         } label: {
             Image(systemName: "ellipsis.circle")
                 .font(.system(size: 15, weight: .medium))
@@ -828,6 +775,94 @@ struct PlayerBar: View {
             return "speaker.wave.1.fill"
         } else {
             return "speaker.wave.2.fill"
+        }
+    }
+}
+
+// MARK: - CompactVisibleActionButtons
+
+@available(macOS 26.0, *)
+private struct CompactVisibleActionButtons: View {
+    let playerNamespace: Namespace.ID
+
+    @Environment(PlayerService.self) private var playerService
+
+    var body: some View {
+        @Bindable var player = self.playerService
+
+        HStack(spacing: 12) {
+            Button {
+                HapticService.toggle()
+                self.playerService.dislikeCurrentTrack()
+            } label: {
+                Image(systemName: self.playerService.currentTrackLikeStatus == .dislike
+                    ? "hand.thumbsdown.fill"
+                    : "hand.thumbsdown")
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundStyle(self.playerService.currentTrackLikeStatus == .dislike ? .red : .primary.opacity(0.85))
+                    .contentTransition(.symbolEffect(.replace))
+            }
+            .buttonStyle(.pressable)
+            .symbolEffect(.bounce, value: self.playerService.currentTrackLikeStatus == .dislike)
+            .accessibilityLabel(String(localized: "Dislike"))
+            .accessibilityValue(self.playerService.currentTrackLikeStatus == .dislike ? String(localized: "Disliked") : String(localized: "Not disliked"))
+            .disabled(self.playerService.currentTrack == nil)
+
+            Button {
+                HapticService.toggle()
+                self.playerService.likeCurrentTrack()
+            } label: {
+                Image(systemName: self.playerService.currentTrackLikeStatus == .like
+                    ? "hand.thumbsup.fill"
+                    : "hand.thumbsup")
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundStyle(self.playerService.currentTrackLikeStatus == .like ? .red : .primary.opacity(0.85))
+                    .contentTransition(.symbolEffect(.replace))
+            }
+            .buttonStyle(.pressable)
+            .symbolEffect(.bounce, value: self.playerService.currentTrackLikeStatus == .like)
+            .accessibilityLabel(String(localized: "Like"))
+            .accessibilityValue(self.playerService.currentTrackLikeStatus == .like ? String(localized: "Liked") : String(localized: "Not liked"))
+            .disabled(self.playerService.currentTrack == nil)
+
+            Button {
+                HapticService.toggle()
+                withAnimation(AppAnimation.standard) {
+                    player.showLyrics.toggle()
+                }
+            } label: {
+                Image(systemName: "quote.bubble")
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundStyle(self.playerService.showLyrics ? .red : .primary.opacity(0.85))
+            }
+            .buttonStyle(.pressable)
+            .glassEffectID("compactLyrics", in: self.playerNamespace)
+            .accessibilityIdentifier(AccessibilityID.PlayerBar.lyricsButton)
+            .accessibilityLabel(String(localized: "Lyrics"))
+            .accessibilityValue(self.playerService.showLyrics ? String(localized: "Showing") : String(localized: "Hidden"))
+
+            Button {
+                guard self.playerService.currentTrackHasVideo else { return }
+                HapticService.toggle()
+                DiagnosticsLogger.player.debug(
+                    "Video button clicked, toggling showVideo from \(self.playerService.showVideo)"
+                )
+                withAnimation(AppAnimation.standard) {
+                    player.showVideo.toggle()
+                }
+            } label: {
+                Image(systemName: self.playerService.showVideo ? "tv.fill" : "tv")
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundStyle(self.playerService.showVideo ? .red : .primary.opacity(0.85))
+                    .contentTransition(.symbolEffect(.replace))
+            }
+            .buttonStyle(.pressable)
+            .glassEffectID("compactVideo", in: self.playerNamespace)
+            .keyboardShortcut("v", modifiers: [.command, .shift])
+            .accessibilityIdentifier(AccessibilityID.PlayerBar.videoButton)
+            .accessibilityLabel(String(localized: "Video"))
+            .accessibilityValue(self.playerService.showVideo ? String(localized: "Playing") : String(localized: "Off"))
+            .disabled(self.playerService.currentTrack == nil || !self.playerService.currentTrackHasVideo)
         }
     }
 }

--- a/Sources/Kaset/Views/PlayerBar.swift
+++ b/Sources/Kaset/Views/PlayerBar.swift
@@ -198,6 +198,7 @@ struct PlayerBar: View {
         ZStack {
             if self.playerService.isCurrentItemLive {
                 self.liveIndicatorView
+                    .opacity(self.showsSeekControls ? 1 : 0)
                     .transition(.opacity)
             } else {
                 self.seekBarView

--- a/Sources/Kaset/Views/PlayerBar.swift
+++ b/Sources/Kaset/Views/PlayerBar.swift
@@ -6,6 +6,7 @@ import SwiftUI
 @available(macOS 26.0, *)
 struct PlayerBar: View {
     private static let brandAccent = PackageResourceLookup.brandAccent
+    private static let compactLayoutThreshold: CGFloat = 980
 
     @Environment(PlayerService.self) private var playerService
     @Environment(WebKitManager.self) private var webKitManager
@@ -24,6 +25,8 @@ struct PlayerBar: View {
     /// Local volume value for smooth slider dragging.
     @State private var volumeValue: Double = 1.0
     @State private var isAdjustingVolume = false
+
+    @State private var playerBarWidth: CGFloat = 0
 
     /// Cached formatted progress string to avoid repeated formatting.
     @State private var formattedProgress: String = "0:00"
@@ -57,6 +60,12 @@ struct PlayerBar: View {
         .padding(.bottom, 8)
         .background(alignment: .bottom) {
             self.playerAreaFade
+        }
+        .background {
+            GeometryReader { proxy in
+                Color.clear
+                    .preference(key: PlayerBarWidthPreferenceKey.self, value: proxy.size.width)
+            }
         }
         .background {
             // Keyboard shortcuts for media controls
@@ -97,6 +106,11 @@ struct PlayerBar: View {
                 }
                 .keyboardShortcut(.downArrow, modifiers: .command)
                 .opacity(0)
+            }
+        }
+        .onPreferenceChange(PlayerBarWidthPreferenceKey.self) { width in
+            if abs(width - self.playerBarWidth) > 0.5 {
+                self.playerBarWidth = width
             }
         }
         .onChange(of: self.playerService.progress) { _, newValue in
@@ -176,18 +190,22 @@ struct PlayerBar: View {
         self.isHoveringSeekBar && self.playerService.currentTrack != nil
     }
 
+    private var isCompactLayout: Bool {
+        self.playerBarWidth > 0 && self.playerBarWidth < Self.compactLayoutThreshold
+    }
+
     private var seekInteractionLayer: some View {
-        Group {
-            if self.showsSeekControls {
-                if self.playerService.isCurrentItemLive {
-                    self.liveIndicatorView
-                        .transition(.opacity)
-                } else {
-                    self.seekBarView
-                        .transition(.opacity)
-                }
-            } else if !self.playerService.isCurrentItemLive {
+        ZStack {
+            if self.playerService.isCurrentItemLive {
+                self.liveIndicatorView
+                    .transition(.opacity)
+            } else {
+                self.seekBarView
+                    .opacity(self.showsSeekControls ? 1 : 0)
+                    .allowsHitTesting(self.showsSeekControls)
+
                 self.compactProgressView
+                    .opacity(self.showsSeekControls ? 0 : 1)
             }
         }
         .frame(height: self.showsSeekControls ? 28 : 10, alignment: .bottom)
@@ -516,23 +534,13 @@ struct PlayerBar: View {
 
     private var volumeControl: some View {
         HStack(spacing: 8) {
-            // Like/Dislike/Library actions
-            self.actionButtons
-
-            // AirPlay button
-            Button {
-                HapticService.toggle()
-                self.playerService.showAirPlayPicker()
-            } label: {
-                Image(systemName: "airplayaudio")
-                    .font(.system(size: 15, weight: .medium))
-                    .foregroundStyle(self.playerService.isAirPlayConnected ? .red : .primary.opacity(0.85))
-                    .contentTransition(.symbolEffect(.replace))
+            if self.isCompactLayout {
+                self.compactActionsMenu
+            } else {
+                // Like/Dislike/Library actions
+                self.actionButtons
+                self.airPlayButton
             }
-            .buttonStyle(.pressable)
-            .accessibilityIdentifier(AccessibilityID.PlayerBar.airplayButton)
-            .accessibilityLabel(self.playerService.isAirPlayConnected ? String(localized: "AirPlay Connected") : String(localized: "AirPlay"))
-            .disabled(self.playerService.currentTrack == nil)
 
             Divider()
                 .frame(height: 20)
@@ -543,36 +551,157 @@ struct PlayerBar: View {
                 .foregroundStyle(.primary.opacity(0.85))
                 .frame(width: 18)
 
-            // Volume slider with immediate updates
-            Slider(value: self.$volumeValue, in: 0 ... 1) { editing in
-                if editing {
-                    // User started dragging
-                    self.isAdjustingVolume = true
-                } else {
-                    // User finished dragging/clicking - apply volume change
-                    self.isAdjustingVolume = false
-                    // Always apply volume when interaction ends to ensure WebView is synced
-                    Task {
-                        await self.playerService.setVolume(self.volumeValue)
-                    }
-                }
-            }
-            .frame(width: 80)
-            .controlSize(.small)
-            .tint(Self.brandAccent)
-            .onChange(of: self.volumeValue) { oldValue, newValue in
-                // Apply volume changes in real-time during dragging for immediate feedback
-                if self.isAdjustingVolume {
-                    // Haptic feedback at slider boundaries
-                    if (oldValue > 0 && newValue == 0) || (oldValue < 1 && newValue == 1) {
-                        HapticService.sliderBoundary()
-                    }
-                    Task {
-                        await self.playerService.setVolume(newValue)
-                    }
+            self.volumeSlider
+        }
+    }
+
+    private var airPlayButton: some View {
+        Button {
+            HapticService.toggle()
+            self.playerService.showAirPlayPicker()
+        } label: {
+            Image(systemName: "airplayaudio")
+                .font(.system(size: 15, weight: .medium))
+                .foregroundStyle(self.playerService.isAirPlayConnected ? .red : .primary.opacity(0.85))
+                .contentTransition(.symbolEffect(.replace))
+        }
+        .buttonStyle(.pressable)
+        .accessibilityIdentifier(AccessibilityID.PlayerBar.airplayButton)
+        .accessibilityLabel(self.playerService.isAirPlayConnected ? String(localized: "AirPlay Connected") : String(localized: "AirPlay"))
+        .disabled(self.playerService.currentTrack == nil)
+    }
+
+    private var volumeSlider: some View {
+        Slider(value: self.$volumeValue, in: 0 ... 1) { editing in
+            if editing {
+                // User started dragging
+                self.isAdjustingVolume = true
+            } else {
+                // User finished dragging/clicking - apply volume change
+                self.isAdjustingVolume = false
+                // Always apply volume when interaction ends to ensure WebView is synced
+                Task {
+                    await self.playerService.setVolume(self.volumeValue)
                 }
             }
         }
+        .frame(width: 80)
+        .controlSize(.small)
+        .tint(Self.brandAccent)
+        .onChange(of: self.volumeValue) { oldValue, newValue in
+            // Apply volume changes in real-time during dragging for immediate feedback
+            if self.isAdjustingVolume {
+                // Haptic feedback at slider boundaries
+                if (oldValue > 0 && newValue == 0) || (oldValue < 1 && newValue == 1) {
+                    HapticService.sliderBoundary()
+                }
+                Task {
+                    await self.playerService.setVolume(newValue)
+                }
+            }
+        }
+    }
+
+    private var compactActionsMenu: some View {
+        @Bindable var player = self.playerService
+
+        return Menu {
+            Button {
+                HapticService.toggle()
+                self.playerService.showAirPlayPicker()
+            } label: {
+                Label(
+                    self.playerService.isAirPlayConnected ? String(localized: "AirPlay Connected") : String(localized: "AirPlay"),
+                    systemImage: "airplayaudio"
+                )
+            }
+            .disabled(self.playerService.currentTrack == nil)
+
+            Divider()
+
+            Button {
+                HapticService.toggle()
+                self.playerService.dislikeCurrentTrack()
+            } label: {
+                Label(
+                    self.playerService.currentTrackLikeStatus == .dislike ? String(localized: "Disliked") : String(localized: "Dislike"),
+                    systemImage: self.playerService.currentTrackLikeStatus == .dislike
+                        ? "hand.thumbsdown.fill"
+                        : "hand.thumbsdown"
+                )
+            }
+            .disabled(self.playerService.currentTrack == nil)
+
+            Button {
+                HapticService.toggle()
+                self.playerService.likeCurrentTrack()
+            } label: {
+                Label(
+                    self.playerService.currentTrackLikeStatus == .like ? String(localized: "Liked") : String(localized: "Like"),
+                    systemImage: self.playerService.currentTrackLikeStatus == .like
+                        ? "hand.thumbsup.fill"
+                        : "hand.thumbsup"
+                )
+            }
+            .disabled(self.playerService.currentTrack == nil)
+
+            Divider()
+
+            Button {
+                HapticService.toggle()
+                withAnimation(AppAnimation.standard) {
+                    player.showLyrics.toggle()
+                }
+            } label: {
+                Label(String(localized: "Lyrics"), systemImage: "quote.bubble")
+            }
+
+            Button {
+                HapticService.toggle()
+                withAnimation(AppAnimation.standard) {
+                    player.showQueue.toggle()
+                }
+            } label: {
+                Label(String(localized: "Queue"), systemImage: "list.bullet")
+            }
+
+            Button {
+                HapticService.toggle()
+                _ = player.toggleMiniPlayer(mode: .switchFromMainWindow)
+            } label: {
+                Label(
+                    self.playerService.isMiniPlayerVisible
+                        ? String(localized: "Return to Kaset")
+                        : String(localized: "Switch to Mini Player"),
+                    systemImage: self.playerService.isMiniPlayerVisible
+                        ? "macwindow"
+                        : "rectangle.inset.bottomright.filled"
+                )
+            }
+
+            Divider()
+
+            Button {
+                guard self.playerService.currentTrackHasVideo else { return }
+                HapticService.toggle()
+                DiagnosticsLogger.player.debug(
+                    "Video button clicked, toggling showVideo from \(self.playerService.showVideo)"
+                )
+                withAnimation(AppAnimation.standard) {
+                    player.showVideo.toggle()
+                }
+            } label: {
+                Label(String(localized: "Video"), systemImage: self.playerService.showVideo ? "tv.fill" : "tv")
+            }
+            .keyboardShortcut("v", modifiers: [.command, .shift])
+            .disabled(self.playerService.currentTrack == nil || !self.playerService.currentTrackHasVideo)
+        } label: {
+            Image(systemName: "ellipsis.circle")
+                .font(.system(size: 15, weight: .medium))
+                .foregroundStyle(.primary.opacity(0.85))
+        }
+        .menuStyle(.borderlessButton)
+        .accessibilityLabel(String(localized: "More"))
     }
 
     // MARK: - Action Buttons (Like/Dislike/Lyrics/Queue)
@@ -712,4 +841,14 @@ struct PlayerBar: View {
         .frame(width: 600)
         .padding()
         .background(Color(nsColor: .windowBackgroundColor))
+}
+
+// MARK: - PlayerBarWidthPreferenceKey
+
+private struct PlayerBarWidthPreferenceKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
 }


### PR DESCRIPTION

## Description

Fixes PlayerBar control overflow at narrow window widths by switching secondary controls into a compact overflow menu and increasing the main window minimum width to match the compact layout breakpoint.

## AI Prompt (Optional)

<details>
<summary>🤖 AI Prompt Used</summary>

```
Fix PlayerBar layout at narrow widths.
```

**AI Tool:** Codex

</details>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [x] 🎨 UI/UX improvement
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🧪 Test update
- [ ] 🔧 Build/CI configuration

## Related Issues

Fixes #<!-- issue number -->

## Changes Made

- Added width tracking for `PlayerBar` to detect compact layouts below 980pt.
- Moved AirPlay, like/dislike, lyrics, queue, mini player, and video actions into a compact “More” menu at narrow widths.
- Kept volume controls visible while reducing horizontal pressure on the PlayerBar.
- Preserved seek/progress layout by layering expanded seek controls over compact progress state.
- Updated main window minimum width from 900pt to 980pt.

## Testing

- [x] Unit tests pass (`xcodebuild test -only-testing:KasetTests`)
- [x] Manual testing performed
- [x] UI tested on macOS 26+

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `swiftlint --strict && swiftformat .`
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally
- [ ] I have updated documentation if needed
- [x] I have checked for any performance implications
- [x] My changes generate no new warnings

## Screenshots

- Added screenshots or recordings showing the PlayerBar at narrow and normal widths.
<img width="1092" height="790" alt="Screenshot 2026-05-28 at 4 54 57 PM" src="https://github.com/user-attachments/assets/ab8a1ab8-2413-4900-b940-c015e2f681d6" />

## Additional Notes

This is a layout-only fix. It does not change playback behavior or introduce new dependencies.