### PR TITLE
Media remote controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,6 @@ Thumbs.db
 
 # IDE
 .idea/
-.vscode/
 *.swp
 *.swo
 *~
@@ -66,10 +65,3 @@ TEMP_*
 build/
 .codex/environments/environment.toml
 Build
-
-# Agent-specific files
-.agents/
-docs/plans/
-dump_methods.swift
-dump_wkext.swift
-test_wkwebext.swift

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ Thumbs.db
 
 # IDE
 .idea/
+.vscode/
 *.swp
 *.swo
 *~
@@ -65,3 +66,10 @@ TEMP_*
 build/
 .codex/environments/environment.toml
 Build
+
+# Agent-specific files
+.agents/
+docs/plans/
+dump_methods.swift
+dump_wkext.swift
+test_wkwebext.swift

--- a/Info.plist
+++ b/Info.plist
@@ -49,5 +49,11 @@
 	<string>Kaset processes its own music output through a built-in equalizer. This permission only covers Kaset's own playback — no other app's audio is captured.</string>
 	<key>NSScreenCaptureUsageDescription</key>
 	<string>Kaset taps its own audio output (not the screen) so the built-in equalizer can apply effects to your music. No screen content is recorded.</string>
+
+	<!-- Bonjour Services Advertisement -->
+	<key>NSBonjourServices</key>
+	<array>
+		<string>_http._tcp</string>
+	</array>
 </dict>
 </plist>

--- a/Kaset.entitlements
+++ b/Kaset.entitlements
@@ -8,6 +8,8 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 	<key>com.apple.security.files.bookmarks.app-scope</key>

--- a/Scripts/build-app.sh
+++ b/Scripts/build-app.sh
@@ -357,6 +357,12 @@ ${APP_LOCALIZATIONS_PLIST}
     <string>${BUILD_TIMESTAMP}</string>
     <key>KasetGitCommit</key>
     <string>${GIT_COMMIT}</string>
+    
+    <!-- Bonjour Services Advertisement -->
+    <key>NSBonjourServices</key>
+    <array>
+        <string>_http._tcp</string>
+    </array>
 </dict>
 </plist>
 PLIST

--- a/Sources/Kaset/KasetApp.swift
+++ b/Sources/Kaset/KasetApp.swift
@@ -79,6 +79,7 @@ struct KasetApp: App {
 
         // Set shared instance for AppleScript access
         PlayerService.shared = player
+        LocalControlServer.shared.configure(playerService: player)
 
         // Create account service
         let account = AccountService(ytMusicClient: client, authService: auth)
@@ -200,6 +201,15 @@ struct KasetApp: App {
                     }
                     .onChange(of: self.settings.keepMiniPlayerOnTop) { _, _ in
                         MiniPlayerWindowController.shared.syncWindowState()
+                    }
+                    .onChange(of: self.settings.localControlServerEnabled) { _, _ in
+                        LocalControlServer.shared.applySettings()
+                    }
+                    .onChange(of: self.settings.localControlServerPort) { _, _ in
+                        LocalControlServer.shared.applySettings()
+                    }
+                    .onChange(of: self.settings.localControlServerAllowsLAN) { _, _ in
+                        LocalControlServer.shared.applySettings()
                     }
             }
         }

--- a/Sources/Kaset/KasetApp.swift
+++ b/Sources/Kaset/KasetApp.swift
@@ -77,9 +77,14 @@ struct KasetApp: App {
         player.setYTMusicClient(client)
         SongLikeStatusManager.shared.setClient(client)
 
+        let lyricsService = SyncedLyricsService(providers: [
+            YTMusicSyncedProvider(client: client),
+            LRCLibProvider(),
+        ])
+
         // Set shared instance for AppleScript access
         PlayerService.shared = player
-        LocalControlServer.shared.configure(playerService: player)
+        LocalControlServer.shared.configure(playerService: player, syncedLyricsService: lyricsService)
 
         // Create account service
         let account = AccountService(ytMusicClient: client, authService: auth)
@@ -93,10 +98,7 @@ struct KasetApp: App {
         _webKitManager = State(initialValue: webkit)
         _playerService = State(initialValue: player)
         _sharedClient = State(initialValue: client)
-        _syncedLyricsService = State(initialValue: SyncedLyricsService(providers: [
-            YTMusicSyncedProvider(client: client),
-            LRCLibProvider(),
-        ]))
+        _syncedLyricsService = State(initialValue: lyricsService)
         _notificationService = State(initialValue: NotificationService(playerService: player))
         _accountService = State(initialValue: account)
 

--- a/Sources/Kaset/Services/API/Parsers/SearchResponseParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/SearchResponseParser.swift
@@ -5,6 +5,7 @@ enum SearchResponseParser {
     private static let logger = DiagnosticsLogger.api
 
     /// Parses a search response.
+    /// Parses a search response.
     static func parse(_ data: [String: Any]) -> SearchResponse {
         var songs: [Song] = []
         var albums: [Album] = []
@@ -26,22 +27,9 @@ enum SearchResponseParser {
         }
 
         for sectionData in sectionContents {
-            // Parse musicCardShelfRenderer (Top Result section)
-            if let cardShelfRenderer = sectionData["musicCardShelfRenderer"] as? [String: Any] {
-                if let item = parseCardShelfRenderer(cardShelfRenderer) {
-                    Self.appendItem(item, songs: &songs, albums: &albums, artists: &artists, playlists: &playlists)
-                }
-            }
-
-            // Parse musicShelfRenderer (regular results)
-            if let shelfRenderer = sectionData["musicShelfRenderer"] as? [String: Any],
-               let shelfContents = shelfRenderer["contents"] as? [[String: Any]]
-            {
-                for itemData in shelfContents {
-                    if let item = parseSearchResultItem(itemData) {
-                        Self.appendItem(item, songs: &songs, albums: &albums, artists: &artists, playlists: &playlists)
-                    }
-                }
+            let items = Self.extractItems(from: sectionData)
+            for item in items {
+                Self.appendItem(item, songs: &songs, albums: &albums, artists: &artists, playlists: &playlists)
             }
         }
 
@@ -82,25 +70,101 @@ enum SearchResponseParser {
               let sectionContents = sectionListRenderer["contents"] as? [[String: Any]]
         else {
             // Try tabbed structure as fallback
-            let response = self.parse(data)
+            let response = Self.parse(data)
             return response.songs
         }
 
         for sectionData in sectionContents {
-            if let shelfRenderer = sectionData["musicShelfRenderer"] as? [String: Any],
-               let shelfContents = shelfRenderer["contents"] as? [[String: Any]]
-            {
-                for itemData in shelfContents {
-                    if let item = parseSearchResultItem(itemData),
-                       case let .song(song) = item
-                    {
-                        songs.append(song)
-                    }
+            let items = Self.extractItems(from: sectionData)
+            for item in items {
+                if case let .song(song) = item {
+                    songs.append(song)
                 }
             }
         }
 
         return songs
+    }
+
+    /// Helper to extract all search result items from a section renderer (handles card shelf, regular shelf, and item section renderers).
+    private static func extractItems(from sectionData: [String: Any]) -> [SearchResultItem] {
+        var items: [SearchResultItem] = []
+
+        // 1. Parse musicCardShelfRenderer (Top Result section)
+        if let cardShelfRenderer = sectionData["musicCardShelfRenderer"] as? [String: Any] {
+            if let item = Self.parseCardShelfRenderer(cardShelfRenderer) {
+                items.append(item)
+            }
+        }
+
+        // 2. Parse musicShelfRenderer (regular results)
+        if let shelfRenderer = sectionData["musicShelfRenderer"] as? [String: Any],
+           let shelfContents = shelfRenderer["contents"] as? [[String: Any]]
+        {
+            for itemData in shelfContents {
+                if let item = Self.parseSearchResultItem(itemData) {
+                    items.append(item)
+                }
+            }
+        }
+
+        // 3. Parse itemSectionRenderer (regular results nested in a section)
+        if let itemSectionRenderer = sectionData["itemSectionRenderer"] as? [String: Any],
+           let itemContents = itemSectionRenderer["contents"] as? [[String: Any]]
+        {
+            for itemContent in itemContents {
+                if let item = Self.parseSearchResultItem(itemContent) {
+                    items.append(item)
+                } else if let shelfRenderer = itemContent["musicShelfRenderer"] as? [String: Any],
+                          let shelfContents = shelfRenderer["contents"] as? [[String: Any]]
+                {
+                    for itemData in shelfContents {
+                        if let item = Self.parseSearchResultItem(itemData) {
+                            items.append(item)
+                        }
+                    }
+                }
+            }
+        }
+
+        return items
+    }
+
+    /// Helper to extract all podcast shows from a section renderer (handles regular shelf and item section renderers).
+    private static func extractPodcastShows(from sectionData: [String: Any]) -> [PodcastShow] {
+        var shows: [PodcastShow] = []
+
+        // 1. Parse musicShelfRenderer
+        if let shelfRenderer = sectionData["musicShelfRenderer"] as? [String: Any],
+           let shelfContents = shelfRenderer["contents"] as? [[String: Any]]
+        {
+            for itemData in shelfContents {
+                if let show = Self.parsePodcastShowFromSearchResult(itemData) {
+                    shows.append(show)
+                }
+            }
+        }
+
+        // 2. Parse itemSectionRenderer
+        if let itemSectionRenderer = sectionData["itemSectionRenderer"] as? [String: Any],
+           let itemContents = itemSectionRenderer["contents"] as? [[String: Any]]
+        {
+            for itemContent in itemContents {
+                if let show = Self.parsePodcastShowFromSearchResult(itemContent) {
+                    shows.append(show)
+                } else if let shelfRenderer = itemContent["musicShelfRenderer"] as? [String: Any],
+                          let shelfContents = shelfRenderer["contents"] as? [[String: Any]]
+                {
+                    for itemData in shelfContents {
+                        if let show = Self.parsePodcastShowFromSearchResult(itemData) {
+                            shows.append(show)
+                        }
+                    }
+                }
+            }
+        }
+
+        return shows
     }
 
     // MARK: - Item Parsing
@@ -290,22 +354,17 @@ enum SearchResponseParser {
     static func parseAlbumsOnly(_ data: [String: Any]) -> ([Album], String?) {
         var albums: [Album] = []
 
-        guard let sectionListRenderer = getSectionListRenderer(from: data),
+        guard let sectionListRenderer = Self.getSectionListRenderer(from: data),
               let sectionContents = sectionListRenderer["contents"] as? [[String: Any]]
         else {
             return ([], nil)
         }
 
         for sectionData in sectionContents {
-            if let shelfRenderer = sectionData["musicShelfRenderer"] as? [String: Any],
-               let shelfContents = shelfRenderer["contents"] as? [[String: Any]]
-            {
-                for itemData in shelfContents {
-                    if let item = parseSearchResultItem(itemData),
-                       case let .album(album) = item
-                    {
-                        albums.append(album)
-                    }
+            let items = Self.extractItems(from: sectionData)
+            for item in items {
+                if case let .album(album) = item {
+                    albums.append(album)
                 }
             }
         }
@@ -318,22 +377,17 @@ enum SearchResponseParser {
     static func parseArtistsOnly(_ data: [String: Any]) -> ([Artist], String?) {
         var artists: [Artist] = []
 
-        guard let sectionListRenderer = getSectionListRenderer(from: data),
+        guard let sectionListRenderer = Self.getSectionListRenderer(from: data),
               let sectionContents = sectionListRenderer["contents"] as? [[String: Any]]
         else {
             return ([], nil)
         }
 
         for sectionData in sectionContents {
-            if let shelfRenderer = sectionData["musicShelfRenderer"] as? [String: Any],
-               let shelfContents = shelfRenderer["contents"] as? [[String: Any]]
-            {
-                for itemData in shelfContents {
-                    if let item = parseSearchResultItem(itemData),
-                       case let .artist(artist) = item
-                    {
-                        artists.append(artist)
-                    }
+            let items = Self.extractItems(from: sectionData)
+            for item in items {
+                if case let .artist(artist) = item {
+                    artists.append(artist)
                 }
             }
         }
@@ -346,22 +400,17 @@ enum SearchResponseParser {
     static func parsePlaylistsOnly(_ data: [String: Any]) -> ([Playlist], String?) {
         var playlists: [Playlist] = []
 
-        guard let sectionListRenderer = getSectionListRenderer(from: data),
+        guard let sectionListRenderer = Self.getSectionListRenderer(from: data),
               let sectionContents = sectionListRenderer["contents"] as? [[String: Any]]
         else {
             return ([], nil)
         }
 
         for sectionData in sectionContents {
-            if let shelfRenderer = sectionData["musicShelfRenderer"] as? [String: Any],
-               let shelfContents = shelfRenderer["contents"] as? [[String: Any]]
-            {
-                for itemData in shelfContents {
-                    if let item = parseSearchResultItem(itemData),
-                       case let .playlist(playlist) = item
-                    {
-                        playlists.append(playlist)
-                    }
+            let items = Self.extractItems(from: sectionData)
+            for item in items {
+                if case let .playlist(playlist) = item {
+                    playlists.append(playlist)
                 }
             }
         }
@@ -374,22 +423,15 @@ enum SearchResponseParser {
     static func parsePodcastsOnly(_ data: [String: Any]) -> ([PodcastShow], String?) {
         var podcasts: [PodcastShow] = []
 
-        guard let sectionListRenderer = getSectionListRenderer(from: data),
+        guard let sectionListRenderer = Self.getSectionListRenderer(from: data),
               let sectionContents = sectionListRenderer["contents"] as? [[String: Any]]
         else {
             return ([], nil)
         }
 
         for sectionData in sectionContents {
-            if let shelfRenderer = sectionData["musicShelfRenderer"] as? [String: Any],
-               let shelfContents = shelfRenderer["contents"] as? [[String: Any]]
-            {
-                for itemData in shelfContents {
-                    if let show = Self.parsePodcastShowFromSearchResult(itemData) {
-                        podcasts.append(show)
-                    }
-                }
-            }
+            let shows = Self.extractPodcastShows(from: sectionData)
+            podcasts.append(contentsOf: shows)
         }
 
         let token = Self.extractContinuationToken(from: sectionListRenderer)
@@ -430,22 +472,17 @@ enum SearchResponseParser {
     static func parseSongsWithContinuation(_ data: [String: Any]) -> ([Song], String?) {
         var songs: [Song] = []
 
-        guard let sectionListRenderer = getSectionListRenderer(from: data),
+        guard let sectionListRenderer = Self.getSectionListRenderer(from: data),
               let sectionContents = sectionListRenderer["contents"] as? [[String: Any]]
         else {
             return ([], nil)
         }
 
         for sectionData in sectionContents {
-            if let shelfRenderer = sectionData["musicShelfRenderer"] as? [String: Any],
-               let shelfContents = shelfRenderer["contents"] as? [[String: Any]]
-            {
-                for itemData in shelfContents {
-                    if let item = parseSearchResultItem(itemData),
-                       case let .song(song) = item
-                    {
-                        songs.append(song)
-                    }
+            let items = Self.extractItems(from: sectionData)
+            for item in items {
+                if case let .song(song) = item {
+                    songs.append(song)
                 }
             }
         }
@@ -474,7 +511,7 @@ enum SearchResponseParser {
                     // Try to parse as podcast show first (for podcast search continuation)
                     if let show = Self.parsePodcastShowFromSearchResult(itemData) {
                         podcastShows.append(show)
-                    } else if let item = parseSearchResultItem(itemData) {
+                    } else if let item = Self.parseSearchResultItem(itemData) {
                         Self.appendItem(item, songs: &songs, albums: &albums, artists: &artists, playlists: &playlists)
                     }
                 }

--- a/Sources/Kaset/Services/API/YTMusicClient.swift
+++ b/Sources/Kaset/Services/API/YTMusicClient.swift
@@ -859,12 +859,21 @@ final class YTMusicClient: YTMusicClientProtocol {
         ]
 
         // No caching for queue endpoint - we want fresh results each time
-        let data = try await request("music/get_queue", body: body, ttl: nil)
+        do {
+            let data = try await request("music/get_queue", body: body, ttl: nil)
+            let tracks = PlaylistParser.parseQueueTracks(data)
+            if !tracks.isEmpty {
+                self.logger.info("Fetched \(tracks.count) tracks from queue endpoint")
+                return tracks
+            }
+        } catch {
+            self.logger.warning("Failed to fetch via get_queue: \(error.localizedDescription). Trying getPlaylist fallback.")
+        }
 
-        let tracks = PlaylistParser.parseQueueTracks(data)
-        self.logger.info("Fetched \(tracks.count) tracks from queue endpoint")
-
-        return tracks
+        // Fallback: Fetch via getPlaylist
+        self.logger.info("Falling back to getPlaylist for \(playlistId)")
+        let playlist = try await self.getPlaylist(id: playlistId)
+        return playlist.detail.tracks
     }
 
     /// Fetches a batch of playlist tracks using the provided continuation token.

--- a/Sources/Kaset/Services/LocalControlServer.swift
+++ b/Sources/Kaset/Services/LocalControlServer.swift
@@ -66,7 +66,11 @@ final class LocalControlServer {
                 using: parameters,
                 on: NWEndpoint.Port(rawValue: port) ?? .any
             )
-            listener.service = nil
+            if allowsLAN {
+                listener.service = NWListener.Service(name: "kaset", type: "_http._tcp")
+            } else {
+                listener.service = nil
+            }
             listener.newConnectionHandler = { [weak self, weak playerService] connection in
                 Task { @MainActor in
                     guard let self, let playerService else {
@@ -152,7 +156,7 @@ final class LocalControlServer {
         }
 
         let routed = Self.route(request)
-        if routed != .check, routed != .requestApproval {
+        if routed != .webInterface, routed != .check, routed != .requestApproval {
             if SettingsManager.shared.localControlServerAllowsLAN, !Self.isAuthorized(request) {
                 return .unauthorized(message: "Missing or invalid token")
             }
@@ -160,7 +164,7 @@ final class LocalControlServer {
 
         switch routed {
         case .webInterface:
-            return .html(Self.remoteControlHTML(token: request.queryItems["token"] ?? ""))
+            return .html(Self.remoteControlHTML())
         case .check:
             let deviceId = request.queryItems["device_id"] ?? ""
             if RemoteDeviceManager.shared.isDeviceApproved(deviceId: deviceId) {
@@ -177,10 +181,15 @@ final class LocalControlServer {
             let deviceName = request.formItems["device_name"] ?? request.queryItems["device_name"] ?? "Remote Web Browser"
             let pin = request.formItems["pin"] ?? request.queryItems["pin"] ?? ""
             
-            if RemoteDeviceManager.shared.requestApproval(deviceId: deviceId, deviceName: deviceName, pin: pin) {
-                return .json(["status": "pending"])
+            if !pin.isEmpty {
+                if let token = RemoteDeviceManager.shared.verifyPinAndApprove(deviceId: deviceId, deviceName: deviceName, pin: pin) {
+                    return .json(["status": "approved", "token": token])
+                } else {
+                    return .json(["status": "invalid_pin"])
+                }
             } else {
-                return .json(["status": "invalid_pin"])
+                RemoteDeviceManager.shared.requestApproval(deviceId: deviceId, deviceName: deviceName)
+                return .json(["status": "pending"])
             }
         case .status:
             return .json(self.statusPayload(playerService: playerService))
@@ -447,7 +456,6 @@ final class LocalControlServer {
     }
 
     static func isAuthorized(_ request: HTTPRequest) -> Bool {
-        let globalToken = SettingsManager.shared.localControlServerToken
         let requestToken: String
         if let token = request.queryItems["token"] ?? request.formItems["token"] {
             requestToken = token
@@ -457,72 +465,328 @@ final class LocalControlServer {
             return false
         }
 
-        if !globalToken.isEmpty, requestToken == globalToken {
-            return true
-        }
-
         return RemoteDeviceManager.shared.approvedDevices.contains(where: { $0.token == requestToken })
     }
 
-    static func remoteControlHTML(token: String) -> String {
-        """
+    static func remoteControlHTML() -> String {
+        #"""
         <!doctype html>
         <html lang="en">
         <head>
           <meta charset="utf-8">
           <meta name="viewport" content="width=device-width, initial-scale=1">
           <title>Kaset Remote</title>
+          <link rel="preconnect" href="https://fonts.googleapis.com">
+          <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+          <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
           <style>
-            body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, sans-serif; background: #111; color: #f6f6f6; text-align: center; }
-            main { max-width: 520px; margin: 0 auto; padding: 24px; box-sizing: border-box; }
-            h1 { font-size: 28px; margin: 0 0 16px; }
-            .card { padding: 24px; border: 1px solid #333; border-radius: 16px; background: #1c1c1f; margin-bottom: 18px; }
-            .title { font-size: 22px; font-weight: 700; margin-bottom: 6px; }
-            .artist { color: #bbb; margin-bottom: 12px; }
-            .controls { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-top: 18px; }
-            button { min-height: 58px; border: 0; border-radius: 12px; background: #f6f6f6; color: #111; font-size: 18px; font-weight: 700; cursor: pointer; }
-            button:disabled { background: #555; color: #aaa; }
-            button:active:not(:disabled) { transform: scale(0.98); }
-            input[type="range"] { width: 100%; margin-top: 22px; }
-            input[type="text"] { width: 100%; padding: 12px; font-size: 18px; border-radius: 8px; border: 1px solid #444; background: #2c2c2f; color: #fff; box-sizing: border-box; text-align: center; margin-bottom: 12px; }
-            .status { color: #999; margin-top: 14px; font-size: 14px; }
+            body {
+              margin: 0;
+              font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+              background: radial-gradient(circle at top, #2b0d11 0%, #0c0c0e 70%, #050505 100%);
+              color: #f6f6f6;
+              min-height: 100vh;
+              display: flex;
+              align-items: center;
+              justify-content: center;
+            }
+            main {
+              width: 100%;
+              max-width: 440px;
+              padding: 24px;
+              box-sizing: border-box;
+            }
+            h1 {
+              font-size: 24px;
+              font-weight: 800;
+              margin: 0 0 24px;
+              text-align: center;
+              letter-spacing: -0.5px;
+              background: linear-gradient(135deg, #fff 0%, #a1a1a6 100%);
+              -webkit-background-clip: text;
+              -webkit-text-fill-color: transparent;
+            }
+            .card {
+              padding: 32px 24px;
+              border: 1px solid rgba(255, 255, 255, 0.08);
+              border-radius: 24px;
+              background: rgba(28, 28, 30, 0.55);
+              backdrop-filter: blur(20px);
+              -webkit-backdrop-filter: blur(20px);
+              box-shadow: 0 16px 40px rgba(0, 0, 0, 0.5);
+              transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+            }
+            .title {
+              font-size: 20px;
+              font-weight: 700;
+              margin-bottom: 6px;
+              color: #fff;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+              text-align: center;
+            }
+            .artist {
+              font-size: 15px;
+              color: #a1a1a6;
+              margin-bottom: 24px;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+              text-align: center;
+            }
+            .controls {
+              display: flex;
+              justify-content: center;
+              align-items: center;
+              gap: 24px;
+              margin-top: 12px;
+            }
+            .control-btn {
+              display: flex;
+              align-items: center;
+              justify-content: center;
+              border: 0;
+              border-radius: 50%;
+              background: rgba(255, 255, 255, 0.08);
+              color: #fff;
+              cursor: pointer;
+              transition: all 0.2s ease;
+              outline: none;
+            }
+            .control-btn:hover {
+              background: rgba(255, 255, 255, 0.15);
+              transform: scale(1.05);
+            }
+            .control-btn:active {
+              transform: scale(0.95);
+            }
+            .control-btn.prev, .control-btn.next {
+              width: 54px;
+              height: 54px;
+            }
+            .control-btn.play-pause {
+              width: 72px;
+              height: 72px;
+              background: #fff;
+              color: #000;
+              box-shadow: 0 4px 16px rgba(255, 255, 255, 0.2);
+            }
+            .control-btn.play-pause:hover {
+              background: #f0f0f5;
+              transform: scale(1.05);
+              box-shadow: 0 6px 20px rgba(255, 255, 255, 0.3);
+            }
+            .control-btn.play-pause:active {
+              transform: scale(0.95);
+            }
+            .volume-container {
+              display: flex;
+              align-items: center;
+              gap: 12px;
+              margin-top: 28px;
+            }
+            .volume-icon {
+              color: #8e8e93;
+              display: flex;
+              align-items: center;
+            }
+            input[type="range"] {
+              -webkit-appearance: none;
+              width: 100%;
+              height: 4px;
+              border-radius: 2px;
+              background: rgba(255, 255, 255, 0.15);
+              outline: none;
+              margin: 0;
+              cursor: pointer;
+            }
+            input[type="range"]::-webkit-slider-thumb {
+              -webkit-appearance: none;
+              width: 14px;
+              height: 14px;
+              border-radius: 50%;
+              background: #fff;
+              cursor: pointer;
+              box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+              transition: transform 0.1s ease;
+            }
+            input[type="range"]::-webkit-slider-thumb:hover {
+              transform: scale(1.25);
+            }
+            
+            /* Input & Forms */
+            input[type="text"] {
+              width: 100%;
+              padding: 16px;
+              font-size: 22px;
+              font-weight: 700;
+              letter-spacing: 6px;
+              border-radius: 16px;
+              border: 1px solid rgba(255, 255, 255, 0.12);
+              background: rgba(255, 255, 255, 0.05);
+              color: #fff;
+              box-sizing: border-box;
+              text-align: center;
+              margin-bottom: 20px;
+              outline: none;
+              transition: all 0.25s ease;
+            }
+            input[type="text"]:focus {
+              border-color: #ff3b30;
+              background: rgba(255, 255, 255, 0.08);
+              box-shadow: 0 0 0 4px rgba(255, 59, 48, 0.2);
+            }
+            button.action-btn {
+              width: 100%;
+              min-height: 56px;
+              border: 0;
+              border-radius: 16px;
+              background: linear-gradient(135deg, #ff2d55 0%, #ff3b30 100%);
+              color: #fff;
+              font-size: 16px;
+              font-weight: 600;
+              cursor: pointer;
+              box-shadow: 0 4px 16px rgba(255, 45, 85, 0.35);
+              transition: all 0.2s ease;
+              outline: none;
+            }
+            button.action-btn:hover {
+              transform: translateY(-1px);
+              box-shadow: 0 6px 20px rgba(255, 45, 85, 0.45);
+            }
+            button.action-btn:active {
+              transform: translateY(1px) scale(0.99);
+            }
+            .link-btn {
+              display: inline-block;
+              margin-top: 20px;
+              color: rgba(255, 255, 255, 0.5);
+              text-decoration: none;
+              font-size: 14px;
+              font-weight: 500;
+              transition: color 0.2s ease;
+              cursor: pointer;
+            }
+            .link-btn:hover {
+              color: #fff;
+              text-decoration: underline;
+            }
+            
+            .status-container {
+              margin-top: 20px;
+              padding: 12px;
+              border-radius: 12px;
+              background: rgba(255, 255, 255, 0.03);
+              font-size: 13px;
+              color: #8e8e93;
+              text-align: center;
+            }
+            .status-pending {
+              color: #ff9500;
+              font-weight: 600;
+              animation: pulse 2s infinite ease-in-out;
+              display: flex;
+              align-items: center;
+              justify-content: center;
+              gap: 6px;
+            }
+            @keyframes pulse {
+              0% { opacity: 0.6; }
+              50% { opacity: 1; }
+              100% { opacity: 0.6; }
+            }
+            
             .hidden { display: none !important; }
-            .error { color: #ff5b5b; font-weight: bold; margin-bottom: 10px; }
+            .error { color: #ff453a; font-size: 14px; font-weight: 600; margin-bottom: 12px; text-align: center; }
+            
+            /* Artwork design */
+            .artwork-container {
+              width: 100%;
+              aspect-ratio: 1;
+              border-radius: 20px;
+              background: rgba(255, 255, 255, 0.03);
+              margin-bottom: 24px;
+              display: flex;
+              align-items: center;
+              justify-content: center;
+              overflow: hidden;
+              border: 1px solid rgba(255, 255, 255, 0.06);
+              box-shadow: 0 12px 32px rgba(0, 0, 0, 0.5);
+            }
+            .artwork-image {
+              width: 100%;
+              height: 100%;
+              object-fit: cover;
+            }
+            .artwork-placeholder {
+              color: rgba(255, 255, 255, 0.15);
+              display: flex;
+              flex-direction: column;
+              align-items: center;
+              gap: 12px;
+            }
           </style>
         </head>
         <body>
           <main>
             <h1>Kaset Remote</h1>
 
-            <!-- Auth Screen: Enter PIN -->
+            <!-- Auth Screen: Enter PIN / Request Access -->
             <section id="screen-auth" class="card hidden">
-              <div class="title">Access Required</div>
-              <p>Enter the 4-digit PIN shown in Kaset settings on the Mac.</p>
+              <div class="title" style="margin-bottom: 8px;">Access Required</div>
+              <p style="color: #a1a1a6; font-size: 14px; line-height: 1.5; margin: 0 0 24px; text-align: center;">
+                Enter the global PIN shown in Kaset settings on your Mac, or request access directly.
+              </p>
+              
               <div id="auth-error" class="error hidden">Invalid PIN, please try again.</div>
-              <input id="pin-input" type="text" maxlength="6" placeholder="Enter PIN">
-              <button onclick="requestAccess()" style="width: 100%;">Request Access</button>
-            </section>
-
-            <!-- Pending Screen: Waiting for host approval -->
-            <section id="screen-pending" class="card hidden">
-              <div class="title">Approval Pending</div>
-              <p>Approval request sent. Please approve this device on your Mac.</p>
-              <div class="status">Waiting for host approval...</div>
+              
+              <input id="pin-input" type="text" maxlength="6" placeholder="••••">
+              
+              <button class="action-btn" onclick="requestAccess()">Login with PIN</button>
+              
+              <div style="text-align: center;">
+                <a id="request-link" href="#" onclick="requestHostAccess(); return false;" class="link-btn">Request Access from Host</a>
+              </div>
+              
+              <div id="status-container" class="status-container hidden"></div>
             </section>
 
             <!-- Controller Screen: Music Player -->
             <section id="screen-player" class="hidden">
               <div class="card">
+                <div class="artwork-container">
+                  <div id="artwork-wrapper" class="artwork-placeholder" style="width: 100%; height: 100%; display: flex; align-items: center; justify-content: center;">
+                    <svg width="64" height="64" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18V5l12-2v13"></path><circle cx="6" cy="18" r="3"></circle><circle cx="18" cy="16" r="3"></circle></svg>
+                  </div>
+                </div>
                 <div class="title" id="title">Loading...</div>
                 <div class="artist" id="artist"></div>
-                <div class="status" id="status"></div>
+                
+                <div class="controls">
+                  <button class="control-btn prev" onclick="send('previous')" aria-label="Previous">
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M6 6h2v12H6zm3.5 6l8.5 6V6z"/></svg>
+                  </button>
+                  <button id="play-pause-btn" class="control-btn play-pause" onclick="send('play-pause')" aria-label="Play/Pause">
+                    <svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z"/></svg>
+                  </button>
+                  <button class="control-btn next" onclick="send('next')" aria-label="Next">
+                    <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M6 18l8.5-6L6 6v12zM16 6v12h2V6h-2z"/></svg>
+                  </button>
+                </div>
+                
+                <div class="volume-container">
+                  <span class="volume-icon">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M18.5 12c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM5 9v6h4l5 5V4L9 9H5z"/></svg>
+                  </span>
+                  <input id="volume" type="range" min="0" max="1" step="0.01" onchange="setVolume(this.value)">
+                  <span class="volume-icon">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z"/></svg>
+                  </span>
+                </div>
+                
+                <div class="status-container" id="status" style="margin-top: 24px;"></div>
               </div>
-              <section class="controls">
-                <button onclick="send('previous')">Previous</button>
-                <button onclick="send('play-pause')">Play/Pause</button>
-                <button onclick="send('next')">Next</button>
-              </section>
-              <input id="volume" type="range" min="0" max="1" step="0.01" onchange="setVolume(this.value)">
             </section>
           </main>
 
@@ -536,13 +800,12 @@ final class LocalControlServer {
             const deviceName = /iPad|iPhone|iPod/.test(navigator.userAgent) ? 'iOS Device' : 
                                /Android/.test(navigator.userAgent) ? 'Android Device' : 'Web Remote';
 
-            let activeToken = new URLSearchParams(location.search).get('token') || localStorage.getItem('kaset_active_token') || '';
+            let activeToken = localStorage.getItem('kaset_active_token') || '';
             let checkInterval = null;
             let refreshInterval = null;
 
             function showScreen(id) {
               document.getElementById('screen-auth').classList.add('hidden');
-              document.getElementById('screen-pending').classList.add('hidden');
               document.getElementById('screen-player').classList.add('hidden');
               document.getElementById(id).classList.remove('hidden');
             }
@@ -580,9 +843,25 @@ final class LocalControlServer {
                     clearInterval(checkInterval);
                     startPlayer();
                   } else if (data.status === 'pending') {
-                    showScreen('screen-pending');
+                    showScreen('screen-auth');
+                    const statusDiv = document.getElementById('status-container');
+                    statusDiv.innerHTML = '<div class="status-pending"><span style="width:8px; height:8px; background:#ff9500; border-radius:50%; display:inline-block; animation: pulse 1s infinite ease-in-out;"></span>Access requested. Please approve on your Mac.</div>';
+                    statusDiv.classList.remove('hidden');
+                    
+                    const requestLink = document.getElementById('request-link');
+                    requestLink.style.pointerEvents = 'none';
+                    requestLink.style.opacity = '0.5';
+                    requestLink.innerText = 'Request Sent (Waiting...)';
                   } else {
                     showScreen('screen-auth');
+                    const statusDiv = document.getElementById('status-container');
+                    statusDiv.innerHTML = '';
+                    statusDiv.classList.add('hidden');
+                    
+                    const requestLink = document.getElementById('request-link');
+                    requestLink.style.pointerEvents = 'auto';
+                    requestLink.style.opacity = '1';
+                    requestLink.innerText = 'Request Access from Host';
                   }
                 } catch (e) {
                   showScreen('screen-auth');
@@ -595,11 +874,36 @@ final class LocalControlServer {
 
             async function requestAccess() {
               const pin = document.getElementById('pin-input').value;
+              if (!pin) return;
               document.getElementById('auth-error').classList.add('hidden');
               try {
                 const body = 'device_id=' + encodeURIComponent(deviceId) + 
-                            '&device_name=' + encodeURIComponent(deviceName) + 
-                            '&pin=' + encodeURIComponent(pin);
+                             '&device_name=' + encodeURIComponent(deviceName) + 
+                             '&pin=' + encodeURIComponent(pin);
+                const res = await fetch('/request_approval', {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                  body: body
+                });
+                const data = await res.json();
+                if (data.status === 'approved') {
+                  activeToken = data.token;
+                  localStorage.setItem('kaset_active_token', activeToken);
+                  if (checkInterval) clearInterval(checkInterval);
+                  startPlayer();
+                } else {
+                  document.getElementById('auth-error').classList.remove('hidden');
+                }
+              } catch (e) {
+                document.getElementById('auth-error').classList.remove('hidden');
+              }
+            }
+
+            async function requestHostAccess() {
+              document.getElementById('auth-error').classList.add('hidden');
+              try {
+                const body = 'device_id=' + encodeURIComponent(deviceId) + 
+                             '&device_name=' + encodeURIComponent(deviceName);
                 const res = await fetch('/request_approval', {
                   method: 'POST',
                   headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
@@ -608,11 +912,9 @@ final class LocalControlServer {
                 const data = await res.json();
                 if (data.status === 'pending') {
                   pollApproval();
-                } else {
-                  document.getElementById('auth-error').classList.remove('hidden');
                 }
               } catch (e) {
-                document.getElementById('auth-error').classList.remove('hidden');
+                // Ignore
               }
             }
 
@@ -648,10 +950,25 @@ final class LocalControlServer {
                 const data = await res.json();
                 document.getElementById('title').textContent = data.track?.title || 'Nothing playing';
                 document.getElementById('artist').textContent = data.track?.artist || '';
-                document.getElementById('status').textContent = data.state + ' • volume ' + Math.round((data.volume || 0) * 100) + '%';
+                
+                if (data.track && data.track.artworkURL) {
+                  document.getElementById('artwork-wrapper').innerHTML = '<img class="artwork-image" src="' + data.track.artworkURL + '" alt="Artwork">';
+                } else {
+                  document.getElementById('artwork-wrapper').innerHTML = '<svg width="64" height="64" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18V5l12-2v13"></path><circle cx="6" cy="18" r="3"></circle><circle cx="18" cy="16" r="3"></circle></svg>';
+                }
+                
+                const playPauseBtn = document.getElementById('play-pause-btn');
+                if (data.isPlaying) {
+                  playPauseBtn.innerHTML = '<svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor"><path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z"/></svg>';
+                } else {
+                  playPauseBtn.innerHTML = '<svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z"/></svg>';
+                }
+
+                document.getElementById('status').textContent = data.state.toUpperCase() + ' • VOLUME ' + Math.round((data.volume || 0) * 100) + '%';
                 document.getElementById('volume').value = data.volume || 0;
               } catch (error) {
                 document.getElementById('title').textContent = 'Cannot reach Kaset';
+                document.getElementById('artist').textContent = '';
                 document.getElementById('status').textContent = String(error);
               }
             }
@@ -660,7 +977,7 @@ final class LocalControlServer {
           </script>
         </body>
         </html>
-        """
+        """#
     }
 
     static func getLocalIPAddresses() -> [String] {
@@ -711,17 +1028,24 @@ final class LocalControlServer {
     static func localControlURLs() -> [URL] {
         let settings = SettingsManager.shared
         let port = settings.localControlServerPort
-        let token = settings.localControlServerToken
 
         var urls: [URL] = []
-        if let localhostURL = URL(string: "http://127.0.0.1:\(port)/?token=\(token)") {
+        if let localhostURL = URL(string: "http://127.0.0.1:\(port)/") {
             urls.append(localhostURL)
         }
 
         if settings.localControlServerAllowsLAN {
+            // 1. System mDNS URL using the computer's local hostname
+            let hostName = ProcessInfo.processInfo.hostName
+            let cleanHost = hostName.hasSuffix(".local") ? hostName : "\(hostName).local"
+            if let hostLocal = URL(string: "http://\(cleanHost):\(port)/") {
+                urls.append(hostLocal)
+            }
+
+            // 2. Fallback raw local IP URLs
             let ips = Self.getLocalIPAddresses()
             for ip in ips {
-                if let url = URL(string: "http://\(ip):\(port)/?token=\(token)") {
+                if let url = URL(string: "http://\(ip):\(port)/") {
                     urls.append(url)
                 }
             }

--- a/Sources/Kaset/Services/LocalControlServer.swift
+++ b/Sources/Kaset/Services/LocalControlServer.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import Darwin
 import Foundation
 @preconcurrency import Network
@@ -107,7 +108,11 @@ final class LocalControlServer {
             self.logger.error("Local control server could not start: \(error.localizedDescription)")
         }
     }
+}
 
+// MARK: - LocalControlServer Connections
+
+extension LocalControlServer {
     private func handleConnection(_ connection: NWConnection, playerService: PlayerService) {
         guard SettingsManager.shared.localControlServerAllowsLAN || self.isLoopback(connection.endpoint) else {
             connection.cancel()
@@ -115,7 +120,7 @@ final class LocalControlServer {
         }
 
         connection.start(queue: .main)
-        connection.receive(minimumIncompleteLength: 1, maximumLength: 16384) { [weak self, weak playerService] data, _, _, _ in
+        self.readRequest(connection: connection, accumulatedData: Data()) { [weak self, weak playerService] data in
             Task { @MainActor in
                 guard let self, let playerService else {
                     connection.cancel()
@@ -135,6 +140,79 @@ final class LocalControlServer {
         }
     }
 
+    private func readRequest(
+        connection: NWConnection,
+        accumulatedData: Data,
+        completion: @escaping @MainActor @Sendable (Data?) -> Void
+    ) {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 16384) { [weak self] data, _, isComplete, error in
+            Task { @MainActor in
+                guard let self else {
+                    connection.cancel()
+                    return
+                }
+
+                if error != nil {
+                    completion(nil)
+                    return
+                }
+
+                var newAccumulated = accumulatedData
+                if let data {
+                    newAccumulated.append(data)
+                }
+
+                if self.isRequestComplete(newAccumulated) {
+                    completion(newAccumulated)
+                } else if isComplete {
+                    completion(newAccumulated.isEmpty ? nil : newAccumulated)
+                } else {
+                    self.readRequest(connection: connection, accumulatedData: newAccumulated, completion: completion)
+                }
+            }
+        }
+    }
+
+    private func isRequestComplete(_ data: Data) -> Bool {
+        // Look for the end of headers: \r\n\r\n
+        guard let range = data.range(of: Data("\r\n\r\n".utf8)) else {
+            // Also check for \n\n just in case
+            if let lfRange = data.range(of: Data("\n\n".utf8)) {
+                return self.isRequestComplete(data, headerBoundaryEnd: lfRange.upperBound)
+            }
+            return false
+        }
+        return self.isRequestComplete(data, headerBoundaryEnd: range.upperBound)
+    }
+
+    private func isRequestComplete(_ data: Data, headerBoundaryEnd: Data.Index) -> Bool {
+        let headersData = data.subdata(in: 0 ..< headerBoundaryEnd)
+        guard let headersText = String(data: headersData, encoding: .utf8) else {
+            return true // Cannot parse as UTF-8, stop reading
+        }
+
+        let lines = headersText.components(separatedBy: "\r\n")
+        var contentLength: Int?
+
+        for line in lines {
+            let parts = line.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+            guard parts.count == 2 else { continue }
+            let key = parts[0].trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            let value = parts[1].trimmingCharacters(in: .whitespacesAndNewlines)
+            if key == "content-length", let length = Int(value) {
+                contentLength = length
+                break
+            }
+        }
+
+        if let contentLength {
+            let bodySize = data.count - headerBoundaryEnd
+            return bodySize >= contentLength
+        }
+
+        return true
+    }
+
     private func isLoopback(_ endpoint: NWEndpoint) -> Bool {
         guard case let .hostPort(host, _) = endpoint else { return false }
         switch host {
@@ -151,6 +229,7 @@ final class LocalControlServer {
         }
     }
 
+    // swiftlint:disable cyclomatic_complexity function_body_length
     private func response(for request: HTTPRequest, playerService: PlayerService) async -> HTTPResponse {
         if request.method == "OPTIONS" {
             return .empty()
@@ -344,6 +423,8 @@ final class LocalControlServer {
         }
     }
 
+    // swiftlint:enable cyclomatic_complexity function_body_length
+
     private func statusPayload(playerService: PlayerService) -> [String: Any] {
         var payload: [String: Any] = [
             "state": playerService.state.apiValue,
@@ -417,6 +498,7 @@ final class LocalControlServer {
         return payload
     }
 
+    // swiftlint:disable cyclomatic_complexity
     static func route(_ request: HTTPRequest) -> Route {
         switch (request.method, request.path) {
         case ("GET", "/"), ("GET", "/remote"):
@@ -459,6 +541,8 @@ final class LocalControlServer {
             .methodNotAllowed
         }
     }
+
+    // swiftlint:enable cyclomatic_complexity
 
     private static func volumeRoute(_ request: HTTPRequest) -> Route {
         let queryValue = request.queryItems["value"] ?? request.queryItems["level"]
@@ -642,7 +726,8 @@ final class LocalControlServer {
                       !key.isEmpty
                 else { continue }
                 let rawValue = parts.count > 1 ? String(parts[1]) : ""
-                result[key] = rawValue.replacingOccurrences(of: "+", with: " ").removingPercentEncoding ?? rawValue
+                let decodedValue = rawValue.replacingOccurrences(of: "+", with: " ").removingPercentEncoding ?? rawValue
+                result[key] = decodedValue.trimmingCharacters(in: .whitespacesAndNewlines)
             }
             return result
         }
@@ -725,7 +810,12 @@ final class LocalControlServer {
 
         return RemoteDeviceManager.shared.approvedDevices.contains(where: { $0.token == requestToken })
     }
+}
 
+// MARK: - LocalControlServer Helpers
+
+extension LocalControlServer {
+    // swiftlint:disable function_body_length trailing_whitespace
     static func remoteControlHTML() -> String {
         #"""
         <!doctype html>
@@ -1773,13 +1863,13 @@ final class LocalControlServer {
                 } else {
                   currentVideoId = '';
                 }
-                
+
                 if (data.track && data.track.artworkURL) {
                   document.getElementById('artwork-wrapper').innerHTML = '<img class="artwork-image" src="' + data.track.artworkURL + '" alt="Artwork">';
                 } else {
                   document.getElementById('artwork-wrapper').innerHTML = '<svg width="64" height="64" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18V5l12-2v13"></path><circle cx="6" cy="18" r="3"></circle><circle cx="18" cy="16" r="3"></circle></svg>';
                 }
-                
+
                 const playPauseBtn = document.getElementById('play-pause-btn');
                 if (data.isPlaying) {
                   playPauseBtn.innerHTML = '<svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor"><path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z"/></svg>';
@@ -1828,6 +1918,8 @@ final class LocalControlServer {
         </html>
         """#
     }
+
+    // swiftlint:enable function_body_length trailing_whitespace
 
     static func getLocalIPAddresses() -> [String] {
         var addresses: [String] = []

--- a/Sources/Kaset/Services/LocalControlServer.swift
+++ b/Sources/Kaset/Services/LocalControlServer.swift
@@ -211,6 +211,31 @@ final class LocalControlServer {
         case .volume(let value):
             await playerService.setVolume(value)
             return .json(["ok": true, "action": "volume", "volume": playerService.volume])
+        case .search:
+            let query = request.queryItems["q"] ?? request.queryItems["query"] ?? ""
+            guard !query.isEmpty else {
+                return .json(["results": []])
+            }
+            guard let client = playerService.ytMusicClient else {
+                return .json(["ok": false, "error": "API client not initialized"])
+            }
+            do {
+                let songs = try await client.searchSongs(query: query)
+                let results = songs.map { Self.trackPayload($0) }
+                return .json(["results": results])
+            } catch {
+                return .json(["ok": false, "error": error.localizedDescription])
+            }
+        case .playQueueIndex(let index):
+            guard index >= 0 && index < playerService.queue.count else {
+                return .json(["ok": false, "error": "Index out of bounds"])
+            }
+            let queue = playerService.queue
+            await playerService.playQueue(queue, startingAt: index)
+            return .json(["ok": true, "action": "playQueueIndex", "index": index])
+        case .playTrack(let videoId):
+            await playerService.play(videoId: videoId)
+            return .json(["ok": true, "action": "playTrack", "videoId": videoId])
         case .notFound:
             return .notFound(message: "Unknown endpoint")
         case .methodNotAllowed:
@@ -238,6 +263,8 @@ final class LocalControlServer {
         } else {
             payload["track"] = NSNull()
         }
+
+        payload["queue"] = playerService.queue.map { Self.trackPayload($0) }
 
         return payload
     }
@@ -289,6 +316,12 @@ final class LocalControlServer {
             .previous
         case ("POST", "/volume"):
             Self.volumeRoute(request)
+        case ("GET", "/search"):
+            .search
+        case ("POST", "/play_index"):
+            Self.playIndexRoute(request)
+        case ("POST", "/play_track"):
+            Self.playTrackRoute(request)
         case ("GET", _), ("POST", _):
             .notFound
         default:
@@ -305,6 +338,23 @@ final class LocalControlServer {
         return .volume(max(0, min(1, value)))
     }
 
+    private static func playIndexRoute(_ request: HTTPRequest) -> Route {
+        let queryValue = request.queryItems["index"] ?? request.formItems["index"]
+        guard let rawValue = queryValue, let index = Int(rawValue) else {
+            return .badRequest("Missing integer index value")
+        }
+        return .playQueueIndex(index)
+    }
+
+    private static func playTrackRoute(_ request: HTTPRequest) -> Route {
+        let queryValue = request.queryItems["videoId"] ?? request.queryItems["video_id"] ??
+                         request.formItems["videoId"] ?? request.formItems["video_id"]
+        guard let videoId = queryValue, !videoId.isEmpty else {
+            return .badRequest("Missing videoId parameter")
+        }
+        return .playTrack(videoId)
+    }
+
     enum Route: Equatable {
         case webInterface
         case check
@@ -316,6 +366,9 @@ final class LocalControlServer {
         case next
         case previous
         case volume(Double)
+        case search
+        case playQueueIndex(Int)
+        case playTrack(String)
         case notFound
         case methodNotAllowed
         case badRequest(String)
@@ -726,6 +779,116 @@ final class LocalControlServer {
               align-items: center;
               gap: 12px;
             }
+
+            /* Search elements */
+            .search-results-dropdown {
+              position: absolute;
+              top: 50px;
+              left: 0;
+              right: 0;
+              background: rgba(28, 28, 30, 0.95);
+              border: 1px solid rgba(255, 255, 255, 0.12);
+              border-radius: 14px;
+              z-index: 100;
+              max-height: 280px;
+              overflow-y: auto;
+              box-shadow: 0 10px 25px rgba(0, 0, 0, 0.6);
+              backdrop-filter: blur(15px);
+              -webkit-backdrop-filter: blur(15px);
+            }
+            .search-result-item {
+              padding: 12px 16px;
+              display: flex;
+              align-items: center;
+              gap: 12px;
+              cursor: pointer;
+              border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+              transition: background 0.2s ease;
+              text-align: left;
+            }
+            .search-result-item:hover {
+              background: rgba(255, 255, 255, 0.08);
+            }
+            .search-result-item img {
+              width: 40px;
+              height: 40px;
+              border-radius: 6px;
+              object-fit: cover;
+            }
+            .search-result-info {
+              flex: 1;
+              min-width: 0;
+            }
+            .search-result-title {
+              font-size: 14px;
+              font-weight: 600;
+              color: #fff;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+            .search-result-artist {
+              font-size: 12px;
+              color: #8e8e93;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+            
+            /* Queue elements */
+            .queue-list {
+              display: flex;
+              flex-direction: column;
+              gap: 4px;
+              max-height: 320px;
+              overflow-y: auto;
+              padding-right: 4px;
+            }
+            .queue-item {
+              padding: 10px 12px;
+              display: flex;
+              align-items: center;
+              gap: 12px;
+              border-radius: 10px;
+              cursor: pointer;
+              transition: all 0.2s ease;
+              text-align: left;
+            }
+            .queue-item:hover {
+              background: rgba(255, 255, 255, 0.06);
+            }
+            .queue-item.active {
+              background: rgba(255, 45, 85, 0.12);
+              border: 1px solid rgba(255, 45, 85, 0.3);
+            }
+            .queue-item img {
+              width: 36px;
+              height: 36px;
+              border-radius: 4px;
+              object-fit: cover;
+            }
+            .queue-item-info {
+              flex: 1;
+              min-width: 0;
+            }
+            .queue-item-title {
+              font-size: 13.5px;
+              font-weight: 600;
+              color: #fff;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+            .queue-item-title.active {
+              color: #ff2d55;
+            }
+            .queue-item-artist {
+              font-size: 11.5px;
+              color: #8e8e93;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
           </style>
         </head>
         <body>
@@ -755,6 +918,13 @@ final class LocalControlServer {
             <!-- Controller Screen: Music Player -->
             <section id="screen-player" class="hidden">
               <div class="card">
+                <!-- Search Bar -->
+                <div style="position: relative; margin-bottom: 20px;">
+                  <input id="search-input" type="text" placeholder="Search songs..." oninput="handleSearch(this.value)" style="font-size: 15px; padding: 12px 16px; letter-spacing: 0; text-align: left; margin-bottom: 0; border-radius: 12px;">
+                  <div id="search-results" class="search-results-dropdown hidden"></div>
+                </div>
+
+                <!-- Artwork -->
                 <div class="artwork-container">
                   <div id="artwork-wrapper" class="artwork-placeholder" style="width: 100%; height: 100%; display: flex; align-items: center; justify-content: center;">
                     <svg width="64" height="64" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18V5l12-2v13"></path><circle cx="6" cy="18" r="3"></circle><circle cx="18" cy="16" r="3"></circle></svg>
@@ -787,6 +957,17 @@ final class LocalControlServer {
                 
                 <div class="status-container" id="status" style="margin-top: 24px;"></div>
               </div>
+
+              <!-- Queue Panel -->
+              <div class="card" style="margin-top: 20px; padding: 20px 16px;">
+                <div style="font-size: 16px; font-weight: 700; text-align: left; margin-bottom: 12px; display: flex; justify-content: space-between; align-items: center;">
+                  <span>Up Next</span>
+                  <span id="queue-count" style="font-size: 12px; color: #8e8e93; font-weight: 500;">0 songs</span>
+                </div>
+                <div id="queue-list" class="queue-list">
+                  <!-- Queue items dynamically loaded -->
+                </div>
+              </div>
             </section>
           </main>
 
@@ -803,6 +984,7 @@ final class LocalControlServer {
             let activeToken = localStorage.getItem('kaset_active_token') || '';
             let checkInterval = null;
             let refreshInterval = null;
+            let searchTimeout = null;
 
             function showScreen(id) {
               document.getElementById('screen-auth').classList.add('hidden');
@@ -937,6 +1119,68 @@ final class LocalControlServer {
               refresh();
             }
 
+            async function playQueueIndex(index) {
+              await fetch(withToken('/play_index?index=' + index), { method: 'POST' });
+              refresh();
+            }
+
+            async function playTrack(videoId) {
+              await fetch(withToken('/play_track?videoId=' + encodeURIComponent(videoId)), { method: 'POST' });
+              refresh();
+            }
+
+            function handleSearch(query) {
+              if (searchTimeout) clearTimeout(searchTimeout);
+              if (!query || query.trim() === '') {
+                document.getElementById('search-results').classList.add('hidden');
+                return;
+              }
+              searchTimeout = setTimeout(() => performSearch(query), 400);
+            }
+
+            async function performSearch(query) {
+              try {
+                const res = await fetch(withToken('/search?q=' + encodeURIComponent(query)));
+                if (res.status === 401) return;
+                const data = await res.json();
+                const resultsDiv = document.getElementById('search-results');
+                resultsDiv.innerHTML = '';
+                if (data.results && data.results.length > 0) {
+                  data.results.forEach(song => {
+                    const item = document.createElement('div');
+                    item.className = 'search-result-item';
+                    const artworkUrl = song.artworkURL || 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="%23888" stroke-width="1.5"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></svg>';
+                    item.innerHTML = `
+                      <img src="${artworkUrl}" alt="Artwork">
+                      <div class="search-result-info">
+                        <div class="search-result-title">${song.title}</div>
+                        <div class="search-result-artist">${song.artist}</div>
+                      </div>
+                    `;
+                    item.onclick = () => {
+                      playTrack(song.videoId);
+                      resultsDiv.classList.add('hidden');
+                      document.getElementById('search-input').value = '';
+                    };
+                    resultsDiv.appendChild(item);
+                  });
+                  resultsDiv.classList.remove('hidden');
+                } else {
+                  resultsDiv.classList.add('hidden');
+                }
+              } catch (e) {
+                console.error(e);
+              }
+            }
+
+            document.addEventListener('click', (e) => {
+              const searchResults = document.getElementById('search-results');
+              const searchInput = document.getElementById('search-input');
+              if (searchResults && e.target !== searchResults && e.target !== searchInput) {
+                searchResults.classList.add('hidden');
+              }
+            });
+
             async function refresh() {
               try {
                 const res = await fetch(withToken('/status'));
@@ -966,6 +1210,32 @@ final class LocalControlServer {
 
                 document.getElementById('status').textContent = data.state.toUpperCase() + ' • VOLUME ' + Math.round((data.volume || 0) * 100) + '%';
                 document.getElementById('volume').value = data.volume || 0;
+
+                // Render queue
+                const queueList = document.getElementById('queue-list');
+                const queueCount = document.getElementById('queue-count');
+                if (data.queue && data.queue.length > 0) {
+                  queueCount.textContent = data.queue.length + ' songs';
+                  queueList.innerHTML = '';
+                  data.queue.forEach((song, idx) => {
+                    const isActive = idx === data.queueIndex;
+                    const item = document.createElement('div');
+                    item.className = 'queue-item' + (isActive ? ' active' : '');
+                    const artworkUrl = song.artworkURL || 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="%23888" stroke-width="1.5"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></svg>';
+                    item.innerHTML = `
+                      <img src="${artworkUrl}" alt="Artwork">
+                      <div class="queue-item-info">
+                        <div class="queue-item-title${isActive ? ' active' : ''}">${song.title}</div>
+                        <div class="queue-item-artist">${song.artist}</div>
+                      </div>
+                    `;
+                    item.onclick = () => playQueueIndex(idx);
+                    queueList.appendChild(item);
+                  });
+                } else {
+                  queueCount.textContent = '0 songs';
+                  queueList.innerHTML = '<div style="color:#8e8e93; font-size:13px; text-align:center; padding:20px 0;">Queue is empty</div>';
+                }
               } catch (error) {
                 document.getElementById('title').textContent = 'Cannot reach Kaset';
                 document.getElementById('artist').textContent = '';

--- a/Sources/Kaset/Services/LocalControlServer.swift
+++ b/Sources/Kaset/Services/LocalControlServer.swift
@@ -414,6 +414,9 @@ extension LocalControlServer {
             } catch {
                 return .json(["ok": false, "error": error.localizedDescription])
             }
+        case .clearQueue:
+            playerService.clearQueueEntirely()
+            return .json(["ok": true, "action": "clearQueue"])
         case .notFound:
             return .notFound(message: "Unknown endpoint")
         case .methodNotAllowed:
@@ -535,6 +538,8 @@ extension LocalControlServer {
             self.playPlaylistRoute(request)
         case ("GET", "/playlist_tracks"):
             self.playlistTracksRoute(request)
+        case ("POST", "/clear_queue"):
+            .clearQueue
         case ("GET", _), ("POST", _):
             .notFound
         default:
@@ -658,6 +663,7 @@ extension LocalControlServer {
         case addToQueue(videoId: String?, playlistId: String?, song: Song?)
         case playPlaylist(playlistId: String)
         case playlistTracks(playlistId: String)
+        case clearQueue
         case notFound
         case methodNotAllowed
         case badRequest(String)
@@ -903,6 +909,31 @@ extension LocalControlServer {
             .share-btn:hover {
               color: #fff !important;
               background: rgba(255, 255, 255, 0.08) !important;
+            }
+            
+            /* Toast Message */
+            .toast {
+              position: fixed;
+              bottom: 32px;
+              left: 50%;
+              transform: translate(-50%, 100px);
+              background: rgba(28, 28, 30, 0.95);
+              border: 1px solid rgba(255, 255, 255, 0.15);
+              border-radius: 16px;
+              padding: 12px 20px;
+              color: #fff;
+              font-size: 14px;
+              font-weight: 600;
+              box-shadow: 0 12px 32px rgba(0, 0, 0, 0.6);
+              display: flex;
+              align-items: center;
+              gap: 8px;
+              z-index: 9999;
+              transition: transform 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+              pointer-events: none;
+            }
+            .toast.show {
+              transform: translate(-50%, 0);
             }
             .controls {
               display: flex;
@@ -1342,6 +1373,10 @@ extension LocalControlServer {
           </style>
         </head>
         <body>
+          <div id="toast" class="toast">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path><polyline points="22 4 12 14.01 9 11.01"></polyline></svg>
+            <span id="toast-message"></span>
+          </div>
           <main>
             <h1>Kaset Remote</h1>
 
@@ -1433,7 +1468,10 @@ extension LocalControlServer {
               <!-- Queue Panel -->
               <div class="card" style="margin-top: 20px; padding: 20px 16px;">
                 <div style="font-size: 16px; font-weight: 700; text-align: left; margin-bottom: 12px; display: flex; justify-content: space-between; align-items: center;">
-                  <span>Up Next</span>
+                  <span style="display: flex; align-items: center; gap: 8px;">
+                    <span>Up Next</span>
+                    <button id="clear-queue-btn" onclick="clearQueue()" style="background: none; border: 1px solid rgba(255, 45, 85, 0.4); color: #ff2d55; font-size: 11px; font-weight: 600; padding: 3px 8px; border-radius: 6px; cursor: pointer; outline: none; transition: all 0.2s ease;">Clear</button>
+                  </span>
                   <span id="queue-count" style="font-size: 12px; color: #8e8e93; font-weight: 500;">0 songs</span>
                 </div>
                 <div id="queue-list" class="queue-list">
@@ -1634,6 +1672,7 @@ extension LocalControlServer {
                 headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
                 body: body
               });
+              showToast('"' + title + '" will play next');
               refresh();
             }
 
@@ -1647,7 +1686,26 @@ extension LocalControlServer {
                 headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
                 body: body
               });
+              showToast('Added "' + title + '" to queue');
               refresh();
+            }
+
+            function showToast(message) {
+              const toast = document.getElementById('toast');
+              const toastMsg = document.getElementById('toast-message');
+              toastMsg.textContent = message;
+              toast.classList.add('show');
+              setTimeout(() => {
+                toast.classList.remove('show');
+              }, 2500);
+            }
+
+            async function clearQueue() {
+              if (confirm('Are you sure you want to clear the queue?')) {
+                await fetch(withToken('/clear_queue'), { method: 'POST' });
+                showToast('Queue cleared');
+                refresh();
+              }
             }
 
             function escapeJS(str) {
@@ -1728,15 +1786,20 @@ extension LocalControlServer {
               if (!currentPlaylistId) return;
               
               let endpoint = '';
+              let msg = '';
               if (action === 'play') {
                 endpoint = '/play_playlist?playlistId=' + encodeURIComponent(currentPlaylistId);
+                msg = 'Playing "' + currentPlaylistTitle + '"';
               } else if (action === 'next') {
                 endpoint = '/play_next?playlistId=' + encodeURIComponent(currentPlaylistId);
+                msg = '"' + currentPlaylistTitle + '" will play next';
               } else if (action === 'queue') {
                 endpoint = '/add_to_queue?playlistId=' + encodeURIComponent(currentPlaylistId);
+                msg = 'Added "' + currentPlaylistTitle + '" to queue';
               }
               
               await fetch(withToken(endpoint), { method: 'POST' });
+              if (msg) showToast(msg);
               closePlaylistDetails();
               refresh();
             }

--- a/Sources/Kaset/Services/LocalControlServer.swift
+++ b/Sources/Kaset/Services/LocalControlServer.swift
@@ -1,6 +1,8 @@
-import Foundation
 import Darwin
+import Foundation
 @preconcurrency import Network
+
+// MARK: - LocalControlServer
 
 /// HTTP API for local automation and remote-control companions.
 @MainActor
@@ -29,7 +31,7 @@ final class LocalControlServer {
             return
         }
 
-        let port = UInt16(min(max(settings.localControlServerPort, 1024), 65_535))
+        let port = UInt16(min(max(settings.localControlServerPort, 1024), 65535))
         let allowsLAN = settings.localControlServerAllowsLAN
         if self.listener != nil, self.activePort == port, self.activeAllowsLAN == allowsLAN {
             return
@@ -113,18 +115,17 @@ final class LocalControlServer {
         }
 
         connection.start(queue: .main)
-        connection.receive(minimumIncompleteLength: 1, maximumLength: 16_384) { [weak self, weak playerService] data, _, _, _ in
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 16384) { [weak self, weak playerService] data, _, _, _ in
             Task { @MainActor in
                 guard let self, let playerService else {
                     connection.cancel()
                     return
                 }
 
-                let response: HTTPResponse
-                if let data, let request = HTTPRequest(data: data) {
-                    response = await self.response(for: request, playerService: playerService)
+                let response: HTTPResponse = if let data, let request = HTTPRequest(data: data) {
+                    await self.response(for: request, playerService: playerService)
                 } else {
-                    response = .badRequest(message: "Invalid HTTP request")
+                    .badRequest(message: "Invalid HTTP request")
                 }
 
                 connection.send(content: response.serialized(), completion: .contentProcessed { _ in
@@ -137,13 +138,13 @@ final class LocalControlServer {
     private func isLoopback(_ endpoint: NWEndpoint) -> Bool {
         guard case let .hostPort(host, _) = endpoint else { return false }
         switch host {
-        case .ipv4(let address):
+        case let .ipv4(address):
             guard let loopbackAddress = IPv4Address("127.0.0.1") else { return false }
             return address == loopbackAddress
-        case .ipv6(let address):
+        case let .ipv6(address):
             guard let loopbackAddress = IPv6Address("::1") else { return false }
             return address == loopbackAddress
-        case .name(let name, _):
+        case let .name(name, _):
             return name == "localhost"
         default:
             return false
@@ -180,7 +181,7 @@ final class LocalControlServer {
             let deviceId = request.formItems["device_id"] ?? request.queryItems["device_id"] ?? ""
             let deviceName = request.formItems["device_name"] ?? request.queryItems["device_name"] ?? "Remote Web Browser"
             let pin = request.formItems["pin"] ?? request.queryItems["pin"] ?? ""
-            
+
             if !pin.isEmpty {
                 if let token = RemoteDeviceManager.shared.verifyPinAndApprove(deviceId: deviceId, deviceName: deviceName, pin: pin) {
                     return .json(["status": "approved", "token": token])
@@ -208,7 +209,7 @@ final class LocalControlServer {
         case .previous:
             await playerService.previous()
             return .json(["ok": true, "action": "previous"])
-        case .volume(let value):
+        case let .volume(value):
             await playerService.setVolume(value)
             return .json(["ok": true, "action": "volume", "volume": playerService.volume])
         case .search:
@@ -238,15 +239,15 @@ final class LocalControlServer {
                     var items: [[String: Any]] = []
                     for item in response.allItems {
                         switch item {
-                        case .song(let song):
+                        case let .song(song):
                             var p = Self.trackPayload(song)
                             p["type"] = "song"
                             items.append(p)
-                        case .album(let album):
+                        case let .album(album):
                             var p = Self.albumPayload(album)
                             p["type"] = "album"
                             items.append(p)
-                        case .playlist(let playlist):
+                        case let .playlist(playlist):
                             var p = Self.playlistPayload(playlist)
                             p["type"] = "playlist"
                             items.append(p)
@@ -259,14 +260,14 @@ final class LocalControlServer {
             } catch {
                 return .json(["ok": false, "error": error.localizedDescription])
             }
-        case .playQueueIndex(let index):
-            guard index >= 0 && index < playerService.queue.count else {
+        case let .playQueueIndex(index):
+            guard index >= 0, index < playerService.queue.count else {
                 return .json(["ok": false, "error": "Index out of bounds"])
             }
             let queue = playerService.queue
             await playerService.playQueue(queue, startingAt: index)
             return .json(["ok": true, "action": "playQueueIndex", "index": index])
-        case .playTrack(let videoId):
+        case let .playTrack(videoId):
             let song = Song(
                 id: videoId,
                 title: "Loading...",
@@ -278,11 +279,11 @@ final class LocalControlServer {
             )
             await playerService.playWithRadio(song: song)
             return .json(["ok": true, "action": "playTrack", "videoId": videoId])
-        case .playNext(let videoId, let playlistId, let song):
-            if let song = song {
+        case let .playNext(videoId, playlistId, song):
+            if let song {
                 playerService.insertNextInQueue([song])
                 return .json(["ok": true, "action": "playNext", "videoId": videoId ?? ""])
-            } else if let playlistId = playlistId {
+            } else if let playlistId {
                 guard let client = playerService.ytMusicClient else {
                     return .json(["ok": false, "error": "API client not initialized"])
                 }
@@ -295,11 +296,11 @@ final class LocalControlServer {
                 }
             }
             return .badRequest(message: "Missing parameters")
-        case .addToQueue(let videoId, let playlistId, let song):
-            if let song = song {
+        case let .addToQueue(videoId, playlistId, song):
+            if let song {
                 playerService.appendToQueue([song])
                 return .json(["ok": true, "action": "addToQueue", "videoId": videoId ?? ""])
-            } else if let playlistId = playlistId {
+            } else if let playlistId {
                 guard let client = playerService.ytMusicClient else {
                     return .json(["ok": false, "error": "API client not initialized"])
                 }
@@ -312,7 +313,7 @@ final class LocalControlServer {
                 }
             }
             return .badRequest(message: "Missing parameters")
-        case .playPlaylist(let playlistId):
+        case let .playPlaylist(playlistId):
             guard let client = playerService.ytMusicClient else {
                 return .json(["ok": false, "error": "API client not initialized"])
             }
@@ -323,7 +324,7 @@ final class LocalControlServer {
             } catch {
                 return .json(["ok": false, "error": error.localizedDescription])
             }
-        case .playlistTracks(let playlistId):
+        case let .playlistTracks(playlistId):
             guard let client = playerService.ytMusicClient else {
                 return .json(["ok": false, "error": "API client not initialized"])
             }
@@ -338,7 +339,7 @@ final class LocalControlServer {
             return .notFound(message: "Unknown endpoint")
         case .methodNotAllowed:
             return .methodNotAllowed(message: "Unsupported method")
-        case .badRequest(let message):
+        case let .badRequest(message):
             return .badRequest(message: message)
         }
     }
@@ -437,21 +438,21 @@ final class LocalControlServer {
         case ("POST", "/previous"):
             .previous
         case ("POST", "/volume"):
-            Self.volumeRoute(request)
+            self.volumeRoute(request)
         case ("GET", "/search"):
             .search
         case ("POST", "/play_index"):
-            Self.playIndexRoute(request)
+            self.playIndexRoute(request)
         case ("POST", "/play_track"):
-            Self.playTrackRoute(request)
+            self.playTrackRoute(request)
         case ("POST", "/play_next"):
-            Self.playNextRoute(request)
+            self.playNextRoute(request)
         case ("POST", "/add_to_queue"):
-            Self.addToQueueRoute(request)
+            self.addToQueueRoute(request)
         case ("POST", "/play_playlist"):
-            Self.playPlaylistRoute(request)
+            self.playPlaylistRoute(request)
         case ("GET", "/playlist_tracks"):
-            Self.playlistTracksRoute(request)
+            self.playlistTracksRoute(request)
         case ("GET", _), ("POST", _):
             .notFound
         default:
@@ -478,7 +479,7 @@ final class LocalControlServer {
 
     private static func playTrackRoute(_ request: HTTPRequest) -> Route {
         let queryValue = request.queryItems["videoId"] ?? request.queryItems["video_id"] ??
-                         request.formItems["videoId"] ?? request.formItems["video_id"]
+            request.formItems["videoId"] ?? request.formItems["video_id"]
         guard let videoId = queryValue, !videoId.isEmpty else {
             return .badRequest("Missing videoId parameter")
         }
@@ -488,13 +489,13 @@ final class LocalControlServer {
     private static func playNextRoute(_ request: HTTPRequest) -> Route {
         let videoId = request.queryItems["videoId"] ?? request.queryItems["video_id"] ?? request.formItems["videoId"] ?? request.formItems["video_id"]
         let playlistId = request.queryItems["playlistId"] ?? request.queryItems["playlist_id"] ?? request.formItems["playlistId"] ?? request.formItems["playlist_id"]
-        
-        if let videoId = videoId, !videoId.isEmpty {
+
+        if let videoId, !videoId.isEmpty {
             let title = request.queryItems["title"] ?? request.formItems["title"] ?? "Loading..."
             let artist = request.queryItems["artist"] ?? request.formItems["artist"] ?? ""
             let artworkURL = request.queryItems["artworkURL"] ?? request.formItems["artworkURL"] ?? request.queryItems["artwork_url"] ?? request.formItems["artwork_url"]
             let artists = artist.isEmpty ? [] : [Artist(id: UUID().uuidString, name: artist, thumbnailURL: nil)]
-            
+
             let song = Song(
                 id: videoId,
                 title: title,
@@ -505,23 +506,23 @@ final class LocalControlServer {
                 videoId: videoId
             )
             return .playNext(videoId: videoId, playlistId: nil, song: song)
-        } else if let playlistId = playlistId, !playlistId.isEmpty {
+        } else if let playlistId, !playlistId.isEmpty {
             return .playNext(videoId: nil, playlistId: playlistId, song: nil)
         } else {
             return .badRequest("Missing videoId or playlistId parameter")
         }
     }
-    
+
     private static func addToQueueRoute(_ request: HTTPRequest) -> Route {
         let videoId = request.queryItems["videoId"] ?? request.queryItems["video_id"] ?? request.formItems["videoId"] ?? request.formItems["video_id"]
         let playlistId = request.queryItems["playlistId"] ?? request.queryItems["playlist_id"] ?? request.formItems["playlistId"] ?? request.formItems["playlist_id"]
-        
-        if let videoId = videoId, !videoId.isEmpty {
+
+        if let videoId, !videoId.isEmpty {
             let title = request.queryItems["title"] ?? request.formItems["title"] ?? "Loading..."
             let artist = request.queryItems["artist"] ?? request.formItems["artist"] ?? ""
             let artworkURL = request.queryItems["artworkURL"] ?? request.formItems["artworkURL"] ?? request.queryItems["artwork_url"] ?? request.formItems["artwork_url"]
             let artists = artist.isEmpty ? [] : [Artist(id: UUID().uuidString, name: artist, thumbnailURL: nil)]
-            
+
             let song = Song(
                 id: videoId,
                 title: title,
@@ -532,7 +533,7 @@ final class LocalControlServer {
                 videoId: videoId
             )
             return .addToQueue(videoId: videoId, playlistId: nil, song: song)
-        } else if let playlistId = playlistId, !playlistId.isEmpty {
+        } else if let playlistId, !playlistId.isEmpty {
             return .addToQueue(videoId: nil, playlistId: playlistId, song: nil)
         } else {
             return .badRequest("Missing videoId or playlistId parameter")
@@ -1279,13 +1280,18 @@ final class LocalControlServer {
               <div class="card">
                 <!-- Search Bar and Tabs -->
                 <div style="position: relative; margin-bottom: 20px;">
-                  <input id="search-input" type="text" placeholder="Search..." oninput="handleSearch(this.value)" style="font-size: 15px; padding: 12px 16px; letter-spacing: 0; text-align: left; margin-bottom: 0; border-radius: 12px;">
+                  <div class="search-input-wrapper" style="position: relative; display: flex; align-items: center; width: 100%;">
+                    <input id="search-input" type="text" placeholder="Search..." oninput="handleSearch(this.value)" onfocus="handleSearchFocus(this)" onblur="handleSearchBlur()" style="font-size: 15px; padding: 12px 40px 12px 16px; letter-spacing: 0; text-align: left; margin-bottom: 0; border-radius: 12px;">
+                    <button id="clear-search-btn" onclick="clearSearch()" style="position: absolute; right: 12px; background: none; border: none; color: #8e8e93; cursor: pointer; padding: 4px; display: none; align-items: center; justify-content: center; outline: none;">
+                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+                    </button>
+                  </div>
                   
                   <div class="search-tabs">
-                    <button class="search-tab active" onclick="setSearchFilter('all')">All</button>
-                    <button class="search-tab" onclick="setSearchFilter('songs')">Songs</button>
-                    <button class="search-tab" onclick="setSearchFilter('albums')">Albums</button>
-                    <button class="search-tab" onclick="setSearchFilter('playlists')">Playlists</button>
+                    <button class="search-tab active" onclick="setSearchFilter(this, 'all')">All</button>
+                    <button class="search-tab" onclick="setSearchFilter(this, 'songs')">Songs</button>
+                    <button class="search-tab" onclick="setSearchFilter(this, 'albums')">Albums</button>
+                    <button class="search-tab" onclick="setSearchFilter(this, 'playlists')">Playlists</button>
                   </div>
                   
                   <div id="search-results" class="search-results-dropdown hidden"></div>
@@ -1566,12 +1572,12 @@ final class LocalControlServer {
               }
             }
 
-            function setSearchFilter(filter) {
+            function setSearchFilter(element, filter) {
               currentSearchFilter = filter;
               document.querySelectorAll('.search-tab').forEach(tab => {
                 tab.classList.remove('active');
               });
-              event.target.classList.add('active');
+              element.classList.add('active');
               
               const query = document.getElementById('search-input').value;
               if (query && query.trim() !== '') {
@@ -1645,7 +1651,36 @@ final class LocalControlServer {
               refresh();
             }
 
+            let searchInputFocused = false;
+
+            function handleSearchFocus(input) {
+              if (!searchInputFocused) {
+                setTimeout(() => input.select(), 50);
+                searchInputFocused = true;
+              }
+            }
+
+            function handleSearchBlur() {
+              searchInputFocused = false;
+            }
+
+            function clearSearch() {
+              const input = document.getElementById('search-input');
+              input.value = '';
+              input.focus();
+              document.getElementById('clear-search-btn').style.display = 'none';
+              document.getElementById('search-results').classList.add('hidden');
+              if (searchTimeout) clearTimeout(searchTimeout);
+            }
+
             function handleSearch(query) {
+              const clearBtn = document.getElementById('clear-search-btn');
+              if (query && query.length > 0) {
+                clearBtn.style.display = 'flex';
+              } else {
+                clearBtn.style.display = 'none';
+              }
+
               if (searchTimeout) clearTimeout(searchTimeout);
               if (!query || query.trim() === '') {
                 document.getElementById('search-results').classList.add('hidden');
@@ -1875,7 +1910,6 @@ final class LocalControlServer {
             .replacingOccurrences(of: "\r", with: "\\r")
     }
 }
-
 
 private extension PlayerService.PlaybackState {
     var apiValue: String {

--- a/Sources/Kaset/Services/LocalControlServer.swift
+++ b/Sources/Kaset/Services/LocalControlServer.swift
@@ -473,49 +473,178 @@ final class LocalControlServer {
           <meta name="viewport" content="width=device-width, initial-scale=1">
           <title>Kaset Remote</title>
           <style>
-            body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, sans-serif; background: #111; color: #f6f6f6; }
-            main { max-width: 520px; margin: 0 auto; padding: 24px; }
+            body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, sans-serif; background: #111; color: #f6f6f6; text-align: center; }
+            main { max-width: 520px; margin: 0 auto; padding: 24px; box-sizing: border-box; }
             h1 { font-size: 28px; margin: 0 0 16px; }
-            .track { min-height: 120px; padding: 18px; border: 1px solid #333; border-radius: 12px; background: #1c1c1f; }
+            .card { padding: 24px; border: 1px solid #333; border-radius: 16px; background: #1c1c1f; margin-bottom: 18px; }
             .title { font-size: 22px; font-weight: 700; margin-bottom: 6px; }
-            .artist { color: #bbb; }
+            .artist { color: #bbb; margin-bottom: 12px; }
             .controls { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-top: 18px; }
-            button { min-height: 58px; border: 0; border-radius: 12px; background: #f6f6f6; color: #111; font-size: 18px; font-weight: 700; }
-            button:active { transform: scale(0.98); }
-            input { width: 100%; margin-top: 22px; }
+            button { min-height: 58px; border: 0; border-radius: 12px; background: #f6f6f6; color: #111; font-size: 18px; font-weight: 700; cursor: pointer; }
+            button:disabled { background: #555; color: #aaa; }
+            button:active:not(:disabled) { transform: scale(0.98); }
+            input[type="range"] { width: 100%; margin-top: 22px; }
+            input[type="text"] { width: 100%; padding: 12px; font-size: 18px; border-radius: 8px; border: 1px solid #444; background: #2c2c2f; color: #fff; box-sizing: border-box; text-align: center; margin-bottom: 12px; }
             .status { color: #999; margin-top: 14px; font-size: 14px; }
+            .hidden { display: none !important; }
+            .error { color: #ff5b5b; font-weight: bold; margin-bottom: 10px; }
           </style>
         </head>
         <body>
           <main>
             <h1>Kaset Remote</h1>
-            <section class="track">
-              <div class="title" id="title">Loading...</div>
-              <div class="artist" id="artist"></div>
-              <div class="status" id="status"></div>
+
+            <!-- Auth Screen: Enter PIN -->
+            <section id="screen-auth" class="card hidden">
+              <div class="title">Access Required</div>
+              <p>Enter the 4-digit PIN shown in Kaset settings on the Mac.</p>
+              <div id="auth-error" class="error hidden">Invalid PIN, please try again.</div>
+              <input id="pin-input" type="text" maxlength="6" placeholder="Enter PIN">
+              <button onclick="requestAccess()" style="width: 100%;">Request Access</button>
             </section>
-            <section class="controls">
-              <button onclick="send('previous')">Previous</button>
-              <button onclick="send('play-pause')">Play/Pause</button>
-              <button onclick="send('next')">Next</button>
+
+            <!-- Pending Screen: Waiting for host approval -->
+            <section id="screen-pending" class="card hidden">
+              <div class="title">Approval Pending</div>
+              <p>Approval request sent. Please approve this device on your Mac.</p>
+              <div class="status">Waiting for host approval...</div>
             </section>
-            <input id="volume" type="range" min="0" max="1" step="0.01" onchange="setVolume(this.value)">
-            <div class="status">Keep this page open on your phone or another device on the same Wi-Fi.</div>
+
+            <!-- Controller Screen: Music Player -->
+            <section id="screen-player" class="hidden">
+              <div class="card">
+                <div class="title" id="title">Loading...</div>
+                <div class="artist" id="artist"></div>
+                <div class="status" id="status"></div>
+              </div>
+              <section class="controls">
+                <button onclick="send('previous')">Previous</button>
+                <button onclick="send('play-pause')">Play/Pause</button>
+                <button onclick="send('next')">Next</button>
+              </section>
+              <input id="volume" type="range" min="0" max="1" step="0.01" onchange="setVolume(this.value)">
+            </section>
           </main>
+
           <script>
-            const token = new URLSearchParams(location.search).get('token') || '\(Self.escapeJavaScriptString(token))';
-            const withToken = path => path + (path.includes('?') ? '&' : '?') + 'token=' + encodeURIComponent(token);
+            let deviceId = localStorage.getItem('kaset_device_id');
+            if (!deviceId) {
+              deviceId = 'device_' + Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
+              localStorage.setItem('kaset_device_id', deviceId);
+            }
+
+            const deviceName = /iPad|iPhone|iPod/.test(navigator.userAgent) ? 'iOS Device' : 
+                               /Android/.test(navigator.userAgent) ? 'Android Device' : 'Web Remote';
+
+            let activeToken = new URLSearchParams(location.search).get('token') || localStorage.getItem('kaset_active_token') || '';
+            let checkInterval = null;
+            let refreshInterval = null;
+
+            function showScreen(id) {
+              document.getElementById('screen-auth').classList.add('hidden');
+              document.getElementById('screen-pending').classList.add('hidden');
+              document.getElementById('screen-player').classList.add('hidden');
+              document.getElementById(id).classList.remove('hidden');
+            }
+
+            async function startup() {
+              if (activeToken) {
+                const valid = await checkToken(activeToken);
+                if (valid) {
+                  startPlayer();
+                  return;
+                }
+              }
+              pollApproval();
+            }
+
+            async function checkToken(token) {
+              try {
+                const res = await fetch('/status?token=' + encodeURIComponent(token));
+                return res.status === 200;
+              } catch (e) {
+                return false;
+              }
+            }
+
+            async function pollApproval() {
+              if (checkInterval) clearInterval(checkInterval);
+
+              async function runCheck() {
+                try {
+                  const res = await fetch('/check?device_id=' + encodeURIComponent(deviceId) + '&device_name=' + encodeURIComponent(deviceName));
+                  const data = await res.json();
+                  if (data.status === 'approved') {
+                    activeToken = data.token;
+                    localStorage.setItem('kaset_active_token', activeToken);
+                    clearInterval(checkInterval);
+                    startPlayer();
+                  } else if (data.status === 'pending') {
+                    showScreen('screen-pending');
+                  } else {
+                    showScreen('screen-auth');
+                  }
+                } catch (e) {
+                  showScreen('screen-auth');
+                }
+              }
+
+              await runCheck();
+              checkInterval = setInterval(runCheck, 2000);
+            }
+
+            async function requestAccess() {
+              const pin = document.getElementById('pin-input').value;
+              document.getElementById('auth-error').classList.add('hidden');
+              try {
+                const body = 'device_id=' + encodeURIComponent(deviceId) + 
+                            '&device_name=' + encodeURIComponent(deviceName) + 
+                            '&pin=' + encodeURIComponent(pin);
+                const res = await fetch('/request_approval', {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                  body: body
+                });
+                const data = await res.json();
+                if (data.status === 'pending') {
+                  pollApproval();
+                } else {
+                  document.getElementById('auth-error').classList.remove('hidden');
+                }
+              } catch (e) {
+                document.getElementById('auth-error').classList.remove('hidden');
+              }
+            }
+
+            function startPlayer() {
+              showScreen('screen-player');
+              refresh();
+              if (refreshInterval) clearInterval(refreshInterval);
+              refreshInterval = setInterval(refresh, 2000);
+            }
+
+            const withToken = path => path + (path.includes('?') ? '&' : '?') + 'token=' + encodeURIComponent(activeToken);
+
             async function send(action) {
               await fetch(withToken('/' + action), { method: 'POST' });
               refresh();
             }
+
             async function setVolume(value) {
               await fetch(withToken('/volume?value=' + encodeURIComponent(value)), { method: 'POST' });
               refresh();
             }
+
             async function refresh() {
               try {
                 const res = await fetch(withToken('/status'));
+                if (res.status === 401) {
+                  localStorage.removeItem('kaset_active_token');
+                  activeToken = '';
+                  clearInterval(refreshInterval);
+                  pollApproval();
+                  return;
+                }
                 const data = await res.json();
                 document.getElementById('title').textContent = data.track?.title || 'Nothing playing';
                 document.getElementById('artist').textContent = data.track?.artist || '';
@@ -526,8 +655,8 @@ final class LocalControlServer {
                 document.getElementById('status').textContent = String(error);
               }
             }
-            refresh();
-            setInterval(refresh, 2000);
+
+            startup();
           </script>
         </body>
         </html>

--- a/Sources/Kaset/Services/LocalControlServer.swift
+++ b/Sources/Kaset/Services/LocalControlServer.swift
@@ -15,11 +15,15 @@ final class LocalControlServer {
     private weak var playerService: PlayerService?
     private var activePort: UInt16?
     private var activeAllowsLAN = false
+    private var sleepTimerTask: Task<Void, Never>?
+    private var sleepTimerTarget: Date?
+    private weak var syncedLyricsService: SyncedLyricsService?
 
     private init() {}
 
-    func configure(playerService: PlayerService) {
+    func configure(playerService: PlayerService, syncedLyricsService: SyncedLyricsService) {
         self.playerService = playerService
+        self.syncedLyricsService = syncedLyricsService
         self.applySettings()
     }
 
@@ -291,6 +295,41 @@ extension LocalControlServer {
         case let .volume(value):
             await playerService.setVolume(value)
             return .json(["ok": true, "action": "volume", "volume": playerService.volume])
+        case let .seek(time):
+            await playerService.seek(to: time)
+            return .json(["ok": true, "action": "seek", "progress": playerService.progress])
+        case .toggleShuffle:
+            playerService.toggleShuffle()
+            return .json(["ok": true, "action": "toggleShuffle", "shuffleEnabled": playerService.shuffleEnabled])
+        case .cycleRepeatMode:
+            playerService.cycleRepeatMode()
+            let modeStr = playerService.repeatMode == .one ? "one" : (playerService.repeatMode == .all ? "all" : "off")
+            return .json(["ok": true, "action": "cycleRepeatMode", "repeatMode": modeStr])
+        case .toggleMute:
+            await playerService.toggleMute()
+            return .json(["ok": true, "action": "toggleMute", "isMuted": playerService.isMuted, "volume": playerService.volume])
+        case let .sleepTimer(duration, cancel):
+            self.sleepTimerTask?.cancel()
+            self.sleepTimerTask = nil
+            self.sleepTimerTarget = nil
+
+            if cancel {
+                return .json(["ok": true, "action": "sleepTimer", "status": "cancelled"])
+            }
+
+            if let minutes = duration, minutes > 0 {
+                let seconds = minutes * 60.0
+                self.sleepTimerTarget = Date().addingTimeInterval(seconds)
+                self.sleepTimerTask = Task { [weak self, weak playerService] in
+                    try? await Task.sleep(for: .seconds(seconds))
+                    guard !Task.isCancelled else { return }
+                    await playerService?.pause()
+                    self?.sleepTimerTask = nil
+                    self?.sleepTimerTarget = nil
+                }
+                return .json(["ok": true, "action": "sleepTimer", "status": "scheduled", "duration": minutes])
+            }
+            return .badRequest(message: "Missing duration or cancel parameter")
         case .search:
             let query = request.queryItems["q"] ?? request.queryItems["query"] ?? ""
             let filter = request.queryItems["filter"] ?? "all"
@@ -437,8 +476,10 @@ extension LocalControlServer {
             "volume": playerService.volume,
             "isMuted": playerService.isMuted,
             "shuffleEnabled": playerService.shuffleEnabled,
+            "repeatMode": playerService.repeatMode == .one ? "one" : (playerService.repeatMode == .all ? "all" : "off"),
             "queueIndex": playerService.currentIndex,
             "queueCount": playerService.queue.count,
+            "currentTimeMs": playerService.currentTimeMs,
         ]
 
         if let track = playerService.currentTrack {
@@ -448,6 +489,49 @@ extension LocalControlServer {
         }
 
         payload["queue"] = playerService.queue.map { Self.trackPayload($0) }
+
+        if let target = self.sleepTimerTarget {
+            let remaining = max(0, target.timeIntervalSinceNow)
+            payload["sleepTimerRemaining"] = remaining
+        } else {
+            payload["sleepTimerRemaining"] = 0
+        }
+
+        if let syncedLyricsService = self.syncedLyricsService {
+            switch syncedLyricsService.currentLyrics {
+            case let .synced(synced):
+                payload["lyrics"] = [
+                    "type": "synced",
+                    "source": synced.source,
+                    "lines": synced.lines.map { line in
+                        var linePayload: [String: Any] = [
+                            "timeInMs": line.timeInMs,
+                            "duration": line.duration,
+                            "text": line.text,
+                        ]
+                        if let rom = line.romanizedText {
+                            linePayload["romanizedText"] = rom
+                        }
+                        return linePayload
+                    },
+                ]
+            case let .plain(plain):
+                payload["lyrics"] = [
+                    "type": "plain",
+                    "source": plain.source ?? "",
+                    "text": plain.text,
+                    "lines": plain.lines,
+                ]
+            case .unavailable:
+                payload["lyrics"] = [
+                    "type": "unavailable",
+                ]
+            }
+        } else {
+            payload["lyrics"] = [
+                "type": "unavailable",
+            ]
+        }
 
         return payload
     }
@@ -524,6 +608,16 @@ extension LocalControlServer {
             .previous
         case ("POST", "/volume"):
             self.volumeRoute(request)
+        case ("POST", "/seek"):
+            Self.seekRoute(request)
+        case ("POST", "/toggle_shuffle"):
+            .toggleShuffle
+        case ("POST", "/cycle_repeat"):
+            .cycleRepeatMode
+        case ("POST", "/toggle_mute"):
+            .toggleMute
+        case ("POST", "/sleep_timer"):
+            Self.sleepTimerRoute(request)
         case ("GET", "/search"):
             .search
         case ("POST", "/play_index"):
@@ -548,6 +642,24 @@ extension LocalControlServer {
     }
 
     // swiftlint:enable cyclomatic_complexity
+
+    private static func seekRoute(_ request: HTTPRequest) -> Route {
+        let queryValue = request.queryItems["time"] ?? request.queryItems["to"]
+        let bodyValue = request.formItems["time"] ?? request.formItems["to"]
+        guard let rawValue = queryValue ?? bodyValue, let value = Double(rawValue) else {
+            return .badRequest("Missing numeric time value")
+        }
+        return .seek(value)
+    }
+
+    private static func sleepTimerRoute(_ request: HTTPRequest) -> Route {
+        let cancelQuery = request.queryItems["cancel"] ?? request.formItems["cancel"]
+        let isCancel = cancelQuery?.lowercased() == "true"
+        let durationQuery = request.queryItems["duration"] ?? request.queryItems["time"] ??
+                             request.formItems["duration"] ?? request.formItems["time"]
+        let duration = durationQuery.flatMap { Double($0) }
+        return .sleepTimer(duration: duration, cancel: isCancel)
+    }
 
     private static func volumeRoute(_ request: HTTPRequest) -> Route {
         let queryValue = request.queryItems["value"] ?? request.queryItems["level"]
@@ -656,6 +768,11 @@ extension LocalControlServer {
         case next
         case previous
         case volume(Double)
+        case seek(TimeInterval)
+        case toggleShuffle
+        case cycleRepeatMode
+        case toggleMute
+        case sleepTimer(duration: TimeInterval?, cancel: Bool)
         case search
         case playQueueIndex(Int)
         case playTrack(String)
@@ -862,7 +979,7 @@ extension LocalControlServer {
               -webkit-text-fill-color: transparent;
             }
             .card {
-              padding: 32px 24px;
+              padding: 24px;
               border: 1px solid rgba(255, 255, 255, 0.08);
               border-radius: 24px;
               background: rgba(28, 28, 30, 0.55);
@@ -871,9 +988,10 @@ extension LocalControlServer {
               box-shadow: 0 16px 40px rgba(0, 0, 0, 0.5);
               transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
               position: relative;
+              margin-bottom: 20px;
             }
             .title {
-              font-size: 20px;
+              font-size: 19px;
               font-weight: 700;
               margin-bottom: 6px;
               color: #fff;
@@ -883,9 +1001,9 @@ extension LocalControlServer {
               text-align: center;
             }
             .artist {
-              font-size: 15px;
+              font-size: 14px;
               color: #a1a1a6;
-              margin-bottom: 24px;
+              margin-bottom: 20px;
               overflow: hidden;
               text-overflow: ellipsis;
               white-space: nowrap;
@@ -939,7 +1057,7 @@ extension LocalControlServer {
               display: flex;
               justify-content: center;
               align-items: center;
-              gap: 24px;
+              gap: 16px;
               margin-top: 12px;
             }
             .control-btn {
@@ -948,26 +1066,34 @@ extension LocalControlServer {
               justify-content: center;
               border: 0;
               border-radius: 50%;
-              background: rgba(255, 255, 255, 0.08);
+              background: rgba(255, 255, 255, 0.06);
               color: #fff;
               cursor: pointer;
               transition: all 0.2s ease;
               outline: none;
             }
             .control-btn:hover {
-              background: rgba(255, 255, 255, 0.15);
+              background: rgba(255, 255, 255, 0.12);
               transform: scale(1.05);
             }
             .control-btn:active {
               transform: scale(0.95);
             }
             .control-btn.prev, .control-btn.next {
-              width: 54px;
-              height: 54px;
+              width: 46px;
+              height: 46px;
+            }
+            .control-btn.skip-back, .control-btn.skip-forward {
+              width: 44px;
+              height: 44px;
+              color: #a1a1a6;
+            }
+            .control-btn.skip-back:hover, .control-btn.skip-forward:hover {
+              color: #fff;
             }
             .control-btn.play-pause {
-              width: 72px;
-              height: 72px;
+              width: 68px;
+              height: 68px;
               background: #fff;
               color: #000;
               box-shadow: 0 4px 16px rgba(255, 255, 255, 0.2);
@@ -984,12 +1110,24 @@ extension LocalControlServer {
               display: flex;
               align-items: center;
               gap: 12px;
-              margin-top: 28px;
+              margin-top: 24px;
             }
-            .volume-icon {
+            .volume-icon-btn {
+              background: none;
+              border: none;
               color: #8e8e93;
+              cursor: pointer;
+              padding: 6px;
               display: flex;
               align-items: center;
+              justify-content: center;
+              border-radius: 50%;
+              transition: all 0.2s ease;
+              outline: none;
+            }
+            .volume-icon-btn:hover {
+              color: #fff;
+              background: rgba(255, 255, 255, 0.08);
             }
             input[type="range"] {
               -webkit-appearance: none;
@@ -1074,7 +1212,7 @@ extension LocalControlServer {
             }
             
             .status-container {
-              margin-top: 20px;
+              margin-top: 16px;
               padding: 12px;
               border-radius: 12px;
               background: rgba(255, 255, 255, 0.03);
@@ -1157,11 +1295,40 @@ extension LocalControlServer {
               color: #fff;
               box-shadow: 0 2px 8px rgba(255, 45, 85, 0.3);
             }
+            
+            /* Secondary bottom row controls */
+            .secondary-controls {
+              display: flex;
+              justify-content: space-around;
+              align-items: center;
+              margin-top: 16px;
+              border-top: 1px solid rgba(255, 255, 255, 0.06);
+              padding-top: 12px;
+            }
+            .sec-btn {
+              background: none;
+              border: none;
+              color: #8e8e93;
+              cursor: pointer;
+              padding: 8px;
+              border-radius: 8px;
+              transition: all 0.2s ease;
+              display: flex;
+              align-items: center;
+              justify-content: center;
+              outline: none;
+            }
+            .sec-btn:hover {
+              color: #fff;
+            }
+            .sec-btn.active {
+              color: #ff2d55;
+            }
 
             /* Search elements */
             .search-results-dropdown {
               position: absolute;
-              top: 96px;
+              top: 56px;
               left: 0;
               right: 0;
               background: rgba(28, 28, 30, 0.96);
@@ -1301,6 +1468,7 @@ extension LocalControlServer {
             .playlist-act-btn.play {
               background: #ff2d55;
               border-color: #ff2d55;
+              color: #fff;
             }
             .playlist-act-btn:hover {
               background: rgba(255, 255, 255, 0.12);
@@ -1316,12 +1484,36 @@ extension LocalControlServer {
               gap: 4px;
             }
             
-            /* Queue elements */
+            /* Tabs for Queue and Lyrics panels */
+            .panel-tabs {
+              display: flex;
+              gap: 12px;
+              margin-bottom: 12px;
+              border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+              padding-bottom: 8px;
+            }
+            .panel-tab {
+              border: none;
+              background: none;
+              font-size: 13px;
+              font-weight: 700;
+              color: #a1a1a6;
+              padding: 4px 8px;
+              cursor: pointer;
+              transition: all 0.2s ease;
+              border-bottom: 2px solid transparent;
+            }
+            .panel-tab.active {
+              color: #fff;
+              border-bottom-color: #ff2d55;
+            }
+            
+            /* Queue & Lyrics containers */
             .queue-list {
               display: flex;
               flex-direction: column;
               gap: 4px;
-              max-height: 320px;
+              max-height: 280px;
               overflow-y: auto;
               padding-right: 4px;
             }
@@ -1370,6 +1562,53 @@ extension LocalControlServer {
               text-overflow: ellipsis;
               white-space: nowrap;
             }
+            
+            /* Lyrics styling */
+            .lyrics-pane {
+              max-height: 280px;
+              overflow-y: auto;
+              padding: 8px 12px;
+              box-sizing: border-box;
+              text-align: center;
+              font-size: 15px;
+              font-weight: 600;
+              color: rgba(255, 255, 255, 0.45);
+              line-height: 1.6;
+              scroll-behavior: smooth;
+            }
+            .lyric-line {
+              padding: 8px 0;
+              transition: all 0.3s ease;
+              cursor: pointer;
+            }
+            .lyric-line:hover {
+              color: rgba(255, 255, 255, 0.8);
+            }
+            .lyric-line.active {
+              color: #fff;
+              font-size: 18px;
+              font-weight: 700;
+              text-shadow: 0 0 15px rgba(255, 255, 255, 0.3);
+            }
+            .lyric-romanized {
+              font-size: 12px;
+              font-weight: 400;
+              color: #8e8e93;
+              margin-top: 2px;
+              line-height: 1.4;
+            }
+            
+            /* Sleep timer selection menu */
+            .sleep-menu {
+              margin-top: 12px;
+              padding: 12px;
+              border-radius: 12px;
+              border: 1px solid rgba(255, 255, 255, 0.08);
+              background: rgba(255, 255, 255, 0.02);
+              display: flex;
+              flex-direction: column;
+              gap: 8px;
+            }
           </style>
         </head>
         <body>
@@ -1404,7 +1643,7 @@ extension LocalControlServer {
             <section id="screen-player" class="hidden">
               <div class="card">
                 <!-- Search Bar and Tabs -->
-                <div style="position: relative; margin-bottom: 20px;">
+                <div style="position: relative; margin-bottom: 16px;">
                   <div class="search-input-wrapper" style="position: relative; display: flex; align-items: center; width: 100%;">
                     <input id="search-input" type="text" placeholder="Search..." oninput="handleSearch(this.value)" onfocus="handleSearchFocus(this)" onblur="handleSearchBlur()" style="font-size: 15px; padding: 12px 40px 12px 16px; letter-spacing: 0; text-align: left; margin-bottom: 0; border-radius: 12px;">
                     <button id="clear-search-btn" onclick="clearSearch()" style="position: absolute; right: 12px; background: none; border: none; color: #8e8e93; cursor: pointer; padding: 4px; display: none; align-items: center; justify-content: center; outline: none;">
@@ -1439,43 +1678,96 @@ extension LocalControlServer {
                     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8"></path><polyline points="16 6 12 2 8 6"></polyline><line x1="12" y1="2" x2="12" y2="15"></line></svg>
                   </button>
                 </div>
+
+                <!-- Seek Progress Slider -->
+                <div style="margin-top: 14px; margin-bottom: 8px;">
+                  <input id="progress-slider" type="range" min="0" max="100" value="0" oninput="handleProgressInput(this.value)" onchange="handleProgressChange(this.value)">
+                  <div style="display: flex; justify-content: space-between; font-size: 11px; color: #8e8e93; margin-top: 6px; font-weight: 500;">
+                    <span id="current-time">0:00</span>
+                    <span id="total-time">0:00</span>
+                  </div>
+                </div>
                 
+                <!-- Playback controls with Skip -10 / +10 -->
                 <div class="controls">
                   <button class="control-btn prev" onclick="send('previous')" aria-label="Previous">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M6 6h2v12H6zm3.5 6l8.5 6V6z"/></svg>
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M6 6h2v12H6zm3.5 6l8.5 6V6z"/></svg>
+                  </button>
+                  <button class="control-btn skip-back" onclick="skipTime(-10)" aria-label="Skip Backward 10s">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"></path><polyline points="3 3 3 8 8 8"></polyline><text x="12" y="15" font-size="7.5" font-family="'Inter', sans-serif" font-weight="800" text-anchor="middle" fill="currentColor" stroke="none">10</text></svg>
                   </button>
                   <button id="play-pause-btn" class="control-btn play-pause" onclick="send('play-pause')" aria-label="Play/Pause">
-                    <svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z"/></svg>
+                    <svg width="26" height="26" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z"/></svg>
+                  </button>
+                  <button class="control-btn skip-forward" onclick="skipTime(10)" aria-label="Skip Forward 10s">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"></path><polyline points="21 3 21 8 16 8"></polyline><text x="12" y="15" font-size="7.5" font-family="'Inter', sans-serif" font-weight="800" text-anchor="middle" fill="currentColor" stroke="none">10</text></svg>
                   </button>
                   <button class="control-btn next" onclick="send('next')" aria-label="Next">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor"><path d="M6 18l8.5-6L6 6v12zM16 6v12h2V6h-2z"/></svg>
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M6 18l8.5-6L6 6v12zM16 6v12h2V6h-2z"/></svg>
                   </button>
                 </div>
                 
+                <!-- Volume Control & Mute -->
                 <div class="volume-container">
-                  <span class="volume-icon">
-                    <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M18.5 12c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM5 9v6h4l5 5V4L9 9H5z"/></svg>
-                  </span>
+                  <button id="mute-btn" class="volume-icon-btn" onclick="send('toggle_mute')" aria-label="Mute/Unmute">
+                    <span id="volume-icon">
+                      <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M18.5 12c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM5 9v6h4l5 5V4L9 9H5z"/></svg>
+                    </span>
+                  </button>
                   <input id="volume" type="range" min="0" max="1" step="0.01" onchange="setVolume(this.value)">
-                  <span class="volume-icon">
-                    <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z"/></svg>
-                  </span>
                 </div>
                 
-                <div class="status-container" id="status" style="margin-top: 24px;"></div>
+                <!-- Shuffle, Repeat, Sleep Toggles -->
+                <div class="secondary-controls">
+                  <button id="shuffle-btn" class="sec-btn" onclick="send('toggle_shuffle')" title="Toggle Shuffle">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 3 21 3 21 8"></polyline><line x1="4" y1="20" x2="21" y2="3"></line><polyline points="21 16 21 21 16 21"></polyline><line x1="15" y1="15" x2="21" y2="21"></line><line x1="4" y1="4" x2="9" y2="9"></line></svg>
+                  </button>
+                  <button id="sleep-btn" class="sec-btn" onclick="toggleSleepMenu()" title="Sleep Timer" style="gap: 4px; font-size: 11px; font-weight: 700;">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v20M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"></path></svg>
+                    <span id="sleep-label">Timer</span>
+                  </button>
+                  <button id="repeat-btn" class="sec-btn" onclick="send('cycle_repeat')" title="Cycle Repeat" style="position: relative;">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><polyline points="17 1 21 5 17 9"></polyline><path d="M3 11V9a4 4 0 0 1 4-4h14M7 23 3 19 7 15"></path><path d="M21 13v2a4 4 0 0 1-4 4H3"></path></svg>
+                    <span id="repeat-badge" style="position: absolute; top: -1px; right: -1px; font-size: 8px; font-weight: 900; background: #ff2d55; color: white; border-radius: 50%; width: 10px; height: 10px; display: none; align-items: center; justify-content: center; line-height: 1;">1</span>
+                  </button>
+                </div>
+
+                <!-- Sleep Menu -->
+                <div id="sleep-menu" class="sleep-menu hidden">
+                  <div style="font-size: 12px; font-weight: 700; text-align: center; color: #fff; margin-bottom: 4px;">Stop Playback in:</div>
+                  <div style="display: flex; gap: 6px;">
+                    <button class="search-tab" onclick="setSleepTimer(15)">15m</button>
+                    <button class="search-tab" onclick="setSleepTimer(30)">30m</button>
+                    <button class="search-tab" onclick="setSleepTimer(45)">45m</button>
+                    <button class="search-tab" onclick="setSleepTimer(60)">60m</button>
+                  </div>
+                  <button class="search-tab" id="cancel-sleep-btn" onclick="setSleepTimer(0)" style="display: none; border-color: rgba(255, 45, 85, 0.4); color: #ff2d55; margin-top: 4px; width: 100%;">Cancel Timer</button>
+                </div>
+                
+                <div class="status-container" id="status"></div>
               </div>
 
-              <!-- Queue Panel -->
-              <div class="card" style="margin-top: 20px; padding: 20px 16px;">
-                <div style="font-size: 16px; font-weight: 700; text-align: left; margin-bottom: 12px; display: flex; justify-content: space-between; align-items: center;">
-                  <span style="display: flex; align-items: center; gap: 8px;">
-                    <span>Up Next</span>
-                    <button id="clear-queue-btn" onclick="clearQueue()" style="background: none; border: 1px solid rgba(255, 45, 85, 0.4); color: #ff2d55; font-size: 11px; font-weight: 600; padding: 3px 8px; border-radius: 6px; cursor: pointer; outline: none; transition: all 0.2s ease;">Clear</button>
-                  </span>
-                  <span id="queue-count" style="font-size: 12px; color: #8e8e93; font-weight: 500;">0 songs</span>
+              <!-- Tabs Card: Up Next vs Lyrics -->
+              <div class="card" style="padding: 20px 16px;">
+                <div class="panel-tabs">
+                  <button id="tab-queue" class="panel-tab active" onclick="switchPanelTab('queue')">Up Next</button>
+                  <button id="tab-lyrics" class="panel-tab" onclick="switchPanelTab('lyrics')">Lyrics</button>
                 </div>
-                <div id="queue-list" class="queue-list">
-                  <!-- Queue items dynamically loaded -->
+
+                <!-- Queue Tab Panel -->
+                <div id="panel-queue-content">
+                  <div style="font-size: 14px; font-weight: 700; text-align: left; margin-bottom: 12px; display: flex; justify-content: space-between; align-items: center;">
+                    <button id="clear-queue-btn" onclick="clearQueue()" style="background: none; border: 1px solid rgba(255, 45, 85, 0.4); color: #ff2d55; font-size: 11px; font-weight: 600; padding: 3px 8px; border-radius: 6px; cursor: pointer; outline: none; transition: all 0.2s ease;">Clear Queue</button>
+                    <span id="queue-count" style="font-size: 12px; color: #8e8e93; font-weight: 500;">0 songs</span>
+                  </div>
+                  <div id="queue-list" class="queue-list">
+                    <!-- Queue items dynamically loaded -->
+                  </div>
+                </div>
+
+                <!-- Lyrics Tab Panel -->
+                <div id="panel-lyrics-content" class="lyrics-pane hidden">
+                  <div style="padding: 40px 0; color: #8e8e93;">Play a song to view lyrics</div>
                 </div>
               </div>
             </section>
@@ -1518,6 +1810,17 @@ extension LocalControlServer {
             let currentPlaylistId = '';
             let currentPlaylistTitle = '';
             let currentVideoId = '';
+
+            // Playback progress & Sync tracking
+            let localProgress = 0;
+            let localDuration = 0;
+            let localCurrentTimeMs = 0;
+            let localIsPlaying = false;
+            let isDraggingProgress = false;
+            let lastRefreshTime = Date.now();
+            let activeTab = 'queue';
+            let lyricsData = null;
+            let lastActiveLyricIndex = -1;
 
             function showScreen(id) {
               document.getElementById('screen-auth').classList.add('hidden');
@@ -1638,6 +1941,25 @@ extension LocalControlServer {
               refresh();
               if (refreshInterval) clearInterval(refreshInterval);
               refreshInterval = setInterval(refresh, 2000);
+
+              // Periodic 100ms smooth ticker loop (dead reckoning)
+              setInterval(() => {
+                if (localIsPlaying && !isDraggingProgress && localDuration > 0) {
+                  const now = Date.now();
+                  const delta = (now - lastRefreshTime) / 1000;
+                  lastRefreshTime = now;
+                  
+                  localProgress = Math.min(localProgress + delta, localDuration);
+                  localCurrentTimeMs = Math.min(localCurrentTimeMs + Math.round(delta * 1000), localDuration * 1000);
+                  
+                  updateProgressUI();
+                  if (activeTab === 'lyrics') {
+                    highlightSyncedLyrics();
+                  }
+                } else {
+                  lastRefreshTime = Date.now();
+                }
+              }, 100);
             }
 
             const withToken = path => path + (path.includes('?') ? '&' : '?') + 'token=' + encodeURIComponent(activeToken);
@@ -1907,6 +2229,173 @@ extension LocalControlServer {
               }
             });
 
+            // Seek slider handlers
+            function handleProgressInput(val) {
+              isDraggingProgress = true;
+              const targetTime = (val / 100) * localDuration;
+              document.getElementById('current-time').textContent = formatTime(targetTime);
+            }
+
+            async function handleProgressChange(val) {
+              const targetTime = (val / 100) * localDuration;
+              isDraggingProgress = false;
+              localProgress = targetTime;
+              localCurrentTimeMs = Math.round(targetTime * 1000);
+              await fetch(withToken('/seek?time=' + targetTime), { method: 'POST' });
+              refresh();
+            }
+
+            async function skipTime(delta) {
+              const targetTime = Math.max(0, Math.min(localProgress + delta, localDuration));
+              localProgress = targetTime;
+              localCurrentTimeMs = Math.round(targetTime * 1000);
+              updateProgressUI();
+              await fetch(withToken('/seek?time=' + targetTime), { method: 'POST' });
+              refresh();
+            }
+
+            // Sleep timer handlers
+            function toggleSleepMenu() {
+              const menu = document.getElementById('sleep-menu');
+              menu.classList.toggle('hidden');
+            }
+
+            async function setSleepTimer(minutes) {
+              let url = '/sleep_timer';
+              if (minutes === 0) {
+                url += '?cancel=true';
+                showToast('Sleep timer cancelled');
+              } else {
+                url += '?duration=' + minutes;
+                showToast('Sleep timer set for ' + minutes + ' minutes');
+              }
+              document.getElementById('sleep-menu').classList.add('hidden');
+              await fetch(withToken(url), { method: 'POST' });
+              refresh();
+            }
+
+            // Lyrics vs Queue panel switching
+            function switchPanelTab(tab) {
+              activeTab = tab;
+              document.querySelectorAll('.panel-tab').forEach(t => t.classList.remove('active'));
+              
+              if (tab === 'queue') {
+                document.getElementById('tab-queue').classList.add('active');
+                document.getElementById('panel-queue-content').classList.remove('hidden');
+                document.getElementById('panel-lyrics-content').classList.add('hidden');
+              } else {
+                document.getElementById('tab-lyrics').classList.add('active');
+                document.getElementById('panel-queue-content').classList.add('hidden');
+                document.getElementById('panel-lyrics-content').classList.remove('hidden');
+                lastActiveLyricIndex = -1;
+                renderLyrics();
+              }
+            }
+
+            // Sync elapsed / duration timers & update slider
+            function updateProgressUI() {
+              if (localDuration > 0) {
+                document.getElementById('progress-slider').value = (localProgress / localDuration) * 100;
+                document.getElementById('total-time').textContent = formatTime(localDuration);
+              } else {
+                document.getElementById('progress-slider').value = 0;
+                document.getElementById('total-time').textContent = '0:00';
+              }
+              document.getElementById('current-time').textContent = formatTime(localProgress);
+            }
+
+            function formatTime(seconds) {
+              if (isNaN(seconds) || seconds < 0) return '0:00';
+              const m = Math.floor(seconds / 60);
+              const s = Math.floor(seconds % 60);
+              return m + ':' + (s < 10 ? '0' : '') + s;
+            }
+
+            // Synchronized / static lyrics rendering
+            function renderLyrics() {
+              const container = document.getElementById('panel-lyrics-content');
+              if (!lyricsData || lyricsData.type === 'unavailable') {
+                container.innerHTML = '<div style="padding: 40px 0; color: #8e8e93;">There aren\'t any lyrics available for this song.</div>';
+                return;
+              }
+
+              if (lyricsData.type === 'plain') {
+                container.innerHTML = `<div style="text-align: center; padding: 10px 0; color: #fff; font-size: 15px; font-weight: 500; white-space: pre-wrap;">${lyricsData.text}</div>`;
+                if (lyricsData.source) {
+                  container.innerHTML += `<div style="color: #8e8e93; font-size: 11px; margin-top: 24px;">Source: ${lyricsData.source}</div>`;
+                }
+                return;
+              }
+
+              if (lyricsData.type === 'synced' && lyricsData.lines) {
+                container.innerHTML = '';
+                lyricsData.lines.forEach((line, idx) => {
+                  const el = document.createElement('div');
+                  el.className = 'lyric-line';
+                  el.id = 'lyric-line-' + idx;
+                  el.setAttribute('data-time', line.timeInMs);
+                  
+                  let innerHTML = `<span>${line.text}</span>`;
+                  if (line.romanizedText) {
+                    innerHTML += `<div class="lyric-romanized">${line.romanizedText}</div>`;
+                  }
+                  el.innerHTML = innerHTML;
+                  
+                  el.onclick = () => seekToMs(line.timeInMs);
+                  container.appendChild(el);
+                });
+                highlightSyncedLyrics();
+              }
+            }
+
+            async function seekToMs(ms) {
+              const seconds = ms / 1000.0;
+              localProgress = seconds;
+              localCurrentTimeMs = ms;
+              updateProgressUI();
+              highlightSyncedLyrics();
+              await fetch(withToken('/seek?time=' + seconds), { method: 'POST' });
+              refresh();
+            }
+
+            function highlightSyncedLyrics() {
+              if (!lyricsData || lyricsData.type !== 'synced') return;
+              
+              const container = document.getElementById('panel-lyrics-content');
+              const lines = lyricsData.lines;
+              if (!lines || lines.length === 0) return;
+
+              let activeIdx = -1;
+              for (let i = 0; i < lines.length; i++) {
+                if (localCurrentTimeMs >= lines[i].timeInMs) {
+                  activeIdx = i;
+                } else {
+                  break;
+                }
+              }
+
+              if (activeIdx !== lastActiveLyricIndex) {
+                lastActiveLyricIndex = activeIdx;
+                
+                // Reset classes
+                container.querySelectorAll('.lyric-line').forEach(el => el.classList.remove('active'));
+                
+                if (activeIdx !== -1) {
+                  const activeEl = document.getElementById('lyric-line-' + activeIdx);
+                  if (activeEl) {
+                    activeEl.classList.add('active');
+                    
+                    // Smoothly scroll container to center the active line
+                    const targetScroll = activeEl.offsetTop - container.offsetHeight / 2 + activeEl.offsetHeight / 2;
+                    container.scrollTo({
+                      top: targetScroll,
+                      behavior: 'smooth'
+                    });
+                  }
+                }
+              }
+            }
+
             async function refresh() {
               try {
                 const res = await fetch(withToken('/status'));
@@ -1935,13 +2424,79 @@ extension LocalControlServer {
 
                 const playPauseBtn = document.getElementById('play-pause-btn');
                 if (data.isPlaying) {
-                  playPauseBtn.innerHTML = '<svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor"><path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z"/></svg>';
+                  playPauseBtn.innerHTML = '<svg width="26" height="26" viewBox="0 0 24 24" fill="currentColor"><path d="M6 19h4V5H6v14zm8-14v14h4V5h-4z"/></svg>';
                 } else {
-                  playPauseBtn.innerHTML = '<svg width="28" height="28" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z"/></svg>';
+                  playPauseBtn.innerHTML = '<svg width="26" height="26" viewBox="0 0 24 24" fill="currentColor"><path d="M8 5v14l11-7z"/></svg>';
                 }
 
                 document.getElementById('status').textContent = data.state.toUpperCase() + ' • VOLUME ' + Math.round((data.volume || 0) * 100) + '%';
                 document.getElementById('volume').value = data.volume || 0;
+
+                // Sync local progress times if not dragging
+                if (!isDraggingProgress) {
+                  localProgress = data.progress || 0;
+                  localDuration = data.duration || 0;
+                  localCurrentTimeMs = data.currentTimeMs || 0;
+                  localIsPlaying = data.isPlaying || false;
+                  lastRefreshTime = Date.now();
+                  updateProgressUI();
+                }
+
+                // Volume & Mute UI State
+                const volumeIcon = document.getElementById('volume-icon');
+                if (data.isMuted || data.volume === 0) {
+                  volumeIcon.innerHTML = '<svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M16.5 12c0-1.77-1.02-3.29-2.5-4.03v2.21l2.45 2.45c.03-.21.05-.42.05-.63zm2.5 0c0 .94-.2 1.82-.54 2.64l1.51 1.51C20.63 14.91 21 13.5 21 12c0-4.28-2.99-7.86-7-8.77v2.06c2.89.86 5 3.54 5 6.71zM4.27 3L3 4.27 7.73 9H3v6h4l5 5v-6.73l4.25 4.25c-.67.52-1.42.93-2.25 1.18v2.06c1.38-.31 2.63-.95 3.69-1.81L19.73 21 21 19.73l-9-9L4.27 3zM12 4L9.91 6.09 12 8.18V4z"/></svg>';
+                } else if (data.volume < 0.3) {
+                  volumeIcon.innerHTML = '<svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M7 9v6h4l5 5V4L11 9H7z"/></svg>';
+                } else if (data.volume < 0.7) {
+                  volumeIcon.innerHTML = '<svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M18.5 12c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM5 9v6h4l5 5V4L9 9H5z"/></svg>';
+                } else {
+                  volumeIcon.innerHTML = '<svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor"><path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z"/></svg>';
+                }
+
+                // Shuffle UI
+                const shuffleBtn = document.getElementById('shuffle-btn');
+                if (data.shuffleEnabled) {
+                  shuffleBtn.classList.add('active');
+                } else {
+                  shuffleBtn.classList.remove('active');
+                }
+
+                // Repeat UI
+                const repeatBtn = document.getElementById('repeat-btn');
+                const repeatBadge = document.getElementById('repeat-badge');
+                if (data.repeatMode === 'one') {
+                  repeatBtn.classList.add('active');
+                  repeatBadge.style.display = 'flex';
+                } else if (data.repeatMode === 'all') {
+                  repeatBtn.classList.add('active');
+                  repeatBadge.style.display = 'none';
+                } else {
+                  repeatBtn.classList.remove('active');
+                  repeatBadge.style.display = 'none';
+                }
+
+                // Sleep Timer UI
+                const sleepLabel = document.getElementById('sleep-label');
+                const cancelSleepBtn = document.getElementById('cancel-sleep-btn');
+                if (data.sleepTimerRemaining > 0) {
+                  const remMin = Math.ceil(data.sleepTimerRemaining / 60.0);
+                  sleepLabel.textContent = remMin + 'm left';
+                  document.getElementById('sleep-btn').classList.add('active');
+                  cancelSleepBtn.style.display = 'block';
+                } else {
+                  sleepLabel.textContent = 'Timer';
+                  document.getElementById('sleep-btn').classList.remove('active');
+                  cancelSleepBtn.style.display = 'none';
+                }
+
+                // Render Lyrics when active and lyrics loaded or modified
+                const oldLyricsString = lyricsData ? JSON.stringify(lyricsData) : '';
+                lyricsData = data.lyrics;
+                const newLyricsString = lyricsData ? JSON.stringify(lyricsData) : '';
+                if (activeTab === 'lyrics' && oldLyricsString !== newLyricsString) {
+                  renderLyrics();
+                }
 
                 // Render queue
                 const queueList = document.getElementById('queue-list');

--- a/Sources/Kaset/Services/LocalControlServer.swift
+++ b/Sources/Kaset/Services/LocalControlServer.swift
@@ -234,7 +234,16 @@ final class LocalControlServer {
             await playerService.playQueue(queue, startingAt: index)
             return .json(["ok": true, "action": "playQueueIndex", "index": index])
         case .playTrack(let videoId):
-            await playerService.play(videoId: videoId)
+            let song = Song(
+                id: videoId,
+                title: "Loading...",
+                artists: [],
+                album: nil,
+                duration: nil,
+                thumbnailURL: nil,
+                videoId: videoId
+            )
+            await playerService.playWithRadio(song: song)
             return .json(["ok": true, "action": "playTrack", "videoId": videoId])
         case .notFound:
             return .notFound(message: "Unknown endpoint")

--- a/Sources/Kaset/Services/LocalControlServer.swift
+++ b/Sources/Kaset/Services/LocalControlServer.swift
@@ -213,16 +213,49 @@ final class LocalControlServer {
             return .json(["ok": true, "action": "volume", "volume": playerService.volume])
         case .search:
             let query = request.queryItems["q"] ?? request.queryItems["query"] ?? ""
+            let filter = request.queryItems["filter"] ?? "all"
             guard !query.isEmpty else {
-                return .json(["results": []])
+                return .json(["results": [], "type": filter])
             }
             guard let client = playerService.ytMusicClient else {
                 return .json(["ok": false, "error": "API client not initialized"])
             }
             do {
-                let songs = try await client.searchSongs(query: query)
-                let results = songs.map { Self.trackPayload($0) }
-                return .json(["results": results])
+                if filter == "songs" {
+                    let songs = try await client.searchSongs(query: query)
+                    let results = songs.map { Self.trackPayload($0) }
+                    return .json(["results": results, "type": "songs"])
+                } else if filter == "albums" {
+                    let response = try await client.searchAlbums(query: query)
+                    let results = response.albums.map { Self.albumPayload($0) }
+                    return .json(["results": results, "type": "albums"])
+                } else if filter == "playlists" {
+                    let response = try await client.searchCommunityPlaylists(query: query)
+                    let results = response.playlists.map { Self.playlistPayload($0) }
+                    return .json(["results": results, "type": "playlists"])
+                } else {
+                    let response = try await client.search(query: query)
+                    var items: [[String: Any]] = []
+                    for item in response.allItems {
+                        switch item {
+                        case .song(let song):
+                            var p = Self.trackPayload(song)
+                            p["type"] = "song"
+                            items.append(p)
+                        case .album(let album):
+                            var p = Self.albumPayload(album)
+                            p["type"] = "album"
+                            items.append(p)
+                        case .playlist(let playlist):
+                            var p = Self.playlistPayload(playlist)
+                            p["type"] = "playlist"
+                            items.append(p)
+                        default:
+                            break
+                        }
+                    }
+                    return .json(["results": items, "type": "all"])
+                }
             } catch {
                 return .json(["ok": false, "error": error.localizedDescription])
             }
@@ -245,6 +278,62 @@ final class LocalControlServer {
             )
             await playerService.playWithRadio(song: song)
             return .json(["ok": true, "action": "playTrack", "videoId": videoId])
+        case .playNext(let videoId, let playlistId, let song):
+            if let song = song {
+                playerService.insertNextInQueue([song])
+                return .json(["ok": true, "action": "playNext", "videoId": videoId ?? ""])
+            } else if let playlistId = playlistId {
+                guard let client = playerService.ytMusicClient else {
+                    return .json(["ok": false, "error": "API client not initialized"])
+                }
+                do {
+                    let tracks = try await client.getPlaylistAllTracks(playlistId: playlistId)
+                    playerService.insertNextInQueue(tracks)
+                    return .json(["ok": true, "action": "playNext", "playlistId": playlistId])
+                } catch {
+                    return .json(["ok": false, "error": error.localizedDescription])
+                }
+            }
+            return .badRequest(message: "Missing parameters")
+        case .addToQueue(let videoId, let playlistId, let song):
+            if let song = song {
+                playerService.appendToQueue([song])
+                return .json(["ok": true, "action": "addToQueue", "videoId": videoId ?? ""])
+            } else if let playlistId = playlistId {
+                guard let client = playerService.ytMusicClient else {
+                    return .json(["ok": false, "error": "API client not initialized"])
+                }
+                do {
+                    let tracks = try await client.getPlaylistAllTracks(playlistId: playlistId)
+                    playerService.appendToQueue(tracks)
+                    return .json(["ok": true, "action": "addToQueue", "playlistId": playlistId])
+                } catch {
+                    return .json(["ok": false, "error": error.localizedDescription])
+                }
+            }
+            return .badRequest(message: "Missing parameters")
+        case .playPlaylist(let playlistId):
+            guard let client = playerService.ytMusicClient else {
+                return .json(["ok": false, "error": "API client not initialized"])
+            }
+            do {
+                let tracks = try await client.getPlaylistAllTracks(playlistId: playlistId)
+                await playerService.playQueue(tracks, startingAt: 0)
+                return .json(["ok": true, "action": "playPlaylist", "playlistId": playlistId])
+            } catch {
+                return .json(["ok": false, "error": error.localizedDescription])
+            }
+        case .playlistTracks(let playlistId):
+            guard let client = playerService.ytMusicClient else {
+                return .json(["ok": false, "error": "API client not initialized"])
+            }
+            do {
+                let response = try await client.getPlaylist(id: playlistId)
+                let tracks = response.detail.tracks.map { Self.trackPayload($0) }
+                return .json(["ok": true, "tracks": tracks, "title": response.detail.title, "playlistId": playlistId])
+            } catch {
+                return .json(["ok": false, "error": error.localizedDescription])
+            }
         case .notFound:
             return .notFound(message: "Unknown endpoint")
         case .methodNotAllowed:
@@ -303,6 +392,30 @@ final class LocalControlServer {
         return payload
     }
 
+    static func albumPayload(_ album: Album) -> [String: Any] {
+        var payload: [String: Any] = [
+            "id": album.id,
+            "title": album.title,
+            "artist": album.artistsDisplay,
+        ]
+        if let artworkURL = album.thumbnailURL?.absoluteString {
+            payload["artworkURL"] = artworkURL
+        }
+        return payload
+    }
+
+    static func playlistPayload(_ playlist: Playlist) -> [String: Any] {
+        var payload: [String: Any] = [
+            "id": playlist.id,
+            "title": playlist.title,
+            "artist": playlist.author?.name ?? playlist.description ?? "",
+        ]
+        if let artworkURL = playlist.thumbnailURL?.absoluteString {
+            payload["artworkURL"] = artworkURL
+        }
+        return payload
+    }
+
     static func route(_ request: HTTPRequest) -> Route {
         switch (request.method, request.path) {
         case ("GET", "/"), ("GET", "/remote"):
@@ -331,6 +444,14 @@ final class LocalControlServer {
             Self.playIndexRoute(request)
         case ("POST", "/play_track"):
             Self.playTrackRoute(request)
+        case ("POST", "/play_next"):
+            Self.playNextRoute(request)
+        case ("POST", "/add_to_queue"):
+            Self.addToQueueRoute(request)
+        case ("POST", "/play_playlist"):
+            Self.playPlaylistRoute(request)
+        case ("GET", "/playlist_tracks"):
+            Self.playlistTracksRoute(request)
         case ("GET", _), ("POST", _):
             .notFound
         default:
@@ -364,6 +485,76 @@ final class LocalControlServer {
         return .playTrack(videoId)
     }
 
+    private static func playNextRoute(_ request: HTTPRequest) -> Route {
+        let videoId = request.queryItems["videoId"] ?? request.queryItems["video_id"] ?? request.formItems["videoId"] ?? request.formItems["video_id"]
+        let playlistId = request.queryItems["playlistId"] ?? request.queryItems["playlist_id"] ?? request.formItems["playlistId"] ?? request.formItems["playlist_id"]
+        
+        if let videoId = videoId, !videoId.isEmpty {
+            let title = request.queryItems["title"] ?? request.formItems["title"] ?? "Loading..."
+            let artist = request.queryItems["artist"] ?? request.formItems["artist"] ?? ""
+            let artworkURL = request.queryItems["artworkURL"] ?? request.formItems["artworkURL"] ?? request.queryItems["artwork_url"] ?? request.formItems["artwork_url"]
+            let artists = artist.isEmpty ? [] : [Artist(id: UUID().uuidString, name: artist, thumbnailURL: nil)]
+            
+            let song = Song(
+                id: videoId,
+                title: title,
+                artists: artists,
+                album: nil,
+                duration: nil,
+                thumbnailURL: artworkURL.flatMap { URL(string: $0) },
+                videoId: videoId
+            )
+            return .playNext(videoId: videoId, playlistId: nil, song: song)
+        } else if let playlistId = playlistId, !playlistId.isEmpty {
+            return .playNext(videoId: nil, playlistId: playlistId, song: nil)
+        } else {
+            return .badRequest("Missing videoId or playlistId parameter")
+        }
+    }
+    
+    private static func addToQueueRoute(_ request: HTTPRequest) -> Route {
+        let videoId = request.queryItems["videoId"] ?? request.queryItems["video_id"] ?? request.formItems["videoId"] ?? request.formItems["video_id"]
+        let playlistId = request.queryItems["playlistId"] ?? request.queryItems["playlist_id"] ?? request.formItems["playlistId"] ?? request.formItems["playlist_id"]
+        
+        if let videoId = videoId, !videoId.isEmpty {
+            let title = request.queryItems["title"] ?? request.formItems["title"] ?? "Loading..."
+            let artist = request.queryItems["artist"] ?? request.formItems["artist"] ?? ""
+            let artworkURL = request.queryItems["artworkURL"] ?? request.formItems["artworkURL"] ?? request.queryItems["artwork_url"] ?? request.formItems["artwork_url"]
+            let artists = artist.isEmpty ? [] : [Artist(id: UUID().uuidString, name: artist, thumbnailURL: nil)]
+            
+            let song = Song(
+                id: videoId,
+                title: title,
+                artists: artists,
+                album: nil,
+                duration: nil,
+                thumbnailURL: artworkURL.flatMap { URL(string: $0) },
+                videoId: videoId
+            )
+            return .addToQueue(videoId: videoId, playlistId: nil, song: song)
+        } else if let playlistId = playlistId, !playlistId.isEmpty {
+            return .addToQueue(videoId: nil, playlistId: playlistId, song: nil)
+        } else {
+            return .badRequest("Missing videoId or playlistId parameter")
+        }
+    }
+
+    private static func playPlaylistRoute(_ request: HTTPRequest) -> Route {
+        let playlistId = request.queryItems["playlistId"] ?? request.queryItems["playlist_id"] ?? request.formItems["playlistId"] ?? request.formItems["playlist_id"]
+        guard let id = playlistId, !id.isEmpty else {
+            return .badRequest("Missing playlistId parameter")
+        }
+        return .playPlaylist(playlistId: id)
+    }
+
+    private static func playlistTracksRoute(_ request: HTTPRequest) -> Route {
+        let playlistId = request.queryItems["playlistId"] ?? request.queryItems["playlist_id"] ?? request.formItems["playlistId"] ?? request.formItems["playlist_id"] ?? request.queryItems["id"] ?? request.formItems["id"]
+        guard let id = playlistId, !id.isEmpty else {
+            return .badRequest("Missing playlistId parameter")
+        }
+        return .playlistTracks(playlistId: id)
+    }
+
     enum Route: Equatable {
         case webInterface
         case check
@@ -378,6 +569,10 @@ final class LocalControlServer {
         case search
         case playQueueIndex(Int)
         case playTrack(String)
+        case playNext(videoId: String?, playlistId: String?, song: Song?)
+        case addToQueue(videoId: String?, playlistId: String?, song: Song?)
+        case playPlaylist(playlistId: String)
+        case playlistTracks(playlistId: String)
         case notFound
         case methodNotAllowed
         case badRequest(String)
@@ -557,6 +752,7 @@ final class LocalControlServer {
               max-width: 440px;
               padding: 24px;
               box-sizing: border-box;
+              position: relative;
             }
             h1 {
               font-size: 24px;
@@ -577,6 +773,7 @@ final class LocalControlServer {
               -webkit-backdrop-filter: blur(20px);
               box-shadow: 0 16px 40px rgba(0, 0, 0, 0.5);
               transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+              position: relative;
             }
             .title {
               font-size: 20px;
@@ -596,6 +793,25 @@ final class LocalControlServer {
               text-overflow: ellipsis;
               white-space: nowrap;
               text-align: center;
+            }
+            .share-btn {
+              position: absolute;
+              right: 8px;
+              top: 0;
+              background: none;
+              border: none;
+              color: #a1a1a6;
+              cursor: pointer;
+              padding: 8px;
+              border-radius: 50%;
+              transition: all 0.2s ease;
+              display: flex;
+              align-items: center;
+              justify-content: center;
+            }
+            .share-btn:hover {
+              color: #fff !important;
+              background: rgba(255, 255, 255, 0.08) !important;
             }
             .controls {
               display: flex;
@@ -788,29 +1004,59 @@ final class LocalControlServer {
               align-items: center;
               gap: 12px;
             }
+            
+            /* Search tabs */
+            .search-tabs {
+              display: flex;
+              gap: 6px;
+              margin-top: 8px;
+              margin-bottom: 8px;
+            }
+            .search-tab {
+              flex: 1;
+              padding: 8px 4px;
+              border: 1px solid rgba(255, 255, 255, 0.1);
+              background: rgba(255, 255, 255, 0.04);
+              color: #a1a1a6;
+              border-radius: 8px;
+              font-size: 11px;
+              font-weight: 600;
+              cursor: pointer;
+              transition: all 0.2s ease;
+              outline: none;
+            }
+            .search-tab:hover {
+              background: rgba(255, 255, 255, 0.1);
+              color: #fff;
+            }
+            .search-tab.active {
+              background: #ff2d55;
+              border-color: #ff2d55;
+              color: #fff;
+              box-shadow: 0 2px 8px rgba(255, 45, 85, 0.3);
+            }
 
             /* Search elements */
             .search-results-dropdown {
               position: absolute;
-              top: 50px;
+              top: 96px;
               left: 0;
               right: 0;
-              background: rgba(28, 28, 30, 0.95);
-              border: 1px solid rgba(255, 255, 255, 0.12);
+              background: rgba(28, 28, 30, 0.96);
+              border: 1px solid rgba(255, 255, 255, 0.14);
               border-radius: 14px;
               z-index: 100;
               max-height: 280px;
               overflow-y: auto;
-              box-shadow: 0 10px 25px rgba(0, 0, 0, 0.6);
-              backdrop-filter: blur(15px);
-              -webkit-backdrop-filter: blur(15px);
+              box-shadow: 0 12px 32px rgba(0, 0, 0, 0.75);
+              backdrop-filter: blur(20px);
+              -webkit-backdrop-filter: blur(20px);
             }
             .search-result-item {
-              padding: 12px 16px;
+              padding: 10px 14px;
               display: flex;
               align-items: center;
               gap: 12px;
-              cursor: pointer;
               border-bottom: 1px solid rgba(255, 255, 255, 0.05);
               transition: background 0.2s ease;
               text-align: left;
@@ -842,6 +1088,110 @@ final class LocalControlServer {
               overflow: hidden;
               text-overflow: ellipsis;
               white-space: nowrap;
+            }
+            
+            /* Action Buttons inside items */
+            .result-actions {
+              display: flex;
+              gap: 6px;
+            }
+            .result-act-btn {
+              background: rgba(255, 255, 255, 0.06);
+              border: none;
+              color: #a1a1a6;
+              border-radius: 6px;
+              width: 28px;
+              height: 28px;
+              display: flex;
+              align-items: center;
+              justify-content: center;
+              cursor: pointer;
+              transition: all 0.2s ease;
+            }
+            .result-act-btn:hover {
+              background: rgba(255, 255, 255, 0.16);
+              color: #fff;
+            }
+
+            /* Playlist Details Panel */
+            .playlist-details-pane {
+              position: absolute;
+              top: 50px;
+              left: 24px;
+              right: 24px;
+              bottom: 24px;
+              background: rgba(18, 18, 20, 0.98);
+              border: 1px solid rgba(255, 255, 255, 0.12);
+              border-radius: 20px;
+              z-index: 110;
+              display: flex;
+              flex-direction: column;
+              box-shadow: 0 16px 40px rgba(0, 0, 0, 0.85);
+              backdrop-filter: blur(24px);
+              -webkit-backdrop-filter: blur(24px);
+              padding: 20px;
+              box-sizing: border-box;
+            }
+            .playlist-details-header {
+              margin-bottom: 14px;
+              flex-shrink: 0;
+            }
+            .back-btn {
+              background: none;
+              border: none;
+              color: #ff2d55;
+              display: flex;
+              align-items: center;
+              gap: 6px;
+              font-size: 14px;
+              font-weight: 600;
+              cursor: pointer;
+              padding: 0;
+              margin-bottom: 10px;
+            }
+            .playlist-title {
+              font-size: 16px;
+              font-weight: 800;
+              color: #fff;
+              margin-bottom: 12px;
+              text-align: left;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              white-space: nowrap;
+            }
+            .playlist-actions {
+              display: flex;
+              gap: 8px;
+              margin-bottom: 4px;
+            }
+            .playlist-act-btn {
+              flex: 1;
+              padding: 8px;
+              border: 1px solid rgba(255, 255, 255, 0.08);
+              background: rgba(255, 255, 255, 0.04);
+              color: #fff;
+              border-radius: 8px;
+              font-size: 12px;
+              font-weight: 600;
+              cursor: pointer;
+              transition: all 0.2s ease;
+            }
+            .playlist-act-btn.play {
+              background: #ff2d55;
+              border-color: #ff2d55;
+            }
+            .playlist-act-btn:hover {
+              background: rgba(255, 255, 255, 0.12);
+            }
+            .playlist-act-btn.play:hover {
+              background: #ff3b30;
+            }
+            .playlist-tracks-list {
+              flex: 1;
+              overflow-y: auto;
+              display: flex;
+              flex-direction: column;
+              gap: 4px;
             }
             
             /* Queue elements */
@@ -927,9 +1277,17 @@ final class LocalControlServer {
             <!-- Controller Screen: Music Player -->
             <section id="screen-player" class="hidden">
               <div class="card">
-                <!-- Search Bar -->
+                <!-- Search Bar and Tabs -->
                 <div style="position: relative; margin-bottom: 20px;">
-                  <input id="search-input" type="text" placeholder="Search songs..." oninput="handleSearch(this.value)" style="font-size: 15px; padding: 12px 16px; letter-spacing: 0; text-align: left; margin-bottom: 0; border-radius: 12px;">
+                  <input id="search-input" type="text" placeholder="Search..." oninput="handleSearch(this.value)" style="font-size: 15px; padding: 12px 16px; letter-spacing: 0; text-align: left; margin-bottom: 0; border-radius: 12px;">
+                  
+                  <div class="search-tabs">
+                    <button class="search-tab active" onclick="setSearchFilter('all')">All</button>
+                    <button class="search-tab" onclick="setSearchFilter('songs')">Songs</button>
+                    <button class="search-tab" onclick="setSearchFilter('albums')">Albums</button>
+                    <button class="search-tab" onclick="setSearchFilter('playlists')">Playlists</button>
+                  </div>
+                  
                   <div id="search-results" class="search-results-dropdown hidden"></div>
                 </div>
 
@@ -939,8 +1297,17 @@ final class LocalControlServer {
                     <svg width="64" height="64" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18V5l12-2v13"></path><circle cx="6" cy="18" r="3"></circle><circle cx="18" cy="16" r="3"></circle></svg>
                   </div>
                 </div>
-                <div class="title" id="title">Loading...</div>
-                <div class="artist" id="artist"></div>
+                
+                <!-- Title & Artist & Share -->
+                <div style="display: flex; align-items: center; justify-content: center; position: relative; margin-bottom: 12px;">
+                  <div style="flex: 1; min-width: 0; padding-left: 32px; padding-right: 32px;">
+                    <div class="title" id="title">Loading...</div>
+                    <div class="artist" id="artist" style="margin-bottom: 0;"></div>
+                  </div>
+                  <button id="share-btn" class="share-btn" onclick="shareCurrentSong()" aria-label="Share">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8"></path><polyline points="16 6 12 2 8 6"></polyline><line x1="12" y1="2" x2="12" y2="15"></line></svg>
+                  </button>
+                </div>
                 
                 <div class="controls">
                   <button class="control-btn prev" onclick="send('previous')" aria-label="Previous">
@@ -978,6 +1345,25 @@ final class LocalControlServer {
                 </div>
               </div>
             </section>
+
+            <!-- Album / Playlist Track Detail Panel -->
+            <section id="playlist-details" class="playlist-details-pane hidden">
+              <div class="playlist-details-header">
+                <button class="back-btn" onclick="closePlaylistDetails()">
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="19" y1="12" x2="5" y2="12"></line><polyline points="12 19 5 12 12 5"></polyline></svg>
+                  <span>Back</span>
+                </button>
+                <div class="playlist-title" id="p-title">Playlist Details</div>
+                <div class="playlist-actions">
+                  <button class="playlist-act-btn play" onclick="playlistAction('play')">Play</button>
+                  <button class="playlist-act-btn" onclick="playlistAction('next')">Play Next</button>
+                  <button class="playlist-act-btn" onclick="playlistAction('queue')">Add Queue</button>
+                </div>
+              </div>
+              <div id="playlist-tracks-list" class="playlist-tracks-list">
+                <!-- Tracks dynamically loaded -->
+              </div>
+            </section>
           </main>
 
           <script>
@@ -994,6 +1380,10 @@ final class LocalControlServer {
             let checkInterval = null;
             let refreshInterval = null;
             let searchTimeout = null;
+            let currentSearchFilter = 'all';
+            let currentPlaylistId = '';
+            let currentPlaylistTitle = '';
+            let currentVideoId = '';
 
             function showScreen(id) {
               document.getElementById('screen-auth').classList.add('hidden');
@@ -1138,6 +1528,123 @@ final class LocalControlServer {
               refresh();
             }
 
+            async function playNext(videoId, title, artist, artworkURL) {
+              const body = 'videoId=' + encodeURIComponent(videoId) +
+                           '&title=' + encodeURIComponent(title) +
+                           '&artist=' + encodeURIComponent(artist) +
+                           '&artworkURL=' + encodeURIComponent(artworkURL);
+              await fetch(withToken('/play_next'), {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: body
+              });
+              refresh();
+            }
+
+            async function addToQueue(videoId, title, artist, artworkURL) {
+              const body = 'videoId=' + encodeURIComponent(videoId) +
+                           '&title=' + encodeURIComponent(title) +
+                           '&artist=' + encodeURIComponent(artist) +
+                           '&artworkURL=' + encodeURIComponent(artworkURL);
+              await fetch(withToken('/add_to_queue'), {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: body
+              });
+              refresh();
+            }
+
+            function escapeJS(str) {
+              if (!str) return '';
+              return str.replace(/\\/g, '\\\\').replace(/'/g, "\\'").replace(/"/g, '\\"');
+            }
+
+            function shareCurrentSong() {
+              if (currentVideoId) {
+                const shareUrl = "https://music.youtube.com/watch?v=" + currentVideoId;
+                window.open(shareUrl, '_blank');
+              }
+            }
+
+            function setSearchFilter(filter) {
+              currentSearchFilter = filter;
+              document.querySelectorAll('.search-tab').forEach(tab => {
+                tab.classList.remove('active');
+              });
+              event.target.classList.add('active');
+              
+              const query = document.getElementById('search-input').value;
+              if (query && query.trim() !== '') {
+                performSearch(query);
+              }
+            }
+
+            async function openPlaylistDetails(id, title) {
+              currentPlaylistId = id;
+              currentPlaylistTitle = title;
+              
+              const pane = document.getElementById('playlist-details');
+              const list = document.getElementById('playlist-tracks-list');
+              document.getElementById('p-title').innerText = title;
+              list.innerHTML = '<div style="color:#8e8e93; font-size:13px; text-align:center; padding:40px 0;">Loading tracks...</div>';
+              pane.classList.remove('hidden');
+              
+              try {
+                const res = await fetch(withToken('/playlist_tracks?id=' + encodeURIComponent(id)));
+                if (res.status === 401) return;
+                const data = await res.json();
+                if (data.ok && data.tracks) {
+                  list.innerHTML = '';
+                  data.tracks.forEach(song => {
+                    const item = document.createElement('div');
+                    item.className = 'search-result-item';
+                    const artworkUrl = song.artworkURL || 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="%23888" stroke-width="1.5"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></svg>';
+                    item.innerHTML = `
+                      <img src="${artworkUrl}" alt="Artwork" onclick="playTrack('${song.videoId}')" style="cursor:pointer;">
+                      <div class="search-result-info" onclick="playTrack('${song.videoId}')" style="cursor:pointer;">
+                        <div class="search-result-title">${song.title}</div>
+                        <div class="search-result-artist">${song.artist}</div>
+                      </div>
+                      <div class="result-actions">
+                        <button class="result-act-btn" onclick="playNext('${song.videoId}', '${escapeJS(song.title)}', '${escapeJS(song.artist)}', '${song.artworkURL || ''}')" title="Play Next">
+                          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="5 4 15 12 5 20"></polyline><line x1="19" y1="5" x2="19" y2="19"></line></svg>
+                        </button>
+                        <button class="result-act-btn" onclick="addToQueue('${song.videoId}', '${escapeJS(song.title)}', '${escapeJS(song.artist)}', '${song.artworkURL || ''}')" title="Add to Queue">
+                          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>
+                        </button>
+                      </div>
+                    `;
+                    list.appendChild(item);
+                  });
+                } else {
+                  list.innerHTML = '<div style="color:#ff453a; font-size:13px; text-align:center; padding:40px 0;">Failed to load tracks.</div>';
+                }
+              } catch (e) {
+                list.innerHTML = '<div style="color:#ff453a; font-size:13px; text-align:center; padding:40px 0;">Error loading tracks.</div>';
+              }
+            }
+
+            function closePlaylistDetails() {
+              document.getElementById('playlist-details').classList.add('hidden');
+            }
+
+            async function playlistAction(action) {
+              if (!currentPlaylistId) return;
+              
+              let endpoint = '';
+              if (action === 'play') {
+                endpoint = '/play_playlist?playlistId=' + encodeURIComponent(currentPlaylistId);
+              } else if (action === 'next') {
+                endpoint = '/play_next?playlistId=' + encodeURIComponent(currentPlaylistId);
+              } else if (action === 'queue') {
+                endpoint = '/add_to_queue?playlistId=' + encodeURIComponent(currentPlaylistId);
+              }
+              
+              await fetch(withToken(endpoint), { method: 'POST' });
+              closePlaylistDetails();
+              refresh();
+            }
+
             function handleSearch(query) {
               if (searchTimeout) clearTimeout(searchTimeout);
               if (!query || query.trim() === '') {
@@ -1149,7 +1656,7 @@ final class LocalControlServer {
 
             async function performSearch(query) {
               try {
-                const res = await fetch(withToken('/search?q=' + encodeURIComponent(query)));
+                const res = await fetch(withToken('/search?q=' + encodeURIComponent(query) + '&filter=' + currentSearchFilter));
                 if (res.status === 401) return;
                 const data = await res.json();
                 const resultsDiv = document.getElementById('search-results');
@@ -1159,18 +1666,40 @@ final class LocalControlServer {
                     const item = document.createElement('div');
                     item.className = 'search-result-item';
                     const artworkUrl = song.artworkURL || 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="%23888" stroke-width="1.5"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></svg>';
-                    item.innerHTML = `
-                      <img src="${artworkUrl}" alt="Artwork">
-                      <div class="search-result-info">
-                        <div class="search-result-title">${song.title}</div>
-                        <div class="search-result-artist">${song.artist}</div>
-                      </div>
-                    `;
-                    item.onclick = () => {
-                      playTrack(song.videoId);
-                      resultsDiv.classList.add('hidden');
-                      document.getElementById('search-input').value = '';
-                    };
+                    
+                    const isSong = song.type === 'song' || data.type === 'songs';
+                    
+                    if (isSong) {
+                      item.innerHTML = `
+                        <img src="${artworkUrl}" alt="Artwork" onclick="playTrack('${song.videoId}')" style="cursor:pointer;">
+                        <div class="search-result-info" onclick="playTrack('${song.videoId}')" style="cursor:pointer;">
+                          <div class="search-result-title">${song.title}</div>
+                          <div class="search-result-artist">${song.artist}</div>
+                        </div>
+                        <div class="result-actions">
+                          <button class="result-act-btn" onclick="playNext('${song.videoId}', '${escapeJS(song.title)}', '${escapeJS(song.artist)}', '${song.artworkURL || ''}')" title="Play Next">
+                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="5 4 15 12 5 20"></polyline><line x1="19" y1="5" x2="19" y2="19"></line></svg>
+                          </button>
+                          <button class="result-act-btn" onclick="addToQueue('${song.videoId}', '${escapeJS(song.title)}', '${escapeJS(song.artist)}', '${song.artworkURL || ''}')" title="Add to Queue">
+                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"></line><line x1="5" y1="12" x2="19" y2="12"></line></svg>
+                          </button>
+                        </div>
+                      `;
+                    } else {
+                      const typeLabel = song.type === 'album' ? 'Album' : 'Playlist';
+                      item.innerHTML = `
+                        <img src="${artworkUrl}" alt="Artwork" onclick="openPlaylistDetails('${song.id}', '${escapeJS(song.title)}')" style="cursor:pointer;">
+                        <div class="search-result-info" onclick="openPlaylistDetails('${song.id}', '${escapeJS(song.title)}')" style="cursor:pointer;">
+                          <div class="search-result-title">${song.title}</div>
+                          <div class="search-result-artist">${song.artist || typeLabel}</div>
+                        </div>
+                        <div class="result-actions">
+                          <button class="result-act-btn" onclick="openPlaylistDetails('${song.id}', '${escapeJS(song.title)}')" title="View Tracks">
+                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="8" y1="6" x2="21" y2="6"></line><line x1="8" y1="12" x2="21" y2="12"></line><line x1="8" y1="18" x2="21" y2="18"></line><line x1="3" y1="6" x2="3.01" y2="6"></line><line x1="3" y1="12" x2="3.01" y2="12"></line><line x1="3" y1="18" x2="3.01" y2="18"></line></svg>
+                          </button>
+                        </div>
+                      `;
+                    }
                     resultsDiv.appendChild(item);
                   });
                   resultsDiv.classList.remove('hidden');
@@ -1185,7 +1714,7 @@ final class LocalControlServer {
             document.addEventListener('click', (e) => {
               const searchResults = document.getElementById('search-results');
               const searchInput = document.getElementById('search-input');
-              if (searchResults && e.target !== searchResults && e.target !== searchInput) {
+              if (searchResults && e.target !== searchResults && e.target !== searchInput && !searchResults.contains(e.target)) {
                 searchResults.classList.add('hidden');
               }
             });
@@ -1203,6 +1732,12 @@ final class LocalControlServer {
                 const data = await res.json();
                 document.getElementById('title').textContent = data.track?.title || 'Nothing playing';
                 document.getElementById('artist').textContent = data.track?.artist || '';
+                
+                if (data.track) {
+                  currentVideoId = data.track.videoId || '';
+                } else {
+                  currentVideoId = '';
+                }
                 
                 if (data.track && data.track.artworkURL) {
                   document.getElementById('artwork-wrapper').innerHTML = '<img class="artwork-image" src="' + data.track.artworkURL + '" alt="Artwork">';

--- a/Sources/Kaset/Services/LocalControlServer.swift
+++ b/Sources/Kaset/Services/LocalControlServer.swift
@@ -1,0 +1,625 @@
+import Foundation
+import Darwin
+@preconcurrency import Network
+
+/// HTTP API for local automation and remote-control companions.
+@MainActor
+final class LocalControlServer {
+    static let shared = LocalControlServer()
+
+    private let logger = DiagnosticsLogger.network
+    private var listener: NWListener?
+    private weak var playerService: PlayerService?
+    private var activePort: UInt16?
+    private var activeAllowsLAN = false
+
+    private init() {}
+
+    func configure(playerService: PlayerService) {
+        self.playerService = playerService
+        self.applySettings()
+    }
+
+    func applySettings() {
+        guard let playerService else { return }
+        let settings = SettingsManager.shared
+
+        guard settings.localControlServerEnabled else {
+            self.stop()
+            return
+        }
+
+        let port = UInt16(min(max(settings.localControlServerPort, 1024), 65_535))
+        let allowsLAN = settings.localControlServerAllowsLAN
+        if self.listener != nil, self.activePort == port, self.activeAllowsLAN == allowsLAN {
+            return
+        }
+
+        self.stop()
+        self.start(port: port, allowsLAN: allowsLAN, playerService: playerService)
+    }
+
+    func stop() {
+        self.listener?.cancel()
+        self.listener = nil
+        self.activePort = nil
+        self.activeAllowsLAN = false
+    }
+
+    private func start(port: UInt16, allowsLAN: Bool, playerService: PlayerService) {
+        let hostAddress = allowsLAN ? "0.0.0.0" : "127.0.0.1"
+
+        do {
+            let parameters = NWParameters.tcp
+            parameters.allowLocalEndpointReuse = true
+
+            if !allowsLAN {
+                if let bindAddress = IPv4Address("127.0.0.1") {
+                    parameters.requiredLocalEndpoint = .hostPort(
+                        host: .ipv4(bindAddress),
+                        port: NWEndpoint.Port(rawValue: port) ?? .any
+                    )
+                }
+            }
+
+            let listener = try NWListener(
+                using: parameters,
+                on: NWEndpoint.Port(rawValue: port) ?? .any
+            )
+            listener.service = nil
+            listener.newConnectionHandler = { [weak self, weak playerService] connection in
+                Task { @MainActor in
+                    guard let self, let playerService else {
+                        connection.cancel()
+                        return
+                    }
+                    self.handleConnection(connection, playerService: playerService)
+                }
+            }
+            listener.stateUpdateHandler = { [weak self] state in
+                Task { @MainActor in
+                    guard let self else { return }
+                    switch state {
+                    case .ready:
+                        self.logger.info("Local control server listening on \(hostAddress):\(port)")
+                    case let .failed(error):
+                        self.logger.error("Local control server failed: \(error.localizedDescription)")
+                        self.stop()
+                    case .cancelled:
+                        self.logger.info("Local control server stopped")
+                    default:
+                        break
+                    }
+                }
+            }
+
+            self.listener = listener
+            self.activePort = port
+            self.activeAllowsLAN = allowsLAN
+            listener.start(queue: .main)
+        } catch {
+            self.logger.error("Local control server could not start: \(error.localizedDescription)")
+        }
+    }
+
+    private func handleConnection(_ connection: NWConnection, playerService: PlayerService) {
+        guard SettingsManager.shared.localControlServerAllowsLAN || self.isLoopback(connection.endpoint) else {
+            connection.cancel()
+            return
+        }
+
+        connection.start(queue: .main)
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 16_384) { [weak self, weak playerService] data, _, _, _ in
+            Task { @MainActor in
+                guard let self, let playerService else {
+                    connection.cancel()
+                    return
+                }
+
+                let response: HTTPResponse
+                if let data, let request = HTTPRequest(data: data) {
+                    response = await self.response(for: request, playerService: playerService)
+                } else {
+                    response = .badRequest(message: "Invalid HTTP request")
+                }
+
+                connection.send(content: response.serialized(), completion: .contentProcessed { _ in
+                    connection.cancel()
+                })
+            }
+        }
+    }
+
+    private func isLoopback(_ endpoint: NWEndpoint) -> Bool {
+        guard case let .hostPort(host, _) = endpoint else { return false }
+        switch host {
+        case .ipv4(let address):
+            guard let loopbackAddress = IPv4Address("127.0.0.1") else { return false }
+            return address == loopbackAddress
+        case .ipv6(let address):
+            guard let loopbackAddress = IPv6Address("::1") else { return false }
+            return address == loopbackAddress
+        case .name(let name, _):
+            return name == "localhost"
+        default:
+            return false
+        }
+    }
+
+    private func response(for request: HTTPRequest, playerService: PlayerService) async -> HTTPResponse {
+        if request.method == "OPTIONS" {
+            return .empty()
+        }
+
+        let routed = Self.route(request)
+        if routed != .check, routed != .requestApproval {
+            if SettingsManager.shared.localControlServerAllowsLAN, !Self.isAuthorized(request) {
+                return .unauthorized(message: "Missing or invalid token")
+            }
+        }
+
+        switch routed {
+        case .webInterface:
+            return .html(Self.remoteControlHTML(token: request.queryItems["token"] ?? ""))
+        case .check:
+            let deviceId = request.queryItems["device_id"] ?? ""
+            if RemoteDeviceManager.shared.isDeviceApproved(deviceId: deviceId) {
+                RemoteDeviceManager.shared.updateDeviceActivity(deviceId: deviceId)
+                let token = RemoteDeviceManager.shared.deviceToken(deviceId: deviceId)
+                return .json(["status": "approved", "token": token])
+            } else if RemoteDeviceManager.shared.pendingRequests.contains(where: { $0.deviceId == deviceId }) {
+                return .json(["status": "pending"])
+            } else {
+                return .json(["status": "unauthorized"])
+            }
+        case .requestApproval:
+            let deviceId = request.formItems["device_id"] ?? request.queryItems["device_id"] ?? ""
+            let deviceName = request.formItems["device_name"] ?? request.queryItems["device_name"] ?? "Remote Web Browser"
+            let pin = request.formItems["pin"] ?? request.queryItems["pin"] ?? ""
+            
+            if RemoteDeviceManager.shared.requestApproval(deviceId: deviceId, deviceName: deviceName, pin: pin) {
+                return .json(["status": "pending"])
+            } else {
+                return .json(["status": "invalid_pin"])
+            }
+        case .status:
+            return .json(self.statusPayload(playerService: playerService))
+        case .play:
+            await playerService.resume()
+            return .json(["ok": true, "action": "play"])
+        case .pause:
+            await playerService.pause()
+            return .json(["ok": true, "action": "pause"])
+        case .playPause:
+            await playerService.playPause()
+            return .json(["ok": true, "action": "play-pause"])
+        case .next:
+            await playerService.next()
+            return .json(["ok": true, "action": "next"])
+        case .previous:
+            await playerService.previous()
+            return .json(["ok": true, "action": "previous"])
+        case .volume(let value):
+            await playerService.setVolume(value)
+            return .json(["ok": true, "action": "volume", "volume": playerService.volume])
+        case .notFound:
+            return .notFound(message: "Unknown endpoint")
+        case .methodNotAllowed:
+            return .methodNotAllowed(message: "Unsupported method")
+        case .badRequest(let message):
+            return .badRequest(message: message)
+        }
+    }
+
+    private func statusPayload(playerService: PlayerService) -> [String: Any] {
+        var payload: [String: Any] = [
+            "state": playerService.state.apiValue,
+            "isPlaying": playerService.isPlaying,
+            "progress": playerService.progress,
+            "duration": playerService.duration,
+            "volume": playerService.volume,
+            "isMuted": playerService.isMuted,
+            "shuffleEnabled": playerService.shuffleEnabled,
+            "queueIndex": playerService.currentIndex,
+            "queueCount": playerService.queue.count,
+        ]
+
+        if let track = playerService.currentTrack {
+            payload["track"] = Self.trackPayload(track)
+        } else {
+            payload["track"] = NSNull()
+        }
+
+        return payload
+    }
+
+    static func trackPayload(_ track: Song) -> [String: Any] {
+        var payload: [String: Any] = [
+            "id": track.id,
+            "videoId": track.videoId,
+            "title": track.title,
+            "artists": track.artists.map(\.name),
+            "artist": track.artistsDisplay,
+        ]
+
+        if let album = track.album?.title {
+            payload["album"] = album
+        }
+        if let artworkURL = (track.thumbnailURL ?? track.fallbackThumbnailURL)?.absoluteString {
+            payload["artworkURL"] = artworkURL
+        }
+        if let duration = track.duration {
+            payload["duration"] = duration
+        }
+        if let isExplicit = track.isExplicit {
+            payload["isExplicit"] = isExplicit
+        }
+
+        return payload
+    }
+
+    static func route(_ request: HTTPRequest) -> Route {
+        switch (request.method, request.path) {
+        case ("GET", "/"), ("GET", "/remote"):
+            .webInterface
+        case ("GET", "/check"):
+            .check
+        case ("POST", "/request_approval"):
+            .requestApproval
+        case ("GET", "/status"):
+            .status
+        case ("POST", "/play"):
+            .play
+        case ("POST", "/pause"):
+            .pause
+        case ("POST", "/play-pause"), ("POST", "/toggle"):
+            .playPause
+        case ("POST", "/next"):
+            .next
+        case ("POST", "/previous"):
+            .previous
+        case ("POST", "/volume"):
+            Self.volumeRoute(request)
+        case ("GET", _), ("POST", _):
+            .notFound
+        default:
+            .methodNotAllowed
+        }
+    }
+
+    private static func volumeRoute(_ request: HTTPRequest) -> Route {
+        let queryValue = request.queryItems["value"] ?? request.queryItems["level"]
+        let bodyValue = request.formItems["value"] ?? request.formItems["level"]
+        guard let rawValue = queryValue ?? bodyValue, let value = Double(rawValue) else {
+            return .badRequest("Missing numeric volume value")
+        }
+        return .volume(max(0, min(1, value)))
+    }
+
+    enum Route: Equatable {
+        case webInterface
+        case check
+        case requestApproval
+        case status
+        case play
+        case pause
+        case playPause
+        case next
+        case previous
+        case volume(Double)
+        case notFound
+        case methodNotAllowed
+        case badRequest(String)
+    }
+
+    struct HTTPRequest {
+        let method: String
+        let path: String
+        let headers: [String: String]
+        let queryItems: [String: String]
+        let formItems: [String: String]
+
+        init?(data: Data) {
+            guard let text = String(data: data, encoding: .utf8) else { return nil }
+            let parts = text.components(separatedBy: "\r\n\r\n")
+            let head = parts.first ?? ""
+            let body = parts.dropFirst().joined(separator: "\r\n\r\n")
+            let headLines = head.components(separatedBy: "\r\n")
+            guard let requestLine = headLines.first else { return nil }
+            let tokens = requestLine.split(separator: " ")
+            guard tokens.count >= 2 else { return nil }
+
+            self.method = tokens[0].uppercased()
+            let target = String(tokens[1])
+            let splitTarget = target.split(separator: "?", maxSplits: 1, omittingEmptySubsequences: false)
+            self.path = splitTarget.first.map(String.init) ?? "/"
+            self.headers = Self.parseHeaders(Array(headLines.dropFirst()))
+            self.queryItems = splitTarget.count > 1 ? Self.parseFormEncoded(String(splitTarget[1])) : [:]
+            self.formItems = Self.parseFormEncoded(body)
+        }
+
+        init(
+            method: String,
+            path: String,
+            headers: [String: String] = [:],
+            queryItems: [String: String] = [:],
+            formItems: [String: String] = [:]
+        ) {
+            self.method = method.uppercased()
+            self.path = path
+            self.headers = Dictionary(uniqueKeysWithValues: headers.map { ($0.key.lowercased(), $0.value) })
+            self.queryItems = queryItems
+            self.formItems = formItems
+        }
+
+        private static func parseHeaders(_ lines: [String]) -> [String: String] {
+            var headers: [String: String] = [:]
+            for line in lines {
+                let parts = line.split(separator: ":", maxSplits: 1, omittingEmptySubsequences: false)
+                guard parts.count == 2 else { continue }
+                let key = parts[0].trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+                let value = parts[1].trimmingCharacters(in: .whitespacesAndNewlines)
+                if !key.isEmpty {
+                    headers[key] = value
+                }
+            }
+            return headers
+        }
+
+        private static func parseFormEncoded(_ value: String) -> [String: String] {
+            var result: [String: String] = [:]
+            for pair in value.split(separator: "&") {
+                let parts = pair.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+                guard let firstPart = parts.first,
+                      let key = String(firstPart).removingPercentEncoding,
+                      !key.isEmpty
+                else { continue }
+                let rawValue = parts.count > 1 ? String(parts[1]) : ""
+                result[key] = rawValue.replacingOccurrences(of: "+", with: " ").removingPercentEncoding ?? rawValue
+            }
+            return result
+        }
+    }
+
+    struct HTTPResponse {
+        let statusCode: Int
+        let reason: String
+        let body: Data
+        let contentType: String
+
+        static func json(_ payload: [String: Any], statusCode: Int = 200, reason: String = "OK") -> HTTPResponse {
+            let body = (try? JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])) ?? Data()
+            return HTTPResponse(
+                statusCode: statusCode,
+                reason: reason,
+                body: body,
+                contentType: "application/json; charset=utf-8"
+            )
+        }
+
+        static func html(_ html: String) -> HTTPResponse {
+            HTTPResponse(
+                statusCode: 200,
+                reason: "OK",
+                body: Data(html.utf8),
+                contentType: "text/html; charset=utf-8"
+            )
+        }
+
+        static func empty() -> HTTPResponse {
+            HTTPResponse(statusCode: 204, reason: "No Content", body: Data(), contentType: "text/plain; charset=utf-8")
+        }
+
+        static func badRequest(message: String) -> HTTPResponse {
+            .json(["ok": false, "error": message], statusCode: 400, reason: "Bad Request")
+        }
+
+        static func unauthorized(message: String) -> HTTPResponse {
+            .json(["ok": false, "error": message], statusCode: 401, reason: "Unauthorized")
+        }
+
+        static func notFound(message: String) -> HTTPResponse {
+            .json(["ok": false, "error": message], statusCode: 404, reason: "Not Found")
+        }
+
+        static func methodNotAllowed(message: String) -> HTTPResponse {
+            .json(["ok": false, "error": message], statusCode: 405, reason: "Method Not Allowed")
+        }
+
+        func serialized() -> Data {
+            var data = Data()
+            let header = [
+                "HTTP/1.1 \(self.statusCode) \(self.reason)",
+                "Content-Type: \(self.contentType)",
+                "Content-Length: \(self.body.count)",
+                "Cache-Control: no-store",
+                "Connection: close",
+                "Access-Control-Allow-Origin: *",
+                "Access-Control-Allow-Methods: GET, POST, OPTIONS",
+                "Access-Control-Allow-Headers: Authorization, Content-Type",
+                "",
+                "",
+            ].joined(separator: "\r\n")
+            data.append(Data(header.utf8))
+            data.append(self.body)
+            return data
+        }
+    }
+
+    static func isAuthorized(_ request: HTTPRequest) -> Bool {
+        let globalToken = SettingsManager.shared.localControlServerToken
+        let requestToken: String
+        if let token = request.queryItems["token"] ?? request.formItems["token"] {
+            requestToken = token
+        } else if let auth = request.headers["authorization"], auth.hasPrefix("Bearer ") {
+            requestToken = String(auth.dropFirst(7))
+        } else {
+            return false
+        }
+
+        if !globalToken.isEmpty, requestToken == globalToken {
+            return true
+        }
+
+        return RemoteDeviceManager.shared.approvedDevices.contains(where: { $0.token == requestToken })
+    }
+
+    static func remoteControlHTML(token: String) -> String {
+        """
+        <!doctype html>
+        <html lang="en">
+        <head>
+          <meta charset="utf-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1">
+          <title>Kaset Remote</title>
+          <style>
+            body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, sans-serif; background: #111; color: #f6f6f6; }
+            main { max-width: 520px; margin: 0 auto; padding: 24px; }
+            h1 { font-size: 28px; margin: 0 0 16px; }
+            .track { min-height: 120px; padding: 18px; border: 1px solid #333; border-radius: 12px; background: #1c1c1f; }
+            .title { font-size: 22px; font-weight: 700; margin-bottom: 6px; }
+            .artist { color: #bbb; }
+            .controls { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-top: 18px; }
+            button { min-height: 58px; border: 0; border-radius: 12px; background: #f6f6f6; color: #111; font-size: 18px; font-weight: 700; }
+            button:active { transform: scale(0.98); }
+            input { width: 100%; margin-top: 22px; }
+            .status { color: #999; margin-top: 14px; font-size: 14px; }
+          </style>
+        </head>
+        <body>
+          <main>
+            <h1>Kaset Remote</h1>
+            <section class="track">
+              <div class="title" id="title">Loading...</div>
+              <div class="artist" id="artist"></div>
+              <div class="status" id="status"></div>
+            </section>
+            <section class="controls">
+              <button onclick="send('previous')">Previous</button>
+              <button onclick="send('play-pause')">Play/Pause</button>
+              <button onclick="send('next')">Next</button>
+            </section>
+            <input id="volume" type="range" min="0" max="1" step="0.01" onchange="setVolume(this.value)">
+            <div class="status">Keep this page open on your phone or another device on the same Wi-Fi.</div>
+          </main>
+          <script>
+            const token = new URLSearchParams(location.search).get('token') || '\(Self.escapeJavaScriptString(token))';
+            const withToken = path => path + (path.includes('?') ? '&' : '?') + 'token=' + encodeURIComponent(token);
+            async function send(action) {
+              await fetch(withToken('/' + action), { method: 'POST' });
+              refresh();
+            }
+            async function setVolume(value) {
+              await fetch(withToken('/volume?value=' + encodeURIComponent(value)), { method: 'POST' });
+              refresh();
+            }
+            async function refresh() {
+              try {
+                const res = await fetch(withToken('/status'));
+                const data = await res.json();
+                document.getElementById('title').textContent = data.track?.title || 'Nothing playing';
+                document.getElementById('artist').textContent = data.track?.artist || '';
+                document.getElementById('status').textContent = data.state + ' • volume ' + Math.round((data.volume || 0) * 100) + '%';
+                document.getElementById('volume').value = data.volume || 0;
+              } catch (error) {
+                document.getElementById('title').textContent = 'Cannot reach Kaset';
+                document.getElementById('status').textContent = String(error);
+              }
+            }
+            refresh();
+            setInterval(refresh, 2000);
+          </script>
+        </body>
+        </html>
+        """
+    }
+
+    static func getLocalIPAddresses() -> [String] {
+        var addresses: [String] = []
+        var ifaddr: UnsafeMutablePointer<ifaddrs>?
+        guard getifaddrs(&ifaddr) == 0 else { return [] }
+        defer { freeifaddrs(ifaddr) }
+
+        var ptr = ifaddr
+        while let interface = ptr {
+            defer { ptr = interface.pointee.ifa_next }
+            let flags = Int32(interface.pointee.ifa_flags)
+
+            guard (flags & IFF_UP) != 0, (flags & IFF_LOOPBACK) == 0 else {
+                continue
+            }
+
+            guard let addrPointer = interface.pointee.ifa_addr else {
+                continue
+            }
+
+            let addr = addrPointer.pointee
+            if Int32(addr.sa_family) == AF_INET {
+                var hostname = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+                if getnameinfo(
+                    addrPointer,
+                    socklen_t(addr.sa_len),
+                    &hostname,
+                    socklen_t(hostname.count),
+                    nil,
+                    0,
+                    NI_NUMERICHOST
+                ) == 0 {
+                    hostname.withUnsafeBufferPointer { buffer in
+                        if let baseAddress = buffer.baseAddress {
+                            let ip = String(cString: baseAddress)
+                            if !ip.isEmpty {
+                                addresses.append(ip)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return addresses
+    }
+
+    static func localControlURLs() -> [URL] {
+        let settings = SettingsManager.shared
+        let port = settings.localControlServerPort
+        let token = settings.localControlServerToken
+
+        var urls: [URL] = []
+        if let localhostURL = URL(string: "http://127.0.0.1:\(port)/?token=\(token)") {
+            urls.append(localhostURL)
+        }
+
+        if settings.localControlServerAllowsLAN {
+            let ips = Self.getLocalIPAddresses()
+            for ip in ips {
+                if let url = URL(string: "http://\(ip):\(port)/?token=\(token)") {
+                    urls.append(url)
+                }
+            }
+        }
+        return urls
+    }
+
+    private static func escapeJavaScriptString(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "'", with: "\\'")
+            .replacingOccurrences(of: "\n", with: "\\n")
+            .replacingOccurrences(of: "\r", with: "\\r")
+    }
+}
+
+
+private extension PlayerService.PlaybackState {
+    var apiValue: String {
+        switch self {
+        case .idle: "idle"
+        case .loading: "loading"
+        case .playing: "playing"
+        case .paused: "paused"
+        case .buffering: "buffering"
+        case .ended: "ended"
+        case .error: "error"
+        }
+    }
+}

--- a/Sources/Kaset/Services/LocalControlServer.swift
+++ b/Sources/Kaset/Services/LocalControlServer.swift
@@ -609,7 +609,7 @@ extension LocalControlServer {
         case ("POST", "/volume"):
             self.volumeRoute(request)
         case ("POST", "/seek"):
-            Self.seekRoute(request)
+            self.seekRoute(request)
         case ("POST", "/toggle_shuffle"):
             .toggleShuffle
         case ("POST", "/cycle_repeat"):
@@ -617,7 +617,7 @@ extension LocalControlServer {
         case ("POST", "/toggle_mute"):
             .toggleMute
         case ("POST", "/sleep_timer"):
-            Self.sleepTimerRoute(request)
+            self.sleepTimerRoute(request)
         case ("GET", "/search"):
             .search
         case ("POST", "/play_index"):
@@ -656,7 +656,7 @@ extension LocalControlServer {
         let cancelQuery = request.queryItems["cancel"] ?? request.formItems["cancel"]
         let isCancel = cancelQuery?.lowercased() == "true"
         let durationQuery = request.queryItems["duration"] ?? request.queryItems["time"] ??
-                             request.formItems["duration"] ?? request.formItems["time"]
+            request.formItems["duration"] ?? request.formItems["time"]
         let duration = durationQuery.flatMap { Double($0) }
         return .sleepTimer(duration: duration, cancel: isCancel)
     }
@@ -1793,6 +1793,17 @@ extension LocalControlServer {
           </main>
 
           <script>
+            function getHighResArtwork(url) {
+              if (!url) return '';
+              if (url.includes('googleusercontent.com') || url.includes('ggpht.com')) {
+                return url.replace(/=w\d+-h\d+.*$/, '=w544-h544-l90-rj').replace(/=s\d+.*$/, '=w544-h544-l90-rj');
+              }
+              if (url.includes('i.ytimg.com/vi/') && url.includes('hqdefault.jpg')) {
+                return url.replace('hqdefault.jpg', 'maxresdefault.jpg');
+              }
+              return url;
+            }
+
             let deviceId = localStorage.getItem('kaset_device_id');
             if (!deviceId) {
               deviceId = 'device_' + Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
@@ -2074,9 +2085,10 @@ extension LocalControlServer {
                   data.tracks.forEach(song => {
                     const item = document.createElement('div');
                     item.className = 'search-result-item';
-                    const artworkUrl = song.artworkURL || 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="%23888" stroke-width="1.5"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></svg>';
+                    const origArtworkUrl = song.artworkURL || '';
+                    const artworkUrl = getHighResArtwork(origArtworkUrl) || 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="%23888" stroke-width="1.5"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></svg>';
                     item.innerHTML = `
-                      <img src="${artworkUrl}" alt="Artwork" onclick="playTrack('${song.videoId}')" style="cursor:pointer;">
+                      <img src="${artworkUrl}" onerror="this.onerror=null; ${origArtworkUrl ? `this.src='${origArtworkUrl}';` : ''}" alt="Artwork" onclick="playTrack('${song.videoId}')" style="cursor:pointer;">
                       <div class="search-result-info" onclick="playTrack('${song.videoId}')" style="cursor:pointer;">
                         <div class="search-result-title">${song.title}</div>
                         <div class="search-result-artist">${song.artist}</div>
@@ -2175,13 +2187,14 @@ extension LocalControlServer {
                   data.results.forEach(song => {
                     const item = document.createElement('div');
                     item.className = 'search-result-item';
-                    const artworkUrl = song.artworkURL || 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="%23888" stroke-width="1.5"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></svg>';
+                    const origArtworkUrl = song.artworkURL || '';
+                    const artworkUrl = getHighResArtwork(origArtworkUrl) || 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="%23888" stroke-width="1.5"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></svg>';
                     
                     const isSong = song.type === 'song' || data.type === 'songs';
                     
                     if (isSong) {
                       item.innerHTML = `
-                        <img src="${artworkUrl}" alt="Artwork" onclick="playTrack('${song.videoId}')" style="cursor:pointer;">
+                        <img src="${artworkUrl}" onerror="this.onerror=null; ${origArtworkUrl ? `this.src='${origArtworkUrl}';` : ''}" alt="Artwork" onclick="playTrack('${song.videoId}')" style="cursor:pointer;">
                         <div class="search-result-info" onclick="playTrack('${song.videoId}')" style="cursor:pointer;">
                           <div class="search-result-title">${song.title}</div>
                           <div class="search-result-artist">${song.artist}</div>
@@ -2198,7 +2211,7 @@ extension LocalControlServer {
                     } else {
                       const typeLabel = song.type === 'album' ? 'Album' : 'Playlist';
                       item.innerHTML = `
-                        <img src="${artworkUrl}" alt="Artwork" onclick="openPlaylistDetails('${song.id}', '${escapeJS(song.title)}')" style="cursor:pointer;">
+                        <img src="${artworkUrl}" onerror="this.onerror=null; ${origArtworkUrl ? `this.src='${origArtworkUrl}';` : ''}" alt="Artwork" onclick="openPlaylistDetails('${song.id}', '${escapeJS(song.title)}')" style="cursor:pointer;">
                         <div class="search-result-info" onclick="openPlaylistDetails('${song.id}', '${escapeJS(song.title)}')" style="cursor:pointer;">
                           <div class="search-result-title">${song.title}</div>
                           <div class="search-result-artist">${song.artist || typeLabel}</div>
@@ -2417,7 +2430,8 @@ extension LocalControlServer {
                 }
 
                 if (data.track && data.track.artworkURL) {
-                  document.getElementById('artwork-wrapper').innerHTML = '<img class="artwork-image" src="' + data.track.artworkURL + '" alt="Artwork">';
+                  const highResUrl = getHighResArtwork(data.track.artworkURL);
+                  document.getElementById('artwork-wrapper').innerHTML = '<img class="artwork-image" src="' + highResUrl + '" onerror="this.onerror=null; this.src=\'' + data.track.artworkURL + '\';" alt="Artwork">';
                 } else {
                   document.getElementById('artwork-wrapper').innerHTML = '<svg width="64" height="64" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18V5l12-2v13"></path><circle cx="6" cy="18" r="3"></circle><circle cx="18" cy="16" r="3"></circle></svg>';
                 }
@@ -2508,9 +2522,10 @@ extension LocalControlServer {
                     const isActive = idx === data.queueIndex;
                     const item = document.createElement('div');
                     item.className = 'queue-item' + (isActive ? ' active' : '');
-                    const artworkUrl = song.artworkURL || 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="%23888" stroke-width="1.5"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></svg>';
+                    const origArtworkUrl = song.artworkURL || '';
+                    const artworkUrl = getHighResArtwork(origArtworkUrl) || 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="%23888" stroke-width="1.5"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></svg>';
                     item.innerHTML = `
-                      <img src="${artworkUrl}" alt="Artwork">
+                      <img src="${artworkUrl}" onerror="this.onerror=null; ${origArtworkUrl ? `this.src='${origArtworkUrl}';` : ''}" alt="Artwork">
                       <div class="queue-item-info">
                         <div class="queue-item-title${isActive ? ' active' : ''}">${song.title}</div>
                         <div class="queue-item-artist">${song.artist}</div>

--- a/Sources/Kaset/Services/RemoteDeviceManager.swift
+++ b/Sources/Kaset/Services/RemoteDeviceManager.swift
@@ -1,0 +1,135 @@
+import Foundation
+import Observation
+
+struct RemoteDevice: Codable, Identifiable, Hashable {
+    var id: String { self.deviceId }
+    let deviceId: String
+    let name: String
+    let token: String
+    let approvedAt: Date
+    var lastActive: Date
+}
+
+struct PendingApproval: Codable, Identifiable, Hashable {
+    var id: String { self.deviceId }
+    let deviceId: String
+    let name: String
+    let requestedAt: Date
+}
+
+@Observable
+@MainActor
+final class RemoteDeviceManager {
+    static let shared = RemoteDeviceManager()
+
+    private enum Keys {
+        static let approvedDevices = "kaset.remote.approvedDevices"
+        static let pendingRequests = "kaset.remote.pendingRequests"
+        static let globalPin = "kaset.remote.globalPin"
+    }
+
+    var approvedDevices: [RemoteDevice] = [] {
+        didSet { self.saveApprovedDevices() }
+    }
+
+    var pendingRequests: [PendingApproval] = [] {
+        didSet { self.savePendingRequests() }
+    }
+
+    var globalPin: String = "" {
+        didSet {
+            UserDefaults.standard.set(self.globalPin, forKey: Keys.globalPin)
+        }
+    }
+
+    private init() {
+        self.globalPin = UserDefaults.standard.string(forKey: Keys.globalPin) ?? Self.generateRandomPin()
+        self.loadApprovedDevices()
+        self.loadPendingRequests()
+    }
+
+    func requestApproval(deviceId: String, deviceName: String, pin: String) -> Bool {
+        guard pin == self.globalPin else { return false }
+        if self.approvedDevices.contains(where: { $0.deviceId == deviceId }) { return true }
+        if !self.pendingRequests.contains(where: { $0.deviceId == deviceId }) {
+            self.pendingRequests.append(PendingApproval(
+                deviceId: deviceId,
+                name: deviceName,
+                requestedAt: Date()
+            ))
+        }
+        return true
+    }
+
+    func approveDevice(deviceId: String) {
+        guard let pending = self.pendingRequests.first(where: { $0.deviceId == deviceId }) else { return }
+        self.pendingRequests.removeAll(where: { $0.deviceId == deviceId })
+        self.approvedDevices.append(RemoteDevice(
+            deviceId: deviceId,
+            name: pending.name,
+            token: UUID().uuidString.lowercased(),
+            approvedAt: Date(),
+            lastActive: Date()
+        ))
+    }
+
+    func denyDevice(deviceId: String) {
+        self.pendingRequests.removeAll(where: { $0.deviceId == deviceId })
+    }
+
+    func revokeDevice(deviceId: String) {
+        self.approvedDevices.removeAll(where: { $0.deviceId == deviceId })
+    }
+
+    func isDeviceApproved(deviceId: String) -> Bool {
+        self.approvedDevices.contains(where: { $0.deviceId == deviceId })
+    }
+
+    func deviceToken(deviceId: String) -> String {
+        self.approvedDevices.first(where: { $0.deviceId == deviceId })?.token ?? ""
+    }
+
+    func updateDeviceActivity(deviceId: String) {
+        if let idx = self.approvedDevices.firstIndex(where: { $0.deviceId == deviceId }) {
+            var device = self.approvedDevices[idx]
+            device.lastActive = Date()
+            self.approvedDevices[idx] = device
+        }
+    }
+
+    func clearAll() {
+        self.approvedDevices = []
+        self.pendingRequests = []
+        self.globalPin = Self.generateRandomPin()
+    }
+
+    private static func generateRandomPin() -> String {
+        String((0..<4).map { _ in "0123456789".randomElement()! })
+    }
+
+    private func saveApprovedDevices() {
+        if let data = try? JSONEncoder().encode(self.approvedDevices) {
+            UserDefaults.standard.set(data, forKey: Keys.approvedDevices)
+        }
+    }
+
+    private func loadApprovedDevices() {
+        if let data = UserDefaults.standard.data(forKey: Keys.approvedDevices),
+           let devices = try? JSONDecoder().decode([RemoteDevice].self, from: data) {
+            self.approvedDevices = devices
+        }
+    }
+
+    private func savePendingRequests() {
+        if let data = try? JSONEncoder().encode(self.pendingRequests) {
+            UserDefaults.standard.set(data, forKey: Keys.pendingRequests)
+        }
+    }
+
+    private func loadPendingRequests() {
+        if let data = UserDefaults.standard.data(forKey: Keys.pendingRequests),
+           let pending = try? JSONDecoder().decode([PendingApproval].self, from: data) {
+            self.pendingRequests = pending
+        }
+    }
+}

--- a/Sources/Kaset/Services/RemoteDeviceManager.swift
+++ b/Sources/Kaset/Services/RemoteDeviceManager.swift
@@ -48,9 +48,8 @@ final class RemoteDeviceManager {
         self.loadPendingRequests()
     }
 
-    func requestApproval(deviceId: String, deviceName: String, pin: String) -> Bool {
-        guard pin == self.globalPin else { return false }
-        if self.approvedDevices.contains(where: { $0.deviceId == deviceId }) { return true }
+    func requestApproval(deviceId: String, deviceName: String) {
+        if self.approvedDevices.contains(where: { $0.deviceId == deviceId }) { return }
         if !self.pendingRequests.contains(where: { $0.deviceId == deviceId }) {
             self.pendingRequests.append(PendingApproval(
                 deviceId: deviceId,
@@ -58,7 +57,23 @@ final class RemoteDeviceManager {
                 requestedAt: Date()
             ))
         }
-        return true
+    }
+
+    func verifyPinAndApprove(deviceId: String, deviceName: String, pin: String) -> String? {
+        guard pin == self.globalPin else { return nil }
+        self.pendingRequests.removeAll(where: { $0.deviceId == deviceId })
+        if let idx = self.approvedDevices.firstIndex(where: { $0.deviceId == deviceId }) {
+            return self.approvedDevices[idx].token
+        }
+        let token = UUID().uuidString.lowercased()
+        self.approvedDevices.append(RemoteDevice(
+            deviceId: deviceId,
+            name: deviceName,
+            token: token,
+            approvedAt: Date(),
+            lastActive: Date()
+        ))
+        return token
     }
 
     func approveDevice(deviceId: String) {

--- a/Sources/Kaset/Services/RemoteDeviceManager.swift
+++ b/Sources/Kaset/Services/RemoteDeviceManager.swift
@@ -1,8 +1,13 @@
 import Foundation
 import Observation
 
+// MARK: - RemoteDevice
+
 struct RemoteDevice: Codable, Identifiable, Hashable {
-    var id: String { self.deviceId }
+    var id: String {
+        self.deviceId
+    }
+
     let deviceId: String
     let name: String
     let token: String
@@ -10,12 +15,19 @@ struct RemoteDevice: Codable, Identifiable, Hashable {
     var lastActive: Date
 }
 
+// MARK: - PendingApproval
+
 struct PendingApproval: Codable, Identifiable, Hashable {
-    var id: String { self.deviceId }
+    var id: String {
+        self.deviceId
+    }
+
     let deviceId: String
     let name: String
     let requestedAt: Date
 }
+
+// MARK: - RemoteDeviceManager
 
 @Observable
 @MainActor
@@ -119,7 +131,7 @@ final class RemoteDeviceManager {
     }
 
     private static func generateRandomPin() -> String {
-        String((0..<4).map { _ in "0123456789".randomElement()! })
+        String((0 ..< 4).map { _ in "0123456789".randomElement()! })
     }
 
     private func saveApprovedDevices() {
@@ -130,7 +142,8 @@ final class RemoteDeviceManager {
 
     private func loadApprovedDevices() {
         if let data = UserDefaults.standard.data(forKey: Keys.approvedDevices),
-           let devices = try? JSONDecoder().decode([RemoteDevice].self, from: data) {
+           let devices = try? JSONDecoder().decode([RemoteDevice].self, from: data)
+        {
             self.approvedDevices = devices
         }
     }
@@ -143,7 +156,8 @@ final class RemoteDeviceManager {
 
     private func loadPendingRequests() {
         if let data = UserDefaults.standard.data(forKey: Keys.pendingRequests),
-           let pending = try? JSONDecoder().decode([PendingApproval].self, from: data) {
+           let pending = try? JSONDecoder().decode([PendingApproval].self, from: data)
+        {
             self.pendingRequests = pending
         }
     }

--- a/Sources/Kaset/Services/SettingsManager.swift
+++ b/Sources/Kaset/Services/SettingsManager.swift
@@ -20,6 +20,9 @@ final class SettingsManager {
         static let scrobbleMinSeconds = "settings.scrobbleMinSeconds"
         static let mediaControlStyle = "settings.mediaControlStyle"
         static let playbackAudioQuality = "settings.playbackAudioQuality"
+        static let localControlServerEnabled = "settings.localControlServerEnabled"
+        static let localControlServerPort = "settings.localControlServerPort"
+        static let localControlServerAllowsLAN = "settings.localControlServerAllowsLAN"
         static let syncedLyricsEnabled = "settings.syncedLyricsEnabled"
         static let romanizationEnabled = "settings.romanizationEnabled"
         static let contentLanguage = "settings.contentLanguage"
@@ -223,6 +226,30 @@ final class SettingsManager {
         }
     }
 
+    /// Whether Kaset exposes the local control HTTP API.
+    var localControlServerEnabled: Bool {
+        didSet {
+            UserDefaults.standard.set(self.localControlServerEnabled, forKey: Keys.localControlServerEnabled)
+        }
+    }
+
+    /// Port for the loopback-only local control HTTP API.
+    var localControlServerPort: Int {
+        didSet {
+            UserDefaults.standard.set(
+                Self.clampLocalControlServerPort(self.localControlServerPort),
+                forKey: Keys.localControlServerPort
+            )
+        }
+    }
+
+    /// Whether the local control HTTP API accepts connections from the local network.
+    var localControlServerAllowsLAN: Bool {
+        didSet {
+            UserDefaults.standard.set(self.localControlServerAllowsLAN, forKey: Keys.localControlServerAllowsLAN)
+        }
+    }
+
     /// Per-service enabled flags stored as a dictionary.
     private var enabledServices: [String: Bool] {
         didSet {
@@ -327,6 +354,11 @@ final class SettingsManager {
         self.syncedLyricsEnabled = UserDefaults.standard.object(forKey: Keys.syncedLyricsEnabled) as? Bool ?? true
         self.romanizationEnabled = UserDefaults.standard.object(forKey: Keys.romanizationEnabled) as? Bool ?? true
         self.keepMiniPlayerOnTop = UserDefaults.standard.object(forKey: Keys.keepMiniPlayerOnTop) as? Bool ?? false
+        self.localControlServerEnabled = UserDefaults.standard.object(forKey: Keys.localControlServerEnabled) as? Bool ?? false
+        self.localControlServerPort = Self.clampLocalControlServerPort(
+            UserDefaults.standard.object(forKey: Keys.localControlServerPort) as? Int ?? 26538
+        )
+        self.localControlServerAllowsLAN = UserDefaults.standard.object(forKey: Keys.localControlServerAllowsLAN) as? Bool ?? false
         #if DEBUG
             self.useLegacyMacOS15UI = UserDefaults.standard.object(forKey: Keys.useLegacyMacOS15UI) as? Bool ?? false
         #endif
@@ -389,5 +421,9 @@ final class SettingsManager {
     /// Returns the NavigationItem to use on app launch.
     var launchNavigationItem: NavigationItem {
         self.launchPage.navigationItem
+    }
+
+    private static func clampLocalControlServerPort(_ port: Int) -> Int {
+        min(max(port, 1024), 65535)
     }
 }

--- a/Sources/Kaset/Views/GeneralSettingsView.swift
+++ b/Sources/Kaset/Views/GeneralSettingsView.swift
@@ -108,37 +108,48 @@ struct GeneralSettingsView: View {
                 }
 
                 if self.settings.localControlServerEnabled {
-                    VStack(alignment: .leading, spacing: 6) {
-                        Text("Active Remote URL(s)")
+                    let urls = LocalControlServer.localControlURLs()
+                    let primaryURL = urls.first { $0.host?.lowercased().hasSuffix(".local") == true } ??
+                        urls.first { $0.host != "127.0.0.1" } ??
+                        urls.first
+
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Remote Control Access")
                             .font(.headline)
 
-                        ForEach(LocalControlServer.localControlURLs(), id: \.self) { url in
-                            VStack(alignment: .leading, spacing: 4) {
-                                HStack {
-                                    Text(url.absoluteString)
-                                        .font(.system(.caption, design: .monospaced))
-                                        .textSelection(.enabled)
-                                    Spacer()
-                                    Button {
-                                        NSPasteboard.general.clearContents()
-                                        NSPasteboard.general.setString(url.absoluteString, forType: .string)
-                                    } label: {
-                                        Image(systemName: "doc.on.doc")
-                                    }
-                                    .buttonStyle(.borderless)
-                                    .help("Copy URL")
+                        if let primary = primaryURL, primary.host != "127.0.0.1" {
+                            HStack {
+                                Spacer()
+                                VStack(spacing: 4) {
+                                    QRCodeView(urlString: primary.absoluteString)
+                                        .help("Scan with your phone to open the Remote Control page")
+                                    Text("Scan to connect")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
                                 }
+                                Spacer()
+                            }
+                            .padding(.vertical, 4)
+                        }
 
-                                // Show QR code for LAN URL (non-localhost)
-                                if url.host != "127.0.0.1" {
-                                    HStack {
-                                        Spacer()
-                                        QRCodeView(urlString: url.absoluteString)
-                                            .help("Scan with your phone to open the Remote Control page")
-                                        Spacer()
-                                    }
-                                    .padding(.vertical, 4)
+                        Text("Connection URL(s)")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+
+                        ForEach(urls, id: \.self) { url in
+                            HStack {
+                                Text(url.absoluteString)
+                                    .font(.system(.caption, design: .monospaced))
+                                    .textSelection(.enabled)
+                                Spacer()
+                                Button {
+                                    NSPasteboard.general.clearContents()
+                                    NSPasteboard.general.setString(url.absoluteString, forType: .string)
+                                } label: {
+                                    Image(systemName: "doc.on.doc")
                                 }
+                                .buttonStyle(.borderless)
+                                .help("Copy URL")
                             }
                         }
                     }

--- a/Sources/Kaset/Views/GeneralSettingsView.swift
+++ b/Sources/Kaset/Views/GeneralSettingsView.swift
@@ -9,6 +9,7 @@ struct GeneralSettingsView: View {
     @State private var settings = SettingsManager.shared
     @State private var cacheSize: String = .init(localized: "Calculating...")
     @State private var isClearing = false
+    @State private var selectedQRURL: URL?
 
     /// The updater service for managing app updates.
     var updaterService: UpdaterService
@@ -113,19 +114,32 @@ struct GeneralSettingsView: View {
                         urls.first { $0.host != "127.0.0.1" } ??
                         urls.first
 
+                    let activeQRURL: URL? = if let selected = self.selectedQRURL, urls.contains(selected) {
+                        selected
+                    } else {
+                        primaryURL
+                    }
+
                     VStack(alignment: .leading, spacing: 8) {
                         Text("Remote Control Access")
                             .font(.headline)
 
-                        if let primary = primaryURL, primary.host != "127.0.0.1" {
+                        if let active = activeQRURL, active.host != "127.0.0.1" {
                             HStack {
                                 Spacer()
                                 VStack(spacing: 4) {
-                                    QRCodeView(urlString: primary.absoluteString)
+                                    QRCodeView(urlString: active.absoluteString)
                                         .help("Scan with your phone to open the Remote Control page")
                                     Text("Scan to connect")
                                         .font(.caption)
                                         .foregroundStyle(.secondary)
+                                    if active.host?.lowercased().hasSuffix(".local") == true {
+                                        Text("Android devices: select an IP URL below if scanning fails.")
+                                            .font(.system(size: 9))
+                                            .foregroundStyle(.secondary)
+                                            .multilineTextAlignment(.center)
+                                            .frame(maxWidth: 220)
+                                    }
                                 }
                                 Spacer()
                             }
@@ -138,9 +152,20 @@ struct GeneralSettingsView: View {
 
                         ForEach(urls, id: \.self) { url in
                             HStack {
+                                Button {
+                                    self.selectedQRURL = url
+                                } label: {
+                                    Image(systemName: activeQRURL == url ? "record.circle" : "circle")
+                                        .foregroundStyle(activeQRURL == url ? .blue : .secondary)
+                                }
+                                .buttonStyle(.borderless)
+                                .help("Show QR code for this URL")
+
                                 Text(url.absoluteString)
                                     .font(.system(.caption, design: .monospaced))
                                     .textSelection(.enabled)
+                                    .foregroundStyle(activeQRURL == url ? .primary : .secondary)
+
                                 Spacer()
                                 Button {
                                     NSPasteboard.general.clearContents()

--- a/Sources/Kaset/Views/GeneralSettingsView.swift
+++ b/Sources/Kaset/Views/GeneralSettingsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import CoreImage.CIFilterBuiltins
 
 /// Settings view for general app preferences.
 struct GeneralSettingsView: View {
@@ -12,6 +13,7 @@ struct GeneralSettingsView: View {
 
     var body: some View {
         @Bindable var updater = self.updaterService
+        @Bindable var deviceManager = RemoteDeviceManager.shared
 
         Form {
             // MARK: - General Section
@@ -75,6 +77,138 @@ struct GeneralSettingsView: View {
                     }
                 }
                 .help("Choose which buttons appear in the Now Playing widget in Control Center")
+
+                // Local Control API
+                Toggle("Local Control API", isOn: self.$settings.localControlServerEnabled)
+                    .help("Expose an HTTP API for automation and remote control")
+
+                Stepper(
+                    "Local Control Port: \(self.settings.localControlServerPort)",
+                    value: self.$settings.localControlServerPort,
+                    in: 1024 ... 65_535
+                )
+                .disabled(!self.settings.localControlServerEnabled)
+                .help("Local API endpoint: http://127.0.0.1:\(self.settings.localControlServerPort)")
+
+                Toggle("Allow Local Network Remote", isOn: self.$settings.localControlServerAllowsLAN)
+                    .disabled(!self.settings.localControlServerEnabled)
+                    .help("Allow devices on the same Wi-Fi to open Kaset Remote using this Mac's IP address")
+
+                HStack {
+                    Text("Global PIN")
+                    Spacer()
+                    TextField("PIN", text: $deviceManager.globalPin)
+                        .frame(width: 80)
+                        .textFieldStyle(.roundedBorder)
+                        .multilineTextAlignment(.center)
+                        .disabled(!self.settings.localControlServerEnabled)
+                        .help("The security PIN that remote devices must enter to request access")
+                }
+
+                if self.settings.localControlServerEnabled {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Active Remote URL(s)")
+                            .font(.headline)
+                        
+                        ForEach(LocalControlServer.localControlURLs(), id: \.self) { url in
+                            VStack(alignment: .leading, spacing: 4) {
+                                HStack {
+                                    Text(url.absoluteString)
+                                        .font(.system(.caption, design: .monospaced))
+                                        .textSelection(.enabled)
+                                    Spacer()
+                                    Button {
+                                        NSPasteboard.general.clearContents()
+                                        NSPasteboard.general.setString(url.absoluteString, forType: .string)
+                                    } label: {
+                                        Image(systemName: "doc.on.doc")
+                                    }
+                                    .buttonStyle(.borderless)
+                                    .help("Copy URL")
+                                }
+                                
+                                // Show QR code for LAN URL (non-localhost)
+                                if url.host != "127.0.0.1" {
+                                    HStack {
+                                        Spacer()
+                                        QRCodeView(urlString: url.absoluteString)
+                                            .help("Scan with your phone to open the Remote Control page")
+                                        Spacer()
+                                    }
+                                    .padding(.vertical, 4)
+                                }
+                            }
+                        }
+                    }
+                    .padding(.vertical, 4)
+
+                    // Pending Approvals Section
+                    if !deviceManager.pendingRequests.isEmpty {
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text("Pending Approvals (\(deviceManager.pendingRequests.count))")
+                                .font(.headline)
+                                .foregroundStyle(.orange)
+                            
+                            ForEach(deviceManager.pendingRequests) { request in
+                                HStack {
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text(request.name)
+                                            .font(.subheadline)
+                                        Text(request.requestedAt, style: .time)
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                    }
+                                    Spacer()
+                                    Button("Approve") {
+                                        deviceManager.approveDevice(deviceId: request.deviceId)
+                                    }
+                                    .buttonStyle(.borderedProminent)
+                                    .tint(.green)
+                                    
+                                    Button("Deny") {
+                                        deviceManager.denyDevice(deviceId: request.deviceId)
+                                    }
+                                    .buttonStyle(.bordered)
+                                    .tint(.red)
+                                }
+                                .padding(.vertical, 2)
+                            }
+                        }
+                        .padding(.vertical, 4)
+                    }
+
+                    // Approved Devices Section
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Approved Devices (\(deviceManager.approvedDevices.count))")
+                            .font(.headline)
+                        
+                        if deviceManager.approvedDevices.isEmpty {
+                            Text("No approved devices yet.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        } else {
+                            ForEach(deviceManager.approvedDevices) { device in
+                                HStack {
+                                    VStack(alignment: .leading, spacing: 2) {
+                                        Text(device.name)
+                                            .font(.subheadline)
+                                        Text("Active: \(device.lastActive, style: .relative)")
+                                            .font(.caption)
+                                            .foregroundStyle(.secondary)
+                                    }
+                                    Spacer()
+                                    Button("Revoke") {
+                                        deviceManager.revokeDevice(deviceId: device.deviceId)
+                                    }
+                                    .buttonStyle(.bordered)
+                                    .tint(.red)
+                                }
+                                .padding(.vertical, 2)
+                            }
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
 
                 // Default Launch Page
                 Picker("Default Page on Launch", selection: self.$settings.defaultLaunchPage) {
@@ -211,5 +345,42 @@ struct GeneralSettingsView: View {
         await ImageCache.shared.clearAllCaches()
         await self.updateCacheSize()
         self.isClearing = false
+    }
+}
+
+struct QRCodeView: View {
+    let urlString: String
+
+    var body: some View {
+        if let image = self.generateQRCode(from: self.urlString) {
+            Image(nsImage: image)
+                .interpolation(.none)
+                .resizable()
+                .scaledToFit()
+                .frame(width: 120, height: 120)
+                .padding(6)
+                .background(.white)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+        } else {
+            VStack {
+                Image(systemName: "xmark.circle")
+                Text("QR Error")
+            }
+        }
+    }
+
+    private func generateQRCode(from string: String) -> NSImage? {
+        let context = CIContext()
+        let filter = CIFilter.qrCodeGenerator()
+        filter.message = Data(string.utf8)
+
+        if let outputImage = filter.outputImage {
+            let transform = CGAffineTransform(scaleX: 10, y: 10)
+            let scaledImage = outputImage.transformed(by: transform)
+            if let cgImage = context.createCGImage(scaledImage, from: scaledImage.extent) {
+                return NSImage(cgImage: cgImage, size: NSSize(width: 120, height: 120))
+            }
+        }
+        return nil
     }
 }

--- a/Sources/Kaset/Views/GeneralSettingsView.swift
+++ b/Sources/Kaset/Views/GeneralSettingsView.swift
@@ -1,5 +1,7 @@
-import SwiftUI
 import CoreImage.CIFilterBuiltins
+import SwiftUI
+
+// MARK: - GeneralSettingsView
 
 /// Settings view for general app preferences.
 struct GeneralSettingsView: View {
@@ -85,7 +87,7 @@ struct GeneralSettingsView: View {
                 Stepper(
                     "Local Control Port: \(self.settings.localControlServerPort)",
                     value: self.$settings.localControlServerPort,
-                    in: 1024 ... 65_535
+                    in: 1024 ... 65535
                 )
                 .disabled(!self.settings.localControlServerEnabled)
                 .help("Local API endpoint: http://127.0.0.1:\(self.settings.localControlServerPort)")
@@ -109,7 +111,7 @@ struct GeneralSettingsView: View {
                     VStack(alignment: .leading, spacing: 6) {
                         Text("Active Remote URL(s)")
                             .font(.headline)
-                        
+
                         ForEach(LocalControlServer.localControlURLs(), id: \.self) { url in
                             VStack(alignment: .leading, spacing: 4) {
                                 HStack {
@@ -126,7 +128,7 @@ struct GeneralSettingsView: View {
                                     .buttonStyle(.borderless)
                                     .help("Copy URL")
                                 }
-                                
+
                                 // Show QR code for LAN URL (non-localhost)
                                 if url.host != "127.0.0.1" {
                                     HStack {
@@ -148,7 +150,7 @@ struct GeneralSettingsView: View {
                             Text("Pending Approvals (\(deviceManager.pendingRequests.count))")
                                 .font(.headline)
                                 .foregroundStyle(.orange)
-                            
+
                             ForEach(deviceManager.pendingRequests) { request in
                                 HStack {
                                     VStack(alignment: .leading, spacing: 2) {
@@ -164,7 +166,7 @@ struct GeneralSettingsView: View {
                                     }
                                     .buttonStyle(.borderedProminent)
                                     .tint(.green)
-                                    
+
                                     Button("Deny") {
                                         deviceManager.denyDevice(deviceId: request.deviceId)
                                     }
@@ -181,7 +183,7 @@ struct GeneralSettingsView: View {
                     VStack(alignment: .leading, spacing: 6) {
                         Text("Approved Devices (\(deviceManager.approvedDevices.count))")
                             .font(.headline)
-                        
+
                         if deviceManager.approvedDevices.isEmpty {
                             Text("No approved devices yet.")
                                 .font(.caption)
@@ -347,6 +349,8 @@ struct GeneralSettingsView: View {
         self.isClearing = false
     }
 }
+
+// MARK: - QRCodeView
 
 struct QRCodeView: View {
     let urlString: String

--- a/Tests/KasetTests/LocalControlServerTests.swift
+++ b/Tests/KasetTests/LocalControlServerTests.swift
@@ -1,0 +1,175 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+@Suite(.serialized, .tags(.service))
+@MainActor
+struct LocalControlServerTests {
+    @Test("Routes status and transport controls")
+    func routesStatusAndTransportControls() {
+        #expect(LocalControlServer.route(.init(method: "GET", path: "/")) == .webInterface)
+        #expect(LocalControlServer.route(.init(method: "GET", path: "/remote")) == .webInterface)
+        #expect(LocalControlServer.route(.init(method: "GET", path: "/status")) == .status)
+        #expect(LocalControlServer.route(.init(method: "POST", path: "/play")) == .play)
+        #expect(LocalControlServer.route(.init(method: "POST", path: "/pause")) == .pause)
+        #expect(LocalControlServer.route(.init(method: "POST", path: "/play-pause")) == .playPause)
+        #expect(LocalControlServer.route(.init(method: "POST", path: "/toggle")) == .playPause)
+        #expect(LocalControlServer.route(.init(method: "POST", path: "/next")) == .next)
+        #expect(LocalControlServer.route(.init(method: "POST", path: "/previous")) == .previous)
+    }
+
+    @Test("Routes check and request_approval")
+    func routesDeviceVerification() {
+        #expect(LocalControlServer.route(.init(method: "GET", path: "/check")) == .check)
+        #expect(LocalControlServer.route(.init(method: "POST", path: "/request_approval")) == .requestApproval)
+    }
+
+    @Test("Routes volume from query and clamps value")
+    func routesVolumeFromQueryAndClampsValue() {
+        #expect(LocalControlServer.route(.init(
+            method: "POST",
+            path: "/volume",
+            queryItems: ["value": "0.42"]
+        )) == .volume(0.42))
+
+        #expect(LocalControlServer.route(.init(
+            method: "POST",
+            path: "/volume",
+            queryItems: ["value": "2"]
+        )) == .volume(1))
+    }
+
+    @Test("Routes invalid requests to errors")
+    func routesInvalidRequestsToErrors() {
+        #expect(LocalControlServer.route(.init(method: "GET", path: "/missing")) == .notFound)
+        #expect(LocalControlServer.route(.init(method: "DELETE", path: "/status")) == .methodNotAllowed)
+        #expect(LocalControlServer.route(.init(method: "POST", path: "/volume")) == .badRequest("Missing numeric volume value"))
+    }
+
+    @Test("Parses raw HTTP request target and form body")
+    func parsesRawHTTPRequest() throws {
+        let raw = """
+        POST /volume?level=0.3 HTTP/1.1\r
+        Host: 127.0.0.1\r
+        Authorization: Bearer secret\r
+        Content-Type: application/x-www-form-urlencoded\r
+        \r
+        value=0.7
+        """
+
+        let request = try #require(LocalControlServer.HTTPRequest(data: Data(raw.utf8)))
+
+        #expect(request.method == "POST")
+        #expect(request.path == "/volume")
+        #expect(request.headers["authorization"] == "Bearer secret")
+        #expect(request.queryItems["level"] == "0.3")
+        #expect(request.formItems["value"] == "0.7")
+        #expect(LocalControlServer.route(request) == .volume(0.3))
+    }
+
+    @Test("Authorizes query form and bearer tokens")
+    func authorizesTokenSources() {
+        let settings = SettingsManager.shared
+        let originalToken = settings.localControlServerToken
+        defer {
+            settings.localControlServerToken = originalToken
+        }
+        settings.localControlServerToken = "secret-token"
+
+        #expect(LocalControlServer.isAuthorized(.init(
+            method: "GET",
+            path: "/status",
+            queryItems: ["token": "secret-token"]
+        )))
+        #expect(LocalControlServer.isAuthorized(.init(
+            method: "POST",
+            path: "/next",
+            headers: ["Authorization": "Bearer secret-token"]
+        )))
+        #expect(LocalControlServer.isAuthorized(.init(
+            method: "POST",
+            path: "/volume",
+            formItems: ["token": "secret-token"]
+        )))
+        #expect(!LocalControlServer.isAuthorized(.init(
+            method: "GET",
+            path: "/status",
+            queryItems: ["token": "wrong"]
+        )))
+    }
+
+    @Test("Track payload includes currently playing metadata")
+    func trackPayloadIncludesMetadata() throws {
+        let track = Song(
+            id: "song-id",
+            title: "A Song",
+            artists: [Artist(id: "UCartist", name: "Artist")],
+            album: Album(
+                id: "MPREalbum",
+                title: "Album",
+                artists: nil,
+                thumbnailURL: nil,
+                year: nil,
+                trackCount: nil
+            ),
+            duration: 123,
+            thumbnailURL: URL(string: "https://example.com/art.jpg"),
+            videoId: "video-id",
+            isExplicit: true
+        )
+
+        let payload = LocalControlServer.trackPayload(track)
+
+        #expect(payload["id"] as? String == "song-id")
+        #expect(payload["videoId"] as? String == "video-id")
+        #expect(payload["title"] as? String == "A Song")
+        #expect(payload["artist"] as? String == "Artist")
+        #expect(payload["artists"] as? [String] == ["Artist"])
+        #expect(payload["album"] as? String == "Album")
+        #expect(payload["artworkURL"] as? String == "https://example.com/art.jpg")
+        #expect(payload["duration"] as? TimeInterval == 123)
+        #expect(payload["isExplicit"] as? Bool == true)
+    }
+
+    @Test("HTTP response serializes JSON headers and body")
+    func httpResponseSerializesJSON() throws {
+        let response = LocalControlServer.HTTPResponse.json(["ok": true])
+        let text = try #require(String(data: response.serialized(), encoding: .utf8))
+
+        #expect(text.contains("HTTP/1.1 200 OK"))
+        #expect(text.contains("Content-Type: application/json"))
+        #expect(text.contains("\"ok\":true"))
+    }
+
+    @Test("Remote control HTML contains controls and token")
+    func remoteControlHTMLContainsControlsAndToken() {
+        let html = LocalControlServer.remoteControlHTML(token: "abc123")
+
+        #expect(html.contains("Kaset Remote"))
+        #expect(html.contains("Previous"))
+        #expect(html.contains("Play/Pause"))
+        #expect(html.contains("Next"))
+        #expect(html.contains("abc123"))
+    }
+
+    @Test("Discovers local control URLs starting with localhost")
+    func discoversLocalControlURLs() {
+        let settings = SettingsManager.shared
+        let originalToken = settings.localControlServerToken
+        let originalLAN = settings.localControlServerAllowsLAN
+        defer {
+            settings.localControlServerToken = originalToken
+            settings.localControlServerAllowsLAN = originalLAN
+        }
+        settings.localControlServerToken = "test-token"
+        settings.localControlServerAllowsLAN = true
+
+        let urls = LocalControlServer.localControlURLs()
+        #expect(!urls.isEmpty)
+        #expect(urls[0].absoluteString == "http://127.0.0.1:\(settings.localControlServerPort)/?token=test-token")
+
+        for url in urls {
+            #expect(url.query?.contains("token=test-token") == true)
+        }
+    }
+}

--- a/Tests/KasetTests/LocalControlServerTests.swift
+++ b/Tests/KasetTests/LocalControlServerTests.swift
@@ -71,7 +71,7 @@ struct LocalControlServerTests {
     func authorizesTokenSources() {
         let manager = RemoteDeviceManager.shared
         manager.clearAll()
-        
+
         let testToken = "mock-device-token-xyz"
         manager.approvedDevices = [
             RemoteDevice(
@@ -80,7 +80,7 @@ struct LocalControlServerTests {
                 token: testToken,
                 approvedAt: Date(),
                 lastActive: Date()
-            )
+            ),
         ]
 
         #expect(LocalControlServer.isAuthorized(.init(
@@ -106,7 +106,7 @@ struct LocalControlServerTests {
     }
 
     @Test("Track payload includes currently playing metadata")
-    func trackPayloadIncludesMetadata() throws {
+    func trackPayloadIncludesMetadata() {
         let track = Song(
             id: "song-id",
             title: "A Song",

--- a/Tests/KasetTests/LocalControlServerTests.swift
+++ b/Tests/KasetTests/LocalControlServerTests.swift
@@ -69,27 +69,34 @@ struct LocalControlServerTests {
 
     @Test("Authorizes query form and bearer tokens")
     func authorizesTokenSources() {
-        let settings = SettingsManager.shared
-        let originalToken = settings.localControlServerToken
-        defer {
-            settings.localControlServerToken = originalToken
-        }
-        settings.localControlServerToken = "secret-token"
+        let manager = RemoteDeviceManager.shared
+        manager.clearAll()
+        
+        let testToken = "mock-device-token-xyz"
+        manager.approvedDevices = [
+            RemoteDevice(
+                deviceId: "test-device",
+                name: "Test Phone",
+                token: testToken,
+                approvedAt: Date(),
+                lastActive: Date()
+            )
+        ]
 
         #expect(LocalControlServer.isAuthorized(.init(
             method: "GET",
             path: "/status",
-            queryItems: ["token": "secret-token"]
+            queryItems: ["token": testToken]
         )))
         #expect(LocalControlServer.isAuthorized(.init(
             method: "POST",
             path: "/next",
-            headers: ["Authorization": "Bearer secret-token"]
+            headers: ["Authorization": "Bearer \(testToken)"]
         )))
         #expect(LocalControlServer.isAuthorized(.init(
             method: "POST",
             path: "/volume",
-            formItems: ["token": "secret-token"]
+            formItems: ["token": testToken]
         )))
         #expect(!LocalControlServer.isAuthorized(.init(
             method: "GET",
@@ -141,35 +148,31 @@ struct LocalControlServerTests {
         #expect(text.contains("\"ok\":true"))
     }
 
-    @Test("Remote control HTML contains controls and token")
-    func remoteControlHTMLContainsControlsAndToken() {
-        let html = LocalControlServer.remoteControlHTML(token: "abc123")
+    @Test("Remote control HTML contains controls and elements")
+    func remoteControlHTMLContainsControlsAndElements() {
+        let html = LocalControlServer.remoteControlHTML()
 
         #expect(html.contains("Kaset Remote"))
         #expect(html.contains("Previous"))
         #expect(html.contains("Play/Pause"))
         #expect(html.contains("Next"))
-        #expect(html.contains("abc123"))
     }
 
     @Test("Discovers local control URLs starting with localhost")
     func discoversLocalControlURLs() {
         let settings = SettingsManager.shared
-        let originalToken = settings.localControlServerToken
         let originalLAN = settings.localControlServerAllowsLAN
         defer {
-            settings.localControlServerToken = originalToken
             settings.localControlServerAllowsLAN = originalLAN
         }
-        settings.localControlServerToken = "test-token"
         settings.localControlServerAllowsLAN = true
 
         let urls = LocalControlServer.localControlURLs()
         #expect(!urls.isEmpty)
-        #expect(urls[0].absoluteString == "http://127.0.0.1:\(settings.localControlServerPort)/?token=test-token")
+        #expect(urls[0].absoluteString == "http://127.0.0.1:\(settings.localControlServerPort)/")
 
         for url in urls {
-            #expect(url.query?.contains("token=test-token") == true)
+            #expect(url.query == nil)
         }
     }
 }

--- a/Tests/KasetTests/RemoteDeviceManagerTests.swift
+++ b/Tests/KasetTests/RemoteDeviceManagerTests.swift
@@ -1,5 +1,5 @@
-import Testing
 import Foundation
+import Testing
 @testable import Kaset
 
 @Suite(.serialized)

--- a/Tests/KasetTests/RemoteDeviceManagerTests.swift
+++ b/Tests/KasetTests/RemoteDeviceManagerTests.swift
@@ -11,23 +11,31 @@ struct RemoteDeviceManagerTests {
         manager.clearAll()
         manager.globalPin = "4321"
 
-        // Verify request with wrong PIN
-        #expect(!manager.requestApproval(deviceId: "dev-1", deviceName: "Test Phone", pin: "0000"))
+        // Verify request with wrong PIN fails direct login
+        #expect(manager.verifyPinAndApprove(deviceId: "dev-1", deviceName: "Test Phone", pin: "0000") == nil)
         #expect(manager.pendingRequests.isEmpty)
-
-        // Verify request with correct PIN
-        #expect(manager.requestApproval(deviceId: "dev-1", deviceName: "Test Phone", pin: "4321"))
-        #expect(manager.pendingRequests.count == 1)
         #expect(!manager.isDeviceApproved(deviceId: "dev-1"))
 
-        // Approve device
-        manager.approveDevice(deviceId: "dev-1")
-        #expect(manager.pendingRequests.isEmpty)
+        // Verify request with correct PIN directly logs in and approves
+        let token = manager.verifyPinAndApprove(deviceId: "dev-1", deviceName: "Test Phone", pin: "4321")
+        #expect(token != nil)
         #expect(manager.isDeviceApproved(deviceId: "dev-1"))
-        #expect(!manager.deviceToken(deviceId: "dev-1").isEmpty)
+        #expect(manager.deviceToken(deviceId: "dev-1") == token)
+        #expect(manager.pendingRequests.isEmpty)
 
         // Revoke device
         manager.revokeDevice(deviceId: "dev-1")
         #expect(!manager.isDeviceApproved(deviceId: "dev-1"))
+
+        // Verify request approval queueing (no PIN)
+        manager.requestApproval(deviceId: "dev-2", deviceName: "Test Phone 2")
+        #expect(manager.pendingRequests.count == 1)
+        #expect(!manager.isDeviceApproved(deviceId: "dev-2"))
+
+        // Approve device
+        manager.approveDevice(deviceId: "dev-2")
+        #expect(manager.pendingRequests.isEmpty)
+        #expect(manager.isDeviceApproved(deviceId: "dev-2"))
+        #expect(!manager.deviceToken(deviceId: "dev-2").isEmpty)
     }
 }

--- a/Tests/KasetTests/RemoteDeviceManagerTests.swift
+++ b/Tests/KasetTests/RemoteDeviceManagerTests.swift
@@ -1,0 +1,33 @@
+import Testing
+import Foundation
+@testable import Kaset
+
+@Suite(.serialized)
+@MainActor
+struct RemoteDeviceManagerTests {
+    @Test("Manages device approval flow and persists correctly")
+    func managesDeviceFlow() {
+        let manager = RemoteDeviceManager.shared
+        manager.clearAll()
+        manager.globalPin = "4321"
+
+        // Verify request with wrong PIN
+        #expect(!manager.requestApproval(deviceId: "dev-1", deviceName: "Test Phone", pin: "0000"))
+        #expect(manager.pendingRequests.isEmpty)
+
+        // Verify request with correct PIN
+        #expect(manager.requestApproval(deviceId: "dev-1", deviceName: "Test Phone", pin: "4321"))
+        #expect(manager.pendingRequests.count == 1)
+        #expect(!manager.isDeviceApproved(deviceId: "dev-1"))
+
+        // Approve device
+        manager.approveDevice(deviceId: "dev-1")
+        #expect(manager.pendingRequests.isEmpty)
+        #expect(manager.isDeviceApproved(deviceId: "dev-1"))
+        #expect(!manager.deviceToken(deviceId: "dev-1").isEmpty)
+
+        // Revoke device
+        manager.revokeDevice(deviceId: "dev-1")
+        #expect(!manager.isDeviceApproved(deviceId: "dev-1"))
+    }
+}

--- a/Tests/KasetTests/SearchResponseParserTests.swift
+++ b/Tests/KasetTests/SearchResponseParserTests.swift
@@ -65,6 +65,39 @@ struct SearchResponseParserTests {
         #expect(response.playlists.count == 1)
     }
 
+    @Test("Parse response with itemSectionRenderer contents")
+    func parseItemSectionRendererResults() {
+        let contents: [[String: Any]] = [
+            ["itemSectionRenderer": ["contents": self.makeSongItems(count: 2)]],
+            ["itemSectionRenderer": ["contents": [
+                ["musicShelfRenderer": ["contents": self.makeSongItems(count: 1)]],
+            ]]],
+            ["itemSectionRenderer": ["contents": self.makeAlbumItems(count: 1)]],
+        ]
+        let data: [String: Any] = [
+            "contents": [
+                "tabbedSearchResultsRenderer": [
+                    "tabs": [[
+                        "tabRenderer": [
+                            "content": [
+                                "sectionListRenderer": [
+                                    "contents": contents,
+                                ],
+                            ],
+                        ],
+                    ]],
+                ],
+            ],
+        ]
+
+        let response = SearchResponseParser.parse(data)
+
+        #expect(response.songs.count == 3)
+        #expect(response.albums.count == 1)
+        #expect(response.artists.isEmpty)
+        #expect(response.playlists.isEmpty)
+    }
+
     @Test("Song has correct video ID")
     func songHasVideoId() {
         let data = self.makeSearchResponseData(songs: 1, albums: 0, artists: 0, playlists: 0)

--- a/docs/adr/0020-local-control-device-approval.md
+++ b/docs/adr/0020-local-control-device-approval.md
@@ -1,0 +1,32 @@
+# ADR-0020: Secure Local Control Device Approval & PIN Verification
+
+## Status
+Accepted
+
+## Context
+Kaset previously had a local HTTP control server (`LocalControlServer`) that allowed simple playback control, but it operated either without authentication or used a single global access token. Exposing a global token over the local network is insecure and cumbersome for users who want to connect secondary devices (like mobile phones or tablets) to control media playback on their Mac. There was a need for a secure, user-friendly registration and approval flow:
+- A device should be able to scan a QR code on the Mac's screen to open the controller.
+- The user should be prompted to input a 4-to-6 digit PIN to request connection.
+- The host Mac must show a queue of pending devices to Approve or Deny.
+- Approved devices must receive a unique device-specific session token, with the ability for the host to revoke access at any time.
+- All implementations must be 100% native (no external Node/Python services, no new third-party dependencies).
+
+We implemented a secure, local-first registration and approval flow supporting two connection methods:
+1. **`RemoteDeviceManager`**: A new MainActor-isolated service managing approved and pending devices. It stores `RemoteDevice` and `PendingApproval` lists, persisting them in `UserDefaults` via standard JSON encoding.
+2. **Enhanced `LocalControlServer`**:
+   - Added `/check` (auto-login check) and `/request_approval` (PIN verification request) endpoints.
+   - Bypassed general authentication check for these registration endpoints and the main remote web interface HTML page.
+   - Support dual connection modes:
+     - **Direct PIN Login**: If the client provides the correct PIN via `/request_approval`, the server directly creates an approved device entry, issues a session token, and returns it immediately to log the device in.
+     - **Request Host Access**: A client can request access without entering a PIN. This registers the device as `pending` in the host's approval queue. The host Mac can then approve or deny the request from settings.
+   - Upgraded the served controller HTML with a client-side state machine using `localStorage` for device UUID, handling the PIN login, direct request-host-access actions, and pending state polling loops.
+3. **Static URLs & QR Codes**:
+   - Discovered LAN URLs and generated QR codes are completely static (e.g. `http://<computer-name>.local:<PORT>/`) with no tokens exposed in the query string.
+   - Friendly Bonjour names like `kaset.local` were removed from URLs to focus on the reliable system local hostname.
+4. **GeneralSettingsView Integration**: Integrated controls to toggle the server, view the global security PIN, view active LAN URLs, scan QR codes, and manage the pending/approved device lists (Approve/Deny/Revoke buttons).
+
+## Consequences
+- **Security**: The global token is completely removed. Client session tokens are never exposed in URL history or query logs; they are generated on successful PIN verification and stored in the browser's `localStorage`. Denied or revoked devices are immediately blocked from hitting control endpoints.
+- **Convenience**: Users can pair their devices in seconds via QR code scans and a simple PIN entry.
+- **Portability**: Keep dependencies at zero; the implementation uses built-in Apple frameworks (`Network`, `CoreImage`, `SwiftUI`, `Foundation`).
+- **Network Permissions**: Packaged sandboxed builds require the `com.apple.security.network.server` entitlement enabled in `Kaset.entitlements` to allow local port binding.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -54,3 +54,4 @@ What becomes easier or more difficult because of this change?
 | [0017](0017-equalizer.md) | 6-Band Equalizer via Core Audio Process Tap | Implemented |
 | [0018](0018-artist-page-episodes.md) | Artist Page — Episodes, Singles, Playlists, Podcasts, Related Artists | Accepted |
 | [0019](0019-podcasts-availability.md) | Region-Aware Podcasts Tab Visibility | Implemented |
+| [0020](0020-local-control-device-approval.md) | Secure Local Control Device Approval & PIN Verification | Accepted |


### PR DESCRIPTION
## Description

This PR implements a robust **Media Remote Control Interface** that allows users to remotely control playback, manage queue items, and execute search queries on their Mac's Kaset app from a mobile browser or remote device.

## AI Prompt (Optional)

<details>
<summary>🤖 AI Prompt Used</summary>

```
1. Implement a local control server in LocalControlServer.swift that replaces token-based URL parameters with static URLs and PIN-based authorization.
2. Build a remote control web player UI with standard controls (Play, Pause, Next, Previous, Volume), queue list display, and share/forward button.
3. Enhance the search bar UI to include category filter tabs: All, Songs, Albums, Playlists. Make clicking a song play it.
4. Implement a clear (cross) button to reset search input, and add an auto-select-all text focus behavior.
5. Upgrade SearchResponseParser.swift to navigate and parse search results nested under itemSectionRenderer blocks, restoring full search capabilities under the 'All' filter.
6. Add unit tests for itemSectionRenderer parsing to SearchResponseParserTests.swift.
7. Implement TCP chunk accumulation in LocalControlServer to ensure full HTTP POST bodies are read before processing, resolving PIN validation failures over fragmented USB-tethered links.
8. Select a single case-insensitive `.local` hostname URL as the primary QR code target in settings to prevent cluttering the interface with multiple codes, and provide simple text copy actions for alternative raw IP addresses.
9. Implement a fallback in YTMusicClient.getPlaylistAllTracks to call getPlaylist when get_queue returns no tracks, enabling the remote control Play/Play Next/Add Queue detail actions to function correctly on Albums.
10. Build a local toast notification system in the remote web control page to confirm play-next, clear-queue, and add-to-queue actions.
11. Add a 'Clear' queue button to the remote web control's queue panel, communicating with a new POST /clear_queue endpoint to purge Kaset's active queue.
```

**AI Tool:** Antigravity CLI

</details>

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [x] 🎨 UI/UX improvement
- [ ] ♻️ Refactoring (no functional changes)
- [x] 🧪 Test update
- [ ] 🔧 Build/CI configuration

## Related Issues

Fixes #199

## Changes Made

- **Local Control Server & PIN Security**: Replaced token URL security with an interactive PIN-approval gateway, saving device IDs to an authorized database. Implemented a recursive TCP buffer reader to correctly accumulate the full request payload before PIN validation over cable/USB-tethered links.
- **Settings View & Dynamic QR Code**: Added a dynamic QR code selector allowing users to choose their active host URL. Includes warning notices for Android users when `.local` (mDNS) fails, prompting them to select a raw IP address.
- **Remote Web UI**: Built a responsive player page with artwork rendering, playback states, volume adjustment, and full queue browsing.
- **Search & Filters**: Added autocomplete search matching with filters (All, Songs, Albums, Playlists). Tapping a result triggers play/queue actions.
- **UI Enhancements**: Added a clear search input cross button and an input focus handler that highlights/selects all text on tap.
- **Search Parser Upgrade**: Expanded `SearchResponseParser` to extract search items nested within `itemSectionRenderer` containers, restoring "All" tab results.
- **Album Actions & Client Fallback**: Implemented a fallback in `getPlaylistAllTracks` that falls back to `getPlaylist` when the queue API returns empty, restoring Play, Play Next, and Add Queue actions on Albums.
- **Action Confirmation (Toasts)**: Integrated a lightweight, responsive toast notification overlay on the remote web player page, rendering immediate feedback when queue actions or transport items are modified.
- **Queue Purging**: Added a "Clear" button to the remote web player's Queue panel linking to a new `POST /clear_queue` endpoint on the server, allowing users to wipe the active playback queue.
- **Unit Tests**: Added `parseItemSectionRendererResults` in `SearchResponseParserTests` ensuring 100% correct parsing behavior.

## Testing

- [x] Unit tests pass (`swift test --skip KasetUITests`)
- [x] Manual testing performed
- [x] UI tested on macOS 26+

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `swiftlint --strict && swiftformat .`
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally
- [x] I have updated documentation if needed
- [x] I have checked for any performance implications
- [x] My changes generate no new warnings

## Screenshots

## Player UI
<details>
<summary>Click to expand (4 images)</summary>
<br>
<img src="https://github.com/user-attachments/assets/629c197d-2703-43f0-b3f7-1340f7eab499" width="280">
<img src="https://github.com/user-attachments/assets/14934833-b415-49a9-a609-6bc3f4d32b1b" width="280">
<img src="https://github.com/user-attachments/assets/163fabf2-edca-4d03-bbea-2c6c055f063b" width="280">
<img src="https://github.com/user-attachments/assets/7ed4ea34-656e-4747-9df8-ad48219ce9a7" width="280">
</details>

## Search UI
<details>
<summary>Click to expand (4 images)</summary>
<br>
<img src="https://github.com/user-attachments/assets/e3256f01-beb9-48df-938d-29a28f9f033f" width="280">
<img src="https://github.com/user-attachments/assets/3374e733-02c3-4458-8b3d-9ce74f7d788c" width="280">
<img src="https://github.com/user-attachments/assets/40cac232-70e3-49c4-bfe7-b38222f13815" width="280">
<img src="https://github.com/user-attachments/assets/069e86a8-f51b-4a45-bb67-36828f86f996" width="280">
</details>

## Desktop UI
<details>
<summary>Click to expand (4 images)</summary>
<br>
<img src="https://github.com/user-attachments/assets/307c003c-cf53-4dcf-945a-a0ae73fb1a97" width="400">
<img src="https://github.com/user-attachments/assets/b60030ae-25a3-4551-a585-f4bdaeeb52d5" width="400">
<img src="https://github.com/user-attachments/assets/e971903b-3e5a-4355-8eff-34655e0cb71d" width="400">
<img src="https://github.com/user-attachments/assets/3029e496-1838-47b1-8d5d-3de81096cf84" width="400">
</details>
