### PR TITLE
Fix deprecated Homebrew macOS dependency syntax

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -466,7 +466,7 @@ jobs:
             # Homebrew casks can gate on macOS release symbols, but not this
             # app's exact 15.4 patch minimum; LSMinimumSystemVersion and
             # Sparkle's appcast enforce 15.4 at launch/update time.
-            depends_on macos: ">= :sequoia"
+            depends_on macos: :sequoia
 
             app "Kaset.app"
 

--- a/Casks/kaset.rb
+++ b/Casks/kaset.rb
@@ -10,7 +10,7 @@ cask "kaset" do
   deprecate! date: "2026-01-06", because: "has moved to the tap at https://github.com/sozercan/homebrew-repo"
 
   auto_updates false
-  depends_on macos: ">= :tahoe"
+  depends_on macos: :tahoe
 
   app "Kaset.app"
 


### PR DESCRIPTION
## Summary
- Replace deprecated Homebrew `depends_on macos: ">= :tahoe"` syntax in `Casks/kaset.rb` with symbol syntax.
- Update generated cask content in `.github/workflows/release.yml` to use `depends_on macos: :sequoia`.

Fixes #293.

## Validation
- `ruby -c Casks/kaset.rb`
- Parsed `.github/workflows/release.yml` with Ruby YAML
- Confirmed no remaining `depends_on macos: ">=` occurrences under `Casks` or `.github/workflows`

## Review
- Runtime reviewer returned no findings; local Swift/Ruby tools were unavailable in reviewer image, but independent Ruby container validation passed.