### PR TITLE
Add playlist card hover play button

### DIFF
--- a/Sources/Kaset/Views/ChartsView.swift
+++ b/Sources/Kaset/Views/ChartsView.swift
@@ -74,13 +74,29 @@ struct ChartsView: View {
                 .font(.title2)
                 .fontWeight(.semibold)
         } itemContent: { index, item in
-            HomeSectionItemCard(item: item, rank: section.isChart ? index + 1 : nil) {
+            HomeSectionItemCard(
+                item: item,
+                rank: section.isChart ? index + 1 : nil,
+                playAction: self.playlistPlayAction(for: item)
+            ) {
                 self.playItem(item, in: section, at: index)
             }
         }
     }
 
     // MARK: - Actions
+
+    private func playlistPlayAction(for item: HomeSectionItem) -> (() -> Void)? {
+        guard case let .playlist(playlist) = item else { return nil }
+
+        return {
+            SongActionsHelper.playPlaylist(
+                playlist,
+                client: self.viewModel.client,
+                playerService: self.playerService
+            )
+        }
+    }
 
     private func playItem(_ item: HomeSectionItem, in _: HomeSection, at _: Int) {
         switch item {

--- a/Sources/Kaset/Views/ExploreView.swift
+++ b/Sources/Kaset/Views/ExploreView.swift
@@ -74,13 +74,29 @@ struct ExploreView: View {
                 .font(.title2)
                 .fontWeight(.semibold)
         } itemContent: { index, item in
-            HomeSectionItemCard(item: item, rank: section.isChart ? index + 1 : nil) {
+            HomeSectionItemCard(
+                item: item,
+                rank: section.isChart ? index + 1 : nil,
+                playAction: self.playlistPlayAction(for: item)
+            ) {
                 self.playItem(item, in: section, at: index)
             }
         }
     }
 
     // MARK: - Actions
+
+    private func playlistPlayAction(for item: HomeSectionItem) -> (() -> Void)? {
+        guard case let .playlist(playlist) = item else { return nil }
+
+        return {
+            SongActionsHelper.playPlaylist(
+                playlist,
+                client: self.viewModel.client,
+                playerService: self.playerService
+            )
+        }
+    }
 
     private func playItem(_ item: HomeSectionItem, in _: HomeSection, at _: Int) {
         switch item {

--- a/Sources/Kaset/Views/HomeView.swift
+++ b/Sources/Kaset/Views/HomeView.swift
@@ -94,7 +94,11 @@ struct HomeView: View {
                 .font(.title2)
                 .fontWeight(.semibold)
         } itemContent: { index, item in
-            HomeSectionItemCard(item: item, rank: section.isChart ? index + 1 : nil) {
+            HomeSectionItemCard(
+                item: item,
+                rank: section.isChart ? index + 1 : nil,
+                playAction: self.playlistPlayAction(for: item)
+            ) {
                 self.playItem(item, in: section, at: index)
             }
             .contextMenu {
@@ -104,6 +108,18 @@ struct HomeView: View {
     }
 
     // MARK: - Context Menu
+
+    private func playlistPlayAction(for item: HomeSectionItem) -> (() -> Void)? {
+        guard case let .playlist(playlist) = item else { return nil }
+
+        return {
+            SongActionsHelper.playPlaylist(
+                playlist,
+                client: self.viewModel.client,
+                playerService: self.playerService
+            )
+        }
+    }
 
     @ViewBuilder
     private func contextMenuItems(for item: HomeSectionItem, in _: HomeSection, at _: Int) -> some View {

--- a/Sources/Kaset/Views/MoodsAndGenresView.swift
+++ b/Sources/Kaset/Views/MoodsAndGenresView.swift
@@ -84,13 +84,32 @@ struct MoodsAndGenresView: View {
                 .font(.title2)
                 .fontWeight(.semibold)
         } itemContent: { index, item in
-            HomeSectionItemCard(item: item) {
+            HomeSectionItemCard(
+                item: item,
+                playAction: self.playlistPlayAction(for: item)
+            ) {
                 self.playItem(item, in: section, at: index)
             }
         }
     }
 
     // MARK: - Actions
+
+    private func playlistPlayAction(for item: HomeSectionItem) -> (() -> Void)? {
+        guard case let .playlist(playlist) = item,
+              !MoodCategory.isMoodCategory(playlist.id)
+        else {
+            return nil
+        }
+
+        return {
+            SongActionsHelper.playPlaylist(
+                playlist,
+                client: self.viewModel.client,
+                playerService: self.playerService
+            )
+        }
+    }
 
     private func playItem(_ item: HomeSectionItem, in _: HomeSection, at _: Int) {
         switch item {

--- a/Sources/Kaset/Views/NewReleasesView.swift
+++ b/Sources/Kaset/Views/NewReleasesView.swift
@@ -74,13 +74,29 @@ struct NewReleasesView: View {
                 .font(.title2)
                 .fontWeight(.semibold)
         } itemContent: { index, item in
-            HomeSectionItemCard(item: item, rank: section.isChart ? index + 1 : nil) {
+            HomeSectionItemCard(
+                item: item,
+                rank: section.isChart ? index + 1 : nil,
+                playAction: self.playlistPlayAction(for: item)
+            ) {
                 self.playItem(item, in: section, at: index)
             }
         }
     }
 
     // MARK: - Actions
+
+    private func playlistPlayAction(for item: HomeSectionItem) -> (() -> Void)? {
+        guard case let .playlist(playlist) = item else { return nil }
+
+        return {
+            SongActionsHelper.playPlaylist(
+                playlist,
+                client: self.viewModel.client,
+                playerService: self.playerService
+            )
+        }
+    }
 
     private func playItem(_ item: HomeSectionItem, in _: HomeSection, at _: Int) {
         switch item {

--- a/Sources/Kaset/Views/SharedViews/HomeSectionItemCard.swift
+++ b/Sources/Kaset/Views/SharedViews/HomeSectionItemCard.swift
@@ -6,6 +6,7 @@ import SwiftUI
 struct HomeSectionItemCard: View {
     let item: HomeSectionItem
     let rank: Int?
+    let playAction: (() -> Void)?
     let action: () -> Void
 
     /// Card dimensions.
@@ -16,21 +17,41 @@ struct HomeSectionItemCard: View {
     @State private var isHovering = false
     @State private var failedThumbnailURLs: Set<URL> = []
 
-    init(item: HomeSectionItem, rank: Int? = nil, action: @escaping () -> Void) {
+    init(
+        item: HomeSectionItem,
+        rank: Int? = nil,
+        playAction: (() -> Void)? = nil,
+        action: @escaping () -> Void
+    ) {
         self.item = item
         self.rank = rank
+        self.playAction = playAction
         self.action = action
     }
 
     var body: some View {
-        Button(action: self.action) {
-            if let rank {
-                self.chartContent(rank: rank)
-            } else {
-                self.regularContent
+        ZStack(alignment: .topLeading) {
+            Button(action: self.action) {
+                if let rank {
+                    self.chartContent(rank: rank)
+                } else {
+                    self.regularContent
+                }
+            }
+            .buttonStyle(.interactiveCard(showShadow: false, hoverScale: 1))
+
+            if self.showsPlaylistPlayButton {
+                self.playButton
             }
         }
-        .buttonStyle(.interactiveCard)
+        .scaleEffect(self.isHovering ? 1.02 : 1)
+        .shadow(
+            color: self.isHovering ? .black.opacity(0.15) : .clear,
+            radius: self.isHovering ? 12 : 0,
+            x: 0,
+            y: self.isHovering ? 4 : 0
+        )
+        .animation(AppAnimation.spring, value: self.isHovering)
         .onHover { hovering in
             withAnimation(AppAnimation.quick) {
                 self.isHovering = hovering
@@ -92,16 +113,8 @@ struct HomeSectionItemCard: View {
         .overlay {
             // Play overlay on hover (for songs)
             if case .song = self.item, self.isHovering {
-                Circle()
-                    .fill(.ultraThinMaterial)
-                    .frame(width: 48, height: 48)
-                    .overlay {
-                        Image(systemName: "play.fill")
-                            .font(.title2)
-                            .foregroundStyle(.primary)
-                            .offset(x: 2)
-                    }
-                    .transition(.scale.combined(with: .opacity))
+                self.playButtonChrome
+                    .transition(.opacity)
             }
         }
         .overlay(alignment: .topTrailing) {
@@ -111,6 +124,35 @@ struct HomeSectionItemCard: View {
                     .padding(6)
             }
         }
+    }
+
+    private var showsPlaylistPlayButton: Bool {
+        guard case .playlist = self.item else { return false }
+        return self.playAction != nil && self.isHovering
+    }
+
+    private var playButton: some View {
+        ZStack {
+            Button {
+                self.playAction?()
+            } label: {
+                self.playButtonChrome
+            }
+            .buttonStyle(.plain)
+        }
+        .frame(width: self.thumbnailSize.width, height: self.thumbnailSize.height)
+        .transition(.opacity)
+        .accessibilityLabel(String(localized: "Play \(self.item.title)"))
+        .accessibilityHint(String(localized: "Starts this playlist without opening it"))
+    }
+
+    private var playButtonChrome: some View {
+        Image(systemName: "play.fill")
+            .font(.title2)
+            .foregroundStyle(.primary)
+            .offset(x: 2)
+            .frame(width: 48, height: 48)
+            .compatGlass(interactive: true, in: .circle)
     }
 
     @ViewBuilder

--- a/Sources/Kaset/Views/SharedViews/SongActionsHelper.swift
+++ b/Sources/Kaset/Views/SharedViews/SongActionsHelper.swift
@@ -249,6 +249,55 @@ enum SongActionsHelper {
         }
     }
 
+    /// Plays a playlist immediately, replacing the current queue.
+    static func playPlaylist(
+        _ playlist: Playlist,
+        client: any YTMusicClientProtocol,
+        playerService: PlayerService
+    ) {
+        Task {
+            do {
+                let response = try await client.getPlaylist(id: playlist.id)
+                var songs = response.detail.tracks
+
+                do {
+                    let allTracks = try await client.getPlaylistAllTracks(playlistId: playlist.id)
+                    if allTracks.count >= songs.count, !allTracks.isEmpty {
+                        songs = allTracks
+                    }
+                } catch {
+                    DiagnosticsLogger.ui.debug("Falling back to browse playlist tracks: \(error.localizedDescription)")
+                }
+
+                guard !songs.isEmpty else { return }
+
+                let songsWithPlaylistArtwork = songs.map { song in
+                    Song(
+                        id: song.id,
+                        title: song.title,
+                        artists: song.artists,
+                        album: song.album,
+                        duration: song.duration,
+                        thumbnailURL: song.thumbnailURL ?? playlist.thumbnailURL,
+                        videoId: song.videoId,
+                        isPlayable: song.isPlayable,
+                        hasVideo: song.hasVideo,
+                        musicVideoType: song.musicVideoType,
+                        likeStatus: song.likeStatus,
+                        isInLibrary: song.isInLibrary,
+                        feedbackTokens: song.feedbackTokens,
+                        isExplicit: song.isExplicit
+                    )
+                }
+
+                await playerService.playQueue(songsWithPlaylistArtwork, startingAt: 0)
+                DiagnosticsLogger.ui.info("Playing playlist '\(playlist.title)' (\(songsWithPlaylistArtwork.count) songs)")
+            } catch {
+                DiagnosticsLogger.ui.error("Failed to play playlist: \(error.localizedDescription)")
+            }
+        }
+    }
+
     /// Permanently deletes a playlist owned by the user.
     static func deletePlaylist(
         _ playlist: Playlist,


### PR DESCRIPTION
## Summary
- Add a Liquid Glass play button overlay for playlist cards on hover
- Keep card hover scaling active while hovering the play button
- Play playlists directly through the API-backed queue path without opening the playlist first

## Verification
- swift build
- swift test --skip KasetUITests