### PR TITLE
Fix release signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,7 +285,6 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          REQUIRE_DEVELOPER_ID: ${{ inputs.require_developer_id || 'false' }}
         run: |
           FILE="${{ steps.artifact.outputs.filename }}"
 
@@ -296,18 +295,14 @@ jobs:
             exit 0
           fi
 
-          if [ -z "$APPLE_ID" ] || [ -z "$APPLE_APP_SPECIFIC_PASSWORD" ] || [ -z "$APPLE_TEAM_ID" ]; then
-            if [ "$REQUIRE_DEVELOPER_ID" = "true" ]; then
-              echo "ERROR: APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, and APPLE_TEAM_ID secrets are required for notarization." >&2
-              exit 1
-            fi
-            echo "WARN: Notarization secrets are missing; skipping DMG notarization." >&2
-            echo "WARN: The app is Developer ID signed but the DMG will not be notarized/stapled." >&2
-            exit 0
-          fi
-
           codesign --force --timestamp --sign "$APP_IDENTITY" "$FILE"
           codesign --verify --verbose=2 "$FILE"
+
+          if [ -z "$APPLE_ID" ] || [ -z "$APPLE_APP_SPECIFIC_PASSWORD" ] || [ -z "$APPLE_TEAM_ID" ]; then
+            echo "ERROR: APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, and APPLE_TEAM_ID secrets are required for notarized Developer ID releases." >&2
+            echo "A Developer ID certificate was imported, so publishing an unnotarized DMG would be a release misconfiguration." >&2
+            exit 1
+          fi
 
           xcrun notarytool submit "$FILE" \
             --apple-id "$APPLE_ID" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,11 @@ on:
         description: "Optional tag/label used for naming the release asset"
         required: false
         default: ""
+      require_developer_id:
+        description: "Fail unless a Developer ID Application certificate and notarization secrets are configured"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -71,34 +76,81 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Using version: $VERSION"
 
-      - name: Import Developer ID Application certificate
+      - name: Configure release signing
         id: import_cert
         env:
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
           MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
           MACOS_KEYCHAIN_PWD: ${{ secrets.MACOS_KEYCHAIN_PWD }}
+          REQUIRE_DEVELOPER_ID: ${{ inputs.require_developer_id || 'false' }}
         run: |
-          # Official releases must be signed for outside-the-Mac-App-Store distribution.
-          # Do not silently fall back to ad-hoc or Apple Development signing here: that
-          # creates artifacts that Sparkle/Gatekeeper cannot reliably install.
+          set -euo pipefail
+
+          require_developer_id() {
+            [[ "$REQUIRE_DEVELOPER_ID" == "true" ]]
+          }
+
+          use_adhoc_signing() {
+            local reason="$1"
+            if require_developer_id; then
+              echo "ERROR: $reason" >&2
+              echo "Developer ID signing was required by workflow input." >&2
+              exit 1
+            fi
+
+            echo "WARN: $reason" >&2
+            echo "WARN: Falling back to ad-hoc signing. The release will not be notarized and macOS Gatekeeper may warn users." >&2
+            echo "identity=" >> "$GITHUB_OUTPUT"
+            echo "signing_mode=adhoc" >> "$GITHUB_OUTPUT"
+          }
+
+          use_development_signing() {
+            local identity_hash="$1"
+            local reason="$2"
+            if require_developer_id; then
+              echo "ERROR: $reason" >&2
+              echo "Developer ID signing was required by workflow input." >&2
+              exit 1
+            fi
+
+            echo "WARN: $reason" >&2
+            echo "WARN: Using Apple Development signing. The release will not be notarized and macOS Gatekeeper may warn users." >&2
+            echo "::add-mask::$identity_hash"
+            echo "Using Apple Development signing identity."
+            echo "identity=$identity_hash" >> "$GITHUB_OUTPUT"
+            echo "signing_mode=dev" >> "$GITHUB_OUTPUT"
+          }
+
+          # Developer ID Application signing + notarization is the preferred
+          # distribution path, but it requires a paid Apple Developer Program
+          # membership. Maintainer builds without that account intentionally use
+          # Apple Development signing when the existing non-paid-account .p12 is
+          # available, then ad-hoc signing as a last resort.
           if [ -z "$MACOS_CERTIFICATE" ] || [ -z "$MACOS_CERTIFICATE_PWD" ] || [ -z "$MACOS_KEYCHAIN_PWD" ]; then
-            echo "ERROR: MACOS_CERTIFICATE, MACOS_CERTIFICATE_PWD, and MACOS_KEYCHAIN_PWD are required for release signing." >&2
-            echo "MACOS_CERTIFICATE must contain a Developer ID Application certificate exported as base64 .p12." >&2
-            exit 1
+            use_adhoc_signing "MACOS_CERTIFICATE, MACOS_CERTIFICATE_PWD, or MACOS_KEYCHAIN_PWD is not configured."
+            exit 0
           fi
 
           KEYCHAIN_PATH="$RUNNER_TEMP/kaset-signing.keychain-db"
           CERT_PATH="$RUNNER_TEMP/cert.p12"
 
-          echo "$MACOS_CERTIFICATE" | base64 --decode > "$CERT_PATH"
+          if ! printf '%s' "$MACOS_CERTIFICATE" | base64 --decode > "$CERT_PATH"; then
+            use_adhoc_signing "MACOS_CERTIFICATE is not valid base64."
+            exit 0
+          fi
 
           security create-keychain -p "$MACOS_KEYCHAIN_PWD" "$KEYCHAIN_PATH"
           security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
           security unlock-keychain -p "$MACOS_KEYCHAIN_PWD" "$KEYCHAIN_PATH"
           # Restrict private-key access to codesign rather than -A (all apps).
-          security import "$CERT_PATH" -P "$MACOS_CERTIFICATE_PWD" \
+          if ! security import "$CERT_PATH" -P "$MACOS_CERTIFICATE_PWD" \
             -t cert -f pkcs12 -k "$KEYCHAIN_PATH" \
-            -T /usr/bin/codesign -T /usr/bin/security
+            -T /usr/bin/codesign -T /usr/bin/security; then
+            rm -f "$CERT_PATH"
+            use_adhoc_signing "MACOS_CERTIFICATE could not be imported."
+            exit 0
+          fi
+
           security set-key-partition-list -S apple-tool:,apple:,codesign: \
             -s -k "$MACOS_KEYCHAIN_PWD" "$KEYCHAIN_PATH" >/dev/null
 
@@ -108,17 +160,24 @@ jobs:
 
           rm -f "$CERT_PATH"
 
-          IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" \
-            | grep "Developer ID Application" | head -1 | sed -E 's/.*"(.+)".*/\1/' || true)
-          if [ -z "$IDENTITY" ]; then
-            echo "ERROR: Imported keychain has no Developer ID Application identity" >&2
-            security find-identity -v -p codesigning "$KEYCHAIN_PATH"
-            exit 1
+          IDENTITY_HASH=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" 2>/dev/null \
+            | awk '/Developer ID Application/ { print $2; exit }' || true)
+          if [ -n "$IDENTITY_HASH" ]; then
+            echo "::add-mask::$IDENTITY_HASH"
+            echo "Using Developer ID Application signing identity."
+            echo "identity=$IDENTITY_HASH" >> "$GITHUB_OUTPUT"
+            echo "signing_mode=developer-id" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
-          echo "Using signing identity: $IDENTITY"
-          echo "identity=$IDENTITY" >> "$GITHUB_OUTPUT"
-          echo "signing_mode=developer-id" >> "$GITHUB_OUTPUT"
+          DEVELOPMENT_IDENTITY_HASH=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" 2>/dev/null \
+            | awk '/Apple Development/ { print $2; exit }' || true)
+          if [ -n "$DEVELOPMENT_IDENTITY_HASH" ]; then
+            use_development_signing "$DEVELOPMENT_IDENTITY_HASH" "Imported keychain has no Developer ID Application identity."
+            exit 0
+          fi
+
+          use_adhoc_signing "Imported keychain has no Developer ID Application or Apple Development identity."
 
       - name: Build release app
         env:
@@ -132,7 +191,12 @@ jobs:
           Scripts/build-app.sh release
 
       - name: Verify release app
-        run: Scripts/verify-release-app.sh --require-developer-id .build/app/Kaset.app
+        run: |
+          VERIFY_ARGS=()
+          if [ "${{ steps.import_cert.outputs.signing_mode }}" = "developer-id" ]; then
+            VERIFY_ARGS+=(--require-developer-id)
+          fi
+          Scripts/verify-release-app.sh "${VERIFY_ARGS[@]}" .build/app/Kaset.app
 
       - name: Cache Homebrew
         id: cache-homebrew
@@ -217,15 +281,29 @@ jobs:
       - name: Sign and notarize DMG
         env:
           APP_IDENTITY: ${{ steps.import_cert.outputs.identity }}
+          SIGNING_MODE: ${{ steps.import_cert.outputs.signing_mode }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          REQUIRE_DEVELOPER_ID: ${{ inputs.require_developer_id || 'false' }}
         run: |
           FILE="${{ steps.artifact.outputs.filename }}"
 
+          if [ "$SIGNING_MODE" != "developer-id" ]; then
+            echo "Skipping DMG Developer ID signing and notarization because SIGNING_MODE=$SIGNING_MODE."
+            echo "This release will rely on checksum verification, GitHub/Homebrew transport, and Sparkle EdDSA update signatures."
+            echo "macOS Gatekeeper may warn users because Developer ID notarization requires a paid Apple Developer Program membership."
+            exit 0
+          fi
+
           if [ -z "$APPLE_ID" ] || [ -z "$APPLE_APP_SPECIFIC_PASSWORD" ] || [ -z "$APPLE_TEAM_ID" ]; then
-            echo "ERROR: APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, and APPLE_TEAM_ID secrets are required for notarization." >&2
-            exit 1
+            if [ "$REQUIRE_DEVELOPER_ID" = "true" ]; then
+              echo "ERROR: APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, and APPLE_TEAM_ID secrets are required for notarization." >&2
+              exit 1
+            fi
+            echo "WARN: Notarization secrets are missing; skipping DMG notarization." >&2
+            echo "WARN: The app is Developer ID signed but the DMG will not be notarized/stapled." >&2
+            exit 0
           fi
 
           codesign --force --timestamp --sign "$APP_IDENTITY" "$FILE"
@@ -275,13 +353,14 @@ jobs:
             exit 0
           fi
 
-          # Write private key to temp file
-          echo "$SPARKLE_PRIVATE_KEY" > /tmp/sparkle_key
-          chmod 600 /tmp/sparkle_key
+          # Write private key to a runner-temp file and always remove it before the step exits.
+          SPARKLE_KEY_FILE=$(mktemp "$RUNNER_TEMP/kaset-sparkle-key.XXXXXX")
+          trap 'rm -f "$SPARKLE_KEY_FILE"' EXIT
+          printf '%s' "$SPARKLE_PRIVATE_KEY" > "$SPARKLE_KEY_FILE"
+          chmod 600 "$SPARKLE_KEY_FILE"
 
-          # Sign the DMG and capture output
-          SIGN_OUTPUT=$("$SIGN_UPDATE" --ed-key-file /tmp/sparkle_key "${{ steps.artifact.outputs.filename }}")
-          rm -f /tmp/sparkle_key
+          # Sign the DMG and capture output. Do not echo SIGN_OUTPUT: it contains the public update signature.
+          SIGN_OUTPUT=$("$SIGN_UPDATE" --ed-key-file "$SPARKLE_KEY_FILE" "${{ steps.artifact.outputs.filename }}")
 
           # Parse signature and length from output
           # Output format: sparkle:edSignature="..." length="..."

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,8 @@ Thumbs.db
 .env
 .env.local
 *.pem
+*.p12
+*.key
 
 TEMP_*
 build/

--- a/Sources/APIExplorer/main.swift
+++ b/Sources/APIExplorer/main.swift
@@ -38,7 +38,9 @@ import Foundation
 
 // MARK: - Configuration
 
-let apiKey = "AIzaSyC9XL3ZjWddXya6X74dJoCTL-WEYFDNX30"
+let apiKeyEnvironmentVariable = "KASET_YTMUSIC_API_KEY"
+let webClientURL = URL(string: "https://music.youtube.com")!
+nonisolated(unsafe) var cachedAPIKey: String?
 let clientVersion = "1.20231204.01.00"
 let baseURL = "https://music.youtube.com/youtubei/v1"
 let origin = "https://music.youtube.com"
@@ -160,6 +162,65 @@ func computeSAPISIDHASH(sapisid: String) -> String {
     return "\(timestamp)_\(hashHex)"
 }
 
+// MARK: - API Key Resolution
+
+func resolveAPIKey() async throws -> String {
+    if let cachedAPIKey {
+        return cachedAPIKey
+    }
+
+    if let override = ProcessInfo.processInfo.environment[apiKeyEnvironmentVariable],
+       !override.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    {
+        let trimmed = override.trimmingCharacters(in: .whitespacesAndNewlines)
+        cachedAPIKey = trimmed
+        return trimmed
+    }
+
+    var request = URLRequest(url: webClientURL)
+    request.setValue(
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
+        forHTTPHeaderField: "User-Agent"
+    )
+    let (data, response) = try await URLSession.shared.data(for: request)
+    if let httpResponse = response as? HTTPURLResponse,
+       !(200 ... 399).contains(httpResponse.statusCode)
+    {
+        throw NSError(
+            domain: "APIExplorer",
+            code: httpResponse.statusCode,
+            userInfo: [NSLocalizedDescriptionKey: "Could not load YouTube Music web client configuration"]
+        )
+    }
+
+    guard let html = String(data: data, encoding: .utf8),
+          let key = extractInnertubeAPIKey(from: html)
+    else {
+        throw NSError(
+            domain: "APIExplorer",
+            code: -1,
+            userInfo: [NSLocalizedDescriptionKey: "Could not resolve YouTube Music API configuration"]
+        )
+    }
+
+    cachedAPIKey = key
+    return key
+}
+
+func extractInnertubeAPIKey(from html: String) -> String? {
+    let pattern = #""INNERTUBE_API_KEY"\s*:\s*"([^"]+)""#
+    guard let regex = try? NSRegularExpression(pattern: pattern),
+          let match = regex.firstMatch(
+              in: html,
+              range: NSRange(html.startIndex ..< html.endIndex, in: html)
+          ),
+          let range = Range(match.range(at: 1), in: html)
+    else {
+        return nil
+    }
+    return String(html[range])
+}
+
 // MARK: - Request Builder
 
 func buildContext(brandAccountId: String? = nil) -> [String: Any] {
@@ -217,8 +278,13 @@ func buildHeaders(authenticated: Bool = false, authUserIndex: Int? = nil) -> [St
 func makeRequest(endpoint: String, body: [String: Any], authenticated: Bool = false) async throws
     -> (data: [String: Any], statusCode: Int)
 {
-    let urlString = "\(baseURL)/\(endpoint)?key=\(apiKey)&prettyPrint=false"
-    guard let url = URL(string: urlString) else {
+    let apiKey = try await resolveAPIKey()
+    var components = URLComponents(string: "\(baseURL)/\(endpoint)")
+    components?.queryItems = [
+        URLQueryItem(name: "key", value: apiKey),
+        URLQueryItem(name: "prettyPrint", value: "false"),
+    ]
+    guard let url = components?.url else {
         throw NSError(
             domain: "APIExplorer", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid URL"]
         )
@@ -860,7 +926,14 @@ func discoverAccounts(verbose: Bool) async {
 private func fetchAccountInfo(authUserIndex: Int, verbose: Bool) async -> (
     name: String, handle: String?
 )? {
-    let url = URL(string: "\(baseURL)/account/account_menu?key=\(apiKey)")!
+    guard let apiKey = try? await resolveAPIKey() else {
+        return nil
+    }
+    var components = URLComponents(string: "\(baseURL)/account/account_menu")
+    components?.queryItems = [URLQueryItem(name: "key", value: apiKey)]
+    guard let url = components?.url else {
+        return nil
+    }
     var request = URLRequest(url: url)
     request.httpMethod = "POST"
 

--- a/Sources/Kaset/Services/API/YTMusicClient.swift
+++ b/Sources/Kaset/Services/API/YTMusicClient.swift
@@ -39,6 +39,7 @@ final class YTMusicClient: YTMusicClientProtocol {
     private let authService: AuthService
     private let webKitManager: WebKitManager
     private let session: URLSession
+    private let apiKeyResolver: YTMusicAPIKeyResolver
     private let logger = DiagnosticsLogger.api
 
     /// Provider for the current brand account ID.
@@ -49,16 +50,6 @@ final class YTMusicClient: YTMusicClientProtocol {
     /// YouTube Music API base URL.
     private static let baseURL = "https://music.youtube.com/youtubei/v1"
 
-    /// Environment override for the YouTube Music web client API key.
-    /// Do not commit a concrete key; resolve it from the live web client at runtime instead.
-    private static let apiKeyEnvironmentVariable = "KASET_YTMUSIC_API_KEY"
-
-    /// YouTube Music web client page used to resolve the current Innertube API key.
-    private static let webClientURL = URL(string: "https://music.youtube.com")!
-
-    /// Cached runtime-resolved API key. Never log this value.
-    private static var resolvedAPIKey: String?
-
     /// Client version for WEB_REMIX.
     private static let clientVersion = "1.20231204.01.00"
 
@@ -68,24 +59,37 @@ final class YTMusicClient: YTMusicClientProtocol {
     /// Separate continuation token for account-backed recommendation surfaces that reuse `FEmusic_home`.
     private var personalizedRecommendationsContinuationToken: String?
 
-    init(authService: AuthService, webKitManager: WebKitManager = .shared) {
+    init(
+        authService: AuthService,
+        webKitManager: WebKitManager = .shared,
+        session: URLSession? = nil,
+        apiKeyResolver: YTMusicAPIKeyResolver? = nil
+    ) {
         self.authService = authService
         self.webKitManager = webKitManager
 
-        let configuration = URLSessionConfiguration.default
-        configuration.httpAdditionalHeaders = [
-            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
-            "Accept-Encoding": "gzip, deflate, br",
-        ]
-        // Increase connection pool for parallel requests (HTTP/2 multiplexing is automatic)
-        configuration.httpMaximumConnectionsPerHost = 6
-        // Use shared URL cache for transport-level caching
-        configuration.urlCache = URLCache.shared
-        configuration.requestCachePolicy = .useProtocolCachePolicy
-        // Reduce timeout for faster failure detection
-        configuration.timeoutIntervalForRequest = 15
-        configuration.timeoutIntervalForResource = 30
-        self.session = URLSession(configuration: configuration)
+        let resolvedSession: URLSession
+        if let session {
+            resolvedSession = session
+        } else {
+            let configuration = URLSessionConfiguration.default
+            configuration.httpAdditionalHeaders = [
+                "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
+                "Accept-Encoding": "gzip, deflate, br",
+            ]
+            // Increase connection pool for parallel requests (HTTP/2 multiplexing is automatic)
+            configuration.httpMaximumConnectionsPerHost = 6
+            // Use shared URL cache for transport-level caching
+            configuration.urlCache = URLCache.shared
+            configuration.requestCachePolicy = .useProtocolCachePolicy
+            // Reduce timeout for faster failure detection
+            configuration.timeoutIntervalForRequest = 15
+            configuration.timeoutIntervalForResource = 30
+            resolvedSession = URLSession(configuration: configuration)
+        }
+
+        self.session = resolvedSession
+        self.apiKeyResolver = apiKeyResolver ?? YTMusicAPIKeyResolver(session: resolvedSession)
     }
 
     // MARK: - Generic Pagination Methods
@@ -1735,61 +1739,7 @@ final class YTMusicClient: YTMusicClientProtocol {
 
     /// Resolves the current YouTube Music web client API key without storing a concrete key in source.
     private func resolveAPIKey() async throws -> String {
-        if let resolvedAPIKey = Self.resolvedAPIKey {
-            return resolvedAPIKey
-        }
-
-        if let override = ProcessInfo.processInfo.environment[Self.apiKeyEnvironmentVariable],
-           !override.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        {
-            let trimmed = override.trimmingCharacters(in: .whitespacesAndNewlines)
-            Self.resolvedAPIKey = trimmed
-            return trimmed
-        }
-
-        do {
-            var request = URLRequest(url: Self.webClientURL)
-            request.setValue(
-                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
-                forHTTPHeaderField: "User-Agent"
-            )
-            let (data, response) = try await self.session.data(for: request)
-            if let httpResponse = response as? HTTPURLResponse,
-               !(200 ... 399).contains(httpResponse.statusCode)
-            {
-                throw YTMusicError.apiError(
-                    message: "Could not load YouTube Music web client configuration",
-                    code: httpResponse.statusCode
-                )
-            }
-
-            guard let html = String(data: data, encoding: .utf8),
-                  let apiKey = Self.extractInnertubeAPIKey(from: html)
-            else {
-                throw YTMusicError.parseError(message: "Could not resolve YouTube Music API configuration")
-            }
-
-            Self.resolvedAPIKey = apiKey
-            return apiKey
-        } catch let error as YTMusicError {
-            throw error
-        } catch {
-            throw YTMusicError.networkError(underlying: error)
-        }
-    }
-
-    private static func extractInnertubeAPIKey(from html: String) -> String? {
-        let pattern = #""INNERTUBE_API_KEY"\s*:\s*"([^"]+)""#
-        guard let regex = try? NSRegularExpression(pattern: pattern),
-              let match = regex.firstMatch(
-                  in: html,
-                  range: NSRange(html.startIndex ..< html.endIndex, in: html)
-              ),
-              let range = Range(match.range(at: 1), in: html)
-        else {
-            return nil
-        }
-        return String(html[range])
+        try await self.apiKeyResolver.resolve()
     }
 
     // MARK: - Nonisolated Network Helper
@@ -1831,5 +1781,87 @@ final class YTMusicClient: YTMusicClientProtocol {
         } catch {
             return .networkError(error)
         }
+    }
+}
+
+// MARK: - YTMusicAPIKeyResolver
+
+/// Resolves the YouTube Music web client's current Innertube API key without storing it in source.
+@MainActor
+final class YTMusicAPIKeyResolver {
+    nonisolated static let environmentVariable = "KASET_YTMUSIC_API_KEY"
+    nonisolated static let defaultWebClientURL = URL(string: "https://music.youtube.com")!
+
+    private let session: URLSession
+    private let environment: @Sendable (String) -> String?
+    private let webClientURL: URL
+    private var cachedAPIKey: String?
+
+    init(
+        session: URLSession = .shared,
+        webClientURL: URL = defaultWebClientURL,
+        environment: @escaping @Sendable (String) -> String? = { ProcessInfo.processInfo.environment[$0] }
+    ) {
+        self.session = session
+        self.webClientURL = webClientURL
+        self.environment = environment
+    }
+
+    func resolve() async throws -> String {
+        if let cachedAPIKey {
+            return cachedAPIKey
+        }
+
+        if let override = self.environment(Self.environmentVariable),
+           !override.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+            let trimmed = override.trimmingCharacters(in: .whitespacesAndNewlines)
+            self.cachedAPIKey = trimmed
+            return trimmed
+        }
+
+        do {
+            var request = URLRequest(url: self.webClientURL)
+            request.setValue(
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
+                forHTTPHeaderField: "User-Agent"
+            )
+            let (data, response) = try await self.session.data(for: request)
+            if let httpResponse = response as? HTTPURLResponse,
+               !(200 ... 399).contains(httpResponse.statusCode)
+            {
+                throw YTMusicError.apiError(
+                    message: "Could not load YouTube Music web client configuration",
+                    code: httpResponse.statusCode
+                )
+            }
+
+            guard let html = String(data: data, encoding: .utf8),
+                  let apiKey = Self.extractInnertubeAPIKey(from: html)
+            else {
+                throw YTMusicError.parseError(message: "Could not resolve YouTube Music API configuration")
+            }
+
+            self.cachedAPIKey = apiKey
+            return apiKey
+        } catch let error as YTMusicError {
+            throw error
+        } catch {
+            throw YTMusicError.networkError(underlying: error)
+        }
+    }
+
+    static func extractInnertubeAPIKey(from html: String) -> String? {
+        let pattern = #""INNERTUBE_API_KEY"\s*:\s*"([^"]+)""#
+        guard let regex = try? NSRegularExpression(pattern: pattern),
+              let match = regex.firstMatch(
+                  in: html,
+                  range: NSRange(html.startIndex ..< html.endIndex, in: html)
+              ),
+              let range = Range(match.range(at: 1), in: html)
+        else {
+            return nil
+        }
+        return String(html[range])
     }
 }

--- a/Sources/Kaset/Services/API/YTMusicClient.swift
+++ b/Sources/Kaset/Services/API/YTMusicClient.swift
@@ -49,8 +49,15 @@ final class YTMusicClient: YTMusicClientProtocol {
     /// YouTube Music API base URL.
     private static let baseURL = "https://music.youtube.com/youtubei/v1"
 
-    /// API key used in requests (extracted from YouTube Music web client).
-    private static let apiKey = "AIzaSyC9XL3ZjWddXya6X74dJoCTL-WEYFDNX30"
+    /// Environment override for the YouTube Music web client API key.
+    /// Do not commit a concrete key; resolve it from the live web client at runtime instead.
+    private static let apiKeyEnvironmentVariable = "KASET_YTMUSIC_API_KEY"
+
+    /// YouTube Music web client page used to resolve the current Innertube API key.
+    private static let webClientURL = URL(string: "https://music.youtube.com")!
+
+    /// Cached runtime-resolved API key. Never log this value.
+    private static var resolvedAPIKey: String?
 
     /// Client version for WEB_REMIX.
     private static let clientVersion = "1.20231204.01.00"
@@ -1665,9 +1672,14 @@ final class YTMusicClient: YTMusicClientProtocol {
     private func performRequest(_ endpoint: String, fullBody: [String: Any]) async throws -> [String:
         Any]
     {
-        let urlString = "\(Self.baseURL)/\(endpoint)?key=\(Self.apiKey)&prettyPrint=false"
-        guard let url = URL(string: urlString) else {
-            throw YTMusicError.unknown(message: "Invalid URL: \(urlString)")
+        let apiKey = try await self.resolveAPIKey()
+        var components = URLComponents(string: "\(Self.baseURL)/\(endpoint)")
+        components?.queryItems = [
+            URLQueryItem(name: "key", value: apiKey),
+            URLQueryItem(name: "prettyPrint", value: "false"),
+        ]
+        guard let url = components?.url else {
+            throw YTMusicError.unknown(message: "Invalid API URL for endpoint: \(endpoint)")
         }
 
         var request = URLRequest(url: url)
@@ -1719,6 +1731,65 @@ final class YTMusicClient: YTMusicClientProtocol {
         case let .networkError(error):
             throw YTMusicError.networkError(underlying: error)
         }
+    }
+
+    /// Resolves the current YouTube Music web client API key without storing a concrete key in source.
+    private func resolveAPIKey() async throws -> String {
+        if let resolvedAPIKey = Self.resolvedAPIKey {
+            return resolvedAPIKey
+        }
+
+        if let override = ProcessInfo.processInfo.environment[Self.apiKeyEnvironmentVariable],
+           !override.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+            let trimmed = override.trimmingCharacters(in: .whitespacesAndNewlines)
+            Self.resolvedAPIKey = trimmed
+            return trimmed
+        }
+
+        do {
+            var request = URLRequest(url: Self.webClientURL)
+            request.setValue(
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
+                forHTTPHeaderField: "User-Agent"
+            )
+            let (data, response) = try await self.session.data(for: request)
+            if let httpResponse = response as? HTTPURLResponse,
+               !(200 ... 399).contains(httpResponse.statusCode)
+            {
+                throw YTMusicError.apiError(
+                    message: "Could not load YouTube Music web client configuration",
+                    code: httpResponse.statusCode
+                )
+            }
+
+            guard let html = String(data: data, encoding: .utf8),
+                  let apiKey = Self.extractInnertubeAPIKey(from: html)
+            else {
+                throw YTMusicError.parseError(message: "Could not resolve YouTube Music API configuration")
+            }
+
+            Self.resolvedAPIKey = apiKey
+            return apiKey
+        } catch let error as YTMusicError {
+            throw error
+        } catch {
+            throw YTMusicError.networkError(underlying: error)
+        }
+    }
+
+    private static func extractInnertubeAPIKey(from html: String) -> String? {
+        let pattern = #""INNERTUBE_API_KEY"\s*:\s*"([^"]+)""#
+        guard let regex = try? NSRegularExpression(pattern: pattern),
+              let match = regex.firstMatch(
+                  in: html,
+                  range: NSRange(html.startIndex ..< html.endIndex, in: html)
+              ),
+              let range = Range(match.range(at: 1), in: html)
+        else {
+            return nil
+        }
+        return String(html[range])
     }
 
     // MARK: - Nonisolated Network Helper

--- a/Tests/KasetTests/YTMusicClientTests.swift
+++ b/Tests/KasetTests/YTMusicClientTests.swift
@@ -3,6 +3,8 @@ import Foundation
 import Testing
 @testable import Kaset
 
+// MARK: - YTMusicClientTests
+
 /// Tests for YTMusicClient.
 @Suite(.tags(.api))
 struct YTMusicClientTests {
@@ -235,5 +237,149 @@ struct YTMusicClientTests {
 
         // Should not throw for valid ID
         try await mockClient.unsubscribeFromPodcast(showId: "MPSPPLXz2p9abc123")
+    }
+}
+
+// MARK: - YTMusicAPIKeyResolverTests
+
+/// Tests for runtime resolution of the YouTube Music web client API key.
+@Suite(.serialized, .tags(.api))
+struct YTMusicAPIKeyResolverTests {
+    @Test("Extracts Innertube API key from web client HTML")
+    @MainActor
+    func extractsInnertubeAPIKey() {
+        let html = #"ytcfg.set({"INNERTUBE_API_KEY":"test-api-key","INNERTUBE_API_VERSION":"v1"});"#
+
+        #expect(YTMusicAPIKeyResolver.extractInnertubeAPIKey(from: html) == "test-api-key")
+    }
+
+    @Test("Environment override is trimmed and avoids network fetch")
+    @MainActor
+    func environmentOverrideAvoidsNetworkFetch() async throws {
+        let session = MockURLProtocol.makeMockSession()
+        MockURLProtocol.requestHandler = { _ in
+            throw URLError(.badServerResponse)
+        }
+        defer {
+            MockURLProtocol.reset()
+        }
+
+        let resolver = YTMusicAPIKeyResolver(
+            session: session,
+            environment: { name in
+                name == YTMusicAPIKeyResolver.environmentVariable ? "  env-api-key\n" : nil
+            }
+        )
+
+        let apiKey = try await resolver.resolve()
+
+        #expect(apiKey == "env-api-key")
+    }
+
+    @Test("Fetches and caches API key from mocked web client HTML")
+    @MainActor
+    func fetchesAndCachesAPIKeyFromHTML() async throws {
+        let session = MockURLProtocol.makeMockSession()
+        let html = #"ytcfg.set({"INNERTUBE_API_KEY":"mock-html-api-key"});"#
+        nonisolated(unsafe) var requestCount = 0
+
+        MockURLProtocol.requestHandler = { request in
+            requestCount += 1
+            guard let url = request.url,
+                  let response = HTTPURLResponse(
+                      url: url,
+                      statusCode: 200,
+                      httpVersion: nil,
+                      headerFields: ["Content-Type": "text/html"]
+                  )
+            else {
+                throw URLError(.badURL)
+            }
+
+            return (response, Data(html.utf8))
+        }
+        defer {
+            MockURLProtocol.reset()
+        }
+
+        let resolver = YTMusicAPIKeyResolver(session: session, environment: { _ in nil })
+
+        let first = try await resolver.resolve()
+        let second = try await resolver.resolve()
+
+        #expect(first == "mock-html-api-key")
+        #expect(second == "mock-html-api-key")
+        #expect(requestCount == 1)
+    }
+
+    @Test("HTTP failures map to YTMusic API errors")
+    @MainActor
+    func httpFailureMapsToAPIError() async throws {
+        let session = MockURLProtocol.makeMockSession()
+        MockURLProtocol.requestHandler = { request in
+            guard let url = request.url,
+                  let response = HTTPURLResponse(
+                      url: url,
+                      statusCode: 503,
+                      httpVersion: nil,
+                      headerFields: ["Content-Type": "text/html"]
+                  )
+            else {
+                throw URLError(.badURL)
+            }
+
+            return (response, Data("temporarily unavailable".utf8))
+        }
+        defer {
+            MockURLProtocol.reset()
+        }
+
+        let resolver = YTMusicAPIKeyResolver(session: session, environment: { _ in nil })
+
+        do {
+            _ = try await resolver.resolve()
+            Issue.record("Expected resolver to throw for HTTP 503")
+        } catch let error as YTMusicError {
+            guard case let .apiError(_, code) = error else {
+                Issue.record("Expected apiError, got \(error)")
+                return
+            }
+            #expect(code == 503)
+        }
+    }
+
+    @Test("HTML without API key maps to parse error")
+    @MainActor
+    func missingAPIKeyMapsToParseError() async throws {
+        let session = MockURLProtocol.makeMockSession()
+        MockURLProtocol.requestHandler = { request in
+            guard let url = request.url,
+                  let response = HTTPURLResponse(
+                      url: url,
+                      statusCode: 200,
+                      httpVersion: nil,
+                      headerFields: ["Content-Type": "text/html"]
+                  )
+            else {
+                throw URLError(.badURL)
+            }
+
+            return (response, Data("<html></html>".utf8))
+        }
+        defer {
+            MockURLProtocol.reset()
+        }
+
+        let resolver = YTMusicAPIKeyResolver(session: session, environment: { _ in nil })
+
+        do {
+            _ = try await resolver.resolve()
+            Issue.record("Expected resolver to throw for missing API key")
+        } catch let error as YTMusicError {
+            guard case .parseError = error else {
+                Issue.record("Expected parseError, got \(error)")
+                return
+            }
+        }
     }
 }

--- a/docs/adr/0007-sparkle-auto-updates.md
+++ b/docs/adr/0007-sparkle-auto-updates.md
@@ -47,9 +47,10 @@ We integrate [Sparkle 2.x](https://sparkle-project.org/) for automatic update ch
    - Kaset entitlements must allow Sparkle's installer/status mach lookup services
    - CI verifies packaged apps so future releases cannot regress this configuration
 
-6. **Developer ID distribution**
-   - Release builds must use a Developer ID Application certificate, not Apple Development or ad-hoc signing
-   - Release DMGs must be notarized and stapled before Sparkle signing, checksum calculation, and upload
+6. **Signing tiers**
+   - Preferred release builds use a Developer ID Application certificate and notarized/stapled DMGs
+   - Maintainer builds without a paid Apple Developer Program account may use the existing Apple Development certificate, then ad-hoc signing as a last resort
+   - Non-Developer-ID releases are still Sparkle EdDSA-signed, but macOS Gatekeeper may warn users because the app/DMG cannot be notarized
 
 ### Architecture
 
@@ -97,14 +98,15 @@ We integrate [Sparkle 2.x](https://sparkle-project.org/) for automatic update ch
 ### Release Process
 
 1. Tag new version: `git tag v1.2.3`
-2. CI builds and signs the app with Developer ID Application
-3. CI verifies the packaged app has Sparkle's sandbox installer configuration
-4. CI creates the DMG
-5. CI signs, notarizes, and staples the DMG for Developer ID distribution
-6. CI signs the final stapled DMG with Sparkle's EdDSA key
-7. CI updates `appcast.xml` with the final DMG length and signature
-8. CI uploads DMG to GitHub Releases
-9. Users receive update on next check
+2. CI imports the configured signing certificate
+3. CI signs the app with Developer ID Application when available, otherwise Apple Development, otherwise ad-hoc
+4. CI verifies the packaged app has Sparkle's sandbox installer configuration
+5. CI creates the DMG
+6. If using Developer ID and notarization credentials are configured, CI signs, notarizes, and staples the DMG
+7. CI signs the final DMG with Sparkle's EdDSA key
+8. CI updates `appcast.xml` with the final DMG length and signature
+9. CI uploads DMG to GitHub Releases
+10. Users receive update on next check
 
 ## Consequences
 
@@ -172,15 +174,28 @@ These exceptions are required because Kaset is sandboxed and Sparkle installs up
 
 ### Signing and Notarizing a Release
 
-Release CI must use a Developer ID Application identity and notarize/staple the DMG before calculating checksums, signing with Sparkle, or uploading. The release workflow expects these GitHub Secrets:
+Release CI supports two signing tiers:
 
-- `MACOS_CERTIFICATE` — base64-encoded `.p12` containing a Developer ID Application certificate
+1. **Preferred paid-account tier** — `MACOS_CERTIFICATE` contains a Developer ID Application `.p12`, and notarization secrets are configured. CI signs the app, signs/notarizes/staples the DMG, then calculates checksums and Sparkle-signs the final artifact.
+2. **Maintainer no-paid-account tier** — `MACOS_CERTIFICATE` contains an Apple Development `.p12` from the maintainer's non-paid developer account. CI signs the app for entitlements/XPC packaging, skips Developer ID DMG signing and notarization, then still signs the update with Sparkle EdDSA.
+
+The release workflow expects these GitHub Secrets for the no-paid-account path:
+
+- `MACOS_CERTIFICATE` — base64-encoded `.p12` containing an Apple Development certificate
 - `MACOS_CERTIFICATE_PWD` — password for the `.p12`
 - `MACOS_KEYCHAIN_PWD` — temporary CI keychain password
-- `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID` — notarization credentials
 - `SPARKLE_PRIVATE_KEY` — EdDSA private key for the appcast enclosure signature
 
+For the preferred Developer ID path, `MACOS_CERTIFICATE` should instead contain a Developer ID Application `.p12`, and these additional notarization secrets should be configured:
+
+- `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID`
+
 ```bash
+# No-paid-account path verifies Sparkle packaging and signing integrity, but not Developer ID.
+Scripts/verify-release-app.sh .build/app/Kaset.app
+Scripts/sign-update.sh ./build/Kaset-v1.2.3.dmg
+
+# Preferred paid-account path adds Developer ID and notarization checks.
 Scripts/verify-release-app.sh --require-developer-id .build/app/Kaset.app
 codesign --force --timestamp --sign "Developer ID Application: ..." kaset-v1.2.3.dmg
 xcrun notarytool submit kaset-v1.2.3.dmg --wait ...
@@ -188,7 +203,7 @@ xcrun stapler staple kaset-v1.2.3.dmg
 Scripts/sign-update.sh ./build/Kaset-v1.2.3.dmg
 ```
 
-Do not ship release artifacts signed only with Apple Development or ad-hoc identities. Sparkle may verify the EdDSA signature, but Gatekeeper and the Sparkle installer path still require a properly signed/notarized distribution artifact for reliable outside-the-Mac-App-Store installs.
+Non-Developer-ID releases may show Gatekeeper warnings because a paid Apple Developer Program membership is required for Developer ID signing and notarization. Sparkle's EdDSA signature still protects update integrity, and Homebrew/GitHub distribution still provides checksums/transport integrity, but this is not equivalent to a notarized Developer ID distribution artifact.
 
 ### Broken-Updater Recovery
 

--- a/docs/api-discovery.md
+++ b/docs/api-discovery.md
@@ -32,7 +32,7 @@ The YouTube Music API (`youtubei/v1`) is an internal API used by the YouTube Mus
 | Property | Value |
 |----------|-------|
 | Base URL | `https://music.youtube.com/youtubei/v1` |
-| API Key | `AIzaSyC9XL3ZjWddXya6X74dJoCTL-WEYFDNX30` |
+| API Key | Resolved at runtime from `INNERTUBE_API_KEY` in the YouTube Music web client config |
 | Client Name | `WEB_REMIX` |
 | Client Version | `1.20231204.01.00` |
 | Protocol | HTTPS POST with JSON body |


### PR DESCRIPTION
## Summary

Fixes the release workflow for maintainers who do not have a paid Apple Developer Program account.

Changes:
- allow release CI to use the existing Apple Development `.p12` secret when no Developer ID Application identity is available
- keep Developer ID + notarization as the preferred/optional strict path via `require_developer_id`
- skip DMG notarization when release signing is Apple Development/ad-hoc, while still producing the DMG and Sparkle EdDSA update signature
- avoid leaking certificate identity names/emails in release logs; mask identity hashes and avoid dumping keychain identities
- store Sparkle private key material only in a `$RUNNER_TEMP` file with `trap` cleanup
- remove the committed YouTube Music web-client API-key-shaped value and resolve it from the live web client config at runtime
- ignore local `.p12` and `.key` files
- update ADR/API docs for the no-paid-account release path

## Security notes

- No signing passwords, `.p12` contents, Sparkle private key, cookies, SAPISID values, or GitHub tokens are printed.
- Current tracked-file scan found no Google API-key-shaped literals, GitHub tokens, private key blocks, AWS keys, Slack tokens, or tracked cert/key material.
- The old API-key-shaped value is removed from the working tree; if it is considered sensitive, rotate/revoke it separately because it still exists in repository history.

## Verification

- `ruby -e 'require "yaml"; YAML.load_file(ARGV[0]); puts "YAML OK"' .github/workflows/release.yml`
- `bash -n Scripts/build-app.sh Scripts/verify-release-app.sh`
- simulated release signing workflow branches:
  - empty secrets -> `signing_mode=adhoc`
  - Apple Development identity -> `signing_mode=dev`
- tracked-file exact secret-pattern scan -> none found
- release workflow log-leak scan -> none found
- tracked cert/key material scan -> none found
- `swiftformat .`
- `swift build`
- `swift run api-explorer browse FEmusic_home` -> HTTP 200
- `swift test --filter YTMusicClientTests` -> 18 tests passed
- `git diff --check`

Note: `swift test --skip KasetUITests` was attempted locally with a 180s timeout; it timed out without reporting failures before timeout. The original failed release CI run had already passed unit tests before failing on signing.

UI tests were not run.
