### PR TITLE
Fix deprecated Homebrew macOS dependency syntax

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -466,7 +466,7 @@ jobs:
             # Homebrew casks can gate on macOS release symbols, but not this
             # app's exact 15.4 patch minimum; LSMinimumSystemVersion and
             # Sparkle's appcast enforce 15.4 at launch/update time.
-            depends_on macos: ">= :sequoia"
+            depends_on macos: :sequoia
 
             app "Kaset.app"
 

--- a/Casks/kaset.rb
+++ b/Casks/kaset.rb
@@ -10,7 +10,7 @@ cask "kaset" do
   deprecate! date: "2026-01-06", because: "has moved to the tap at https://github.com/sozercan/homebrew-repo"
 
   auto_updates false
-  depends_on macos: ">= :tahoe"
+  depends_on macos: :tahoe
 
   app "Kaset.app"
 


### PR DESCRIPTION
## Summary
- Replace deprecated Homebrew `depends_on macos:` string comparison syntax with symbol syntax in the cask
- Update generated cask content in the release workflow to use symbol syntax
- Preserve existing intended minimum macOS requirements (`:tahoe` for the current cask and `:sequoia` for generated release content)

Fixes #293

## Validation
- `git diff --check`
- `ruby -c Casks/kaset.rb` using `ruby:3.3-alpine`
- YAML parse of `.github/workflows/release.yml` using Ruby
- Verified no remaining `depends_on macos: ">= ..."` patterns in `Casks/` or `.github/workflows/release.yml`

## Review
- Orka reviewer returned `LGTM`