### PR TITLE
Fix carousel hover edge clipping

### DIFF
--- a/Sources/Kaset/Views/SharedViews/CarouselShelf.swift
+++ b/Sources/Kaset/Views/SharedViews/CarouselShelf.swift
@@ -4,7 +4,9 @@ import SwiftUI
 
 /// A native horizontal shelf with edge fades and glass paging controls.
 struct CarouselShelf<Content: View>: View {
-    private static var hoverBleed: CGFloat { 4 }
+    private static var hoverBleed: CGFloat {
+        4
+    }
 
     let accessibilityLabel: String
     let fadeWidth: CGFloat
@@ -46,13 +48,11 @@ struct CarouselShelf<Content: View>: View {
         } action: { _, newMetrics in
             self.scrollMetrics = newMetrics
         }
-        .padding(.horizontal, Self.hoverBleed)
-        .padding(.vertical, Self.hoverBleed)
+        .padding(Self.hoverBleed)
         .mask {
             self.edgeFadeMask
         }
-        .padding(.horizontal, -Self.hoverBleed)
-        .padding(.vertical, -Self.hoverBleed)
+        .padding(-Self.hoverBleed)
         .overlay(alignment: Alignment(horizontal: .leading, vertical: self.controlVerticalAlignment)) {
             if self.showsLeadingControl {
                 self.controlButton(for: .leading)

--- a/Sources/Kaset/Views/SharedViews/CarouselShelf.swift
+++ b/Sources/Kaset/Views/SharedViews/CarouselShelf.swift
@@ -4,6 +4,8 @@ import SwiftUI
 
 /// A native horizontal shelf with edge fades and glass paging controls.
 struct CarouselShelf<Content: View>: View {
+    private static var hoverBleed: CGFloat { 4 }
+
     let accessibilityLabel: String
     let fadeWidth: CGFloat
     let pageFraction: CGFloat
@@ -44,9 +46,13 @@ struct CarouselShelf<Content: View>: View {
         } action: { _, newMetrics in
             self.scrollMetrics = newMetrics
         }
+        .padding(.horizontal, Self.hoverBleed)
+        .padding(.vertical, Self.hoverBleed)
         .mask {
             self.edgeFadeMask
         }
+        .padding(.horizontal, -Self.hoverBleed)
+        .padding(.vertical, -Self.hoverBleed)
         .overlay(alignment: Alignment(horizontal: .leading, vertical: self.controlVerticalAlignment)) {
             if self.showsLeadingControl {
                 self.controlButton(for: .leading)


### PR DESCRIPTION
## Summary
- Add a small internal bleed around carousel shelves so scaled hover cards are not clipped at the leading edge
- Cancel the bleed externally so shelf alignment stays unchanged

## Verification
- swift build