### PR TITLE
Fix playlist quick-play follow-up issues

### DIFF
--- a/Sources/Kaset/Views/ExploreView.swift
+++ b/Sources/Kaset/Views/ExploreView.swift
@@ -61,6 +61,7 @@ struct ExploreView: View {
             .padding(.horizontal, 24)
             .padding(.vertical, 20)
         }
+        .accessibilityIdentifier(AccessibilityID.Explore.scrollView)
     }
 
     private func sectionView(_ section: HomeSection) -> some View {

--- a/Sources/Kaset/Views/SharedViews/HomeSectionItemCard.swift
+++ b/Sources/Kaset/Views/SharedViews/HomeSectionItemCard.swift
@@ -125,7 +125,7 @@ struct HomeSectionItemCard: View {
         .overlay {
             // Play overlay on hover (for songs)
             if case .song = self.item, self.isHovering {
-                self.playButtonChrome(interactive: false)
+                SongCoverPlayOverlay()
                     .transition(.opacity)
             }
         }
@@ -148,29 +148,13 @@ struct HomeSectionItemCard: View {
     }
 
     private var playButton: some View {
-        Button {
-            self.playAction?()
-        } label: {
-            self.playButtonChrome(interactive: true)
-        }
-        .buttonStyle(.plain)
-        .frame(width: Self.playButtonSize.width, height: Self.playButtonSize.height)
-        .offset(
-            x: (self.thumbnailSize.width - Self.playButtonSize.width) / 2,
-            y: (self.thumbnailSize.height - Self.playButtonSize.height) / 2
+        PlaylistPlayButton(
+            title: self.item.title,
+            size: Self.playButtonSize,
+            action: { self.playAction?() }
         )
+        .frame(width: self.thumbnailSize.width, height: self.thumbnailSize.height)
         .transition(.opacity)
-        .accessibilityLabel(String(localized: "Play \(self.item.title)"))
-        .accessibilityHint(String(localized: "Starts this playlist without opening it"))
-    }
-
-    private func playButtonChrome(interactive: Bool) -> some View {
-        Image(systemName: "play.fill")
-            .font(.title2)
-            .foregroundStyle(.primary)
-            .offset(x: 2)
-            .frame(width: Self.playButtonSize.width, height: Self.playButtonSize.height)
-            .compatGlass(interactive: interactive, in: .circle)
     }
 
     @ViewBuilder
@@ -339,6 +323,75 @@ struct HomeSectionItemCard: View {
 
         let subtitle = song.artistsDisplay.lowercased()
         return subtitle.contains("views") || subtitle.contains("video")
+    }
+}
+
+// MARK: - PlaylistPlayButton
+
+private struct PlaylistPlayButton: View {
+    let title: String
+    let size: CGSize
+    let action: () -> Void
+
+    @State private var isHovering = false
+
+    var body: some View {
+        Button(action: self.action) {
+            PlaylistPlayButtonChrome(size: self.size, interactive: self.isHovering)
+                .contentShape(.circle)
+        }
+        .buttonStyle(.plain)
+        .frame(width: self.size.width, height: self.size.height)
+        .contentShape(.circle)
+        .onHover { hovering in
+            withAnimation(AppAnimation.quick) {
+                self.isHovering = hovering
+            }
+        }
+        .accessibilityLabel(String(localized: "Play \(self.title)"))
+        .accessibilityHint(String(localized: "Starts this playlist without opening it"))
+    }
+}
+
+// MARK: - PlaylistPlayButtonChrome
+
+private struct PlaylistPlayButtonChrome: View {
+    let size: CGSize
+    let interactive: Bool
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .fill(.primary.opacity(0.001))
+                .frame(width: self.size.width, height: self.size.height)
+                .compatGlass(interactive: false, in: .circle)
+                .opacity(self.interactive ? 0.48 : 0.34)
+
+            Image(systemName: "play.fill")
+                .font(.title2)
+                .foregroundStyle(.primary)
+                .offset(x: 2)
+                .opacity(self.interactive ? 1 : 0.88)
+                .scaleEffect(self.interactive ? 1.04 : 1)
+        }
+        .frame(width: self.size.width, height: self.size.height)
+    }
+}
+
+// MARK: - SongCoverPlayOverlay
+
+private struct SongCoverPlayOverlay: View {
+    var body: some View {
+        Rectangle()
+            .fill(.black.opacity(0.18))
+            .overlay {
+                Image(systemName: "play.fill")
+                    .font(.system(size: 36, weight: .semibold))
+                    .foregroundStyle(.white)
+                    .shadow(color: .black.opacity(0.35), radius: 8, x: 0, y: 2)
+                    .offset(x: 3)
+            }
+            .allowsHitTesting(false)
     }
 }
 

--- a/Sources/Kaset/Views/SharedViews/HomeSectionItemCard.swift
+++ b/Sources/Kaset/Views/SharedViews/HomeSectionItemCard.swift
@@ -51,10 +51,6 @@ struct HomeSectionItemCard: View {
                 }
             }
             .buttonStyle(.interactiveCard(showShadow: false, hoverScale: 1))
-
-            if self.showsPlaylistPlayButton {
-                self.playButton
-            }
         }
         .scaleEffect(self.isHovering ? 1.02 : 1)
         .shadow(
@@ -125,7 +121,7 @@ struct HomeSectionItemCard: View {
         .overlay {
             // Play overlay on hover (for songs)
             if case .song = self.item, self.isHovering {
-                SongCoverPlayOverlay()
+                SongCoverPlayOverlay(size: Self.playButtonSize)
                     .transition(.opacity)
             }
         }
@@ -138,23 +134,9 @@ struct HomeSectionItemCard: View {
         }
     }
 
-    private var showsPlaylistPlayButton: Bool {
-        self.supportsPlaylistPlayAction && self.isHovering
-    }
-
     private var supportsPlaylistPlayAction: Bool {
         guard case .playlist = self.item else { return false }
         return self.playAction != nil
-    }
-
-    private var playButton: some View {
-        PlaylistPlayButton(
-            title: self.item.title,
-            size: Self.playButtonSize,
-            action: { self.playAction?() }
-        )
-        .frame(width: self.thumbnailSize.width, height: self.thumbnailSize.height)
-        .transition(.opacity)
     }
 
     @ViewBuilder
@@ -326,71 +308,29 @@ struct HomeSectionItemCard: View {
     }
 }
 
-// MARK: - PlaylistPlayButton
+// MARK: - LiquidGlassPlayIcon
 
-private struct PlaylistPlayButton: View {
-    let title: String
-    let size: CGSize
-    let action: () -> Void
-
-    @State private var isHovering = false
-
-    var body: some View {
-        Button(action: self.action) {
-            PlaylistPlayButtonChrome(size: self.size, interactive: self.isHovering)
-                .contentShape(.circle)
-        }
-        .buttonStyle(.plain)
-        .frame(width: self.size.width, height: self.size.height)
-        .contentShape(.circle)
-        .onHover { hovering in
-            withAnimation(AppAnimation.quick) {
-                self.isHovering = hovering
-            }
-        }
-        .accessibilityLabel(String(localized: "Play \(self.title)"))
-        .accessibilityHint(String(localized: "Starts this playlist without opening it"))
-    }
-}
-
-// MARK: - PlaylistPlayButtonChrome
-
-private struct PlaylistPlayButtonChrome: View {
+private struct LiquidGlassPlayIcon: View {
     let size: CGSize
     let interactive: Bool
 
     var body: some View {
-        ZStack {
-            Circle()
-                .fill(.primary.opacity(0.001))
-                .frame(width: self.size.width, height: self.size.height)
-                .compatGlass(interactive: false, in: .circle)
-                .opacity(self.interactive ? 0.48 : 0.34)
-
-            Image(systemName: "play.fill")
-                .font(.title2)
-                .foregroundStyle(.primary)
-                .offset(x: 2)
-                .opacity(self.interactive ? 1 : 0.88)
-                .scaleEffect(self.interactive ? 1.04 : 1)
-        }
-        .frame(width: self.size.width, height: self.size.height)
+        Image(systemName: "play.fill")
+            .font(.title2)
+            .foregroundStyle(.primary)
+            .offset(x: 2)
+            .frame(width: self.size.width, height: self.size.height)
+            .compatGlass(interactive: self.interactive, in: .circle)
     }
 }
 
 // MARK: - SongCoverPlayOverlay
 
 private struct SongCoverPlayOverlay: View {
+    let size: CGSize
+
     var body: some View {
-        Rectangle()
-            .fill(.black.opacity(0.18))
-            .overlay {
-                Image(systemName: "play.fill")
-                    .font(.system(size: 36, weight: .semibold))
-                    .foregroundStyle(.white)
-                    .shadow(color: .black.opacity(0.35), radius: 8, x: 0, y: 2)
-                    .offset(x: 3)
-            }
+        LiquidGlassPlayIcon(size: self.size, interactive: false)
             .allowsHitTesting(false)
     }
 }

--- a/Sources/Kaset/Views/SharedViews/SongActionsHelper.swift
+++ b/Sources/Kaset/Views/SharedViews/SongActionsHelper.swift
@@ -52,32 +52,6 @@ enum SongActionsHelper {
         }
     }
 
-    private static func loadPlaylistContinuations(
-        startingWith tracks: [Song],
-        continuationToken: String?,
-        client: any YTMusicClientProtocol
-    ) async -> [Song] {
-        var songs = tracks
-        var nextContinuationToken = continuationToken
-        var seenVideoIds = Set(songs.map(\.videoId))
-
-        while let token = nextContinuationToken {
-            do {
-                let response = try await client.getPlaylistContinuation(token: token)
-                let newTracks = response.tracks.filter { seenVideoIds.insert($0.videoId).inserted }
-                guard !newTracks.isEmpty else { break }
-
-                songs.append(contentsOf: newTracks)
-                nextContinuationToken = response.continuationToken
-            } catch {
-                DiagnosticsLogger.ui.debug("Falling back to loaded playlist tracks: \(error.localizedDescription)")
-                break
-            }
-        }
-
-        return songs
-    }
-
     private static func cleanedArtistPreservingMetadata(_ artist: Artist) -> Artist? {
         var cleanName = artist.name
 
@@ -340,37 +314,30 @@ enum SongActionsHelper {
                         DiagnosticsLogger.ui.debug("Falling back to browse playlist tracks: \(error.localizedDescription)")
                     }
                 } else {
-                    songs = await self.loadPlaylistContinuations(
-                        startingWith: songs,
-                        continuationToken: response.continuationToken,
-                        client: client
+                    let playableSongs = PlaylistPlaybackHelper.playableSongsWithPlaylistArtwork(songs, playlist: playlist)
+                    guard !playableSongs.isEmpty else { return }
+
+                    await playerService.playQueue(playableSongs, startingAt: 0)
+                    DiagnosticsLogger.ui.info("Playing playlist '\(playlist.title)' (\(playableSongs.count) initial songs)")
+
+                    await PlaylistPlaybackHelper.appendContinuations(
+                        PlaylistPlaybackHelper.ContinuationContext(
+                            continuationToken: response.continuationToken,
+                            existingVideoIds: Set(songs.map(\.videoId)),
+                            expectedQueueEntryIDs: playerService.queueEntryIDs,
+                            playlist: playlist,
+                            client: client,
+                            playerService: playerService
+                        )
                     )
+                    return
                 }
 
-                let playableSongs = songs.filter(\.isPlayable)
+                let playableSongs = PlaylistPlaybackHelper.playableSongsWithPlaylistArtwork(songs, playlist: playlist)
                 guard !playableSongs.isEmpty else { return }
 
-                let songsWithPlaylistArtwork = playableSongs.map { song in
-                    Song(
-                        id: song.id,
-                        title: song.title,
-                        artists: song.artists,
-                        album: song.album,
-                        duration: song.duration,
-                        thumbnailURL: song.thumbnailURL ?? playlist.thumbnailURL,
-                        videoId: song.videoId,
-                        isPlayable: song.isPlayable,
-                        hasVideo: song.hasVideo,
-                        musicVideoType: song.musicVideoType,
-                        likeStatus: song.likeStatus,
-                        isInLibrary: song.isInLibrary,
-                        feedbackTokens: song.feedbackTokens,
-                        isExplicit: song.isExplicit
-                    )
-                }
-
-                await playerService.playQueue(songsWithPlaylistArtwork, startingAt: 0)
-                DiagnosticsLogger.ui.info("Playing playlist '\(playlist.title)' (\(songsWithPlaylistArtwork.count) songs)")
+                await playerService.playQueue(playableSongs, startingAt: 0)
+                DiagnosticsLogger.ui.info("Playing playlist '\(playlist.title)' (\(playableSongs.count) songs)")
             } catch {
                 DiagnosticsLogger.ui.error("Failed to play playlist: \(error.localizedDescription)")
             }
@@ -862,6 +829,68 @@ enum SongActionsHelper {
                 DiagnosticsLogger.ui.info("Playing album '\(album.title)' (\(songs.count) songs)")
             } catch {
                 DiagnosticsLogger.ui.error("Failed to play album: \(error.localizedDescription)")
+            }
+        }
+    }
+}
+
+// MARK: - PlaylistPlaybackHelper
+
+@MainActor
+private enum PlaylistPlaybackHelper {
+    struct ContinuationContext {
+        let continuationToken: String?
+        let existingVideoIds: Set<String>
+        let expectedQueueEntryIDs: [UUID]
+        let playlist: Playlist
+        let client: any YTMusicClientProtocol
+        let playerService: PlayerService
+    }
+
+    static func playableSongsWithPlaylistArtwork(_ songs: [Song], playlist: Playlist) -> [Song] {
+        songs.filter(\.isPlayable).map { song in
+            Song(
+                id: song.id,
+                title: song.title,
+                artists: song.artists,
+                album: song.album,
+                duration: song.duration,
+                thumbnailURL: song.thumbnailURL ?? playlist.thumbnailURL,
+                videoId: song.videoId,
+                isPlayable: song.isPlayable,
+                hasVideo: song.hasVideo,
+                musicVideoType: song.musicVideoType,
+                likeStatus: song.likeStatus,
+                isInLibrary: song.isInLibrary,
+                feedbackTokens: song.feedbackTokens,
+                isExplicit: song.isExplicit
+            )
+        }
+    }
+
+    static func appendContinuations(_ context: ContinuationContext) async {
+        var nextContinuationToken = context.continuationToken
+        var seenVideoIds = context.existingVideoIds
+
+        while let token = nextContinuationToken, !Task.isCancelled {
+            do {
+                let response = try await context.client.getPlaylistContinuation(token: token)
+                let newTracks = response.tracks.filter { seenVideoIds.insert($0.videoId).inserted }
+                guard !newTracks.isEmpty else { break }
+
+                let playableSongs = Self.playableSongsWithPlaylistArtwork(newTracks, playlist: context.playlist)
+                if !playableSongs.isEmpty {
+                    guard Array(context.playerService.queueEntryIDs.prefix(context.expectedQueueEntryIDs.count)) == context.expectedQueueEntryIDs else {
+                        DiagnosticsLogger.ui.debug("Discarding playlist continuations because the queue changed")
+                        return
+                    }
+                    context.playerService.appendToQueue(playableSongs)
+                }
+
+                nextContinuationToken = response.continuationToken
+            } catch {
+                DiagnosticsLogger.ui.debug("Stopped loading playlist continuations: \(error.localizedDescription)")
+                break
             }
         }
     }

--- a/Tests/KasetTests/Helpers/MockYTMusicClient.swift
+++ b/Tests/KasetTests/Helpers/MockYTMusicClient.swift
@@ -67,6 +67,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     var rateSongDelay: Duration?
     var getSongDelay: Duration?
     var getPodcastsDelay: Duration?
+    var playlistContinuationDelay: Duration?
     var shouldAutoUpdatePlaylistLibraryOnMutation = true
     var shouldAutoUpdatePodcastLibraryOnMutation = true
     var shouldAutoUpdateArtistLibraryOnMutation = true
@@ -88,6 +89,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
 
     private(set) var getSongCalled = false
     private(set) var getSongVideoIds: [String] = []
+    private(set) var getPlaylistContinuationReturnCount = 0
 
     // MARK: - Continuation State
 
@@ -621,6 +623,12 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.getPlaylistContinuationCalled = true
         self.getPlaylistContinuationCallCount += 1
         self.getPlaylistContinuationTokens.append(token)
+        defer {
+            self.getPlaylistContinuationReturnCount += 1
+        }
+        if let playlistContinuationDelay {
+            try? await Task.sleep(for: playlistContinuationDelay)
+        }
         if let error = shouldThrowError { throw error }
         guard let (playlistId, index) = Self.parsePlaylistContinuationToken(token),
               let continuations = playlistContinuationTracks[playlistId],

--- a/Tests/KasetTests/SongActionsHelperTests.swift
+++ b/Tests/KasetTests/SongActionsHelperTests.swift
@@ -47,6 +47,16 @@ struct SongActionsHelperTests {
         }
     }
 
+    private func awaitPlaylistContinuationReturns(_ expectedCount: Int = 1) async {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(1))
+
+        while self.mockClient.getPlaylistContinuationReturnCount < expectedCount {
+            guard clock.now < deadline else { return }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+    }
+
     @Test("canQuickPlayPlaylist rejects mood category browse IDs")
     func canQuickPlayPlaylistRejectsMoodCategories() {
         let playlist = TestFixtures.makePlaylist(id: "VL-test-playlist")
@@ -121,6 +131,87 @@ struct SongActionsHelperTests {
         #expect(playerService.queue.map(\.videoId) == ["playable", "playable-continuation"])
         #expect(playerService.currentTrack?.videoId == "playable")
         #expect(playerService.queue.first?.thumbnailURL == playlist.thumbnailURL)
+    }
+
+    @Test("playPlaylist starts playback before loading continuations")
+    func playPlaylistStartsBeforeContinuations() async {
+        let playlist = TestFixtures.makePlaylist(id: "VL-test-playlist", title: "Test Playlist")
+        let initial = Song(
+            id: "initial",
+            title: "Initial",
+            artists: [],
+            videoId: "initial"
+        )
+        let continuation = Song(
+            id: "continuation",
+            title: "Continuation",
+            artists: [],
+            videoId: "continuation"
+        )
+        self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(
+            playlist: playlist,
+            tracks: [initial],
+            duration: nil
+        )
+        self.mockClient.playlistContinuationTracks[playlist.id] = [[continuation]]
+        self.mockClient.playlistContinuationDelay = .milliseconds(250)
+        let playerService = PlayerService()
+
+        SongActionsHelper.playPlaylist(
+            playlist,
+            client: self.mockClient,
+            playerService: playerService
+        )
+        await self.awaitQueueCount(1, in: playerService)
+
+        #expect(playerService.currentTrack?.videoId == "initial")
+        #expect(playerService.queue.map(\.videoId) == ["initial"])
+
+        await self.awaitQueueCount(2, in: playerService)
+        #expect(playerService.queue.map(\.videoId) == ["initial", "continuation"])
+    }
+
+    @Test("playPlaylist discards continuations after queue replacement")
+    func playPlaylistDiscardsContinuationsAfterQueueReplacement() async {
+        let playlist = TestFixtures.makePlaylist(id: "VL-test-playlist", title: "Test Playlist")
+        let initial = Song(
+            id: "initial",
+            title: "Initial",
+            artists: [],
+            videoId: "initial"
+        )
+        let continuation = Song(
+            id: "continuation",
+            title: "Continuation",
+            artists: [],
+            videoId: "continuation"
+        )
+        let replacement = Song(
+            id: "replacement",
+            title: "Replacement",
+            artists: [],
+            videoId: "replacement"
+        )
+        self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(
+            playlist: playlist,
+            tracks: [initial],
+            duration: nil
+        )
+        self.mockClient.playlistContinuationTracks[playlist.id] = [[continuation]]
+        self.mockClient.playlistContinuationDelay = .milliseconds(250)
+        let playerService = PlayerService()
+
+        SongActionsHelper.playPlaylist(
+            playlist,
+            client: self.mockClient,
+            playerService: playerService
+        )
+        await self.awaitQueueCount(1, in: playerService)
+
+        await playerService.playQueue([replacement], startingAt: 0)
+        await self.awaitPlaylistContinuationReturns()
+
+        #expect(playerService.queue.map(\.videoId) == ["replacement"])
     }
 
     @Test("addPlaylistToLibrary keeps optimistic playlist when refresh response is stale")

--- a/Tests/KasetUITests/ExploreViewUITests.swift
+++ b/Tests/KasetUITests/ExploreViewUITests.swift
@@ -19,7 +19,7 @@ final class ExploreViewUITests: KasetUITestCase {
 
         navigateToExplore()
 
-        let scrollView = app.scrollViews.firstMatch
+        let scrollView = app.scrollViews["exploreView.scrollView"].firstMatch
         XCTAssertTrue(waitForElement(scrollView, timeout: 10))
     }
 
@@ -28,7 +28,7 @@ final class ExploreViewUITests: KasetUITestCase {
 
         navigateToExplore()
 
-        let scrollView = app.scrollViews.firstMatch
+        let scrollView = app.scrollViews["exploreView.scrollView"].firstMatch
         XCTAssertTrue(waitForElement(scrollView))
 
         scrollView.swipeUp()


### PR DESCRIPTION
## Summary
This follows up on `299efc5` (`Add playlist card hover play button`) to fix the remaining interaction and playback issues with playlist quick-play.

- Make playlist quick-play start playback from the first loaded playlist batch immediately, then append continuation tracks in the background.
- Make the full circular quick-play button clickable, rather than only the play icon inside it.
- Keep delayed continuation loads from appending into a newer queue if the user starts something else.
- Align song-card hover affordances with existing behavior by treating the whole song cover as playable.
- Smooth the quick-play button’s liquid-glass hover state.

## Fixed Issues
- In `299efc5`, playlist quick-play could feel delayed because playback waited for playlist continuations before starting.
- The circular play button looked like one clickable control, but only the icon itself was reliably clickable.
- Delayed continuation loads could otherwise keep mutating the queue after playback had moved on.
- Song cards already played when clicking the cover, but the hover UI still presented a small centered play button.

## Validation
- `swiftformat .`
- `swiftlint --strict`
- `swift build`
- `swift test --filter SongActionsHelperTests`
- `swift test --skip KasetUITests`
- `git diff --check`
