### PR TITLE
Add watched-progress bar to YouTube video thumbnails

### DIFF
--- a/Sources/Kaset/Models/YouTube/YouTubeVideo.swift
+++ b/Sources/Kaset/Models/YouTube/YouTubeVideo.swift
@@ -21,6 +21,9 @@ struct YouTubeVideo: Identifiable, Hashable {
     let isLive: Bool
     /// Whether this is a YouTube Short (vertical, ≤60s).
     let isShort: Bool
+    /// Percent of the video the signed-in user has already watched (0–100),
+    /// when YouTube reports resume progress. `nil` when unwatched or unavailable.
+    let watchedPercent: Int?
 
     var id: String {
         self.videoId
@@ -36,7 +39,8 @@ struct YouTubeVideo: Identifiable, Hashable {
         publishedText: String? = nil,
         thumbnailURL: URL? = nil,
         isLive: Bool = false,
-        isShort: Bool = false
+        isShort: Bool = false,
+        watchedPercent: Int? = nil
     ) {
         self.videoId = videoId
         self.title = title
@@ -48,5 +52,6 @@ struct YouTubeVideo: Identifiable, Hashable {
         self.thumbnailURL = thumbnailURL
         self.isLive = isLive
         self.isShort = isShort
+        self.watchedPercent = watchedPercent
     }
 }

--- a/Sources/Kaset/Services/API/Parsers/YouTube/YouTubeItemParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/YouTube/YouTubeItemParser.swift
@@ -70,7 +70,8 @@ enum YouTubeItemParser {
             publishedText: self.text(from: renderer["publishedTimeText"]),
             thumbnailURL: self.thumbnailURL(fromThumbnail: renderer["thumbnail"]),
             isLive: isLive,
-            isShort: self.isShort(navigationContainer: renderer["navigationEndpoint"])
+            isShort: self.isShort(navigationContainer: renderer["navigationEndpoint"]),
+            watchedPercent: self.watchedPercent(ofRenderer: renderer)
         )
     }
 
@@ -191,7 +192,8 @@ enum YouTubeItemParser {
             publishedText: publishedText,
             thumbnailURL: self.thumbnailURL(fromLockup: lockup),
             isLive: badgeText?.localizedCaseInsensitiveCompare("live") == .orderedSame,
-            isShort: isShort
+            isShort: isShort,
+            watchedPercent: self.watchedPercent(ofLockup: lockup)
         )
     }
 
@@ -379,6 +381,55 @@ enum YouTubeItemParser {
             }
         }
         return nil
+    }
+
+    // MARK: - Watched Progress
+
+    /// Resume-progress percent from a lockup's thumbnail overlay
+    /// (`progressBar`, a sibling of the `badges` key read by
+    /// `thumbnailBadgeText(of:)`). `nil` when the video is unwatched.
+    private static func watchedPercent(ofLockup lockup: [String: Any]) -> Int? {
+        let overlays = (
+            (lockup["contentImage"] as? [String: Any])?["thumbnailViewModel"] as? [String: Any]
+        )?["overlays"] as? [[String: Any]] ?? []
+
+        for overlay in overlays {
+            guard let bottom = overlay["thumbnailBottomOverlayViewModel"] as? [String: Any],
+                  let bar = bottom["progressBar"] as? [String: Any],
+                  let viewModel = bar["thumbnailOverlayProgressBarViewModel"] as? [String: Any]
+            else {
+                continue
+            }
+            if let percent = Self.percentValue(viewModel["startPercent"]) {
+                return percent
+            }
+        }
+        return nil
+    }
+
+    /// Resume-progress percent from a legacy `videoRenderer.thumbnailOverlays`
+    /// array (`thumbnailOverlayResumePlaybackRenderer.percentDurationWatched`).
+    private static func watchedPercent(ofRenderer renderer: [String: Any]) -> Int? {
+        guard let overlays = renderer["thumbnailOverlays"] as? [[String: Any]] else {
+            return nil
+        }
+
+        for overlay in overlays {
+            guard let resume = overlay["thumbnailOverlayResumePlaybackRenderer"] as? [String: Any]
+            else {
+                continue
+            }
+            if let percent = Self.percentValue(resume["percentDurationWatched"]) {
+                return percent
+            }
+        }
+        return nil
+    }
+
+    /// Coerces an InnerTube percent (Int or Double encoding) into a clamped 0…100 Int.
+    private static func percentValue(_ raw: Any?) -> Int? {
+        let value = (raw as? Int) ?? (raw as? Double).map(Int.init)
+        return value.map { min(max($0, 0), 100) }
     }
 
     // MARK: - Badges

--- a/Sources/Kaset/Services/API/Parsers/YouTube/YouTubeItemParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/YouTube/YouTubeItemParser.swift
@@ -426,10 +426,15 @@ enum YouTubeItemParser {
         return nil
     }
 
-    /// Coerces an InnerTube percent (Int or Double encoding) into a clamped 0…100 Int.
+    /// Coerces an InnerTube percent (Int or Double encoding) into a clamped
+    /// 1…100 Int. A non-positive percent means "no resume progress" (YouTube
+    /// emits this for unwatched/preview lockups), so it maps to `nil` and the
+    /// progress bar stays hidden.
     private static func percentValue(_ raw: Any?) -> Int? {
-        let value = (raw as? Int) ?? (raw as? Double).map(Int.init)
-        return value.map { min(max($0, 0), 100) }
+        guard let value = (raw as? Int) ?? (raw as? Double).map(Int.init) else {
+            return nil
+        }
+        return value > 0 ? min(value, 100) : nil
     }
 
     // MARK: - Badges

--- a/Sources/Kaset/Views/YouTube/VideoCard.swift
+++ b/Sources/Kaset/Views/YouTube/VideoCard.swift
@@ -52,6 +52,12 @@ struct VideoCard: View {
         if let metaText = self.metaText {
             parts.append(metaText)
         }
+        if let percent = self.video.watchedPercent {
+            parts.append(String(
+                localized: "Watched \(percent)%",
+                comment: "Accessibility label for a partially-watched video card"
+            ))
+        }
         return parts.joined(separator: ", ")
     }
 }
@@ -80,10 +86,32 @@ struct VideoThumbnailView: View {
                 }
         }
         .aspectRatio(16 / 9, contentMode: .fit)
+        .overlay(alignment: .bottom) {
+            if let percent = self.video.watchedPercent {
+                self.watchedProgressBar(percent: percent)
+            }
+        }
         .clipShape(.rect(cornerRadius: 8))
         .overlay(alignment: .bottomTrailing) {
             self.badge
         }
+    }
+
+    /// Thin red resume-progress bar pinned flush to the thumbnail's bottom edge.
+    /// Clipped by the parent's rounded corners; decorative (described via the
+    /// card's combined accessibility label).
+    @ViewBuilder
+    private func watchedProgressBar(percent: Int) -> some View {
+        let fraction = CGFloat(min(max(percent, 0), 100)) / 100
+        ZStack(alignment: .leading) {
+            Rectangle()
+                .fill(.white.opacity(0.3))
+            Rectangle()
+                .fill(.red)
+                .scaleEffect(x: fraction, anchor: .leading)
+        }
+        .frame(height: 3)
+        .accessibilityHidden(true)
     }
 
     @ViewBuilder
@@ -116,7 +144,8 @@ struct VideoThumbnailView: View {
             channelName: "Apple Developer",
             lengthText: "28:01",
             viewCountText: "29K views",
-            publishedText: "1 year ago"
+            publishedText: "1 year ago",
+            watchedPercent: 65
         )
     )
     .frame(width: 320)

--- a/Sources/Kaset/Views/YouTube/VideoCard.swift
+++ b/Sources/Kaset/Views/YouTube/VideoCard.swift
@@ -98,8 +98,10 @@ struct VideoThumbnailView: View {
     }
 
     /// Thin red resume-progress bar pinned flush to the thumbnail's bottom edge.
-    /// Clipped by the parent's rounded corners; decorative (described via the
-    /// card's combined accessibility label).
+    /// Clipped by the parent's rounded corners. Exposed as its own labeled
+    /// accessibility element so consumers that combine children (the related
+    /// rail and list rows) announce the watched percent; `VideoCard` overrides
+    /// this with its own curated label, which already includes it.
     @ViewBuilder
     private func watchedProgressBar(percent: Int) -> some View {
         let fraction = CGFloat(min(max(percent, 0), 100)) / 100
@@ -111,7 +113,11 @@ struct VideoThumbnailView: View {
                 .scaleEffect(x: fraction, anchor: .leading)
         }
         .frame(height: 3)
-        .accessibilityHidden(true)
+        .accessibilityElement()
+        .accessibilityLabel(Text(
+            "Watched \(percent)%",
+            comment: "Accessibility label describing how much of a video has been watched"
+        ))
     }
 
     @ViewBuilder

--- a/Tests/KasetTests/YouTubeItemParserTests.swift
+++ b/Tests/KasetTests/YouTubeItemParserTests.swift
@@ -193,6 +193,73 @@ struct YouTubeItemParserTests {
         #expect(playlist.firstVideoId == "first1")
     }
 
+    // MARK: - Watched progress
+
+    /// Builds a minimal video `lockupViewModel` whose bottom overlay optionally
+    /// carries a duration badge and/or a resume `progressBar`.
+    private func makeProgressLockup(
+        badgeText: String? = "32:23",
+        startPercent: Any? = nil
+    ) -> [String: Any] {
+        var bottomOverlay: [String: Any] = [:]
+        if let badgeText {
+            bottomOverlay["badges"] = [["thumbnailBadgeViewModel": ["text": badgeText]]]
+        }
+        if let startPercent {
+            bottomOverlay["progressBar"] = [
+                "thumbnailOverlayProgressBarViewModel": ["startPercent": startPercent],
+            ]
+        }
+        return [
+            "contentId": "progress123",
+            "contentType": "LOCKUP_CONTENT_TYPE_VIDEO",
+            "contentImage": [
+                "thumbnailViewModel": [
+                    "overlays": [["thumbnailBottomOverlayViewModel": bottomOverlay]],
+                ],
+            ],
+            "metadata": [
+                "lockupMetadataViewModel": ["title": ["content": "Progress Video"]],
+            ],
+        ]
+    }
+
+    @Test("Parses startPercent from a lockup progress overlay")
+    func parsesLockupWatchedPercent() throws {
+        let lockup = self.makeProgressLockup(startPercent: 77)
+        let video = try #require(YouTubeItemParser.video(fromLockup: lockup))
+        #expect(video.watchedPercent == 77)
+    }
+
+    @Test("Unwatched lockup has no progress and still parses its duration badge")
+    func unwatchedLockupHasNilProgress() throws {
+        let lockup = self.makeProgressLockup(startPercent: nil)
+        let video = try #require(YouTubeItemParser.video(fromLockup: lockup))
+        #expect(video.watchedPercent == nil)
+        // Reading the sibling progressBar key must not disturb badge parsing.
+        #expect(video.lengthText == "32:23")
+    }
+
+    @Test("Clamps and coerces an out-of-range Double startPercent")
+    func clampsLockupWatchedPercent() throws {
+        let lockup = self.makeProgressLockup(startPercent: 150.0)
+        let video = try #require(YouTubeItemParser.video(fromLockup: lockup))
+        #expect(video.watchedPercent == 100)
+    }
+
+    @Test("Parses percentDurationWatched from a legacy videoRenderer")
+    func parsesLegacyWatchedPercent() throws {
+        let renderer: [String: Any] = [
+            "videoId": "legacy123",
+            "title": ["runs": [["text": "Legacy Video"]]],
+            "thumbnailOverlays": [
+                ["thumbnailOverlayResumePlaybackRenderer": ["percentDurationWatched": 100]],
+            ],
+        ]
+        let video = try #require(YouTubeItemParser.video(fromVideoRenderer: renderer))
+        #expect(video.watchedPercent == 100)
+    }
+
     // MARK: - channelRenderer
 
     @Test("Parses a channelRenderer with swapped handle/subscriber fields")

--- a/Tests/KasetTests/YouTubeItemParserTests.swift
+++ b/Tests/KasetTests/YouTubeItemParserTests.swift
@@ -247,6 +247,13 @@ struct YouTubeItemParserTests {
         #expect(video.watchedPercent == 100)
     }
 
+    @Test("Treats a zero-percent progress overlay as unwatched")
+    func zeroPercentLockupIsUnwatched() throws {
+        let lockup = self.makeProgressLockup(startPercent: 0)
+        let video = try #require(YouTubeItemParser.video(fromLockup: lockup))
+        #expect(video.watchedPercent == nil)
+    }
+
     @Test("Parses percentDurationWatched from a legacy videoRenderer")
     func parsesLegacyWatchedPercent() throws {
         let renderer: [String: Any] = [


### PR DESCRIPTION
## Description

Adds a thin red **watched-progress bar** across the bottom of YouTube video thumbnails — matching the YouTube web UI — so partially-watched videos show how far you've already watched right from the feed.

YouTube already returns this resume data in the InnerTube feed; Kaset just wasn't surfacing it. The bar appears on every YouTube surface that shares `VideoThumbnailView` (home, watch history, subscriptions, channel, explore, related, playlist detail) and is automatically absent when there's no progress. Shorts are unaffected (they bypass `VideoThumbnailView`, matching YouTube — Shorts have no resume bar).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🎨 UI/UX improvement

## Changes Made

- **`YouTubeVideo`** — added an optional `watchedPercent: Int?` (0–100). It's appended to the memberwise init with a default, so all existing construction sites compile unchanged. Presence means "watched" (most feed items omit it).
- **`YouTubeItemParser`** — parses progress from the **two** renderer shapes YouTube serves, both confirmed against the live API:
  - **Lockup** (home/feed): `lockupViewModel.contentImage.thumbnailViewModel.overlays[].thumbnailBottomOverlayViewModel.progressBar.thumbnailOverlayProgressBarViewModel.startPercent`
  - **Legacy `videoRenderer`** (search/history): `thumbnailOverlays[].thumbnailOverlayResumePlaybackRenderer.percentDurationWatched`
  - Both go through a tolerant `0...100` clamp (accepts Int or Double). The lockup helper reads `progressBar`, a sibling of the existing `badges` key, so it doesn't disturb duration-badge parsing.
- **`VideoThumbnailView`** — renders a 3pt red bar as an overlay placed **before** `.clipShape(...)` (so the rounded corners clip its ends), gated on `watchedPercent != nil`. The duration badge keeps its `.bottomTrailing` + `padding(6)` placement and does not overlap. The bar is `accessibilityHidden`; instead a "Watched N%" string is appended to the card's combined accessibility label.

> Note: the bar is **static** — it reflects progress at fetch time and does not live-update while watching, consistent with how the feed data is delivered.

## Testing

- [x] Unit tests pass (`swift test --skip KasetUITests` — **1406 tests pass**)
- [x] Manual testing performed (verified both renderer shapes against the live API via `swift run api-explorer --youtube browse FEwhat_to_watch` and `FEhistory`)

New Swift Testing cases in `YouTubeItemParserTests`:
- Parses `startPercent` from a lockup progress overlay
- Unwatched lockup → `watchedPercent == nil`, and the duration badge still parses (regression guard)
- Clamps/coerces an out-of-range `Double` (`150.0` → `100`)
- Parses `percentDurationWatched` from a legacy `videoRenderer`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `swiftlint --strict && swiftformat .` (0 violations, 0 reformats)
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally
- [x] I have checked for any performance implications (recursive parse walk is unchanged; one extra shallow overlay read per item)
- [x] My changes generate no new warnings

## Additional Notes

Ran the repo's `$autoreview` (Codex) closeout on the change: **no accepted/actionable findings** ("patch is correct").
