### PR TITLE
Fix sandboxed Sparkle update installation

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -10,6 +10,8 @@ on:
     paths:
       - "**.swift"
       - "Package.swift"
+      - "Info.plist"
+      - "Kaset.entitlements"
       - "Sources/**"
       - "Tests/**"
       - "Scripts/**"
@@ -18,6 +20,8 @@ on:
     paths:
       - "**.swift"
       - "Package.swift"
+      - "Info.plist"
+      - "Kaset.entitlements"
       - "Sources/**"
       - "Tests/**"
       - "Scripts/**"
@@ -65,6 +69,9 @@ jobs:
           echo "MARKETING_VERSION=0.0.0-dev.${{ steps.slug.outputs.sha_short }}" > version.env
           echo "BUILD_NUMBER=${{ github.run_number }}" >> version.env
           Scripts/build-app.sh release
+
+      - name: Verify packaged app
+        run: Scripts/verify-release-app.sh .build/app/Kaset.app
 
       - name: Create DMG
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,25 +71,20 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Using version: $VERSION"
 
-      - name: Import Apple Development certificate
+      - name: Import Developer ID Application certificate
         id: import_cert
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
           MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
           MACOS_KEYCHAIN_PWD: ${{ secrets.MACOS_KEYCHAIN_PWD }}
         run: |
-          # All three secrets must be present; otherwise fall back to ad-hoc.
-          # Failing partway through import would leave the workflow in a worse
-          # state than ad-hoc, so validate up front.
+          # Official releases must be signed for outside-the-Mac-App-Store distribution.
+          # Do not silently fall back to ad-hoc or Apple Development signing here: that
+          # creates artifacts that Sparkle/Gatekeeper cannot reliably install.
           if [ -z "$MACOS_CERTIFICATE" ] || [ -z "$MACOS_CERTIFICATE_PWD" ] || [ -z "$MACOS_KEYCHAIN_PWD" ]; then
-            if [ -n "$MACOS_CERTIFICATE" ]; then
-              echo "WARN: MACOS_CERTIFICATE is set but MACOS_CERTIFICATE_PWD or MACOS_KEYCHAIN_PWD is missing; falling back to ad-hoc signing."
-            else
-              echo "No MACOS_CERTIFICATE secret set; falling back to ad-hoc signing."
-            fi
-            echo "identity=" >> "$GITHUB_OUTPUT"
-            echo "signing_mode=adhoc" >> "$GITHUB_OUTPUT"
-            exit 0
+            echo "ERROR: MACOS_CERTIFICATE, MACOS_CERTIFICATE_PWD, and MACOS_KEYCHAIN_PWD are required for release signing." >&2
+            echo "MACOS_CERTIFICATE must contain a Developer ID Application certificate exported as base64 .p12." >&2
+            exit 1
           fi
 
           KEYCHAIN_PATH="$RUNNER_TEMP/kaset-signing.keychain-db"
@@ -114,16 +109,16 @@ jobs:
           rm -f "$CERT_PATH"
 
           IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" \
-            | grep "Apple Development" | head -1 | sed -E 's/.*"(.+)".*/\1/')
+            | grep "Developer ID Application" | head -1 | sed -E 's/.*"(.+)".*/\1/' || true)
           if [ -z "$IDENTITY" ]; then
-            echo "ERROR: Imported keychain has no Apple Development identity"
+            echo "ERROR: Imported keychain has no Developer ID Application identity" >&2
             security find-identity -v -p codesigning "$KEYCHAIN_PATH"
             exit 1
           fi
 
           echo "Using signing identity: $IDENTITY"
           echo "identity=$IDENTITY" >> "$GITHUB_OUTPUT"
-          echo "signing_mode=dev" >> "$GITHUB_OUTPUT"
+          echo "signing_mode=developer-id" >> "$GITHUB_OUTPUT"
 
       - name: Build release app
         env:
@@ -135,6 +130,9 @@ jobs:
           echo "MARKETING_VERSION=${{ steps.version.outputs.version }}" > version.env
           echo "BUILD_NUMBER=${{ github.run_number }}" >> version.env
           Scripts/build-app.sh release
+
+      - name: Verify release app
+        run: Scripts/verify-release-app.sh --require-developer-id .build/app/Kaset.app
 
       - name: Cache Homebrew
         id: cache-homebrew
@@ -215,6 +213,33 @@ jobs:
 
       - name: Rename DMG
         run: mv kaset.dmg "${{ steps.artifact.outputs.filename }}"
+
+      - name: Sign and notarize DMG
+        env:
+          APP_IDENTITY: ${{ steps.import_cert.outputs.identity }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          FILE="${{ steps.artifact.outputs.filename }}"
+
+          if [ -z "$APPLE_ID" ] || [ -z "$APPLE_APP_SPECIFIC_PASSWORD" ] || [ -z "$APPLE_TEAM_ID" ]; then
+            echo "ERROR: APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, and APPLE_TEAM_ID secrets are required for notarization." >&2
+            exit 1
+          fi
+
+          codesign --force --timestamp --sign "$APP_IDENTITY" "$FILE"
+          codesign --verify --verbose=2 "$FILE"
+
+          xcrun notarytool submit "$FILE" \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --wait
+
+          xcrun stapler staple "$FILE"
+          xcrun stapler validate "$FILE"
+          spctl --assess --type open --verbose=4 "$FILE"
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,10 @@ on:
     paths:
       - "**.swift"
       - "Package.swift"
+      - "Info.plist"
+      - "Kaset.entitlements"
       - "Sources/**"
+      - "Scripts/**"
       - "Tests/**"
       - ".github/workflows/tests.yml"
   pull_request:
@@ -18,7 +21,10 @@ on:
     paths:
       - "**.swift"
       - "Package.swift"
+      - "Info.plist"
+      - "Kaset.entitlements"
       - "Sources/**"
+      - "Scripts/**"
       - "Tests/**"
       - ".github/workflows/tests.yml"
   workflow_dispatch:
@@ -85,6 +91,9 @@ jobs:
         env:
           KASET_SIGNING: adhoc
         run: Scripts/build-app.sh debug
+
+      - name: Verify packaged app
+        run: Scripts/verify-release-app.sh .build/app/Kaset.app
 
       - name: Install app for UI tests
         run: |

--- a/Info.plist
+++ b/Info.plist
@@ -33,6 +33,9 @@
 	<key>SUAllowsAutomaticUpdates</key>
 	<true/>
 
+	<key>SUEnableInstallerLauncherService</key>
+	<true/>
+
 	<!-- AppleScript Support -->
 	<key>NSAppleScriptEnabled</key>
 	<true/>

--- a/Kaset.entitlements
+++ b/Kaset.entitlements
@@ -15,5 +15,12 @@
 	<!-- Required for Core Audio process tap (Equalizer feature). -->
 	<key>com.apple.security.device.audio-input</key>
 	<true/>
+
+	<!-- Required by Sparkle's sandboxed installer launcher/status services. -->
+	<key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
+	<array>
+		<string>com.sertacozercan.Kaset-spks</string>
+		<string>com.sertacozercan.Kaset-spki</string>
+	</array>
 </dict>
 </plist>

--- a/Scripts/build-app.sh
+++ b/Scripts/build-app.sh
@@ -330,6 +330,8 @@ ${APP_LOCALIZATIONS_PLIST}
     <integer>86400</integer>
     <key>SUAllowsAutomaticUpdates</key>
     <true/>
+    <key>SUEnableInstallerLauncherService</key>
+    <true/>
 
     <!-- AppleScript Support -->
     <key>NSAppleScriptEnabled</key>
@@ -375,24 +377,41 @@ if [[ "$SIGNING_MODE" == "unsigned" || "$SIGNING_MODE" == "none" ]]; then
 fi
 
 echo "🔏 Signing app..."
-if [[ "$SIGNING_MODE" == "adhoc" ]]; then
-  CODESIGN_ARGS=(--force --sign -)
-elif [[ "$SIGNING_MODE" == "dev" ]]; then
-  if [[ -n "${APP_IDENTITY:-}" ]]; then
-    CODESIGN_ID="$APP_IDENTITY"
-  else
-    CODESIGN_ID=$(security find-identity -v -p codesigning | grep "Apple Development" | head -1 | awk '{print $2}')
-  fi
-  if [[ -z "$CODESIGN_ID" ]]; then
-    echo "WARN: No Apple Development certificate found. Falling back to ad-hoc signing."
+case "$SIGNING_MODE" in
+  adhoc)
     CODESIGN_ARGS=(--force --sign -)
-  else
-    CODESIGN_ARGS=(--force --options runtime --sign "$CODESIGN_ID")
-  fi
-else
-  CODESIGN_ID="${APP_IDENTITY:-Developer ID Application}"
-  CODESIGN_ARGS=(--force --timestamp --options runtime --sign "$CODESIGN_ID")
-fi
+    ;;
+  dev|development)
+    if [[ -n "${APP_IDENTITY:-}" ]]; then
+      CODESIGN_ID="$APP_IDENTITY"
+    else
+      CODESIGN_ID=$(security find-identity -v -p codesigning | grep "Apple Development" | head -1 | awk '{print $2}' || true)
+    fi
+    if [[ -z "$CODESIGN_ID" ]]; then
+      echo "WARN: No Apple Development certificate found. Falling back to ad-hoc signing."
+      CODESIGN_ARGS=(--force --sign -)
+    else
+      CODESIGN_ARGS=(--force --options runtime --sign "$CODESIGN_ID")
+    fi
+    ;;
+  developer-id|distribution|release)
+    if [[ -n "${APP_IDENTITY:-}" ]]; then
+      CODESIGN_ID="$APP_IDENTITY"
+    else
+      CODESIGN_ID=$(security find-identity -v -p codesigning | grep "Developer ID Application" | head -1 | sed -E 's/.*"(.+)".*/\1/' || true)
+    fi
+    if [[ -z "$CODESIGN_ID" ]]; then
+      echo "ERROR: No Developer ID Application certificate found for release signing." >&2
+      exit 1
+    fi
+    CODESIGN_ARGS=(--force --timestamp --options runtime --sign "$CODESIGN_ID")
+    ;;
+  *)
+    echo "ERROR: Unknown KASET_SIGNING mode: $SIGNING_MODE" >&2
+    echo "Expected one of: adhoc, dev, developer-id, unsigned" >&2
+    exit 1
+    ;;
+esac
 
 resign() { codesign "${CODESIGN_ARGS[@]}" "$1"; }
 

--- a/Scripts/generate-appcast.sh
+++ b/Scripts/generate-appcast.sh
@@ -3,7 +3,7 @@
 # generate-appcast.sh - Generates/updates appcast.xml from signed releases
 #
 # Usage:
-#   ./Tools/generate-appcast.sh [releases-directory]
+#   ./Scripts/generate-appcast.sh [releases-directory]
 #
 # This script uses Sparkle's generate_appcast tool to automatically create
 # or update the appcast.xml file based on signed release archives.

--- a/Scripts/sign-update.sh
+++ b/Scripts/sign-update.sh
@@ -3,7 +3,7 @@
 # sign-update.sh - Signs a release DMG/ZIP for Sparkle distribution
 #
 # Usage:
-#   ./Tools/sign-update.sh path/to/Kaset.dmg
+#   ./Scripts/sign-update.sh path/to/Kaset.dmg
 #
 # Prerequisites:
 #   1. Sparkle must be added as a Swift Package dependency

--- a/Scripts/verify-release-app.sh
+++ b/Scripts/verify-release-app.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Verifies the packaged Kaset.app has the release-critical settings that are
+# easy to regress when building outside Xcode.
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "$0")/.." && pwd)
+APP_PATH="$ROOT/.build/app/Kaset.app"
+REQUIRE_DEVELOPER_ID=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --require-developer-id)
+      REQUIRE_DEVELOPER_ID=true
+      shift
+      ;;
+    --help|-h)
+      cat <<USAGE
+Usage: Scripts/verify-release-app.sh [--require-developer-id] [path/to/Kaset.app]
+
+Checks:
+  - Info.plist contains Sparkle's sandboxed installer launcher key
+  - sandbox entitlements include Sparkle's installer/status mach lookups
+  - Sparkle Installer.xpc is embedded
+  - codesign verification succeeds
+  - optional Developer ID Application signing identity is used
+USAGE
+      exit 0
+      ;;
+    *)
+      APP_PATH="$1"
+      shift
+      ;;
+  esac
+done
+
+INFO_PLIST="$APP_PATH/Contents/Info.plist"
+ENTITLEMENTS_PLIST=$(mktemp "${TMPDIR:-/tmp}/kaset-entitlements.XXXXXX.plist")
+CODESIGN_DETAILS=$(mktemp "${TMPDIR:-/tmp}/kaset-codesign.XXXXXX.txt")
+trap 'rm -f "$ENTITLEMENTS_PLIST" "$CODESIGN_DETAILS"' EXIT
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+[[ -d "$APP_PATH" ]] || fail "App bundle not found: $APP_PATH"
+[[ -f "$INFO_PLIST" ]] || fail "Info.plist not found: $INFO_PLIST"
+
+plutil -lint "$INFO_PLIST" >/dev/null
+
+codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+codesign -d --entitlements :- "$APP_PATH" >"$ENTITLEMENTS_PLIST" 2>/dev/null || fail "Could not read app entitlements"
+plutil -lint "$ENTITLEMENTS_PLIST" >/dev/null
+codesign -dv --verbose=4 "$APP_PATH" >"$CODESIGN_DETAILS" 2>&1 || fail "Could not read code signature details"
+
+python3 - "$APP_PATH" "$INFO_PLIST" "$ENTITLEMENTS_PLIST" <<'PY'
+import plistlib
+import sys
+from pathlib import Path
+
+app_path = Path(sys.argv[1])
+info_path = Path(sys.argv[2])
+entitlements_path = Path(sys.argv[3])
+
+with info_path.open("rb") as handle:
+    info = plistlib.load(handle)
+with entitlements_path.open("rb") as handle:
+    entitlements = plistlib.load(handle)
+
+errors: list[str] = []
+bundle_id = info.get("CFBundleIdentifier")
+expected_bundle_id = "com.sertacozercan.Kaset"
+if bundle_id != expected_bundle_id:
+    errors.append(f"CFBundleIdentifier must be {expected_bundle_id}, found {bundle_id!r}")
+
+if info.get("SUEnableInstallerLauncherService") is not True:
+    errors.append("SUEnableInstallerLauncherService must be true for sandboxed Sparkle updates")
+
+installer_xpc = app_path / "Contents/Frameworks/Sparkle.framework/Versions/B/XPCServices/Installer.xpc"
+if not installer_xpc.exists():
+    errors.append(f"Sparkle Installer.xpc is missing at {installer_xpc}")
+
+if entitlements.get("com.apple.security.app-sandbox") is True:
+    expected_mach_services = {
+        f"{expected_bundle_id}-spks",
+        f"{expected_bundle_id}-spki",
+    }
+    actual_mach_services = set(
+        entitlements.get("com.apple.security.temporary-exception.mach-lookup.global-name") or []
+    )
+    missing = sorted(expected_mach_services - actual_mach_services)
+    if missing:
+        errors.append(
+            "Sandboxed Sparkle updates require mach lookup exceptions: "
+            + ", ".join(missing)
+        )
+else:
+    errors.append("Kaset release app must be sandboxed")
+
+if errors:
+    for error in errors:
+        print(f"ERROR: {error}", file=sys.stderr)
+    sys.exit(1)
+PY
+
+if [[ "$REQUIRE_DEVELOPER_ID" == true ]]; then
+  if ! grep -q '^Authority=Developer ID Application:' "$CODESIGN_DETAILS"; then
+    cat "$CODESIGN_DETAILS" >&2
+    fail "Release builds must be signed with a Developer ID Application certificate"
+  fi
+  if grep -q '^Authority=Apple Development:' "$CODESIGN_DETAILS"; then
+    cat "$CODESIGN_DETAILS" >&2
+    fail "Release builds must not be signed with an Apple Development certificate"
+  fi
+fi
+
+echo "✅ Release app verification passed: $APP_PATH"

--- a/docs/adr/0007-sparkle-auto-updates.md
+++ b/docs/adr/0007-sparkle-auto-updates.md
@@ -42,6 +42,15 @@ We integrate [Sparkle 2.x](https://sparkle-project.org/) for automatic update ch
    - Manual "Check for Updates..." menu item
    - Settings UI showing last check date
 
+5. **Sandboxed installer support**
+   - Kaset is sandboxed, so Sparkle's installer launcher XPC service must be enabled
+   - Kaset entitlements must allow Sparkle's installer/status mach lookup services
+   - CI verifies packaged apps so future releases cannot regress this configuration
+
+6. **Developer ID distribution**
+   - Release builds must use a Developer ID Application certificate, not Apple Development or ad-hoc signing
+   - Release DMGs must be notarized and stapled before Sparkle signing, checksum calculation, and upload
+
 ### Architecture
 
 ```
@@ -88,11 +97,14 @@ We integrate [Sparkle 2.x](https://sparkle-project.org/) for automatic update ch
 ### Release Process
 
 1. Tag new version: `git tag v1.2.3`
-2. CI builds, archives, and creates DMG
-3. CI signs DMG with EdDSA key
-4. CI updates `appcast.xml` with new entry
-5. CI uploads DMG to GitHub Releases
-6. Users receive update on next check
+2. CI builds and signs the app with Developer ID Application
+3. CI verifies the packaged app has Sparkle's sandbox installer configuration
+4. CI creates the DMG
+5. CI signs, notarizes, and staples the DMG for Developer ID distribution
+6. CI signs the final stapled DMG with Sparkle's EdDSA key
+7. CI updates `appcast.xml` with the final DMG length and signature
+8. CI uploads DMG to GitHub Releases
+9. Users receive update on next check
 
 ## Consequences
 
@@ -114,7 +126,8 @@ We integrate [Sparkle 2.x](https://sparkle-project.org/) for automatic update ch
 
 ### Neutral
 
-- **Info.plist configuration**: Requires `SUFeedURL`, `SUPublicEDKey` entries
+- **Info.plist configuration**: Requires `SUFeedURL`, `SUPublicEDKey`, and `SUEnableInstallerLauncherService` entries
+- **Entitlements configuration**: Sandboxed builds require Sparkle installer/status mach lookup exceptions
 - **Homebrew Cask**: Users installing via Cask may see duplicate update prompts
 
 ## Implementation Notes
@@ -133,7 +146,22 @@ We integrate [Sparkle 2.x](https://sparkle-project.org/) for automatic update ch
 
 <key>SUScheduledCheckInterval</key>
 <integer>86400</integer>
+
+<key>SUEnableInstallerLauncherService</key>
+<true/>
 ```
+
+### Required Sandboxed-App Entitlements
+
+```xml
+<key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
+<array>
+    <string>com.sertacozercan.Kaset-spks</string>
+    <string>com.sertacozercan.Kaset-spki</string>
+</array>
+```
+
+These exceptions are required because Kaset is sandboxed and Sparkle installs updates through its installer launcher/status services outside the app sandbox.
 
 ### Key Generation
 
@@ -142,11 +170,29 @@ We integrate [Sparkle 2.x](https://sparkle-project.org/) for automatic update ch
 ./DerivedData/.../SourcePackages/artifacts/sparkle/Sparkle/bin/generate_keys
 ```
 
-### Signing a Release
+### Signing and Notarizing a Release
+
+Release CI must use a Developer ID Application identity and notarize/staple the DMG before calculating checksums, signing with Sparkle, or uploading. The release workflow expects these GitHub Secrets:
+
+- `MACOS_CERTIFICATE` — base64-encoded `.p12` containing a Developer ID Application certificate
+- `MACOS_CERTIFICATE_PWD` — password for the `.p12`
+- `MACOS_KEYCHAIN_PWD` — temporary CI keychain password
+- `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID` — notarization credentials
+- `SPARKLE_PRIVATE_KEY` — EdDSA private key for the appcast enclosure signature
 
 ```bash
-./Tools/sign-update.sh ./build/Kaset-v1.2.3.dmg
+Scripts/verify-release-app.sh --require-developer-id .build/app/Kaset.app
+codesign --force --timestamp --sign "Developer ID Application: ..." kaset-v1.2.3.dmg
+xcrun notarytool submit kaset-v1.2.3.dmg --wait ...
+xcrun stapler staple kaset-v1.2.3.dmg
+Scripts/sign-update.sh ./build/Kaset-v1.2.3.dmg
 ```
+
+Do not ship release artifacts signed only with Apple Development or ad-hoc identities. Sparkle may verify the EdDSA signature, but Gatekeeper and the Sparkle installer path still require a properly signed/notarized distribution artifact for reliable outside-the-Mac-App-Store installs.
+
+### Broken-Updater Recovery
+
+If a shipped sandboxed build is missing `SUEnableInstallerLauncherService` or the mach lookup exceptions, that build may download an update but fail before launching Sparkle's installer. A later fixed appcast entry cannot repair that already-installed app by itself; affected users need one manual upgrade path, such as downloading the fixed DMG or running the Homebrew upgrade. After the fixed build is installed, future Sparkle updates can use the corrected installer configuration.
 
 ## References
 


### PR DESCRIPTION
## Summary

Fixes #269.

This fixes the Sparkle updater failure that occurs after the app downloads an update and tries to launch the installer. The packaged app is sandboxed, but Sparkle's sandboxed installer launcher service was not enabled and the required mach lookup exceptions were missing.

Changes:
- enable `SUEnableInstallerLauncherService` in both static and generated app Info.plists
- add Sparkle installer/status mach lookup entitlements for the sandboxed app
- add `Scripts/verify-release-app.sh` to guard release-critical Sparkle packaging settings
- run the verification script in release/dev/test packaging workflows
- harden release workflow to require Developer ID Application signing and notarized/stapled DMGs before checksum/Sparkle signing/upload
- update ADR-0007 with sandboxed Sparkle requirements, release signing/notarization requirements, and recovery notes for already-broken installs

## Important release note

Users on currently broken builds may need one manual update via the fixed DMG or Homebrew because the installed app controls Sparkle's installer-launch path. After a fixed build is installed, future Sparkle updates should use the corrected sandbox configuration.

The release workflow now expects a Developer ID Application `.p12` in `MACOS_CERTIFICATE` and notarization secrets (`APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID`).

## Verification

- `plutil -lint Info.plist Kaset.entitlements`
- `bash -n Scripts/build-app.sh Scripts/verify-release-app.sh`
- YAML parse for modified workflows
- `swiftformat .`
- `swiftlint --strict`
- `swift build`
- `swift test --skip KasetUITests` — 1392 tests / 109 suites passed
- `KASET_SIGNING=adhoc Scripts/build-app.sh debug`
- `Scripts/verify-release-app.sh .build/app/Kaset.app`
- `git diff --check`

UI tests were not run.


### Additional local Sparkle validation

Validated without publishing a release by using a local appcast and local update DMG:

- built two packaged test apps signed with the local Apple Development identity
- patched both to a temporary test bundle ID and local Sparkle feed/public key
- served a local `appcast.xml` and update DMG from `127.0.0.1`
- launched the old app with UI-test auth bypass to avoid real YouTube credentials/cookies
- triggered Sparkle update UI
- Sparkle downloaded the local DMG and replaced the installed temp app bundle
- confirmed installed temp app changed from build `269001` to `269002`

This validates the sandboxed Sparkle installer-launch path without publishing a GitHub release or using a paid Developer ID/notarization flow.
