### PR TITLE
Fix All search aggregation

### DIFF
--- a/Sources/Kaset/ViewModels/SearchViewModel.swift
+++ b/Sources/Kaset/ViewModels/SearchViewModel.swift
@@ -155,6 +155,11 @@ final class SearchViewModel {
     @ObservationIgnored private var suppressedSuggestionsQuery: String?
     // swiftformat:enable modifierOrder
 
+    private struct SearchAllAttempt {
+        let response: SearchResponse?
+        let error: (any Error)?
+    }
+
     init(client: any YTMusicClientProtocol) {
         self.client = client
     }
@@ -331,29 +336,29 @@ final class SearchViewModel {
     /// Performs the broadest search for the All filter by combining the mixed search response
     /// with the dedicated result-type searches.
     private func searchAll(query: String) async throws -> SearchResponse {
-        async let mixedResults = self.bestEffortSearch(label: "mixed search") {
+        async let mixedResults = self.attemptSearch(label: "mixed search") {
             try await self.client.search(query: query)
         }
-        async let songResults = self.bestEffortSearch(label: "songs search") {
+        async let songResults = self.attemptSearch(label: "songs search") {
             try await self.client.searchSongsWithPagination(query: query)
         }
-        async let albumResults = self.bestEffortSearch(label: "albums search") {
+        async let albumResults = self.attemptSearch(label: "albums search") {
             try await self.client.searchAlbums(query: query)
         }
-        async let artistResults = self.bestEffortSearch(label: "artists search") {
+        async let artistResults = self.attemptSearch(label: "artists search") {
             try await self.client.searchArtists(query: query)
         }
-        async let featuredPlaylistResults = self.bestEffortSearch(label: "featured playlists search") {
+        async let featuredPlaylistResults = self.attemptSearch(label: "featured playlists search") {
             try await self.client.searchFeaturedPlaylists(query: query)
         }
-        async let communityPlaylistResults = self.bestEffortSearch(label: "community playlists search") {
+        async let communityPlaylistResults = self.attemptSearch(label: "community playlists search") {
             try await self.client.searchCommunityPlaylists(query: query)
         }
-        async let podcastResults = self.bestEffortSearch(label: "podcasts search") {
+        async let podcastResults = self.attemptSearch(label: "podcasts search") {
             try await self.client.searchPodcasts(query: query)
         }
 
-        let responses = await [
+        let attempts = await [
             mixedResults,
             songResults,
             albumResults,
@@ -363,20 +368,35 @@ final class SearchViewModel {
             podcastResults,
         ]
 
+        if let authError = attempts.compactMap(\.error).first(where: Self.isAuthenticationError) {
+            throw authError
+        }
+
+        let responses = attempts.compactMap(\.response)
+        guard !responses.isEmpty else {
+            throw attempts.compactMap(\.error).first ?? YTMusicError.unknown(message: "All-filter search failed")
+        }
+
         return Self.mergeSearchResponses(responses)
     }
 
-    /// Runs a search request and falls back to an empty response if a specific endpoint fails.
-    private func bestEffortSearch(
+    /// Runs one All-filter search request, preserving failures so total failure still surfaces as an error.
+    private func attemptSearch(
         label: String,
         operation: @escaping @Sendable () async throws -> SearchResponse
-    ) async -> SearchResponse {
+    ) async -> SearchAllAttempt {
         do {
-            return try await operation()
+            let response = try await operation()
+            return SearchAllAttempt(response: response, error: nil)
         } catch {
             self.logger.debug("All-filter \(label) failed: \(error.localizedDescription)")
-            return .empty
+            return SearchAllAttempt(response: nil, error: error)
         }
+    }
+
+    private static func isAuthenticationError(_ error: any Error) -> Bool {
+        guard let ytError = error as? YTMusicError else { return false }
+        return ytError.requiresReauth
     }
 
     /// Combines multiple search responses while keeping the first occurrence of each item.

--- a/Sources/Kaset/ViewModels/SearchViewModel.swift
+++ b/Sources/Kaset/ViewModels/SearchViewModel.swift
@@ -71,9 +71,17 @@ final class SearchViewModel {
     /// Filter for result types.
     var selectedFilter: SearchFilter = .all {
         didSet {
-            if oldValue != self.selectedFilter, !self.query.isEmpty, self.lastSearchedQuery != nil {
-                // Filter changed - perform a new filtered search
+            guard oldValue != self.selectedFilter, !self.query.isEmpty else { return }
+
+            // If we've previously searched this query, perform a filtered search
+            // to get the best results for the selected filter. If no prior
+            // search exists (e.g. user typed a query but hasn't pressed Enter),
+            // perform an immediate search for the current filter so clicking
+            // filter chips always produces results.
+            if self.lastSearchedQuery != nil {
                 self.searchWithFilter()
+            } else {
+                self.searchImmediately()
             }
         }
     }
@@ -284,7 +292,7 @@ final class SearchViewModel {
                 = switch currentFilter
             {
             case .all:
-                try await self.client.search(query: currentQuery)
+                try await self.searchAll(query: currentQuery)
             case .songs:
                 try await self.client.searchSongsWithPagination(query: currentQuery)
             case .albums:
@@ -318,6 +326,99 @@ final class SearchViewModel {
                 self.loadingState = .error(LoadingError(from: error))
             }
         }
+    }
+
+    /// Performs the broadest search for the All filter by combining the mixed search response
+    /// with the dedicated result-type searches.
+    private func searchAll(query: String) async throws -> SearchResponse {
+        async let mixedResults = self.bestEffortSearch(label: "mixed search") {
+            try await self.client.search(query: query)
+        }
+        async let songResults = self.bestEffortSearch(label: "songs search") {
+            try await self.client.searchSongsWithPagination(query: query)
+        }
+        async let albumResults = self.bestEffortSearch(label: "albums search") {
+            try await self.client.searchAlbums(query: query)
+        }
+        async let artistResults = self.bestEffortSearch(label: "artists search") {
+            try await self.client.searchArtists(query: query)
+        }
+        async let featuredPlaylistResults = self.bestEffortSearch(label: "featured playlists search") {
+            try await self.client.searchFeaturedPlaylists(query: query)
+        }
+        async let communityPlaylistResults = self.bestEffortSearch(label: "community playlists search") {
+            try await self.client.searchCommunityPlaylists(query: query)
+        }
+        async let podcastResults = self.bestEffortSearch(label: "podcasts search") {
+            try await self.client.searchPodcasts(query: query)
+        }
+
+        let responses = await [
+            mixedResults,
+            songResults,
+            albumResults,
+            artistResults,
+            featuredPlaylistResults,
+            communityPlaylistResults,
+            podcastResults,
+        ]
+
+        return Self.mergeSearchResponses(responses)
+    }
+
+    /// Runs a search request and falls back to an empty response if a specific endpoint fails.
+    private func bestEffortSearch(
+        label: String,
+        operation: @escaping @Sendable () async throws -> SearchResponse
+    ) async -> SearchResponse {
+        do {
+            return try await operation()
+        } catch {
+            self.logger.debug("All-filter \(label) failed: \(error.localizedDescription)")
+            return .empty
+        }
+    }
+
+    /// Combines multiple search responses while keeping the first occurrence of each item.
+    private static func mergeSearchResponses(_ responses: [SearchResponse]) -> SearchResponse {
+        var songs: [Song] = []
+        var albums: [Album] = []
+        var artists: [Artist] = []
+        var playlists: [Playlist] = []
+        var podcastShows: [PodcastShow] = []
+
+        var seenSongIDs: Set<String> = []
+        var seenAlbumIDs: Set<String> = []
+        var seenArtistIDs: Set<String> = []
+        var seenPlaylistIDs: Set<String> = []
+        var seenPodcastIDs: Set<String> = []
+
+        for response in responses {
+            for song in response.songs where seenSongIDs.insert(song.id).inserted {
+                songs.append(song)
+            }
+            for album in response.albums where seenAlbumIDs.insert(album.id).inserted {
+                albums.append(album)
+            }
+            for artist in response.artists where seenArtistIDs.insert(artist.id).inserted {
+                artists.append(artist)
+            }
+            for playlist in response.playlists where seenPlaylistIDs.insert(playlist.id).inserted {
+                playlists.append(playlist)
+            }
+            for podcastShow in response.podcastShows where seenPodcastIDs.insert(podcastShow.id).inserted {
+                podcastShows.append(podcastShow)
+            }
+        }
+
+        return SearchResponse(
+            songs: songs,
+            albums: albums,
+            artists: artists,
+            playlists: playlists,
+            podcastShows: podcastShows,
+            continuationToken: nil
+        )
     }
 
     /// Loads more search results via continuation.

--- a/Tests/KasetTests/Helpers/MockYTMusicClient.swift
+++ b/Tests/KasetTests/Helpers/MockYTMusicClient.swift
@@ -49,6 +49,14 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     var podcastsSections: [PodcastSection] = []
     var podcastsContinuationSections: [[PodcastSection]] = []
     var searchResponse: SearchResponse = .empty
+    var mixedSearchResponse: SearchResponse?
+    var songsSearchResponse: SearchResponse?
+    var albumsSearchResponse: SearchResponse?
+    var artistsSearchResponse: SearchResponse?
+    var playlistsSearchResponse: SearchResponse?
+    var featuredPlaylistsSearchResponse: SearchResponse?
+    var communityPlaylistsSearchResponse: SearchResponse?
+    var podcastsSearchResponse: SearchResponse?
     var searchContinuationResponses: [SearchResponse] = []
     var searchSuggestions: [SearchSuggestion] = []
     var libraryPlaylists: [Playlist] = []
@@ -394,14 +402,14 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.searchQueries.append(query)
         self._searchContinuationIndex = 0
         if let error = shouldThrowError { throw error }
-        return self.searchResponse
+        return self.mixedSearchResponse ?? self.searchResponse
     }
 
     func searchSongs(query: String) async throws -> [Song] {
         self.searchCalled = true
         self.searchQueries.append(query)
         if let error = shouldThrowError { throw error }
-        return self.searchResponse.songs
+        return (self.songsSearchResponse ?? self.searchResponse).songs
     }
 
     func searchSongsWithPagination(query: String) async throws -> SearchResponse {
@@ -410,8 +418,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self._searchContinuationIndex = 0
         if let error = shouldThrowError { throw error }
         let hasMore = !self.searchContinuationResponses.isEmpty
+        let response = self.songsSearchResponse ?? self.searchResponse
         return SearchResponse(
-            songs: self.searchResponse.songs,
+            songs: response.songs,
             albums: [],
             artists: [],
             playlists: [],
@@ -425,9 +434,10 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self._searchContinuationIndex = 0
         if let error = shouldThrowError { throw error }
         let hasMore = !self.searchContinuationResponses.isEmpty
+        let response = self.albumsSearchResponse ?? self.searchResponse
         return SearchResponse(
             songs: [],
-            albums: self.searchResponse.albums,
+            albums: response.albums,
             artists: [],
             playlists: [],
             continuationToken: hasMore ? "mock-token" : nil
@@ -440,10 +450,11 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self._searchContinuationIndex = 0
         if let error = shouldThrowError { throw error }
         let hasMore = !self.searchContinuationResponses.isEmpty
+        let response = self.artistsSearchResponse ?? self.searchResponse
         return SearchResponse(
             songs: [],
             albums: [],
-            artists: self.searchResponse.artists,
+            artists: response.artists,
             playlists: [],
             continuationToken: hasMore ? "mock-token" : nil
         )
@@ -455,11 +466,12 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self._searchContinuationIndex = 0
         if let error = shouldThrowError { throw error }
         let hasMore = !self.searchContinuationResponses.isEmpty
+        let response = self.playlistsSearchResponse ?? self.searchResponse
         return SearchResponse(
             songs: [],
             albums: [],
             artists: [],
-            playlists: self.searchResponse.playlists,
+            playlists: response.playlists,
             continuationToken: hasMore ? "mock-token" : nil
         )
     }
@@ -470,11 +482,12 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self._searchContinuationIndex = 0
         if let error = shouldThrowError { throw error }
         let hasMore = !self.searchContinuationResponses.isEmpty
+        let response = self.featuredPlaylistsSearchResponse ?? self.searchResponse
         return SearchResponse(
             songs: [],
             albums: [],
             artists: [],
-            playlists: self.searchResponse.playlists,
+            playlists: response.playlists,
             continuationToken: hasMore ? "mock-token" : nil
         )
     }
@@ -485,11 +498,12 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self._searchContinuationIndex = 0
         if let error = shouldThrowError { throw error }
         let hasMore = !self.searchContinuationResponses.isEmpty
+        let response = self.communityPlaylistsSearchResponse ?? self.searchResponse
         return SearchResponse(
             songs: [],
             albums: [],
             artists: [],
-            playlists: self.searchResponse.playlists,
+            playlists: response.playlists,
             continuationToken: hasMore ? "mock-token" : nil
         )
     }
@@ -500,12 +514,13 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self._searchContinuationIndex = 0
         if let error = shouldThrowError { throw error }
         let hasMore = !self.searchContinuationResponses.isEmpty
+        let response = self.podcastsSearchResponse ?? self.searchResponse
         return SearchResponse(
             songs: [],
             albums: [],
             artists: [],
-            playlists: [],
-            podcastShows: [],
+            playlists: response.playlists,
+            podcastShows: response.podcastShows,
             continuationToken: hasMore ? "mock-token" : nil
         )
     }

--- a/Tests/KasetTests/SearchViewModelTests.swift
+++ b/Tests/KasetTests/SearchViewModelTests.swift
@@ -209,4 +209,24 @@ struct SearchViewModelTests {
         #expect(self.viewModel.results.podcastShows.count == 1)
         #expect(self.mockClient.searchQueries.count == 7)
     }
+
+    @Test("All filter reports error when every aggregate request fails")
+    func allFilterReportsErrorWhenEveryAggregateRequestFails() async {
+        self.mockClient.shouldThrowError = YTMusicError.networkError(underlying: URLError(.notConnectedToInternet))
+
+        self.viewModel.query = "lofi"
+        self.viewModel.selectedFilter = .all
+        self.viewModel.searchImmediately()
+        try? await Task.sleep(for: .milliseconds(50))
+
+        guard case let .error(error) = self.viewModel.loadingState else {
+            Issue.record("Expected all-filter total failure to surface an error")
+            return
+        }
+
+        #expect(error.title == "Connection Error")
+        #expect(error.isRetryable)
+        #expect(self.viewModel.results.isEmpty)
+        #expect(self.mockClient.searchQueries.count == 7)
+    }
 }

--- a/Tests/KasetTests/SearchViewModelTests.swift
+++ b/Tests/KasetTests/SearchViewModelTests.swift
@@ -151,4 +151,62 @@ struct SearchViewModelTests {
         #expect(self.viewModel.filteredItems.isEmpty)
         #expect(self.viewModel.shouldShowFilters)
     }
+
+    @Test("All filter aggregates category-specific search results when mixed search is empty")
+    func allFilterAggregatesCategorySpecificSearchResults() async {
+        let songsResponse = TestFixtures.makeSearchResponse(
+            songCount: 2,
+            albumCount: 0,
+            artistCount: 0,
+            playlistCount: 0
+        )
+        let albumsResponse = TestFixtures.makeSearchResponse(
+            songCount: 0,
+            albumCount: 1,
+            artistCount: 0,
+            playlistCount: 0
+        )
+        let artistsResponse = TestFixtures.makeSearchResponse(
+            songCount: 0,
+            albumCount: 0,
+            artistCount: 1,
+            playlistCount: 0
+        )
+        let playlistsResponse = TestFixtures.makeSearchResponse(
+            songCount: 0,
+            albumCount: 0,
+            artistCount: 0,
+            playlistCount: 1
+        )
+        let podcastsResponse = SearchResponse(
+            songs: [],
+            albums: [],
+            artists: [],
+            playlists: [],
+            podcastShows: [TestFixtures.makePodcastShow()],
+            continuationToken: nil
+        )
+
+        self.mockClient.mixedSearchResponse = .empty
+        self.mockClient.songsSearchResponse = songsResponse
+        self.mockClient.albumsSearchResponse = albumsResponse
+        self.mockClient.artistsSearchResponse = artistsResponse
+        self.mockClient.featuredPlaylistsSearchResponse = playlistsResponse
+        self.mockClient.communityPlaylistsSearchResponse = playlistsResponse
+        self.mockClient.podcastsSearchResponse = podcastsResponse
+
+        self.viewModel.query = "lofi"
+        self.viewModel.selectedFilter = .all
+        self.viewModel.searchImmediately()
+        try? await Task.sleep(for: .milliseconds(50))
+
+        #expect(self.viewModel.loadingState == .loaded)
+        #expect(self.viewModel.filteredItems.count == 6)
+        #expect(self.viewModel.results.songs.count == 2)
+        #expect(self.viewModel.results.albums.count == 1)
+        #expect(self.viewModel.results.artists.count == 1)
+        #expect(self.viewModel.results.playlists.count == 1)
+        #expect(self.viewModel.results.podcastShows.count == 1)
+        #expect(self.mockClient.searchQueries.count == 7)
+    }
 }


### PR DESCRIPTION
## Description

Ensure the Search "All" filter shows results from every relevant search source when the mixed response is empty by aggregating the category-specific search endpoints and deduplicating the merged results.

## AI Prompt (Optional)

<!-- 
If this PR was generated with AI assistance (GitHub Copilot, Claude, Cursor, etc.), 
share the prompt that created these changes. This helps reviewers:
- Understand your intent better than code alone
- Validate the approach before reviewing implementation
- Run the prompt themselves to verify or iterate

If you want to submit a "prompt request" (prompt-only, no code), please open a
new issue using the "Prompt Request" issue template instead of a pull request.
-->

<details>
<summary>🤖 AI Prompt Used</summary>

```
AI Tool: GitHub Copilot (GPT-5.2-Codex)
```

**AI Tool:** <!-- e.g., GitHub Copilot, Claude, Cursor -->

</details>

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🧪 Test update
- [ ] 🔧 Build/CI configuration

## Related Issues

[Bug]: no result seen on All filter #263 

## Changes Made

- When "All" returns nothing, the app now also queries songs, albums, artists, playlists, and podcasts and combines those results so users see relevant items. I also made the filter switch trigger a search immediately when needed. 

## Testing

<!-- Describe how you tested these changes -->

- [x] Unit tests pass (`xcodebuild test -only-testing:KasetTests`)
- [x] Manual testing performed
- [x] UI tested on macOS 26+

## Checklist

<!-- Mark completed items with an 'x' -->

- [x] My code follows the project's style guidelines
- [x] I have run `swiftlint --strict && swiftformat .`
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally
- [ ] I have updated documentation if needed
- [x] I have checked for any performance implications
- [x] My changes generate no new warnings

## Screenshots

<img width="1092" height="764" alt="Screenshot 2026-06-07 at 12 23 16 PM" src="https://github.com/user-attachments/assets/baa42bb0-720f-4f85-910b-30fbbef0a9fb" />

## Additional Notes

<!-- Any additional information that reviewers should know -->
