### PR TITLE
Save queue as playlist and improve queue edit mode

### DIFF
--- a/Sources/Kaset/Services/Player/PlayerService+Queue.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+Queue.swift
@@ -278,10 +278,8 @@ extension PlayerService {
     /// Whether the queue contains the same song more than once.
     var queueHasDuplicateEntries: Bool {
         var seenVideoIds = Set<String>()
-        for song in self.queue {
-            if !seenVideoIds.insert(song.videoId).inserted {
-                return true
-            }
+        for song in self.queue where !seenVideoIds.insert(song.videoId).inserted {
+            return true
         }
         return false
     }
@@ -389,7 +387,7 @@ extension PlayerService {
             return
         }
 
-        let removedBeforeCurrent = removedIndices.filter { $0 < self.currentIndex }.count
+        let removedBeforeCurrent = removedIndices.count(where: { $0 < self.currentIndex })
         if removedBeforeCurrent > 0 {
             self.currentIndex = max(0, self.currentIndex - removedBeforeCurrent)
         } else if self.currentIndex >= self.queue.count {

--- a/Sources/Kaset/Services/Player/PlayerService+Queue.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+Queue.swift
@@ -292,11 +292,13 @@ extension PlayerService {
         self.recordQueueStateForUndo()
         let previousCount = self.queue.count
         let currentEntryID = self.currentQueueEntryID
+        let originalCurrentIndex = self.currentIndex
         var remainingEntries = self.queueEntries
         remainingEntries.remove(at: index)
         self.setQueue(entries: remainingEntries)
         self.realignCurrentIndexAfterQueueMutation(
             currentEntryID: currentEntryID,
+            originalCurrentIndex: originalCurrentIndex,
             removedIndex: index
         )
 
@@ -319,6 +321,7 @@ extension PlayerService {
         self.recordQueueStateForUndo()
         let previousCount = self.queue.count
         let currentEntryID = self.currentQueueEntryID
+        let originalCurrentIndex = self.currentIndex
         var remainingEntries = self.queueEntries
         for index in indicesToRemove {
             remainingEntries.remove(at: index)
@@ -326,6 +329,7 @@ extension PlayerService {
         self.setQueue(entries: remainingEntries)
         self.realignCurrentIndexAfterQueueMutation(
             currentEntryID: currentEntryID,
+            originalCurrentIndex: originalCurrentIndex,
             removedIndices: indicesToRemove
         )
 
@@ -368,16 +372,19 @@ extension PlayerService {
 
     private func realignCurrentIndexAfterQueueMutation(
         currentEntryID: UUID?,
+        originalCurrentIndex: Int,
         removedIndex: Int
     ) {
         self.realignCurrentIndexAfterQueueMutation(
             currentEntryID: currentEntryID,
+            originalCurrentIndex: originalCurrentIndex,
             removedIndices: [removedIndex]
         )
     }
 
     private func realignCurrentIndexAfterQueueMutation(
         currentEntryID: UUID?,
+        originalCurrentIndex: Int,
         removedIndices: [Int]
     ) {
         if let currentEntryID,
@@ -387,12 +394,9 @@ extension PlayerService {
             return
         }
 
-        let removedBeforeCurrent = removedIndices.count(where: { $0 < self.currentIndex })
-        if removedBeforeCurrent > 0 {
-            self.currentIndex = max(0, self.currentIndex - removedBeforeCurrent)
-        } else if self.currentIndex >= self.queue.count {
-            self.currentIndex = max(0, self.queue.count - 1)
-        }
+        let removedBeforeCurrent = removedIndices.count(where: { $0 < originalCurrentIndex })
+        let adjustedIndex = max(0, originalCurrentIndex - removedBeforeCurrent)
+        self.currentIndex = min(adjustedIndex, max(0, self.queue.count - 1))
     }
 
     private func realignCurrentIndexAfterDuplicateRemoval(
@@ -424,17 +428,17 @@ extension PlayerService {
         self.recordQueueStateForUndo()
         let previousCount = self.queue.count
         let currentEntryID = self.currentQueueEntryID
+        let originalCurrentIndex = self.currentIndex
+        let indicesToRemove = self.queueEntries.enumerated()
+            .filter { videoIds.contains($0.element.song.videoId) }
+            .map(\.offset)
         let remainingEntries = self.queueEntries.filter { !videoIds.contains($0.song.videoId) }
         self.setQueue(entries: remainingEntries)
-
-        // Adjust currentIndex if needed
-        if let currentEntryID,
-           let newIndex = self.queueEntryIDs.firstIndex(of: currentEntryID)
-        {
-            self.currentIndex = newIndex
-        } else if self.currentIndex >= self.queue.count {
-            self.currentIndex = max(0, self.queue.count - 1)
-        }
+        self.realignCurrentIndexAfterQueueMutation(
+            currentEntryID: currentEntryID,
+            originalCurrentIndex: originalCurrentIndex,
+            removedIndices: indicesToRemove
+        )
 
         self.logger.info("Removed \(previousCount - self.queue.count) songs from queue")
         self.saveQueueForPersistence()

--- a/Sources/Kaset/Services/Player/PlayerService+Queue.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+Queue.swift
@@ -275,26 +275,148 @@ extension PlayerService {
         self.saveQueueForPersistence()
     }
 
-    /// Removes songs from the queue by stable entry IDs.
-    /// - Parameter entryIDs: Set of queue entry IDs to remove.
-    func removeFromQueue(entryIDs: Set<UUID>) {
+    /// Whether the queue contains the same song more than once.
+    var queueHasDuplicateEntries: Bool {
+        var seenVideoIds = Set<String>()
+        for song in self.queue {
+            if !seenVideoIds.insert(song.videoId).inserted {
+                return true
+            }
+        }
+        return false
+    }
+
+    /// Removes the queue entry at the given index, leaving other occurrences of the same song intact.
+    /// - Parameter index: The queue index to remove.
+    func removeFromQueue(at index: Int) {
+        guard self.queueEntries.indices.contains(index) else { return }
         self.clearForwardSkipNavigationStack()
         self.recordQueueStateForUndo()
         let previousCount = self.queue.count
         let currentEntryID = self.currentQueueEntryID
-        let remainingEntries = self.queueEntries.filter { !entryIDs.contains($0.id) }
+        var remainingEntries = self.queueEntries
+        remainingEntries.remove(at: index)
         self.setQueue(entries: remainingEntries)
+        self.realignCurrentIndexAfterQueueMutation(
+            currentEntryID: currentEntryID,
+            removedIndex: index
+        )
 
+        self.logger.info("Removed queue entry at index \(index); queue size \(previousCount) -> \(self.queue.count)")
+        self.saveQueueForPersistence()
+    }
+
+    /// Removes songs from the queue by stable entry IDs.
+    /// - Parameter entryIDs: Set of queue entry IDs to remove.
+    func removeFromQueue(entryIDs: Set<UUID>) {
+        guard !entryIDs.isEmpty else { return }
+        let indicesToRemove = self.queueEntries.enumerated()
+            .filter { entryIDs.contains($0.element.id) }
+            .map(\.offset)
+            .sorted(by: >)
+
+        guard !indicesToRemove.isEmpty else { return }
+
+        self.clearForwardSkipNavigationStack()
+        self.recordQueueStateForUndo()
+        let previousCount = self.queue.count
+        let currentEntryID = self.currentQueueEntryID
+        var remainingEntries = self.queueEntries
+        for index in indicesToRemove {
+            remainingEntries.remove(at: index)
+        }
+        self.setQueue(entries: remainingEntries)
+        self.realignCurrentIndexAfterQueueMutation(
+            currentEntryID: currentEntryID,
+            removedIndices: indicesToRemove
+        )
+
+        self.logger.info("Removed \(previousCount - self.queue.count) songs from queue")
+        self.saveQueueForPersistence()
+    }
+
+    /// Removes later duplicate songs from the queue, keeping the first occurrence of each video ID.
+    func removeDuplicateQueueEntries() {
+        guard self.queueHasDuplicateEntries else { return }
+
+        self.clearForwardSkipNavigationStack()
+        self.recordQueueStateForUndo()
+
+        let currentEntryID = self.currentQueueEntryID
+        var seenVideoIds = Set<String>()
+        var deduplicatedEntries: [QueueEntry] = []
+        var removedCount = 0
+
+        for entry in self.queueEntries {
+            if seenVideoIds.contains(entry.song.videoId) {
+                removedCount += 1
+                continue
+            }
+            seenVideoIds.insert(entry.song.videoId)
+            deduplicatedEntries.append(entry)
+        }
+
+        guard removedCount > 0 else { return }
+
+        let priorEntries = self.queueEntries
+        self.setQueue(entries: deduplicatedEntries)
+        self.realignCurrentIndexAfterDuplicateRemoval(
+            currentEntryID: currentEntryID,
+            priorEntries: priorEntries
+        )
+        self.logger.info("Removed \(removedCount) duplicate queue entries")
+        self.saveQueueForPersistence()
+    }
+
+    private func realignCurrentIndexAfterQueueMutation(
+        currentEntryID: UUID?,
+        removedIndex: Int
+    ) {
+        self.realignCurrentIndexAfterQueueMutation(
+            currentEntryID: currentEntryID,
+            removedIndices: [removedIndex]
+        )
+    }
+
+    private func realignCurrentIndexAfterQueueMutation(
+        currentEntryID: UUID?,
+        removedIndices: [Int]
+    ) {
         if let currentEntryID,
            let newIndex = self.queueEntryIDs.firstIndex(of: currentEntryID)
         {
             self.currentIndex = newIndex
+            return
+        }
+
+        let removedBeforeCurrent = removedIndices.filter { $0 < self.currentIndex }.count
+        if removedBeforeCurrent > 0 {
+            self.currentIndex = max(0, self.currentIndex - removedBeforeCurrent)
         } else if self.currentIndex >= self.queue.count {
             self.currentIndex = max(0, self.queue.count - 1)
         }
+    }
 
-        self.logger.info("Removed \(previousCount - self.queue.count) songs from queue")
-        self.saveQueueForPersistence()
+    private func realignCurrentIndexAfterDuplicateRemoval(
+        currentEntryID: UUID?,
+        priorEntries: [QueueEntry]
+    ) {
+        if let currentEntryID,
+           let keptIndex = self.queueEntries.firstIndex(where: { $0.id == currentEntryID })
+        {
+            self.currentIndex = keptIndex
+            return
+        }
+
+        if let currentEntryID,
+           let removedEntry = priorEntries.first(where: { $0.id == currentEntryID }),
+           let fallbackIndex = self.queueEntries.firstIndex(where: { $0.song.videoId == removedEntry.song.videoId })
+        {
+            self.currentIndex = fallbackIndex
+            return
+        }
+
+        self.currentIndex = min(self.currentIndex, max(0, self.queue.count - 1))
     }
 
     /// Removes songs from the queue by video ID.

--- a/Sources/Kaset/Services/Player/PlayerService+QueuePlaylist.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+QueuePlaylist.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+// MARK: - Queue Playlist Actions
+
+@MainActor
+extension PlayerService {
+    /// Creates a private playlist from the current queue and notifies library views.
+    func saveQueueAsPlaylist(title: String) async throws -> Playlist {
+        guard let client = self.ytMusicClient else {
+            throw YTMusicError.parseError(message: "YouTube Music client is unavailable")
+        }
+
+        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedTitle.isEmpty else {
+            throw YTMusicError.parseError(message: "Playlist name is required")
+        }
+
+        let songs = self.queue
+        let videoIds = songs.map(\.videoId)
+        let playlistId = try await client.createPlaylist(
+            title: trimmedTitle,
+            description: nil,
+            privacyStatus: .private,
+            videoIds: videoIds
+        )
+
+        let playlist = Playlist(
+            id: playlistId,
+            title: trimmedTitle,
+            description: nil,
+            thumbnailURL: songs.first?.thumbnailURL,
+            trackCount: songs.count
+        )
+
+        SongActionsHelper.invalidateLibraryResponseCaches()
+        LibraryMutationBroadcaster.shared.playlistCreated(playlist)
+
+        try? await Task.sleep(for: .milliseconds(500))
+        SongActionsHelper.invalidateLibraryResponseCaches()
+        await LibraryMutationBroadcaster.shared.reconcileCreatedPlaylist(playlist)
+        SongActionsHelper.invalidateLibraryResponseCaches()
+
+        self.logger.info("Saved queue as playlist '\(trimmedTitle)' with \(songs.count) songs")
+        return playlist
+    }
+}

--- a/Sources/Kaset/Utilities/AccessibilityIdentifiers.swift
+++ b/Sources/Kaset/Utilities/AccessibilityIdentifiers.swift
@@ -76,6 +76,7 @@ enum AccessibilityID {
         static let container = "queueView"
         static let scrollView = "queueView.scrollView"
         static let clearButton = "queueView.clearButton"
+        static let saveToPlaylistButton = "queueView.saveToPlaylistButton"
         static let emptyState = "queueView.emptyState"
         static let refineButton = "queueView.refineButton"
         static let suggestionButton = "queueView.suggestionButton"

--- a/Sources/Kaset/Utilities/AccessibilityIdentifiers.swift
+++ b/Sources/Kaset/Utilities/AccessibilityIdentifiers.swift
@@ -77,6 +77,7 @@ enum AccessibilityID {
         static let scrollView = "queueView.scrollView"
         static let clearButton = "queueView.clearButton"
         static let saveToPlaylistButton = "queueView.saveToPlaylistButton"
+        static let removeDuplicatesButton = "queueView.removeDuplicatesButton"
         static let emptyState = "queueView.emptyState"
         static let refineButton = "queueView.refineButton"
         static let suggestionButton = "queueView.suggestionButton"

--- a/Sources/Kaset/Views/QueueSidePanelView.swift
+++ b/Sources/Kaset/Views/QueueSidePanelView.swift
@@ -810,8 +810,6 @@ private struct QueueFooterActions: View {
 
     private func presentSaveQueueAsPlaylistDialog() {
         guard !self.isSavingPlaylist else { return }
-        guard let client = self.playerService.ytMusicClient else { return }
-
         let songs = self.playerService.queue
         guard !songs.isEmpty else { return }
 
@@ -833,7 +831,7 @@ private struct QueueFooterActions: View {
                 self.presentSaveQueueErrorAlert(message: "Playlist name is required.")
                 return
             }
-            Task { await self.saveQueueAsPlaylist(title: title, songs: songs, client: client) }
+            Task { await self.saveQueueAsPlaylist(title: title, songCount: songs.count) }
         }
 
         if let window = NSApp.keyWindow ?? NSApp.mainWindow {
@@ -843,22 +841,14 @@ private struct QueueFooterActions: View {
         }
     }
 
-    private func saveQueueAsPlaylist(
-        title: String,
-        songs: [Song],
-        client: any YTMusicClientProtocol
-    ) async {
+    private func saveQueueAsPlaylist(title: String, songCount: Int) async {
         guard !self.isSavingPlaylist else { return }
         self.isSavingPlaylist = true
         defer { self.isSavingPlaylist = false }
 
         do {
-            _ = try await SongActionsHelper.saveQueueAsPlaylist(
-                songs: songs,
-                title: title,
-                client: client
-            )
-            self.presentSaveQueueSuccessAlert(title: title, songCount: songs.count)
+            _ = try await self.playerService.saveQueueAsPlaylist(title: title)
+            self.presentSaveQueueSuccessAlert(title: title, songCount: songCount)
         } catch {
             DiagnosticsLogger.ui.error("Failed to save queue as playlist: \(error.localizedDescription)")
             self.presentSaveQueueErrorAlert(message: "Unable to save queue as playlist. Please try again.")

--- a/Sources/Kaset/Views/QueueSidePanelView.swift
+++ b/Sources/Kaset/Views/QueueSidePanelView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 // MARK: - QueueSidePanelView
@@ -647,6 +648,8 @@ private struct QueueSidePanelHeader: View {
 private struct QueueFooterActions: View {
     @Environment(PlayerService.self) private var playerService
 
+    @State private var isSavingPlaylist = false
+
     var body: some View {
         HStack(spacing: 12) {
             Button {
@@ -674,6 +677,18 @@ private struct QueueFooterActions: View {
             .buttonStyle(.plain)
 
             Button {
+                self.presentSaveQueueAsPlaylistDialog()
+            } label: {
+                Label(
+                    self.isSavingPlaylist ? "Saving…" : "Save to Playlist",
+                    systemImage: "text.badge.plus"
+                )
+            }
+            .disabled(self.playerService.queue.isEmpty || self.isSavingPlaylist || self.playerService.ytMusicClient == nil)
+            .buttonStyle(.plain)
+            .accessibilityIdentifier(AccessibilityID.Queue.saveToPlaylistButton)
+
+            Button {
                 Task {
                     if self.playerService.isPlaying {
                         await self.playerService.stop()
@@ -691,6 +706,81 @@ private struct QueueFooterActions: View {
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 12)
+    }
+
+    private func presentSaveQueueAsPlaylistDialog() {
+        guard !self.isSavingPlaylist else { return }
+        guard let client = self.playerService.ytMusicClient else { return }
+
+        let songs = self.playerService.queue
+        guard !songs.isEmpty else { return }
+
+        let alert = NSAlert()
+        alert.messageText = "Save Queue to Playlist"
+        alert.informativeText = "Create a private playlist with all \(songs.count) songs from your queue."
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "Save")
+        alert.addButton(withTitle: "Cancel")
+
+        let titleField = NSTextField(frame: NSRect(x: 0, y: 0, width: 280, height: 24))
+        titleField.placeholderString = "Playlist name"
+        alert.accessoryView = titleField
+
+        let handleResponse: (NSApplication.ModalResponse) -> Void = { response in
+            guard response == .alertFirstButtonReturn else { return }
+            let title = titleField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !title.isEmpty else {
+                self.presentSaveQueueErrorAlert(message: "Playlist name is required.")
+                return
+            }
+            Task { await self.saveQueueAsPlaylist(title: title, songs: songs, client: client) }
+        }
+
+        if let window = NSApp.keyWindow ?? NSApp.mainWindow {
+            alert.beginSheetModal(for: window, completionHandler: handleResponse)
+        } else {
+            handleResponse(alert.runModal())
+        }
+    }
+
+    private func saveQueueAsPlaylist(
+        title: String,
+        songs: [Song],
+        client: any YTMusicClientProtocol
+    ) async {
+        guard !self.isSavingPlaylist else { return }
+        self.isSavingPlaylist = true
+        defer { self.isSavingPlaylist = false }
+
+        do {
+            _ = try await SongActionsHelper.saveQueueAsPlaylist(
+                songs: songs,
+                title: title,
+                client: client
+            )
+            self.presentSaveQueueSuccessAlert(title: title, songCount: songs.count)
+        } catch {
+            DiagnosticsLogger.ui.error("Failed to save queue as playlist: \(error.localizedDescription)")
+            self.presentSaveQueueErrorAlert(message: "Unable to save queue as playlist. Please try again.")
+        }
+    }
+
+    private func presentSaveQueueSuccessAlert(title: String, songCount: Int) {
+        let alert = NSAlert()
+        alert.messageText = "Playlist Saved"
+        alert.informativeText = "\"\(title)\" was created with \(songCount) songs."
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
+    }
+
+    private func presentSaveQueueErrorAlert(message: String) {
+        let alert = NSAlert()
+        alert.messageText = "Save Failed"
+        alert.informativeText = message
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
     }
 }
 

--- a/Sources/Kaset/Views/QueueSidePanelView.swift
+++ b/Sources/Kaset/Views/QueueSidePanelView.swift
@@ -111,6 +111,7 @@ struct QueueListControllerRepresentable: NSViewControllerRepresentable {
 
         if !context.coordinator.isDragging {
             viewController.tableView?.reloadData()
+            viewController.tableView?.normalizeVisibleRowFrames()
         }
 
         // Update current track highlighting and waveform animation
@@ -200,6 +201,8 @@ struct QueueListControllerRepresentable: NSViewControllerRepresentable {
 
     @MainActor
     class Coordinator: NSObject, NSTableViewDelegate, NSTableViewDataSource {
+        private static let cellIdentifier = NSUserInterfaceItemIdentifier("QueueTableCell")
+
         var entries: [QueueEntry]
         var currentIndex: Int
         var isPlaying: Bool
@@ -252,7 +255,9 @@ struct QueueListControllerRepresentable: NSViewControllerRepresentable {
                 MainActor.assumeIsolated {
                     // Reset row view so it can be reused without a stuck frame/alpha (fixes misaligned rows).
                     rowView.alphaValue = 1
-                    rowView.frame = originalFrame
+                    var resetFrame = originalFrame
+                    resetFrame.origin.x = 0
+                    rowView.frame = resetFrame
                     self?.onRemove(row)
                 }
             }
@@ -262,8 +267,12 @@ struct QueueListControllerRepresentable: NSViewControllerRepresentable {
             self.entries.count
         }
 
-        func tableView(_: NSTableView, viewFor _: NSTableColumn?, row: Int) -> NSView? {
-            let cellView = QueueTableCellView()
+        func tableView(_ tableView: NSTableView, viewFor _: NSTableColumn?, row: Int) -> NSView? {
+            let cellView = (tableView.makeView(withIdentifier: Self.cellIdentifier, owner: nil) as? QueueTableCellView) ?? {
+                let view = QueueTableCellView()
+                view.identifier = Self.cellIdentifier
+                return view
+            }()
             let entry = self.entries[row]
             let song = entry.song
             let isLiked = self.likeStatusManager.isLiked(song)
@@ -315,8 +324,9 @@ struct QueueListControllerRepresentable: NSViewControllerRepresentable {
             // Dragging session began
         }
 
-        func tableView(_: NSTableView, draggingSession _: NSDraggingSession, endedAt _: NSPoint, operation _: NSDragOperation) {
+        func tableView(_ tableView: NSTableView, draggingSession _: NSDraggingSession, endedAt _: NSPoint, operation _: NSDragOperation) {
             self.isDragging = false
+            (tableView as? DraggableTableView)?.normalizeVisibleRowFrames()
         }
 
         /// Drop Destination
@@ -462,6 +472,27 @@ class DraggableTableView: NSTableView {
         self.draggingDestinationFeedbackStyle = .gap
     }
 
+    /// Resets row views that still carry a horizontal offset from swipe-to-remove feedback.
+    func normalizeVisibleRowFrames() {
+        let visibleRange = self.rows(in: self.visibleRect)
+        guard visibleRange.length > 0 else { return }
+
+        for row in visibleRange.location ..< NSMaxRange(visibleRange) {
+            Self.normalizeRowView(self.rowView(atRow: row, makeIfNecessary: false))
+        }
+    }
+
+    private static func normalizeRowView(_ rowView: NSTableRowView?) {
+        guard let rowView else { return }
+
+        var frame = rowView.frame
+        guard frame.origin.x != 0 || rowView.alphaValue != 1 else { return }
+
+        frame.origin.x = 0
+        rowView.frame = frame
+        rowView.alphaValue = 1
+    }
+
     /// Two-finger horizontal trackpad swipe: row follows finger in real time; release past threshold to remove, or return to cancel.
     override func scrollWheel(with event: NSEvent) {
         let dx = event.scrollingDeltaX
@@ -497,6 +528,10 @@ class DraggableTableView: NSTableView {
             let localPoint = self.convert(point, from: nil)
             let rowAtStart = self.row(at: localPoint)
             self.swipeRemoveTargetRow = rowAtStart
+            if rowAtStart >= 0 {
+                Self.normalizeRowView(self.rowView(atRow: rowAtStart, makeIfNecessary: false))
+            }
+            self.swipeTrackedInitialOriginX = 0
         }
     }
 
@@ -516,9 +551,10 @@ class DraggableTableView: NSTableView {
                 return
             }
             if self.swipeTrackedInitialOriginX == nil {
-                self.swipeTrackedInitialOriginX = rowView.frame.origin.x
+                Self.normalizeRowView(rowView)
+                self.swipeTrackedInitialOriginX = 0
             }
-            let initialX = self.swipeTrackedInitialOriginX!
+            let initialX = self.swipeTrackedInitialOriginX ?? 0
             let maxDrag = rowView.bounds.width * Self.swipeMaxDragFactor
             let clamped = max(-maxDrag, min(maxDrag, self.horizontalSwipeAccumulator))
             var f = rowView.frame
@@ -568,10 +604,7 @@ class DraggableTableView: NSTableView {
                     rowView.animator().alphaValue = 0
                 } completionHandler: {
                     MainActor.assumeIsolated {
-                        rowView.alphaValue = 1
-                        var f = rowView.frame
-                        f.origin.x = initialX
-                        rowView.frame = f
+                        Self.normalizeRowView(rowView)
                         coord.onRemove(row)
                     }
                 }
@@ -582,9 +615,13 @@ class DraggableTableView: NSTableView {
                     context.duration = 0.2
                     context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
                     var f = rowView.frame
-                    f.origin.x = initialX
+                    f.origin.x = 0
                     rowView.animator().frame = f
-                } completionHandler: {}
+                } completionHandler: {
+                    MainActor.assumeIsolated {
+                        Self.normalizeRowView(rowView)
+                    }
+                }
                 return true
             }
         }

--- a/Sources/Kaset/Views/QueueSidePanelView.swift
+++ b/Sources/Kaset/Views/QueueSidePanelView.swift
@@ -657,6 +657,35 @@ private struct QueueSidePanelHeader: View {
     }
 }
 
+// MARK: - QueueFooterIconButton
+
+private struct QueueFooterIconButton: View {
+    let systemImage: String
+    let helpText: String
+    let accessibilityLabel: String
+    var isEnabled: Bool = true
+    var tint: Color = .secondary
+    let action: () -> Void
+
+    var body: some View {
+        Group {
+            Button {
+                guard self.isEnabled else { return }
+                self.action()
+            } label: {
+                Image(systemName: self.systemImage)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(self.tint)
+                    .frame(width: 20, height: 20)
+            }
+            .buttonStyle(.plain)
+            .opacity(self.isEnabled ? 1 : 0.45)
+        }
+        .help(self.helpText)
+        .accessibilityLabel(self.accessibilityLabel)
+    }
+}
+
 // MARK: - QueueFooterActions
 
 private struct QueueFooterActions: View {
@@ -664,59 +693,79 @@ private struct QueueFooterActions: View {
 
     @State private var isSavingPlaylist = false
 
+    private var canSaveQueueAsPlaylist: Bool {
+        !self.playerService.queue.isEmpty
+            && !self.isSavingPlaylist
+            && self.playerService.ytMusicClient != nil
+    }
+
     var body: some View {
-        HStack(spacing: 12) {
-            Button {
-                self.playerService.undoQueue()
-            } label: {
-                Label("Undo", systemImage: "arrow.uturn.backward")
-            }
-            .disabled(!self.playerService.canUndoQueue)
-            .buttonStyle(.plain)
-
-            Button {
-                self.playerService.redoQueue()
-            } label: {
-                Label("Redo", systemImage: "arrow.uturn.forward")
-            }
-            .disabled(!self.playerService.canRedoQueue)
-            .buttonStyle(.plain)
-
-            Button {
-                self.playerService.shuffleQueue()
-            } label: {
-                Label("Shuffle", systemImage: "shuffle")
-            }
-            .disabled(self.playerService.queue.isEmpty)
-            .buttonStyle(.plain)
-
-            Button {
-                self.presentSaveQueueAsPlaylistDialog()
-            } label: {
-                Label(
-                    self.isSavingPlaylist ? "Saving…" : "Save to Playlist",
-                    systemImage: "text.badge.plus"
-                )
-            }
-            .disabled(self.playerService.queue.isEmpty || self.isSavingPlaylist || self.playerService.ytMusicClient == nil)
-            .buttonStyle(.plain)
-            .accessibilityIdentifier(AccessibilityID.Queue.saveToPlaylistButton)
-
-            Button {
-                Task {
-                    if self.playerService.isPlaying {
-                        await self.playerService.stop()
-                    }
-                    self.playerService.clearQueueEntirely()
+        HStack(spacing: 0) {
+            HStack(spacing: 8) {
+                QueueFooterIconButton(
+                    systemImage: "arrow.uturn.backward",
+                    helpText: String(localized: "Undo the last queue change."),
+                    accessibilityLabel: String(localized: "Undo"),
+                    isEnabled: self.playerService.canUndoQueue
+                ) {
+                    self.playerService.undoQueue()
                 }
-            } label: {
-                Label("Clear", systemImage: "trash")
-                    .foregroundStyle(.red)
-            }
-            .disabled(self.playerService.queue.isEmpty)
-            .buttonStyle(.plain)
 
-            Spacer()
+                QueueFooterIconButton(
+                    systemImage: "arrow.uturn.forward",
+                    helpText: String(localized: "Redo the last undone queue change."),
+                    accessibilityLabel: String(localized: "Redo"),
+                    isEnabled: self.playerService.canRedoQueue
+                ) {
+                    self.playerService.redoQueue()
+                }
+            }
+
+            HStack(spacing: 0) {
+                Spacer(minLength: 16)
+
+                QueueFooterIconButton(
+                    systemImage: "shuffle",
+                    helpText: String(localized: "Shuffle the queue, keeping the current song first."),
+                    accessibilityLabel: String(localized: "Shuffle"),
+                    isEnabled: !self.playerService.queue.isEmpty
+                ) {
+                    self.playerService.shuffleQueue()
+                }
+
+                Spacer()
+
+                Group {
+                    QueueFooterIconButton(
+                        systemImage: "text.badge.plus",
+                        helpText: self.isSavingPlaylist
+                            ? String(localized: "Saving queue as playlist…")
+                            : String(localized: "Save the current queue as a new private playlist."),
+                        accessibilityLabel: String(localized: "Save to Playlist"),
+                        isEnabled: self.canSaveQueueAsPlaylist
+                    ) {
+                        self.presentSaveQueueAsPlaylistDialog()
+                    }
+                }
+                .accessibilityIdentifier(AccessibilityID.Queue.saveToPlaylistButton)
+
+                Spacer()
+
+                QueueFooterIconButton(
+                    systemImage: "trash",
+                    helpText: String(localized: "Clear the entire queue and stop playback."),
+                    accessibilityLabel: String(localized: "Clear Queue"),
+                    isEnabled: !self.playerService.queue.isEmpty,
+                    tint: .red
+                ) {
+                    Task {
+                        if self.playerService.isPlaying {
+                            await self.playerService.stop()
+                        }
+                        self.playerService.clearQueueEntirely()
+                    }
+                }
+            }
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 12)

--- a/Sources/Kaset/Views/QueueSidePanelView.swift
+++ b/Sources/Kaset/Views/QueueSidePanelView.swift
@@ -35,8 +35,8 @@ struct QueueSidePanelView: View {
                     onReorder: { source, destination in
                         self.playerService.reorderQueue(from: IndexSet(integer: source), to: destination)
                     },
-                    onRemove: { entryID in
-                        self.playerService.removeFromQueue(entryIDs: Set([entryID]))
+                    onRemove: { index in
+                        self.playerService.removeFromQueue(at: index)
                     },
                     onStartRadio: { song in
                         Task {
@@ -91,7 +91,7 @@ struct QueueListControllerRepresentable: NSViewControllerRepresentable {
     let likeStatusEvent: LikeStatusEvent?
     let onSelect: (Int) -> Void
     let onReorder: (Int, Int) -> Void
-    let onRemove: (UUID) -> Void
+    let onRemove: (Int) -> Void
     let onStartRadio: (Song) -> Void
 
     func makeNSViewController(context: Context) -> QueueListViewController {
@@ -208,7 +208,7 @@ struct QueueListControllerRepresentable: NSViewControllerRepresentable {
         var lastLikeEvent: LikeStatusEvent?
         let onSelect: (Int) -> Void
         let onReorder: (Int, Int) -> Void
-        let onRemove: (UUID) -> Void
+        let onRemove: (Int) -> Void
         let onStartRadio: (Song) -> Void
         weak var viewController: QueueListViewController?
         var isDragging = false
@@ -216,7 +216,7 @@ struct QueueListControllerRepresentable: NSViewControllerRepresentable {
 
         init(entries: [QueueEntry], currentIndex: Int, isPlaying: Bool, favoritesManager: FavoritesManager,
              likeStatusManager: SongLikeStatusManager,
-             onSelect: @escaping (Int) -> Void, onReorder: @escaping (Int, Int) -> Void, onRemove: @escaping (UUID) -> Void, onStartRadio: @escaping (Song) -> Void)
+             onSelect: @escaping (Int) -> Void, onReorder: @escaping (Int, Int) -> Void, onRemove: @escaping (Int) -> Void, onStartRadio: @escaping (Song) -> Void)
         {
             self.entries = entries
             self.currentIndex = currentIndex
@@ -232,16 +232,15 @@ struct QueueListControllerRepresentable: NSViewControllerRepresentable {
 
         /// Removes the row with slide-out animation, then calls onRemove.
         /// - Parameter slideDirection: -1 = slide left, +1 = slide right (matches swipe direction).
-        func removeRowWithAnimation(row: Int, entry: QueueEntry, slideDirection: CGFloat) {
+        func removeRowWithAnimation(row: Int, slideDirection: CGFloat) {
             guard let tableView = viewController?.tableView else {
-                self.onRemove(entry.id)
+                self.onRemove(row)
                 return
             }
             guard let rowView = tableView.rowView(atRow: row, makeIfNecessary: false) else {
-                self.onRemove(entry.id)
+                self.onRemove(row)
                 return
             }
-            let entryID = entry.id
             let offsetX = slideDirection * rowView.bounds.width
             let originalFrame = rowView.frame
             NSAnimationContext.runAnimationGroup { context in
@@ -254,7 +253,7 @@ struct QueueListControllerRepresentable: NSViewControllerRepresentable {
                     // Reset row view so it can be reused without a stuck frame/alpha (fixes misaligned rows).
                     rowView.alphaValue = 1
                     rowView.frame = originalFrame
-                    self?.onRemove(entryID)
+                    self?.onRemove(row)
                 }
             }
         }
@@ -275,7 +274,7 @@ struct QueueListControllerRepresentable: NSViewControllerRepresentable {
                 isPlaying: self.isPlaying,
                 actions: QueueCellActions(
                     onPlay: { [weak self] in self?.onSelect(row) },
-                    onRemove: { [weak self] in self?.onRemove(entry.id) },
+                    onRemove: { [weak self] in self?.onRemove(row) },
                     onToggleLike: { [weak self] in
                         guard let self else { return }
                         if self.likeStatusManager.isLiked(song) {
@@ -381,7 +380,7 @@ struct QueueListControllerRepresentable: NSViewControllerRepresentable {
             if row != self.currentIndex {
                 let removeItem = NSMenuItem(title: "Remove from Queue", action: #selector(Coordinator.contextMenuRemove(_:)), keyEquivalent: "")
                 removeItem.target = self
-                removeItem.representedObject = entry.id.uuidString
+                removeItem.representedObject = NSNumber(value: row)
                 removeItem.image = NSImage(systemSymbolName: "minus.circle", accessibilityDescription: nil)
                 menu.addItem(removeItem)
             }
@@ -408,10 +407,8 @@ struct QueueListControllerRepresentable: NSViewControllerRepresentable {
         }
 
         @objc private func contextMenuRemove(_ sender: NSMenuItem) {
-            guard let entryIDString = sender.representedObject as? String,
-                  let entryID = UUID(uuidString: entryIDString)
-            else { return }
-            self.onRemove(entryID)
+            guard let rowNumber = sender.representedObject as? NSNumber else { return }
+            self.onRemove(rowNumber.intValue)
         }
     }
 }
@@ -542,7 +539,7 @@ class DraggableTableView: NSTableView {
             self.swipeTrackedInitialOriginX = nil
             guard let coord = coordinator,
                   swipeRemoveTargetRow >= 0,
-                  let entry = coord.entries[safe: swipeRemoveTargetRow]
+                  coord.entries[safe: swipeRemoveTargetRow] != nil
             else {
                 self.swipeRemoveTargetRow = -1
                 return false
@@ -561,7 +558,6 @@ class DraggableTableView: NSTableView {
             if passed {
                 let slideDirection: CGFloat = accH > 0 ? 1 : -1
                 let targetX = initialX + slideDirection * rowView.bounds.width
-                let entryID = entry.id
                 self.swipeRemoveCooldownUntil = CFAbsoluteTimeGetCurrent() + Self.swipeRemoveCooldown
                 NSAnimationContext.runAnimationGroup { context in
                     context.duration = 0.2
@@ -576,7 +572,7 @@ class DraggableTableView: NSTableView {
                         var f = rowView.frame
                         f.origin.x = initialX
                         rowView.frame = f
-                        coord.onRemove(entryID)
+                        coord.onRemove(row)
                     }
                 }
                 return true
@@ -602,10 +598,10 @@ class DraggableTableView: NSTableView {
         self.swipeRemoveTargetRow = -1
         if row < 0 { return false }
         if row == coord.currentIndex { return false }
-        guard let entry = coord.entries[safe: row] else { return false }
+        guard coord.entries[safe: row] != nil else { return false }
         let slideDirection: CGFloat = accH > 0 ? 1 : -1
         self.swipeRemoveCooldownUntil = CFAbsoluteTimeGetCurrent() + Self.swipeRemoveCooldown
-        coord.removeRowWithAnimation(row: row, entry: entry, slideDirection: slideDirection)
+        coord.removeRowWithAnimation(row: row, slideDirection: slideDirection)
         return true
     }
 }
@@ -626,6 +622,24 @@ private struct QueueSidePanelHeader: View {
             Text("\(self.playerService.queue.count) songs", comment: "Queue song count")
                 .font(.caption)
                 .foregroundStyle(.secondary)
+
+            Group {
+                Button {
+                    guard self.playerService.queueHasDuplicateEntries else { return }
+                    self.playerService.removeDuplicateQueueEntries()
+                } label: {
+                    Image(systemName: "arrow.triangle.merge")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(.secondary)
+                        .frame(width: 20, height: 20)
+                }
+                .buttonStyle(.plain)
+                .opacity(self.playerService.queueHasDuplicateEntries ? 1 : 0.45)
+                .allowsHitTesting(self.playerService.queueHasDuplicateEntries)
+            }
+            .help(String(localized: "Remove Duplicates: delete repeated songs from the queue and keep the first occurrence of each."))
+            .accessibilityLabel(String(localized: "Remove Duplicates"))
+            .accessibilityIdentifier(AccessibilityID.Queue.removeDuplicatesButton)
 
             Button {
                 self.playerService.toggleQueueDisplayMode()

--- a/Sources/Kaset/Views/QueueTableCellView.swift
+++ b/Sources/Kaset/Views/QueueTableCellView.swift
@@ -13,15 +13,25 @@ struct QueueCellActions {
 // MARK: - QueueTableCellView
 
 class QueueTableCellView: NSView {
+    private static let horizontalPadding: CGFloat = 12
+    private static let columnSpacing: CGFloat = 12
+    private static let indicatorWidth: CGFloat = 24
+    private static let thumbnailSize: CGFloat = 40
+    private static let explicitBadgeSize: CGFloat = 12
+    private static let likeButtonSize: CGFloat = 22
+    private static let durationWidth: CGFloat = 36
+
     private var onPlay: (() -> Void)?
     private var onRemove: (() -> Void)?
     private var isCurrentTrack: Bool = false
     private var isPlaying: Bool = false
-    private var indicatorLabel = NSTextField()
+    private let indicatorContainer = NSView()
+    private let indicatorLabel = NSTextField()
     private var waveformView: NSView?
     private let thumbnailImageView = NSImageView()
     private var imageLoadTask: Task<Void, Never>?
     private var currentSongId: String?
+    private let infoStackView = NSStackView()
     private let titleLabel = NSTextField()
     private let artistLabel = NSTextField()
     private let durationLabel = NSTextField()
@@ -40,26 +50,12 @@ class QueueTableCellView: NSView {
     }
 
     private func setupView() {
-        wantsLayer = true
-        // Fill the row view so layout is consistent when the table reuses row views (fixes misaligned rows).
-        autoresizingMask = [.width, .height]
+        self.wantsLayer = true
+        self.clipsToBounds = true
+        self.autoresizingMask = [.width, .height]
 
-        let stackView = NSStackView()
-        stackView.orientation = .horizontal
-        stackView.spacing = 12
-        stackView.alignment = .centerY
-        stackView.edgeInsets = NSEdgeInsets(top: 8, left: 12, bottom: 8, right: 8) // Reduced right padding
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-
-        // Indicator container (for number or waveform) — keep fixed so long text doesn't shift row layout
-        let indicatorContainer = NSView()
-        indicatorContainer.translatesAutoresizingMaskIntoConstraints = false
-        let indicatorWidth = indicatorContainer.widthAnchor.constraint(equalToConstant: 24)
-        indicatorWidth.priority = .required
-        indicatorWidth.isActive = true
-        indicatorContainer.heightAnchor.constraint(equalToConstant: 20).isActive = true
-        indicatorContainer.setContentHuggingPriority(.required, for: .horizontal)
-        indicatorContainer.setContentCompressionResistancePriority(.required, for: .horizontal)
+        self.indicatorContainer.translatesAutoresizingMaskIntoConstraints = false
+        self.addSubview(self.indicatorContainer)
 
         self.indicatorLabel.isEditable = false
         self.indicatorLabel.isBordered = false
@@ -67,77 +63,93 @@ class QueueTableCellView: NSView {
         self.indicatorLabel.alignment = .center
         self.indicatorLabel.font = NSFont.systemFont(ofSize: 12)
         self.indicatorLabel.translatesAutoresizingMaskIntoConstraints = false
-        indicatorContainer.addSubview(self.indicatorLabel)
-        NSLayoutConstraint.activate([
-            self.indicatorLabel.centerXAnchor.constraint(equalTo: indicatorContainer.centerXAnchor),
-            self.indicatorLabel.centerYAnchor.constraint(equalTo: indicatorContainer.centerYAnchor),
-        ])
+        self.indicatorContainer.addSubview(self.indicatorLabel)
 
         self.thumbnailImageView.wantsLayer = true
         self.thumbnailImageView.layer?.cornerRadius = 4
         self.thumbnailImageView.layer?.masksToBounds = true
-        self.thumbnailImageView.widthAnchor.constraint(equalToConstant: 40).isActive = true
-        self.thumbnailImageView.heightAnchor.constraint(equalToConstant: 40).isActive = true
+        self.thumbnailImageView.translatesAutoresizingMaskIntoConstraints = false
         self.thumbnailImageView.setContentHuggingPriority(.required, for: .horizontal)
         self.thumbnailImageView.setContentCompressionResistancePriority(.required, for: .horizontal)
+        self.addSubview(self.thumbnailImageView)
 
-        let infoStackView = NSStackView()
-        infoStackView.orientation = .vertical
-        infoStackView.spacing = 2
-        infoStackView.alignment = .leading
+        self.infoStackView.orientation = .vertical
+        self.infoStackView.spacing = 2
+        self.infoStackView.alignment = .leading
+        self.infoStackView.translatesAutoresizingMaskIntoConstraints = false
+        self.infoStackView.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        self.infoStackView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        self.addSubview(self.infoStackView)
 
         self.titleLabel.isEditable = false
         self.titleLabel.isBordered = false
         self.titleLabel.backgroundColor = .clear
         self.titleLabel.lineBreakMode = .byTruncatingTail
+        self.titleLabel.cell?.truncatesLastVisibleLine = true
+        self.titleLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        self.titleLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
 
         self.artistLabel.isEditable = false
         self.artistLabel.isBordered = false
         self.artistLabel.backgroundColor = .clear
         self.artistLabel.lineBreakMode = .byTruncatingTail
+        self.artistLabel.cell?.truncatesLastVisibleLine = true
         self.artistLabel.font = NSFont.systemFont(ofSize: 11)
         self.artistLabel.textColor = NSColor.secondaryLabelColor
+        self.artistLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        self.artistLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
 
-        infoStackView.addArrangedSubview(self.titleLabel)
-        infoStackView.addArrangedSubview(self.artistLabel)
-
-        self.durationLabel.isEditable = false
-        self.durationLabel.isBordered = false
-        self.durationLabel.backgroundColor = .clear
-        self.durationLabel.alignment = .right
-        self.durationLabel.font = NSFont.systemFont(ofSize: 11)
-        self.durationLabel.textColor = NSColor.tertiaryLabelColor
-        self.durationLabel.setContentCompressionResistancePriority(.required, for: .horizontal) // Don't compress duration
-
-        // Spacer takes all flexible space so title/artist and duration stay consistently aligned across rows
-        let spacerView = NSView()
-        spacerView.translatesAutoresizingMaskIntoConstraints = false
-        spacerView.setContentHuggingPriority(.defaultLow, for: .horizontal)
-        spacerView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-
-        infoStackView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal) // Truncate before spacer grows
+        self.infoStackView.addArrangedSubview(self.titleLabel)
+        self.infoStackView.addArrangedSubview(self.artistLabel)
 
         self.configureExplicitBadge()
         self.configureLikeButton()
+        self.configureDurationLabel()
+        self.addSubview(self.explicitBadge)
+        self.addSubview(self.likeButton)
+        self.addSubview(self.durationLabel)
 
-        stackView.addArrangedSubview(indicatorContainer)
-        stackView.addArrangedSubview(self.thumbnailImageView)
-        stackView.addArrangedSubview(infoStackView)
-        stackView.addArrangedSubview(self.explicitBadge)
-        stackView.addArrangedSubview(spacerView)
-        stackView.addArrangedSubview(self.likeButton)
-        stackView.addArrangedSubview(self.durationLabel)
-
-        addSubview(stackView)
         NSLayoutConstraint.activate([
-            stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            stackView.topAnchor.constraint(equalTo: topAnchor),
-            stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            self.indicatorContainer.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: Self.horizontalPadding),
+            self.indicatorContainer.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+            self.indicatorContainer.widthAnchor.constraint(equalToConstant: Self.indicatorWidth),
+            self.indicatorContainer.heightAnchor.constraint(equalToConstant: 20),
+
+            self.indicatorLabel.centerXAnchor.constraint(equalTo: self.indicatorContainer.centerXAnchor),
+            self.indicatorLabel.centerYAnchor.constraint(equalTo: self.indicatorContainer.centerYAnchor),
+
+            self.thumbnailImageView.leadingAnchor.constraint(
+                equalTo: self.indicatorContainer.trailingAnchor,
+                constant: Self.columnSpacing
+            ),
+            self.thumbnailImageView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+            self.thumbnailImageView.widthAnchor.constraint(equalToConstant: Self.thumbnailSize),
+            self.thumbnailImageView.heightAnchor.constraint(equalToConstant: Self.thumbnailSize),
+
+            self.durationLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -Self.horizontalPadding),
+            self.durationLabel.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+            self.durationLabel.widthAnchor.constraint(equalToConstant: Self.durationWidth),
+
+            self.likeButton.trailingAnchor.constraint(equalTo: self.durationLabel.leadingAnchor, constant: -8),
+            self.likeButton.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+            self.likeButton.widthAnchor.constraint(equalToConstant: Self.likeButtonSize),
+            self.likeButton.heightAnchor.constraint(equalToConstant: Self.likeButtonSize),
+
+            self.explicitBadge.trailingAnchor.constraint(equalTo: self.likeButton.leadingAnchor, constant: -8),
+            self.explicitBadge.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+            self.explicitBadge.widthAnchor.constraint(equalToConstant: Self.explicitBadgeSize),
+            self.explicitBadge.heightAnchor.constraint(equalToConstant: Self.explicitBadgeSize),
+
+            self.infoStackView.leadingAnchor.constraint(
+                equalTo: self.thumbnailImageView.trailingAnchor,
+                constant: Self.columnSpacing
+            ),
+            self.infoStackView.trailingAnchor.constraint(equalTo: self.explicitBadge.leadingAnchor, constant: -8),
+            self.infoStackView.centerYAnchor.constraint(equalTo: self.centerYAnchor),
         ])
 
         let clickGesture = NSClickGestureRecognizer(target: self, action: #selector(self.handleClick(_:)))
-        addGestureRecognizer(clickGesture)
+        self.addGestureRecognizer(clickGesture)
     }
 
     /// Explicit "E" badge — placed inline at the trailing edge of the title row.
@@ -155,10 +167,8 @@ class QueueTableCellView: NSView {
         self.explicitBadge.layer?.cornerRadius = 2.5
         self.explicitBadge.layer?.masksToBounds = true
         self.explicitBadge.translatesAutoresizingMaskIntoConstraints = false
-        self.explicitBadge.widthAnchor.constraint(equalToConstant: 12).isActive = true
-        self.explicitBadge.heightAnchor.constraint(equalToConstant: 12).isActive = true
         self.explicitBadge.setAccessibilityLabel("Explicit")
-        self.explicitBadge.isHidden = true
+        self.explicitBadge.alphaValue = 0
     }
 
     /// Like (thumbs-up) button — always visible; opacity reflects state.
@@ -171,15 +181,28 @@ class QueueTableCellView: NSView {
         self.likeButton.target = self
         self.likeButton.action = #selector(self.handleLikeClick)
         self.likeButton.translatesAutoresizingMaskIntoConstraints = false
-        self.likeButton.widthAnchor.constraint(equalToConstant: 22).isActive = true
-        self.likeButton.heightAnchor.constraint(equalToConstant: 22).isActive = true
+    }
+
+    private func configureDurationLabel() {
+        self.durationLabel.isEditable = false
+        self.durationLabel.isBordered = false
+        self.durationLabel.backgroundColor = .clear
+        self.durationLabel.alignment = .right
+        self.durationLabel.font = NSFont.systemFont(ofSize: 11)
+        self.durationLabel.textColor = NSColor.tertiaryLabelColor
+        self.durationLabel.translatesAutoresizingMaskIntoConstraints = false
+        self.durationLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+        self.durationLabel.setContentHuggingPriority(.required, for: .horizontal)
     }
 
     override func layout() {
         super.layout()
-        // Ensure we always fill the row view so reused rows don't keep a stale frame (fixes misaligned rows).
-        if let sv = superview, !sv.bounds.isEmpty, frame != sv.bounds {
-            frame = sv.bounds
+        guard let rowView = self.superview, !rowView.bounds.isEmpty else { return }
+
+        var frame = rowView.bounds
+        frame.origin = .zero
+        if self.frame != frame {
+            self.frame = frame
         }
     }
 
@@ -192,7 +215,7 @@ class QueueTableCellView: NSView {
         self.updateAppearance(isCurrentTrack: isCurrentTrack, isPlaying: isPlaying, index: index)
 
         let isExplicit = song.isExplicit ?? false
-        self.explicitBadge.isHidden = !isExplicit
+        self.explicitBadge.alphaValue = isExplicit ? 1 : 0
 
         self.updateLikeState(isLiked: actions.isLiked)
 
@@ -246,45 +269,35 @@ class QueueTableCellView: NSView {
         self.isPlaying = isPlaying
 
         if isCurrentTrack {
-            // Show animated waveform for current track
             self.indicatorLabel.stringValue = ""
             self.indicatorLabel.isHidden = true
 
-            // Create or update waveform view
             if self.waveformView == nil {
                 let waveView = WaveformView(frame: NSRect(x: 0, y: 0, width: 24, height: 16))
                 waveView.translatesAutoresizingMaskIntoConstraints = false
                 self.waveformView = waveView
-
-                // Find indicator container and add waveform
-                if let indicatorContainer = indicatorLabel.superview {
-                    indicatorContainer.addSubview(waveView)
-                    NSLayoutConstraint.activate([
-                        waveView.centerXAnchor.constraint(equalTo: indicatorContainer.centerXAnchor),
-                        waveView.centerYAnchor.constraint(equalTo: indicatorContainer.centerYAnchor),
-                        waveView.widthAnchor.constraint(equalToConstant: 24),
-                        waveView.heightAnchor.constraint(equalToConstant: 16),
-                    ])
-                }
+                self.indicatorContainer.addSubview(waveView)
+                NSLayoutConstraint.activate([
+                    waveView.centerXAnchor.constraint(equalTo: self.indicatorContainer.centerXAnchor),
+                    waveView.centerYAnchor.constraint(equalTo: self.indicatorContainer.centerYAnchor),
+                    waveView.widthAnchor.constraint(equalToConstant: 24),
+                    waveView.heightAnchor.constraint(equalToConstant: 16),
+                ])
             }
 
-            if let waveView = waveformView as? WaveformView {
+            if let waveView = self.waveformView as? WaveformView {
                 waveView.isHidden = false
                 waveView.isAnimating = isPlaying
                 waveView.tintColor = isPlaying ? NSColor.systemRed : NSColor.tertiaryLabelColor
             }
 
-            layer?.backgroundColor = NSColor.systemRed.withAlphaComponent(0.1).cgColor
+            self.layer?.backgroundColor = NSColor.systemRed.withAlphaComponent(0.1).cgColor
         } else {
-            // Show number for non-current tracks
             self.indicatorLabel.isHidden = false
             self.indicatorLabel.stringValue = "\(index + 1)"
             self.indicatorLabel.textColor = NSColor.tertiaryLabelColor
-
-            // Hide waveform
             self.waveformView?.isHidden = true
-
-            layer?.backgroundColor = NSColor.clear.cgColor
+            self.layer?.backgroundColor = NSColor.clear.cgColor
         }
     }
 
@@ -309,7 +322,8 @@ class QueueTableCellView: NSView {
         self.waveformView?.removeFromSuperview()
         self.waveformView = nil
         self.onToggleLikeAction = nil
-        self.explicitBadge.isHidden = true
+        self.explicitBadge.alphaValue = 0
+        self.layer?.backgroundColor = NSColor.clear.cgColor
     }
 }
 
@@ -324,7 +338,7 @@ class WaveformView: NSView {
 
     var tintColor: NSColor = .systemRed {
         didSet {
-            layer?.sublayers?.forEach { $0.backgroundColor = self.tintColor.cgColor }
+            self.layer?.sublayers?.forEach { $0.backgroundColor = self.tintColor.cgColor }
         }
     }
 
@@ -343,14 +357,13 @@ class WaveformView: NSView {
     }
 
     private func setupBars() {
-        wantsLayer = true
-        layer?.backgroundColor = NSColor.clear.cgColor
+        self.wantsLayer = true
+        self.layer?.backgroundColor = NSColor.clear.cgColor
 
-        // Create 3 bars for the waveform
         let barWidth: CGFloat = 3
         let barSpacing: CGFloat = 2
         let totalWidth = CGFloat(3) * barWidth + CGFloat(2) * barSpacing
-        let startX = (bounds.width - totalWidth) / 2
+        let startX = (self.bounds.width - totalWidth) / 2
 
         for i in 0 ..< 3 {
             let bar = CALayer()
@@ -358,11 +371,11 @@ class WaveformView: NSView {
             bar.cornerRadius = 1
             bar.frame = NSRect(
                 x: startX + CGFloat(i) * (barWidth + barSpacing),
-                y: bounds.height / 2 - 4,
+                y: self.bounds.height / 2 - 4,
                 width: barWidth,
                 height: 8
             )
-            layer?.addSublayer(bar)
+            self.layer?.addSublayer(bar)
             self.bars.append(bar)
         }
     }
@@ -372,10 +385,9 @@ class WaveformView: NSView {
             self.startAnimation()
         } else {
             self.stopAnimation()
-            // Reset to static middle position
             for bar in self.bars {
                 bar.frame.size.height = 8
-                bar.frame.origin.y = (bounds.height - 8) / 2
+                bar.frame.origin.y = (self.bounds.height - 8) / 2
             }
         }
     }
@@ -385,7 +397,6 @@ class WaveformView: NSView {
 
         self.startTime = CACurrentMediaTime()
 
-        // Keep the timer on the main run loop and hop explicitly before touching view state.
         let timer = Timer(timeInterval: 1.0 / 30.0, repeats: true) { [weak self] _ in
             Task { @MainActor [weak self] in
                 self?.updateBars()
@@ -411,11 +422,11 @@ class WaveformView: NSView {
         ]
 
         CATransaction.begin()
-        CATransaction.setDisableActions(true) // Disable implicit animations
+        CATransaction.setDisableActions(true)
         for (i, bar) in self.bars.enumerated() {
-            let height = min(barHeights[i], bounds.height)
+            let height = min(barHeights[i], self.bounds.height)
             bar.frame.size.height = height
-            bar.frame.origin.y = (bounds.height - height) / 2
+            bar.frame.origin.y = (self.bounds.height - height) / 2
         }
         CATransaction.commit()
     }

--- a/Sources/Kaset/Views/QueueView.swift
+++ b/Sources/Kaset/Views/QueueView.swift
@@ -111,7 +111,7 @@ struct QueueView: View {
                         favoritesManager: self.favoritesManager,
                         playerService: self.playerService,
                         onRemove: {
-                            self.playerService.removeFromQueue(entryIDs: Set([entry.id]))
+                            self.playerService.removeFromQueue(at: index)
                         },
                         onTap: {
                             Task {

--- a/Sources/Kaset/Views/SharedViews/SongActionsHelper.swift
+++ b/Sources/Kaset/Views/SharedViews/SongActionsHelper.swift
@@ -553,45 +553,6 @@ enum SongActionsHelper {
         DiagnosticsLogger.ui.info("Added song to play next: \(song.title)")
     }
 
-    /// Creates a private playlist from the current queue and notifies library views.
-    static func saveQueueAsPlaylist(
-        songs: [Song],
-        title: String,
-        client: any YTMusicClientProtocol
-    ) async throws -> Playlist {
-        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedTitle.isEmpty else {
-            throw YTMusicError.parseError(message: "Playlist name is required")
-        }
-
-        let videoIds = songs.map(\.videoId)
-        let playlistId = try await client.createPlaylist(
-            title: trimmedTitle,
-            description: nil,
-            privacyStatus: .private,
-            videoIds: videoIds
-        )
-
-        let playlist = Playlist(
-            id: playlistId,
-            title: trimmedTitle,
-            description: nil,
-            thumbnailURL: songs.first?.thumbnailURL,
-            trackCount: songs.count
-        )
-
-        self.invalidateLibraryResponseCaches()
-        LibraryMutationBroadcaster.shared.playlistCreated(playlist)
-
-        try? await Task.sleep(for: .milliseconds(500))
-        self.invalidateLibraryResponseCaches()
-        await LibraryMutationBroadcaster.shared.reconcileCreatedPlaylist(playlist)
-        self.invalidateLibraryResponseCaches()
-
-        DiagnosticsLogger.api.info("Saved queue as playlist '\(trimmedTitle)' with \(songs.count) songs")
-        return playlist
-    }
-
     /// Adds a song to the end of the queue.
     static func addToQueueLast(_ song: Song, playerService: PlayerService) {
         playerService.appendToQueue([song])

--- a/Sources/Kaset/Views/SharedViews/SongActionsHelper.swift
+++ b/Sources/Kaset/Views/SharedViews/SongActionsHelper.swift
@@ -553,6 +553,45 @@ enum SongActionsHelper {
         DiagnosticsLogger.ui.info("Added song to play next: \(song.title)")
     }
 
+    /// Creates a private playlist from the current queue and notifies library views.
+    static func saveQueueAsPlaylist(
+        songs: [Song],
+        title: String,
+        client: any YTMusicClientProtocol
+    ) async throws -> Playlist {
+        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedTitle.isEmpty else {
+            throw YTMusicError.parseError(message: "Playlist name is required")
+        }
+
+        let videoIds = songs.map(\.videoId)
+        let playlistId = try await client.createPlaylist(
+            title: trimmedTitle,
+            description: nil,
+            privacyStatus: .private,
+            videoIds: videoIds
+        )
+
+        let playlist = Playlist(
+            id: playlistId,
+            title: trimmedTitle,
+            description: nil,
+            thumbnailURL: songs.first?.thumbnailURL,
+            trackCount: songs.count
+        )
+
+        self.invalidateLibraryResponseCaches()
+        LibraryMutationBroadcaster.shared.playlistCreated(playlist)
+
+        try? await Task.sleep(for: .milliseconds(500))
+        self.invalidateLibraryResponseCaches()
+        await LibraryMutationBroadcaster.shared.reconcileCreatedPlaylist(playlist)
+        self.invalidateLibraryResponseCaches()
+
+        DiagnosticsLogger.api.info("Saved queue as playlist '\(trimmedTitle)' with \(songs.count) songs")
+        return playlist
+    }
+
     /// Adds a song to the end of the queue.
     static func addToQueueLast(_ song: Song, playerService: PlayerService) {
         playerService.appendToQueue([song])

--- a/Tests/KasetTests/PlayerServiceQueueTests.swift
+++ b/Tests/KasetTests/PlayerServiceQueueTests.swift
@@ -101,17 +101,44 @@ struct PlayerServiceQueueTests {
         #expect(self.playerService.currentIndex == 1)
     }
 
-    @Test("Remove from queue by entry ID removes only the targeted duplicate")
-    func removeFromQueueByEntryIDRemovesSingleDuplicate() async throws {
+    @Test("Remove from queue at index removes only the targeted duplicate")
+    func removeFromQueueAtIndexRemovesSingleDuplicate() async throws {
         let duplicateSong = TestFixtures.makeSong(id: "dup", title: "Duplicate Song")
         await self.playerService.playQueue([duplicateSong, duplicateSong, TestFixtures.makeSong(id: "other")], startingAt: 0)
         let secondEntryID = try #require(self.playerService.queueEntryIDs[safe: 1])
 
-        self.playerService.removeFromQueue(entryIDs: Set([secondEntryID]))
+        self.playerService.removeFromQueue(at: 1)
 
         #expect(self.playerService.queue.count == 2)
         #expect(self.playerService.queue.count(where: { $0.videoId == "dup" }) == 1)
         #expect(!self.playerService.queueEntryIDs.contains(secondEntryID))
+    }
+
+    @Test("Remove duplicate queue entries keeps first occurrence and realigns current track")
+    func removeDuplicateQueueEntriesKeepsFirstOccurrence() async throws {
+        let duplicateSong = TestFixtures.makeSong(id: "dup", title: "Duplicate Song")
+        let otherSong = TestFixtures.makeSong(id: "other", title: "Other Song")
+        await self.playerService.playQueue([duplicateSong, otherSong, duplicateSong, duplicateSong], startingAt: 2)
+        let firstDuplicateEntryID = try #require(self.playerService.queueEntryIDs.first)
+
+        self.playerService.removeDuplicateQueueEntries()
+
+        #expect(self.playerService.queue.count == 2)
+        #expect(self.playerService.queue.map(\.videoId) == ["dup", "other"])
+        #expect(self.playerService.currentIndex == 0)
+        #expect(self.playerService.currentQueueEntryID == firstDuplicateEntryID)
+    }
+
+    @Test("queueHasDuplicateEntries reflects duplicate video IDs")
+    func queueHasDuplicateEntries() async {
+        let duplicateSong = TestFixtures.makeSong(id: "dup", title: "Duplicate Song")
+        await self.playerService.playQueue([duplicateSong, duplicateSong], startingAt: 0)
+
+        #expect(self.playerService.queueHasDuplicateEntries == true)
+
+        self.playerService.removeDuplicateQueueEntries()
+
+        #expect(self.playerService.queueHasDuplicateEntries == false)
     }
 
     @Test("Reorder queue keeps current duplicate entry selected")

--- a/Tests/KasetTests/PlayerServiceQueueTests.swift
+++ b/Tests/KasetTests/PlayerServiceQueueTests.swift
@@ -114,6 +114,30 @@ struct PlayerServiceQueueTests {
         #expect(!self.playerService.queueEntryIDs.contains(secondEntryID))
     }
 
+    @Test("Remove queue entries clamps current index after removing current entry")
+    func removeFromQueueEntryIDsClampsCurrentIndexAfterRemovingCurrentEntry() async {
+        let songs = TestFixtures.makeSongs(count: 4)
+        await self.playerService.playQueue(songs, startingAt: 2)
+        let entryIDs = self.playerService.queueEntryIDs
+
+        self.playerService.removeFromQueue(entryIDs: Set(entryIDs[1 ... 3]))
+
+        #expect(self.playerService.queue.map(\.videoId) == ["video-0"])
+        #expect(self.playerService.currentIndex == 0)
+        #expect(self.playerService.currentQueueEntryID == entryIDs[0])
+    }
+
+    @Test("Remove songs by video ID clamps current index after removing current song")
+    func removeFromQueueVideoIDsClampsCurrentIndexAfterRemovingCurrentSong() async {
+        let songs = TestFixtures.makeSongs(count: 4)
+        await self.playerService.playQueue(songs, startingAt: 2)
+
+        self.playerService.removeFromQueue(videoIds: Set(["video-1", "video-2", "video-3"]))
+
+        #expect(self.playerService.queue.map(\.videoId) == ["video-0"])
+        #expect(self.playerService.currentIndex == 0)
+    }
+
     @Test("Remove duplicate queue entries keeps first occurrence and realigns current track")
     func removeDuplicateQueueEntriesKeepsFirstOccurrence() async throws {
         let duplicateSong = TestFixtures.makeSong(id: "dup", title: "Duplicate Song")

--- a/Tests/KasetTests/SearchViewModelTests.swift
+++ b/Tests/KasetTests/SearchViewModelTests.swift
@@ -14,6 +14,23 @@ struct SearchViewModelTests {
         self.viewModel = SearchViewModel(client: self.mockClient)
     }
 
+    private func waitForSuggestionFetch(
+        query: String,
+        timeout: Duration = .seconds(3)
+    ) async {
+        let clock = ContinuousClock()
+        let deadline = clock.now + timeout
+
+        while clock.now < deadline {
+            if self.mockClient.getSearchSuggestionsQueries.contains(query) {
+                return
+            }
+            try? await Task.sleep(for: .milliseconds(25))
+        }
+
+        Issue.record("Timed out waiting for suggestion fetch for query: \(query)")
+    }
+
     @Test("Initial state is idle with empty query")
     func initialState() {
         #expect(self.viewModel.loadingState == .idle)
@@ -119,14 +136,14 @@ struct SearchViewModelTests {
     }
 
     @Test("Editing after submitted suggestion re-enables autocomplete")
-    func editingAfterSubmittedSuggestionReenablesAutocomplete() async throws {
+    func editingAfterSubmittedSuggestionReenablesAutocomplete() async {
         let suggestion = SearchSuggestion(query: "daft punk")
         self.mockClient.searchSuggestions = [SearchSuggestion(query: "daft punk random access memories")]
 
         self.viewModel.selectSuggestion(suggestion)
         self.viewModel.query = "daft punk r"
         self.viewModel.fetchSuggestions()
-        try await Task.sleep(for: .milliseconds(250))
+        await self.waitForSuggestionFetch(query: "daft punk r")
 
         #expect(self.mockClient.getSearchSuggestionsQueries == ["daft punk r"])
         #expect(self.viewModel.suggestions.count == 1)


### PR DESCRIPTION
# Pull Request: Save Queue as Playlist & Queue Edit Improvements

## Summary

Adds the ability to save the current playback queue as a new private playlist, plus several queue edit-mode fixes and UI polish: per-row removal for duplicate songs, a remove-duplicates action, icon-only footer controls with tooltips, and a layout fix for misaligned queue rows with long titles.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] UI/UX improvement

## Features

### Save Queue to Playlist

- New **Save to Playlist** action in the queue edit panel footer (icon: `text.badge.plus`)
- Opens an `NSAlert` sheet to name the playlist
- Creates a **private** playlist via existing `playlist/create` API, seeding all queue `videoIds` in order
- Updates library caches and notifies `LibraryMutationBroadcaster` (same pattern as song context menu “Create Playlist…”)
- Accessibility ID: `queueView.saveToPlaylistButton`

### Remove Duplicates

- New header button in queue edit mode (icon: `arrow.triangle.merge`)
- Tooltip: *Remove Duplicates: delete repeated songs from the queue and keep the first occurrence of each.*
- Enabled only when `queueHasDuplicateEntries` is true; faded when inactive but still hoverable for the tooltip
- Keeps the first occurrence of each `videoId`; realigns `currentIndex` if the playing entry was a later duplicate
- Accessibility ID: `queueView.removeDuplicatesButton`

### Queue Footer UI (Edit Mode)

- Footer actions are **icon-only** with hover tooltips (Undo, Redo, Shuffle, Save to Playlist, Clear)
- Layout: **Undo + Redo** grouped on the left; **Shuffle**, **Save**, and **Clear** distributed across remaining width
- Clear remains red; disabled states use reduced opacity

## Bug Fixes

### Remove only the selected queue row (duplicates)

**Problem:** Deleting one instance of a duplicated song could remove every copy in the queue.

**Fix:**
- Added `removeFromQueue(at:)` — removes by **index**, not `videoId` or shared entry ID
- Side panel and popup queue UI now pass row index for context menu, swipe, and remove actions
- `removeFromQueue(entryIDs:)` removes by index (highest first) for batch safety

### Misaligned queue rows (long titles)

**Problem:** Rows with long titles (e.g. featured artist lists) could shift left, overlapping the index number and thumbnail.

**Fix:**
- Replaced horizontal `NSStackView` cell layout with **pinned Auto Layout** (fixed leading index + thumbnail, fixed trailing duration/like/badge, truncating middle text)
- Enabled **table cell reuse** via `makeView(withIdentifier:)`
- Normalize row view frames after swipe-to-remove feedback and drag operations
- `clipsToBounds` on cell to prevent visual bleed

## API / Service Changes

| Area | Change |
|------|--------|
| `SongActionsHelper` | `saveQueueAsPlaylist(songs:title:client:)` |
| `PlayerService+Queue` | `queueHasDuplicateEntries`, `removeFromQueue(at:)`, `removeDuplicateQueueEntries()` |
| `YTMusicClient` | No new endpoints — uses existing `playlist/create` |

## Files Changed

```
Sources/Kaset/Services/Player/PlayerService+Queue.swift
Sources/Kaset/Views/QueueSidePanelView.swift
Sources/Kaset/Views/QueueTableCellView.swift
Sources/Kaset/Views/QueueView.swift
Sources/Kaset/Views/SharedViews/SongActionsHelper.swift
Sources/Kaset/Utilities/AccessibilityIdentifiers.swift
Tests/KasetTests/PlayerServiceQueueTests.swift
```

## Testing

### Automated

```bash
swift test --filter PlayerServiceQueueTests
```

New/updated tests:
- `removeFromQueueAtIndexRemovesSingleDuplicate`
- `removeDuplicateQueueEntriesKeepsFirstOccurrence`
- `queueHasDuplicateEntries`

### Manual

- [ ] Build queue with 5+ songs; **Save to Playlist** → name → verify playlist in Library
- [ ] Add same song 2–3 times; remove **one** row → only that position removed
- [ ] With duplicates present, click **Remove Duplicates** → only first occurrences kept
- [ ] Hover footer/header icons → tooltips appear (including when disabled)
- [ ] Scroll queue with long titles → thumbnails and index numbers stay aligned
- [ ] Partial swipe-to-remove then cancel → rows stay aligned

### Build

```bash
swift build
KASET_SIGNING=adhoc ./Scripts/build-app.sh debug
```

Install to `/Applications` (use `ditto`, not `cp -r`, because of Sparkle symlinks):

```bash
ditto .build/app/Kaset.app /Applications/Kaset.app
```

## Checklist

- [x] Uses existing `playlist/create` API (no guessed endpoints)
- [x] No secrets/cookies in code or docs
- [x] Unit tests added for queue duplicate behavior
- [x] Accessibility identifiers for new buttons
- [ ] `swiftlint --strict && swiftformat .` run before submit
- [ ] Full `swift test --skip KasetUITests` run before submit

## Branch

`feature/save-queue-as-playlist`

## Suggested PR Title

**Save queue as playlist and improve queue edit mode (dedupe, alignment, icon footer)**

## Prompt Request (for reviewers)

> Add a "Save to Playlist" button in queue edit mode that saves the full queue via `playlist/create`. Fix queue removal so deleting one duplicate only removes that row. Add a header "Remove Duplicates" control. Make footer actions icon-only with tooltips and fix misaligned rows for long song titles in the AppKit queue table.
