### PR TITLE
Liquid Glass sidebar slide-under

### DIFF
--- a/Sources/Kaset/Utilities/LiquidGlassCompat.swift
+++ b/Sources/Kaset/Utilities/LiquidGlassCompat.swift
@@ -32,17 +32,16 @@ extension View {
         self.modifier(CompatGlassProminentButtonModifier())
     }
 
-    /// Hide a sidebar `List`'s opaque scroll-content background so the
-    /// `NavigationSplitView` column's automatic Liquid Glass shows through
-    /// (macOS 26+). On the legacy macOS 15 path the opaque sidebar material is
-    /// preserved, since there is no column-level glass to reveal there.
+    /// Give the sidebar a translucent frosted appearance.
     ///
-    /// Gated on BOTH `usesLegacyMacOS15UI` AND `#available(macOS 26.0, *)`:
-    /// `usesLegacyMacOS15UI` is a debug toggle, not the OS version, so hiding
-    /// the list background on real macOS 15 hardware would expose the window
-    /// background instead of glass.
-    func compatHideSidebarListBackground() -> some View {
-        self.modifier(CompatHideSidebarListBackgroundModifier())
+    /// On macOS 26 the floating Liquid Glass sidebar is automatic, so this hides
+    /// the `List`'s opaque material to reveal it. On the legacy macOS 15 path it
+    /// instead hides the list background and lays an `.ultraThinMaterial` behind
+    /// the sidebar — the same material the player bar uses — so the panel reads
+    /// as a blurred, translucent surface (vibrant over the window) rather than a
+    /// flat opaque column.
+    func compatTranslucentSidebar() -> some View {
+        self.modifier(CompatTranslucentSidebarModifier())
     }
 }
 
@@ -147,22 +146,22 @@ struct CompatGlassContainer<Content: View>: View {
     }
 }
 
-// MARK: - CompatHideSidebarListBackgroundModifier
+// MARK: - CompatTranslucentSidebarModifier
 
-private struct CompatHideSidebarListBackgroundModifier: ViewModifier {
+private struct CompatTranslucentSidebarModifier: ViewModifier {
     @Environment(\.usesLegacyMacOS15UI) private var usesLegacyMacOS15UI
 
     func body(content: Content) -> some View {
         if !self.usesLegacyMacOS15UI, #available(macOS 26.0, *) {
-            // Reveal the NavigationSplitView column's system Liquid Glass by
-            // dropping the List's own opaque `.sidebar` material. The frosted
-            // column glass (not clear glass) keeps labels legible while detail
-            // content sliding underneath is faintly visible through it.
+            // macOS 26: reveal the system floating Liquid Glass.
             content.scrollContentBackground(.hidden)
         } else {
-            // Legacy macOS 15: keep the opaque sidebar material — there is no
-            // column-level glass to reveal.
+            // Legacy macOS 15: drop the opaque list material and lay an
+            // `.ultraThinMaterial` behind the sidebar so it reads as a blurred,
+            // translucent panel (the same material the player bar uses).
             content
+                .scrollContentBackground(.hidden)
+                .background(.ultraThinMaterial)
         }
     }
 }

--- a/Sources/Kaset/Utilities/LiquidGlassCompat.swift
+++ b/Sources/Kaset/Utilities/LiquidGlassCompat.swift
@@ -31,6 +31,19 @@ extension View {
     func compatGlassProminentButton() -> some View {
         self.modifier(CompatGlassProminentButtonModifier())
     }
+
+    /// Hide a sidebar `List`'s opaque scroll-content background so the
+    /// `NavigationSplitView` column's automatic Liquid Glass shows through
+    /// (macOS 26+). On the legacy macOS 15 path the opaque sidebar material is
+    /// preserved, since there is no column-level glass to reveal there.
+    ///
+    /// Gated on BOTH `usesLegacyMacOS15UI` AND `#available(macOS 26.0, *)`:
+    /// `usesLegacyMacOS15UI` is a debug toggle, not the OS version, so hiding
+    /// the list background on real macOS 15 hardware would expose the window
+    /// background instead of glass.
+    func compatHideSidebarListBackground() -> some View {
+        self.modifier(CompatHideSidebarListBackgroundModifier())
+    }
 }
 
 // MARK: - CompatGlassModifier
@@ -130,6 +143,26 @@ struct CompatGlassContainer<Content: View>: View {
             GlassEffectContainer(spacing: self.spacing) { self.content() }
         } else {
             self.content()
+        }
+    }
+}
+
+// MARK: - CompatHideSidebarListBackgroundModifier
+
+private struct CompatHideSidebarListBackgroundModifier: ViewModifier {
+    @Environment(\.usesLegacyMacOS15UI) private var usesLegacyMacOS15UI
+
+    func body(content: Content) -> some View {
+        if !self.usesLegacyMacOS15UI, #available(macOS 26.0, *) {
+            // Reveal the NavigationSplitView column's system Liquid Glass by
+            // dropping the List's own opaque `.sidebar` material. The frosted
+            // column glass (not clear glass) keeps labels legible while detail
+            // content sliding underneath is faintly visible through it.
+            content.scrollContentBackground(.hidden)
+        } else {
+            // Legacy macOS 15: keep the opaque sidebar material — there is no
+            // column-level glass to reveal.
+            content
         }
     }
 }

--- a/Sources/Kaset/Views/ArtistDetailView.swift
+++ b/Sources/Kaset/Views/ArtistDetailView.swift
@@ -109,8 +109,12 @@ struct ArtistDetailView: View { // swiftlint:disable:this type_body_length
                     self.podcastsSection(detail.podcasts)
                 }
             }
-            .padding(24)
+            .padding(.vertical, 24)
         }
+        // Inset resting content while the scroll view stays edge-to-edge so the
+        // accent backdrop (which ignores the safe area) refracts through the
+        // floating glass sidebar.
+        .contentMargins(.horizontal, DetailContentLayout.horizontalInset, for: .scrollContent)
         .topFade(style: .contentMask)
     }
 

--- a/Sources/Kaset/Views/ArtistDetailView.swift
+++ b/Sources/Kaset/Views/ArtistDetailView.swift
@@ -54,12 +54,15 @@ struct ArtistDetailView: View { // swiftlint:disable:this type_body_length
             VStack(alignment: .leading, spacing: 24) {
                 // Header
                 self.headerView(detail)
+                    .padding(.horizontal, DetailContentLayout.horizontalInset)
 
                 Divider()
+                    .padding(.horizontal, DetailContentLayout.horizontalInset)
 
-                // Songs section
+                // Songs section (vertical list — inset like other non-shelf content)
                 if !detail.songs.isEmpty {
                     self.songsSection()
+                        .padding(.horizontal, DetailContentLayout.horizontalInset)
                 }
 
                 // Latest episodes (includes live radio streams). Episodes are
@@ -111,10 +114,10 @@ struct ArtistDetailView: View { // swiftlint:disable:this type_body_length
             }
             .padding(.vertical, 24)
         }
-        // Inset resting content while the scroll view stays edge-to-edge so the
-        // accent backdrop (which ignores the safe area) refracts through the
-        // floating glass sidebar.
-        .contentMargins(.horizontal, DetailContentLayout.horizontalInset, for: .scrollContent)
+        // The ScrollView stays edge-to-edge: non-scrolling content is inset via
+        // padding above, while horizontal shelves pass `contentInset` so their
+        // tracks reach the under-sidebar band and slide under the floating glass
+        // on macOS 26. The accent backdrop (ignores safe area) refracts through.
         .topFade(style: .contentMask)
     }
 
@@ -440,7 +443,8 @@ struct ArtistDetailView: View { // swiftlint:disable:this type_body_length
     ) -> some View {
         CarouselShelfSection(
             accessibilityLabel: title,
-            items: albums
+            items: albums,
+            contentInset: DetailContentLayout.horizontalInset
         ) {
             self.sectionHeader(title: title, shelfKind: shelfKind)
         } itemContent: { album in
@@ -454,7 +458,8 @@ struct ArtistDetailView: View { // swiftlint:disable:this type_body_length
     private func playlistsSection(_ playlists: [Playlist], title: String) -> some View {
         CarouselShelfSection(
             accessibilityLabel: title,
-            items: playlists
+            items: playlists,
+            contentInset: DetailContentLayout.horizontalInset
         ) {
             self.sectionHeader(title: title, shelfKind: .playlistsByArtist)
         } itemContent: { playlist in
@@ -468,7 +473,8 @@ struct ArtistDetailView: View { // swiftlint:disable:this type_body_length
     private func artistsSection(_ artists: [Artist], title: String) -> some View {
         CarouselShelfSection(
             accessibilityLabel: title,
-            items: artists
+            items: artists,
+            contentInset: DetailContentLayout.horizontalInset
         ) {
             self.sectionHeader(title: title, shelfKind: .relatedArtists)
         } itemContent: { artist in
@@ -628,7 +634,8 @@ struct ArtistDetailView: View { // swiftlint:disable:this type_body_length
     private func episodesSection(_ episodes: [ArtistEpisode]) -> some View {
         CarouselShelfSection(
             accessibilityLabel: String(localized: "Latest episodes"),
-            items: episodes
+            items: episodes,
+            contentInset: DetailContentLayout.horizontalInset
         ) {
             self.sectionHeader(title: "Latest episodes", shelfKind: .episodes)
         } itemContent: { episode in
@@ -699,7 +706,8 @@ struct ArtistDetailView: View { // swiftlint:disable:this type_body_length
     private func singlesSection(_ singles: [Album]) -> some View {
         CarouselShelfSection(
             accessibilityLabel: String(localized: "Singles & EPs"),
-            items: singles
+            items: singles,
+            contentInset: DetailContentLayout.horizontalInset
         ) {
             self.sectionHeader(title: "Singles & EPs", shelfKind: .singles)
         } itemContent: { album in
@@ -715,7 +723,8 @@ struct ArtistDetailView: View { // swiftlint:disable:this type_body_length
     private func playlistsByArtistSection(_ playlists: [Playlist]) -> some View {
         CarouselShelfSection(
             accessibilityLabel: String(localized: "Playlists"),
-            items: playlists
+            items: playlists,
+            contentInset: DetailContentLayout.horizontalInset
         ) {
             self.sectionHeader(title: "Playlists", shelfKind: .playlistsByArtist)
         } itemContent: { playlist in
@@ -753,7 +762,8 @@ struct ArtistDetailView: View { // swiftlint:disable:this type_body_length
     private func podcastsSection(_ podcasts: [PodcastShow]) -> some View {
         CarouselShelfSection(
             accessibilityLabel: String(localized: "Podcasts"),
-            items: podcasts
+            items: podcasts,
+            contentInset: DetailContentLayout.horizontalInset
         ) {
             self.sectionHeader(title: "Podcasts", shelfKind: .podcasts)
         } itemContent: { show in
@@ -795,7 +805,8 @@ struct ArtistDetailView: View { // swiftlint:disable:this type_body_length
     private func relatedArtistsSection(_ artists: [Artist]) -> some View {
         CarouselShelfSection(
             accessibilityLabel: String(localized: "Fans might also like"),
-            items: artists
+            items: artists,
+            contentInset: DetailContentLayout.horizontalInset
         ) {
             self.sectionHeader(title: "Fans might also like", shelfKind: .relatedArtists)
         } itemContent: { artist in

--- a/Sources/Kaset/Views/ArtistEpisodesListView.swift
+++ b/Sources/Kaset/Views/ArtistEpisodesListView.swift
@@ -52,9 +52,11 @@ struct ArtistEpisodesListView: View {
                     Divider().padding(.leading, 24)
                 }
             }
-            .padding(.horizontal, 24)
             .padding(.vertical, 16)
         }
+        // Edge-to-edge with a resting inset so the list extends under the
+        // floating glass sidebar.
+        .contentMargins(.horizontal, DetailContentLayout.horizontalInset, for: .scrollContent)
     }
 
     private func episodeRow(_ episode: ArtistEpisode) -> some View {

--- a/Sources/Kaset/Views/ChartsView.swift
+++ b/Sources/Kaset/Views/ChartsView.swift
@@ -58,7 +58,8 @@ struct ChartsView: View {
                     self.sectionView(section)
                 }
             }
-            .padding(.horizontal, 24)
+            // Edge-to-edge so shelves slide under the glass sidebar; resting
+            // inset is restored per-shelf via contentInset.
             .padding(.vertical, 20)
         }
     }
@@ -68,7 +69,8 @@ struct ChartsView: View {
             accessibilityLabel: section.title,
             items: Array(section.items.enumerated()),
             id: \.element.id,
-            itemAlignment: .top
+            itemAlignment: .top,
+            contentInset: DetailContentLayout.horizontalInset
         ) {
             Text(section.title)
                 .font(.title2)

--- a/Sources/Kaset/Views/ExploreView.swift
+++ b/Sources/Kaset/Views/ExploreView.swift
@@ -58,7 +58,8 @@ struct ExploreView: View {
                     self.sectionView(section)
                 }
             }
-            .padding(.horizontal, 24)
+            // Edge-to-edge so shelves slide under the glass sidebar; resting
+            // inset is restored per-shelf via contentInset.
             .padding(.vertical, 20)
         }
         .accessibilityIdentifier(AccessibilityID.Explore.scrollView)
@@ -69,7 +70,8 @@ struct ExploreView: View {
             accessibilityLabel: section.title,
             items: Array(section.items.enumerated()),
             id: \.element.id,
-            itemAlignment: .top
+            itemAlignment: .top,
+            contentInset: DetailContentLayout.horizontalInset
         ) {
             Text(section.title)
                 .font(.title2)

--- a/Sources/Kaset/Views/HomeView.swift
+++ b/Sources/Kaset/Views/HomeView.swift
@@ -58,15 +58,18 @@ struct HomeView: View {
             LazyVStack(alignment: .leading, spacing: 32) {
                 // Favorites section (hidden when empty)
                 if self.favoritesManager.isVisible {
-                    FavoritesSection(onNavigate: { destination in
-                        if let playlist = destination as? Playlist {
-                            self.navigationPath.append(playlist)
-                        } else if let artist = destination as? Artist {
-                            self.navigationPath.append(artist)
-                        } else if let podcastShow = destination as? PodcastShow {
-                            self.navigationPath.append(podcastShow)
-                        }
-                    })
+                    FavoritesSection(
+                        onNavigate: { destination in
+                            if let playlist = destination as? Playlist {
+                                self.navigationPath.append(playlist)
+                            } else if let artist = destination as? Artist {
+                                self.navigationPath.append(artist)
+                            } else if let podcastShow = destination as? PodcastShow {
+                                self.navigationPath.append(podcastShow)
+                            }
+                        },
+                        contentInset: DetailContentLayout.horizontalInset
+                    )
                     .staggeredAppearance(index: 0)
                 }
 
@@ -78,7 +81,10 @@ struct HomeView: View {
                         }
                 }
             }
-            .padding(.horizontal, 24)
+            // The ScrollView fills the detail column edge-to-edge so shelves
+            // scroll under the floating glass sidebar; each shelf restores a
+            // resting inset via `contentInset`. Only the vertical inset stays
+            // on the stack.
             .padding(.vertical, 20)
         }
     }
@@ -88,7 +94,8 @@ struct HomeView: View {
             accessibilityLabel: section.title,
             items: Array(section.items.enumerated()),
             id: \.element.id,
-            itemAlignment: .top
+            itemAlignment: .top,
+            contentInset: DetailContentLayout.horizontalInset
         ) {
             Text(section.title)
                 .font(.title2)

--- a/Sources/Kaset/Views/LibraryView.swift
+++ b/Sources/Kaset/Views/LibraryView.swift
@@ -153,9 +153,11 @@ struct LibraryView: View {
                 // Combined grid with filtered content
                 self.libraryGrid
             }
-            .padding(.horizontal, 24)
             .padding(.vertical, 20)
         }
+        // Inset the resting content while the scroll view stays edge-to-edge,
+        // so the grid extends under the floating glass sidebar.
+        .contentMargins(.horizontal, DetailContentLayout.horizontalInset, for: .scrollContent)
     }
 
     private var filterChips: some View {

--- a/Sources/Kaset/Views/MoodCategoryDetailView.swift
+++ b/Sources/Kaset/Views/MoodCategoryDetailView.swift
@@ -58,7 +58,8 @@ struct MoodCategoryDetailView: View {
                             self.sectionView(section)
                         }
                     }
-                    .padding(.horizontal, 24)
+                    // Edge-to-edge so shelves slide under the glass sidebar;
+                    // resting inset is restored per-shelf via contentInset.
                     .padding(.vertical, 20)
                 }
             }
@@ -69,7 +70,8 @@ struct MoodCategoryDetailView: View {
         CarouselShelfSection(
             accessibilityLabel: section.title,
             items: section.items,
-            itemAlignment: .top
+            itemAlignment: .top,
+            contentInset: DetailContentLayout.horizontalInset
         ) {
             Text(section.title)
                 .font(.title2)

--- a/Sources/Kaset/Views/MoodsAndGenresView.swift
+++ b/Sources/Kaset/Views/MoodsAndGenresView.swift
@@ -66,7 +66,8 @@ struct MoodsAndGenresView: View {
                             self.sectionView(section)
                         }
                     }
-                    .padding(.horizontal, 24)
+                    // Edge-to-edge so shelves slide under the glass sidebar;
+                    // resting inset is restored per-shelf via contentInset.
                     .padding(.vertical, 20)
                 }
             }
@@ -78,7 +79,8 @@ struct MoodsAndGenresView: View {
             accessibilityLabel: section.title,
             items: Array(section.items.enumerated()),
             id: \.element.id,
-            itemAlignment: .top
+            itemAlignment: .top,
+            contentInset: DetailContentLayout.horizontalInset
         ) {
             Text(section.title)
                 .font(.title2)

--- a/Sources/Kaset/Views/NewReleasesView.swift
+++ b/Sources/Kaset/Views/NewReleasesView.swift
@@ -58,7 +58,8 @@ struct NewReleasesView: View {
                     self.sectionView(section)
                 }
             }
-            .padding(.horizontal, 24)
+            // Edge-to-edge so shelves slide under the glass sidebar; resting
+            // inset is restored per-shelf via contentInset.
             .padding(.vertical, 20)
         }
     }
@@ -68,7 +69,8 @@ struct NewReleasesView: View {
             accessibilityLabel: section.title,
             items: Array(section.items.enumerated()),
             id: \.element.id,
-            itemAlignment: .top
+            itemAlignment: .top,
+            contentInset: DetailContentLayout.horizontalInset
         ) {
             Text(section.title)
                 .font(.title2)

--- a/Sources/Kaset/Views/PlaylistDetailView.swift
+++ b/Sources/Kaset/Views/PlaylistDetailView.swift
@@ -129,8 +129,12 @@ struct PlaylistDetailView: View {
                     fallbackAlbum: fallbackAlbum
                 )
             }
-            .padding(24)
+            .padding(.vertical, 24)
         }
+        // Inset the resting content while the scroll view stays edge-to-edge so
+        // content extends under the floating glass sidebar; the accent backdrop
+        // (which ignores the safe area) refracts through it.
+        .contentMargins(.horizontal, DetailContentLayout.horizontalInset, for: .scrollContent)
         .topFade(style: .contentMask)
     }
 

--- a/Sources/Kaset/Views/PodcastsView.swift
+++ b/Sources/Kaset/Views/PodcastsView.swift
@@ -64,7 +64,8 @@ struct PodcastsView: View {
                     self.sectionView(section)
                 }
             }
-            .padding(.horizontal, 24)
+            // Edge-to-edge so shelves slide under the glass sidebar; resting
+            // inset is restored per-shelf via contentInset.
             .padding(.vertical, 20)
         }
     }
@@ -72,7 +73,8 @@ struct PodcastsView: View {
     private func sectionView(_ section: PodcastSection) -> some View {
         CarouselShelfSection(
             accessibilityLabel: section.title,
-            items: section.items
+            items: section.items,
+            contentInset: DetailContentLayout.horizontalInset
         ) {
             Text(section.title)
                 .font(.title2)
@@ -257,8 +259,11 @@ struct PodcastShowView: View {
                 // Episodes list
                 self.episodesList
             }
-            .padding(24)
+            .padding(.vertical, 24)
         }
+        // Inset resting content while the scroll view stays edge-to-edge so the
+        // accent backdrop refracts through the floating glass sidebar.
+        .contentMargins(.horizontal, DetailContentLayout.horizontalInset, for: .scrollContent)
         .accentBackground(from: self.show.thumbnailURL)
         .navigationTitle(self.show.title)
         .navigationDestination(for: AllEpisodesDestination.self) { destination in
@@ -604,8 +609,11 @@ struct AllEpisodesView: View {
                     }
                 }
             }
-            .padding(24)
+            .padding(.vertical, 24)
         }
+        // Inset resting content while the scroll view stays edge-to-edge so the
+        // accent backdrop refracts through the floating glass sidebar.
+        .contentMargins(.horizontal, DetailContentLayout.horizontalInset, for: .scrollContent)
         .accentBackground(from: self.show.thumbnailURL)
         .localizedNavigationTitle("All Episodes")
         .safeAreaInset(edge: .bottom, spacing: 0) {

--- a/Sources/Kaset/Views/SharedViews/CarouselShelf.swift
+++ b/Sources/Kaset/Views/SharedViews/CarouselShelf.swift
@@ -2,17 +2,15 @@ import SwiftUI
 
 // MARK: - CarouselShelf
 
-/// A native horizontal shelf with edge fades and glass paging controls.
+/// A native horizontal shelf with glass paging controls. The scroll track runs
+/// edge-to-edge so items scroll under the floating Liquid Glass sidebar on
+/// macOS 26 (Apple's "Extending horizontal scrolling under a sidebar" pattern).
 struct CarouselShelf<Content: View>: View {
-    private static var hoverBleed: CGFloat {
-        4
-    }
-
     let accessibilityLabel: String
-    let fadeWidth: CGFloat
     let pageFraction: CGFloat
     let showsControls: Bool
     let controlVerticalAlignment: VerticalAlignment
+    let contentInset: CGFloat
 
     private let content: () -> Content
 
@@ -23,36 +21,41 @@ struct CarouselShelf<Content: View>: View {
 
     init(
         accessibilityLabel: String,
-        fadeWidth: CGFloat = 56,
         pageFraction: CGFloat = 0.85,
         showsControls: Bool = true,
         controlVerticalAlignment: VerticalAlignment = .center,
+        contentInset: CGFloat = 0,
         @ViewBuilder content: @escaping () -> Content
     ) {
         self.accessibilityLabel = accessibilityLabel
-        self.fadeWidth = fadeWidth
         self.pageFraction = pageFraction
         self.showsControls = showsControls
         self.controlVerticalAlignment = controlVerticalAlignment
+        self.contentInset = contentInset
         self.content = content
     }
 
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
-            self.content()
+            // Apple's "Extending horizontal scrolling under a sidebar" pattern:
+            // the ScrollView track must reach the leading/trailing edges so the
+            // system auto-scrolls items UNDER the floating glass sidebar. The
+            // resting inset is therefore a leading Spacer INSIDE the content,
+            // never `.contentMargins`/`.padding` on the ScrollView (which would
+            // stop the track short of the sidebar and defeat the effect).
+            HStack(spacing: 0) {
+                if self.contentInset > 0 {
+                    Spacer(minLength: self.contentInset)
+                }
+                self.content()
+            }
         }
-        .scrollClipDisabled()
         .scrollPosition(self.$scrollPosition)
         .onScrollGeometryChange(for: CarouselShelfScrollMetrics.self) { geometry in
             CarouselShelfScrollMetrics(geometry: geometry)
         } action: { _, newMetrics in
             self.scrollMetrics = newMetrics
         }
-        .padding(Self.hoverBleed)
-        .mask {
-            self.edgeFadeMask
-        }
-        .padding(-Self.hoverBleed)
         .overlay(alignment: Alignment(horizontal: .leading, vertical: self.controlVerticalAlignment)) {
             if self.showsLeadingControl {
                 self.controlButton(for: .leading)
@@ -75,19 +78,6 @@ struct CarouselShelf<Content: View>: View {
         }
         .accessibilityElement(children: .contain)
         .accessibilityLabel(self.accessibilityLabel)
-    }
-
-    private var edgeFadeMask: some View {
-        HStack(spacing: 0) {
-            self.edgeFadeMaskSegment(for: .leading)
-
-            Rectangle()
-                .fill(.black)
-
-            self.edgeFadeMaskSegment(for: .trailing)
-        }
-        .animation(AppAnimation.quick, value: self.hasLeadingOverflow)
-        .animation(AppAnimation.quick, value: self.hasTrailingOverflow)
     }
 
     private var hasLeadingOverflow: Bool {
@@ -135,17 +125,6 @@ struct CarouselShelf<Content: View>: View {
         .accessibilityHint(String(localized: "Scrolls this shelf by one page"))
     }
 
-    private func edgeFadeMaskSegment(for direction: CarouselShelfDirection) -> some View {
-        LinearGradient(
-            colors: direction.maskColors(
-                isFaded: direction == .leading ? self.hasLeadingOverflow : self.hasTrailingOverflow
-            ),
-            startPoint: .leading,
-            endPoint: .trailing
-        )
-        .frame(width: self.fadeWidth)
-    }
-
     private func page(in direction: CarouselShelfDirection) {
         let pageWidth = max(1, self.scrollMetrics.viewportWidth * self.pageFraction)
         let destination = switch direction {
@@ -181,10 +160,10 @@ struct CarouselShelfSection<Items: RandomAccessCollection, ID: Hashable, Header:
     let sectionSpacing: CGFloat
     let itemAlignment: VerticalAlignment
     let itemSpacing: CGFloat
-    let fadeWidth: CGFloat
     let pageFraction: CGFloat
     let showsControls: Bool
     let controlVerticalAlignment: VerticalAlignment
+    let contentInset: CGFloat
 
     private let header: () -> Header
     private let itemContent: (Items.Element) -> ItemContent
@@ -196,10 +175,10 @@ struct CarouselShelfSection<Items: RandomAccessCollection, ID: Hashable, Header:
         sectionSpacing: CGFloat = 12,
         itemAlignment: VerticalAlignment = .center,
         itemSpacing: CGFloat = 16,
-        fadeWidth: CGFloat = 56,
         pageFraction: CGFloat = 0.85,
         showsControls: Bool = true,
         controlVerticalAlignment: VerticalAlignment = .center,
+        contentInset: CGFloat = 0,
         @ViewBuilder header: @escaping () -> Header,
         @ViewBuilder itemContent: @escaping (Items.Element) -> ItemContent
     ) {
@@ -209,10 +188,10 @@ struct CarouselShelfSection<Items: RandomAccessCollection, ID: Hashable, Header:
         self.sectionSpacing = sectionSpacing
         self.itemAlignment = itemAlignment
         self.itemSpacing = itemSpacing
-        self.fadeWidth = fadeWidth
         self.pageFraction = pageFraction
         self.showsControls = showsControls
         self.controlVerticalAlignment = controlVerticalAlignment
+        self.contentInset = contentInset
         self.header = header
         self.itemContent = itemContent
     }
@@ -220,13 +199,17 @@ struct CarouselShelfSection<Items: RandomAccessCollection, ID: Hashable, Header:
     var body: some View {
         VStack(alignment: .leading, spacing: self.sectionSpacing) {
             self.header()
+                // Inset only the header so the title stays clear of the
+                // floating glass sidebar; the shelf below reaches edge-to-edge
+                // and insets its own resting content via `contentInset`.
+                .padding(.leading, self.contentInset)
 
             CarouselShelf(
                 accessibilityLabel: self.accessibilityLabel,
-                fadeWidth: self.fadeWidth,
                 pageFraction: self.pageFraction,
                 showsControls: self.showsControls,
-                controlVerticalAlignment: self.controlVerticalAlignment
+                controlVerticalAlignment: self.controlVerticalAlignment,
+                contentInset: self.contentInset
             ) {
                 LazyHStack(alignment: self.itemAlignment, spacing: self.itemSpacing) {
                     ForEach(self.items, id: self.id) { item in
@@ -245,10 +228,10 @@ extension CarouselShelfSection where Items.Element: Identifiable, ID == Items.El
         sectionSpacing: CGFloat = 12,
         itemAlignment: VerticalAlignment = .center,
         itemSpacing: CGFloat = 16,
-        fadeWidth: CGFloat = 56,
         pageFraction: CGFloat = 0.85,
         showsControls: Bool = true,
         controlVerticalAlignment: VerticalAlignment = .center,
+        contentInset: CGFloat = 0,
         @ViewBuilder header: @escaping () -> Header,
         @ViewBuilder itemContent: @escaping (Items.Element) -> ItemContent
     ) {
@@ -259,10 +242,10 @@ extension CarouselShelfSection where Items.Element: Identifiable, ID == Items.El
             sectionSpacing: sectionSpacing,
             itemAlignment: itemAlignment,
             itemSpacing: itemSpacing,
-            fadeWidth: fadeWidth,
             pageFraction: pageFraction,
             showsControls: showsControls,
             controlVerticalAlignment: controlVerticalAlignment,
+            contentInset: contentInset,
             header: header,
             itemContent: itemContent
         )
@@ -305,19 +288,6 @@ private enum CarouselShelfDirection: Hashable {
             "chevron.left"
         case .trailing:
             "chevron.right"
-        }
-    }
-
-    func maskColors(isFaded: Bool) -> [Color] {
-        guard isFaded else {
-            return [.black, .black]
-        }
-
-        switch self {
-        case .leading:
-            return [.clear, .black]
-        case .trailing:
-            return [.black, .clear]
         }
     }
 }

--- a/Sources/Kaset/Views/SharedViews/CarouselShelf.swift
+++ b/Sources/Kaset/Views/SharedViews/CarouselShelf.swift
@@ -65,14 +65,16 @@ struct CarouselShelf<Content: View>: View {
         .overlay(alignment: Alignment(horizontal: .leading, vertical: self.controlVerticalAlignment)) {
             if self.showsLeadingControl {
                 self.controlButton(for: .leading)
-                    .padding(.leading, 4)
+                    // Sit at the resting inset (not the column edge) so the
+                    // button clears the floating-sidebar band on macOS 26.
+                    .padding(.leading, self.contentInset + 4)
                     .transition(.opacity.combined(with: .scale(scale: 0.9)))
             }
         }
         .overlay(alignment: Alignment(horizontal: .trailing, vertical: self.controlVerticalAlignment)) {
             if self.showsTrailingControl {
                 self.controlButton(for: .trailing)
-                    .padding(.trailing, 4)
+                    .padding(.trailing, self.contentInset + 4)
                     .transition(.opacity.combined(with: .scale(scale: 0.9)))
             }
         }

--- a/Sources/Kaset/Views/SharedViews/CarouselShelf.swift
+++ b/Sources/Kaset/Views/SharedViews/CarouselShelf.swift
@@ -40,14 +40,20 @@ struct CarouselShelf<Content: View>: View {
             // Apple's "Extending horizontal scrolling under a sidebar" pattern:
             // the ScrollView track must reach the leading/trailing edges so the
             // system auto-scrolls items UNDER the floating glass sidebar. The
-            // resting inset is therefore a leading Spacer INSIDE the content,
-            // never `.contentMargins`/`.padding` on the ScrollView (which would
-            // stop the track short of the sidebar and defeat the effect).
+            // resting insets are therefore Spacers INSIDE the content (leading
+            // and trailing), never `.contentMargins`/`.padding` on the
+            // ScrollView (which would stop the track short of the sidebar and
+            // defeat the effect).
             HStack(spacing: 0) {
                 if self.contentInset > 0 {
-                    Spacer(minLength: self.contentInset)
+                    Spacer()
+                        .frame(width: self.contentInset)
                 }
                 self.content()
+                if self.contentInset > 0 {
+                    Spacer()
+                        .frame(width: self.contentInset)
+                }
             }
         }
         .scrollPosition(self.$scrollPosition)

--- a/Sources/Kaset/Views/SharedViews/CarouselShelf.swift
+++ b/Sources/Kaset/Views/SharedViews/CarouselShelf.swift
@@ -205,10 +205,12 @@ struct CarouselShelfSection<Items: RandomAccessCollection, ID: Hashable, Header:
     var body: some View {
         VStack(alignment: .leading, spacing: self.sectionSpacing) {
             self.header()
-                // Inset only the header so the title stays clear of the
-                // floating glass sidebar; the shelf below reaches edge-to-edge
-                // and insets its own resting content via `contentInset`.
-                .padding(.leading, self.contentInset)
+                // Inset the header on both edges so the title stays clear of the
+                // floating glass sidebar and any trailing header content (e.g. a
+                // "See all" link) keeps its margin. The shelf below reaches
+                // edge-to-edge and insets its own resting content via
+                // `contentInset`.
+                .padding(.horizontal, self.contentInset)
 
             CarouselShelf(
                 accessibilityLabel: self.accessibilityLabel,

--- a/Sources/Kaset/Views/SharedViews/DetailContentLayout.swift
+++ b/Sources/Kaset/Views/SharedViews/DetailContentLayout.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+// MARK: - DetailContentLayout
+
+/// Shared layout constants for detail-column content that slides under the
+/// floating Liquid Glass sidebar on macOS 26.
+///
+/// On macOS 26 the `NavigationSplitView` sidebar renders as a floating,
+/// translucent Liquid Glass panel and the detail column extends full-width
+/// beneath it. To get the Apple Music "content slides under the sidebar" look,
+/// detail scroll views must reach the column's leading/trailing edges (so their
+/// content can scroll underneath the glass) while keeping a resting inset so
+/// text and controls stay clear of the sidebar when not scrolling.
+///
+/// Apply ``horizontalInset`` as that resting inset:
+/// - On scroll views, via `.contentMargins(.horizontal:for: .scrollContent)`,
+///   which keeps the scroll view edge-to-edge but insets the *content*.
+/// - On non-scrolling headers, via `.padding(.horizontal:)`.
+///
+/// Both `.contentMargins` and `.padding` are available on macOS 14+, so the
+/// resting layout is identical on the legacy macOS 15 path (where there is no
+/// floating sidebar to slide under).
+enum DetailContentLayout {
+    /// Horizontal resting inset (points) for detail content.
+    ///
+    /// Matches the previous fixed `.padding(.horizontal, 24)` so the resting
+    /// layout is visually unchanged; only the scroll-under behavior is new.
+    static let horizontalInset: CGFloat = 24
+}

--- a/Sources/Kaset/Views/SharedViews/FavoritesSection.swift
+++ b/Sources/Kaset/Views/SharedViews/FavoritesSection.swift
@@ -14,11 +14,17 @@ struct FavoritesSection: View {
     /// Binding to navigation path for navigation within the section.
     var onNavigate: ((any Hashable) -> Void)?
 
+    /// Resting horizontal inset for the shelf content, so items rest clear of
+    /// the floating glass sidebar while still scrolling underneath it.
+    /// Defaults to `0` (edge-to-edge) to preserve existing call sites.
+    var contentInset: CGFloat = 0
+
     var body: some View {
         CarouselShelfSection(
             accessibilityLabel: String(localized: "Favorites"),
             items: self.favoritesManager.items,
-            showsControls: self.draggedItem == nil
+            showsControls: self.draggedItem == nil,
+            contentInset: self.contentInset
         ) {
             Text("Favorites")
                 .font(.title2)

--- a/Sources/Kaset/Views/Sidebar.swift
+++ b/Sources/Kaset/Views/Sidebar.swift
@@ -87,7 +87,7 @@ struct Sidebar: View {
             }
         }
         .listStyle(.sidebar)
-        .compatHideSidebarListBackground()
+        .compatTranslucentSidebar()
         .accessibilityIdentifier(AccessibilityID.Sidebar.container)
         .safeAreaInset(edge: .bottom, spacing: 0) {
             // Source toggle + profile section at bottom (shared with YouTubeSidebar)

--- a/Sources/Kaset/Views/Sidebar.swift
+++ b/Sources/Kaset/Views/Sidebar.swift
@@ -12,89 +12,84 @@ struct Sidebar: View {
     @Environment(SidebarPinnedItemsManager.self) private var sidebarPinnedItemsManager
     @Environment(PodcastsAvailabilityService.self) private var podcastsAvailability
 
-    /// Namespace for glass effect morphing.
-    @Namespace private var sidebarNamespace
-
     var body: some View {
-        VStack(spacing: 0) {
-            CompatGlassContainer(spacing: 0) {
-                List(selection: self.sidebarSelection) {
-                    // Main navigation
-                    Section {
-                        NavigationLink(value: SidebarSelection.navigation(.search)) {
-                            Label(NavigationItem.search.displayName, systemImage: NavigationItem.search.icon)
-                        }
-                        .accessibilityIdentifier(AccessibilityID.Sidebar.searchItem)
-
-                        NavigationLink(value: SidebarSelection.navigation(.home)) {
-                            Label(NavigationItem.home.displayName, systemImage: NavigationItem.home.icon)
-                        }
-                        .accessibilityIdentifier(AccessibilityID.Sidebar.homeItem)
-                    }
-
-                    // Discover section
-                    Section(String(localized: "Discover")) {
-                        NavigationLink(value: SidebarSelection.navigation(.explore)) {
-                            Label(NavigationItem.explore.displayName, systemImage: NavigationItem.explore.icon)
-                        }
-                        .accessibilityIdentifier(AccessibilityID.Sidebar.exploreItem)
-
-                        NavigationLink(value: SidebarSelection.navigation(.charts)) {
-                            Label(NavigationItem.charts.displayName, systemImage: NavigationItem.charts.icon)
-                        }
-                        .accessibilityIdentifier(AccessibilityID.Sidebar.chartsItem)
-
-                        NavigationLink(value: SidebarSelection.navigation(.moodsAndGenres)) {
-                            Label(NavigationItem.moodsAndGenres.displayName, systemImage: NavigationItem.moodsAndGenres.icon)
-                        }
-                        .accessibilityIdentifier(AccessibilityID.Sidebar.moodsAndGenresItem)
-
-                        NavigationLink(value: SidebarSelection.navigation(.newReleases)) {
-                            Label(NavigationItem.newReleases.displayName, systemImage: NavigationItem.newReleases.icon)
-                        }
-                        .accessibilityIdentifier(AccessibilityID.Sidebar.newReleasesItem)
-
-                        if self.podcastsAvailability.availability != .unavailable {
-                            NavigationLink(value: SidebarSelection.navigation(.podcasts)) {
-                                Label(NavigationItem.podcasts.displayName, systemImage: NavigationItem.podcasts.icon)
-                            }
-                            .accessibilityIdentifier(AccessibilityID.Sidebar.podcastsItem)
-                        }
-                    }
-
-                    // Collection section
-                    Section(String(localized: "Collection")) {
-                        NavigationLink(value: SidebarSelection.navigation(.library)) {
-                            Label(NavigationItem.library.displayName, systemImage: NavigationItem.library.icon)
-                        }
-                        .accessibilityIdentifier(AccessibilityID.Sidebar.libraryItem)
-
-                        NavigationLink(value: SidebarSelection.navigation(.likedMusic)) {
-                            Label(NavigationItem.likedMusic.displayName, systemImage: NavigationItem.likedMusic.icon)
-                        }
-                        .accessibilityIdentifier(AccessibilityID.Sidebar.likedMusicItem)
-
-                        NavigationLink(value: SidebarSelection.navigation(.history)) {
-                            Label(NavigationItem.history.displayName, systemImage: NavigationItem.history.icon)
-                        }
-                        .accessibilityIdentifier(AccessibilityID.Sidebar.historyItem)
-                    }
-
-                    if self.sidebarPinnedItemsManager.isVisible {
-                        Section(String(localized: "Playlists")) {
-                            ForEach(self.sidebarPinnedItemsManager.items) { item in
-                                self.sidebarPinnedRow(item)
-                            }
-                            .onMove { source, destination in
-                                self.sidebarPinnedItemsManager.move(from: source, to: destination)
-                            }
-                        }
-                    }
+        List(selection: self.sidebarSelection) {
+            // Main navigation
+            Section {
+                NavigationLink(value: SidebarSelection.navigation(.search)) {
+                    Label(NavigationItem.search.displayName, systemImage: NavigationItem.search.icon)
                 }
-                .listStyle(.sidebar)
-                .accessibilityIdentifier(AccessibilityID.Sidebar.container)
+                .accessibilityIdentifier(AccessibilityID.Sidebar.searchItem)
+
+                NavigationLink(value: SidebarSelection.navigation(.home)) {
+                    Label(NavigationItem.home.displayName, systemImage: NavigationItem.home.icon)
+                }
+                .accessibilityIdentifier(AccessibilityID.Sidebar.homeItem)
             }
 
+            // Discover section
+            Section(String(localized: "Discover")) {
+                NavigationLink(value: SidebarSelection.navigation(.explore)) {
+                    Label(NavigationItem.explore.displayName, systemImage: NavigationItem.explore.icon)
+                }
+                .accessibilityIdentifier(AccessibilityID.Sidebar.exploreItem)
+
+                NavigationLink(value: SidebarSelection.navigation(.charts)) {
+                    Label(NavigationItem.charts.displayName, systemImage: NavigationItem.charts.icon)
+                }
+                .accessibilityIdentifier(AccessibilityID.Sidebar.chartsItem)
+
+                NavigationLink(value: SidebarSelection.navigation(.moodsAndGenres)) {
+                    Label(NavigationItem.moodsAndGenres.displayName, systemImage: NavigationItem.moodsAndGenres.icon)
+                }
+                .accessibilityIdentifier(AccessibilityID.Sidebar.moodsAndGenresItem)
+
+                NavigationLink(value: SidebarSelection.navigation(.newReleases)) {
+                    Label(NavigationItem.newReleases.displayName, systemImage: NavigationItem.newReleases.icon)
+                }
+                .accessibilityIdentifier(AccessibilityID.Sidebar.newReleasesItem)
+
+                if self.podcastsAvailability.availability != .unavailable {
+                    NavigationLink(value: SidebarSelection.navigation(.podcasts)) {
+                        Label(NavigationItem.podcasts.displayName, systemImage: NavigationItem.podcasts.icon)
+                    }
+                    .accessibilityIdentifier(AccessibilityID.Sidebar.podcastsItem)
+                }
+            }
+
+            // Collection section
+            Section(String(localized: "Collection")) {
+                NavigationLink(value: SidebarSelection.navigation(.library)) {
+                    Label(NavigationItem.library.displayName, systemImage: NavigationItem.library.icon)
+                }
+                .accessibilityIdentifier(AccessibilityID.Sidebar.libraryItem)
+
+                NavigationLink(value: SidebarSelection.navigation(.likedMusic)) {
+                    Label(NavigationItem.likedMusic.displayName, systemImage: NavigationItem.likedMusic.icon)
+                }
+                .accessibilityIdentifier(AccessibilityID.Sidebar.likedMusicItem)
+
+                NavigationLink(value: SidebarSelection.navigation(.history)) {
+                    Label(NavigationItem.history.displayName, systemImage: NavigationItem.history.icon)
+                }
+                .accessibilityIdentifier(AccessibilityID.Sidebar.historyItem)
+            }
+
+            if self.sidebarPinnedItemsManager.isVisible {
+                Section(String(localized: "Playlists")) {
+                    ForEach(self.sidebarPinnedItemsManager.items) { item in
+                        self.sidebarPinnedRow(item)
+                    }
+                    .onMove { source, destination in
+                        self.sidebarPinnedItemsManager.move(from: source, to: destination)
+                    }
+                }
+            }
+        }
+        .listStyle(.sidebar)
+        .compatHideSidebarListBackground()
+        .accessibilityIdentifier(AccessibilityID.Sidebar.container)
+        .safeAreaInset(edge: .bottom, spacing: 0) {
             // Source toggle + profile section at bottom (shared with YouTubeSidebar)
             SidebarFooterView()
         }

--- a/Sources/Kaset/Views/TopSongsView.swift
+++ b/Sources/Kaset/Views/TopSongsView.swift
@@ -64,9 +64,11 @@ struct TopSongsView: View {
                     }
                 }
             }
-            .padding(.horizontal, 24)
             .padding(.vertical, 16)
         }
+        // Edge-to-edge with a resting inset so the list extends under the
+        // floating glass sidebar; the accent backdrop refracts through it.
+        .contentMargins(.horizontal, DetailContentLayout.horizontalInset, for: .scrollContent)
     }
 
     // MARK: - Song Row

--- a/Sources/Kaset/Views/YouTube/YouTubeChannelView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeChannelView.swift
@@ -61,8 +61,11 @@ struct YouTubeChannelView: View {
                     }
                 }
             }
-            .padding(20)
+            .padding(.vertical, 20)
         }
+        // Edge-to-edge with a resting inset so content extends under the
+        // floating glass sidebar.
+        .contentMargins(.horizontal, DetailContentLayout.horizontalInset, for: .scrollContent)
     }
 
     private func header(for channel: YouTubeChannel) -> some View {

--- a/Sources/Kaset/Views/YouTube/YouTubeExploreView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeExploreView.swift
@@ -67,8 +67,11 @@ struct YouTubeExploreView: View {
                     .buttonStyle(.interactiveCard)
                 }
             }
-            .padding(20)
+            .padding(.vertical, 20)
         }
+        // Edge-to-edge with a resting inset so the grid extends under the
+        // floating glass sidebar.
+        .contentMargins(.horizontal, DetailContentLayout.horizontalInset, for: .scrollContent)
     }
 }
 

--- a/Sources/Kaset/Views/YouTube/YouTubeHistoryView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeHistoryView.swift
@@ -59,7 +59,10 @@ struct YouTubeHistoryView: View {
                         }
                 }
             }
-            .padding(20)
+            .padding(.vertical, 20)
         }
+        // Edge-to-edge with a resting inset so the grid extends under the
+        // floating glass sidebar.
+        .contentMargins(.horizontal, DetailContentLayout.horizontalInset, for: .scrollContent)
     }
 }

--- a/Sources/Kaset/Views/YouTube/YouTubeHomeView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeHomeView.swift
@@ -63,8 +63,11 @@ struct YouTubeHomeView: View {
                         }
                 }
             }
-            .padding(20)
+            .padding(.vertical, 20)
         }
+        // Edge-to-edge with a resting inset so the grid extends under the
+        // floating glass sidebar.
+        .contentMargins(.horizontal, DetailContentLayout.horizontalInset, for: .scrollContent)
     }
 
     private var loadingGrid: some View {
@@ -82,8 +85,9 @@ struct YouTubeHomeView: View {
                     }
                 }
             }
-            .padding(20)
+            .padding(.vertical, 20)
         }
+        .contentMargins(.horizontal, DetailContentLayout.horizontalInset, for: .scrollContent)
         .disabled(true)
     }
 }

--- a/Sources/Kaset/Views/YouTube/YouTubePlaylistDetailView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubePlaylistDetailView.swift
@@ -73,7 +73,10 @@ struct YouTubePlaylistDetailView: View {
                     }
                 }
             }
-            .padding(20)
+            .padding(.vertical, 20)
         }
+        // Edge-to-edge with a resting inset so content extends under the
+        // floating glass sidebar.
+        .contentMargins(.horizontal, DetailContentLayout.horizontalInset, for: .scrollContent)
     }
 }

--- a/Sources/Kaset/Views/YouTube/YouTubePlaylistsView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubePlaylistsView.swift
@@ -51,7 +51,10 @@ struct YouTubePlaylistsView: View {
                     .buttonStyle(.interactiveCard)
                 }
             }
-            .padding(20)
+            .padding(.vertical, 20)
         }
+        // Edge-to-edge with a resting inset so the grid extends under the
+        // floating glass sidebar.
+        .contentMargins(.horizontal, DetailContentLayout.horizontalInset, for: .scrollContent)
     }
 }

--- a/Sources/Kaset/Views/YouTube/YouTubeSidebar.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeSidebar.swift
@@ -11,34 +11,32 @@ struct YouTubeSidebar: View {
     @Binding var selection: YouTubeNavigationItem?
 
     var body: some View {
-        VStack(spacing: 0) {
-            CompatGlassContainer(spacing: 0) {
-                List(selection: self.listSelection) {
-                    // Main navigation
-                    Section {
-                        self.row(for: .search)
-                        self.row(for: .home)
-                        self.row(for: .subscriptions)
-                    }
-
-                    // Discover section
-                    Section(String(localized: "Discover")) {
-                        self.row(for: .explore)
-                        self.row(for: .shorts)
-                    }
-
-                    // Collection section
-                    Section(String(localized: "Collection")) {
-                        self.row(for: .likedVideos)
-                        self.row(for: .watchLater)
-                        self.row(for: .playlists)
-                        self.row(for: .history)
-                    }
-                }
-                .listStyle(.sidebar)
-                .accessibilityIdentifier(AccessibilityID.YouTubeSidebar.container)
+        List(selection: self.listSelection) {
+            // Main navigation
+            Section {
+                self.row(for: .search)
+                self.row(for: .home)
+                self.row(for: .subscriptions)
             }
 
+            // Discover section
+            Section(String(localized: "Discover")) {
+                self.row(for: .explore)
+                self.row(for: .shorts)
+            }
+
+            // Collection section
+            Section(String(localized: "Collection")) {
+                self.row(for: .likedVideos)
+                self.row(for: .watchLater)
+                self.row(for: .playlists)
+                self.row(for: .history)
+            }
+        }
+        .listStyle(.sidebar)
+        .compatHideSidebarListBackground()
+        .accessibilityIdentifier(AccessibilityID.YouTubeSidebar.container)
+        .safeAreaInset(edge: .bottom, spacing: 0) {
             SidebarFooterView()
         }
         .navigationSplitViewColumnWidth(min: 200, ideal: 220, max: 300)

--- a/Sources/Kaset/Views/YouTube/YouTubeSidebar.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeSidebar.swift
@@ -34,7 +34,7 @@ struct YouTubeSidebar: View {
             }
         }
         .listStyle(.sidebar)
-        .compatHideSidebarListBackground()
+        .compatTranslucentSidebar()
         .accessibilityIdentifier(AccessibilityID.YouTubeSidebar.container)
         .safeAreaInset(edge: .bottom, spacing: 0) {
             SidebarFooterView()

--- a/Sources/Kaset/Views/YouTube/YouTubeSubscriptionsView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeSubscriptionsView.swift
@@ -49,6 +49,7 @@ struct YouTubeSubscriptionsView: View {
                     } description: {
                         Text("Videos from channels you subscribe to appear here.", comment: "Empty subscriptions feed description")
                     }
+                    .padding(.horizontal, DetailContentLayout.horizontalInset)
                 } else {
                     LazyVGrid(columns: Self.columns, spacing: 20) {
                         ForEach(self.viewModel.videos) { video in
@@ -66,18 +67,24 @@ struct YouTubeSubscriptionsView: View {
                                 }
                         }
                     }
+                    // Vertical grid: inset its resting content; the channel rail
+                    // above keeps its own edge-to-edge track so it slides under
+                    // the floating glass sidebar on macOS 26.
+                    .padding(.horizontal, DetailContentLayout.horizontalInset)
                 }
             }
             .padding(.vertical, 20)
         }
-        // Edge-to-edge with a resting inset so content extends under the
-        // floating glass sidebar.
-        .contentMargins(.horizontal, DetailContentLayout.horizontalInset, for: .scrollContent)
     }
 
     private var channelRail: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 16) {
+                // Leading resting inset INSIDE the track so the rail reaches the
+                // detail-column edge and slides under the floating glass sidebar.
+                Spacer()
+                    .frame(width: DetailContentLayout.horizontalInset - 2)
+
                 ForEach(self.viewModel.channels) { channel in
                     NavigationLink(value: YouTubeRoute.channel(channelId: channel.channelId)) {
                         VStack(spacing: 6) {
@@ -110,8 +117,12 @@ struct YouTubeSubscriptionsView: View {
                     .buttonStyle(.plain)
                     .accessibilityLabel(channel.name)
                 }
+
+                // Trailing resting inset.
+                Spacer()
+                    .frame(width: DetailContentLayout.horizontalInset - 2)
             }
-            .padding(.horizontal, 2)
+            .padding(.vertical, 2)
         }
         .accessibilityIdentifier(AccessibilityID.YouTubeContent.subscriptionsRail)
     }

--- a/Sources/Kaset/Views/YouTube/YouTubeSubscriptionsView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeSubscriptionsView.swift
@@ -79,48 +79,50 @@ struct YouTubeSubscriptionsView: View {
 
     private var channelRail: some View {
         ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 16) {
-                // Leading resting inset INSIDE the track so the rail reaches the
-                // detail-column edge and slides under the floating glass sidebar.
+            // Outer spacing:0 so the leading/trailing Spacers produce an exact
+            // resting inset (no extra HStack spacing inflation); the rail track
+            // stays edge-to-edge and slides under the floating glass sidebar.
+            HStack(spacing: 0) {
                 Spacer()
-                    .frame(width: DetailContentLayout.horizontalInset - 2)
+                    .frame(width: DetailContentLayout.horizontalInset)
 
-                ForEach(self.viewModel.channels) { channel in
-                    NavigationLink(value: YouTubeRoute.channel(channelId: channel.channelId)) {
-                        VStack(spacing: 6) {
-                            CachedAsyncImage(
-                                url: channel.thumbnailURL,
-                                targetSize: CGSize(width: 112, height: 112)
-                            ) { image in
-                                image
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fill)
-                            } placeholder: {
-                                Circle()
-                                    .fill(.quaternary)
-                                    .overlay {
-                                        Image(systemName: "person.fill")
-                                            .foregroundStyle(.tertiary)
-                                    }
+                HStack(spacing: 16) {
+                    ForEach(self.viewModel.channels) { channel in
+                        NavigationLink(value: YouTubeRoute.channel(channelId: channel.channelId)) {
+                            VStack(spacing: 6) {
+                                CachedAsyncImage(
+                                    url: channel.thumbnailURL,
+                                    targetSize: CGSize(width: 112, height: 112)
+                                ) { image in
+                                    image
+                                        .resizable()
+                                        .aspectRatio(contentMode: .fill)
+                                } placeholder: {
+                                    Circle()
+                                        .fill(.quaternary)
+                                        .overlay {
+                                            Image(systemName: "person.fill")
+                                                .foregroundStyle(.tertiary)
+                                        }
+                                }
+                                .frame(width: 56, height: 56)
+                                .clipShape(.circle)
+
+                                Text(channel.name)
+                                    .font(.system(size: 11))
+                                    .foregroundStyle(.primary)
+                                    .lineLimit(1)
+                                    .frame(width: 72)
                             }
-                            .frame(width: 56, height: 56)
-                            .clipShape(.circle)
-
-                            Text(channel.name)
-                                .font(.system(size: 11))
-                                .foregroundStyle(.primary)
-                                .lineLimit(1)
-                                .frame(width: 72)
+                            .contentShape(Rectangle())
                         }
-                        .contentShape(Rectangle())
+                        .buttonStyle(.plain)
+                        .accessibilityLabel(channel.name)
                     }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel(channel.name)
                 }
 
-                // Trailing resting inset.
                 Spacer()
-                    .frame(width: DetailContentLayout.horizontalInset - 2)
+                    .frame(width: DetailContentLayout.horizontalInset)
             }
             .padding(.vertical, 2)
         }

--- a/Sources/Kaset/Views/YouTube/YouTubeSubscriptionsView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeSubscriptionsView.swift
@@ -68,8 +68,11 @@ struct YouTubeSubscriptionsView: View {
                     }
                 }
             }
-            .padding(20)
+            .padding(.vertical, 20)
         }
+        // Edge-to-edge with a resting inset so content extends under the
+        // floating glass sidebar.
+        .contentMargins(.horizontal, DetailContentLayout.horizontalInset, for: .scrollContent)
     }
 
     private var channelRail: some View {

--- a/Tests/KasetTests/LiquidGlassCompatTests.swift
+++ b/Tests/KasetTests/LiquidGlassCompatTests.swift
@@ -54,6 +54,21 @@ struct LiquidGlassCompatTests {
         #expect(String(describing: button).isEmpty == false)
     }
 
+    @Test("compatTranslucentSidebar returns a view on every OS")
+    func compatTranslucentSidebarConstructs() {
+        let view = List { Text("Home") }.compatTranslucentSidebar()
+        #expect(String(describing: view).isEmpty == false)
+    }
+
+    @Test("compatTranslucentSidebar constructs when legacy macOS 15 UI is forced")
+    func compatTranslucentSidebarConstructsWithLegacyEnvironment() {
+        // Exercises the .ultraThinMaterial fallback branch end-to-end.
+        let view = List { Text("Home") }
+            .compatTranslucentSidebar()
+            .environment(\.usesLegacyMacOS15UI, true)
+        #expect(String(describing: view).isEmpty == false)
+    }
+
     @Test("CompatGlassContainer renders its content")
     func compatGlassContainerRendersContent() {
         let container = CompatGlassContainer(spacing: 4) {

--- a/docs/adr/0021-liquid-glass-sidebar-slide-under.md
+++ b/docs/adr/0021-liquid-glass-sidebar-slide-under.md
@@ -1,0 +1,109 @@
+# ADR-0021: Liquid Glass Sidebar Slide-Under
+
+## Status
+
+Accepted
+
+## Context
+
+On macOS 26 (Tahoe), `NavigationSplitView` renders its sidebar as a floating
+Liquid Glass panel that sits in a functional layer *above* the detail column.
+Apple Music uses this so browse content (album/playlist shelves) is faintly
+visible, blurred, *through* the sidebar as it scrolls — the content slides
+under the glass rather than stopping at the column boundary.
+
+Kaset did not get this effect for free, for two independent reasons:
+
+1. **The sidebar read as opaque.** The sidebar's `List(.sidebar)` painted the
+   stock opaque `.sidebar` vibrancy material on top of the system Liquid Glass,
+   occluding it. The glass was present but hidden, so the panel looked like a
+   solid dark column. (The `GlassEffectContainer`/`VStack` wrapper was inert —
+   `GlassEffectContainer` paints no background of its own.)
+
+2. **Detail content never reached under the sidebar.** Every detail scroll view
+   inset its content with a fixed `.padding(.horizontal, 24)`, so nothing was
+   physically positioned in the band beneath the sidebar. The frosted glass had
+   only the bare window background to sample, reinforcing the opaque look.
+
+This contradicts the prior guidance in `architecture.md` ("Reserve glass for
+navigation/floating controls — not for content areas") and its description of
+the sidebar as "a standard SwiftUI `List` with `.listStyle(.sidebar)`", so a
+decision record is warranted.
+
+Several plausible-but-wrong levers were ruled out on-device and against the
+macOS 26.5 SDK / Apple docs (WWDC 2025 sessions 256 & 323; the Landmarks
+"Extending horizontal scrolling under a sidebar or inspector" sample):
+
+- **`.scrollClipDisabled()`** only disables clipping on a scroll view's own
+  frame within the detail column's coordinate space. It never routes content
+  into the under-sidebar band, so it does not produce the effect.
+- **`.contentMargins(.horizontal, …)` on a *horizontal* shelf** stops the
+  scroll track short of the leading edge, which *defeats* the system's
+  auto-scroll-under behavior.
+- **`.backgroundExtensionEffect()`** mirrors and blurs a *single view's own
+  pixels* into the safe area. It is for static hero/backdrop images, not for
+  moving a live card grid under the sidebar.
+
+## Decision
+
+**Use the standard `NavigationSplitView` column sidebar (no overlay/ZStack
+rebuild) and route real content into the band under the floating glass, the way
+Apple's Landmarks sample does.** Two coordinated changes:
+
+1. **Reveal the system sidebar glass (subtractive).** Make `List` the sidebar
+   column root and hide its opaque scroll-content background via
+   `.scrollContentBackground(.hidden)`, exposed through a gated compat shim
+   `compatHideSidebarListBackground()`. The footer rides the same glass via
+   `.safeAreaInset(edge: .bottom)`. No explicit `.glassEffect()` is added — that
+   would be glass-on-glass and darken the panel. Applied to both `Sidebar` and
+   `YouTubeSidebar`.
+
+2. **Route detail content under the sidebar.**
+   - *Horizontal shelves* (`CarouselShelf`): run the scroll track edge-to-edge
+     and move the resting inset into a leading `Spacer` *inside* the row
+     (`contentInset`). When the track touches the leading edge, the system
+     auto-scrolls live cards under the glass. The old leading edge-fade `.mask`
+     was removed because it faded cards to transparent in exactly the band that
+     should refract through the glass.
+   - *Vertical grids/lists and accent-backdrop detail pages*: convert fixed
+     `.padding(.horizontal, 24)` to
+     `.contentMargins(.horizontal, …, for: .scrollContent)` so the scroll view
+     reaches the column edge while keeping an unchanged resting inset. (Vertical
+     content does not visibly *slide* under the sidebar — that is inherently a
+     horizontal-scroll effect — but its edge and any accent backdrop refract
+     through the glass.)
+
+A shared `DetailContentLayout.horizontalInset` constant (24) keeps the resting
+inset consistent across all surfaces.
+
+### Gating
+
+`compatHideSidebarListBackground()` is gated on **both**
+`!usesLegacyMacOS15UI` **and** `#available(macOS 26.0, *)`. The
+`usesLegacyMacOS15UI` flag is a debug toggle, not the OS version: gating on the
+flag alone would hide the list background on real macOS 15 hardware, where there
+is no column-level glass to reveal, exposing the window background instead. The
+`.contentMargins`/`Spacer` layout changes are macOS 14+ and produce the same
+resting layout on the legacy path (there is simply no glass to slide under).
+
+## Consequences
+
+- The sidebar is a translucent Liquid Glass panel; horizontal shelves slide
+  under it as Apple Music does. The show-through is a faint, blurred, tinted
+  hint (not crisp transparency) — this is the intended native appearance and
+  keeps sidebar labels legible.
+- The effect is macOS 26 only. The legacy macOS 15 path keeps the opaque sidebar
+  and the same resting content layout.
+- `CarouselShelf` lost its edge-fade mask, `fadeWidth`, `hoverBleed`, and the
+  associated `maskColors`. The paging-control affordances are unchanged.
+- This refines the previous "glass is for navigation, not content" guidance:
+  content is not *given* a glass material; rather, standard content is allowed
+  to pass beneath the system-provided navigation glass.
+
+## References
+
+- Apple — Landmarks: Extending horizontal scrolling under a sidebar or inspector
+- Apple — `View.backgroundExtensionEffect()`, `View.scrollContentBackground(_:)`
+- Apple — Adopting Liquid Glass (Technology Overviews)
+- WWDC 2025 — Sessions 256 (What's new in SwiftUI) and 323 (Build a SwiftUI app
+  with the new design)

--- a/docs/adr/0021-liquid-glass-sidebar-slide-under.md
+++ b/docs/adr/0021-liquid-glass-sidebar-slide-under.md
@@ -53,10 +53,15 @@ Apple's Landmarks sample does.** Two coordinated changes:
 1. **Reveal the system sidebar glass (subtractive).** Make `List` the sidebar
    column root and hide its opaque scroll-content background via
    `.scrollContentBackground(.hidden)`, exposed through a gated compat shim
-   `compatHideSidebarListBackground()`. The footer rides the same glass via
+   `compatTranslucentSidebar()`. The footer rides the same glass via
    `.safeAreaInset(edge: .bottom)`. No explicit `.glassEffect()` is added — that
    would be glass-on-glass and darken the panel. Applied to both `Sidebar` and
-   `YouTubeSidebar`.
+   `YouTubeSidebar`. On the legacy macOS 15 path the same shim instead lays an
+   `.ultraThinMaterial` behind the sidebar so it still reads as a blurred,
+   translucent panel (the material the player bar uses) rather than a flat
+   opaque column. Note this material is vibrant over the *window* (desktop),
+   not the detail cards — true content-through under the sidebar is a macOS 26
+   behavior.
 
 2. **Route detail content under the sidebar.**
    - *Horizontal shelves* (`CarouselShelf`): run the scroll track edge-to-edge
@@ -78,13 +83,14 @@ inset consistent across all surfaces.
 
 ### Gating
 
-`compatHideSidebarListBackground()` is gated on **both**
-`!usesLegacyMacOS15UI` **and** `#available(macOS 26.0, *)`. The
-`usesLegacyMacOS15UI` flag is a debug toggle, not the OS version: gating on the
-flag alone would hide the list background on real macOS 15 hardware, where there
-is no column-level glass to reveal, exposing the window background instead. The
-`.contentMargins`/`Spacer` layout changes are macOS 14+ and produce the same
-resting layout on the legacy path (there is simply no glass to slide under).
+`compatTranslucentSidebar()` branches on **both** `!usesLegacyMacOS15UI`
+**and** `#available(macOS 26.0, *)`. The `usesLegacyMacOS15UI` flag is a debug
+toggle, not the OS version. On macOS 26 (non-legacy) it hides the list
+background to reveal the system Liquid Glass; otherwise (legacy flag, or real
+macOS 15 where the `#available` check is false at runtime) it falls back to an
+`.ultraThinMaterial` frosted panel. The `.contentMargins`/`Spacer` layout
+changes are macOS 14+ and produce the same resting layout on the legacy path
+(there is simply no glass to slide under).
 
 ## Consequences
 
@@ -92,8 +98,9 @@ resting layout on the legacy path (there is simply no glass to slide under).
   under it as Apple Music does. The show-through is a faint, blurred, tinted
   hint (not crisp transparency) — this is the intended native appearance and
   keeps sidebar labels legible.
-- The effect is macOS 26 only. The legacy macOS 15 path keeps the opaque sidebar
-  and the same resting content layout.
+- The effect is macOS 26 only. The legacy macOS 15 path keeps the same resting
+  content layout and renders the sidebar as a frosted `.ultraThinMaterial`
+  panel (translucent over the window, not the detail cards).
 - `CarouselShelf` lost its edge-fade mask, `fadeWidth`, `hoverBleed`, and the
   associated `maskColors`. The paging-control affordances are unchanged.
 - This refines the previous "glass is for navigation, not content" guidance:

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -55,3 +55,4 @@ What becomes easier or more difficult because of this change?
 | [0018](0018-artist-page-episodes.md) | Artist Page — Episodes, Singles, Playlists, Podcasts, Related Artists | Accepted |
 | [0019](0019-podcasts-availability.md) | Region-Aware Podcasts Tab Visibility | Implemented |
 | [0020](0020-youtube-source-toggle.md) | Native YouTube Client Behind a Source Toggle | Accepted |
+| [0021](0021-liquid-glass-sidebar-slide-under.md) | Liquid Glass Sidebar Slide-Under | Accepted |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -880,7 +880,7 @@ The app uses Apple's **Liquid Glass** design language introduced in macOS 26 whe
 | Component | Glass Pattern |
 |-----------|---------------|
 | `PlayerBar` | `.glassEffect(.regular.interactive(), in: .capsule)` |
-| `Sidebar` | Wrapped in `GlassEffectContainer` |
+| `Sidebar` | `List(.sidebar)` with `.scrollContentBackground(.hidden)` (macOS 26) so the system Liquid Glass shows through; detail content slides under it (ADR-0021) |
 | `QueueView` / `LyricsView` | `.glassEffectTransition(.materialize)` |
 | Search field | `.glassEffect(.regular, in: .capsule)` |
 | Search suggestions | `.glassEffect(.regular, in: .rect(cornerRadius: 8))` |
@@ -891,7 +891,7 @@ The app uses Apple's **Liquid Glass** design language introduced in macOS 26 whe
 2. **Use `.glassEffectTransition(.materialize)`** for panels that appear/disappear
 3. **Use `@Namespace` + `.glassEffectID()`** for morphing between states
 4. **Avoid glass-on-glass** — don't apply `.buttonStyle(.glass)` to buttons already inside a glass container
-5. **Reserve glass for navigation/floating controls** — not for content areas
+5. **Reserve glass for navigation/floating controls** — don't apply a glass *material* to content. Content may, however, pass *beneath* the system-provided navigation glass: on macOS 26 detail content slides under the floating `NavigationSplitView` sidebar and refracts through it (see ADR-0021)
 
 ## Foundation Models (Apple Intelligence)
 
@@ -1140,7 +1140,10 @@ Clean, minimal sidebar with only functional navigation:
 **Design Principles**:
 - Only show items that have implemented functionality
 - Remove placeholder items (Artists, Albums, Songs, Liked Songs, etc.)
-- Use standard SwiftUI `List` with `.listStyle(.sidebar)`
+- Use standard SwiftUI `List` with `.listStyle(.sidebar)` as the column root
+- On macOS 26, hide the list's opaque background
+  (`compatHideSidebarListBackground()`) so the floating Liquid Glass shows
+  through and detail content slides under it (ADR-0021)
 
 ### Persistent UI Elements
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1141,9 +1141,10 @@ Clean, minimal sidebar with only functional navigation:
 - Only show items that have implemented functionality
 - Remove placeholder items (Artists, Albums, Songs, Liked Songs, etc.)
 - Use standard SwiftUI `List` with `.listStyle(.sidebar)` as the column root
-- On macOS 26, hide the list's opaque background
-  (`compatHideSidebarListBackground()`) so the floating Liquid Glass shows
-  through and detail content slides under it (ADR-0021)
+- Apply `compatTranslucentSidebar()`: on macOS 26 it hides the list's opaque
+  background so the floating Liquid Glass shows through and detail content
+  slides under it; on legacy macOS 15 it falls back to an `.ultraThinMaterial`
+  frosted panel (ADR-0021)
 
 ### Persistent UI Elements
 


### PR DESCRIPTION
## Summary

On macOS 26 (Tahoe), make detail content slide **under** the floating Liquid Glass sidebar like Apple Music — the sidebar is a translucent glass panel and content is faintly visible (blurred) through it as shelves scroll. Two coordinated changes:

- **Reveal the system sidebar glass (subtractive).** Make `List` the sidebar column root and hide its opaque `.sidebar` material via a gated `compatTranslucentSidebar()` (`.scrollContentBackground(.hidden)`), with the footer on the same glass via `.safeAreaInset(.bottom)`. No explicit `.glassEffect()` is added (that would be glass-on-glass). On legacy macOS 15 the same shim falls back to an `.ultraThinMaterial` frosted panel instead. Applied to both `Sidebar` and `YouTubeSidebar`.
- **Route detail content under the sidebar.** Horizontal shelves (`CarouselShelf`) run their scroll track edge-to-edge with the resting inset in leading **and** trailing `Spacer`s, so the system auto-scrolls live cards under the glass (Apple's "extending horizontal scrolling under a sidebar" pattern). Vertical grids/lists and accent-backdrop detail pages convert fixed `.padding(.horizontal, 24)` to `.contentMargins(.horizontal, …, for: .scrollContent)` so content reaches the column edge with an unchanged resting inset.

A shared `DetailContentLayout.horizontalInset` keeps the inset consistent. Removed the now-dead leading edge-fade mask / `fadeWidth` / `hoverBleed` from `CarouselShelf`.

Decision recorded in **ADR-0021**, with `architecture.md` updated to refine the prior "glass for navigation, not content" guidance.

## Coverage

- **Music browse:** Home, Explore, Charts, New Releases, Moods & Genres, Podcasts, Library, Mood Category
- **Music detail (accent backdrop):** Playlist, Artist, Podcast Show, All Episodes, Top Songs, Artist Episodes
- **YouTube:** sidebar parity + Home, Explore, History, Channel, Playlists, Playlist Detail, Subscriptions

## Notes / caveats

- Gating is on **both** `!usesLegacyMacOS15UI` **and** `#available(macOS 26.0, *)` — the flag is a debug toggle, not the OS version, so gating on it alone would regress real macOS 15 hardware. The `.contentMargins`/`Spacer` layout (macOS 14+) yields the same resting layout on legacy; there's just no glass to slide under.
- Vertical grids/lists don't visibly **slide** under the sidebar — that's inherently a horizontal-shelf effect. Their edges and accent backdrops refract through the glass.
- **History** and **Search results** are intentionally left as-is: their rows are already full-width with internal resting insets, so they extend correctly without refactoring their row/divider/hover coupling.
- Dead ends documented in the ADR so they aren't re-tried: `.scrollClipDisabled()`, `.contentMargins` on horizontal shelves, and `.backgroundExtensionEffect()` (hero images only) do **not** route live content under the sidebar.

## Test plan

- [x] `swift build` clean (no warnings)
- [x] `swiftlint --strict` — 0 violations / 410 files
- [x] `swiftformat .` clean
- [x] `swift test --skip KasetUITests` — 1396 tests pass
- [x] Autoreview (Codex) clean — found 1 trailing-inset regression, fixed, re-reviewed clean
- [x] Verified on macOS 26 (Tahoe): shelves slide under the translucent sidebar
- [ ] Reviewer: confirm legacy macOS 15 path renders the frosted/translucent `.ultraThinMaterial` sidebar + unchanged resting layout
