### PR TITLE
Fix media key skip behavior

### DIFF
--- a/Sources/Kaset/Services/Player/NowPlayingManager.swift
+++ b/Sources/Kaset/Services/Player/NowPlayingManager.swift
@@ -18,6 +18,8 @@ final class NowPlayingManager {
     private var isConfigured = false
     private let settings = SettingsManager.shared
     private static let defaultSkipInterval: TimeInterval = 15
+    private var lastSkipTarget: TimeInterval?
+    private var lastSkipVideoId: String?
 
     private init() {}
 
@@ -180,12 +182,38 @@ final class NowPlayingManager {
         }
 
         let interval = (event as? MPSkipIntervalCommandEvent)?.interval ?? Self.defaultSkipInterval
-        let target = switch direction {
-        case .forward:
-            player.progress + interval
-        case .backward:
-            player.progress - interval
+        let currentVideoId = player.currentTrack?.videoId ?? player.pendingPlayVideoId
+        if self.lastSkipVideoId != currentVideoId {
+            self.lastSkipTarget = nil
+            self.lastSkipVideoId = currentVideoId
         }
+
+        let baseProgress = if let lastSkipTarget = self.lastSkipTarget {
+            switch direction {
+            case .forward:
+                max(player.progress, lastSkipTarget)
+            case .backward:
+                min(player.progress, lastSkipTarget)
+            }
+        } else {
+            player.progress
+        }
+
+        let rawTarget = switch direction {
+        case .forward:
+            baseProgress + interval
+        case .backward:
+            baseProgress - interval
+        }
+        let target = if player.duration > 0 {
+            min(max(0, rawTarget), player.duration)
+        } else {
+            max(0, rawTarget)
+        }
+
+        self.lastSkipTarget = target
+        self.lastSkipVideoId = currentVideoId
+        player.progress = target
         Task { @MainActor in
             await player.seek(to: target)
         }

--- a/Sources/Kaset/Services/Player/NowPlayingManager.swift
+++ b/Sources/Kaset/Services/Player/NowPlayingManager.swift
@@ -18,8 +18,10 @@ final class NowPlayingManager {
     private var isConfigured = false
     private let settings = SettingsManager.shared
     private static let defaultSkipInterval: TimeInterval = 15
+    private static let skipTargetCoalescingWindow: Duration = .seconds(1)
     private var lastSkipTarget: TimeInterval?
     private var lastSkipVideoId: String?
+    private var lastSkipIssuedAt: ContinuousClock.Instant?
 
     private init() {}
 
@@ -56,6 +58,14 @@ final class NowPlayingManager {
     private func syncMediaControlSetting() {
         let useNextPrev = self.settings.mediaControlStyle == .nextPreviousTrack
         SingletonPlayerWebView.shared.setMediaControlStyle(useNextPrev: useNextPrev)
+        self.syncSkipCommandAvailability(useNextPrev: useNextPrev)
+    }
+
+    private func syncSkipCommandAvailability(useNextPrev: Bool) {
+        let commandCenter = MPRemoteCommandCenter.shared()
+        let enableSkipCommands = !useNextPrev
+        commandCenter.skipForwardCommand.isEnabled = enableSkipCommands
+        commandCenter.skipBackwardCommand.isEnabled = enableSkipCommands
     }
 
     /// Syncs the preferred playback audio quality setting to the singleton WebView and its bootstrap state.
@@ -107,46 +117,58 @@ final class NowPlayingManager {
 
         // Next track command
         commandCenter.nextTrackCommand.isEnabled = true
-        commandCenter.nextTrackCommand.addTarget { _ in
+        commandCenter.nextTrackCommand.addTarget { [weak self] _ in
+            guard let self else { return .commandFailed }
             Task { @MainActor in
-                await player.next()
+                await self.handleNextPreviousMediaKey(direction: .forward, player: player)
             }
             return .success
         }
 
         // Previous track command
         commandCenter.previousTrackCommand.isEnabled = true
-        commandCenter.previousTrackCommand.addTarget { _ in
+        commandCenter.previousTrackCommand.addTarget { [weak self] _ in
+            guard let self else { return .commandFailed }
             Task { @MainActor in
-                await player.previous()
+                await self.handleNextPreviousMediaKey(direction: .backward, player: player)
             }
             return .success
         }
 
         // Skip forward command (Control Center skip buttons or media keys)
-        commandCenter.skipForwardCommand.isEnabled = true
+        commandCenter.skipForwardCommand.isEnabled = self.settings.mediaControlStyle == .skipForwardBackward
         commandCenter.skipForwardCommand.preferredIntervals = [NSNumber(value: Self.defaultSkipInterval)]
         commandCenter.skipForwardCommand.addTarget { [weak self] event in
             guard let self else { return .commandFailed }
-            return self.handleSkipCommand(event: event, direction: .forward, player: player)
+            let interval = (event as? MPSkipIntervalCommandEvent)?.interval ?? Self.defaultSkipInterval
+            Task { @MainActor in
+                await self.handleSkipCommand(interval: interval, direction: .forward, player: player)
+            }
+            return .success
         }
 
         // Skip backward command (Control Center skip buttons or media keys)
-        commandCenter.skipBackwardCommand.isEnabled = true
+        commandCenter.skipBackwardCommand.isEnabled = self.settings.mediaControlStyle == .skipForwardBackward
         commandCenter.skipBackwardCommand.preferredIntervals = [NSNumber(value: Self.defaultSkipInterval)]
         commandCenter.skipBackwardCommand.addTarget { [weak self] event in
             guard let self else { return .commandFailed }
-            return self.handleSkipCommand(event: event, direction: .backward, player: player)
+            let interval = (event as? MPSkipIntervalCommandEvent)?.interval ?? Self.defaultSkipInterval
+            Task { @MainActor in
+                await self.handleSkipCommand(interval: interval, direction: .backward, player: player)
+            }
+            return .success
         }
 
         // Change playback position command
         commandCenter.changePlaybackPositionCommand.isEnabled = true
-        commandCenter.changePlaybackPositionCommand.addTarget { event in
+        commandCenter.changePlaybackPositionCommand.addTarget { [weak self] event in
+            guard let self else { return .commandFailed }
             guard let positionEvent = event as? MPChangePlaybackPositionCommandEvent else {
                 return .commandFailed
             }
             let position = positionEvent.positionTime
             Task { @MainActor in
+                self.clearSkipCoalescingTarget()
                 await player.seek(to: position)
             }
             return .success
@@ -160,43 +182,53 @@ final class NowPlayingManager {
         case backward
     }
 
+    private func handleNextPreviousMediaKey(direction: SkipDirection, player: PlayerService) async {
+        if self.settings.mediaControlStyle == .skipForwardBackward {
+            await self.handleSkipCommand(interval: Self.defaultSkipInterval, direction: direction, player: player)
+        } else {
+            await self.handleTrackNavigation(direction: direction, player: player)
+        }
+    }
+
     private func handleSkipCommand(
-        event: MPRemoteCommandEvent,
+        interval: TimeInterval,
         direction: SkipDirection,
         player: PlayerService
-    ) -> MPRemoteCommandHandlerStatus {
+    ) async {
         guard player.currentTrack != nil || player.pendingPlayVideoId != nil || !player.queue.isEmpty else {
-            return .noActionableNowPlayingItem
+            return
         }
 
         if self.settings.mediaControlStyle == .nextPreviousTrack {
-            Task { @MainActor in
-                switch direction {
-                case .forward:
-                    await player.next()
-                case .backward:
-                    await player.previous()
-                }
-            }
-            return .success
+            await self.handleTrackNavigation(direction: direction, player: player)
+            return
         }
 
-        let interval = (event as? MPSkipIntervalCommandEvent)?.interval ?? Self.defaultSkipInterval
+        let now = ContinuousClock.now
         let currentVideoId = player.currentTrack?.videoId ?? player.pendingPlayVideoId
-        if self.lastSkipVideoId != currentVideoId {
-            self.lastSkipTarget = nil
+        if let currentVideoId {
+            if self.lastSkipVideoId != currentVideoId {
+                self.clearSkipCoalescingTarget()
+            }
             self.lastSkipVideoId = currentVideoId
         }
 
-        let baseProgress = if let lastSkipTarget = self.lastSkipTarget {
-            switch direction {
-            case .forward:
-                max(player.progress, lastSkipTarget)
-            case .backward:
-                min(player.progress, lastSkipTarget)
-            }
+        guard let playbackSnapshot = await SingletonPlayerWebView.shared.currentPlaybackSnapshot(),
+              self.playbackSnapshot(playbackSnapshot, matches: currentVideoId)
+        else {
+            self.clearSkipCoalescingTarget()
+            return
+        }
+
+        let reportedProgress = playbackSnapshot.progress
+        let reportedDuration = playbackSnapshot.duration
+
+        // WebView progress can lag behind rapid media-key repeats. Briefly use the cached
+        // target so repeated or reversed skips accumulate before stale observer updates land.
+        let baseProgress = if self.canCoalesceSkipTarget(at: now), let lastSkipTarget = self.lastSkipTarget {
+            lastSkipTarget
         } else {
-            player.progress
+            reportedProgress
         }
 
         let rawTarget = switch direction {
@@ -205,18 +237,43 @@ final class NowPlayingManager {
         case .backward:
             baseProgress - interval
         }
-        let target = if player.duration > 0 {
-            min(max(0, rawTarget), player.duration)
+        let target = if reportedDuration > 0 {
+            min(max(0, rawTarget), reportedDuration)
         } else {
             max(0, rawTarget)
         }
 
         self.lastSkipTarget = target
-        self.lastSkipVideoId = currentVideoId
+        self.lastSkipIssuedAt = now
         player.progress = target
-        Task { @MainActor in
-            await player.seek(to: target)
+        await player.seek(to: target)
+    }
+
+    private func playbackSnapshot(
+        _ snapshot: SingletonPlayerWebView.PlaybackSnapshot?,
+        matches currentVideoId: String?
+    ) -> Bool {
+        guard let snapshotVideoId = snapshot?.videoId, let currentVideoId else { return true }
+        return snapshotVideoId == currentVideoId
+    }
+
+    private func handleTrackNavigation(direction: SkipDirection, player: PlayerService) async {
+        self.clearSkipCoalescingTarget()
+        switch direction {
+        case .forward:
+            await player.next()
+        case .backward:
+            await player.previous()
         }
-        return .success
+    }
+
+    private func canCoalesceSkipTarget(at now: ContinuousClock.Instant) -> Bool {
+        guard let lastSkipIssuedAt = self.lastSkipIssuedAt else { return false }
+        return now - lastSkipIssuedAt <= Self.skipTargetCoalescingWindow
+    }
+
+    private func clearSkipCoalescingTarget() {
+        self.lastSkipTarget = nil
+        self.lastSkipIssuedAt = nil
     }
 }

--- a/Sources/Kaset/Services/Player/NowPlayingManager.swift
+++ b/Sources/Kaset/Services/Player/NowPlayingManager.swift
@@ -126,10 +126,7 @@ final class NowPlayingManager {
         commandCenter.skipForwardCommand.preferredIntervals = [NSNumber(value: Self.defaultSkipInterval)]
         commandCenter.skipForwardCommand.addTarget { [weak self] event in
             guard let self else { return .commandFailed }
-            Task { @MainActor in
-                await self.handleSkipCommand(event: event, direction: .forward, player: player)
-            }
-            return .success
+            return self.handleSkipCommand(event: event, direction: .forward, player: player)
         }
 
         // Skip backward command (Control Center skip buttons or media keys)
@@ -137,10 +134,7 @@ final class NowPlayingManager {
         commandCenter.skipBackwardCommand.preferredIntervals = [NSNumber(value: Self.defaultSkipInterval)]
         commandCenter.skipBackwardCommand.addTarget { [weak self] event in
             guard let self else { return .commandFailed }
-            Task { @MainActor in
-                await self.handleSkipCommand(event: event, direction: .backward, player: player)
-            }
-            return .success
+            return self.handleSkipCommand(event: event, direction: .backward, player: player)
         }
 
         // Change playback position command
@@ -168,15 +162,21 @@ final class NowPlayingManager {
         event: MPRemoteCommandEvent,
         direction: SkipDirection,
         player: PlayerService
-    ) async {
+    ) -> MPRemoteCommandHandlerStatus {
+        guard player.currentTrack != nil || player.pendingPlayVideoId != nil || !player.queue.isEmpty else {
+            return .noActionableNowPlayingItem
+        }
+
         if self.settings.mediaControlStyle == .nextPreviousTrack {
-            switch direction {
-            case .forward:
-                await player.next()
-            case .backward:
-                await player.previous()
+            Task { @MainActor in
+                switch direction {
+                case .forward:
+                    await player.next()
+                case .backward:
+                    await player.previous()
+                }
             }
-            return
+            return .success
         }
 
         let interval = (event as? MPSkipIntervalCommandEvent)?.interval ?? Self.defaultSkipInterval
@@ -186,6 +186,9 @@ final class NowPlayingManager {
         case .backward:
             player.progress - interval
         }
-        await player.seek(to: target)
+        Task { @MainActor in
+            await player.seek(to: target)
+        }
+        return .success
     }
 }

--- a/Sources/Kaset/Services/Player/NowPlayingManager.swift
+++ b/Sources/Kaset/Services/Player/NowPlayingManager.swift
@@ -17,6 +17,7 @@ final class NowPlayingManager {
     private let logger = DiagnosticsLogger.player
     private var isConfigured = false
     private let settings = SettingsManager.shared
+    private static let defaultSkipInterval: TimeInterval = 15
 
     private init() {}
 
@@ -71,6 +72,8 @@ final class NowPlayingManager {
         commandCenter.togglePlayPauseCommand.removeTarget(nil)
         commandCenter.nextTrackCommand.removeTarget(nil)
         commandCenter.previousTrackCommand.removeTarget(nil)
+        commandCenter.skipForwardCommand.removeTarget(nil)
+        commandCenter.skipBackwardCommand.removeTarget(nil)
         commandCenter.changePlaybackPositionCommand.removeTarget(nil)
 
         // Play command
@@ -118,6 +121,28 @@ final class NowPlayingManager {
             return .success
         }
 
+        // Skip forward command (Control Center skip buttons or media keys)
+        commandCenter.skipForwardCommand.isEnabled = true
+        commandCenter.skipForwardCommand.preferredIntervals = [NSNumber(value: Self.defaultSkipInterval)]
+        commandCenter.skipForwardCommand.addTarget { [weak self] event in
+            guard let self else { return .commandFailed }
+            Task { @MainActor in
+                await self.handleSkipCommand(event: event, direction: .forward, player: player)
+            }
+            return .success
+        }
+
+        // Skip backward command (Control Center skip buttons or media keys)
+        commandCenter.skipBackwardCommand.isEnabled = true
+        commandCenter.skipBackwardCommand.preferredIntervals = [NSNumber(value: Self.defaultSkipInterval)]
+        commandCenter.skipBackwardCommand.addTarget { [weak self] event in
+            guard let self else { return .commandFailed }
+            Task { @MainActor in
+                await self.handleSkipCommand(event: event, direction: .backward, player: player)
+            }
+            return .success
+        }
+
         // Change playback position command
         commandCenter.changePlaybackPositionCommand.isEnabled = true
         commandCenter.changePlaybackPositionCommand.addTarget { event in
@@ -132,5 +157,35 @@ final class NowPlayingManager {
         }
 
         self.logger.info("Remote commands configured")
+    }
+
+    private enum SkipDirection {
+        case forward
+        case backward
+    }
+
+    private func handleSkipCommand(
+        event: MPRemoteCommandEvent,
+        direction: SkipDirection,
+        player: PlayerService
+    ) async {
+        if self.settings.mediaControlStyle == .nextPreviousTrack {
+            switch direction {
+            case .forward:
+                await player.next()
+            case .backward:
+                await player.previous()
+            }
+            return
+        }
+
+        let interval = (event as? MPSkipIntervalCommandEvent)?.interval ?? Self.defaultSkipInterval
+        let target = switch direction {
+        case .forward:
+            player.progress + interval
+        case .backward:
+            player.progress - interval
+        }
+        await player.seek(to: target)
     }
 }

--- a/Sources/Kaset/Views/SingletonPlayerWebView+PlaybackControls.swift
+++ b/Sources/Kaset/Views/SingletonPlayerWebView+PlaybackControls.swift
@@ -3,6 +3,98 @@ import WebKit
 // MARK: - SingletonPlayerWebView Playback Controls Extension
 
 extension SingletonPlayerWebView {
+    struct PlaybackSnapshot {
+        let progress: TimeInterval
+        let duration: TimeInterval
+        let videoId: String?
+    }
+
+    /// Reads playback time from the live WebView video element.
+    func currentPlaybackSnapshot() async -> PlaybackSnapshot? {
+        guard let webView else { return nil }
+
+        let script = """
+            (function() {
+                function currentPlayerData() {
+                    const ytmusicPlayer = document.querySelector('ytmusic-player');
+                    if (ytmusicPlayer && ytmusicPlayer.playerApi
+                        && typeof ytmusicPlayer.playerApi.getVideoData === 'function') {
+                        const data = ytmusicPlayer.playerApi.getVideoData();
+                        if (data && typeof data === 'object') return data;
+                    }
+
+                    const moviePlayer = document.getElementById('movie_player');
+                    if (moviePlayer && typeof moviePlayer.getVideoData === 'function') {
+                        const data = moviePlayer.getVideoData();
+                        if (data && typeof data === 'object') return data;
+                    }
+
+                    return null;
+                }
+
+                function currentVideoId() {
+                    const playerData = currentPlayerData();
+                    if (playerData) {
+                        const playerVideoId = playerData.video_id || playerData.videoId || '';
+                        if (playerVideoId) return playerVideoId;
+                    }
+
+                    try {
+                        const url = new URL(window.location.href);
+                        return url.searchParams.get('v') || '';
+                    } catch (e) {
+                        return '';
+                    }
+                }
+
+                const video = document.querySelector('video');
+                if (!video) return null;
+                return {
+                    progress: Number.isFinite(video.currentTime) ? video.currentTime : 0,
+                    duration: Number.isFinite(video.duration) ? video.duration : 0,
+                    videoId: currentVideoId()
+                };
+            })();
+        """
+
+        return await withCheckedContinuation { continuation in
+            webView.evaluateJavaScript(script) { result, error in
+                if let error {
+                    self.logger.error("currentPlaybackSnapshot error: \(error.localizedDescription)")
+                    continuation.resume(returning: nil)
+                    return
+                }
+
+                guard let dictionary = result as? [String: Any] else {
+                    continuation.resume(returning: nil)
+                    return
+                }
+
+                let progress = Self.timeInterval(from: dictionary["progress"])
+                let duration = Self.timeInterval(from: dictionary["duration"])
+                let videoId = (dictionary["videoId"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+                continuation.resume(returning: PlaybackSnapshot(
+                    progress: progress,
+                    duration: duration,
+                    videoId: videoId
+                ))
+            }
+        }
+    }
+
+    private static func timeInterval(from value: Any?) -> TimeInterval {
+        switch value {
+        case let number as NSNumber:
+            number.doubleValue
+        case let double as Double:
+            double
+        case let string as String:
+            Double(string) ?? 0
+        default:
+            0
+        }
+    }
+
     /// Toggle play/pause.
     func playPause() {
         guard let webView else { return }

--- a/Sources/Kaset/Views/SingletonPlayerWebView+PlaybackPreferences.swift
+++ b/Sources/Kaset/Views/SingletonPlayerWebView+PlaybackPreferences.swift
@@ -24,15 +24,16 @@ extension SingletonPlayerWebView {
                 } catch (e) {}
                 window.__kasetUseNextPrev = \(jsBoolean);
                 // Wrap setActionHandler at document start so YouTube's seekforward/seekbackward
-                // registrations are blocked before Control Center can reflect them. Without this
-                // the existing RAF override only clears them on the next frame, leaving a window
-                // where the macOS Now Playing widget briefly shows the 15s skip buttons.
+                // registrations stay owned by the native remote command handlers. Without this,
+                // WebKit and MPRemoteCommandCenter can both handle the same 15s skip command.
                 try {
                     var ms = navigator.mediaSession;
                     if (ms && !ms.__kasetSetActionHandlerWrapped) {
                         var orig = ms.setActionHandler.bind(ms);
                         ms.setActionHandler = function(type, handler) {
-                            if (window.__kasetUseNextPrev && (type === 'seekforward' || type === 'seekbackward')) {
+                            if (type === 'seekforward' || type === 'seekbackward'
+                                    || (!window.__kasetUseNextPrev
+                                        && (type === 'nexttrack' || type === 'previoustrack'))) {
                                 return orig(type, null);
                             }
                             return orig(type, handler);
@@ -46,7 +47,7 @@ extension SingletonPlayerWebView {
 
     static func mediaControlStyleSyncScript(useNextPrev: Bool) -> String {
         let jsBoolean = useNextPrev ? "true" : "false"
-        let restoreSeekHandlers = if useNextPrev {
+        let clearWebViewSkipHandlers = if useNextPrev {
             ""
         } else {
             """
@@ -54,16 +55,8 @@ extension SingletonPlayerWebView {
                     var ms = navigator.mediaSession;
                     ms.setActionHandler('nexttrack', null);
                     ms.setActionHandler('previoustrack', null);
-                    ms.setActionHandler('seekforward', function(d) {
-                        var v = document.querySelector('video');
-                        if (v) v.currentTime = Math.min(v.duration,
-                            v.currentTime + ((d && d.seekOffset) || 15));
-                    });
-                    ms.setActionHandler('seekbackward', function(d) {
-                        var v = document.querySelector('video');
-                        if (v) v.currentTime = Math.max(0,
-                            v.currentTime - ((d && d.seekOffset) || 15));
-                    });
+                    ms.setActionHandler('seekforward', null);
+                    ms.setActionHandler('seekbackward', null);
                 } catch (e) {}
             """
         }
@@ -77,7 +70,7 @@ extension SingletonPlayerWebView {
                 if (typeof window.__kasetRefreshMediaControlStyle === 'function') {
                     window.__kasetRefreshMediaControlStyle();
                 }
-                \(restoreSeekHandlers)
+                \(clearWebViewSkipHandlers)
             })();
         """
     }

--- a/Tests/KasetTests/MediaControlScriptTests.swift
+++ b/Tests/KasetTests/MediaControlScriptTests.swift
@@ -45,8 +45,8 @@ struct MediaControlScriptTests {
         #expect(calls == "seekforward:clear,seekbackward:clear,nexttrack:set")
     }
 
-    @Test("Bootstrap wrapper passes seekforward/seekbackward through when nextPrev is disabled")
-    func bootstrapWrapperPassesSeekHandlersInSkipMode() throws {
+    @Test("Bootstrap wrapper clears seekforward/seekbackward when skip mode uses native handlers")
+    func bootstrapWrapperClearsSeekHandlersInSkipMode() throws {
         let context = try #require(self.makeBootstrapWrapperContext())
 
         self.evaluate(SingletonPlayerWebView.mediaControlStyleBootstrapScript(useNextPrev: false), in: context)
@@ -54,12 +54,14 @@ struct MediaControlScriptTests {
             """
             navigator.mediaSession.setActionHandler('seekforward', function() {});
             navigator.mediaSession.setActionHandler('seekbackward', function() {});
+            navigator.mediaSession.setActionHandler('nexttrack', function() {});
+            navigator.mediaSession.setActionHandler('previoustrack', function() {});
             """,
             in: context
         )
 
         let calls = context.evaluateScript("mediaSessionCalls.join(',')")?.toString() ?? ""
-        #expect(calls == "seekforward:set,seekbackward:set")
+        #expect(calls == "seekforward:clear,seekbackward:clear,nexttrack:clear,previoustrack:clear")
     }
 
     @Test("Bootstrap wrapper honors runtime toggle skip → nextPrev")
@@ -72,7 +74,7 @@ struct MediaControlScriptTests {
         self.evaluate("navigator.mediaSession.setActionHandler('seekforward', function() {});", in: context)
 
         let calls = context.evaluateScript("mediaSessionCalls.join(',')")?.toString() ?? ""
-        #expect(calls == "seekforward:set,seekforward:clear")
+        #expect(calls == "seekforward:clear,seekforward:clear")
     }
 
     @Test("Bootstrap wrapper honors runtime toggle nextPrev → skip")
@@ -83,9 +85,10 @@ struct MediaControlScriptTests {
         self.evaluate("navigator.mediaSession.setActionHandler('seekforward', function() {});", in: context)
         self.evaluate("window.__kasetUseNextPrev = false;", in: context)
         self.evaluate("navigator.mediaSession.setActionHandler('seekforward', function() {});", in: context)
+        self.evaluate("navigator.mediaSession.setActionHandler('nexttrack', function() {});", in: context)
 
         let calls = context.evaluateScript("mediaSessionCalls.join(',')")?.toString() ?? ""
-        #expect(calls == "seekforward:clear,seekforward:set")
+        #expect(calls == "seekforward:clear,seekforward:clear,nexttrack:clear")
     }
 
     @Test("Bootstrap wrapper installs only once per page even on repeat injection")

--- a/docs/playback.md
+++ b/docs/playback.md
@@ -157,7 +157,7 @@ player WebView from `SingletonPlayerWebView+PlaybackPreferences.swift` and
 
 | Script | Injection timing | Purpose |
 |--------|------------------|---------|
-| Media control bootstrap | document start | Wraps `navigator.mediaSession.setActionHandler` so the macOS media keys can use either seek-forward/back or next/previous behavior. |
+| Media control bootstrap | document start | Wraps `navigator.mediaSession.setActionHandler` so seek-forward/back commands stay owned by Swift remote-command handlers while next/previous behavior can still be mirrored into the WebView when needed. |
 | Playback audio-quality bootstrap | document start | Stores the preferred `SettingsManager.PlaybackAudioQuality` value on `window.__kasetPlaybackAudioQuality` before YouTube's player finishes booting. |
 | Playback audio-quality override | document end | Finds candidate YouTube player APIs, asks them to use the preferred audio quality, and reports sanitized diagnostics back to Swift. |
 | Playback audio-quality sync | runtime preference changes | Updates `window.__kasetPlaybackAudioQuality` and immediately reapplies the preference if the override script is already installed. |


### PR DESCRIPTION
## Description

Ensure media key skip actions advance to the next track (instead of restarting) when Kaset is in the background by handling skip forward/back remote commands and routing them based on the selected media control style.

## AI Prompt

<details>
<summary>🤖 AI Prompt Used</summary>

**AI Tool:** GitHub Copilot (GPT-5.2-Codex)

</details>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #255

## Changes Made

- Add skip forward/back handlers to `MPRemoteCommandCenter`.
- Route skip commands to next/previous when the setting uses Next/Previous Track.
- Seek forward/back by the skip interval when using Skip Forward/Backward mode.

## Testing

- [x] `swift build`
- [x] `swiftlint --strict && swiftformat .`
- [x] `swift test` (runTests tool; all passed)
- [x] Manual: Media key skip while another app is frontmost

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `swiftlint --strict && swiftformat .`
- [x] Build passes locally
- [x] New and existing unit tests pass locally
- [ ] I have added tests that prove my fix/feature works
- [ ] I have updated documentation if needed
- [x] My changes generate no new warnings