### PR TITLE
Fix quitting from Dock or AppleScript

### DIFF
--- a/Sources/Kaset/AppDelegate.swift
+++ b/Sources/Kaset/AppDelegate.swift
@@ -15,6 +15,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Using strong reference to prevent deallocation when window is hidden.
     private var mainWindow: NSWindow?
 
+    /// Tracks when the app is quitting so we can allow window closures.
+    private var isTerminating = false
+
     func applicationDidFinishLaunching(_: Notification) {
         DiagnosticsLogger.app.info("AppDelegate: applicationDidFinishLaunching")
         // Set up notification center delegate to show notifications in foreground
@@ -44,6 +47,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Save queue for persistence on next launch
         self.playerService?.saveQueueForPersistence()
         DiagnosticsLogger.player.info("Application will terminate - saved queue for persistence")
+    }
+
+    func applicationShouldTerminate(_: NSApplication) -> NSApplication.TerminateReply {
+        self.isTerminating = true
+        return .terminateNow
     }
 
     /// Registers for system sleep and wake notifications to handle playback appropriately.
@@ -250,7 +258,7 @@ extension AppDelegate: NSWindowDelegate {
     /// In UI test mode, close normally to avoid process conflicts.
     func windowShouldClose(_ sender: NSWindow) -> Bool {
         // In UI test mode, allow normal close behavior
-        if UITestConfig.isUITestMode {
+        if UITestConfig.isUITestMode || self.isTerminating {
             return true
         }
 

--- a/Sources/Kaset/Resources/Kaset.sdef
+++ b/Sources/Kaset/Resources/Kaset.sdef
@@ -9,6 +9,13 @@
             <cocoa class="NSQuitCommand"/>
         </command>
 
+        <class name="application" code="capp" description="Kaset's top-level scripting object.">
+            <cocoa class="NSApplication"/>
+            <responds-to command="quit">
+                <cocoa method="terminate:"/>
+            </responds-to>
+        </class>
+
     </suite>
 
     <!-- Kaset Suite -->

--- a/Tests/KasetTests/ScriptingDefinitionTests.swift
+++ b/Tests/KasetTests/ScriptingDefinitionTests.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Testing
+
+@Suite(.serialized, .tags(.service))
+struct ScriptingDefinitionTests {
+    @Test("Standard quit command is bound to NSApplication terminate")
+    func standardQuitCommandIsBoundToApplicationTerminate() throws {
+        let testFileURL = URL(fileURLWithPath: #filePath)
+        let repositoryRoot = testFileURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let sdefURL = repositoryRoot.appendingPathComponent("Sources/Kaset/Resources/Kaset.sdef")
+        let data = try Data(contentsOf: sdefURL)
+        let document = try XMLDocument(data: data)
+
+        let quitCommandNodes = try document.nodes(
+            forXPath: "//suite[@name='Standard Suite']/command[@name='quit' and @code='aevtquit']/cocoa[@class='NSQuitCommand']"
+        )
+        #expect(!quitCommandNodes.isEmpty)
+
+        let terminateBindingNodes = try document.nodes(
+            forXPath: "//suite[@name='Standard Suite']/class[@name='application' and @code='capp']/responds-to[@command='quit']/cocoa[@method='terminate:']"
+        )
+        #expect(!terminateBindingNodes.isEmpty)
+    }
+}


### PR DESCRIPTION
## Description

Ensure Kaset quits reliably when using Dock menu Quit or AppleScript by allowing window closures during termination while preserving hide-on-close behaviour for normal window closes.

## AI Prompt

<details>
<summary>🤖 AI Prompt Used</summary>

**AI Tool:** GitHub Copilot (GPT-5.2-Codex)

</details>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #247

## Changes Made

- Track termination state and allow window closure during app quit.
- Preserve hide-on-close behavior for normal window closes.

## Testing

- [x] `swift build`
- [x] `swiftlint --strict && swiftformat .`
- [x] `swift test` (runTests tool; all passed)
- [x] Manual: Dock menu Quit
- [x] Manual: AppleScript `tell application "Kaset" to quit`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `swiftlint --strict && swiftformat .`
- [x] Build passes locally
- [x] New and existing unit tests pass locally
- [ ] I have added tests that prove my fix/feature works
- [ ] I have updated documentation if needed
- [x] My changes generate no new warnings