### PR TITLE
Add playlist card hover play button

### DIFF
--- a/Sources/Kaset/Views/ChartsView.swift
+++ b/Sources/Kaset/Views/ChartsView.swift
@@ -74,13 +74,29 @@ struct ChartsView: View {
                 .font(.title2)
                 .fontWeight(.semibold)
         } itemContent: { index, item in
-            HomeSectionItemCard(item: item, rank: section.isChart ? index + 1 : nil) {
+            HomeSectionItemCard(
+                item: item,
+                rank: section.isChart ? index + 1 : nil,
+                playAction: self.playlistPlayAction(for: item)
+            ) {
                 self.playItem(item, in: section, at: index)
             }
         }
     }
 
     // MARK: - Actions
+
+    private func playlistPlayAction(for item: HomeSectionItem) -> (() -> Void)? {
+        guard case let .playlist(playlist) = item else { return nil }
+
+        return {
+            SongActionsHelper.playPlaylist(
+                playlist,
+                client: self.viewModel.client,
+                playerService: self.playerService
+            )
+        }
+    }
 
     private func playItem(_ item: HomeSectionItem, in _: HomeSection, at _: Int) {
         switch item {

--- a/Sources/Kaset/Views/ChartsView.swift
+++ b/Sources/Kaset/Views/ChartsView.swift
@@ -87,7 +87,11 @@ struct ChartsView: View {
     // MARK: - Actions
 
     private func playlistPlayAction(for item: HomeSectionItem) -> (() -> Void)? {
-        guard case let .playlist(playlist) = item else { return nil }
+        guard case let .playlist(playlist) = item,
+              SongActionsHelper.canQuickPlayPlaylist(playlist)
+        else {
+            return nil
+        }
 
         return {
             SongActionsHelper.playPlaylist(

--- a/Sources/Kaset/Views/ExploreView.swift
+++ b/Sources/Kaset/Views/ExploreView.swift
@@ -87,7 +87,11 @@ struct ExploreView: View {
     // MARK: - Actions
 
     private func playlistPlayAction(for item: HomeSectionItem) -> (() -> Void)? {
-        guard case let .playlist(playlist) = item else { return nil }
+        guard case let .playlist(playlist) = item,
+              SongActionsHelper.canQuickPlayPlaylist(playlist)
+        else {
+            return nil
+        }
 
         return {
             SongActionsHelper.playPlaylist(

--- a/Sources/Kaset/Views/ExploreView.swift
+++ b/Sources/Kaset/Views/ExploreView.swift
@@ -74,13 +74,29 @@ struct ExploreView: View {
                 .font(.title2)
                 .fontWeight(.semibold)
         } itemContent: { index, item in
-            HomeSectionItemCard(item: item, rank: section.isChart ? index + 1 : nil) {
+            HomeSectionItemCard(
+                item: item,
+                rank: section.isChart ? index + 1 : nil,
+                playAction: self.playlistPlayAction(for: item)
+            ) {
                 self.playItem(item, in: section, at: index)
             }
         }
     }
 
     // MARK: - Actions
+
+    private func playlistPlayAction(for item: HomeSectionItem) -> (() -> Void)? {
+        guard case let .playlist(playlist) = item else { return nil }
+
+        return {
+            SongActionsHelper.playPlaylist(
+                playlist,
+                client: self.viewModel.client,
+                playerService: self.playerService
+            )
+        }
+    }
 
     private func playItem(_ item: HomeSectionItem, in _: HomeSection, at _: Int) {
         switch item {

--- a/Sources/Kaset/Views/HomeView.swift
+++ b/Sources/Kaset/Views/HomeView.swift
@@ -110,7 +110,11 @@ struct HomeView: View {
     // MARK: - Context Menu
 
     private func playlistPlayAction(for item: HomeSectionItem) -> (() -> Void)? {
-        guard case let .playlist(playlist) = item else { return nil }
+        guard case let .playlist(playlist) = item,
+              SongActionsHelper.canQuickPlayPlaylist(playlist)
+        else {
+            return nil
+        }
 
         return {
             SongActionsHelper.playPlaylist(

--- a/Sources/Kaset/Views/HomeView.swift
+++ b/Sources/Kaset/Views/HomeView.swift
@@ -94,7 +94,11 @@ struct HomeView: View {
                 .font(.title2)
                 .fontWeight(.semibold)
         } itemContent: { index, item in
-            HomeSectionItemCard(item: item, rank: section.isChart ? index + 1 : nil) {
+            HomeSectionItemCard(
+                item: item,
+                rank: section.isChart ? index + 1 : nil,
+                playAction: self.playlistPlayAction(for: item)
+            ) {
                 self.playItem(item, in: section, at: index)
             }
             .contextMenu {
@@ -104,6 +108,18 @@ struct HomeView: View {
     }
 
     // MARK: - Context Menu
+
+    private func playlistPlayAction(for item: HomeSectionItem) -> (() -> Void)? {
+        guard case let .playlist(playlist) = item else { return nil }
+
+        return {
+            SongActionsHelper.playPlaylist(
+                playlist,
+                client: self.viewModel.client,
+                playerService: self.playerService
+            )
+        }
+    }
 
     @ViewBuilder
     private func contextMenuItems(for item: HomeSectionItem, in _: HomeSection, at _: Int) -> some View {

--- a/Sources/Kaset/Views/MoodsAndGenresView.swift
+++ b/Sources/Kaset/Views/MoodsAndGenresView.swift
@@ -84,13 +84,32 @@ struct MoodsAndGenresView: View {
                 .font(.title2)
                 .fontWeight(.semibold)
         } itemContent: { index, item in
-            HomeSectionItemCard(item: item) {
+            HomeSectionItemCard(
+                item: item,
+                playAction: self.playlistPlayAction(for: item)
+            ) {
                 self.playItem(item, in: section, at: index)
             }
         }
     }
 
     // MARK: - Actions
+
+    private func playlistPlayAction(for item: HomeSectionItem) -> (() -> Void)? {
+        guard case let .playlist(playlist) = item,
+              !MoodCategory.isMoodCategory(playlist.id)
+        else {
+            return nil
+        }
+
+        return {
+            SongActionsHelper.playPlaylist(
+                playlist,
+                client: self.viewModel.client,
+                playerService: self.playerService
+            )
+        }
+    }
 
     private func playItem(_ item: HomeSectionItem, in _: HomeSection, at _: Int) {
         switch item {

--- a/Sources/Kaset/Views/MoodsAndGenresView.swift
+++ b/Sources/Kaset/Views/MoodsAndGenresView.swift
@@ -97,7 +97,7 @@ struct MoodsAndGenresView: View {
 
     private func playlistPlayAction(for item: HomeSectionItem) -> (() -> Void)? {
         guard case let .playlist(playlist) = item,
-              !MoodCategory.isMoodCategory(playlist.id)
+              SongActionsHelper.canQuickPlayPlaylist(playlist)
         else {
             return nil
         }

--- a/Sources/Kaset/Views/NewReleasesView.swift
+++ b/Sources/Kaset/Views/NewReleasesView.swift
@@ -74,13 +74,29 @@ struct NewReleasesView: View {
                 .font(.title2)
                 .fontWeight(.semibold)
         } itemContent: { index, item in
-            HomeSectionItemCard(item: item, rank: section.isChart ? index + 1 : nil) {
+            HomeSectionItemCard(
+                item: item,
+                rank: section.isChart ? index + 1 : nil,
+                playAction: self.playlistPlayAction(for: item)
+            ) {
                 self.playItem(item, in: section, at: index)
             }
         }
     }
 
     // MARK: - Actions
+
+    private func playlistPlayAction(for item: HomeSectionItem) -> (() -> Void)? {
+        guard case let .playlist(playlist) = item else { return nil }
+
+        return {
+            SongActionsHelper.playPlaylist(
+                playlist,
+                client: self.viewModel.client,
+                playerService: self.playerService
+            )
+        }
+    }
 
     private func playItem(_ item: HomeSectionItem, in _: HomeSection, at _: Int) {
         switch item {

--- a/Sources/Kaset/Views/NewReleasesView.swift
+++ b/Sources/Kaset/Views/NewReleasesView.swift
@@ -87,7 +87,11 @@ struct NewReleasesView: View {
     // MARK: - Actions
 
     private func playlistPlayAction(for item: HomeSectionItem) -> (() -> Void)? {
-        guard case let .playlist(playlist) = item else { return nil }
+        guard case let .playlist(playlist) = item,
+              SongActionsHelper.canQuickPlayPlaylist(playlist)
+        else {
+            return nil
+        }
 
         return {
             SongActionsHelper.playPlaylist(

--- a/Sources/Kaset/Views/SharedViews/HomeSectionItemCard.swift
+++ b/Sources/Kaset/Views/SharedViews/HomeSectionItemCard.swift
@@ -12,6 +12,7 @@ struct HomeSectionItemCard: View {
     /// Card dimensions.
     private static let squareThumbnailSize = CGSize(width: 160, height: 160)
     private static let videoThumbnailSize = CGSize(width: 284, height: 160)
+    private static let playButtonSize = CGSize(width: 48, height: 48)
 
     /// Hover state for play overlay.
     @State private var isHovering = false
@@ -30,6 +31,17 @@ struct HomeSectionItemCard: View {
     }
 
     var body: some View {
+        if self.supportsPlaylistPlayAction {
+            self.cardContent
+                .accessibilityAction(named: Text("Play \(self.item.title)")) {
+                    self.playAction?()
+                }
+        } else {
+            self.cardContent
+        }
+    }
+
+    private var cardContent: some View {
         ZStack(alignment: .topLeading) {
             Button(action: self.action) {
                 if let rank {
@@ -127,20 +139,26 @@ struct HomeSectionItemCard: View {
     }
 
     private var showsPlaylistPlayButton: Bool {
+        self.supportsPlaylistPlayAction && self.isHovering
+    }
+
+    private var supportsPlaylistPlayAction: Bool {
         guard case .playlist = self.item else { return false }
-        return self.playAction != nil && self.isHovering
+        return self.playAction != nil
     }
 
     private var playButton: some View {
-        ZStack {
-            Button {
-                self.playAction?()
-            } label: {
-                self.playButtonChrome
-            }
-            .buttonStyle(.plain)
+        Button {
+            self.playAction?()
+        } label: {
+            self.playButtonChrome
         }
-        .frame(width: self.thumbnailSize.width, height: self.thumbnailSize.height)
+        .buttonStyle(.plain)
+        .frame(width: Self.playButtonSize.width, height: Self.playButtonSize.height)
+        .offset(
+            x: (self.thumbnailSize.width - Self.playButtonSize.width) / 2,
+            y: (self.thumbnailSize.height - Self.playButtonSize.height) / 2
+        )
         .transition(.opacity)
         .accessibilityLabel(String(localized: "Play \(self.item.title)"))
         .accessibilityHint(String(localized: "Starts this playlist without opening it"))
@@ -151,7 +169,7 @@ struct HomeSectionItemCard: View {
             .font(.title2)
             .foregroundStyle(.primary)
             .offset(x: 2)
-            .frame(width: 48, height: 48)
+            .frame(width: Self.playButtonSize.width, height: Self.playButtonSize.height)
             .compatGlass(interactive: true, in: .circle)
     }
 

--- a/Sources/Kaset/Views/SharedViews/HomeSectionItemCard.swift
+++ b/Sources/Kaset/Views/SharedViews/HomeSectionItemCard.swift
@@ -6,6 +6,7 @@ import SwiftUI
 struct HomeSectionItemCard: View {
     let item: HomeSectionItem
     let rank: Int?
+    let playAction: (() -> Void)?
     let action: () -> Void
 
     /// Card dimensions.
@@ -16,21 +17,41 @@ struct HomeSectionItemCard: View {
     @State private var isHovering = false
     @State private var failedThumbnailURLs: Set<URL> = []
 
-    init(item: HomeSectionItem, rank: Int? = nil, action: @escaping () -> Void) {
+    init(
+        item: HomeSectionItem,
+        rank: Int? = nil,
+        playAction: (() -> Void)? = nil,
+        action: @escaping () -> Void
+    ) {
         self.item = item
         self.rank = rank
+        self.playAction = playAction
         self.action = action
     }
 
     var body: some View {
-        Button(action: self.action) {
-            if let rank {
-                self.chartContent(rank: rank)
-            } else {
-                self.regularContent
+        ZStack(alignment: .topLeading) {
+            Button(action: self.action) {
+                if let rank {
+                    self.chartContent(rank: rank)
+                } else {
+                    self.regularContent
+                }
+            }
+            .buttonStyle(.interactiveCard(showShadow: false, hoverScale: 1))
+
+            if self.showsPlaylistPlayButton {
+                self.playButton
             }
         }
-        .buttonStyle(.interactiveCard)
+        .scaleEffect(self.isHovering ? 1.02 : 1)
+        .shadow(
+            color: self.isHovering ? .black.opacity(0.15) : .clear,
+            radius: self.isHovering ? 12 : 0,
+            x: 0,
+            y: self.isHovering ? 4 : 0
+        )
+        .animation(AppAnimation.spring, value: self.isHovering)
         .onHover { hovering in
             withAnimation(AppAnimation.quick) {
                 self.isHovering = hovering
@@ -92,16 +113,8 @@ struct HomeSectionItemCard: View {
         .overlay {
             // Play overlay on hover (for songs)
             if case .song = self.item, self.isHovering {
-                Circle()
-                    .fill(.ultraThinMaterial)
-                    .frame(width: 48, height: 48)
-                    .overlay {
-                        Image(systemName: "play.fill")
-                            .font(.title2)
-                            .foregroundStyle(.primary)
-                            .offset(x: 2)
-                    }
-                    .transition(.scale.combined(with: .opacity))
+                self.playButtonChrome
+                    .transition(.opacity)
             }
         }
         .overlay(alignment: .topTrailing) {
@@ -111,6 +124,35 @@ struct HomeSectionItemCard: View {
                     .padding(6)
             }
         }
+    }
+
+    private var showsPlaylistPlayButton: Bool {
+        guard case .playlist = self.item else { return false }
+        return self.playAction != nil && self.isHovering
+    }
+
+    private var playButton: some View {
+        ZStack {
+            Button {
+                self.playAction?()
+            } label: {
+                self.playButtonChrome
+            }
+            .buttonStyle(.plain)
+        }
+        .frame(width: self.thumbnailSize.width, height: self.thumbnailSize.height)
+        .transition(.opacity)
+        .accessibilityLabel(String(localized: "Play \(self.item.title)"))
+        .accessibilityHint(String(localized: "Starts this playlist without opening it"))
+    }
+
+    private var playButtonChrome: some View {
+        Image(systemName: "play.fill")
+            .font(.title2)
+            .foregroundStyle(.primary)
+            .offset(x: 2)
+            .frame(width: 48, height: 48)
+            .compatGlass(interactive: true, in: .circle)
     }
 
     @ViewBuilder

--- a/Sources/Kaset/Views/SharedViews/HomeSectionItemCard.swift
+++ b/Sources/Kaset/Views/SharedViews/HomeSectionItemCard.swift
@@ -125,7 +125,7 @@ struct HomeSectionItemCard: View {
         .overlay {
             // Play overlay on hover (for songs)
             if case .song = self.item, self.isHovering {
-                self.playButtonChrome
+                self.playButtonChrome(interactive: false)
                     .transition(.opacity)
             }
         }
@@ -151,7 +151,7 @@ struct HomeSectionItemCard: View {
         Button {
             self.playAction?()
         } label: {
-            self.playButtonChrome
+            self.playButtonChrome(interactive: true)
         }
         .buttonStyle(.plain)
         .frame(width: Self.playButtonSize.width, height: Self.playButtonSize.height)
@@ -164,13 +164,13 @@ struct HomeSectionItemCard: View {
         .accessibilityHint(String(localized: "Starts this playlist without opening it"))
     }
 
-    private var playButtonChrome: some View {
+    private func playButtonChrome(interactive: Bool) -> some View {
         Image(systemName: "play.fill")
             .font(.title2)
             .foregroundStyle(.primary)
             .offset(x: 2)
             .frame(width: Self.playButtonSize.width, height: Self.playButtonSize.height)
-            .compatGlass(interactive: true, in: .circle)
+            .compatGlass(interactive: interactive, in: .circle)
     }
 
     @ViewBuilder

--- a/Sources/Kaset/Views/SharedViews/SongActionsHelper.swift
+++ b/Sources/Kaset/Views/SharedViews/SongActionsHelper.swift
@@ -249,6 +249,55 @@ enum SongActionsHelper {
         }
     }
 
+    /// Plays a playlist immediately, replacing the current queue.
+    static func playPlaylist(
+        _ playlist: Playlist,
+        client: any YTMusicClientProtocol,
+        playerService: PlayerService
+    ) {
+        Task {
+            do {
+                let response = try await client.getPlaylist(id: playlist.id)
+                var songs = response.detail.tracks
+
+                do {
+                    let allTracks = try await client.getPlaylistAllTracks(playlistId: playlist.id)
+                    if allTracks.count >= songs.count, !allTracks.isEmpty {
+                        songs = allTracks
+                    }
+                } catch {
+                    DiagnosticsLogger.ui.debug("Falling back to browse playlist tracks: \(error.localizedDescription)")
+                }
+
+                guard !songs.isEmpty else { return }
+
+                let songsWithPlaylistArtwork = songs.map { song in
+                    Song(
+                        id: song.id,
+                        title: song.title,
+                        artists: song.artists,
+                        album: song.album,
+                        duration: song.duration,
+                        thumbnailURL: song.thumbnailURL ?? playlist.thumbnailURL,
+                        videoId: song.videoId,
+                        isPlayable: song.isPlayable,
+                        hasVideo: song.hasVideo,
+                        musicVideoType: song.musicVideoType,
+                        likeStatus: song.likeStatus,
+                        isInLibrary: song.isInLibrary,
+                        feedbackTokens: song.feedbackTokens,
+                        isExplicit: song.isExplicit
+                    )
+                }
+
+                await playerService.playQueue(songsWithPlaylistArtwork, startingAt: 0)
+                DiagnosticsLogger.ui.info("Playing playlist '\(playlist.title)' (\(songsWithPlaylistArtwork.count) songs)")
+            } catch {
+                DiagnosticsLogger.ui.error("Failed to play playlist: \(error.localizedDescription)")
+            }
+        }
+    }
+
     /// Permanently deletes a playlist owned by the user.
     static func deletePlaylist(
         _ playlist: Playlist,

--- a/Sources/Kaset/Views/SharedViews/SongActionsHelper.swift
+++ b/Sources/Kaset/Views/SharedViews/SongActionsHelper.swift
@@ -11,6 +11,73 @@ enum SongActionsHelper {
 
     private static var artistLibraryReconciliationTasks: [String: Task<Void, Never>] = [:]
 
+    /// Whether a playlist card should expose direct playback.
+    static func canQuickPlayPlaylist(_ playlist: Playlist) -> Bool {
+        !MoodCategory.isMoodCategory(playlist.id)
+    }
+
+    private static func isRadioPlaylist(_ playlistId: String) -> Bool {
+        playlistId.contains("RDCLAK") || playlistId.hasPrefix("RD")
+    }
+
+    private static func tracksForPlaylistPlayback(browseTracks: [Song], queueTracks: [Song]) -> [Song] {
+        var browsePlayabilityByVideoId: [String: Bool] = [:]
+        for track in browseTracks {
+            browsePlayabilityByVideoId[track.videoId] = track.isPlayable
+        }
+
+        return queueTracks.map { track in
+            guard let browseIsPlayable = browsePlayabilityByVideoId[track.videoId],
+                  browseIsPlayable != track.isPlayable
+            else {
+                return track
+            }
+
+            return Song(
+                id: track.id,
+                title: track.title,
+                artists: track.artists,
+                album: track.album,
+                duration: track.duration,
+                thumbnailURL: track.thumbnailURL,
+                videoId: track.videoId,
+                isPlayable: browseIsPlayable,
+                hasVideo: track.hasVideo,
+                musicVideoType: track.musicVideoType,
+                likeStatus: track.likeStatus,
+                isInLibrary: track.isInLibrary,
+                feedbackTokens: track.feedbackTokens,
+                isExplicit: track.isExplicit
+            )
+        }
+    }
+
+    private static func loadPlaylistContinuations(
+        startingWith tracks: [Song],
+        continuationToken: String?,
+        client: any YTMusicClientProtocol
+    ) async -> [Song] {
+        var songs = tracks
+        var nextContinuationToken = continuationToken
+        var seenVideoIds = Set(songs.map(\.videoId))
+
+        while let token = nextContinuationToken {
+            do {
+                let response = try await client.getPlaylistContinuation(token: token)
+                let newTracks = response.tracks.filter { seenVideoIds.insert($0.videoId).inserted }
+                guard !newTracks.isEmpty else { break }
+
+                songs.append(contentsOf: newTracks)
+                nextContinuationToken = response.continuationToken
+            } catch {
+                DiagnosticsLogger.ui.debug("Falling back to loaded playlist tracks: \(error.localizedDescription)")
+                break
+            }
+        }
+
+        return songs
+    }
+
     private static func cleanedArtistPreservingMetadata(_ artist: Artist) -> Artist? {
         var cleanName = artist.name
 
@@ -260,18 +327,30 @@ enum SongActionsHelper {
                 let response = try await client.getPlaylist(id: playlist.id)
                 var songs = response.detail.tracks
 
-                do {
-                    let allTracks = try await client.getPlaylistAllTracks(playlistId: playlist.id)
-                    if allTracks.count >= songs.count, !allTracks.isEmpty {
-                        songs = allTracks
+                if self.isRadioPlaylist(playlist.id) {
+                    do {
+                        let allTracks = try await client.getPlaylistAllTracks(playlistId: playlist.id)
+                        if allTracks.count >= songs.count, !allTracks.isEmpty {
+                            songs = self.tracksForPlaylistPlayback(
+                                browseTracks: response.detail.tracks,
+                                queueTracks: allTracks
+                            )
+                        }
+                    } catch {
+                        DiagnosticsLogger.ui.debug("Falling back to browse playlist tracks: \(error.localizedDescription)")
                     }
-                } catch {
-                    DiagnosticsLogger.ui.debug("Falling back to browse playlist tracks: \(error.localizedDescription)")
+                } else {
+                    songs = await self.loadPlaylistContinuations(
+                        startingWith: songs,
+                        continuationToken: response.continuationToken,
+                        client: client
+                    )
                 }
 
-                guard !songs.isEmpty else { return }
+                let playableSongs = songs.filter(\.isPlayable)
+                guard !playableSongs.isEmpty else { return }
 
-                let songsWithPlaylistArtwork = songs.map { song in
+                let songsWithPlaylistArtwork = playableSongs.map { song in
                     Song(
                         id: song.id,
                         title: song.title,

--- a/Tests/KasetTests/Helpers/MockYTMusicClient.swift
+++ b/Tests/KasetTests/Helpers/MockYTMusicClient.swift
@@ -73,6 +73,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     var likedSongs: [Song] = []
     var likedSongsContinuationSongs: [[Song]] = []
     var playlistDetails: [String: PlaylistDetail] = [:]
+    var playlistAllTracks: [String: [Song]] = [:]
     var playlistContinuationTracks: [String: [[Song]]] = [:]
     var artistDetails: [String: ArtistDetail] = [:]
     var artistSongs: [String: [Song]] = [:]
@@ -638,6 +639,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
 
     func getPlaylistAllTracks(playlistId: String) async throws -> [Song] {
         if let error = shouldThrowError { throw error }
+        if let tracks = self.playlistAllTracks[playlistId] {
+            return tracks
+        }
         guard let detail = playlistDetails[playlistId] else {
             throw YTMusicError.parseError(message: "Playlist not found: \(playlistId)")
         }
@@ -962,6 +966,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.getPlaylistContinuationCalled = false
         self.getPlaylistContinuationCallCount = 0
         self.getPlaylistContinuationTokens = []
+        self.playlistAllTracks = [:]
         self.getArtistCalled = false
         self.getArtistIds = []
         self.getArtistSongsCalled = false

--- a/Tests/KasetTests/SongActionsHelperTests.swift
+++ b/Tests/KasetTests/SongActionsHelperTests.swift
@@ -37,6 +37,92 @@ struct SongActionsHelperTests {
         }
     }
 
+    private func awaitQueueCount(_ expectedCount: Int, in playerService: PlayerService) async {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(1))
+
+        while playerService.queue.count != expectedCount {
+            guard clock.now < deadline else { return }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+    }
+
+    @Test("canQuickPlayPlaylist rejects mood category browse IDs")
+    func canQuickPlayPlaylistRejectsMoodCategories() {
+        let playlist = TestFixtures.makePlaylist(id: "VL-test-playlist")
+        let moodCategory = TestFixtures.makePlaylist(id: "FEmusic_moods_and_genres_category_test")
+
+        #expect(SongActionsHelper.canQuickPlayPlaylist(playlist))
+        #expect(!SongActionsHelper.canQuickPlayPlaylist(moodCategory))
+    }
+
+    @Test("playPlaylist filters unavailable initial and continuation tracks before queueing")
+    func playPlaylistFiltersUnavailableTracks() async {
+        let playlist = TestFixtures.makePlaylist(id: "VL-test-playlist", title: "Test Playlist")
+        let unavailableFirst = Song(
+            id: "unavailable-first",
+            title: "Unavailable First",
+            artists: [],
+            videoId: "unavailable-first",
+            isPlayable: false
+        )
+        let playable = Song(
+            id: "playable",
+            title: "Playable",
+            artists: [],
+            videoId: "playable"
+        )
+        let unavailableContinuation = Song(
+            id: "unavailable-continuation",
+            title: "Unavailable Continuation",
+            artists: [],
+            videoId: "unavailable-continuation",
+            isPlayable: false
+        )
+        let playableContinuation = Song(
+            id: "playable-continuation",
+            title: "Playable Continuation",
+            artists: [],
+            videoId: "playable-continuation"
+        )
+        self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(
+            playlist: playlist,
+            tracks: [unavailableFirst, playable],
+            duration: nil
+        )
+        self.mockClient.playlistContinuationTracks[playlist.id] = [
+            [unavailableContinuation, playableContinuation],
+        ]
+        self.mockClient.playlistAllTracks[playlist.id] = [
+            Song(
+                id: "unavailable-first",
+                title: "Unavailable First",
+                artists: [],
+                videoId: "unavailable-first"
+            ),
+            playable,
+            Song(
+                id: "unavailable-continuation",
+                title: "Unavailable Continuation",
+                artists: [],
+                videoId: "unavailable-continuation"
+            ),
+            playableContinuation,
+        ]
+        let playerService = PlayerService()
+
+        SongActionsHelper.playPlaylist(
+            playlist,
+            client: self.mockClient,
+            playerService: playerService
+        )
+        await self.awaitQueueCount(2, in: playerService)
+
+        #expect(playerService.queue.map(\.videoId) == ["playable", "playable-continuation"])
+        #expect(playerService.currentTrack?.videoId == "playable")
+        #expect(playerService.queue.first?.thumbnailURL == playlist.thumbnailURL)
+    }
+
     @Test("addPlaylistToLibrary keeps optimistic playlist when refresh response is stale")
     func addPlaylistToLibraryPreservesOptimisticPlaylist() async {
         let playlist = TestFixtures.makePlaylist(id: "VL-test-playlist", title: "Test Playlist")


### PR DESCRIPTION
## Summary
- Add a Liquid Glass play button overlay for playlist cards on hover
- Keep card hover scaling active while hovering the play button
- Play playlists directly through the API-backed queue path without opening the playlist first

## Verification
- swift build
- swift test --skip KasetUITests