### PR TITLE
refactor: improve library and player architecture

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -7,3 +7,7 @@ The signed-in user's saved YouTube Music collection. Kaset surfaces Library cont
 ## Library Content Identity
 
 The identity rules used to decide whether two Library items refer to the same saved content. YouTube Music can expose the same playlist as either a `VL...` browse ID or a raw playlist ID, and the same followed artist as either an `MPLAUC...` library browse ID or a public `UC...` channel ID. Kaset treats those equivalent forms as one Library item.
+
+## Library Content Parsing
+
+The parser slice that turns YouTube Music Library browse responses into Kaset Library content. It owns Library renderer traversal and item classification before handing identity equivalence to Library Content Identity.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -19,3 +19,11 @@ The rules that merge optimistic local Library mutations with eventually-consiste
 ## Library Mutation Orchestration
 
 The workflows that apply a user-requested Library change to YouTube Music, invalidate stale Library response caches, update visible Library state optimistically, and schedule reconciliation when backend snapshots lag behind the accepted mutation.
+
+## Queue Song Metadata
+
+The rules for preparing songs before they enter Kaset's native queue. This includes stripping generic YouTube Music album labels from artist metadata, applying fallback artist/album/thumbnail values for album-derived queue actions, and preserving playback metadata while rebuilding song values.
+
+## Album Playback Actions
+
+The workflows that fetch album tracks from YouTube Music playlist details, prepare them as queue-ready songs, and either insert them into the queue or replace playback with the album.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -27,3 +27,7 @@ The rules for preparing songs before they enter Kaset's native queue. This inclu
 ## Album Playback Actions
 
 The workflows that fetch album tracks from YouTube Music playlist details, prepare them as queue-ready songs, and either insert them into the queue or replace playback with the album.
+
+## Playlist Playback Actions
+
+The workflows that turn playlist browse data into native playback queues. This includes radio playlist queue fallback, browse playability correction, playlist artwork fallback, continuation loading, duplicate filtering, and discarding continuations when the active queue has changed.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -15,3 +15,7 @@ The parser slice that turns YouTube Music Library browse responses into Kaset Li
 ## Library Content Reconciliation
 
 The rules that merge optimistic local Library mutations with eventually-consistent YouTube Music Library snapshots. Kaset keeps locally added items visible and locally removed items suppressed until backend responses stabilize.
+
+## Library Mutation Orchestration
+
+The workflows that apply a user-requested Library change to YouTube Music, invalidate stale Library response caches, update visible Library state optimistically, and schedule reconciliation when backend snapshots lag behind the accepted mutation.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -11,3 +11,7 @@ The identity rules used to decide whether two Library items refer to the same sa
 ## Library Content Parsing
 
 The parser slice that turns YouTube Music Library browse responses into Kaset Library content. It owns Library renderer traversal and item classification before handing identity equivalence to Library Content Identity.
+
+## Library Content Reconciliation
+
+The rules that merge optimistic local Library mutations with eventually-consistent YouTube Music Library snapshots. Kaset keeps locally added items visible and locally removed items suppressed until backend responses stabilize.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,9 @@
+# Kaset Domain Language
+
+## Library
+
+The signed-in user's saved YouTube Music collection. Kaset surfaces Library content as playlists, followed artists, subscribed podcast shows, and uploaded songs.
+
+## Library Content Identity
+
+The identity rules used to decide whether two Library items refer to the same saved content. YouTube Music can expose the same playlist as either a `VL...` browse ID or a raw playlist ID, and the same followed artist as either an `MPLAUC...` library browse ID or a public `UC...` channel ID. Kaset treats those equivalent forms as one Library item.

--- a/Sources/Kaset/Services/API/Parsers/LibraryContentParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/LibraryContentParser.swift
@@ -1,0 +1,310 @@
+import Foundation
+import os
+
+/// Parser for the signed-in user's Library browse responses.
+enum LibraryContentParser {
+    private static let logger = DiagnosticsLogger.api
+
+    /// Source used for followed-artist content in a combined Library response.
+    enum LibraryArtistsSource {
+        case dedicated
+        case landingFallback
+    }
+
+    /// Parsed Library content from YouTube Music browse responses.
+    struct LibraryContent {
+        let playlists: [Playlist]
+        let artists: [Artist]
+        let podcastShows: [PodcastShow]
+        let uploadedSongsPlaylist: Playlist?
+        let artistsSource: LibraryArtistsSource
+
+        init(
+            playlists: [Playlist],
+            artists: [Artist],
+            podcastShows: [PodcastShow],
+            uploadedSongsPlaylist: Playlist? = nil,
+            artistsSource: LibraryArtistsSource = .dedicated
+        ) {
+            self.playlists = playlists
+            self.artists = artists
+            self.podcastShows = podcastShows
+            self.uploadedSongsPlaylist = uploadedSongsPlaylist
+            self.artistsSource = artistsSource
+        }
+    }
+
+    private struct LibraryItemCandidate {
+        let sourceName: String
+        let browseId: String
+        let browseEndpoint: [String: Any]
+        let title: String
+        let subtitle: String?
+        let thumbnailURL: URL?
+        let allowsRadioPlaylist: Bool
+        let renderer: [String: Any]
+    }
+
+    static func parseLibraryPlaylists(_ data: [String: Any]) -> [Playlist] {
+        self.parseLibraryContent(data).playlists
+    }
+
+    /// Parses library content from browse response, returning playlists, artists, and podcast shows.
+    static func parseLibraryContent(_ data: [String: Any]) -> LibraryContent {
+        var playlists: [Playlist] = []
+        var artists: [Artist] = []
+        var podcastShows: [PodcastShow] = []
+
+        for sectionData in Self.extractLibrarySections(from: data) {
+            Self.appendLibraryItems(
+                from: sectionData,
+                playlists: &playlists,
+                artists: &artists,
+                podcastShows: &podcastShows
+            )
+        }
+
+        return LibraryContent(playlists: playlists, artists: artists, podcastShows: podcastShows)
+    }
+
+    /// Merges library playlists using the dedicated endpoint as authoritative while retaining landing-only items.
+    static func mergedLibraryPlaylists(dedicated dedicatedPlaylists: [Playlist], fallback fallbackPlaylists: [Playlist]) -> [Playlist] {
+        var mergedPlaylists = dedicatedPlaylists
+        var seenPlaylistKeys = Set(dedicatedPlaylists.map { LibraryContentIdentity.playlistKey(for: $0) })
+
+        for playlist in fallbackPlaylists {
+            let playlistKey = LibraryContentIdentity.playlistKey(for: playlist)
+            guard seenPlaylistKeys.insert(playlistKey).inserted else { continue }
+            mergedPlaylists.append(playlist)
+        }
+
+        return mergedPlaylists
+    }
+
+    /// Parses artists from the dedicated library artists browse response.
+    static func parseLibraryArtists(_ data: [String: Any]) -> [Artist] {
+        var artists: [Artist] = []
+        var ignoredPlaylists: [Playlist] = []
+        var ignoredPodcastShows: [PodcastShow] = []
+
+        for sectionData in Self.extractLibrarySections(from: data) {
+            Self.appendLibraryItems(
+                from: sectionData,
+                playlists: &ignoredPlaylists,
+                artists: &artists,
+                podcastShows: &ignoredPodcastShows
+            )
+        }
+
+        return LibraryContentIdentity.deduplicatedArtists(artists)
+    }
+
+    /// Parses the uploaded songs browse endpoint into a virtual playlist tile for Library.
+    static func parseUploadedSongsPlaylist(_ data: [String: Any]) -> Playlist? {
+        let detail = PlaylistParser.parsePlaylistWithContinuation(data, playlistId: Playlist.uploadedSongsBrowseID).detail
+        guard !detail.tracks.isEmpty || (detail.trackCount ?? 0) > 0 else {
+            return nil
+        }
+
+        let title = detail.title == "Unknown Playlist" ? "Uploaded Songs" : detail.title
+        return Playlist(
+            id: Playlist.uploadedSongsBrowseID,
+            title: title,
+            description: nil,
+            thumbnailURL: detail.thumbnailURL ?? detail.tracks.first?.thumbnailURL,
+            trackCount: max(detail.trackCount ?? 0, detail.tracks.count),
+            author: Artist.inline(name: "Uploads", namespace: "library-upload"),
+            canDelete: false
+        )
+    }
+
+    private static func extractLibrarySections(from data: [String: Any]) -> [[String: Any]] {
+        guard let contents = data["contents"] as? [String: Any],
+              let singleColumnBrowseResults = contents["singleColumnBrowseResultsRenderer"] as? [String: Any],
+              let tabs = singleColumnBrowseResults["tabs"] as? [[String: Any]],
+              let firstTab = tabs.first,
+              let tabRenderer = firstTab["tabRenderer"] as? [String: Any],
+              let tabContent = tabRenderer["content"] as? [String: Any],
+              let sectionListRenderer = tabContent["sectionListRenderer"] as? [String: Any],
+              let sectionContents = sectionListRenderer["contents"] as? [[String: Any]]
+        else {
+            return []
+        }
+
+        return sectionContents
+    }
+
+    private static func appendLibraryItems(
+        from sectionData: [String: Any],
+        playlists: inout [Playlist],
+        artists: inout [Artist],
+        podcastShows: inout [PodcastShow]
+    ) {
+        // Try gridRenderer
+        if let gridRenderer = sectionData["gridRenderer"] as? [String: Any],
+           let items = gridRenderer["items"] as? [[String: Any]]
+        {
+            for itemData in items {
+                guard let twoRowRenderer = itemData["musicTwoRowItemRenderer"] as? [String: Any] else { continue }
+                Self.appendLibraryItem(
+                    Self.twoRowCandidate(from: twoRowRenderer),
+                    playlists: &playlists,
+                    artists: &artists,
+                    podcastShows: &podcastShows
+                )
+            }
+        }
+
+        // Try itemSectionRenderer > musicShelfRenderer
+        if let itemSectionRenderer = sectionData["itemSectionRenderer"] as? [String: Any],
+           let itemContents = itemSectionRenderer["contents"] as? [[String: Any]]
+        {
+            for itemContent in itemContents {
+                guard let shelfRenderer = itemContent["musicShelfRenderer"] as? [String: Any],
+                      let shelfContents = shelfRenderer["contents"] as? [[String: Any]]
+                else { continue }
+
+                Self.appendResponsiveLibraryItems(
+                    shelfContents,
+                    playlists: &playlists,
+                    artists: &artists,
+                    podcastShows: &podcastShows
+                )
+            }
+        }
+
+        // Try musicShelfRenderer directly
+        if let shelfRenderer = sectionData["musicShelfRenderer"] as? [String: Any],
+           let shelfContents = shelfRenderer["contents"] as? [[String: Any]]
+        {
+            Self.appendResponsiveLibraryItems(
+                shelfContents,
+                playlists: &playlists,
+                artists: &artists,
+                podcastShows: &podcastShows
+            )
+        }
+    }
+
+    private static func appendResponsiveLibraryItems(
+        _ shelfContents: [[String: Any]],
+        playlists: inout [Playlist],
+        artists: inout [Artist],
+        podcastShows: inout [PodcastShow]
+    ) {
+        for shelfItem in shelfContents {
+            guard let responsiveRenderer = shelfItem["musicResponsiveListItemRenderer"] as? [String: Any] else { continue }
+            Self.appendLibraryItem(
+                Self.responsiveCandidate(from: responsiveRenderer),
+                playlists: &playlists,
+                artists: &artists,
+                podcastShows: &podcastShows
+            )
+        }
+    }
+
+    private static func twoRowCandidate(from data: [String: Any]) -> LibraryItemCandidate? {
+        guard let navigationEndpoint = data["navigationEndpoint"] as? [String: Any],
+              let browseEndpoint = navigationEndpoint["browseEndpoint"] as? [String: Any],
+              let browseId = browseEndpoint["browseId"] as? String
+        else {
+            self.logger.debug("parseLibraryItem: No browseId found")
+            return nil
+        }
+
+        let thumbnails = ParsingHelpers.extractThumbnails(from: data)
+        return LibraryItemCandidate(
+            sourceName: "parseLibraryItem",
+            browseId: browseId,
+            browseEndpoint: browseEndpoint,
+            title: ParsingHelpers.extractTitle(from: data) ?? "Unknown",
+            subtitle: ParsingHelpers.extractSubtitle(from: data),
+            thumbnailURL: thumbnails.last.flatMap { URL(string: $0) },
+            allowsRadioPlaylist: true,
+            renderer: data
+        )
+    }
+
+    private static func responsiveCandidate(from data: [String: Any]) -> LibraryItemCandidate? {
+        guard let navigationEndpoint = data["navigationEndpoint"] as? [String: Any],
+              let browseEndpoint = navigationEndpoint["browseEndpoint"] as? [String: Any],
+              let browseId = browseEndpoint["browseId"] as? String
+        else {
+            self.logger.debug("parseLibraryItemFromResponsive: No browseId found, keys: \(Array(data.keys))")
+            return nil
+        }
+
+        let thumbnails = ParsingHelpers.extractThumbnails(from: data)
+        return LibraryItemCandidate(
+            sourceName: "parseLibraryItemFromResponsive",
+            browseId: browseId,
+            browseEndpoint: browseEndpoint,
+            title: ParsingHelpers.extractTitleFromFlexColumns(data) ?? "Unknown",
+            subtitle: ParsingHelpers.extractSubtitleFromFlexColumns(data),
+            thumbnailURL: thumbnails.last.flatMap { URL(string: $0) },
+            allowsRadioPlaylist: false,
+            renderer: data
+        )
+    }
+
+    private static func appendLibraryItem(
+        _ candidate: LibraryItemCandidate?,
+        playlists: inout [Playlist],
+        artists: inout [Artist],
+        podcastShows: inout [PodcastShow]
+    ) {
+        guard let candidate else { return }
+
+        Self.logger.info("\(candidate.sourceName): browseId=\(candidate.browseId, privacy: .public), title=\(candidate.title, privacy: .public)")
+
+        if candidate.browseId.hasPrefix("MPSPP") {
+            podcastShows.append(Self.podcastShow(from: candidate))
+            Self.logger.info("\(candidate.sourceName): Added podcast show: \(candidate.title)")
+        } else if Self.isPlaylistBrowseID(candidate.browseId, allowsRadioPlaylist: candidate.allowsRadioPlaylist) {
+            playlists.append(Self.playlist(from: candidate))
+            Self.logger.info("\(candidate.sourceName): Added playlist: \(candidate.title)")
+        } else if Artist.isNavigableId(candidate.browseId) {
+            artists.append(Self.artist(from: candidate))
+            Self.logger.info("\(candidate.sourceName): Added artist: \(candidate.title)")
+        } else if candidate.sourceName == "parseLibraryItemFromResponsive" {
+            Self.logger.info("\(candidate.sourceName): Skipping unknown prefix: \(candidate.browseId)")
+        }
+    }
+
+    private static func podcastShow(from candidate: LibraryItemCandidate) -> PodcastShow {
+        PodcastShow(
+            id: candidate.browseId,
+            title: candidate.title,
+            author: candidate.subtitle,
+            description: nil,
+            thumbnailURL: candidate.thumbnailURL,
+            episodeCount: nil
+        )
+    }
+
+    private static func playlist(from candidate: LibraryItemCandidate) -> Playlist {
+        Playlist(
+            id: candidate.browseId,
+            title: candidate.title,
+            description: nil,
+            thumbnailURL: candidate.thumbnailURL,
+            trackCount: nil,
+            author: candidate.subtitle.map { Artist.inline(name: $0, namespace: "playlist-author") },
+            canDelete: PlaylistEditability.canDeletePlaylist(from: candidate.renderer)
+        )
+    }
+
+    private static func artist(from candidate: LibraryItemCandidate) -> Artist {
+        let pageType = ParsingHelpers.extractPageType(from: candidate.browseEndpoint)
+        return Artist(
+            id: candidate.browseId,
+            name: candidate.title,
+            thumbnailURL: candidate.thumbnailURL,
+            profileKind: Artist.profileKind(forPageType: pageType)
+        )
+    }
+
+    private static func isPlaylistBrowseID(_ browseID: String, allowsRadioPlaylist: Bool) -> Bool {
+        browseID.hasPrefix("VL") || browseID.hasPrefix("PL") || (allowsRadioPlaylist && browseID.hasPrefix("RDCLAK"))
+    }
+}

--- a/Sources/Kaset/Services/API/Parsers/PlaylistEditability.swift
+++ b/Sources/Kaset/Services/API/Parsers/PlaylistEditability.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/// Interprets ownership/delete affordances from YouTube Music playlist renderers.
+enum PlaylistEditability {
+    /// Returns true only when the response payload exposes commands that are available
+    /// for playlists the signed-in user can delete. Unknown ownership is treated as false.
+    static func canDeletePlaylist(from value: Any) -> Bool {
+        ResponseTreeSearch.containsKey("deletePlaylistEndpoint", in: value)
+            || ResponseTreeSearch.containsKey("musicEditablePlaylistDetailHeaderRenderer", in: value)
+            || ResponseTreeSearch.containsText("playlist/delete", in: value)
+    }
+}

--- a/Sources/Kaset/Services/API/Parsers/PlaylistParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/PlaylistParser.swift
@@ -17,305 +17,32 @@ enum PlaylistParser {
         var duration: String?
     }
 
+    typealias LibraryArtistsSource = LibraryContentParser.LibraryArtistsSource
+    typealias LibraryContent = LibraryContentParser.LibraryContent
+
     /// Parses library playlists from browse response.
     static func parseLibraryPlaylists(_ data: [String: Any]) -> [Playlist] {
-        self.parseLibraryContent(data).playlists
-    }
-
-    /// Result type for library content parsing containing playlists, artists, and podcast shows.
-    enum LibraryArtistsSource {
-        case dedicated
-        case landingFallback
-    }
-
-    struct LibraryContent {
-        let playlists: [Playlist]
-        let artists: [Artist]
-        let podcastShows: [PodcastShow]
-        let uploadedSongsPlaylist: Playlist?
-        let artistsSource: LibraryArtistsSource
-
-        init(
-            playlists: [Playlist],
-            artists: [Artist],
-            podcastShows: [PodcastShow],
-            uploadedSongsPlaylist: Playlist? = nil,
-            artistsSource: LibraryArtistsSource = .dedicated
-        ) {
-            self.playlists = playlists
-            self.artists = artists
-            self.podcastShows = podcastShows
-            self.uploadedSongsPlaylist = uploadedSongsPlaylist
-            self.artistsSource = artistsSource
-        }
+        LibraryContentParser.parseLibraryPlaylists(data)
     }
 
     /// Parses library content from browse response, returning playlists, artists, and podcast shows.
     static func parseLibraryContent(_ data: [String: Any]) -> LibraryContent {
-        var playlists: [Playlist] = []
-        var artists: [Artist] = []
-        var podcastShows: [PodcastShow] = []
-
-        for sectionData in Self.extractLibrarySections(from: data) {
-            Self.appendLibraryItems(
-                from: sectionData,
-                playlists: &playlists,
-                artists: &artists,
-                podcastShows: &podcastShows
-            )
-        }
-
-        return LibraryContent(playlists: playlists, artists: artists, podcastShows: podcastShows)
+        LibraryContentParser.parseLibraryContent(data)
     }
 
     /// Merges library playlists using the dedicated endpoint as authoritative while retaining landing-only items.
     static func mergedLibraryPlaylists(dedicated dedicatedPlaylists: [Playlist], fallback fallbackPlaylists: [Playlist]) -> [Playlist] {
-        var mergedPlaylists = dedicatedPlaylists
-        var seenPlaylistKeys = Set(dedicatedPlaylists.map { LibraryContentIdentity.playlistKey(for: $0) })
-
-        for playlist in fallbackPlaylists {
-            let playlistKey = LibraryContentIdentity.playlistKey(for: playlist)
-            guard seenPlaylistKeys.insert(playlistKey).inserted else { continue }
-            mergedPlaylists.append(playlist)
-        }
-
-        return mergedPlaylists
+        LibraryContentParser.mergedLibraryPlaylists(dedicated: dedicatedPlaylists, fallback: fallbackPlaylists)
     }
 
     /// Parses artists from the dedicated library artists browse response.
     static func parseLibraryArtists(_ data: [String: Any]) -> [Artist] {
-        var artists: [Artist] = []
-        var ignoredPlaylists: [Playlist] = []
-        var ignoredPodcastShows: [PodcastShow] = []
-
-        for sectionData in Self.extractLibrarySections(from: data) {
-            Self.appendLibraryItems(
-                from: sectionData,
-                playlists: &ignoredPlaylists,
-                artists: &artists,
-                podcastShows: &ignoredPodcastShows
-            )
-        }
-
-        return LibraryContentIdentity.deduplicatedArtists(artists)
+        LibraryContentParser.parseLibraryArtists(data)
     }
 
     /// Parses the uploaded songs browse endpoint into a virtual playlist tile for Library.
     static func parseUploadedSongsPlaylist(_ data: [String: Any]) -> Playlist? {
-        let detail = Self.parsePlaylistWithContinuation(data, playlistId: Playlist.uploadedSongsBrowseID).detail
-        guard !detail.tracks.isEmpty || (detail.trackCount ?? 0) > 0 else {
-            return nil
-        }
-
-        let title = detail.title == "Unknown Playlist" ? "Uploaded Songs" : detail.title
-        return Playlist(
-            id: Playlist.uploadedSongsBrowseID,
-            title: title,
-            description: nil,
-            thumbnailURL: detail.thumbnailURL ?? detail.tracks.first?.thumbnailURL,
-            trackCount: max(detail.trackCount ?? 0, detail.tracks.count),
-            author: Artist.inline(name: "Uploads", namespace: "library-upload"),
-            canDelete: false
-        )
-    }
-
-    private static func extractLibrarySections(from data: [String: Any]) -> [[String: Any]] {
-        guard let contents = data["contents"] as? [String: Any],
-              let singleColumnBrowseResults = contents["singleColumnBrowseResultsRenderer"] as? [String: Any],
-              let tabs = singleColumnBrowseResults["tabs"] as? [[String: Any]],
-              let firstTab = tabs.first,
-              let tabRenderer = firstTab["tabRenderer"] as? [String: Any],
-              let tabContent = tabRenderer["content"] as? [String: Any],
-              let sectionListRenderer = tabContent["sectionListRenderer"] as? [String: Any],
-              let sectionContents = sectionListRenderer["contents"] as? [[String: Any]]
-        else {
-            return []
-        }
-
-        return sectionContents
-    }
-
-    private static func appendLibraryItems(
-        from sectionData: [String: Any],
-        playlists: inout [Playlist],
-        artists: inout [Artist],
-        podcastShows: inout [PodcastShow]
-    ) {
-        // Try gridRenderer
-        if let gridRenderer = sectionData["gridRenderer"] as? [String: Any],
-           let items = gridRenderer["items"] as? [[String: Any]]
-        {
-            for itemData in items {
-                if let twoRowRenderer = itemData["musicTwoRowItemRenderer"] as? [String: Any] {
-                    self.parseLibraryItem(
-                        twoRowRenderer,
-                        playlists: &playlists,
-                        artists: &artists,
-                        podcastShows: &podcastShows
-                    )
-                }
-            }
-        }
-
-        // Try itemSectionRenderer > musicShelfRenderer
-        if let itemSectionRenderer = sectionData["itemSectionRenderer"] as? [String: Any],
-           let itemContents = itemSectionRenderer["contents"] as? [[String: Any]]
-        {
-            for itemContent in itemContents {
-                if let shelfRenderer = itemContent["musicShelfRenderer"] as? [String: Any],
-                   let shelfContents = shelfRenderer["contents"] as? [[String: Any]]
-                {
-                    for shelfItem in shelfContents {
-                        if let responsiveRenderer = shelfItem["musicResponsiveListItemRenderer"] as? [String: Any] {
-                            Self.parseLibraryItemFromResponsive(
-                                responsiveRenderer,
-                                playlists: &playlists,
-                                artists: &artists,
-                                podcastShows: &podcastShows
-                            )
-                        }
-                    }
-                }
-            }
-        }
-
-        // Try musicShelfRenderer directly
-        if let shelfRenderer = sectionData["musicShelfRenderer"] as? [String: Any],
-           let shelfContents = shelfRenderer["contents"] as? [[String: Any]]
-        {
-            for shelfItem in shelfContents {
-                if let responsiveRenderer = shelfItem["musicResponsiveListItemRenderer"] as? [String: Any] {
-                    Self.parseLibraryItemFromResponsive(
-                        responsiveRenderer,
-                        playlists: &playlists,
-                        artists: &artists,
-                        podcastShows: &podcastShows
-                    )
-                }
-            }
-        }
-    }
-
-    /// Parses a library item from twoRowRenderer, adding to the appropriate array.
-    private static func parseLibraryItem(
-        _ data: [String: Any],
-        playlists: inout [Playlist],
-        artists: inout [Artist],
-        podcastShows: inout [PodcastShow]
-    ) {
-        guard let navigationEndpoint = data["navigationEndpoint"] as? [String: Any],
-              let browseEndpoint = navigationEndpoint["browseEndpoint"] as? [String: Any],
-              let browseId = browseEndpoint["browseId"] as? String
-        else {
-            self.logger.debug("parseLibraryItem: No browseId found")
-            return
-        }
-
-        let thumbnails = ParsingHelpers.extractThumbnails(from: data)
-        let thumbnailURL = thumbnails.last.flatMap { URL(string: $0) }
-        let title = ParsingHelpers.extractTitle(from: data) ?? "Unknown"
-        let subtitle = ParsingHelpers.extractSubtitle(from: data)
-
-        Self.logger.info("parseLibraryItem: browseId=\(browseId, privacy: .public), title=\(title, privacy: .public)")
-
-        if browseId.hasPrefix("MPSPP") {
-            // Podcast show
-            let show = PodcastShow(
-                id: browseId,
-                title: title,
-                author: subtitle,
-                description: nil,
-                thumbnailURL: thumbnailURL,
-                episodeCount: nil
-            )
-            podcastShows.append(show)
-            Self.logger.info("parseLibraryItem: Added podcast show: \(title)")
-        } else if browseId.hasPrefix("VL") || browseId.hasPrefix("PL") || browseId.hasPrefix("RDCLAK") {
-            // Playlist (VL prefix for saved playlists, PL for playlist IDs, RDCLAK for radio playlists)
-            let playlist = Playlist(
-                id: browseId,
-                title: title,
-                description: nil,
-                thumbnailURL: thumbnailURL,
-                trackCount: nil,
-                author: subtitle.map { Artist.inline(name: $0, namespace: "playlist-author") },
-                canDelete: Self.canDeletePlaylist(from: data)
-            )
-            playlists.append(playlist)
-            Self.logger.info("parseLibraryItem: Added playlist: \(title)")
-        } else if Artist.isNavigableId(browseId) {
-            let pageType = ParsingHelpers.extractPageType(from: browseEndpoint)
-            let artist = Artist(
-                id: browseId,
-                name: title,
-                thumbnailURL: thumbnailURL,
-                profileKind: Artist.profileKind(forPageType: pageType)
-            )
-            artists.append(artist)
-            Self.logger.info("parseLibraryItem: Added artist: \(title)")
-        }
-    }
-
-    /// Parses a library item from responsiveRenderer, adding to the appropriate array.
-    private static func parseLibraryItemFromResponsive(
-        _ data: [String: Any],
-        playlists: inout [Playlist],
-        artists: inout [Artist],
-        podcastShows: inout [PodcastShow]
-    ) {
-        guard let navigationEndpoint = data["navigationEndpoint"] as? [String: Any],
-              let browseEndpoint = navigationEndpoint["browseEndpoint"] as? [String: Any],
-              let browseId = browseEndpoint["browseId"] as? String
-        else {
-            self.logger.debug("parseLibraryItemFromResponsive: No browseId found, keys: \(Array(data.keys))")
-            return
-        }
-
-        let thumbnails = ParsingHelpers.extractThumbnails(from: data)
-        let thumbnailURL = thumbnails.last.flatMap { URL(string: $0) }
-        let title = ParsingHelpers.extractTitleFromFlexColumns(data) ?? "Unknown"
-        let subtitle = ParsingHelpers.extractSubtitleFromFlexColumns(data)
-
-        Self.logger.info("parseLibraryItemFromResponsive: browseId=\(browseId), title=\(title)")
-
-        if browseId.hasPrefix("MPSPP") {
-            // Podcast show
-            let show = PodcastShow(
-                id: browseId,
-                title: title,
-                author: subtitle,
-                description: nil,
-                thumbnailURL: thumbnailURL,
-                episodeCount: nil
-            )
-            podcastShows.append(show)
-            Self.logger.info("parseLibraryItemFromResponsive: Added podcast show: \(title)")
-        } else if browseId.hasPrefix("VL") || browseId.hasPrefix("PL") {
-            // Playlist
-            let playlist = Playlist(
-                id: browseId,
-                title: title,
-                description: nil,
-                thumbnailURL: thumbnailURL,
-                trackCount: nil,
-                author: subtitle.map { Artist.inline(name: $0, namespace: "playlist-author") },
-                canDelete: Self.canDeletePlaylist(from: data)
-            )
-            playlists.append(playlist)
-            Self.logger.info("parseLibraryItemFromResponsive: Added playlist: \(title)")
-        } else if Artist.isNavigableId(browseId) {
-            let pageType = ParsingHelpers.extractPageType(from: browseEndpoint)
-            let artist = Artist(
-                id: browseId,
-                name: title,
-                thumbnailURL: thumbnailURL,
-                profileKind: Artist.profileKind(forPageType: pageType)
-            )
-            artists.append(artist)
-            Self.logger.info("parseLibraryItemFromResponsive: Added artist: \(title)")
-        } else {
-            Self.logger.info("parseLibraryItemFromResponsive: Skipping unknown prefix: \(browseId)")
-        }
+        LibraryContentParser.parseUploadedSongsPlaylist(data)
     }
 
     /// Parses playlist detail from browse response.
@@ -333,7 +60,7 @@ enum PlaylistParser {
             thumbnailURL: header.thumbnailURL,
             trackCount: trackCount,
             author: header.author,
-            canDelete: Self.canDeletePlaylist(from: data)
+            canDelete: PlaylistEditability.canDeletePlaylist(from: data)
         )
 
         return PlaylistDetail(playlist: playlist, tracks: tracks, duration: header.duration)
@@ -354,7 +81,7 @@ enum PlaylistParser {
             thumbnailURL: header.thumbnailURL,
             trackCount: trackCount,
             author: header.author,
-            canDelete: Self.canDeletePlaylist(from: data)
+            canDelete: PlaylistEditability.canDeletePlaylist(from: data)
         )
 
         let detail = PlaylistDetail(playlist: playlist, tracks: tracks, duration: header.duration)
@@ -1400,7 +1127,7 @@ enum PlaylistParser {
             thumbnailURL: thumbnailURL,
             trackCount: nil,
             author: ParsingHelpers.extractSubtitle(from: data).map { Artist.inline(name: $0, namespace: "playlist-author") },
-            canDelete: Self.canDeletePlaylist(from: data)
+            canDelete: PlaylistEditability.canDeletePlaylist(from: data)
         )
     }
 
@@ -1424,7 +1151,7 @@ enum PlaylistParser {
             thumbnailURL: thumbnailURL,
             trackCount: nil,
             author: ParsingHelpers.extractSubtitleFromFlexColumns(data).map { Artist.inline(name: $0, namespace: "playlist-author") },
-            canDelete: Self.canDeletePlaylist(from: data)
+            canDelete: PlaylistEditability.canDeletePlaylist(from: data)
         )
     }
 
@@ -1432,9 +1159,9 @@ enum PlaylistParser {
 
     /// Parses the response from `playlist/get_add_to_playlist`.
     static func parseAddToPlaylistMenu(_ data: [String: Any]) -> AddToPlaylistMenu {
-        let renderer = Self.findFirstDictionary(named: "addToPlaylistRenderer", in: data) ?? data
+        let renderer = ResponseTreeSearch.firstDictionary(named: "addToPlaylistRenderer", in: data) ?? data
         let title = Self.extractText(from: renderer["title"] as? [String: Any])
-        let canCreatePlaylist = Self.containsKey("createPlaylistEndpoint", in: renderer)
+        let canCreatePlaylist = ResponseTreeSearch.containsKey("createPlaylistEndpoint", in: renderer)
 
         var seenPlaylistIds = Set<String>()
         let options = Self.collectAddToPlaylistOptions(in: renderer).filter { option in
@@ -1683,60 +1410,6 @@ enum PlaylistParser {
         }
         return nil
     }
-
-    private static func findFirstDictionary(named key: String, in value: Any) -> [String: Any]? {
-        if let dictionary = value as? [String: Any] {
-            if let match = dictionary[key] as? [String: Any] {
-                return match
-            }
-            for child in dictionary.values {
-                if let match = Self.findFirstDictionary(named: key, in: child) {
-                    return match
-                }
-            }
-        } else if let array = value as? [Any] {
-            for child in array {
-                if let match = Self.findFirstDictionary(named: key, in: child) {
-                    return match
-                }
-            }
-        }
-        return nil
-    }
-
-    /// Returns true only when the response payload exposes commands that are available
-    /// for playlists the signed-in user can delete. Unknown ownership is treated as false.
-    private static func canDeletePlaylist(from value: Any) -> Bool {
-        self.containsKey("deletePlaylistEndpoint", in: value)
-            || self.containsKey("musicEditablePlaylistDetailHeaderRenderer", in: value)
-            || self.containsText("playlist/delete", in: value)
-    }
-
-    private static func containsKey(_ key: String, in value: Any) -> Bool {
-        if let dictionary = value as? [String: Any] {
-            if dictionary[key] != nil { return true }
-            return dictionary.values.contains { self.containsKey(key, in: $0) }
-        }
-        if let array = value as? [Any] {
-            return array.contains { Self.containsKey(key, in: $0) }
-        }
-        return false
-    }
-
-    private static func containsText(_ text: String, in value: Any) -> Bool {
-        if let string = value as? String {
-            return string.localizedCaseInsensitiveContains(text)
-        }
-        if let dictionary = value as? [String: Any] {
-            return dictionary.values.contains { Self.containsText(text, in: $0) }
-        }
-        if let array = value as? [Any] {
-            return array.contains { Self.containsText(text, in: $0) }
-        }
-        return false
-    }
-
-    // MARK: - Queue Response Parsing
 
     /// Parses tracks from a music/get_queue response.
     /// This endpoint returns ALL tracks for a playlist in a single request (no pagination needed).

--- a/Sources/Kaset/Services/API/Parsers/PlaylistParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/PlaylistParser.swift
@@ -71,11 +71,11 @@ enum PlaylistParser {
     /// Merges library playlists using the dedicated endpoint as authoritative while retaining landing-only items.
     static func mergedLibraryPlaylists(dedicated dedicatedPlaylists: [Playlist], fallback fallbackPlaylists: [Playlist]) -> [Playlist] {
         var mergedPlaylists = dedicatedPlaylists
-        var seenPlaylistIds = Set(dedicatedPlaylists.map { Self.normalizedLibraryPlaylistId($0.id) })
+        var seenPlaylistKeys = Set(dedicatedPlaylists.map { LibraryContentIdentity.playlistKey(for: $0) })
 
         for playlist in fallbackPlaylists {
-            let normalizedPlaylistId = Self.normalizedLibraryPlaylistId(playlist.id)
-            guard seenPlaylistIds.insert(normalizedPlaylistId).inserted else { continue }
+            let playlistKey = LibraryContentIdentity.playlistKey(for: playlist)
+            guard seenPlaylistKeys.insert(playlistKey).inserted else { continue }
             mergedPlaylists.append(playlist)
         }
 
@@ -97,20 +97,7 @@ enum PlaylistParser {
             )
         }
 
-        let normalizedArtists = artists.map { artist in
-            if let publicChannelId = Artist.publicChannelId(for: artist.id) {
-                return Artist(
-                    id: publicChannelId,
-                    name: artist.name,
-                    thumbnailURL: artist.thumbnailURL,
-                    profileKind: artist.profileKind
-                )
-            }
-
-            return artist
-        }
-
-        return Self.deduplicatedArtists(normalizedArtists)
+        return LibraryContentIdentity.deduplicatedArtists(artists)
     }
 
     /// Parses the uploaded songs browse endpoint into a virtual playlist tile for Library.
@@ -130,27 +117,6 @@ enum PlaylistParser {
             author: Artist.inline(name: "Uploads", namespace: "library-upload"),
             canDelete: false
         )
-    }
-
-    private static func normalizedLibraryPlaylistId(_ playlistId: String) -> String {
-        if playlistId.hasPrefix("VL") {
-            return String(playlistId.dropFirst(2))
-        }
-
-        return playlistId
-    }
-
-    private static func deduplicatedArtists(_ artists: [Artist]) -> [Artist] {
-        var seenArtistIds: Set<String> = []
-        var deduplicatedArtists: [Artist] = []
-
-        for artist in artists {
-            let normalizedArtistId = Artist.publicChannelId(for: artist.id) ?? artist.id
-            guard seenArtistIds.insert(normalizedArtistId).inserted else { continue }
-            deduplicatedArtists.append(artist)
-        }
-
-        return deduplicatedArtists
     }
 
     private static func extractLibrarySections(from data: [String: Any]) -> [[String: Any]] {

--- a/Sources/Kaset/Services/API/Parsers/ResponseTreeSearch.swift
+++ b/Sources/Kaset/Services/API/Parsers/ResponseTreeSearch.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Recursive search helpers for YouTube Music response trees.
+enum ResponseTreeSearch {
+    static func firstDictionary(named key: String, in value: Any) -> [String: Any]? {
+        if let dictionary = value as? [String: Any] {
+            if let match = dictionary[key] as? [String: Any] {
+                return match
+            }
+
+            for child in dictionary.values {
+                if let match = self.firstDictionary(named: key, in: child) {
+                    return match
+                }
+            }
+        } else if let array = value as? [Any] {
+            for child in array {
+                if let match = self.firstDictionary(named: key, in: child) {
+                    return match
+                }
+            }
+        }
+
+        return nil
+    }
+
+    static func containsKey(_ key: String, in value: Any) -> Bool {
+        if let dictionary = value as? [String: Any] {
+            if dictionary[key] != nil { return true }
+            return dictionary.values.contains { self.containsKey(key, in: $0) }
+        }
+
+        if let array = value as? [Any] {
+            return array.contains { self.containsKey(key, in: $0) }
+        }
+
+        return false
+    }
+
+    static func containsText(_ text: String, in value: Any) -> Bool {
+        if let string = value as? String {
+            return string.localizedCaseInsensitiveContains(text)
+        }
+
+        if let dictionary = value as? [String: Any] {
+            return dictionary.values.contains { self.containsText(text, in: $0) }
+        }
+
+        if let array = value as? [Any] {
+            return array.contains { self.containsText(text, in: $0) }
+        }
+
+        return false
+    }
+}

--- a/Sources/Kaset/Services/Library/LibraryContentIdentity.swift
+++ b/Sources/Kaset/Services/Library/LibraryContentIdentity.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+/// Centralizes Library identity semantics that YouTube Music exposes through multiple ID shapes.
+///
+/// Library playlist tiles can surface either a `VL...` browse ID or the raw playlist ID, while
+/// followed artists can surface as `MPLAUC...` library browse IDs or public `UC...` channel IDs.
+/// This module gives parsers, view models, and test adapters one interface for equality,
+/// canonical artist values, and stable de-duplication.
+enum LibraryContentIdentity {
+    static func playlistKey(for playlistID: String) -> String {
+        if playlistID.hasPrefix("VL") {
+            return String(playlistID.dropFirst(2))
+        }
+
+        return playlistID
+    }
+
+    static func playlistKey(for playlist: Playlist) -> String {
+        self.playlistKey(for: playlist.id)
+    }
+
+    static func artistKey(for artistID: String) -> String {
+        Artist.publicChannelId(for: artistID) ?? artistID
+    }
+
+    static func artistKey(for artist: Artist) -> String {
+        self.artistKey(for: artist.id)
+    }
+
+    static func canonicalArtist(_ artist: Artist, libraryArtistID: String? = nil) -> Artist {
+        let canonicalArtistID = self.artistKey(for: libraryArtistID ?? artist.id)
+        if artist.id == canonicalArtistID {
+            return artist
+        }
+
+        return Artist(
+            id: canonicalArtistID,
+            name: artist.name,
+            thumbnailURL: artist.thumbnailURL,
+            subtitle: artist.subtitle,
+            profileKind: artist.profileKind
+        )
+    }
+
+    static func deduplicatedPlaylists(_ playlists: [Playlist]) -> [Playlist] {
+        var seenPlaylistKeys: Set<String> = []
+        var deduplicatedPlaylists: [Playlist] = []
+
+        for playlist in playlists {
+            guard seenPlaylistKeys.insert(self.playlistKey(for: playlist)).inserted else { continue }
+            deduplicatedPlaylists.append(playlist)
+        }
+
+        return deduplicatedPlaylists
+    }
+
+    static func deduplicatedArtists(_ artists: [Artist]) -> [Artist] {
+        var seenArtistKeys: Set<String> = []
+        var deduplicatedArtists: [Artist] = []
+
+        for artist in artists {
+            let canonicalArtist = self.canonicalArtist(artist)
+            guard seenArtistKeys.insert(self.artistKey(for: canonicalArtist)).inserted else { continue }
+            deduplicatedArtists.append(canonicalArtist)
+        }
+
+        return deduplicatedArtists
+    }
+
+    static func containsPlaylist(_ playlistID: String, in libraryPlaylistIDs: Set<String>) -> Bool {
+        let playlistKey = self.playlistKey(for: playlistID)
+        return libraryPlaylistIDs.contains { self.playlistKey(for: $0) == playlistKey }
+    }
+
+    static func removingPlaylist(_ playlistID: String, from libraryPlaylistIDs: Set<String>) -> Set<String> {
+        let playlistKey = self.playlistKey(for: playlistID)
+        return libraryPlaylistIDs.filter { self.playlistKey(for: $0) != playlistKey }
+    }
+}

--- a/Sources/Kaset/Services/Library/LibraryContentReconciler.swift
+++ b/Sources/Kaset/Services/Library/LibraryContentReconciler.swift
@@ -1,0 +1,302 @@
+import Foundation
+
+// MARK: - LibraryContentSnapshot
+
+/// Visible Library content plus the ID indexes that power membership checks.
+struct LibraryContentSnapshot {
+    var playlists: [Playlist]
+    var artists: [Artist]
+    var podcastShows: [PodcastShow]
+    var uploadedSongsPlaylist: Playlist?
+    var playlistIds: Set<String>
+    var artistIds: Set<String>
+    var podcastIds: Set<String>
+
+    static let empty = LibraryContentSnapshot(
+        playlists: [],
+        artists: [],
+        podcastShows: [],
+        uploadedSongsPlaylist: nil,
+        playlistIds: [],
+        artistIds: [],
+        podcastIds: []
+    )
+
+    var hasVisibleContent: Bool {
+        !self.playlists.isEmpty || !self.artists.isEmpty || !self.podcastShows.isEmpty
+            || self.uploadedSongsPlaylist != nil
+            || !self.playlistIds.isEmpty || !self.artistIds.isEmpty || !self.podcastIds.isEmpty
+    }
+}
+
+// MARK: - LibraryContentReconciler
+
+/// Reconciles optimistic local Library mutations with eventually-consistent backend snapshots.
+///
+/// YouTube Music can lag or oscillate after add/remove operations. This module owns the
+/// optimistic pending state so callers can ask for visible Library content without knowing
+/// the stabilization rules.
+struct LibraryContentReconciler {
+    struct Result {
+        let snapshot: LibraryContentSnapshot
+        let preservedExistingArtists: Bool
+    }
+
+    private static let playlistMutationStableMatchCount = 2
+    private static let artistMutationStableMatchCount = 2
+
+    private var pendingAddedPlaylists: [String: Playlist] = [:]
+    private var pendingAddedPlaylistMatchCounts: [String: Int] = [:]
+    private var pendingRemovedPlaylistKeys: Set<String> = []
+    private var pendingRemovedPlaylistMissCounts: [String: Int] = [:]
+
+    private struct ArtistReconciliationResult {
+        let artists: [Artist]
+        let artistKeys: Set<String>
+        let preservedExistingArtists: Bool
+    }
+
+    private var pendingAddedArtists: [String: Artist] = [:]
+    private var pendingAddedArtistMatchCounts: [String: Int] = [:]
+    private var pendingRemovedArtistKeys: Set<String> = []
+    private var pendingRemovedArtistMissCounts: [String: Int] = [:]
+
+    mutating func apply(
+        _ content: LibraryContentParser.LibraryContent,
+        currentSnapshot: LibraryContentSnapshot
+    ) -> Result {
+        let playlists = self.reconciledPlaylists(from: content.playlists)
+        let artistResult = self.reconciledArtists(from: content, currentSnapshot: currentSnapshot)
+        let podcastShows = content.podcastShows
+
+        return Result(
+            snapshot: LibraryContentSnapshot(
+                playlists: playlists,
+                artists: artistResult.artists,
+                podcastShows: podcastShows,
+                uploadedSongsPlaylist: content.uploadedSongsPlaylist,
+                playlistIds: Set(playlists.map(\.id)),
+                artistIds: artistResult.artistKeys,
+                podcastIds: Set(podcastShows.map(\.id))
+            ),
+            preservedExistingArtists: artistResult.preservedExistingArtists
+        )
+    }
+
+    func needsArtistReconciliation(artistIds: [String], expectedInLibrary: Bool) -> Bool {
+        let artistKeys = Set(artistIds.map { LibraryContentIdentity.artistKey(for: $0) })
+        if expectedInLibrary {
+            return artistKeys.contains { self.pendingAddedArtists[$0] != nil }
+        }
+
+        return artistKeys.contains { self.pendingRemovedArtistKeys.contains($0) }
+    }
+
+    mutating func addPlaylistId(_ playlistId: String, to snapshot: inout LibraryContentSnapshot) {
+        let playlistKey = LibraryContentIdentity.playlistKey(for: playlistId)
+        self.pendingRemovedPlaylistKeys.remove(playlistKey)
+        self.pendingRemovedPlaylistMissCounts.removeValue(forKey: playlistKey)
+        snapshot.playlistIds.insert(playlistId)
+    }
+
+    mutating func addPlaylist(_ playlist: Playlist, to snapshot: inout LibraryContentSnapshot) {
+        snapshot.playlistIds.insert(playlist.id)
+        let playlistKey = LibraryContentIdentity.playlistKey(for: playlist.id)
+        self.pendingRemovedPlaylistKeys.remove(playlistKey)
+        self.pendingRemovedPlaylistMissCounts.removeValue(forKey: playlistKey)
+        self.pendingAddedPlaylists[playlistKey] = playlist
+        self.pendingAddedPlaylistMatchCounts[playlistKey] = 0
+
+        if let existingIndex = snapshot.playlists.firstIndex(where: { LibraryContentIdentity.playlistKey(for: $0.id) == playlistKey }) {
+            snapshot.playlists[existingIndex] = playlist
+        } else {
+            snapshot.playlists.insert(playlist, at: 0)
+        }
+    }
+
+    mutating func removePlaylistId(_ playlistId: String, from snapshot: inout LibraryContentSnapshot) {
+        let playlistKey = LibraryContentIdentity.playlistKey(for: playlistId)
+        self.pendingAddedPlaylists.removeValue(forKey: playlistKey)
+        self.pendingAddedPlaylistMatchCounts.removeValue(forKey: playlistKey)
+        self.pendingRemovedPlaylistKeys.insert(playlistKey)
+        self.pendingRemovedPlaylistMissCounts[playlistKey] = 0
+        snapshot.playlistIds = LibraryContentIdentity.removingPlaylist(playlistId, from: snapshot.playlistIds)
+    }
+
+    mutating func removePlaylist(_ playlistId: String, from snapshot: inout LibraryContentSnapshot) {
+        self.removePlaylistId(playlistId, from: &snapshot)
+        let playlistKey = LibraryContentIdentity.playlistKey(for: playlistId)
+        snapshot.playlists.removeAll { LibraryContentIdentity.playlistKey(for: $0.id) == playlistKey }
+    }
+
+    mutating func addPodcast(_ podcast: PodcastShow, to snapshot: inout LibraryContentSnapshot) {
+        snapshot.podcastIds.insert(podcast.id)
+        if !snapshot.podcastShows.contains(where: { $0.id == podcast.id }) {
+            snapshot.podcastShows.insert(podcast, at: 0)
+        }
+    }
+
+    mutating func addPodcastId(_ podcastId: String, to snapshot: inout LibraryContentSnapshot) {
+        snapshot.podcastIds.insert(podcastId)
+    }
+
+    mutating func removePodcast(_ podcastId: String, from snapshot: inout LibraryContentSnapshot) {
+        snapshot.podcastIds.remove(podcastId)
+        snapshot.podcastShows.removeAll { $0.id == podcastId }
+    }
+
+    mutating func removePodcastId(_ podcastId: String, from snapshot: inout LibraryContentSnapshot) {
+        snapshot.podcastIds.remove(podcastId)
+    }
+
+    mutating func addArtist(
+        _ artist: Artist,
+        libraryArtistId: String? = nil,
+        to snapshot: inout LibraryContentSnapshot
+    ) {
+        let artistKey = LibraryContentIdentity.artistKey(for: libraryArtistId ?? artist.id)
+        let canonicalArtist = LibraryContentIdentity.canonicalArtist(artist, libraryArtistID: artistKey)
+        self.pendingRemovedArtistKeys.remove(artistKey)
+        self.pendingRemovedArtistMissCounts.removeValue(forKey: artistKey)
+        self.pendingAddedArtists[artistKey] = canonicalArtist
+        self.pendingAddedArtistMatchCounts[artistKey] = 0
+        snapshot.artistIds.insert(artistKey)
+
+        if let existingIndex = snapshot.artists.firstIndex(where: { LibraryContentIdentity.artistKey(for: $0.id) == artistKey }) {
+            snapshot.artists[existingIndex] = canonicalArtist
+        } else {
+            snapshot.artists.insert(canonicalArtist, at: 0)
+        }
+    }
+
+    mutating func addArtistId(_ artistId: String, to snapshot: inout LibraryContentSnapshot) {
+        let artistKey = LibraryContentIdentity.artistKey(for: artistId)
+        self.pendingRemovedArtistKeys.remove(artistKey)
+        self.pendingRemovedArtistMissCounts.removeValue(forKey: artistKey)
+        snapshot.artistIds.insert(artistKey)
+    }
+
+    mutating func removeArtist(_ artistId: String, from snapshot: inout LibraryContentSnapshot) {
+        self.removeArtistId(artistId, from: &snapshot)
+        let artistKey = LibraryContentIdentity.artistKey(for: artistId)
+        snapshot.artists.removeAll { LibraryContentIdentity.artistKey(for: $0.id) == artistKey }
+    }
+
+    mutating func removeArtistId(_ artistId: String, from snapshot: inout LibraryContentSnapshot) {
+        let artistKey = LibraryContentIdentity.artistKey(for: artistId)
+        self.pendingAddedArtists.removeValue(forKey: artistKey)
+        self.pendingAddedArtistMatchCounts.removeValue(forKey: artistKey)
+        self.pendingRemovedArtistKeys.insert(artistKey)
+        self.pendingRemovedArtistMissCounts[artistKey] = 0
+        snapshot.artistIds.remove(artistKey)
+    }
+
+    private mutating func reconciledPlaylists(from backendPlaylists: [Playlist]) -> [Playlist] {
+        let rawPlaylistKeys = Set(backendPlaylists.map { LibraryContentIdentity.playlistKey(for: $0.id) })
+        self.updatePendingPlaylistAdditions(rawPlaylistKeys: rawPlaylistKeys)
+        self.updatePendingPlaylistRemovals(rawPlaylistKeys: rawPlaylistKeys)
+
+        var playlists = backendPlaylists.filter { playlist in
+            !self.pendingRemovedPlaylistKeys.contains(LibraryContentIdentity.playlistKey(for: playlist.id))
+        }
+        playlists = LibraryContentIdentity.deduplicatedPlaylists(playlists)
+        var visiblePlaylistKeys = Set(playlists.map { LibraryContentIdentity.playlistKey(for: $0.id) })
+
+        for (playlistKey, playlist) in self.pendingAddedPlaylists where !visiblePlaylistKeys.contains(playlistKey) {
+            playlists.insert(playlist, at: 0)
+            visiblePlaylistKeys.insert(playlistKey)
+        }
+
+        return playlists
+    }
+
+    private mutating func updatePendingPlaylistAdditions(rawPlaylistKeys: Set<String>) {
+        for playlistKey in Array(self.pendingAddedPlaylists.keys) {
+            if rawPlaylistKeys.contains(playlistKey) {
+                self.pendingAddedPlaylistMatchCounts[playlistKey, default: 0] += 1
+                if self.pendingAddedPlaylistMatchCounts[playlistKey, default: 0] >= Self.playlistMutationStableMatchCount {
+                    self.pendingAddedPlaylists.removeValue(forKey: playlistKey)
+                    self.pendingAddedPlaylistMatchCounts.removeValue(forKey: playlistKey)
+                }
+            } else {
+                self.pendingAddedPlaylistMatchCounts[playlistKey] = 0
+            }
+        }
+    }
+
+    private mutating func updatePendingPlaylistRemovals(rawPlaylistKeys: Set<String>) {
+        for playlistKey in Array(self.pendingRemovedPlaylistKeys) {
+            if rawPlaylistKeys.contains(playlistKey) {
+                self.pendingRemovedPlaylistMissCounts[playlistKey] = 0
+                continue
+            }
+
+            self.pendingRemovedPlaylistMissCounts[playlistKey, default: 0] += 1
+            if self.pendingRemovedPlaylistMissCounts[playlistKey, default: 0] >= Self.playlistMutationStableMatchCount {
+                self.pendingRemovedPlaylistKeys.remove(playlistKey)
+                self.pendingRemovedPlaylistMissCounts.removeValue(forKey: playlistKey)
+            }
+        }
+    }
+
+    private mutating func reconciledArtists(
+        from content: LibraryContentParser.LibraryContent,
+        currentSnapshot: LibraryContentSnapshot
+    ) -> ArtistReconciliationResult {
+        let preservedExistingArtists = content.artistsSource == .landingFallback && !currentSnapshot.artists.isEmpty
+        let sourceArtists = preservedExistingArtists ? currentSnapshot.artists : content.artists
+        let canonicalArtists = sourceArtists.map { LibraryContentIdentity.canonicalArtist($0) }
+        let rawArtistKeys = Set(canonicalArtists.map(\.id))
+
+        if content.artistsSource == .dedicated {
+            self.updatePendingArtistAdditions(rawArtistKeys: rawArtistKeys)
+            self.updatePendingArtistRemovals(rawArtistKeys: rawArtistKeys)
+        }
+
+        var artists = canonicalArtists.filter { artist in
+            !self.pendingRemovedArtistKeys.contains(artist.id)
+        }
+        artists = LibraryContentIdentity.deduplicatedArtists(artists)
+        var visibleArtistKeys = Set(artists.map(\.id))
+
+        for (artistKey, artist) in self.pendingAddedArtists where !visibleArtistKeys.contains(artistKey) {
+            artists.insert(artist, at: 0)
+            visibleArtistKeys.insert(artistKey)
+        }
+
+        return ArtistReconciliationResult(
+            artists: artists,
+            artistKeys: visibleArtistKeys,
+            preservedExistingArtists: preservedExistingArtists
+        )
+    }
+
+    private mutating func updatePendingArtistAdditions(rawArtistKeys: Set<String>) {
+        for artistKey in Array(self.pendingAddedArtists.keys) {
+            if rawArtistKeys.contains(artistKey) {
+                self.pendingAddedArtistMatchCounts[artistKey, default: 0] += 1
+                if self.pendingAddedArtistMatchCounts[artistKey, default: 0] >= Self.artistMutationStableMatchCount {
+                    self.pendingAddedArtists.removeValue(forKey: artistKey)
+                    self.pendingAddedArtistMatchCounts.removeValue(forKey: artistKey)
+                }
+            } else {
+                self.pendingAddedArtistMatchCounts[artistKey] = 0
+            }
+        }
+    }
+
+    private mutating func updatePendingArtistRemovals(rawArtistKeys: Set<String>) {
+        for artistKey in Array(self.pendingRemovedArtistKeys) {
+            if rawArtistKeys.contains(artistKey) {
+                self.pendingRemovedArtistMissCounts[artistKey] = 0
+                continue
+            }
+
+            self.pendingRemovedArtistMissCounts[artistKey, default: 0] += 1
+            if self.pendingRemovedArtistMissCounts[artistKey, default: 0] >= Self.artistMutationStableMatchCount {
+                self.pendingRemovedArtistKeys.remove(artistKey)
+                self.pendingRemovedArtistMissCounts.removeValue(forKey: artistKey)
+            }
+        }
+    }
+}

--- a/Sources/Kaset/Services/Library/LibraryMutationActions.swift
+++ b/Sources/Kaset/Services/Library/LibraryMutationActions.swift
@@ -1,0 +1,335 @@
+import Foundation
+
+/// Orchestrates Library mutations that need optimistic UI updates, cache invalidation,
+/// and eventual-consistency reconciliation after YouTube Music accepts a change.
+@MainActor
+enum LibraryMutationActions {
+    static var artistReconciliationRetryDelays: [Duration] = [.seconds(2), .seconds(3)]
+
+    private static var artistReconciliationTasks: [String: Task<Void, Never>] = [:]
+
+    /// Adds a song to a playlist.
+    static func addSongToPlaylist(
+        _ song: Song,
+        playlist: AddToPlaylistOption,
+        client: any YTMusicClientProtocol
+    ) async {
+        do {
+            try await client.addSongToPlaylist(
+                videoId: song.videoId,
+                playlistId: playlist.playlistId,
+                allowDuplicate: false
+            )
+            self.invalidateResponseCaches()
+            DiagnosticsLogger.api.info("Added song '\(song.title)' to playlist '\(playlist.title)'")
+        } catch {
+            DiagnosticsLogger.api.error("Failed to add song to playlist: \(error.localizedDescription)")
+        }
+    }
+
+    /// Adds a playlist to the library.
+    static func addPlaylistToLibrary(
+        _ playlist: Playlist,
+        client: any YTMusicClientProtocol,
+        libraryViewModel: LibraryViewModel?
+    ) async {
+        do {
+            try await client.subscribeToPlaylist(playlistId: playlist.id)
+            self.invalidateResponseCaches()
+            libraryViewModel?.markNeedsReloadOnActivation()
+            if let libraryViewModel {
+                libraryViewModel.addToLibrary(playlist: playlist)
+                // Library browse responses can lag briefly behind a successful add.
+                try? await Task.sleep(for: .milliseconds(500))
+                await libraryViewModel.refresh()
+                self.invalidateResponseCaches()
+
+                if !libraryViewModel.isInLibrary(playlistId: playlist.id) {
+                    libraryViewModel.addToLibrary(playlist: playlist)
+                    self.invalidateResponseCaches()
+                }
+            }
+            DiagnosticsLogger.api.info("Added playlist to library: \(playlist.title)")
+        } catch {
+            DiagnosticsLogger.api.error("Failed to add playlist to library: \(error.localizedDescription)")
+        }
+    }
+
+    /// Removes a playlist from the library.
+    static func removePlaylistFromLibrary(
+        _ playlist: Playlist,
+        client: any YTMusicClientProtocol,
+        libraryViewModel: LibraryViewModel?
+    ) async {
+        do {
+            try await client.unsubscribeFromPlaylist(playlistId: playlist.id)
+            self.invalidateResponseCaches()
+            libraryViewModel?.markNeedsReloadOnActivation()
+            LibraryMutationBroadcaster.shared.playlistRemoved(playlistId: playlist.id)
+
+            // Library browse responses can lag briefly behind a successful removal.
+            try? await Task.sleep(for: .milliseconds(500))
+            await LibraryMutationBroadcaster.shared.reconcileRemovedPlaylist(playlistId: playlist.id)
+            self.invalidateResponseCaches()
+            DiagnosticsLogger.api.info("Removed playlist from library: \(playlist.title)")
+        } catch {
+            DiagnosticsLogger.api.error("Failed to remove playlist from library: \(error.localizedDescription)")
+        }
+    }
+
+    /// Permanently deletes a playlist owned by the user.
+    static func deletePlaylist(
+        _ playlist: Playlist,
+        client: any YTMusicClientProtocol,
+        libraryViewModel: LibraryViewModel?
+    ) async throws {
+        do {
+            try await client.deletePlaylist(playlistId: playlist.id)
+            self.invalidateResponseCaches()
+            libraryViewModel?.markNeedsReloadOnActivation()
+            LibraryMutationBroadcaster.shared.playlistRemoved(playlistId: playlist.id)
+
+            // Library browse responses can lag briefly behind a successful deletion.
+            try? await Task.sleep(for: .milliseconds(500))
+            await LibraryMutationBroadcaster.shared.reconcileRemovedPlaylist(playlistId: playlist.id)
+            self.invalidateResponseCaches()
+            DiagnosticsLogger.api.info("Deleted playlist: \(playlist.title)")
+        } catch {
+            DiagnosticsLogger.api.error("Failed to delete playlist: \(error.localizedDescription)")
+            throw error
+        }
+    }
+
+    /// Subscribes to a podcast show (adds to library).
+    static func subscribeToPodcast(
+        _ show: PodcastShow,
+        client: any YTMusicClientProtocol,
+        libraryViewModel: LibraryViewModel?
+    ) async throws {
+        try await client.subscribeToPodcast(showId: show.id)
+        self.invalidateResponseCaches()
+        libraryViewModel?.markNeedsReloadOnActivation()
+        if let libraryViewModel {
+            libraryViewModel.addToLibrary(podcast: show)
+
+            // Library browse responses can lag briefly behind a successful subscribe.
+            try? await Task.sleep(for: .milliseconds(500))
+            await libraryViewModel.refresh()
+            self.invalidateResponseCaches()
+
+            if !libraryViewModel.isInLibrary(podcastId: show.id) {
+                libraryViewModel.addToLibrary(podcast: show)
+                self.invalidateResponseCaches()
+            }
+        }
+        DiagnosticsLogger.api.info("Subscribed to podcast: \(show.title)")
+    }
+
+    /// Unsubscribes from a podcast show (removes from library).
+    static func unsubscribeFromPodcast(
+        _ show: PodcastShow,
+        client: any YTMusicClientProtocol,
+        libraryViewModel: LibraryViewModel?
+    ) async throws {
+        DiagnosticsLogger.api.debug("Attempting to unsubscribe from podcast: \(show.id), libraryViewModel is \(libraryViewModel == nil ? "nil" : "present")")
+        try await client.unsubscribeFromPodcast(showId: show.id)
+        self.invalidateResponseCaches()
+        libraryViewModel?.markNeedsReloadOnActivation()
+        if let libraryViewModel {
+            libraryViewModel.removeFromLibrary(podcastId: show.id)
+
+            // Library browse responses can lag briefly behind a successful removal.
+            try? await Task.sleep(for: .milliseconds(500))
+            await libraryViewModel.refresh()
+            self.invalidateResponseCaches()
+
+            if libraryViewModel.isInLibrary(podcastId: show.id) {
+                libraryViewModel.removeFromLibrary(podcastId: show.id)
+                self.invalidateResponseCaches()
+            }
+        }
+        DiagnosticsLogger.api.info("Unsubscribed from podcast: \(show.title)")
+    }
+
+    /// Subscribes to an artist (adds to library).
+    static func subscribeToArtist(
+        _ artist: Artist,
+        channelId: String,
+        client: any YTMusicClientProtocol,
+        libraryViewModel: LibraryViewModel?
+    ) async throws {
+        if let libraryViewModel {
+            self.addArtistToLibrary(artist, channelId: channelId, libraryViewModel: libraryViewModel)
+            libraryViewModel.markNeedsReloadOnActivation()
+        }
+
+        do {
+            try await client.subscribeToArtist(channelId: channelId)
+            Self.invalidateResponseCaches()
+            if let libraryViewModel {
+                Self.scheduleArtistReconciliation(
+                    artist,
+                    channelId: channelId,
+                    expectedInLibrary: true,
+                    libraryViewModel: libraryViewModel
+                )
+            }
+            DiagnosticsLogger.api.info("Subscribed to artist: \(artist.name)")
+        } catch {
+            if let libraryViewModel {
+                Self.removeArtistFromLibrary(artist, channelId: channelId, libraryViewModel: libraryViewModel)
+                libraryViewModel.markNeedsReloadOnActivation()
+            }
+            DiagnosticsLogger.api.error("Failed to subscribe to artist: \(error.localizedDescription)")
+            throw error
+        }
+    }
+
+    /// Unsubscribes from an artist (removes from library).
+    static func unsubscribeFromArtist(
+        _ artist: Artist,
+        channelId: String,
+        client: any YTMusicClientProtocol,
+        libraryViewModel: LibraryViewModel?
+    ) async throws {
+        if let libraryViewModel {
+            self.removeArtistFromLibrary(artist, channelId: channelId, libraryViewModel: libraryViewModel)
+            libraryViewModel.markNeedsReloadOnActivation()
+        }
+
+        do {
+            try await client.unsubscribeFromArtist(channelId: channelId)
+            Self.invalidateResponseCaches()
+            if let libraryViewModel {
+                Self.scheduleArtistReconciliation(
+                    artist,
+                    channelId: channelId,
+                    expectedInLibrary: false,
+                    libraryViewModel: libraryViewModel
+                )
+            }
+            DiagnosticsLogger.api.info("Unsubscribed from artist: \(artist.name)")
+        } catch {
+            if let libraryViewModel {
+                Self.addArtistToLibrary(artist, channelId: channelId, libraryViewModel: libraryViewModel)
+                libraryViewModel.markNeedsReloadOnActivation()
+            }
+            DiagnosticsLogger.api.error("Failed to unsubscribe from artist: \(error.localizedDescription)")
+            throw error
+        }
+    }
+
+    static func invalidateResponseCaches() {
+        // Library mutations can leave stale data in both the app-level cache and URL loading cache.
+        APICache.shared.invalidate(matching: "browse:")
+        APICache.shared.invalidate(matching: "playlist/get_add_to_playlist:")
+        URLCache.shared.removeAllCachedResponses()
+    }
+
+    private static func scheduleArtistReconciliation(
+        _ artist: Artist,
+        channelId: String,
+        expectedInLibrary: Bool,
+        libraryViewModel: LibraryViewModel
+    ) {
+        let normalizedArtistId = Artist.publicChannelId(for: channelId) ?? channelId
+        Self.artistReconciliationTasks[normalizedArtistId]?.cancel()
+
+        Self.artistReconciliationTasks[normalizedArtistId] = Task { @MainActor in
+            defer { Self.artistReconciliationTasks.removeValue(forKey: normalizedArtistId) }
+
+            for delay in Self.artistReconciliationRetryDelays {
+                do {
+                    try await Task.sleep(for: delay)
+                } catch {
+                    return
+                }
+
+                guard !Task.isCancelled else { return }
+
+                Self.invalidateResponseCaches()
+                await libraryViewModel.refresh()
+                Self.invalidateResponseCaches()
+
+                let needsReconciliation = libraryViewModel.needsArtistLibraryReconciliation(
+                    artistIds: Self.artistLibraryAliases(for: artist, channelId: channelId),
+                    expectedInLibrary: expectedInLibrary
+                )
+                let isInLibrary = Self.isArtistInLibrary(
+                    artist,
+                    channelId: channelId,
+                    libraryViewModel: libraryViewModel
+                )
+                if !needsReconciliation, isInLibrary == expectedInLibrary {
+                    DiagnosticsLogger.api.debug(
+                        "Artist library reconciliation converged with backend state for \(artist.name, privacy: .public)"
+                    )
+                    return
+                }
+
+                DiagnosticsLogger.api.debug(
+                    "Artist library reconciliation is still waiting on backend propagation for \(artist.name, privacy: .public)"
+                )
+                if isInLibrary != expectedInLibrary {
+                    DiagnosticsLogger.api.debug(
+                        "Artist library reconciliation is reapplying optimistic state for \(artist.name, privacy: .public)"
+                    )
+                }
+
+                if expectedInLibrary {
+                    Self.addArtistToLibrary(artist, channelId: channelId, libraryViewModel: libraryViewModel)
+                } else {
+                    Self.removeArtistFromLibrary(artist, channelId: channelId, libraryViewModel: libraryViewModel)
+                }
+                libraryViewModel.markNeedsReloadOnActivation()
+            }
+        }
+    }
+
+    private static func addArtistToLibrary(
+        _ artist: Artist,
+        channelId: String,
+        libraryViewModel: LibraryViewModel
+    ) {
+        let libraryArtistId = Self.preferredLibraryArtistId(for: artist, channelId: channelId)
+        libraryViewModel.addToLibrary(artist: artist, libraryArtistId: libraryArtistId)
+        for artistId in Self.artistLibraryAliases(for: artist, channelId: channelId) {
+            libraryViewModel.addToLibrarySet(artistId: artistId)
+        }
+    }
+
+    private static func removeArtistFromLibrary(
+        _ artist: Artist,
+        channelId: String,
+        libraryViewModel: LibraryViewModel
+    ) {
+        for artistId in self.artistLibraryAliases(for: artist, channelId: channelId) {
+            libraryViewModel.removeFromLibrary(artistId: artistId)
+        }
+    }
+
+    private static func isArtistInLibrary(
+        _ artist: Artist,
+        channelId: String,
+        libraryViewModel: LibraryViewModel
+    ) -> Bool {
+        self.artistLibraryAliases(for: artist, channelId: channelId)
+            .contains(where: { libraryViewModel.isInLibrary(artistId: $0) })
+    }
+
+    private static func artistLibraryAliases(for artist: Artist, channelId: String) -> [String] {
+        var ids = Set([channelId, artist.id])
+        if let publicChannelId = artist.publicChannelId {
+            ids.insert(publicChannelId)
+        }
+        return Array(ids)
+    }
+
+    private static func preferredLibraryArtistId(for artist: Artist, channelId: String) -> String {
+        if artist.hasNavigableId {
+            return artist.id
+        }
+
+        return channelId
+    }
+}

--- a/Sources/Kaset/Services/Player/AlbumPlaybackActions.swift
+++ b/Sources/Kaset/Services/Player/AlbumPlaybackActions.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+/// Queue and playback actions for album-backed tracks.
+@MainActor
+enum AlbumPlaybackActions {
+    /// Adds an album's songs to play next (immediately after current track).
+    static func addAlbumToQueueNext(
+        _ album: Album,
+        client: any YTMusicClientProtocol,
+        playerService: PlayerService
+    ) {
+        Task {
+            do {
+                let songs = try await self.albumSongs(album, client: client, purpose: .queue)
+                guard !songs.isEmpty else { return }
+                playerService.insertNextInQueue(songs)
+                DiagnosticsLogger.ui.info("Added album '\(album.title)' (\(songs.count) songs) to play next")
+            } catch {
+                DiagnosticsLogger.ui.error("Failed to add album to queue: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    /// Adds an album's songs to the end of the queue.
+    static func addAlbumToQueueLast(
+        _ album: Album,
+        client: any YTMusicClientProtocol,
+        playerService: PlayerService
+    ) {
+        Task {
+            do {
+                let songs = try await self.albumSongs(album, client: client, purpose: .queue)
+                guard !songs.isEmpty else { return }
+                playerService.appendToQueue(songs)
+                DiagnosticsLogger.ui.info("Added album '\(album.title)' (\(songs.count) songs) to end of queue")
+            } catch {
+                DiagnosticsLogger.ui.error("Failed to add album to queue: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    /// Plays an album immediately, replacing the current queue.
+    static func playAlbum(
+        _ album: Album,
+        client: any YTMusicClientProtocol,
+        playerService: PlayerService
+    ) {
+        Task {
+            do {
+                let response = try await client.getPlaylist(id: album.id)
+                let songs = QueueSongMetadata.albumSongs(
+                    response.detail.tracks,
+                    album: album,
+                    purpose: .playback(trackCount: response.detail.tracks.count)
+                )
+                guard !songs.isEmpty else { return }
+                await playerService.playQueue(songs, startingAt: 0)
+                DiagnosticsLogger.ui.info("Playing album '\(album.title)' (\(songs.count) songs)")
+            } catch {
+                DiagnosticsLogger.ui.error("Failed to play album: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    private static func albumSongs(
+        _ album: Album,
+        client: any YTMusicClientProtocol,
+        purpose: QueueSongMetadata.AlbumSongPurpose
+    ) async throws -> [Song] {
+        let response = try await client.getPlaylist(id: album.id)
+        return QueueSongMetadata.albumSongs(
+            response.detail.tracks,
+            album: album,
+            purpose: purpose
+        )
+    }
+}

--- a/Sources/Kaset/Services/Player/PlaylistPlaybackActions.swift
+++ b/Sources/Kaset/Services/Player/PlaylistPlaybackActions.swift
@@ -1,0 +1,154 @@
+import Foundation
+
+/// Playback actions for playlist-backed queues.
+enum PlaylistPlaybackActions {
+    struct ContinuationContext {
+        let continuationToken: String?
+        let existingVideoIds: Set<String>
+        let expectedQueueEntryIDs: [UUID]
+        let playlist: Playlist
+        let client: any YTMusicClientProtocol
+        let playerService: PlayerService
+    }
+
+    /// Plays a playlist immediately, replacing the current queue.
+    static func playPlaylist(
+        _ playlist: Playlist,
+        client: any YTMusicClientProtocol,
+        playerService: PlayerService
+    ) {
+        Task { @MainActor in
+            do {
+                let response = try await client.getPlaylist(id: playlist.id)
+                var songs = response.detail.tracks
+
+                if self.isRadioPlaylist(playlist.id) {
+                    do {
+                        let allTracks = try await client.getPlaylistAllTracks(playlistId: playlist.id)
+                        if allTracks.count >= songs.count, !allTracks.isEmpty {
+                            songs = self.tracksForPlaylistPlayback(
+                                browseTracks: response.detail.tracks,
+                                queueTracks: allTracks
+                            )
+                        }
+                    } catch {
+                        DiagnosticsLogger.ui.debug("Falling back to browse playlist tracks: \(error.localizedDescription)")
+                    }
+                } else {
+                    let playableSongs = self.playableSongsWithPlaylistArtwork(songs, playlist: playlist)
+                    guard !playableSongs.isEmpty else { return }
+
+                    await playerService.playQueue(playableSongs, startingAt: 0)
+                    DiagnosticsLogger.ui.info("Playing playlist '\(playlist.title)' (\(playableSongs.count) initial songs)")
+
+                    await self.appendContinuations(
+                        ContinuationContext(
+                            continuationToken: response.continuationToken,
+                            existingVideoIds: Set(songs.map(\.videoId)),
+                            expectedQueueEntryIDs: playerService.queueEntryIDs,
+                            playlist: playlist,
+                            client: client,
+                            playerService: playerService
+                        )
+                    )
+                    return
+                }
+
+                let playableSongs = self.playableSongsWithPlaylistArtwork(songs, playlist: playlist)
+                guard !playableSongs.isEmpty else { return }
+
+                await playerService.playQueue(playableSongs, startingAt: 0)
+                DiagnosticsLogger.ui.info("Playing playlist '\(playlist.title)' (\(playableSongs.count) songs)")
+            } catch {
+                DiagnosticsLogger.ui.error("Failed to play playlist: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    static func isRadioPlaylist(_ playlistId: String) -> Bool {
+        playlistId.contains("RDCLAK") || playlistId.hasPrefix("RD")
+    }
+
+    static func tracksForPlaylistPlayback(browseTracks: [Song], queueTracks: [Song]) -> [Song] {
+        var browsePlayabilityByVideoId: [String: Bool] = [:]
+        for track in browseTracks {
+            browsePlayabilityByVideoId[track.videoId] = track.isPlayable
+        }
+
+        return queueTracks.map { track in
+            guard let browseIsPlayable = browsePlayabilityByVideoId[track.videoId],
+                  browseIsPlayable != track.isPlayable
+            else {
+                return track
+            }
+
+            return self.copy(
+                track,
+                thumbnailURL: track.thumbnailURL,
+                isPlayable: browseIsPlayable
+            )
+        }
+    }
+
+    static func playableSongsWithPlaylistArtwork(_ songs: [Song], playlist: Playlist) -> [Song] {
+        songs.filter(\.isPlayable).map { song in
+            self.copy(
+                song,
+                thumbnailURL: song.thumbnailURL ?? playlist.thumbnailURL,
+                isPlayable: song.isPlayable
+            )
+        }
+    }
+
+    @MainActor
+    static func appendContinuations(_ context: ContinuationContext) async {
+        var nextContinuation = context.continuationToken
+        var seenVideoIds = context.existingVideoIds
+
+        while let c = nextContinuation, !Task.isCancelled {
+            do {
+                let response = try await context.client.getPlaylistContinuation(token: c)
+                let newTracks = response.tracks.filter { seenVideoIds.insert($0.videoId).inserted }
+                guard !newTracks.isEmpty else { break }
+
+                let playableSongs = Self.playableSongsWithPlaylistArtwork(newTracks, playlist: context.playlist)
+                if !playableSongs.isEmpty {
+                    guard Array(context.playerService.queueEntryIDs.prefix(context.expectedQueueEntryIDs.count)) == context.expectedQueueEntryIDs else {
+                        DiagnosticsLogger.ui.debug("Discarding playlist continuations because the queue changed")
+                        return
+                    }
+                    context.playerService.appendToQueue(playableSongs)
+                }
+
+                nextContinuation = response.continuationToken
+            } catch {
+                DiagnosticsLogger.ui.debug("Stopped loading playlist continuations: \(error.localizedDescription)")
+                break
+            }
+        }
+    }
+
+    private static func copy(
+        _ song: Song,
+        thumbnailURL: URL?,
+        isPlayable: Bool
+    ) -> Song {
+        let carried = song.feedbackTokens
+        return Song(
+            id: song.id,
+            title: song.title,
+            artists: song.artists,
+            album: song.album,
+            duration: song.duration,
+            thumbnailURL: thumbnailURL,
+            videoId: song.videoId,
+            isPlayable: isPlayable,
+            hasVideo: song.hasVideo,
+            musicVideoType: song.musicVideoType,
+            likeStatus: song.likeStatus,
+            isInLibrary: song.isInLibrary,
+            feedbackTokens: carried,
+            isExplicit: song.isExplicit
+        )
+    }
+}

--- a/Sources/Kaset/Services/Player/QueueSongMetadata.swift
+++ b/Sources/Kaset/Services/Player/QueueSongMetadata.swift
@@ -1,0 +1,156 @@
+import Foundation
+
+/// Prepares song metadata before inserting tracks into the native queue.
+enum QueueSongMetadata {
+    enum AlbumSongPurpose {
+        case queue
+        case playback(trackCount: Int)
+    }
+
+    static func cleanedArtistPreservingMetadata(_ artist: Artist) -> Artist? {
+        var cleanName = artist.name
+
+        if cleanName == "Album" {
+            return nil
+        }
+
+        if cleanName.hasPrefix("Album, ") {
+            cleanName = String(cleanName.dropFirst(7))
+        }
+
+        return Artist(
+            id: artist.id,
+            name: cleanName,
+            thumbnailURL: artist.thumbnailURL,
+            subtitle: artist.subtitle,
+            profileKind: artist.profileKind
+        )
+    }
+
+    static func songsForQueue(
+        _ songs: [Song],
+        fallbackArtist: String? = nil,
+        fallbackAlbum: Album? = nil
+    ) -> [Song] {
+        songs.map { song in
+            let artists = self.queueArtists(for: song, fallbackArtist: fallbackArtist)
+            return self.copy(
+                song,
+                artists: artists,
+                album: song.album ?? fallbackAlbum,
+                thumbnailURL: song.thumbnailURL ?? fallbackAlbum?.thumbnailURL
+            )
+        }
+    }
+
+    static func albumSongs(
+        _ songs: [Song],
+        album: Album,
+        purpose: AlbumSongPurpose
+    ) -> [Song] {
+        let cleanAlbumArtists = (album.artists ?? []).compactMap(Self.cleanedArtistPreservingMetadata)
+        let albumForSong = self.albumForSong(
+            album,
+            artists: cleanAlbumArtists,
+            purpose: purpose
+        )
+
+        return songs.map { song in
+            let baseArtists = !song.artists.isEmpty ? song.artists : cleanAlbumArtists
+            let effectiveArtists = baseArtists.compactMap(Self.cleanedArtistPreservingMetadata)
+            let artists = effectiveArtists.isEmpty ? cleanAlbumArtists : effectiveArtists
+
+            return self.copy(
+                song,
+                artists: artists,
+                album: albumForSong,
+                thumbnailURL: song.thumbnailURL ?? album.thumbnailURL
+            )
+        }
+    }
+
+    private static func queueArtists(for song: Song, fallbackArtist: String?) -> [Artist] {
+        var cleanedArtists = song.artists.compactMap(Self.cleanedArtistPreservingMetadata)
+        if cleanedArtists.isEmpty,
+           let fallbackArtist = self.cleanedFallbackArtistName(fallbackArtist)
+        {
+            cleanedArtists = [Artist(id: "unknown", name: fallbackArtist)]
+        }
+        return cleanedArtists
+    }
+
+    private static func cleanedFallbackArtistName(_ fallbackArtist: String?) -> String? {
+        guard var cleanFallback = fallbackArtist?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !cleanFallback.isEmpty
+        else { return nil }
+
+        if cleanFallback == "Album" {
+            return "Unknown Artist"
+        }
+
+        if cleanFallback.hasPrefix("Album, ") {
+            cleanFallback = String(cleanFallback.dropFirst(7))
+        }
+
+        if cleanFallback.contains("Album,") {
+            let parts = cleanFallback.split(separator: ",", maxSplits: 1)
+            if parts.count > 1 {
+                cleanFallback = String(parts[1]).trimmingCharacters(in: .whitespaces)
+            }
+        }
+
+        return cleanFallback.isEmpty ? nil : cleanFallback
+    }
+
+    private static func albumForSong(
+        _ album: Album,
+        artists: [Artist],
+        purpose: AlbumSongPurpose
+    ) -> Album {
+        switch purpose {
+        case .queue:
+            Album(
+                id: album.id,
+                title: album.title,
+                artists: artists,
+                thumbnailURL: album.thumbnailURL,
+                year: nil,
+                trackCount: album.trackCount
+            )
+        case let .playback(trackCount):
+            Album(
+                id: album.id,
+                title: album.title,
+                artists: artists.isEmpty ? nil : artists,
+                thumbnailURL: album.thumbnailURL,
+                year: album.year,
+                trackCount: trackCount
+            )
+        }
+    }
+
+    private static func copy(
+        _ song: Song,
+        artists: [Artist],
+        album: Album?,
+        thumbnailURL: URL?
+    ) -> Song {
+        let carried = song.feedbackTokens
+        return Song(
+            id: song.id,
+            title: song.title,
+            artists: artists,
+            album: album,
+            duration: song.duration,
+            thumbnailURL: thumbnailURL,
+            videoId: song.videoId,
+            isPlayable: song.isPlayable,
+            hasVideo: song.hasVideo,
+            musicVideoType: song.musicVideoType,
+            likeStatus: song.likeStatus,
+            isInLibrary: song.isInLibrary,
+            feedbackTokens: carried,
+            isExplicit: song.isExplicit
+        )
+    }
+}

--- a/Sources/Kaset/ViewModels/LibraryViewModel.swift
+++ b/Sources/Kaset/ViewModels/LibraryViewModel.swift
@@ -161,56 +161,6 @@ final class LibraryViewModel {
         }
     }
 
-    private static func normalizedPlaylistId(_ playlistId: String) -> String {
-        if playlistId.hasPrefix("VL") {
-            return String(playlistId.dropFirst(2))
-        }
-        return playlistId
-    }
-
-    private static func normalizedArtistId(_ artistId: String) -> String {
-        Artist.publicChannelId(for: artistId) ?? artistId
-    }
-
-    private static func canonicalArtist(_ artist: Artist, normalizedArtistId: String) -> Artist {
-        if artist.id == normalizedArtistId {
-            return artist
-        }
-
-        return Artist(
-            id: normalizedArtistId,
-            name: artist.name,
-            thumbnailURL: artist.thumbnailURL,
-            subtitle: artist.subtitle,
-            profileKind: artist.profileKind
-        )
-    }
-
-    private static func deduplicatedPlaylists(_ playlists: [Playlist]) -> [Playlist] {
-        var seenPlaylistIds: Set<String> = []
-        var deduplicatedPlaylists: [Playlist] = []
-
-        for playlist in playlists {
-            let normalizedPlaylistId = Self.normalizedPlaylistId(playlist.id)
-            guard seenPlaylistIds.insert(normalizedPlaylistId).inserted else { continue }
-            deduplicatedPlaylists.append(playlist)
-        }
-
-        return deduplicatedPlaylists
-    }
-
-    private static func deduplicatedArtists(_ artists: [Artist]) -> [Artist] {
-        var seenArtistIds: Set<String> = []
-        var deduplicatedArtists: [Artist] = []
-
-        for artist in artists {
-            guard seenArtistIds.insert(artist.id).inserted else { continue }
-            deduplicatedArtists.append(artist)
-        }
-
-        return deduplicatedArtists
-    }
-
     private var hasLibrarySnapshot: Bool {
         !self.playlists.isEmpty || !self.artists.isEmpty || !self.podcastShows.isEmpty
             || self.uploadedSongsPlaylist != nil
@@ -226,41 +176,41 @@ final class LibraryViewModel {
         self.podcastShows = content.podcastShows
         self.libraryPodcastIds = Set(content.podcastShows.map(\.id))
 
-        let rawPlaylistIds = Set(content.playlists.map { Self.normalizedPlaylistId($0.id) })
-        for normalizedPlaylistId in Array(self.pendingAddedPlaylists.keys) {
-            if rawPlaylistIds.contains(normalizedPlaylistId) {
-                self.pendingAddedPlaylistMatchCounts[normalizedPlaylistId, default: 0] += 1
-                if self.pendingAddedPlaylistMatchCounts[normalizedPlaylistId, default: 0] >= Self.playlistMutationStableMatchCount {
-                    self.pendingAddedPlaylists.removeValue(forKey: normalizedPlaylistId)
-                    self.pendingAddedPlaylistMatchCounts.removeValue(forKey: normalizedPlaylistId)
+        let rawPlaylistKeys = Set(content.playlists.map { LibraryContentIdentity.playlistKey(for: $0.id) })
+        for playlistKey in Array(self.pendingAddedPlaylists.keys) {
+            if rawPlaylistKeys.contains(playlistKey) {
+                self.pendingAddedPlaylistMatchCounts[playlistKey, default: 0] += 1
+                if self.pendingAddedPlaylistMatchCounts[playlistKey, default: 0] >= Self.playlistMutationStableMatchCount {
+                    self.pendingAddedPlaylists.removeValue(forKey: playlistKey)
+                    self.pendingAddedPlaylistMatchCounts.removeValue(forKey: playlistKey)
                 }
             } else {
-                self.pendingAddedPlaylistMatchCounts[normalizedPlaylistId] = 0
+                self.pendingAddedPlaylistMatchCounts[playlistKey] = 0
             }
         }
 
-        for normalizedPlaylistId in Array(self.pendingRemovedPlaylistIds) {
-            if rawPlaylistIds.contains(normalizedPlaylistId) {
-                self.pendingRemovedPlaylistMissCounts[normalizedPlaylistId] = 0
+        for playlistKey in Array(self.pendingRemovedPlaylistIds) {
+            if rawPlaylistKeys.contains(playlistKey) {
+                self.pendingRemovedPlaylistMissCounts[playlistKey] = 0
                 continue
             }
 
-            self.pendingRemovedPlaylistMissCounts[normalizedPlaylistId, default: 0] += 1
-            if self.pendingRemovedPlaylistMissCounts[normalizedPlaylistId, default: 0] >= Self.playlistMutationStableMatchCount {
-                self.pendingRemovedPlaylistIds.remove(normalizedPlaylistId)
-                self.pendingRemovedPlaylistMissCounts.removeValue(forKey: normalizedPlaylistId)
+            self.pendingRemovedPlaylistMissCounts[playlistKey, default: 0] += 1
+            if self.pendingRemovedPlaylistMissCounts[playlistKey, default: 0] >= Self.playlistMutationStableMatchCount {
+                self.pendingRemovedPlaylistIds.remove(playlistKey)
+                self.pendingRemovedPlaylistMissCounts.removeValue(forKey: playlistKey)
             }
         }
 
         var playlists = content.playlists.filter { playlist in
-            !self.pendingRemovedPlaylistIds.contains(Self.normalizedPlaylistId(playlist.id))
+            !self.pendingRemovedPlaylistIds.contains(LibraryContentIdentity.playlistKey(for: playlist.id))
         }
-        playlists = Self.deduplicatedPlaylists(playlists)
-        var visiblePlaylistIds = Set(playlists.map { Self.normalizedPlaylistId($0.id) })
+        playlists = LibraryContentIdentity.deduplicatedPlaylists(playlists)
+        var visiblePlaylistKeys = Set(playlists.map { LibraryContentIdentity.playlistKey(for: $0.id) })
 
-        for (normalizedPlaylistId, playlist) in self.pendingAddedPlaylists where !visiblePlaylistIds.contains(normalizedPlaylistId) {
+        for (playlistKey, playlist) in self.pendingAddedPlaylists where !visiblePlaylistKeys.contains(playlistKey) {
             playlists.insert(playlist, at: 0)
-            visiblePlaylistIds.insert(normalizedPlaylistId)
+            visiblePlaylistKeys.insert(playlistKey)
         }
 
         self.playlists = playlists
@@ -274,35 +224,32 @@ final class LibraryViewModel {
             sourceArtists = content.artists
         }
 
-        let canonicalArtists = sourceArtists.map { artist in
-            let normalizedArtistId = Self.normalizedArtistId(artist.id)
-            return Self.canonicalArtist(artist, normalizedArtistId: normalizedArtistId)
-        }
-        let rawArtistIds = Set(canonicalArtists.map(\.id))
+        let canonicalArtists = sourceArtists.map { LibraryContentIdentity.canonicalArtist($0) }
+        let rawArtistKeys = Set(canonicalArtists.map(\.id))
 
         if content.artistsSource == .dedicated {
-            for normalizedArtistId in Array(self.pendingAddedArtists.keys) {
-                if rawArtistIds.contains(normalizedArtistId) {
-                    self.pendingAddedArtistMatchCounts[normalizedArtistId, default: 0] += 1
-                    if self.pendingAddedArtistMatchCounts[normalizedArtistId, default: 0] >= Self.artistMutationStableMatchCount {
-                        self.pendingAddedArtists.removeValue(forKey: normalizedArtistId)
-                        self.pendingAddedArtistMatchCounts.removeValue(forKey: normalizedArtistId)
+            for artistKey in Array(self.pendingAddedArtists.keys) {
+                if rawArtistKeys.contains(artistKey) {
+                    self.pendingAddedArtistMatchCounts[artistKey, default: 0] += 1
+                    if self.pendingAddedArtistMatchCounts[artistKey, default: 0] >= Self.artistMutationStableMatchCount {
+                        self.pendingAddedArtists.removeValue(forKey: artistKey)
+                        self.pendingAddedArtistMatchCounts.removeValue(forKey: artistKey)
                     }
                 } else {
-                    self.pendingAddedArtistMatchCounts[normalizedArtistId] = 0
+                    self.pendingAddedArtistMatchCounts[artistKey] = 0
                 }
             }
 
-            for normalizedArtistId in Array(self.pendingRemovedArtistIds) {
-                if rawArtistIds.contains(normalizedArtistId) {
-                    self.pendingRemovedArtistMatchCounts[normalizedArtistId] = 0
+            for artistKey in Array(self.pendingRemovedArtistIds) {
+                if rawArtistKeys.contains(artistKey) {
+                    self.pendingRemovedArtistMatchCounts[artistKey] = 0
                     continue
                 }
 
-                self.pendingRemovedArtistMatchCounts[normalizedArtistId, default: 0] += 1
-                if self.pendingRemovedArtistMatchCounts[normalizedArtistId, default: 0] >= Self.artistMutationStableMatchCount {
-                    self.pendingRemovedArtistIds.remove(normalizedArtistId)
-                    self.pendingRemovedArtistMatchCounts.removeValue(forKey: normalizedArtistId)
+                self.pendingRemovedArtistMatchCounts[artistKey, default: 0] += 1
+                if self.pendingRemovedArtistMatchCounts[artistKey, default: 0] >= Self.artistMutationStableMatchCount {
+                    self.pendingRemovedArtistIds.remove(artistKey)
+                    self.pendingRemovedArtistMatchCounts.removeValue(forKey: artistKey)
                 }
             }
         }
@@ -310,16 +257,16 @@ final class LibraryViewModel {
         var artists = canonicalArtists.filter { artist in
             !self.pendingRemovedArtistIds.contains(artist.id)
         }
-        artists = Self.deduplicatedArtists(artists)
-        var visibleArtistIds = Set(artists.map(\.id))
+        artists = LibraryContentIdentity.deduplicatedArtists(artists)
+        var visibleArtistKeys = Set(artists.map(\.id))
 
-        for (normalizedArtistId, artist) in self.pendingAddedArtists where !visibleArtistIds.contains(normalizedArtistId) {
+        for (artistKey, artist) in self.pendingAddedArtists where !visibleArtistKeys.contains(artistKey) {
             artists.insert(artist, at: 0)
-            visibleArtistIds.insert(normalizedArtistId)
+            visibleArtistKeys.insert(artistKey)
         }
 
         self.artists = artists
-        self.libraryArtistIds = visibleArtistIds
+        self.libraryArtistIds = visibleArtistKeys
     }
 
     private func finishDiscardedLoad() async {
@@ -346,11 +293,7 @@ final class LibraryViewModel {
 
     /// Checks if a playlist is in the user's library.
     func isInLibrary(playlistId: String) -> Bool {
-        let normalizedId = Self.normalizedPlaylistId(playlistId)
-        return self.libraryPlaylistIds.contains { storedId in
-            let normalizedStoredId = Self.normalizedPlaylistId(storedId)
-            return normalizedId == normalizedStoredId || playlistId == storedId
-        }
+        LibraryContentIdentity.containsPlaylist(playlistId, in: self.libraryPlaylistIds)
     }
 
     /// Checks if a podcast show is in the user's library.
@@ -360,24 +303,24 @@ final class LibraryViewModel {
 
     /// Checks if an artist is in the user's library.
     func isInLibrary(artistId: String) -> Bool {
-        self.libraryArtistIds.contains(Self.normalizedArtistId(artistId))
+        self.libraryArtistIds.contains(LibraryContentIdentity.artistKey(for: artistId))
     }
 
     /// Whether artist library state still depends on optimistic local suppression/insertion.
     func needsArtistLibraryReconciliation(artistIds: [String], expectedInLibrary: Bool) -> Bool {
-        let normalizedArtistIds = Set(artistIds.map(Self.normalizedArtistId))
+        let artistKeys = Set(artistIds.map { LibraryContentIdentity.artistKey(for: $0) })
         if expectedInLibrary {
-            return normalizedArtistIds.contains { self.pendingAddedArtists[$0] != nil }
+            return artistKeys.contains { self.pendingAddedArtists[$0] != nil }
         }
-        return normalizedArtistIds.contains { self.pendingRemovedArtistIds.contains($0) }
+        return artistKeys.contains { self.pendingRemovedArtistIds.contains($0) }
     }
 
     /// Adds a playlist ID to the library set (called after successful add to library).
     func addToLibrarySet(playlistId: String) {
         self.markLibraryStateChanged()
-        let normalizedPlaylistId = Self.normalizedPlaylistId(playlistId)
-        self.pendingRemovedPlaylistIds.remove(normalizedPlaylistId)
-        self.pendingRemovedPlaylistMissCounts.removeValue(forKey: normalizedPlaylistId)
+        let playlistKey = LibraryContentIdentity.playlistKey(for: playlistId)
+        self.pendingRemovedPlaylistIds.remove(playlistKey)
+        self.pendingRemovedPlaylistMissCounts.removeValue(forKey: playlistKey)
         self.libraryPlaylistIds.insert(playlistId)
     }
 
@@ -386,12 +329,12 @@ final class LibraryViewModel {
     func addToLibrary(playlist: Playlist) {
         self.markLibraryStateChanged()
         self.libraryPlaylistIds.insert(playlist.id)
-        let normalizedPlaylistId = Self.normalizedPlaylistId(playlist.id)
-        self.pendingRemovedPlaylistIds.remove(normalizedPlaylistId)
-        self.pendingRemovedPlaylistMissCounts.removeValue(forKey: normalizedPlaylistId)
-        self.pendingAddedPlaylists[normalizedPlaylistId] = playlist
-        self.pendingAddedPlaylistMatchCounts[normalizedPlaylistId] = 0
-        if let existingIndex = self.playlists.firstIndex(where: { Self.normalizedPlaylistId($0.id) == normalizedPlaylistId }) {
+        let playlistKey = LibraryContentIdentity.playlistKey(for: playlist.id)
+        self.pendingRemovedPlaylistIds.remove(playlistKey)
+        self.pendingRemovedPlaylistMissCounts.removeValue(forKey: playlistKey)
+        self.pendingAddedPlaylists[playlistKey] = playlist
+        self.pendingAddedPlaylistMatchCounts[playlistKey] = 0
+        if let existingIndex = self.playlists.firstIndex(where: { LibraryContentIdentity.playlistKey(for: $0.id) == playlistKey }) {
             self.playlists[existingIndex] = playlist
         } else {
             self.playlists.insert(playlist, at: 0)
@@ -419,14 +362,14 @@ final class LibraryViewModel {
     /// Updates both the ID set and the artists array for immediate UI update.
     func addToLibrary(artist: Artist, libraryArtistId: String? = nil) {
         self.markLibraryStateChanged()
-        let normalizedArtistId = Self.normalizedArtistId(libraryArtistId ?? artist.id)
-        let canonicalArtist = Self.canonicalArtist(artist, normalizedArtistId: normalizedArtistId)
-        self.pendingRemovedArtistIds.remove(normalizedArtistId)
-        self.pendingRemovedArtistMatchCounts.removeValue(forKey: normalizedArtistId)
-        self.pendingAddedArtists[normalizedArtistId] = canonicalArtist
-        self.pendingAddedArtistMatchCounts[normalizedArtistId] = 0
-        self.libraryArtistIds.insert(normalizedArtistId)
-        if let existingIndex = self.artists.firstIndex(where: { Self.normalizedArtistId($0.id) == normalizedArtistId }) {
+        let artistKey = LibraryContentIdentity.artistKey(for: libraryArtistId ?? artist.id)
+        let canonicalArtist = LibraryContentIdentity.canonicalArtist(artist, libraryArtistID: artistKey)
+        self.pendingRemovedArtistIds.remove(artistKey)
+        self.pendingRemovedArtistMatchCounts.removeValue(forKey: artistKey)
+        self.pendingAddedArtists[artistKey] = canonicalArtist
+        self.pendingAddedArtistMatchCounts[artistKey] = 0
+        self.libraryArtistIds.insert(artistKey)
+        if let existingIndex = self.artists.firstIndex(where: { LibraryContentIdentity.artistKey(for: $0.id) == artistKey }) {
             self.artists[existingIndex] = canonicalArtist
         } else {
             self.artists.insert(canonicalArtist, at: 0)
@@ -436,26 +379,21 @@ final class LibraryViewModel {
     /// Adds an artist ID to the library set (called after successful subscription).
     func addToLibrarySet(artistId: String) {
         self.markLibraryStateChanged()
-        let normalizedArtistId = Self.normalizedArtistId(artistId)
-        self.pendingRemovedArtistIds.remove(normalizedArtistId)
-        self.pendingRemovedArtistMatchCounts.removeValue(forKey: normalizedArtistId)
-        self.libraryArtistIds.insert(normalizedArtistId)
+        let artistKey = LibraryContentIdentity.artistKey(for: artistId)
+        self.pendingRemovedArtistIds.remove(artistKey)
+        self.pendingRemovedArtistMatchCounts.removeValue(forKey: artistKey)
+        self.libraryArtistIds.insert(artistKey)
     }
 
     /// Removes a playlist ID from the library set (called after successful remove from library).
     func removeFromLibrarySet(playlistId: String) {
         self.markLibraryStateChanged()
-        // Remove both the exact ID and normalized versions
-        self.libraryPlaylistIds.remove(playlistId)
-        let normalizedId = Self.normalizedPlaylistId(playlistId)
-        self.pendingAddedPlaylists.removeValue(forKey: normalizedId)
-        self.pendingAddedPlaylistMatchCounts.removeValue(forKey: normalizedId)
-        self.pendingRemovedPlaylistIds.insert(normalizedId)
-        self.pendingRemovedPlaylistMissCounts[normalizedId] = 0
-        self.libraryPlaylistIds = self.libraryPlaylistIds.filter { storedId in
-            let normalizedStoredId = Self.normalizedPlaylistId(storedId)
-            return normalizedId != normalizedStoredId
-        }
+        let playlistKey = LibraryContentIdentity.playlistKey(for: playlistId)
+        self.pendingAddedPlaylists.removeValue(forKey: playlistKey)
+        self.pendingAddedPlaylistMatchCounts.removeValue(forKey: playlistKey)
+        self.pendingRemovedPlaylistIds.insert(playlistKey)
+        self.pendingRemovedPlaylistMissCounts[playlistKey] = 0
+        self.libraryPlaylistIds = LibraryContentIdentity.removingPlaylist(playlistId, from: self.libraryPlaylistIds)
     }
 
     /// Removes a playlist from the library (called after successful remove from library).
@@ -463,8 +401,8 @@ final class LibraryViewModel {
     func removeFromLibrary(playlistId: String) {
         self.markLibraryStateChanged()
         self.removeFromLibrarySet(playlistId: playlistId)
-        let normalizedPlaylistId = Self.normalizedPlaylistId(playlistId)
-        self.playlists.removeAll { Self.normalizedPlaylistId($0.id) == normalizedPlaylistId }
+        let playlistKey = LibraryContentIdentity.playlistKey(for: playlistId)
+        self.playlists.removeAll { LibraryContentIdentity.playlistKey(for: $0.id) == playlistKey }
     }
 
     /// Removes a podcast from the library (called after successful unsubscribe).
@@ -485,24 +423,24 @@ final class LibraryViewModel {
     /// Updates both the ID set and the artists array for immediate UI update.
     func removeFromLibrary(artistId: String) {
         self.markLibraryStateChanged()
-        let normalizedArtistId = Self.normalizedArtistId(artistId)
-        self.pendingAddedArtists.removeValue(forKey: normalizedArtistId)
-        self.pendingAddedArtistMatchCounts.removeValue(forKey: normalizedArtistId)
-        self.pendingRemovedArtistIds.insert(normalizedArtistId)
-        self.pendingRemovedArtistMatchCounts[normalizedArtistId] = 0
-        self.libraryArtistIds.remove(normalizedArtistId)
-        self.artists.removeAll { Self.normalizedArtistId($0.id) == normalizedArtistId }
+        let artistKey = LibraryContentIdentity.artistKey(for: artistId)
+        self.pendingAddedArtists.removeValue(forKey: artistKey)
+        self.pendingAddedArtistMatchCounts.removeValue(forKey: artistKey)
+        self.pendingRemovedArtistIds.insert(artistKey)
+        self.pendingRemovedArtistMatchCounts[artistKey] = 0
+        self.libraryArtistIds.remove(artistKey)
+        self.artists.removeAll { LibraryContentIdentity.artistKey(for: $0.id) == artistKey }
     }
 
     /// Removes an artist ID from the library set (called after successful unsubscribe).
     func removeFromLibrarySet(artistId: String) {
         self.markLibraryStateChanged()
-        let normalizedArtistId = Self.normalizedArtistId(artistId)
-        self.pendingAddedArtists.removeValue(forKey: normalizedArtistId)
-        self.pendingAddedArtistMatchCounts.removeValue(forKey: normalizedArtistId)
-        self.pendingRemovedArtistIds.insert(normalizedArtistId)
-        self.pendingRemovedArtistMatchCounts[normalizedArtistId] = 0
-        self.libraryArtistIds.remove(normalizedArtistId)
+        let artistKey = LibraryContentIdentity.artistKey(for: artistId)
+        self.pendingAddedArtists.removeValue(forKey: artistKey)
+        self.pendingAddedArtistMatchCounts.removeValue(forKey: artistKey)
+        self.pendingRemovedArtistIds.insert(artistKey)
+        self.pendingRemovedArtistMatchCounts[artistKey] = 0
+        self.libraryArtistIds.remove(artistKey)
     }
 
     /// Loads library content (playlists, artists, and podcasts).

--- a/Sources/Kaset/ViewModels/LibraryViewModel.swift
+++ b/Sources/Kaset/ViewModels/LibraryViewModel.swift
@@ -122,36 +122,12 @@ final class LibraryViewModel {
     /// Bumps whenever a library mutation requests a refresh on next Library activation.
     private(set) var activationReloadGeneration: UInt64 = 0
 
-    /// Playlist additions that should stay visible until the server starts returning them consistently.
-    private var pendingAddedPlaylists: [String: Playlist] = [:]
-
-    /// Consecutive backend matches for optimistic playlist additions.
-    private var pendingAddedPlaylistMatchCounts: [String: Int] = [:]
-
-    /// Playlist removals that should stay suppressed until the server stops returning them consistently.
-    private var pendingRemovedPlaylistIds: Set<String> = []
-
-    /// Consecutive backend misses for optimistic playlist removals.
-    private var pendingRemovedPlaylistMissCounts: [String: Int] = [:]
-
-    /// Artist additions that should stay visible until the server starts returning them.
-    private var pendingAddedArtists: [String: Artist] = [:]
-
-    /// Consecutive backend matches for optimistic artist additions.
-    private var pendingAddedArtistMatchCounts: [String: Int] = [:]
-
-    /// Artist removals that should stay suppressed until the server stops returning them.
-    private var pendingRemovedArtistIds: Set<String> = []
-
-    /// Consecutive backend matches for optimistic artist removals.
-    private var pendingRemovedArtistMatchCounts: [String: Int] = [:]
+    /// Reconciles optimistic local Library mutations against backend snapshots.
+    private var contentReconciler = LibraryContentReconciler()
 
     /// The API client (exposed for navigation to detail views).
     let client: any YTMusicClientProtocol
     private let logger = DiagnosticsLogger.api
-
-    private static let playlistMutationStableMatchCount = 2
-    private static let artistMutationStableMatchCount = 2
 
     init(client: any YTMusicClientProtocol, registerForLibraryMutations: Bool = true) {
         self.client = client
@@ -161,112 +137,43 @@ final class LibraryViewModel {
         }
     }
 
+    private var librarySnapshot: LibraryContentSnapshot {
+        get {
+            LibraryContentSnapshot(
+                playlists: self.playlists,
+                artists: self.artists,
+                podcastShows: self.podcastShows,
+                uploadedSongsPlaylist: self.uploadedSongsPlaylist,
+                playlistIds: self.libraryPlaylistIds,
+                artistIds: self.libraryArtistIds,
+                podcastIds: self.libraryPodcastIds
+            )
+        }
+        set {
+            self.playlists = newValue.playlists
+            self.artists = newValue.artists
+            self.podcastShows = newValue.podcastShows
+            self.uploadedSongsPlaylist = newValue.uploadedSongsPlaylist
+            self.libraryPlaylistIds = newValue.playlistIds
+            self.libraryArtistIds = newValue.artistIds
+            self.libraryPodcastIds = newValue.podcastIds
+        }
+    }
+
     private var hasLibrarySnapshot: Bool {
-        !self.playlists.isEmpty || !self.artists.isEmpty || !self.podcastShows.isEmpty
-            || self.uploadedSongsPlaylist != nil
-            || !self.libraryPlaylistIds.isEmpty || !self.libraryArtistIds.isEmpty || !self.libraryPodcastIds.isEmpty
+        self.librarySnapshot.hasVisibleContent
     }
 
     private func markLibraryStateChanged() {
         self.libraryStateRevision &+= 1
     }
 
-    private func applyLibraryContent(_ content: PlaylistParser.LibraryContent) { // swiftlint:disable:this cyclomatic_complexity
-        self.uploadedSongsPlaylist = content.uploadedSongsPlaylist
-        self.podcastShows = content.podcastShows
-        self.libraryPodcastIds = Set(content.podcastShows.map(\.id))
-
-        let rawPlaylistKeys = Set(content.playlists.map { LibraryContentIdentity.playlistKey(for: $0.id) })
-        for playlistKey in Array(self.pendingAddedPlaylists.keys) {
-            if rawPlaylistKeys.contains(playlistKey) {
-                self.pendingAddedPlaylistMatchCounts[playlistKey, default: 0] += 1
-                if self.pendingAddedPlaylistMatchCounts[playlistKey, default: 0] >= Self.playlistMutationStableMatchCount {
-                    self.pendingAddedPlaylists.removeValue(forKey: playlistKey)
-                    self.pendingAddedPlaylistMatchCounts.removeValue(forKey: playlistKey)
-                }
-            } else {
-                self.pendingAddedPlaylistMatchCounts[playlistKey] = 0
-            }
-        }
-
-        for playlistKey in Array(self.pendingRemovedPlaylistIds) {
-            if rawPlaylistKeys.contains(playlistKey) {
-                self.pendingRemovedPlaylistMissCounts[playlistKey] = 0
-                continue
-            }
-
-            self.pendingRemovedPlaylistMissCounts[playlistKey, default: 0] += 1
-            if self.pendingRemovedPlaylistMissCounts[playlistKey, default: 0] >= Self.playlistMutationStableMatchCount {
-                self.pendingRemovedPlaylistIds.remove(playlistKey)
-                self.pendingRemovedPlaylistMissCounts.removeValue(forKey: playlistKey)
-            }
-        }
-
-        var playlists = content.playlists.filter { playlist in
-            !self.pendingRemovedPlaylistIds.contains(LibraryContentIdentity.playlistKey(for: playlist.id))
-        }
-        playlists = LibraryContentIdentity.deduplicatedPlaylists(playlists)
-        var visiblePlaylistKeys = Set(playlists.map { LibraryContentIdentity.playlistKey(for: $0.id) })
-
-        for (playlistKey, playlist) in self.pendingAddedPlaylists where !visiblePlaylistKeys.contains(playlistKey) {
-            playlists.insert(playlist, at: 0)
-            visiblePlaylistKeys.insert(playlistKey)
-        }
-
-        self.playlists = playlists
-        self.libraryPlaylistIds = Set(playlists.map(\.id))
-
-        let sourceArtists: [Artist]
-        if content.artistsSource == .landingFallback, !self.artists.isEmpty {
+    private func applyLibraryContent(_ content: PlaylistParser.LibraryContent) {
+        let result = self.contentReconciler.apply(content, currentSnapshot: self.librarySnapshot)
+        if result.preservedExistingArtists {
             self.logger.debug("Preserving existing artist snapshot because refresh fell back to landing preview")
-            sourceArtists = self.artists
-        } else {
-            sourceArtists = content.artists
         }
-
-        let canonicalArtists = sourceArtists.map { LibraryContentIdentity.canonicalArtist($0) }
-        let rawArtistKeys = Set(canonicalArtists.map(\.id))
-
-        if content.artistsSource == .dedicated {
-            for artistKey in Array(self.pendingAddedArtists.keys) {
-                if rawArtistKeys.contains(artistKey) {
-                    self.pendingAddedArtistMatchCounts[artistKey, default: 0] += 1
-                    if self.pendingAddedArtistMatchCounts[artistKey, default: 0] >= Self.artistMutationStableMatchCount {
-                        self.pendingAddedArtists.removeValue(forKey: artistKey)
-                        self.pendingAddedArtistMatchCounts.removeValue(forKey: artistKey)
-                    }
-                } else {
-                    self.pendingAddedArtistMatchCounts[artistKey] = 0
-                }
-            }
-
-            for artistKey in Array(self.pendingRemovedArtistIds) {
-                if rawArtistKeys.contains(artistKey) {
-                    self.pendingRemovedArtistMatchCounts[artistKey] = 0
-                    continue
-                }
-
-                self.pendingRemovedArtistMatchCounts[artistKey, default: 0] += 1
-                if self.pendingRemovedArtistMatchCounts[artistKey, default: 0] >= Self.artistMutationStableMatchCount {
-                    self.pendingRemovedArtistIds.remove(artistKey)
-                    self.pendingRemovedArtistMatchCounts.removeValue(forKey: artistKey)
-                }
-            }
-        }
-
-        var artists = canonicalArtists.filter { artist in
-            !self.pendingRemovedArtistIds.contains(artist.id)
-        }
-        artists = LibraryContentIdentity.deduplicatedArtists(artists)
-        var visibleArtistKeys = Set(artists.map(\.id))
-
-        for (artistKey, artist) in self.pendingAddedArtists where !visibleArtistKeys.contains(artistKey) {
-            artists.insert(artist, at: 0)
-            visibleArtistKeys.insert(artistKey)
-        }
-
-        self.artists = artists
-        self.libraryArtistIds = visibleArtistKeys
+        self.librarySnapshot = result.snapshot
     }
 
     private func finishDiscardedLoad() async {
@@ -308,139 +215,109 @@ final class LibraryViewModel {
 
     /// Whether artist library state still depends on optimistic local suppression/insertion.
     func needsArtistLibraryReconciliation(artistIds: [String], expectedInLibrary: Bool) -> Bool {
-        let artistKeys = Set(artistIds.map { LibraryContentIdentity.artistKey(for: $0) })
-        if expectedInLibrary {
-            return artistKeys.contains { self.pendingAddedArtists[$0] != nil }
-        }
-        return artistKeys.contains { self.pendingRemovedArtistIds.contains($0) }
+        self.contentReconciler.needsArtistReconciliation(artistIds: artistIds, expectedInLibrary: expectedInLibrary)
     }
 
     /// Adds a playlist ID to the library set (called after successful add to library).
     func addToLibrarySet(playlistId: String) {
         self.markLibraryStateChanged()
-        let playlistKey = LibraryContentIdentity.playlistKey(for: playlistId)
-        self.pendingRemovedPlaylistIds.remove(playlistKey)
-        self.pendingRemovedPlaylistMissCounts.removeValue(forKey: playlistKey)
-        self.libraryPlaylistIds.insert(playlistId)
+        var snapshot = self.librarySnapshot
+        self.contentReconciler.addPlaylistId(playlistId, to: &snapshot)
+        self.librarySnapshot = snapshot
     }
 
     /// Adds a playlist to the library (called after successful add to library).
     /// Updates both the ID set and the playlists array for immediate UI update.
     func addToLibrary(playlist: Playlist) {
         self.markLibraryStateChanged()
-        self.libraryPlaylistIds.insert(playlist.id)
-        let playlistKey = LibraryContentIdentity.playlistKey(for: playlist.id)
-        self.pendingRemovedPlaylistIds.remove(playlistKey)
-        self.pendingRemovedPlaylistMissCounts.removeValue(forKey: playlistKey)
-        self.pendingAddedPlaylists[playlistKey] = playlist
-        self.pendingAddedPlaylistMatchCounts[playlistKey] = 0
-        if let existingIndex = self.playlists.firstIndex(where: { LibraryContentIdentity.playlistKey(for: $0.id) == playlistKey }) {
-            self.playlists[existingIndex] = playlist
-        } else {
-            self.playlists.insert(playlist, at: 0)
-        }
+        var snapshot = self.librarySnapshot
+        self.contentReconciler.addPlaylist(playlist, to: &snapshot)
+        self.librarySnapshot = snapshot
     }
 
     /// Adds a podcast to the library (called after successful subscription).
     /// Updates both the ID set and the shows array for immediate UI update.
     func addToLibrary(podcast: PodcastShow) {
         self.markLibraryStateChanged()
-        self.libraryPodcastIds.insert(podcast.id)
-        // Add to shows array if not already present
-        if !self.podcastShows.contains(where: { $0.id == podcast.id }) {
-            self.podcastShows.insert(podcast, at: 0)
-        }
+        var snapshot = self.librarySnapshot
+        self.contentReconciler.addPodcast(podcast, to: &snapshot)
+        self.librarySnapshot = snapshot
     }
 
     /// Adds a podcast ID to the library set (called after successful subscription).
     func addToLibrarySet(podcastId: String) {
         self.markLibraryStateChanged()
-        self.libraryPodcastIds.insert(podcastId)
+        var snapshot = self.librarySnapshot
+        self.contentReconciler.addPodcastId(podcastId, to: &snapshot)
+        self.librarySnapshot = snapshot
     }
 
     /// Adds an artist to the library (called after successful subscription).
     /// Updates both the ID set and the artists array for immediate UI update.
     func addToLibrary(artist: Artist, libraryArtistId: String? = nil) {
         self.markLibraryStateChanged()
-        let artistKey = LibraryContentIdentity.artistKey(for: libraryArtistId ?? artist.id)
-        let canonicalArtist = LibraryContentIdentity.canonicalArtist(artist, libraryArtistID: artistKey)
-        self.pendingRemovedArtistIds.remove(artistKey)
-        self.pendingRemovedArtistMatchCounts.removeValue(forKey: artistKey)
-        self.pendingAddedArtists[artistKey] = canonicalArtist
-        self.pendingAddedArtistMatchCounts[artistKey] = 0
-        self.libraryArtistIds.insert(artistKey)
-        if let existingIndex = self.artists.firstIndex(where: { LibraryContentIdentity.artistKey(for: $0.id) == artistKey }) {
-            self.artists[existingIndex] = canonicalArtist
-        } else {
-            self.artists.insert(canonicalArtist, at: 0)
-        }
+        var snapshot = self.librarySnapshot
+        self.contentReconciler.addArtist(artist, libraryArtistId: libraryArtistId, to: &snapshot)
+        self.librarySnapshot = snapshot
     }
 
     /// Adds an artist ID to the library set (called after successful subscription).
     func addToLibrarySet(artistId: String) {
         self.markLibraryStateChanged()
-        let artistKey = LibraryContentIdentity.artistKey(for: artistId)
-        self.pendingRemovedArtistIds.remove(artistKey)
-        self.pendingRemovedArtistMatchCounts.removeValue(forKey: artistKey)
-        self.libraryArtistIds.insert(artistKey)
+        var snapshot = self.librarySnapshot
+        self.contentReconciler.addArtistId(artistId, to: &snapshot)
+        self.librarySnapshot = snapshot
     }
 
     /// Removes a playlist ID from the library set (called after successful remove from library).
     func removeFromLibrarySet(playlistId: String) {
         self.markLibraryStateChanged()
-        let playlistKey = LibraryContentIdentity.playlistKey(for: playlistId)
-        self.pendingAddedPlaylists.removeValue(forKey: playlistKey)
-        self.pendingAddedPlaylistMatchCounts.removeValue(forKey: playlistKey)
-        self.pendingRemovedPlaylistIds.insert(playlistKey)
-        self.pendingRemovedPlaylistMissCounts[playlistKey] = 0
-        self.libraryPlaylistIds = LibraryContentIdentity.removingPlaylist(playlistId, from: self.libraryPlaylistIds)
+        var snapshot = self.librarySnapshot
+        self.contentReconciler.removePlaylistId(playlistId, from: &snapshot)
+        self.librarySnapshot = snapshot
     }
 
     /// Removes a playlist from the library (called after successful remove from library).
     /// Updates both the ID set and the playlists array for immediate UI update.
     func removeFromLibrary(playlistId: String) {
         self.markLibraryStateChanged()
-        self.removeFromLibrarySet(playlistId: playlistId)
-        let playlistKey = LibraryContentIdentity.playlistKey(for: playlistId)
-        self.playlists.removeAll { LibraryContentIdentity.playlistKey(for: $0.id) == playlistKey }
+        var snapshot = self.librarySnapshot
+        self.contentReconciler.removePlaylist(playlistId, from: &snapshot)
+        self.librarySnapshot = snapshot
     }
 
     /// Removes a podcast from the library (called after successful unsubscribe).
     /// Updates both the ID set and the shows array for immediate UI update.
     func removeFromLibrary(podcastId: String) {
         self.markLibraryStateChanged()
-        self.libraryPodcastIds.remove(podcastId)
-        self.podcastShows.removeAll { $0.id == podcastId }
+        var snapshot = self.librarySnapshot
+        self.contentReconciler.removePodcast(podcastId, from: &snapshot)
+        self.librarySnapshot = snapshot
     }
 
     /// Removes a podcast ID from the library set (called after successful unsubscribe).
     func removeFromLibrarySet(podcastId: String) {
         self.markLibraryStateChanged()
-        self.libraryPodcastIds.remove(podcastId)
+        var snapshot = self.librarySnapshot
+        self.contentReconciler.removePodcastId(podcastId, from: &snapshot)
+        self.librarySnapshot = snapshot
     }
 
     /// Removes an artist from the library (called after successful unsubscribe).
     /// Updates both the ID set and the artists array for immediate UI update.
     func removeFromLibrary(artistId: String) {
         self.markLibraryStateChanged()
-        let artistKey = LibraryContentIdentity.artistKey(for: artistId)
-        self.pendingAddedArtists.removeValue(forKey: artistKey)
-        self.pendingAddedArtistMatchCounts.removeValue(forKey: artistKey)
-        self.pendingRemovedArtistIds.insert(artistKey)
-        self.pendingRemovedArtistMatchCounts[artistKey] = 0
-        self.libraryArtistIds.remove(artistKey)
-        self.artists.removeAll { LibraryContentIdentity.artistKey(for: $0.id) == artistKey }
+        var snapshot = self.librarySnapshot
+        self.contentReconciler.removeArtist(artistId, from: &snapshot)
+        self.librarySnapshot = snapshot
     }
 
     /// Removes an artist ID from the library set (called after successful unsubscribe).
     func removeFromLibrarySet(artistId: String) {
         self.markLibraryStateChanged()
-        let artistKey = LibraryContentIdentity.artistKey(for: artistId)
-        self.pendingAddedArtists.removeValue(forKey: artistKey)
-        self.pendingAddedArtistMatchCounts.removeValue(forKey: artistKey)
-        self.pendingRemovedArtistIds.insert(artistKey)
-        self.pendingRemovedArtistMatchCounts[artistKey] = 0
-        self.libraryArtistIds.remove(artistKey)
+        var snapshot = self.librarySnapshot
+        self.contentReconciler.removeArtistId(artistId, from: &snapshot)
+        self.librarySnapshot = snapshot
     }
 
     /// Loads library content (playlists, artists, and podcasts).
@@ -529,13 +406,7 @@ final class LibraryViewModel {
         if self.hasLibrarySnapshot {
             self.loadingState = .loadingMore
         } else {
-            self.playlists = []
-            self.artists = []
-            self.podcastShows = []
-            self.uploadedSongsPlaylist = nil
-            self.libraryPlaylistIds = []
-            self.libraryArtistIds = []
-            self.libraryPodcastIds = []
+            self.librarySnapshot = .empty
         }
 
         await self.load()

--- a/Sources/Kaset/Views/SharedViews/SongActionsHelper.swift
+++ b/Sources/Kaset/Views/SharedViews/SongActionsHelper.swift
@@ -53,26 +53,6 @@ enum SongActionsHelper {
         }
     }
 
-    private static func cleanedArtistPreservingMetadata(_ artist: Artist) -> Artist? {
-        var cleanName = artist.name
-
-        if cleanName == "Album" {
-            return nil
-        }
-
-        if cleanName.hasPrefix("Album, ") {
-            cleanName = String(cleanName.dropFirst(7))
-        }
-
-        return Artist(
-            id: artist.id,
-            name: cleanName,
-            thumbnailURL: artist.thumbnailURL,
-            subtitle: artist.subtitle,
-            profileKind: artist.profileKind
-        )
-    }
-
     /// Likes a song via the API (does not play the song).
     static func likeSong(_ song: Song, likeStatusManager: SongLikeStatusManager) {
         let activeAccountID = likeStatusManager.activeAccountID
@@ -353,50 +333,15 @@ enum SongActionsHelper {
         fallbackArtist: String? = nil,
         fallbackAlbum: Album? = nil
     ) {
-        guard !songs.isEmpty else { return }
+        let preparedSongs = QueueSongMetadata.songsForQueue(
+            songs,
+            fallbackArtist: fallbackArtist,
+            fallbackAlbum: fallbackAlbum
+        )
+        guard !preparedSongs.isEmpty else { return }
 
-        // Clean artists and use fallback when empty
-        let cleanedSongs = songs.map { song in
-            var cleanedArtists = song.artists.compactMap(Self.cleanedArtistPreservingMetadata)
-
-            // Use fallback artist if artists are empty (and clean the fallback too)
-            if cleanedArtists.isEmpty, let fallback = fallbackArtist, !fallback.isEmpty {
-                // Clean the fallback string - it might have "Album, " prefix or be "Album"
-                var cleanFallback = fallback
-                if cleanFallback == "Album" {
-                    cleanFallback = "Unknown Artist"
-                } else if cleanFallback.hasPrefix("Album, ") {
-                    cleanFallback = String(cleanFallback.dropFirst(7))
-                }
-                // Also handle case where it's "Album, Artist" but we got it as a combined string
-                if cleanFallback.contains("Album,") {
-                    // Try to extract just the artist part after "Album,"
-                    let parts = cleanFallback.split(separator: ",", maxSplits: 1)
-                    if parts.count > 1 {
-                        cleanFallback = String(parts[1]).trimmingCharacters(in: .whitespaces)
-                    }
-                }
-                cleanedArtists = [Artist(id: "unknown", name: cleanFallback)]
-            }
-
-            // Use fallback album if song doesn't have album info
-            let finalAlbum = song.album ?? fallbackAlbum
-            // Use fallback thumbnail if song doesn't have one
-            let finalThumbnail = song.thumbnailURL ?? fallbackAlbum?.thumbnailURL
-
-            return Song(
-                id: song.id,
-                title: song.title,
-                artists: cleanedArtists,
-                album: finalAlbum,
-                duration: song.duration,
-                thumbnailURL: finalThumbnail,
-                videoId: song.videoId
-            )
-        }
-
-        playerService.insertNextInQueue(cleanedSongs)
-        DiagnosticsLogger.ui.info("Added \(cleanedSongs.count) songs to play next")
+        playerService.insertNextInQueue(preparedSongs)
+        DiagnosticsLogger.ui.info("Added \(preparedSongs.count) songs to play next")
     }
 
     /// Adds multiple songs (e.g., from an album) to the end of the queue.
@@ -409,50 +354,15 @@ enum SongActionsHelper {
         fallbackArtist: String? = nil,
         fallbackAlbum: Album? = nil
     ) {
-        guard !songs.isEmpty else { return }
+        let preparedSongs = QueueSongMetadata.songsForQueue(
+            songs,
+            fallbackArtist: fallbackArtist,
+            fallbackAlbum: fallbackAlbum
+        )
+        guard !preparedSongs.isEmpty else { return }
 
-        // Clean artists and use fallback when empty
-        let cleanedSongs = songs.map { song in
-            var cleanedArtists = song.artists.compactMap(Self.cleanedArtistPreservingMetadata)
-
-            // Use fallback artist if artists are empty (and clean the fallback too)
-            if cleanedArtists.isEmpty, let fallback = fallbackArtist, !fallback.isEmpty {
-                // Clean the fallback string - it might have "Album, " prefix or be "Album"
-                var cleanFallback = fallback
-                if cleanFallback == "Album" {
-                    cleanFallback = "Unknown Artist"
-                } else if cleanFallback.hasPrefix("Album, ") {
-                    cleanFallback = String(cleanFallback.dropFirst(7))
-                }
-                // Also handle case where it's "Album, Artist" but we got it as a combined string
-                if cleanFallback.contains("Album,") {
-                    // Try to extract just the artist part after "Album,"
-                    let parts = cleanFallback.split(separator: ",", maxSplits: 1)
-                    if parts.count > 1 {
-                        cleanFallback = String(parts[1]).trimmingCharacters(in: .whitespaces)
-                    }
-                }
-                cleanedArtists = [Artist(id: "unknown", name: cleanFallback)]
-            }
-
-            // Use fallback album if song doesn't have album info
-            let finalAlbum = song.album ?? fallbackAlbum
-            // Use fallback thumbnail if song doesn't have one
-            let finalThumbnail = song.thumbnailURL ?? fallbackAlbum?.thumbnailURL
-
-            return Song(
-                id: song.id,
-                title: song.title,
-                artists: cleanedArtists,
-                album: finalAlbum,
-                duration: song.duration,
-                thumbnailURL: finalThumbnail,
-                videoId: song.videoId
-            )
-        }
-
-        playerService.appendToQueue(cleanedSongs)
-        DiagnosticsLogger.ui.info("Added \(cleanedSongs.count) songs to end of queue")
+        playerService.appendToQueue(preparedSongs)
+        DiagnosticsLogger.ui.info("Added \(preparedSongs.count) songs to end of queue")
     }
 
     // MARK: - Album Queue Actions
@@ -463,50 +373,11 @@ enum SongActionsHelper {
         client: any YTMusicClientProtocol,
         playerService: PlayerService
     ) {
-        Task {
-            do {
-                // Fetch album tracks - albums are treated as playlists
-                let response = try await client.getPlaylist(id: album.id)
-                var songs = response.detail.tracks
-
-                guard !songs.isEmpty else { return }
-
-                // Clean up album artists - filter out "Album" keyword and clean names
-                let cleanAlbumArtists = (album.artists ?? []).compactMap(Self.cleanedArtistPreservingMetadata)
-
-                // Populate album and artist info for each song
-                songs = songs.map { song in
-                    // Use song artists if available and not empty, otherwise use cleaned album artists
-                    let baseArtists = !song.artists.isEmpty ? song.artists : cleanAlbumArtists
-
-                    // Also clean song artists - filter "Album" keyword and clean names
-                    let effectiveArtists = baseArtists.compactMap(Self.cleanedArtistPreservingMetadata)
-
-                    // Create updated song with album info and proper artists
-                    return Song(
-                        id: song.id,
-                        title: song.title,
-                        artists: effectiveArtists,
-                        album: Album(
-                            id: album.id,
-                            title: album.title,
-                            artists: cleanAlbumArtists,
-                            thumbnailURL: album.thumbnailURL,
-                            year: nil,
-                            trackCount: album.trackCount
-                        ),
-                        duration: song.duration,
-                        thumbnailURL: song.thumbnailURL ?? album.thumbnailURL,
-                        videoId: song.videoId
-                    )
-                }
-
-                playerService.insertNextInQueue(songs)
-                DiagnosticsLogger.ui.info("Added album '\(album.title)' (\(songs.count) songs) to play next")
-            } catch {
-                DiagnosticsLogger.ui.error("Failed to add album to queue: \(error.localizedDescription)")
-            }
-        }
+        AlbumPlaybackActions.addAlbumToQueueNext(
+            album,
+            client: client,
+            playerService: playerService
+        )
     }
 
     /// Adds an album's songs to the end of the queue.
@@ -515,50 +386,11 @@ enum SongActionsHelper {
         client: any YTMusicClientProtocol,
         playerService: PlayerService
     ) {
-        Task {
-            do {
-                // Fetch album tracks - albums are treated as playlists
-                let response = try await client.getPlaylist(id: album.id)
-                var songs = response.detail.tracks
-
-                guard !songs.isEmpty else { return }
-
-                // Clean up album artists - filter out "Album" keyword and clean names
-                let cleanAlbumArtists = (album.artists ?? []).compactMap(Self.cleanedArtistPreservingMetadata)
-
-                // Populate album and artist info for each song
-                songs = songs.map { song in
-                    // Use song artists if available and not empty, otherwise use cleaned album artists
-                    let baseArtists = !song.artists.isEmpty ? song.artists : cleanAlbumArtists
-
-                    // Also clean song artists - filter "Album" keyword and clean names
-                    let effectiveArtists = baseArtists.compactMap(Self.cleanedArtistPreservingMetadata)
-
-                    // Create updated song with album info and proper artists
-                    return Song(
-                        id: song.id,
-                        title: song.title,
-                        artists: effectiveArtists,
-                        album: Album(
-                            id: album.id,
-                            title: album.title,
-                            artists: cleanAlbumArtists,
-                            thumbnailURL: album.thumbnailURL,
-                            year: nil,
-                            trackCount: album.trackCount
-                        ),
-                        duration: song.duration,
-                        thumbnailURL: song.thumbnailURL ?? album.thumbnailURL,
-                        videoId: song.videoId
-                    )
-                }
-
-                playerService.appendToQueue(songs)
-                DiagnosticsLogger.ui.info("Added album '\(album.title)' (\(songs.count) songs) to end of queue")
-            } catch {
-                DiagnosticsLogger.ui.error("Failed to add album to queue: \(error.localizedDescription)")
-            }
-        }
+        AlbumPlaybackActions.addAlbumToQueueLast(
+            album,
+            client: client,
+            playerService: playerService
+        )
     }
 
     /// Plays an album immediately, replacing the current queue.
@@ -567,54 +399,11 @@ enum SongActionsHelper {
         client: any YTMusicClientProtocol,
         playerService: PlayerService
     ) {
-        Task {
-            do {
-                // Fetch album tracks - albums are treated as playlists
-                let response = try await client.getPlaylist(id: album.id)
-                var songs = response.detail.tracks
-
-                guard !songs.isEmpty else { return }
-
-                // Clean up album artists - filter out "Album" keyword and clean names
-                let cleanAlbumArtists = (album.artists ?? []).compactMap(Self.cleanedArtistPreservingMetadata)
-
-                // Populate album and artist info for each song
-                songs = songs.map { song in
-                    // Use song artists if available and not empty, otherwise use cleaned album artists
-                    let baseArtists = !song.artists.isEmpty ? song.artists : cleanAlbumArtists
-
-                    // Also clean song artists - filter "Album" keyword and clean names
-                    let effectiveArtists = baseArtists.compactMap(Self.cleanedArtistPreservingMetadata)
-
-                    // Create album object for the song
-                    let songAlbum = Album(
-                        id: album.id,
-                        title: album.title,
-                        artists: cleanAlbumArtists.isEmpty ? nil : cleanAlbumArtists,
-                        thumbnailURL: album.thumbnailURL,
-                        year: album.year,
-                        trackCount: songs.count
-                    )
-
-                    // Create updated song with album info and proper artists
-                    return Song(
-                        id: song.id,
-                        title: song.title,
-                        artists: effectiveArtists.isEmpty ? cleanAlbumArtists : effectiveArtists,
-                        album: songAlbum,
-                        duration: song.duration,
-                        thumbnailURL: song.thumbnailURL ?? album.thumbnailURL,
-                        videoId: song.videoId
-                    )
-                }
-
-                // Stop current playback and play the album
-                await playerService.playQueue(songs, startingAt: 0)
-                DiagnosticsLogger.ui.info("Playing album '\(album.title)' (\(songs.count) songs)")
-            } catch {
-                DiagnosticsLogger.ui.error("Failed to play album: \(error.localizedDescription)")
-            }
-        }
+        AlbumPlaybackActions.playAlbum(
+            album,
+            client: client,
+            playerService: playerService
+        )
     }
 }
 

--- a/Sources/Kaset/Views/SharedViews/SongActionsHelper.swift
+++ b/Sources/Kaset/Views/SharedViews/SongActionsHelper.swift
@@ -444,12 +444,12 @@ private enum PlaylistPlaybackHelper {
     }
 
     static func appendContinuations(_ context: ContinuationContext) async {
-        var nextContinuationToken = context.continuationToken
+        var nextContinuation = context.continuationToken
         var seenVideoIds = context.existingVideoIds
 
-        while let token = nextContinuationToken, !Task.isCancelled {
+        while let c = nextContinuation, !Task.isCancelled {
             do {
-                let response = try await context.client.getPlaylistContinuation(token: token)
+                let response = try await context.client.getPlaylistContinuation(token: c)
                 let newTracks = response.tracks.filter { seenVideoIds.insert($0.videoId).inserted }
                 guard !newTracks.isEmpty else { break }
 
@@ -462,7 +462,7 @@ private enum PlaylistPlaybackHelper {
                     context.playerService.appendToQueue(playableSongs)
                 }
 
-                nextContinuationToken = response.continuationToken
+                nextContinuation = response.continuationToken
             } catch {
                 DiagnosticsLogger.ui.debug("Stopped loading playlist continuations: \(error.localizedDescription)")
                 break

--- a/Sources/Kaset/Views/SharedViews/SongActionsHelper.swift
+++ b/Sources/Kaset/Views/SharedViews/SongActionsHelper.swift
@@ -7,9 +7,10 @@ import SwiftUI
 /// Helper for common song actions like liking, disliking, adding to library, and queue management.
 @MainActor
 enum SongActionsHelper {
-    static var artistLibraryReconciliationRetryDelays: [Duration] = [.seconds(2), .seconds(3)]
-
-    private static var artistLibraryReconciliationTasks: [String: Task<Void, Never>] = [:]
+    static var artistLibraryReconciliationRetryDelays: [Duration] {
+        get { LibraryMutationActions.artistReconciliationRetryDelays }
+        set { LibraryMutationActions.artistReconciliationRetryDelays = newValue }
+    }
 
     /// Whether a playlist card should expose direct playback.
     static func canQuickPlayPlaylist(_ playlist: Playlist) -> Bool {
@@ -72,113 +73,6 @@ enum SongActionsHelper {
         )
     }
 
-    private static func artistLibraryAliases(for artist: Artist, channelId: String) -> [String] {
-        var ids = Set([channelId, artist.id])
-        if let publicChannelId = artist.publicChannelId {
-            ids.insert(publicChannelId)
-        }
-        return Array(ids)
-    }
-
-    private static func preferredLibraryArtistId(for artist: Artist, channelId: String) -> String {
-        if artist.hasNavigableId {
-            return artist.id
-        }
-
-        return channelId
-    }
-
-    private static func scheduleArtistLibraryReconciliation(
-        _ artist: Artist,
-        channelId: String,
-        expectedInLibrary: Bool,
-        libraryViewModel: LibraryViewModel
-    ) {
-        let normalizedArtistId = Artist.publicChannelId(for: channelId) ?? channelId
-        self.artistLibraryReconciliationTasks[normalizedArtistId]?.cancel()
-
-        self.artistLibraryReconciliationTasks[normalizedArtistId] = Task { @MainActor in
-            defer { self.artistLibraryReconciliationTasks.removeValue(forKey: normalizedArtistId) }
-
-            for delay in self.artistLibraryReconciliationRetryDelays {
-                do {
-                    try await Task.sleep(for: delay)
-                } catch {
-                    return
-                }
-
-                guard !Task.isCancelled else { return }
-
-                self.invalidateLibraryResponseCaches()
-                await libraryViewModel.refresh()
-                self.invalidateLibraryResponseCaches()
-
-                let needsReconciliation = libraryViewModel.needsArtistLibraryReconciliation(
-                    artistIds: self.artistLibraryAliases(for: artist, channelId: channelId),
-                    expectedInLibrary: expectedInLibrary
-                )
-                let isInLibrary = self.isArtistInLibrary(
-                    artist,
-                    channelId: channelId,
-                    libraryViewModel: libraryViewModel
-                )
-                if !needsReconciliation, isInLibrary == expectedInLibrary {
-                    DiagnosticsLogger.api.debug(
-                        "Artist library reconciliation converged with backend state for \(artist.name, privacy: .public)"
-                    )
-                    return
-                }
-
-                DiagnosticsLogger.api.debug(
-                    "Artist library reconciliation is still waiting on backend propagation for \(artist.name, privacy: .public)"
-                )
-                if isInLibrary != expectedInLibrary {
-                    DiagnosticsLogger.api.debug(
-                        "Artist library reconciliation is reapplying optimistic state for \(artist.name, privacy: .public)"
-                    )
-                }
-
-                if expectedInLibrary {
-                    self.addArtistToLibrary(artist, channelId: channelId, libraryViewModel: libraryViewModel)
-                } else {
-                    self.removeArtistFromLibrary(artist, channelId: channelId, libraryViewModel: libraryViewModel)
-                }
-                libraryViewModel.markNeedsReloadOnActivation()
-            }
-        }
-    }
-
-    private static func addArtistToLibrary(
-        _ artist: Artist,
-        channelId: String,
-        libraryViewModel: LibraryViewModel
-    ) {
-        let libraryArtistId = self.preferredLibraryArtistId(for: artist, channelId: channelId)
-        libraryViewModel.addToLibrary(artist: artist, libraryArtistId: libraryArtistId)
-        for artistId in self.artistLibraryAliases(for: artist, channelId: channelId) {
-            libraryViewModel.addToLibrarySet(artistId: artistId)
-        }
-    }
-
-    private static func removeArtistFromLibrary(
-        _ artist: Artist,
-        channelId: String,
-        libraryViewModel: LibraryViewModel
-    ) {
-        for artistId in self.artistLibraryAliases(for: artist, channelId: channelId) {
-            libraryViewModel.removeFromLibrary(artistId: artistId)
-        }
-    }
-
-    private static func isArtistInLibrary(
-        _ artist: Artist,
-        channelId: String,
-        libraryViewModel: LibraryViewModel
-    ) -> Bool {
-        self.artistLibraryAliases(for: artist, channelId: channelId)
-            .contains(where: { libraryViewModel.isInLibrary(artistId: $0) })
-    }
-
     /// Likes a song via the API (does not play the song).
     static func likeSong(_ song: Song, likeStatusManager: SongLikeStatusManager) {
         let activeAccountID = likeStatusManager.activeAccountID
@@ -227,17 +121,7 @@ enum SongActionsHelper {
         playlist: AddToPlaylistOption,
         client: any YTMusicClientProtocol
     ) async {
-        do {
-            try await client.addSongToPlaylist(
-                videoId: song.videoId,
-                playlistId: playlist.playlistId,
-                allowDuplicate: false
-            )
-            self.invalidateLibraryResponseCaches()
-            DiagnosticsLogger.api.info("Added song '\(song.title)' to playlist '\(playlist.title)'")
-        } catch {
-            DiagnosticsLogger.api.error("Failed to add song to playlist: \(error.localizedDescription)")
-        }
+        await LibraryMutationActions.addSongToPlaylist(song, playlist: playlist, client: client)
     }
 
     /// Adds a playlist to the library.
@@ -246,26 +130,11 @@ enum SongActionsHelper {
         client: any YTMusicClientProtocol,
         libraryViewModel: LibraryViewModel?
     ) async {
-        do {
-            try await client.subscribeToPlaylist(playlistId: playlist.id)
-            self.invalidateLibraryResponseCaches()
-            libraryViewModel?.markNeedsReloadOnActivation()
-            if let libraryViewModel {
-                libraryViewModel.addToLibrary(playlist: playlist)
-                // Library browse responses can lag briefly behind a successful add.
-                try? await Task.sleep(for: .milliseconds(500))
-                await libraryViewModel.refresh()
-                self.invalidateLibraryResponseCaches()
-
-                if !libraryViewModel.isInLibrary(playlistId: playlist.id) {
-                    libraryViewModel.addToLibrary(playlist: playlist)
-                    self.invalidateLibraryResponseCaches()
-                }
-            }
-            DiagnosticsLogger.api.info("Added playlist to library: \(playlist.title)")
-        } catch {
-            DiagnosticsLogger.api.error("Failed to add playlist to library: \(error.localizedDescription)")
-        }
+        await LibraryMutationActions.addPlaylistToLibrary(
+            playlist,
+            client: client,
+            libraryViewModel: libraryViewModel
+        )
     }
 
     /// Removes a playlist from the library.
@@ -274,20 +143,11 @@ enum SongActionsHelper {
         client: any YTMusicClientProtocol,
         libraryViewModel: LibraryViewModel?
     ) async {
-        do {
-            try await client.unsubscribeFromPlaylist(playlistId: playlist.id)
-            self.invalidateLibraryResponseCaches()
-            libraryViewModel?.markNeedsReloadOnActivation()
-            LibraryMutationBroadcaster.shared.playlistRemoved(playlistId: playlist.id)
-
-            // Library browse responses can lag briefly behind a successful removal.
-            try? await Task.sleep(for: .milliseconds(500))
-            await LibraryMutationBroadcaster.shared.reconcileRemovedPlaylist(playlistId: playlist.id)
-            self.invalidateLibraryResponseCaches()
-            DiagnosticsLogger.api.info("Removed playlist from library: \(playlist.title)")
-        } catch {
-            DiagnosticsLogger.api.error("Failed to remove playlist from library: \(error.localizedDescription)")
-        }
+        await LibraryMutationActions.removePlaylistFromLibrary(
+            playlist,
+            client: client,
+            libraryViewModel: libraryViewModel
+        )
     }
 
     /// Plays a playlist immediately, replacing the current queue.
@@ -350,21 +210,11 @@ enum SongActionsHelper {
         client: any YTMusicClientProtocol,
         libraryViewModel: LibraryViewModel?
     ) async throws {
-        do {
-            try await client.deletePlaylist(playlistId: playlist.id)
-            self.invalidateLibraryResponseCaches()
-            libraryViewModel?.markNeedsReloadOnActivation()
-            LibraryMutationBroadcaster.shared.playlistRemoved(playlistId: playlist.id)
-
-            // Library browse responses can lag briefly behind a successful deletion.
-            try? await Task.sleep(for: .milliseconds(500))
-            await LibraryMutationBroadcaster.shared.reconcileRemovedPlaylist(playlistId: playlist.id)
-            self.invalidateLibraryResponseCaches()
-            DiagnosticsLogger.api.info("Deleted playlist: \(playlist.title)")
-        } catch {
-            DiagnosticsLogger.api.error("Failed to delete playlist: \(error.localizedDescription)")
-            throw error
-        }
+        try await LibraryMutationActions.deletePlaylist(
+            playlist,
+            client: client,
+            libraryViewModel: libraryViewModel
+        )
     }
 
     /// Shows a confirmation dialog before permanently deleting a playlist owned by the user.
@@ -425,23 +275,11 @@ enum SongActionsHelper {
         client: any YTMusicClientProtocol,
         libraryViewModel: LibraryViewModel?
     ) async throws {
-        try await client.subscribeToPodcast(showId: show.id)
-        self.invalidateLibraryResponseCaches()
-        libraryViewModel?.markNeedsReloadOnActivation()
-        if let libraryViewModel {
-            libraryViewModel.addToLibrary(podcast: show)
-
-            // Library browse responses can lag briefly behind a successful subscribe.
-            try? await Task.sleep(for: .milliseconds(500))
-            await libraryViewModel.refresh()
-            self.invalidateLibraryResponseCaches()
-
-            if !libraryViewModel.isInLibrary(podcastId: show.id) {
-                libraryViewModel.addToLibrary(podcast: show)
-                self.invalidateLibraryResponseCaches()
-            }
-        }
-        DiagnosticsLogger.api.info("Subscribed to podcast: \(show.title)")
+        try await LibraryMutationActions.subscribeToPodcast(
+            show,
+            client: client,
+            libraryViewModel: libraryViewModel
+        )
     }
 
     /// Unsubscribes from a podcast show (removes from library).
@@ -450,24 +288,11 @@ enum SongActionsHelper {
         client: any YTMusicClientProtocol,
         libraryViewModel: LibraryViewModel?
     ) async throws {
-        DiagnosticsLogger.api.debug("Attempting to unsubscribe from podcast: \(show.id), libraryViewModel is \(libraryViewModel == nil ? "nil" : "present")")
-        try await client.unsubscribeFromPodcast(showId: show.id)
-        self.invalidateLibraryResponseCaches()
-        libraryViewModel?.markNeedsReloadOnActivation()
-        if let libraryViewModel {
-            libraryViewModel.removeFromLibrary(podcastId: show.id)
-
-            // Library browse responses can lag briefly behind a successful removal.
-            try? await Task.sleep(for: .milliseconds(500))
-            await libraryViewModel.refresh()
-            self.invalidateLibraryResponseCaches()
-
-            if libraryViewModel.isInLibrary(podcastId: show.id) {
-                libraryViewModel.removeFromLibrary(podcastId: show.id)
-                self.invalidateLibraryResponseCaches()
-            }
-        }
-        DiagnosticsLogger.api.info("Unsubscribed from podcast: \(show.title)")
+        try await LibraryMutationActions.unsubscribeFromPodcast(
+            show,
+            client: client,
+            libraryViewModel: libraryViewModel
+        )
     }
 
     /// Subscribes to an artist (adds to library).
@@ -477,31 +302,12 @@ enum SongActionsHelper {
         client: any YTMusicClientProtocol,
         libraryViewModel: LibraryViewModel?
     ) async throws {
-        if let libraryViewModel {
-            self.addArtistToLibrary(artist, channelId: channelId, libraryViewModel: libraryViewModel)
-            libraryViewModel.markNeedsReloadOnActivation()
-        }
-
-        do {
-            try await client.subscribeToArtist(channelId: channelId)
-            self.invalidateLibraryResponseCaches()
-            if let libraryViewModel {
-                self.scheduleArtistLibraryReconciliation(
-                    artist,
-                    channelId: channelId,
-                    expectedInLibrary: true,
-                    libraryViewModel: libraryViewModel
-                )
-            }
-            DiagnosticsLogger.api.info("Subscribed to artist: \(artist.name)")
-        } catch {
-            if let libraryViewModel {
-                self.removeArtistFromLibrary(artist, channelId: channelId, libraryViewModel: libraryViewModel)
-                libraryViewModel.markNeedsReloadOnActivation()
-            }
-            DiagnosticsLogger.api.error("Failed to subscribe to artist: \(error.localizedDescription)")
-            throw error
-        }
+        try await LibraryMutationActions.subscribeToArtist(
+            artist,
+            channelId: channelId,
+            client: client,
+            libraryViewModel: libraryViewModel
+        )
     }
 
     /// Unsubscribes from an artist (removes from library).
@@ -511,38 +317,16 @@ enum SongActionsHelper {
         client: any YTMusicClientProtocol,
         libraryViewModel: LibraryViewModel?
     ) async throws {
-        if let libraryViewModel {
-            self.removeArtistFromLibrary(artist, channelId: channelId, libraryViewModel: libraryViewModel)
-            libraryViewModel.markNeedsReloadOnActivation()
-        }
-
-        do {
-            try await client.unsubscribeFromArtist(channelId: channelId)
-            self.invalidateLibraryResponseCaches()
-            if let libraryViewModel {
-                self.scheduleArtistLibraryReconciliation(
-                    artist,
-                    channelId: channelId,
-                    expectedInLibrary: false,
-                    libraryViewModel: libraryViewModel
-                )
-            }
-            DiagnosticsLogger.api.info("Unsubscribed from artist: \(artist.name)")
-        } catch {
-            if let libraryViewModel {
-                self.addArtistToLibrary(artist, channelId: channelId, libraryViewModel: libraryViewModel)
-                libraryViewModel.markNeedsReloadOnActivation()
-            }
-            DiagnosticsLogger.api.error("Failed to unsubscribe from artist: \(error.localizedDescription)")
-            throw error
-        }
+        try await LibraryMutationActions.unsubscribeFromArtist(
+            artist,
+            channelId: channelId,
+            client: client,
+            libraryViewModel: libraryViewModel
+        )
     }
 
     static func invalidateLibraryResponseCaches() {
-        // Library mutations can leave stale data in both the app-level cache and URL loading cache.
-        APICache.shared.invalidate(matching: "browse:")
-        APICache.shared.invalidate(matching: "playlist/get_add_to_playlist:")
-        URLCache.shared.removeAllCachedResponses()
+        LibraryMutationActions.invalidateResponseCaches()
     }
 
     // MARK: - Queue Actions

--- a/Sources/Kaset/Views/SharedViews/SongActionsHelper.swift
+++ b/Sources/Kaset/Views/SharedViews/SongActionsHelper.swift
@@ -34,6 +34,7 @@ enum SongActionsHelper {
                 return track
             }
 
+            let carried = track.feedbackTokens
             return Song(
                 id: track.id,
                 title: track.title,
@@ -47,7 +48,7 @@ enum SongActionsHelper {
                 musicVideoType: track.musicVideoType,
                 likeStatus: track.likeStatus,
                 isInLibrary: track.isInLibrary,
-                feedbackTokens: track.feedbackTokens,
+                feedbackTokens: carried,
                 isExplicit: track.isExplicit
             )
         }
@@ -422,7 +423,8 @@ private enum PlaylistPlaybackHelper {
 
     static func playableSongsWithPlaylistArtwork(_ songs: [Song], playlist: Playlist) -> [Song] {
         songs.filter(\.isPlayable).map { song in
-            Song(
+            let carried = song.feedbackTokens
+            return Song(
                 id: song.id,
                 title: song.title,
                 artists: song.artists,
@@ -435,7 +437,7 @@ private enum PlaylistPlaybackHelper {
                 musicVideoType: song.musicVideoType,
                 likeStatus: song.likeStatus,
                 isInLibrary: song.isInLibrary,
-                feedbackTokens: song.feedbackTokens,
+                feedbackTokens: carried,
                 isExplicit: song.isExplicit
             )
         }

--- a/Sources/Kaset/Views/SharedViews/SongActionsHelper.swift
+++ b/Sources/Kaset/Views/SharedViews/SongActionsHelper.swift
@@ -17,43 +17,6 @@ enum SongActionsHelper {
         !MoodCategory.isMoodCategory(playlist.id)
     }
 
-    private static func isRadioPlaylist(_ playlistId: String) -> Bool {
-        playlistId.contains("RDCLAK") || playlistId.hasPrefix("RD")
-    }
-
-    private static func tracksForPlaylistPlayback(browseTracks: [Song], queueTracks: [Song]) -> [Song] {
-        var browsePlayabilityByVideoId: [String: Bool] = [:]
-        for track in browseTracks {
-            browsePlayabilityByVideoId[track.videoId] = track.isPlayable
-        }
-
-        return queueTracks.map { track in
-            guard let browseIsPlayable = browsePlayabilityByVideoId[track.videoId],
-                  browseIsPlayable != track.isPlayable
-            else {
-                return track
-            }
-
-            let carried = track.feedbackTokens
-            return Song(
-                id: track.id,
-                title: track.title,
-                artists: track.artists,
-                album: track.album,
-                duration: track.duration,
-                thumbnailURL: track.thumbnailURL,
-                videoId: track.videoId,
-                isPlayable: browseIsPlayable,
-                hasVideo: track.hasVideo,
-                musicVideoType: track.musicVideoType,
-                likeStatus: track.likeStatus,
-                isInLibrary: track.isInLibrary,
-                feedbackTokens: carried,
-                isExplicit: track.isExplicit
-            )
-        }
-    }
-
     /// Likes a song via the API (does not play the song).
     static func likeSong(_ song: Song, likeStatusManager: SongLikeStatusManager) {
         let activeAccountID = likeStatusManager.activeAccountID
@@ -137,52 +100,11 @@ enum SongActionsHelper {
         client: any YTMusicClientProtocol,
         playerService: PlayerService
     ) {
-        Task {
-            do {
-                let response = try await client.getPlaylist(id: playlist.id)
-                var songs = response.detail.tracks
-
-                if self.isRadioPlaylist(playlist.id) {
-                    do {
-                        let allTracks = try await client.getPlaylistAllTracks(playlistId: playlist.id)
-                        if allTracks.count >= songs.count, !allTracks.isEmpty {
-                            songs = self.tracksForPlaylistPlayback(
-                                browseTracks: response.detail.tracks,
-                                queueTracks: allTracks
-                            )
-                        }
-                    } catch {
-                        DiagnosticsLogger.ui.debug("Falling back to browse playlist tracks: \(error.localizedDescription)")
-                    }
-                } else {
-                    let playableSongs = PlaylistPlaybackHelper.playableSongsWithPlaylistArtwork(songs, playlist: playlist)
-                    guard !playableSongs.isEmpty else { return }
-
-                    await playerService.playQueue(playableSongs, startingAt: 0)
-                    DiagnosticsLogger.ui.info("Playing playlist '\(playlist.title)' (\(playableSongs.count) initial songs)")
-
-                    await PlaylistPlaybackHelper.appendContinuations(
-                        PlaylistPlaybackHelper.ContinuationContext(
-                            continuationToken: response.continuationToken,
-                            existingVideoIds: Set(songs.map(\.videoId)),
-                            expectedQueueEntryIDs: playerService.queueEntryIDs,
-                            playlist: playlist,
-                            client: client,
-                            playerService: playerService
-                        )
-                    )
-                    return
-                }
-
-                let playableSongs = PlaylistPlaybackHelper.playableSongsWithPlaylistArtwork(songs, playlist: playlist)
-                guard !playableSongs.isEmpty else { return }
-
-                await playerService.playQueue(playableSongs, startingAt: 0)
-                DiagnosticsLogger.ui.info("Playing playlist '\(playlist.title)' (\(playableSongs.count) songs)")
-            } catch {
-                DiagnosticsLogger.ui.error("Failed to play playlist: \(error.localizedDescription)")
-            }
-        }
+        PlaylistPlaybackActions.playPlaylist(
+            playlist,
+            client: client,
+            playerService: playerService
+        )
     }
 
     /// Permanently deletes a playlist owned by the user.
@@ -405,68 +327,5 @@ enum SongActionsHelper {
             client: client,
             playerService: playerService
         )
-    }
-}
-
-// MARK: - PlaylistPlaybackHelper
-
-@MainActor
-private enum PlaylistPlaybackHelper {
-    struct ContinuationContext {
-        let continuationToken: String?
-        let existingVideoIds: Set<String>
-        let expectedQueueEntryIDs: [UUID]
-        let playlist: Playlist
-        let client: any YTMusicClientProtocol
-        let playerService: PlayerService
-    }
-
-    static func playableSongsWithPlaylistArtwork(_ songs: [Song], playlist: Playlist) -> [Song] {
-        songs.filter(\.isPlayable).map { song in
-            let carried = song.feedbackTokens
-            return Song(
-                id: song.id,
-                title: song.title,
-                artists: song.artists,
-                album: song.album,
-                duration: song.duration,
-                thumbnailURL: song.thumbnailURL ?? playlist.thumbnailURL,
-                videoId: song.videoId,
-                isPlayable: song.isPlayable,
-                hasVideo: song.hasVideo,
-                musicVideoType: song.musicVideoType,
-                likeStatus: song.likeStatus,
-                isInLibrary: song.isInLibrary,
-                feedbackTokens: carried,
-                isExplicit: song.isExplicit
-            )
-        }
-    }
-
-    static func appendContinuations(_ context: ContinuationContext) async {
-        var nextContinuation = context.continuationToken
-        var seenVideoIds = context.existingVideoIds
-
-        while let c = nextContinuation, !Task.isCancelled {
-            do {
-                let response = try await context.client.getPlaylistContinuation(token: c)
-                let newTracks = response.tracks.filter { seenVideoIds.insert($0.videoId).inserted }
-                guard !newTracks.isEmpty else { break }
-
-                let playableSongs = Self.playableSongsWithPlaylistArtwork(newTracks, playlist: context.playlist)
-                if !playableSongs.isEmpty {
-                    guard Array(context.playerService.queueEntryIDs.prefix(context.expectedQueueEntryIDs.count)) == context.expectedQueueEntryIDs else {
-                        DiagnosticsLogger.ui.debug("Discarding playlist continuations because the queue changed")
-                        return
-                    }
-                    context.playerService.appendToQueue(playableSongs)
-                }
-
-                nextContinuation = response.continuationToken
-            } catch {
-                DiagnosticsLogger.ui.debug("Stopped loading playlist continuations: \(error.localizedDescription)")
-                break
-            }
-        }
     }
 }

--- a/Tests/KasetTests/AlbumPlaybackActionsTests.swift
+++ b/Tests/KasetTests/AlbumPlaybackActionsTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+@Suite(.serialized, .tags(.viewModel), .timeLimit(.minutes(1)))
+@MainActor
+struct AlbumPlaybackActionsTests {
+    var mockClient: MockYTMusicClient
+    var playerService: PlayerService
+
+    init() {
+        self.mockClient = MockYTMusicClient()
+        self.playerService = PlayerService()
+    }
+
+    @Test("Add album to queue last fetches and prepares album songs")
+    func addAlbumToQueueLastFetchesAndPreparesAlbumSongs() async {
+        let album = TestFixtures.makeAlbum(id: "MPRE-album", title: "Album Title", artistName: "Album, Album Artist")
+        let track = Song(id: "track-1", title: "Track 1", artists: [], videoId: "track-1", isExplicit: true)
+        let playlist = TestFixtures.makePlaylist(id: album.id, title: album.title)
+        self.mockClient.playlistDetails[album.id] = PlaylistDetail(
+            playlist: playlist,
+            tracks: [track],
+            duration: nil
+        )
+
+        AlbumPlaybackActions.addAlbumToQueueLast(
+            album,
+            client: self.mockClient,
+            playerService: self.playerService
+        )
+
+        await self.awaitQueueCount(1)
+
+        #expect(self.playerService.queue.first?.title == "Track 1")
+        #expect(self.playerService.queue.first?.artists.map(\.name) == ["Album Artist"])
+        #expect(self.playerService.queue.first?.album?.id == album.id)
+        #expect(self.playerService.queue.first?.thumbnailURL == album.thumbnailURL)
+        #expect(self.playerService.queue.first?.isExplicit == true)
+    }
+
+    private func awaitQueueCount(_ expectedCount: Int) async {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(1))
+
+        while self.playerService.queue.count != expectedCount {
+            guard clock.now < deadline else { return }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+    }
+}

--- a/Tests/KasetTests/Helpers/MockYTMusicClient.swift
+++ b/Tests/KasetTests/Helpers/MockYTMusicClient.swift
@@ -5,13 +5,6 @@ import Foundation
 /// A mock implementation of YTMusicClientProtocol for testing.
 @MainActor
 final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this type_body_length
-    private static func normalizedPlaylistId(_ playlistId: String) -> String {
-        if playlistId.hasPrefix("VL") {
-            return String(playlistId.dropFirst(2))
-        }
-        return playlistId
-    }
-
     private static func playlistContinuationToken(playlistId: String, index: Int) -> String {
         "mock-playlist-continuation|\(playlistId)|\(index)"
     }
@@ -23,10 +16,6 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
               let index = Int(components[2])
         else { return nil }
         return (String(components[1]), index)
-    }
-
-    private static func normalizedArtistId(_ artistId: String) -> String {
-        Artist.publicChannelId(for: artistId) ?? artistId
     }
 
     // MARK: - Response Stubs
@@ -729,9 +718,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.subscribeToPlaylistIds.append(playlistId)
         if let error = shouldThrowError { throw error }
 
-        let normalizedPlaylistId = Self.normalizedPlaylistId(playlistId)
+        let playlistKey = LibraryContentIdentity.playlistKey(for: playlistId)
         if self.shouldAutoUpdatePlaylistLibraryOnMutation,
-           !self.libraryPlaylists.contains(where: { Self.normalizedPlaylistId($0.id) == normalizedPlaylistId })
+           !self.libraryPlaylists.contains(where: { LibraryContentIdentity.playlistKey(for: $0.id) == playlistKey })
         {
             self.libraryPlaylists.insert(TestFixtures.makePlaylist(id: playlistId), at: 0)
         }
@@ -742,13 +731,13 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.deletePlaylistIds.append(playlistId)
         if let error = shouldThrowError { throw error }
 
-        let normalizedPlaylistId = Self.normalizedPlaylistId(playlistId)
+        let playlistKey = LibraryContentIdentity.playlistKey(for: playlistId)
         if self.shouldAutoUpdatePlaylistLibraryOnMutation {
-            self.libraryPlaylists.removeAll { Self.normalizedPlaylistId($0.id) == normalizedPlaylistId }
+            self.libraryPlaylists.removeAll { LibraryContentIdentity.playlistKey(for: $0.id) == playlistKey }
         }
         self.playlistDetails = self.playlistDetails.filter { entry in
-            Self.normalizedPlaylistId(entry.key) != normalizedPlaylistId
-                && Self.normalizedPlaylistId(entry.value.id) != normalizedPlaylistId
+            LibraryContentIdentity.playlistKey(for: entry.key) != playlistKey
+                && LibraryContentIdentity.playlistKey(for: entry.value.id) != playlistKey
         }
     }
 
@@ -778,12 +767,12 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.addSongToPlaylistCalls.append(AddSongToPlaylistCall(videoId: videoId, playlistId: playlistId, allowDuplicate: allowDuplicate))
         if let error = shouldThrowError { throw error }
 
-        let normalizedPlaylistId = Self.normalizedPlaylistId(playlistId)
+        let playlistKey = LibraryContentIdentity.playlistKey(for: playlistId)
         guard self.shouldAutoUpdatePlaylistLibraryOnMutation,
               let song = self.songResponses[videoId]
         else { return }
 
-        for (key, detail) in self.playlistDetails where Self.normalizedPlaylistId(key) == normalizedPlaylistId || Self.normalizedPlaylistId(detail.id) == normalizedPlaylistId {
+        for (key, detail) in self.playlistDetails where LibraryContentIdentity.playlistKey(for: key) == playlistKey || LibraryContentIdentity.playlistKey(for: detail.id) == playlistKey {
             if !detail.tracks.contains(where: { $0.videoId == videoId }) {
                 let playlist = Playlist(
                     id: detail.id,
@@ -807,9 +796,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.unsubscribeFromPlaylistIds.append(playlistId)
         if let error = shouldThrowError { throw error }
 
-        let normalizedPlaylistId = Self.normalizedPlaylistId(playlistId)
+        let playlistKey = LibraryContentIdentity.playlistKey(for: playlistId)
         if self.shouldAutoUpdatePlaylistLibraryOnMutation {
-            self.libraryPlaylists.removeAll { Self.normalizedPlaylistId($0.id) == normalizedPlaylistId }
+            self.libraryPlaylists.removeAll { LibraryContentIdentity.playlistKey(for: $0.id) == playlistKey }
         }
     }
 
@@ -859,12 +848,12 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         }
         if let error = shouldThrowError { throw error }
 
-        let normalizedChannelId = Self.normalizedArtistId(channelId)
+        let artistKey = LibraryContentIdentity.artistKey(for: channelId)
         let artist = self.artistDetails.values.first(where: { $0.channelId == channelId })?.artist
             ?? TestFixtures.makeArtist(id: "MPLA\(channelId)")
 
         if self.shouldAutoUpdateArtistLibraryOnMutation,
-           !self.libraryArtists.contains(where: { Self.normalizedArtistId($0.id) == normalizedChannelId })
+           !self.libraryArtists.contains(where: { LibraryContentIdentity.artistKey(for: $0.id) == artistKey })
         {
             self.libraryArtists.insert(artist, at: 0)
         }
@@ -878,9 +867,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         }
         if let error = shouldThrowError { throw error }
 
-        let normalizedChannelId = Self.normalizedArtistId(channelId)
+        let artistKey = LibraryContentIdentity.artistKey(for: channelId)
         if self.shouldAutoUpdateArtistLibraryOnMutation {
-            self.libraryArtists.removeAll { Self.normalizedArtistId($0.id) == normalizedChannelId }
+            self.libraryArtists.removeAll { LibraryContentIdentity.artistKey(for: $0.id) == artistKey }
         }
     }
 

--- a/Tests/KasetTests/LibraryContentIdentityTests.swift
+++ b/Tests/KasetTests/LibraryContentIdentityTests.swift
@@ -1,0 +1,79 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+@Suite(.tags(.model))
+struct LibraryContentIdentityTests {
+    @Test("Playlist keys collapse VL browse IDs to raw playlist IDs")
+    func playlistKeyCollapsesVLBrowseIDs() {
+        #expect(LibraryContentIdentity.playlistKey(for: "VLPL123") == "PL123")
+        #expect(LibraryContentIdentity.playlistKey(for: "PL123") == "PL123")
+    }
+
+    @Test("Playlist de-duplication keeps first equivalent item")
+    func deduplicatedPlaylistsKeepsFirstEquivalentItem() {
+        let canonicalPlaylist = TestFixtures.makePlaylist(id: "PL123", title: "Canonical")
+        let browsePlaylist = TestFixtures.makePlaylist(id: "VLPL123", title: "Browse")
+        let otherPlaylist = TestFixtures.makePlaylist(id: "VLPL456", title: "Other")
+
+        let playlists = LibraryContentIdentity.deduplicatedPlaylists([
+            canonicalPlaylist,
+            browsePlaylist,
+            otherPlaylist,
+        ])
+
+        #expect(playlists.map(\.id) == ["PL123", "VLPL456"])
+        #expect(playlists.first?.title == "Canonical")
+    }
+
+    @Test("Artist keys collapse library browse IDs to public channel IDs")
+    func artistKeyCollapsesLibraryBrowseIDs() {
+        #expect(LibraryContentIdentity.artistKey(for: "MPLAUC-channel-1") == "UC-channel-1")
+        #expect(LibraryContentIdentity.artistKey(for: "UC-channel-1") == "UC-channel-1")
+    }
+
+    @Test("Canonical artist preserves metadata when rewriting ID")
+    func canonicalArtistPreservesMetadata() {
+        let artist = Artist(
+            id: "MPLAUC-channel-1",
+            name: "Artist 1",
+            thumbnailURL: URL(string: "https://example.com/thumb.jpg"),
+            subtitle: "1.2M subscribers",
+            profileKind: .profile
+        )
+
+        let canonicalArtist = LibraryContentIdentity.canonicalArtist(artist)
+
+        #expect(canonicalArtist.id == "UC-channel-1")
+        #expect(canonicalArtist.name == "Artist 1")
+        #expect(canonicalArtist.thumbnailURL == artist.thumbnailURL)
+        #expect(canonicalArtist.subtitle == "1.2M subscribers")
+        #expect(canonicalArtist.profileKind == .profile)
+    }
+
+    @Test("Artist de-duplication canonicalizes equivalent IDs and keeps first metadata")
+    func deduplicatedArtistsCanonicalizesEquivalentIDs() {
+        let libraryArtist = Artist(
+            id: "MPLAUC-channel-1",
+            name: "Artist from Library",
+            thumbnailURL: nil,
+            subtitle: "Library subtitle",
+            profileKind: .artist
+        )
+        let channelArtist = Artist(
+            id: "UC-channel-1",
+            name: "Artist from Channel",
+            thumbnailURL: nil,
+            subtitle: "Channel subtitle",
+            profileKind: .profile
+        )
+
+        let artists = LibraryContentIdentity.deduplicatedArtists([libraryArtist, channelArtist])
+
+        #expect(artists.count == 1)
+        #expect(artists.first?.id == "UC-channel-1")
+        #expect(artists.first?.name == "Artist from Library")
+        #expect(artists.first?.subtitle == "Library subtitle")
+        #expect(artists.first?.profileKind == .artist)
+    }
+}

--- a/Tests/KasetTests/LibraryContentReconcilerTests.swift
+++ b/Tests/KasetTests/LibraryContentReconcilerTests.swift
@@ -1,0 +1,91 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+@Suite(.tags(.viewModel))
+struct LibraryContentReconcilerTests {
+    @Test("Playlist addition remains visible until backend stabilizes")
+    func playlistAdditionRemainsVisibleUntilBackendStabilizes() {
+        var reconciler = LibraryContentReconciler()
+        var snapshot = LibraryContentSnapshot.empty
+        let playlist = TestFixtures.makePlaylist(id: "VLcreated-playlist", title: "Created Playlist")
+
+        reconciler.addPlaylist(playlist, to: &snapshot)
+        snapshot = reconciler.apply(Self.content(playlists: []), currentSnapshot: snapshot).snapshot
+        #expect(snapshot.playlists.map(\.id) == ["VLcreated-playlist"])
+        #expect(LibraryContentIdentity.containsPlaylist("created-playlist", in: snapshot.playlistIds))
+
+        snapshot = reconciler.apply(Self.content(playlists: [playlist]), currentSnapshot: snapshot).snapshot
+        snapshot = reconciler.apply(Self.content(playlists: [playlist]), currentSnapshot: snapshot).snapshot
+        #expect(snapshot.playlists.map(\.id) == ["VLcreated-playlist"])
+
+        snapshot = reconciler.apply(Self.content(playlists: []), currentSnapshot: snapshot).snapshot
+        #expect(snapshot.playlists.isEmpty)
+        #expect(snapshot.playlistIds.isEmpty)
+    }
+
+    @Test("Playlist removal stays suppressed until backend stabilizes")
+    func playlistRemovalStaysSuppressedUntilBackendStabilizes() {
+        var reconciler = LibraryContentReconciler()
+        let playlist = TestFixtures.makePlaylist(id: "VLold-playlist", title: "Old Playlist")
+        var snapshot = reconciler.apply(Self.content(playlists: [playlist]), currentSnapshot: .empty).snapshot
+
+        reconciler.removePlaylist("old-playlist", from: &snapshot)
+        snapshot = reconciler.apply(Self.content(playlists: [playlist]), currentSnapshot: snapshot).snapshot
+        #expect(snapshot.playlists.isEmpty)
+        #expect(snapshot.playlistIds.isEmpty)
+
+        snapshot = reconciler.apply(Self.content(playlists: []), currentSnapshot: snapshot).snapshot
+        snapshot = reconciler.apply(Self.content(playlists: []), currentSnapshot: snapshot).snapshot
+        #expect(snapshot.playlists.isEmpty)
+
+        snapshot = reconciler.apply(Self.content(playlists: [playlist]), currentSnapshot: snapshot).snapshot
+        #expect(snapshot.playlists.map(\.id) == ["VLold-playlist"])
+    }
+
+    @Test("Landing fallback preserves existing artist snapshot")
+    func landingFallbackPreservesExistingArtists() {
+        var reconciler = LibraryContentReconciler()
+        let authoritativeArtist = TestFixtures.makeArtist(id: "UC-channel-1", name: "Artist 1")
+        let fallbackArtist = TestFixtures.makeArtist(id: "UC-channel-2", name: "Artist 2")
+        var snapshot = reconciler.apply(Self.content(artists: [authoritativeArtist]), currentSnapshot: .empty).snapshot
+
+        let result = reconciler.apply(
+            Self.content(artists: [fallbackArtist], artistsSource: .landingFallback),
+            currentSnapshot: snapshot
+        )
+        snapshot = result.snapshot
+
+        #expect(result.preservedExistingArtists)
+        #expect(snapshot.artists.map(\.id) == ["UC-channel-1"])
+        #expect(snapshot.artistIds == Set(["UC-channel-1"]))
+    }
+
+    @Test("Artist removal stays suppressed through stale backend response")
+    func artistRemovalStaysSuppressedThroughStaleBackendResponse() {
+        var reconciler = LibraryContentReconciler()
+        let artist = TestFixtures.makeArtist(id: "MPLAUC-channel-1", name: "Artist 1")
+        var snapshot = reconciler.apply(Self.content(artists: [artist]), currentSnapshot: .empty).snapshot
+
+        reconciler.removeArtist("UC-channel-1", from: &snapshot)
+        snapshot = reconciler.apply(Self.content(artists: [artist]), currentSnapshot: snapshot).snapshot
+
+        #expect(snapshot.artists.isEmpty)
+        #expect(snapshot.artistIds.isEmpty)
+        #expect(reconciler.needsArtistReconciliation(artistIds: ["MPLAUC-channel-1"], expectedInLibrary: false))
+    }
+
+    private static func content(
+        playlists: [Playlist] = [],
+        artists: [Artist] = [],
+        podcastShows: [PodcastShow] = [],
+        artistsSource: LibraryContentParser.LibraryArtistsSource = .dedicated
+    ) -> LibraryContentParser.LibraryContent {
+        LibraryContentParser.LibraryContent(
+            playlists: playlists,
+            artists: artists,
+            podcastShows: podcastShows,
+            artistsSource: artistsSource
+        )
+    }
+}

--- a/Tests/KasetTests/LibraryMutationActionsTests.swift
+++ b/Tests/KasetTests/LibraryMutationActionsTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+@Suite(.serialized, .tags(.viewModel), .timeLimit(.minutes(1)))
+@MainActor
+struct LibraryMutationActionsTests {
+    var mockClient: MockYTMusicClient
+    var libraryViewModel: LibraryViewModel
+
+    init() {
+        self.mockClient = MockYTMusicClient()
+        self.libraryViewModel = LibraryViewModel(client: self.mockClient)
+        APICache.shared.invalidateAll()
+        URLCache.shared.removeAllCachedResponses()
+        LibraryMutationActions.artistReconciliationRetryDelays = [.milliseconds(1), .milliseconds(1)]
+    }
+
+    @Test("Add song to playlist delegates to client")
+    func addSongToPlaylistDelegatesToClient() async {
+        let song = TestFixtures.makeSong(id: "song-1", title: "Song 1")
+        let playlist = AddToPlaylistOption(
+            playlistId: "VL-target",
+            title: "Target Playlist",
+            subtitle: nil,
+            thumbnailURL: nil,
+            isSelected: false,
+            privacyStatus: nil
+        )
+
+        await LibraryMutationActions.addSongToPlaylist(song, playlist: playlist, client: self.mockClient)
+
+        #expect(self.mockClient.addSongToPlaylistCalls == [
+            MockYTMusicClient.AddSongToPlaylistCall(
+                videoId: "song-1",
+                playlistId: "VL-target",
+                allowDuplicate: false
+            ),
+        ])
+    }
+
+    @Test("Subscribe to artist applies optimistic library state while request is in flight")
+    func subscribeToArtistAppliesOptimisticState() async throws {
+        let artist = TestFixtures.makeArtist(id: "MPLAUC-channel-123", name: "Test Artist")
+        self.mockClient.subscribeToArtistDelay = .milliseconds(700)
+
+        let subscribeTask = Task {
+            try await LibraryMutationActions.subscribeToArtist(
+                artist,
+                channelId: "UC-channel-123",
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel
+            )
+        }
+
+        try await Task.sleep(for: .milliseconds(100))
+
+        #expect(self.libraryViewModel.isInLibrary(artistId: "UC-channel-123"))
+        #expect(self.libraryViewModel.artists.first?.id == "UC-channel-123")
+
+        try await subscribeTask.value
+    }
+
+    @Test("Delete playlist removes it optimistically and calls client")
+    func deletePlaylistRemovesOptimisticallyAndCallsClient() async throws {
+        let playlist = TestFixtures.makePlaylist(id: "VL-owned", title: "Owned Playlist")
+        self.libraryViewModel.addToLibrary(playlist: playlist)
+        self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
+
+        try await LibraryMutationActions.deletePlaylist(
+            playlist,
+            client: self.mockClient,
+            libraryViewModel: self.libraryViewModel
+        )
+
+        #expect(self.mockClient.deletePlaylistCalled)
+        #expect(self.mockClient.deletePlaylistIds == ["VL-owned"])
+        #expect(!self.libraryViewModel.isInLibrary(playlistId: "VL-owned"))
+    }
+}

--- a/Tests/KasetTests/PlaylistEditabilityTests.swift
+++ b/Tests/KasetTests/PlaylistEditabilityTests.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+@Suite(.tags(.parser))
+struct PlaylistEditabilityTests {
+    @Test("Delete affordance is true for explicit delete endpoints")
+    func canDeleteForExplicitDeleteEndpoint() {
+        let response: [String: Any] = [
+            "menu": [
+                "menuRenderer": [
+                    "items": [[
+                        "menuNavigationItemRenderer": [
+                            "navigationEndpoint": [
+                                "deletePlaylistEndpoint": ["playlistId": "VL-owned"],
+                            ],
+                        ],
+                    ]],
+                ],
+            ],
+        ]
+
+        #expect(PlaylistEditability.canDeletePlaylist(from: response))
+    }
+
+    @Test("Delete affordance is true for editable playlist headers")
+    func canDeleteForEditableHeader() {
+        let response: [String: Any] = [
+            "musicEditablePlaylistDetailHeaderRenderer": [
+                "title": ["runs": [["text": "Owned"]]],
+            ],
+        ]
+
+        #expect(PlaylistEditability.canDeletePlaylist(from: response))
+    }
+
+    @Test("Unknown ownership is not deletable")
+    func unknownOwnershipIsNotDeletable() {
+        let response: [String: Any] = [
+            "musicDetailHeaderRenderer": [
+                "title": ["runs": [["text": "Saved Playlist"]]],
+            ],
+        ]
+
+        #expect(!PlaylistEditability.canDeletePlaylist(from: response))
+    }
+}

--- a/Tests/KasetTests/PlaylistPlaybackActionsTests.swift
+++ b/Tests/KasetTests/PlaylistPlaybackActionsTests.swift
@@ -1,0 +1,123 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+@Suite(.serialized, .tags(.viewModel), .timeLimit(.minutes(1)))
+@MainActor
+struct PlaylistPlaybackActionsTests {
+    var mockClient: MockYTMusicClient
+
+    init() {
+        self.mockClient = MockYTMusicClient()
+    }
+
+    @Test("Radio playlist tracks use browse playability when queue endpoint disagrees")
+    func radioPlaylistTracksUseBrowsePlayability() {
+        let browseTrack = Song(
+            id: "track-1",
+            title: "Track 1",
+            artists: [],
+            thumbnailURL: URL(string: "https://example.com/browse.jpg"),
+            videoId: "video-1",
+            isPlayable: false,
+            isExplicit: true
+        )
+        let queueTrack = Song(
+            id: "track-1",
+            title: "Track 1",
+            artists: [],
+            thumbnailURL: URL(string: "https://example.com/queue.jpg"),
+            videoId: "video-1",
+            isPlayable: true,
+            isExplicit: true
+        )
+
+        let tracks = PlaylistPlaybackActions.tracksForPlaylistPlayback(
+            browseTracks: [browseTrack],
+            queueTracks: [queueTrack]
+        )
+
+        #expect(tracks.count == 1)
+        #expect(tracks.first?.isPlayable == false)
+        #expect(tracks.first?.thumbnailURL == queueTrack.thumbnailURL)
+        #expect(tracks.first?.isExplicit == true)
+    }
+
+    @Test("Playable playlist artwork filters unavailable songs and fills missing thumbnails")
+    func playablePlaylistArtworkFiltersAndFillsThumbnails() {
+        let playlist = TestFixtures.makePlaylist(id: "VL-playlist", title: "Playlist")
+        let unavailable = Song(
+            id: "unavailable",
+            title: "Unavailable",
+            artists: [],
+            videoId: "unavailable",
+            isPlayable: false
+        )
+        let playable = Song(
+            id: "playable",
+            title: "Playable",
+            artists: [],
+            thumbnailURL: nil,
+            videoId: "playable",
+            isPlayable: true,
+            isExplicit: true
+        )
+
+        let songs = PlaylistPlaybackActions.playableSongsWithPlaylistArtwork(
+            [unavailable, playable],
+            playlist: playlist
+        )
+
+        #expect(songs.map(\.videoId) == ["playable"])
+        #expect(songs.first?.thumbnailURL == playlist.thumbnailURL)
+        #expect(songs.first?.isExplicit == true)
+    }
+
+    @Test("Playlist playback starts before continuation loading completes")
+    func playlistPlaybackStartsBeforeContinuationLoadingCompletes() async {
+        let playlist = TestFixtures.makePlaylist(id: "VL-test-playlist", title: "Test Playlist")
+        let initial = Song(
+            id: "initial",
+            title: "Initial",
+            artists: [],
+            videoId: "initial"
+        )
+        let continuation = Song(
+            id: "continuation",
+            title: "Continuation",
+            artists: [],
+            videoId: "continuation"
+        )
+        self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(
+            playlist: playlist,
+            tracks: [initial],
+            duration: nil
+        )
+        self.mockClient.playlistContinuationTracks[playlist.id] = [[continuation]]
+        self.mockClient.playlistContinuationDelay = .milliseconds(250)
+        let playerService = PlayerService()
+
+        PlaylistPlaybackActions.playPlaylist(
+            playlist,
+            client: self.mockClient,
+            playerService: playerService
+        )
+        await self.awaitQueueCount(1, in: playerService)
+
+        #expect(playerService.currentTrack?.videoId == "initial")
+        #expect(playerService.queue.map(\.videoId) == ["initial"])
+
+        await self.awaitQueueCount(2, in: playerService)
+        #expect(playerService.queue.map(\.videoId) == ["initial", "continuation"])
+    }
+
+    private func awaitQueueCount(_ expectedCount: Int, in playerService: PlayerService) async {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(1))
+
+        while playerService.queue.count != expectedCount {
+            guard clock.now < deadline else { return }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+    }
+}

--- a/Tests/KasetTests/QueueSongMetadataTests.swift
+++ b/Tests/KasetTests/QueueSongMetadataTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+@Suite(.tags(.model))
+struct QueueSongMetadataTests {
+    @Test("Cleaned artists drop generic Album label and preserve metadata")
+    func cleanedArtistsDropAlbumLabelAndPreserveMetadata() {
+        let thumbnailURL = URL(string: "https://example.com/artist.jpg")
+        let genericArtist = Artist(id: "generic", name: "Album", thumbnailURL: thumbnailURL, subtitle: "ignored", profileKind: .profile)
+        let prefixedArtist = Artist(id: "artist", name: "Album, Real Artist", thumbnailURL: thumbnailURL, subtitle: "subtitle", profileKind: .artist)
+
+        #expect(QueueSongMetadata.cleanedArtistPreservingMetadata(genericArtist) == nil)
+
+        let cleanedArtist = QueueSongMetadata.cleanedArtistPreservingMetadata(prefixedArtist)
+        #expect(cleanedArtist?.id == "artist")
+        #expect(cleanedArtist?.name == "Real Artist")
+        #expect(cleanedArtist?.thumbnailURL == thumbnailURL)
+        #expect(cleanedArtist?.subtitle == "subtitle")
+        #expect(cleanedArtist?.profileKind == .artist)
+    }
+
+    @Test("Queue songs use fallback artist album and thumbnail while preserving playback metadata")
+    func queueSongsUseFallbacksAndPreserveMetadata() {
+        let fallbackAlbum = Album(
+            id: "MPRE-fallback",
+            title: "Fallback Album",
+            artists: [Artist(id: "album-artist", name: "Album Artist")],
+            thumbnailURL: URL(string: "https://example.com/album.jpg"),
+            year: "2024",
+            trackCount: 2
+        )
+        let song = Song(
+            id: "song-1",
+            title: "Song 1",
+            artists: [Artist(id: "generic", name: "Album")],
+            duration: 120,
+            videoId: "video-1",
+            isPlayable: false,
+            hasVideo: true,
+            musicVideoType: .omv,
+            likeStatus: .like,
+            isInLibrary: true,
+            isExplicit: true
+        )
+
+        let preparedSong = QueueSongMetadata.songsForQueue(
+            [song],
+            fallbackArtist: "Album, Fallback Artist",
+            fallbackAlbum: fallbackAlbum
+        ).first
+
+        #expect(preparedSong?.artists.map(\.name) == ["Fallback Artist"])
+        #expect(preparedSong?.album == fallbackAlbum)
+        #expect(preparedSong?.thumbnailURL == fallbackAlbum.thumbnailURL)
+        #expect(preparedSong?.isPlayable == false)
+        #expect(preparedSong?.hasVideo == true)
+        #expect(preparedSong?.musicVideoType == .omv)
+        #expect(preparedSong?.likeStatus == .like)
+        #expect(preparedSong?.isInLibrary == true)
+        #expect(preparedSong?.isExplicit == true)
+    }
+
+    @Test("Album playback songs preserve album year and use loaded track count")
+    func albumPlaybackSongsPreserveAlbumYearAndLoadedTrackCount() {
+        let album = TestFixtures.makeAlbum(id: "MPRE-album", title: "Album Title", artistName: "Album, Album Artist", year: "1999")
+        let track = Song(
+            id: "track-1",
+            title: "Track 1",
+            artists: [],
+            thumbnailURL: nil,
+            videoId: "track-1"
+        )
+
+        let preparedTrack = QueueSongMetadata.albumSongs(
+            [track],
+            album: album,
+            purpose: .playback(trackCount: 1)
+        ).first
+
+        #expect(preparedTrack?.artists.map(\.name) == ["Album Artist"])
+        #expect(preparedTrack?.album?.id == "MPRE-album")
+        #expect(preparedTrack?.album?.title == "Album Title")
+        #expect(preparedTrack?.album?.artists?.map(\.name) == ["Album Artist"])
+        #expect(preparedTrack?.album?.year == "1999")
+        #expect(preparedTrack?.album?.trackCount == 1)
+        #expect(preparedTrack?.thumbnailURL == album.thumbnailURL)
+    }
+}

--- a/Tests/KasetTests/ResponseTreeSearchTests.swift
+++ b/Tests/KasetTests/ResponseTreeSearchTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+@Suite(.tags(.parser))
+struct ResponseTreeSearchTests {
+    @Test("Finds first nested dictionary by key")
+    func findsFirstNestedDictionaryByKey() {
+        let response: [String: Any] = [
+            "outer": [
+                "items": [
+                    ["ignored": true],
+                    ["targetRenderer": ["title": "Match"]],
+                ],
+            ],
+        ]
+
+        let dictionary = ResponseTreeSearch.firstDictionary(named: "targetRenderer", in: response)
+
+        #expect(dictionary?["title"] as? String == "Match")
+    }
+
+    @Test("Detects nested keys and case-insensitive text")
+    func detectsNestedKeysAndText() {
+        let response: [String: Any] = [
+            "actions": [[
+                "command": [
+                    "deletePlaylistEndpoint": ["playlistId": "VL123"],
+                    "label": "Playlist/Delete",
+                ],
+            ]],
+        ]
+
+        #expect(ResponseTreeSearch.containsKey("deletePlaylistEndpoint", in: response))
+        #expect(ResponseTreeSearch.containsText("playlist/delete", in: response))
+        #expect(!ResponseTreeSearch.containsKey("createPlaylistEndpoint", in: response))
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,6 +16,7 @@ Sources/
       │   ├── API/      → YTMusicClient, Parsers/
       │   ├── Audio/    → EqualizerService, EqualizerAudioEngine, ProcessTapHelper, BiquadFilter
       │   ├── Auth/     → AuthService (login state machine)
+      │   ├── Library/  → Library identity and optimistic reconciliation modules
       │   ├── Player/   → PlayerService, NowPlayingManager (media keys)
       │   ├── Scripting/→ ScriptCommands (AppleScript integration)
       │   ├── WebKit/   → WebKitManager (cookie persistence)
@@ -58,6 +59,10 @@ final class HomeViewModel {
 - **Source of Truth**: Services are `@MainActor @Observable` singletons
 - **Environment Injection**: Views access services via `@Environment`
 - **Cookie Persistence**: `WKWebsiteDataStore` with persistent identifier
+
+### Library State Reconciliation
+
+`LibraryViewModel` owns observable Library UI state, while `LibraryContentReconciler` owns optimistic add/remove reconciliation for eventually-consistent YouTube Music Library responses. This keeps pending mutation stabilization rules behind a small interface instead of spreading them across view models and action helpers.
 
 ## Key Services
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,7 +17,7 @@ Sources/
       │   ├── Audio/    → EqualizerService, EqualizerAudioEngine, ProcessTapHelper, BiquadFilter
       │   ├── Auth/     → AuthService (login state machine)
       │   ├── Library/  → Library identity and optimistic reconciliation modules
-      │   ├── Player/   → PlayerService, NowPlayingManager (media keys)
+      │   ├── Player/   → PlayerService, NowPlayingManager, queue metadata and album playback actions
       │   ├── Scripting/→ ScriptCommands (AppleScript integration)
       │   ├── WebKit/   → WebKitManager (cookie persistence)
       │   └── HapticService.swift → Force Touch trackpad haptic feedback
@@ -157,6 +157,11 @@ Response parsing is extracted into specialized modules:
 | `LyricsParser.swift` | Lyrics extraction |
 
 **Design**: Static enum-based parsers with pure functions for testability.
+
+
+### Queue Song Metadata and Album Playback
+
+`QueueSongMetadata` prepares song values before they enter the native queue, centralizing artist cleanup and fallback album/thumbnail rules. `AlbumPlaybackActions` owns album-specific fetch/queue/play workflows so SwiftUI action helpers do not duplicate album-track enrichment logic.
 
 ### PlayerService
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -140,9 +140,12 @@ Response parsing is extracted into specialized modules:
 | Parser | Purpose |
 |--------|---------|
 | `ParsingHelpers.swift` | Shared utilities (thumbnails, artists, duration) |
+| `ResponseTreeSearch.swift` | Recursive search helpers for nested YouTube Music response trees |
 | `HomeResponseParser.swift` | Home/Explore page sections |
 | `SearchResponseParser.swift` | Search results |
-| `PlaylistParser.swift` | Playlist details, library playlists, queue tracks, pagination, add-to-playlist menu options, create-playlist IDs, and ownership/delete affordances |
+| `LibraryContentParser.swift` | Library browse content, including playlists, followed artists, podcast shows, and uploaded-song virtual tile parsing |
+| `PlaylistEditability.swift` | Playlist ownership/delete affordance detection |
+| `PlaylistParser.swift` | Playlist details, queue tracks, pagination, add-to-playlist menu options, and create-playlist IDs |
 | `ArtistParser.swift` | Artist details (songs, albums, subscription status) |
 | `RadioQueueParser.swift` | Radio queue from "next" endpoint |
 | `SongMetadataParser.swift` | Full song metadata with feedback tokens |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -161,7 +161,7 @@ Response parsing is extracted into specialized modules:
 
 ### Queue Song Metadata and Album Playback
 
-`QueueSongMetadata` prepares song values before they enter the native queue, centralizing artist cleanup and fallback album/thumbnail rules. `AlbumPlaybackActions` owns album-specific fetch/queue/play workflows so SwiftUI action helpers do not duplicate album-track enrichment logic.
+`QueueSongMetadata` prepares song values before they enter the native queue, centralizing artist cleanup and fallback album/thumbnail rules. `AlbumPlaybackActions` owns album-specific fetch/queue/play workflows so SwiftUI action helpers do not duplicate album-track enrichment logic. `PlaylistPlaybackActions` owns playlist playback, radio queue fallback, playlist-artwork fallback, and continuation append/cancel behavior.
 
 ### PlayerService
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -62,7 +62,7 @@ final class HomeViewModel {
 
 ### Library State Reconciliation
 
-`LibraryViewModel` owns observable Library UI state, while `LibraryContentReconciler` owns optimistic add/remove reconciliation for eventually-consistent YouTube Music Library responses. This keeps pending mutation stabilization rules behind a small interface instead of spreading them across view models and action helpers.
+`LibraryViewModel` owns observable Library UI state, while `LibraryContentReconciler` owns optimistic add/remove reconciliation for eventually-consistent YouTube Music Library responses. `LibraryMutationActions` owns mutation orchestration: calling YouTube Music, invalidating stale caches, applying optimistic state, and scheduling delayed reconciliation when backend snapshots lag. This keeps pending mutation stabilization rules behind small Library interfaces instead of spreading them across view models and action helpers.
 
 ## Key Services
 


### PR DESCRIPTION
## Summary

Refactors Kaset architecture around the Library and Player domains by moving repeated behavior out of UI/action helpers and large parser/view-model surfaces into deeper, tested modules.

### Library/API modules
- Add `LibraryContentIdentity` for playlist/artist identity equivalence and de-duplication.
- Add `LibraryContentParser`, `ResponseTreeSearch`, and `PlaylistEditability` to isolate Library browse parsing and recursive response-tree helpers.
- Add `LibraryContentReconciler` for optimistic Library state reconciliation against eventually-consistent backend snapshots.
- Add `LibraryMutationActions` for Library mutation orchestration, cache invalidation, optimistic updates, and delayed artist reconciliation.

### Player modules
- Add `QueueSongMetadata` for queue song metadata preparation and fallback artist/album/thumbnail rules.
- Add `AlbumPlaybackActions` for album queue/play workflows.
- Add `PlaylistPlaybackActions` for playlist playback, radio queue fallback, artwork fallback, continuation loading, and queue-change cancellation.

### Documentation and tests
- Update `CONTEXT.md` and `docs/architecture.md` with the new domain language and module responsibilities.
- Add direct unit coverage for the new Library and Player modules.

## Why

The previous architecture concentrated several distinct behaviors inside `PlaylistParser`, `LibraryViewModel`, and `SongActionsHelper`. That made each caller/test responsible for knowing YouTube Music identity quirks, eventual-consistency rules, mutation cache invalidation, and queue metadata normalization. The new modules put those rules behind smaller interfaces with better locality and leverage.

## Validation

- `swift build`
- `swift test --skip KasetUITests`
- `swiftlint --strict`
- `Scripts/compile_and_run.sh --wait`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

UI tests were not run because this repo requires explicit confirmation before launching UI tests.
