### PR TITLE
Add YouTube home sections: Continue Watching + personalized topic rails

### DIFF
--- a/Sources/Kaset/Models/YouTube/YouTubeFeed.swift
+++ b/Sources/Kaset/Models/YouTube/YouTubeFeed.swift
@@ -19,6 +19,49 @@ struct YouTubeFeed {
     static let empty = YouTubeFeed(videos: [], continuation: nil)
 }
 
+// MARK: - YouTubeHomeSection
+
+/// A titled, side-scrolling section on the YouTube (video) home surface.
+///
+/// Unlike `YouTubeFeed` (a flat recommendation page), this preserves a shelf
+/// title so the home can render YouTube-Music-style rails: Continue Watching,
+/// the home response's own titled shelves, and one rail per personalized
+/// filter-chip topic (Gaming, Music, AI, …).
+struct YouTubeHomeSection: Identifiable {
+    /// What produced this section, used for placement and empty-state rules.
+    enum Kind: Hashable {
+        /// Started-but-unfinished videos from watch history.
+        case continueWatching
+        /// A titled shelf the home response itself returned (e.g. "Breaking news").
+        case shelf
+        /// A personalized filter-chip topic feed (e.g. "Gaming").
+        case topic
+        /// The flat recommendation grid ("For you").
+        case forYou
+    }
+
+    let id: String
+    let title: String
+    let videos: [YouTubeVideo]
+    let kind: Kind
+}
+
+// MARK: - YouTubeHomeChip
+
+/// A personalized filter chip from the home feed's chip bar. Each chip's
+/// `continuation` browses (via the `browse` continuation endpoint) to a
+/// topic-filtered, personalized video feed used to build a home rail.
+struct YouTubeHomeChip: Identifiable {
+    /// Stable identity for SwiftUI; the topic title is unique within the bar.
+    var id: String {
+        self.title
+    }
+
+    let title: String
+    /// InnerTube continuation token that browses this chip's topic feed.
+    let continuation: String
+}
+
 // MARK: - YouTubeSearchResponse
 
 /// Results of a YouTube search, split by result kind.

--- a/Sources/Kaset/Models/YouTube/YouTubeFeed.swift
+++ b/Sources/Kaset/Models/YouTube/YouTubeFeed.swift
@@ -36,8 +36,6 @@ struct YouTubeHomeSection: Identifiable {
         case shelf
         /// A personalized filter-chip topic feed (e.g. "Gaming").
         case topic
-        /// The flat recommendation grid ("For you").
-        case forYou
     }
 
     let id: String

--- a/Sources/Kaset/Services/API/MockUITestYouTubeClient.swift
+++ b/Sources/Kaset/Services/API/MockUITestYouTubeClient.swift
@@ -16,6 +16,28 @@ final class MockUITestYouTubeClient: YouTubeClientProtocol {
         nil
     }
 
+    func getHomeChips() async throws -> [YouTubeHomeChip] {
+        [
+            YouTubeHomeChip(title: "Gaming", continuation: "mock-chip-gaming"),
+            YouTubeHomeChip(title: "Music", continuation: "mock-chip-music"),
+        ]
+    }
+
+    func getHomeShelves() async throws -> [YouTubeHomeSection] {
+        [
+            YouTubeHomeSection(
+                id: "shelf-1-Breaking news",
+                title: "Breaking news",
+                videos: Self.sampleVideos,
+                kind: .shelf
+            ),
+        ]
+    }
+
+    func getHomeTopicFeed(continuation _: String) async throws -> YouTubeFeed {
+        YouTubeFeed(videos: Self.sampleVideos, continuation: nil)
+    }
+
     func search(query _: String, filter: YouTubeSearchFilter) async throws -> YouTubeSearchResponse {
         switch filter {
         case .all:
@@ -132,7 +154,7 @@ final class MockUITestYouTubeClient: YouTubeClientProtocol {
     }
 
     func getHistory() async throws -> YouTubeFeed {
-        YouTubeFeed(videos: Self.sampleVideos, continuation: nil)
+        YouTubeFeed(videos: Self.sampleHistoryVideos, continuation: nil)
     }
 
     func getUserPlaylists() async throws -> [YouTubePlaylist] {
@@ -176,6 +198,42 @@ final class MockUITestYouTubeClient: YouTubeClientProtocol {
             lengthText: "1:02:03",
             viewCountText: "3K views",
             publishedText: "3 days ago"
+        ),
+    ]
+
+    /// History fixture including partially-watched videos so the Continue
+    /// Watching rail renders under UI-test mode (watchedPercent within 1…95).
+    private static let sampleHistoryVideos = [
+        YouTubeVideo(
+            videoId: "mock-history-1",
+            title: "Mock History One",
+            channelName: "Mock Channel",
+            channelId: "UCmockchannel",
+            lengthText: "12:00",
+            viewCountText: "5K views",
+            publishedText: "1 day ago",
+            watchedPercent: 35
+        ),
+        YouTubeVideo(
+            videoId: "mock-history-2",
+            title: "Mock History Two",
+            channelName: "Another Channel",
+            channelId: "UCanotherchannel",
+            lengthText: "8:20",
+            viewCountText: "9K views",
+            publishedText: "2 days ago",
+            watchedPercent: 80
+        ),
+        // Fully watched: excluded from Continue Watching, present in history.
+        YouTubeVideo(
+            videoId: "mock-history-3",
+            title: "Mock History Three",
+            channelName: "Mock Channel",
+            channelId: "UCmockchannel",
+            lengthText: "4:10",
+            viewCountText: "1K views",
+            publishedText: "3 days ago",
+            watchedPercent: 100
         ),
     ]
 

--- a/Sources/Kaset/Services/API/Parsers/YouTube/YouTubeFeedParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/YouTube/YouTubeFeedParser.swift
@@ -52,6 +52,113 @@ enum YouTubeFeedParser {
         )
     }
 
+    // MARK: - Home Sections (Chips & Shelves)
+
+    /// Parses the home feed's personalized filter-chip bar into browsable
+    /// topic chips. The selected "All" chip (which has no continuation token)
+    /// is skipped so callers get only the topic rails.
+    ///
+    /// Path: `…richGridRenderer.header.feedFilterChipBarRenderer.contents[]`
+    /// `.chipCloudChipRenderer` → title via `text(from:)`, continuation at
+    /// `navigationEndpoint.continuationCommand.token`.
+    static func parseChips(_ data: [String: Any]) -> [YouTubeHomeChip] {
+        guard let chips = chipBarContents(data) else { return [] }
+
+        var result: [YouTubeHomeChip] = []
+        var seen = Set<String>()
+        for entry in chips {
+            guard let chip = entry["chipCloudChipRenderer"] as? [String: Any] else { continue }
+            // The default "All" chip is pre-selected and carries no token.
+            if chip["isSelected"] as? Bool == true { continue }
+            guard let title = YouTubeItemParser.text(from: chip["text"]),
+                  let continuation = (
+                      (chip["navigationEndpoint"] as? [String: Any])?["continuationCommand"]
+                          as? [String: Any]
+                  )?["token"] as? String,
+                  !continuation.isEmpty,
+                  seen.insert(title).inserted
+            else {
+                continue
+            }
+            result.append(YouTubeHomeChip(title: title, continuation: continuation))
+        }
+        return result
+    }
+
+    /// Parses the titled shelves the home response itself returns (e.g.
+    /// "Breaking news"), preserving each shelf's title and videos. Loose
+    /// recommendation items and Shorts shelves are ignored here (they belong
+    /// to the flat grid / Shorts surface respectively).
+    ///
+    /// Path: `…richGridRenderer.contents[].richSectionRenderer.content`
+    /// `.richShelfRenderer{ title, contents[] }`.
+    static func parseHomeShelves(_ data: [String: Any]) -> [YouTubeHomeSection] {
+        guard let contents = richGridContents(data) else { return [] }
+
+        var sections: [YouTubeHomeSection] = []
+        var index = 0
+        for entry in contents {
+            guard let section = entry["richSectionRenderer"] as? [String: Any],
+                  let content = section["content"] as? [String: Any],
+                  let shelf = content["richShelfRenderer"] as? [String: Any],
+                  let title = YouTubeItemParser.text(from: shelf["title"])
+            else {
+                continue
+            }
+
+            var videos: [YouTubeVideo] = []
+            var shorts: [YouTubeVideo] = []
+            var continuation: String?
+            Self.collect(in: shelf["contents"] as Any, videos: &videos, shorts: &shorts, continuation: &continuation)
+            let deduped = Self.deduplicate(videos)
+            guard !deduped.isEmpty else { continue }
+
+            index += 1
+            sections.append(YouTubeHomeSection(
+                id: "shelf-\(index)-\(title)",
+                title: title,
+                videos: deduped,
+                kind: .shelf
+            ))
+        }
+        return sections
+    }
+
+    /// `richGridRenderer.contents` from a home browse response, if present.
+    private static func richGridContents(_ data: [String: Any]) -> [[String: Any]]? {
+        self.richGridRenderer(data)?["contents"] as? [[String: Any]]
+    }
+
+    /// `feedFilterChipBarRenderer.contents` from a home browse response.
+    private static func chipBarContents(_ data: [String: Any]) -> [[String: Any]]? {
+        guard let header = richGridRenderer(data)?["header"] as? [String: Any],
+              let bar = header["feedFilterChipBarRenderer"] as? [String: Any]
+        else {
+            return nil
+        }
+        return bar["contents"] as? [[String: Any]]
+    }
+
+    /// Navigates to the home `richGridRenderer`
+    /// (`contents.twoColumnBrowseResultsRenderer.tabs[].tabRenderer.content`).
+    private static func richGridRenderer(_ data: [String: Any]) -> [String: Any]? {
+        let tabs = (
+            (data["contents"] as? [String: Any])?["twoColumnBrowseResultsRenderer"]
+                as? [String: Any]
+        )?["tabs"] as? [[String: Any]] ?? []
+
+        for tab in tabs {
+            guard let tabRenderer = tab["tabRenderer"] as? [String: Any],
+                  let content = tabRenderer["content"] as? [String: Any],
+                  let grid = content["richGridRenderer"] as? [String: Any]
+            else {
+                continue
+            }
+            return grid
+        }
+        return nil
+    }
+
     // MARK: - Collection
 
     /// Recursively collects regular videos and the first continuation token,

--- a/Sources/Kaset/Services/API/YouTubeClient.swift
+++ b/Sources/Kaset/Services/API/YouTubeClient.swift
@@ -105,6 +105,39 @@ final class YouTubeClient: YouTubeClientProtocol {
         return feed
     }
 
+    func getHomeChips() async throws -> [YouTubeHomeChip] {
+        // Chips ride along in the home feed response; the shared TTL means this
+        // is a cache hit right after the home grid loads (cf. getShorts()).
+        let data = try await self.request(
+            "browse",
+            body: ["browseId": "FEwhat_to_watch"],
+            ttl: APICache.TTL.home
+        )
+        let chips = YouTubeFeedParser.parseChips(data)
+        self.logger.info("YouTube home chips: \(chips.count) topics")
+        return chips
+    }
+
+    func getHomeShelves() async throws -> [YouTubeHomeSection] {
+        // Same cached home response; extracts the response's own titled shelves.
+        let data = try await self.request(
+            "browse",
+            body: ["browseId": "FEwhat_to_watch"],
+            ttl: APICache.TTL.home
+        )
+        let shelves = YouTubeFeedParser.parseHomeShelves(data)
+        self.logger.info("YouTube home shelves: \(shelves.count)")
+        return shelves
+    }
+
+    func getHomeTopicFeed(continuation: String) async throws -> YouTubeFeed {
+        // A chip browse uses the same `browse` continuation wire shape as
+        // pagination, but returns a fresh topic-filtered grid (reload
+        // semantics) with its own trailing continuation token.
+        let data = try await self.request("browse", body: ["continuation": continuation])
+        return YouTubeFeedParser.parseContinuation(data)
+    }
+
     // MARK: - Search
 
     func search(query: String, filter: YouTubeSearchFilter) async throws -> YouTubeSearchResponse {

--- a/Sources/Kaset/Services/YouTubeProtocols.swift
+++ b/Sources/Kaset/Services/YouTubeProtocols.swift
@@ -20,6 +20,18 @@ protocol YouTubeClientProtocol: Sendable {
     /// Whether more home feed pages are available.
     var hasMoreHomeFeed: Bool { get }
 
+    /// Fetches the personalized filter-chip topics from the home feed
+    /// (Gaming, Music, AI, …), each browsable into a topic-filtered rail.
+    func getHomeChips() async throws -> [YouTubeHomeChip]
+
+    /// Fetches the titled shelves the home response itself returns (e.g.
+    /// "Breaking news"), preserving each shelf's title and videos.
+    func getHomeShelves() async throws -> [YouTubeHomeSection]
+
+    /// Browses a home filter chip's continuation token into a personalized,
+    /// topic-filtered feed for a home rail.
+    func getHomeTopicFeed(continuation: String) async throws -> YouTubeFeed
+
     // MARK: Search
 
     /// Searches YouTube with an optional result-kind filter.

--- a/Sources/Kaset/ViewModels/YouTube/YouTubeHomeViewModel.swift
+++ b/Sources/Kaset/ViewModels/YouTube/YouTubeHomeViewModel.swift
@@ -8,11 +8,24 @@ final class YouTubeHomeViewModel {
     /// Current loading state.
     private(set) var loadingState: LoadingState = .idle
 
+    /// Personalized side-scrolling sections shown above the recommendation
+    /// grid: Continue Watching, the home response's own titled shelves, then a
+    /// rail per personalized filter-chip topic. Empty until loaded.
+    private(set) var sections: [YouTubeHomeSection] = []
+
     /// Videos to display in the feed grid.
     private(set) var videos: [YouTubeVideo] = []
 
     /// Whether more feed pages are available.
     private(set) var hasMoreVideos = true
+
+    /// Resume-progress band for the Continue Watching rail: started but not
+    /// effectively finished. `nil`/0 = not started; ≥96 = finished.
+    private static let continueWatchingRange = 1 ... 95
+
+    /// Cap on Continue Watching items and on topic rails shown at first paint.
+    private static let continueWatchingCap = 20
+    private static let topicRailCap = 8
 
     /// Invalidates stale in-flight loads when a newer one starts
     /// (SwiftUI restarts .task during launch/layout churn; latest wins).
@@ -31,11 +44,57 @@ final class YouTubeHomeViewModel {
         let generation = self.loadGeneration
         self.loadingState = .loading
         do {
+            // Continue Watching reads history (a different endpoint), so start
+            // it concurrently with the home feed. Chips and shelves come from
+            // the SAME `FEwhat_to_watch` response, so await the home feed first
+            // to warm the cache, then read them as cache hits rather than
+            // racing three identical network requests.
+            async let continueWatching = self.continueWatchingSection()
             let feed = try await client.getHomeFeed()
+
             guard generation == self.loadGeneration else { return }
+            // Publish the recommendation grid immediately so first paint does
+            // not wait on the optional rails (topic chips fan out to several
+            // browse requests; a slow one must not block the grid). When the
+            // grid is empty, the rails are the only content worth showing, so
+            // keep the loading state until they resolve to avoid flashing the
+            // empty placeholder.
             self.videos = feed.videos
             self.hasMoreVideos = self.client.hasMoreHomeFeed
-            self.loadingState = .loaded
+            let gridReady = !feed.videos.isEmpty
+            if gridReady {
+                // Publish the new grid with a cleared rail set so a reload (a
+                // `.task` restart after a prior load) never renders the previous
+                // load's Continue Watching/topic rails above the fresh grid
+                // while the new rail fetches are still in flight. The new rails
+                // populate below once they resolve.
+                self.sections = []
+                self.loadingState = .loaded
+            }
+
+            async let shelves = self.shelfSections()
+            async let topics = self.topicSections()
+
+            var sections: [YouTubeHomeSection] = []
+            if let continueWatching = await continueWatching {
+                sections.append(continueWatching)
+            }
+            await sections.append(contentsOf: shelves)
+            await sections.append(contentsOf: topics)
+
+            // The section helpers isolate per-rail failures by resolving to
+            // empty rather than throwing — including when a cancelled `.task`
+            // makes their requests fail. Surface that cancellation here so a
+            // cancelled load aborts instead of publishing empty rails (or
+            // marking an empty grid `.loaded`) as if it had succeeded.
+            try Task.checkCancellation()
+            guard generation == self.loadGeneration else { return }
+            self.sections = sections
+            // Only flip the state here when the grid did not already publish it,
+            // so a concurrent loadMore()'s `.loadingMore` is not clobbered.
+            if !gridReady {
+                self.loadingState = .loaded
+            }
         } catch {
             guard generation == self.loadGeneration else { return }
             // A cancelled load (view went away mid-flight) is not an
@@ -53,6 +112,7 @@ final class YouTubeHomeViewModel {
     func refresh() async {
         self.loadingState = .idle
         self.videos = []
+        self.sections = []
         await self.load()
     }
 
@@ -80,6 +140,105 @@ final class YouTubeHomeViewModel {
             // Keep existing content; just stop paginating on error.
             self.loadingState = .loaded
             self.hasMoreVideos = false
+        }
+    }
+
+    // MARK: - Sections
+
+    /// Started-but-unfinished videos from watch history (deduped, capped).
+    private func continueWatchingSection() async -> YouTubeHomeSection? {
+        do {
+            let history = try await self.client.getHistory()
+            var seen = Set<String>()
+            let resumable = history.videos.filter { video in
+                guard let percent = video.watchedPercent,
+                      Self.continueWatchingRange.contains(percent),
+                      !video.isShort,
+                      !video.isLive
+                else {
+                    return false
+                }
+                return seen.insert(video.videoId).inserted
+            }
+            .prefix(Self.continueWatchingCap)
+
+            guard !resumable.isEmpty else { return nil }
+            return YouTubeHomeSection(
+                id: "continue-watching",
+                title: String(localized: "Continue Watching", comment: "YouTube home rail of partially-watched videos"),
+                videos: Array(resumable),
+                kind: .continueWatching
+            )
+        } catch {
+            if !(error is CancellationError) {
+                self.logger.error("Continue Watching unavailable: \(error.localizedDescription)")
+            }
+            return nil
+        }
+    }
+
+    /// The home response's own titled shelves (e.g. "Breaking news").
+    private func shelfSections() async -> [YouTubeHomeSection] {
+        do {
+            return try await self.client.getHomeShelves()
+        } catch {
+            if !(error is CancellationError) {
+                self.logger.error("Home shelves unavailable: \(error.localizedDescription)")
+            }
+            return []
+        }
+    }
+
+    /// One rail per personalized filter-chip topic, fetched concurrently and
+    /// returned in chip order. Empty topic feeds are dropped.
+    private func topicSections() async -> [YouTubeHomeSection] {
+        let chips: [YouTubeHomeChip]
+        do {
+            chips = try await Array(self.client.getHomeChips().prefix(Self.topicRailCap))
+        } catch {
+            if !(error is CancellationError) {
+                self.logger.error("Home chips unavailable: \(error.localizedDescription)")
+            }
+            return []
+        }
+        guard !chips.isEmpty else { return [] }
+
+        // Fetch all topic feeds concurrently, preserving chip order via index.
+        let indexed = await withTaskGroup(of: (Int, YouTubeHomeSection?).self) { group in
+            for (index, chip) in chips.enumerated() {
+                group.addTask {
+                    await (index, self.topicSection(for: chip))
+                }
+            }
+            var collected: [(Int, YouTubeHomeSection?)] = []
+            for await result in group {
+                collected.append(result)
+            }
+            return collected
+        }
+
+        return indexed
+            .sorted { $0.0 < $1.0 }
+            .compactMap(\.1)
+    }
+
+    /// Browses a single chip token into a topic section, or `nil` on
+    /// failure / empty result.
+    private func topicSection(for chip: YouTubeHomeChip) async -> YouTubeHomeSection? {
+        do {
+            let feed = try await self.client.getHomeTopicFeed(continuation: chip.continuation)
+            guard !feed.videos.isEmpty else { return nil }
+            return YouTubeHomeSection(
+                id: "topic-\(chip.title)",
+                title: chip.title,
+                videos: feed.videos,
+                kind: .topic
+            )
+        } catch {
+            if !(error is CancellationError) {
+                self.logger.error("Topic rail '\(chip.title)' unavailable: \(error.localizedDescription)")
+            }
+            return nil
         }
     }
 }

--- a/Sources/Kaset/ViewModels/YouTube/YouTubeHomeViewModel.swift
+++ b/Sources/Kaset/ViewModels/YouTube/YouTubeHomeViewModel.swift
@@ -32,6 +32,11 @@ final class YouTubeHomeViewModel {
     private static let continueWatchingCap = 20
     private static let topicRailCap = 8
 
+    /// Backstop on how many fully-filtered continuation pages `loadMore()` will
+    /// walk in one call before giving up, so a pathological feed (every page's
+    /// videos already shown) can't spin indefinitely.
+    private static let maxEmptyContinuationPages = 5
+
     /// Invalidates stale in-flight loads when a newer one starts
     /// (SwiftUI restarts .task during launch/layout churn; latest wins).
     private var loadGeneration = 0
@@ -143,7 +148,17 @@ final class YouTubeHomeViewModel {
 
         self.loadingState = .loadingMore
         do {
-            if let feed = try await client.getHomeFeedContinuation() {
+            // A continuation page can filter to nothing (all its videos already
+            // appear in the grid or in a shelf rail) while more pages remain.
+            // The only pagination trigger is the grid's `ProgressView` sentinel,
+            // which won't re-fire if nothing was appended — so keep fetching
+            // until at least one new video lands or the feed is exhausted. The
+            // bound is a defensive backstop against a pathological feed.
+            for _ in 0 ..< Self.maxEmptyContinuationPages {
+                guard let feed = try await client.getHomeFeedContinuation() else {
+                    self.hasMoreVideos = false
+                    break
+                }
                 var existing = Set(self.videos.map(\.videoId))
                 // Skip videos already in the grid and any that belong to a
                 // titled shelf rail (consistent with the first page).
@@ -152,8 +167,11 @@ final class YouTubeHomeViewModel {
                 }
                 self.videos.append(contentsOf: newVideos)
                 self.hasMoreVideos = self.client.hasMoreHomeFeed
-            } else {
-                self.hasMoreVideos = false
+                // Stop once this page added something, or there is nothing left
+                // to try (a fully-filtered page with no further continuation).
+                if !newVideos.isEmpty || !self.hasMoreVideos {
+                    break
+                }
             }
             self.loadingState = .loaded
         } catch {

--- a/Sources/Kaset/ViewModels/YouTube/YouTubeHomeViewModel.swift
+++ b/Sources/Kaset/ViewModels/YouTube/YouTubeHomeViewModel.swift
@@ -52,16 +52,33 @@ final class YouTubeHomeViewModel {
             async let continueWatching = self.continueWatchingSection()
             let feed = try await client.getHomeFeed()
 
+            // Shelves and topics both read the now-cached home response for
+            // their chip/shelf data; their topic browses (slow) fan out from
+            // there. Shelves are a cache hit, so awaiting them before first
+            // paint is cheap and lets us de-duplicate the grid (below).
+            async let shelvesTask = self.shelfSections()
+            async let topics = self.topicSections()
+            let shelves = await shelvesTask
+
+            try Task.checkCancellation()
             guard generation == self.loadGeneration else { return }
+
+            // `YouTubeFeedParser.parse` collects shelf videos into `feed.videos`
+            // too, and the shelf rail surfaces them again — exclude shelf video
+            // IDs from the grid so a shelf video is not rendered twice (once in
+            // its rail, once under "For you").
+            let shelfVideoIDs = Set(shelves.flatMap { section in section.videos.map(\.videoId) })
+            let gridVideos = feed.videos.filter { !shelfVideoIDs.contains($0.videoId) }
+
             // Publish the recommendation grid immediately so first paint does
-            // not wait on the optional rails (topic chips fan out to several
+            // not wait on the optional topic rails (chips fan out to several
             // browse requests; a slow one must not block the grid). When the
             // grid is empty, the rails are the only content worth showing, so
             // keep the loading state until they resolve to avoid flashing the
             // empty placeholder.
-            self.videos = feed.videos
+            self.videos = gridVideos
             self.hasMoreVideos = self.client.hasMoreHomeFeed
-            let gridReady = !feed.videos.isEmpty
+            let gridReady = !gridVideos.isEmpty
             if gridReady {
                 // Publish the new grid with a cleared rail set so a reload (a
                 // `.task` restart after a prior load) never renders the previous
@@ -72,14 +89,11 @@ final class YouTubeHomeViewModel {
                 self.loadingState = .loaded
             }
 
-            async let shelves = self.shelfSections()
-            async let topics = self.topicSections()
-
             var sections: [YouTubeHomeSection] = []
             if let continueWatching = await continueWatching {
                 sections.append(continueWatching)
             }
-            await sections.append(contentsOf: shelves)
+            sections.append(contentsOf: shelves)
             await sections.append(contentsOf: topics)
 
             // The section helpers isolate per-rail failures by resolving to

--- a/Sources/Kaset/ViewModels/YouTube/YouTubeHomeViewModel.swift
+++ b/Sources/Kaset/ViewModels/YouTube/YouTubeHomeViewModel.swift
@@ -19,6 +19,11 @@ final class YouTubeHomeViewModel {
     /// Whether more feed pages are available.
     private(set) var hasMoreVideos = true
 
+    /// Video IDs already surfaced in titled shelf rails, excluded from the flat
+    /// "For you" grid (including continuation pages) so a shelf video is never
+    /// rendered twice.
+    private var shelfVideoIDs: Set<String> = []
+
     /// Resume-progress band for the Continue Watching rail: started but not
     /// effectively finished. `nil`/0 = not started; ≥96 = finished.
     private static let continueWatchingRange = 1 ... 95
@@ -66,9 +71,10 @@ final class YouTubeHomeViewModel {
             // `YouTubeFeedParser.parse` collects shelf videos into `feed.videos`
             // too, and the shelf rail surfaces them again — exclude shelf video
             // IDs from the grid so a shelf video is not rendered twice (once in
-            // its rail, once under "For you").
-            let shelfVideoIDs = Set(shelves.flatMap { section in section.videos.map(\.videoId) })
-            let gridVideos = feed.videos.filter { !shelfVideoIDs.contains($0.videoId) }
+            // its rail, once under "For you"). Stored so continuation pages
+            // apply the same filter.
+            self.shelfVideoIDs = Set(shelves.flatMap { section in section.videos.map(\.videoId) })
+            let gridVideos = feed.videos.filter { !self.shelfVideoIDs.contains($0.videoId) }
 
             // Publish the recommendation grid immediately so first paint does
             // not wait on the optional topic rails (chips fan out to several
@@ -127,6 +133,7 @@ final class YouTubeHomeViewModel {
         self.loadingState = .idle
         self.videos = []
         self.sections = []
+        self.shelfVideoIDs = []
         await self.load()
     }
 
@@ -137,8 +144,13 @@ final class YouTubeHomeViewModel {
         self.loadingState = .loadingMore
         do {
             if let feed = try await client.getHomeFeedContinuation() {
-                let existing = Set(self.videos.map(\.videoId))
-                self.videos.append(contentsOf: feed.videos.filter { !existing.contains($0.videoId) })
+                var existing = Set(self.videos.map(\.videoId))
+                // Skip videos already in the grid and any that belong to a
+                // titled shelf rail (consistent with the first page).
+                let newVideos = feed.videos.filter { video in
+                    !self.shelfVideoIDs.contains(video.videoId) && existing.insert(video.videoId).inserted
+                }
+                self.videos.append(contentsOf: newVideos)
                 self.hasMoreVideos = self.client.hasMoreHomeFeed
             } else {
                 self.hasMoreVideos = false

--- a/Sources/Kaset/Views/YouTube/YouTubeHomeView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeHomeView.swift
@@ -26,13 +26,20 @@ struct YouTubeHomeView: View {
                     }
                 }
             case .loaded, .loadingMore:
-                if self.viewModel.sections.isEmpty, self.viewModel.videos.isEmpty {
+                if self.viewModel.sections.isEmpty,
+                   self.viewModel.videos.isEmpty,
+                   !self.viewModel.hasMoreVideos
+                {
                     ContentUnavailableView {
                         Label(String(localized: "No recommendations yet"), systemImage: "play.rectangle")
                     } description: {
                         Text("Watch some videos to build your feed.", comment: "Empty YouTube home feed description")
                     }
                 } else {
+                    // Route to feedContent when there is anything to show OR more
+                    // pages remain — feedContent hosts the pagination sentinel,
+                    // which must mount so loadMore() can fetch the next page even
+                    // when the first render has no renderable rails/videos yet.
                     self.feedContent
                 }
             }

--- a/Sources/Kaset/Views/YouTube/YouTubeHomeView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeHomeView.swift
@@ -55,7 +55,12 @@ struct YouTubeHomeView: View {
                     self.sectionRail(section)
                 }
 
-                if !self.viewModel.videos.isEmpty {
+                // Render the grid whenever there are flat videos OR more pages
+                // to fetch. The pagination sentinel lives inside the grid, so
+                // gating the whole grid on a non-empty `videos` would strand the
+                // continuation when the first page's flat videos are all shelf
+                // videos (filtered out) but more pages remain.
+                if !self.viewModel.videos.isEmpty || self.viewModel.hasMoreVideos {
                     self.forYouGrid
                 }
             }
@@ -88,7 +93,10 @@ struct YouTubeHomeView: View {
     /// The flat "For you" recommendation grid with infinite-scroll pagination.
     private var forYouGrid: some View {
         VStack(alignment: .leading, spacing: 12) {
-            if !self.viewModel.sections.isEmpty {
+            // Show the heading only when there are rails above it AND grid
+            // videos to label; an empty grid (just the pagination sentinel)
+            // should not show a dangling "For you" title.
+            if !self.viewModel.sections.isEmpty, !self.viewModel.videos.isEmpty {
                 Text("For you", comment: "YouTube home recommendation grid heading")
                     .font(.title2)
                     .fontWeight(.semibold)

--- a/Sources/Kaset/Views/YouTube/YouTubeHomeView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeHomeView.swift
@@ -26,14 +26,14 @@ struct YouTubeHomeView: View {
                     }
                 }
             case .loaded, .loadingMore:
-                if self.viewModel.videos.isEmpty {
+                if self.viewModel.sections.isEmpty, self.viewModel.videos.isEmpty {
                     ContentUnavailableView {
                         Label(String(localized: "No recommendations yet"), systemImage: "play.rectangle")
                     } description: {
                         Text("Watch some videos to build your feed.", comment: "Empty YouTube home feed description")
                     }
                 } else {
-                    self.feedGrid
+                    self.feedContent
                 }
             }
         }
@@ -44,8 +44,57 @@ struct YouTubeHomeView: View {
         }
     }
 
-    private var feedGrid: some View {
+    /// Personalized rails (Continue Watching, shelves, topics) stacked above
+    /// the "For you" recommendation grid. The ScrollView track stays
+    /// edge-to-edge so rails slide under the floating glass sidebar; each rail
+    /// and the grid restore their own resting inset.
+    private var feedContent: some View {
         ScrollView {
+            LazyVStack(alignment: .leading, spacing: 32) {
+                ForEach(self.viewModel.sections) { section in
+                    self.sectionRail(section)
+                }
+
+                if !self.viewModel.videos.isEmpty {
+                    self.forYouGrid
+                }
+            }
+            .padding(.vertical, 20)
+        }
+    }
+
+    /// A single horizontal rail of video cards with a title header.
+    private func sectionRail(_ section: YouTubeHomeSection) -> some View {
+        CarouselShelfSection(
+            accessibilityLabel: section.title,
+            items: section.videos,
+            itemAlignment: .top,
+            contentInset: DetailContentLayout.horizontalInset
+        ) {
+            Text(section.title)
+                .font(.title2)
+                .fontWeight(.semibold)
+        } itemContent: { video in
+            NavigationLink(value: YouTubeRoute.watch(video)) {
+                // VideoCard has no intrinsic width; pin it for the horizontal
+                // LazyHStack (matches the music video card width).
+                VideoCard(video: video)
+                    .frame(width: 284)
+            }
+            .buttonStyle(.interactiveCard)
+        }
+    }
+
+    /// The flat "For you" recommendation grid with infinite-scroll pagination.
+    private var forYouGrid: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if !self.viewModel.sections.isEmpty {
+                Text("For you", comment: "YouTube home recommendation grid heading")
+                    .font(.title2)
+                    .fontWeight(.semibold)
+                    .padding(.horizontal, DetailContentLayout.horizontalInset)
+            }
+
             LazyVGrid(columns: Self.columns, spacing: 20) {
                 ForEach(self.viewModel.videos) { video in
                     NavigationLink(value: YouTubeRoute.watch(video)) {
@@ -63,11 +112,10 @@ struct YouTubeHomeView: View {
                         }
                 }
             }
-            .padding(.vertical, 20)
+            // Vertical grid insets its resting content; rails above keep their
+            // own edge-to-edge track so they slide under the glass sidebar.
+            .padding(.horizontal, DetailContentLayout.horizontalInset)
         }
-        // Edge-to-edge with a resting inset so the grid extends under the
-        // floating glass sidebar.
-        .contentMargins(.horizontal, DetailContentLayout.horizontalInset, for: .scrollContent)
     }
 
     private var loadingGrid: some View {

--- a/Tests/KasetTests/Helpers/MockYouTubeClient.swift
+++ b/Tests/KasetTests/Helpers/MockYouTubeClient.swift
@@ -31,8 +31,19 @@ final class MockYouTubeClient: YouTubeClientProtocol {
     private(set) var lastSearchFilter: YouTubeSearchFilter?
 
     var hasMoreHomeFeed: Bool {
-        self.homeFeedContinuation != nil
+        // When a multi-page queue is configured it drives "has more"; otherwise
+        // fall back to the single-page `homeFeedContinuation`.
+        if !self.homeContinuationPages.isEmpty {
+            return true
+        }
+        return self.homeFeedContinuation != nil
     }
+
+    /// Optional queue of continuation pages, consumed front-to-back by
+    /// `getHomeFeedContinuation()`. Takes precedence over the single-page
+    /// `homeFeedContinuation` when non-empty. Lets tests exercise multi-page
+    /// pagination (e.g. a fully-filtered page followed by a page with videos).
+    var homeContinuationPages: [YouTubeFeed] = []
 
     // MARK: - YouTubeClientProtocol
 
@@ -44,6 +55,9 @@ final class MockYouTubeClient: YouTubeClientProtocol {
 
     func getHomeFeedContinuation() async throws -> YouTubeFeed? {
         if let error { throw error }
+        if !self.homeContinuationPages.isEmpty {
+            return self.homeContinuationPages.removeFirst()
+        }
         let continuation = self.homeFeedContinuation
         self.homeFeedContinuation = nil
         return continuation

--- a/Tests/KasetTests/Helpers/MockYouTubeClient.swift
+++ b/Tests/KasetTests/Helpers/MockYouTubeClient.swift
@@ -8,6 +8,12 @@ final class MockYouTubeClient: YouTubeClientProtocol {
 
     var homeFeed = YouTubeFeed.empty
     var homeFeedContinuation: YouTubeFeed?
+    var homeChips: [YouTubeHomeChip] = []
+    var homeShelves: [YouTubeHomeSection] = []
+    /// Topic feeds keyed by chip continuation; `getHomeTopicFeed` returns the
+    /// match (or `.empty`). Set `homeTopicError` to make one continuation throw.
+    var homeTopicFeeds: [String: YouTubeFeed] = [:]
+    var homeTopicError: (continuation: String, error: Error)?
     var searchResponse = YouTubeSearchResponse.empty
     var searchContinuation: YouTubeSearchResponse?
     var watchNextData = WatchNextData.empty
@@ -41,6 +47,37 @@ final class MockYouTubeClient: YouTubeClientProtocol {
         let continuation = self.homeFeedContinuation
         self.homeFeedContinuation = nil
         return continuation
+    }
+
+    private(set) var homeChipsCallCount = 0
+    private(set) var requestedTopicContinuations: [String] = []
+
+    func getHomeChips() async throws -> [YouTubeHomeChip] {
+        if let error { throw error }
+        self.homeChipsCallCount += 1
+        return self.homeChips
+    }
+
+    func getHomeShelves() async throws -> [YouTubeHomeSection] {
+        if let error { throw error }
+        return self.homeShelves
+    }
+
+    /// Awaited inside `getHomeTopicFeed` before it returns, so a test can hold
+    /// a topic rail open and observe that the home grid already rendered
+    /// without waiting on the rail. Receives the chip continuation.
+    var beforeTopicReturn: (@Sendable (String) async -> Void)?
+
+    func getHomeTopicFeed(continuation: String) async throws -> YouTubeFeed {
+        if let error { throw error }
+        self.requestedTopicContinuations.append(continuation)
+        if let beforeTopicReturn {
+            await beforeTopicReturn(continuation)
+        }
+        if let homeTopicError, homeTopicError.continuation == continuation {
+            throw homeTopicError.error
+        }
+        return self.homeTopicFeeds[continuation] ?? .empty
     }
 
     func search(query: String, filter: YouTubeSearchFilter) async throws -> YouTubeSearchResponse {
@@ -181,16 +218,22 @@ final class MockYouTubeClient: YouTubeClientProtocol {
     nonisolated static func makeVideo(
         videoId: String = "test-video",
         title: String = "Test Video",
-        channelName: String = "Test Channel"
+        channelName: String = "Test Channel",
+        isLive: Bool = false,
+        isShort: Bool = false,
+        watchedPercent: Int? = nil
     ) -> YouTubeVideo {
         YouTubeVideo(
             videoId: videoId,
             title: title,
             channelName: channelName,
             channelId: "UCtest",
-            lengthText: "10:00",
+            lengthText: isLive ? nil : "10:00",
             viewCountText: "1K views",
-            publishedText: "1 day ago"
+            publishedText: "1 day ago",
+            isLive: isLive,
+            isShort: isShort,
+            watchedPercent: watchedPercent
         )
     }
 

--- a/Tests/KasetTests/YouTubeHomeViewModelTests.swift
+++ b/Tests/KasetTests/YouTubeHomeViewModelTests.swift
@@ -2,6 +2,8 @@ import Foundation
 import Testing
 @testable import Kaset
 
+// MARK: - YouTubeHomeViewModelTests
+
 @Suite("YouTubeHomeViewModel", .serialized, .tags(.viewModel), .timeLimit(.minutes(1)))
 @MainActor
 struct YouTubeHomeViewModelTests {
@@ -83,5 +85,242 @@ struct YouTubeHomeViewModelTests {
 
         #expect(self.mockClient.homeFeedCallCount == 2)
         #expect(self.sut.loadingState == .loaded)
+    }
+
+    // MARK: - Sections
+
+    @Test("Continue Watching keeps only videos started but not finished")
+    func continueWatchingFiltersByProgress() async {
+        self.mockClient.historyFeed = YouTubeFeed(
+            videos: [
+                MockYouTubeClient.makeVideo(videoId: "started", watchedPercent: 40),
+                MockYouTubeClient.makeVideo(videoId: "edge-1", watchedPercent: 1),
+                MockYouTubeClient.makeVideo(videoId: "edge-95", watchedPercent: 95),
+                MockYouTubeClient.makeVideo(videoId: "finished", watchedPercent: 96),
+                MockYouTubeClient.makeVideo(videoId: "fully", watchedPercent: 100),
+                MockYouTubeClient.makeVideo(videoId: "not-started", watchedPercent: nil),
+                MockYouTubeClient.makeVideo(videoId: "zero", watchedPercent: 0),
+                MockYouTubeClient.makeVideo(videoId: "short", isShort: true, watchedPercent: 50),
+                MockYouTubeClient.makeVideo(videoId: "live", isLive: true, watchedPercent: 50),
+            ],
+            continuation: nil
+        )
+
+        await self.sut.load()
+
+        let section = self.sut.sections.first { $0.kind == .continueWatching }
+        #expect(section != nil)
+        #expect(section?.videos.map(\.videoId) == ["started", "edge-1", "edge-95"])
+    }
+
+    @Test("Continue Watching section is omitted when nothing is resumable")
+    func continueWatchingOmittedWhenEmpty() async {
+        self.mockClient.historyFeed = YouTubeFeed(
+            videos: [MockYouTubeClient.makeVideo(videoId: "finished", watchedPercent: 100)],
+            continuation: nil
+        )
+
+        await self.sut.load()
+
+        #expect(self.sut.sections.contains { $0.kind == .continueWatching } == false)
+    }
+
+    @Test("Sections are ordered: continue watching, shelves, then topics")
+    func sectionOrdering() async {
+        self.mockClient.historyFeed = YouTubeFeed(
+            videos: [MockYouTubeClient.makeVideo(videoId: "resume", watchedPercent: 30)],
+            continuation: nil
+        )
+        self.mockClient.homeShelves = [
+            YouTubeHomeSection(
+                id: "shelf-1-Breaking news",
+                title: "Breaking news",
+                videos: MockYouTubeClient.makeVideos(count: 2),
+                kind: .shelf
+            ),
+        ]
+        self.mockClient.homeChips = [
+            YouTubeHomeChip(title: "Gaming", continuation: "tok-gaming"),
+            YouTubeHomeChip(title: "Music", continuation: "tok-music"),
+        ]
+        self.mockClient.homeTopicFeeds = [
+            "tok-gaming": YouTubeFeed(videos: MockYouTubeClient.makeVideos(count: 3), continuation: nil),
+            "tok-music": YouTubeFeed(videos: MockYouTubeClient.makeVideos(count: 3), continuation: nil),
+        ]
+
+        await self.sut.load()
+
+        #expect(self.sut.sections.map(\.kind) == [.continueWatching, .shelf, .topic, .topic])
+        #expect(self.sut.sections.map(\.title) == ["Continue Watching", "Breaking news", "Gaming", "Music"])
+    }
+
+    @Test("A failing topic fetch omits only that rail")
+    func failingTopicOmitsOnlyThatRail() async {
+        self.mockClient.homeChips = [
+            YouTubeHomeChip(title: "Gaming", continuation: "tok-gaming"),
+            YouTubeHomeChip(title: "Music", continuation: "tok-music"),
+        ]
+        self.mockClient.homeTopicFeeds = [
+            "tok-music": YouTubeFeed(videos: MockYouTubeClient.makeVideos(count: 3), continuation: nil),
+        ]
+        // Gaming throws; Music succeeds. (Note: `error` on the mock is global,
+        // so use the per-continuation topic error to fail just one rail.)
+        self.mockClient.homeTopicError = (
+            continuation: "tok-gaming",
+            error: YTMusicError.networkError(underlying: URLError(.timedOut))
+        )
+
+        await self.sut.load()
+
+        let topics = self.sut.sections.filter { $0.kind == .topic }
+        #expect(topics.map(\.title) == ["Music"])
+        #expect(self.sut.loadingState == .loaded)
+    }
+
+    @Test("Empty topic feeds are dropped")
+    func emptyTopicFeedsDropped() async {
+        self.mockClient.homeChips = [YouTubeHomeChip(title: "Gaming", continuation: "tok-gaming")]
+        self.mockClient.homeTopicFeeds = ["tok-gaming": .empty]
+
+        await self.sut.load()
+
+        #expect(self.sut.sections.contains { $0.kind == .topic } == false)
+    }
+
+    @Test("Topic-only sections still load when the grid is empty")
+    func sectionsRenderWithEmptyGrid() async {
+        self.mockClient.homeFeed = .empty
+        self.mockClient.homeChips = [YouTubeHomeChip(title: "Gaming", continuation: "tok-gaming")]
+        self.mockClient.homeTopicFeeds = [
+            "tok-gaming": YouTubeFeed(videos: MockYouTubeClient.makeVideos(count: 2), continuation: nil),
+        ]
+
+        await self.sut.load()
+
+        #expect(self.sut.loadingState == .loaded)
+        #expect(self.sut.videos.isEmpty)
+        #expect(self.sut.sections.map(\.kind) == [.topic])
+    }
+
+    @Test("The recommendation grid renders without waiting on slow topic rails")
+    func gridRendersBeforeSlowRails() async {
+        self.mockClient.homeFeed = YouTubeFeed(
+            videos: MockYouTubeClient.makeVideos(count: 3),
+            continuation: nil
+        )
+        self.mockClient.homeChips = [YouTubeHomeChip(title: "Gaming", continuation: "tok-gaming")]
+        self.mockClient.homeTopicFeeds = [
+            "tok-gaming": YouTubeFeed(videos: MockYouTubeClient.makeVideos(count: 2), continuation: nil),
+        ]
+
+        // Gate the topic rail open until the test releases it, simulating a
+        // slow chip browse. The grid must publish before this resolves.
+        let gate = AsyncGate()
+        self.mockClient.beforeTopicReturn = { _ in await gate.wait() }
+
+        async let loadDone: Void = self.sut.load()
+
+        // Spin until the topic fetch is in flight (the rail is now blocked).
+        while self.mockClient.requestedTopicContinuations.isEmpty {
+            await Task.yield()
+        }
+
+        // Grid is already rendered even though the rail has not returned.
+        #expect(self.sut.loadingState == .loaded)
+        #expect(self.sut.videos.count == 3)
+        #expect(self.sut.sections.isEmpty)
+
+        // Release the rail and let load() finish; the section now appears.
+        await gate.open()
+        await loadDone
+        #expect(self.sut.sections.map(\.kind) == [.topic])
+    }
+
+    @Test("A cancelled load aborts instead of publishing empty rails")
+    func cancelledLoadAbortsRails() async {
+        // Empty grid so the worst case is exercised: a cancelled load must not
+        // mark the empty grid `.loaded` or publish empty sections.
+        self.mockClient.homeFeed = .empty
+        self.mockClient.homeChips = [YouTubeHomeChip(title: "Gaming", continuation: "tok-gaming")]
+        self.mockClient.homeTopicFeeds = [
+            "tok-gaming": YouTubeFeed(videos: MockYouTubeClient.makeVideos(count: 2), continuation: nil),
+        ]
+
+        // Hold the topic rail open until the test cancels the load.
+        let gate = AsyncGate()
+        self.mockClient.beforeTopicReturn = { _ in await gate.wait() }
+
+        let task = Task { await self.sut.load() }
+
+        // Wait until the rail fetch is in flight, then cancel mid-load.
+        while self.mockClient.requestedTopicContinuations.isEmpty {
+            await Task.yield()
+        }
+        task.cancel()
+        await gate.open()
+        await task.value
+
+        // The load was cancelled: it must reset to idle and publish nothing,
+        // rather than leaving an empty grid `.loaded` with no rails.
+        #expect(self.sut.loadingState == .idle)
+        #expect(self.sut.sections.isEmpty)
+    }
+
+    @Test("A reload clears stale rails before showing the new grid")
+    func reloadClearsStaleRailsBeforeNewGrid() async {
+        self.mockClient.homeFeed = YouTubeFeed(
+            videos: MockYouTubeClient.makeVideos(count: 3),
+            continuation: nil
+        )
+        self.mockClient.homeChips = [YouTubeHomeChip(title: "Gaming", continuation: "tok-gaming")]
+        self.mockClient.homeTopicFeeds = [
+            "tok-gaming": YouTubeFeed(videos: MockYouTubeClient.makeVideos(count: 2), continuation: nil),
+        ]
+
+        // First load fully populates a topic rail.
+        await self.sut.load()
+        #expect(self.sut.sections.map(\.kind) == [.topic])
+
+        // Second load (e.g. a `.task` restart) with the rail held open: the new
+        // grid must publish with the stale rail already cleared, not lingering.
+        let gate = AsyncGate()
+        self.mockClient.beforeTopicReturn = { _ in await gate.wait() }
+
+        async let reloadDone: Void = self.sut.load()
+        while self.mockClient.requestedTopicContinuations.count < 2 {
+            await Task.yield()
+        }
+
+        #expect(self.sut.loadingState == .loaded)
+        #expect(self.sut.videos.count == 3)
+        #expect(self.sut.sections.isEmpty) // stale rail cleared, not shown above the new grid
+
+        await gate.open()
+        await reloadDone
+        #expect(self.sut.sections.map(\.kind) == [.topic]) // fresh rail repopulates
+    }
+}
+
+// MARK: - AsyncGate
+
+/// A one-shot async gate: `wait()` suspends until `open()` is called.
+private actor AsyncGate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        if self.isOpen { return }
+        await withCheckedContinuation { continuation in
+            self.waiters.append(continuation)
+        }
+    }
+
+    func open() {
+        self.isOpen = true
+        let pending = self.waiters
+        self.waiters.removeAll()
+        for continuation in pending {
+            continuation.resume()
+        }
     }
 }

--- a/Tests/KasetTests/YouTubeHomeViewModelTests.swift
+++ b/Tests/KasetTests/YouTubeHomeViewModelTests.swift
@@ -209,6 +209,36 @@ struct YouTubeHomeViewModelTests {
         #expect(self.sut.hasMoreVideos == false)
     }
 
+    @Test("loadMore walks past a fully-filtered continuation page")
+    func loadMoreSkipsFullyFilteredPage() async {
+        let shelfVideo = MockYouTubeClient.makeVideo(videoId: "shelf-vid")
+        // Grid starts non-empty so the sentinel exists.
+        self.mockClient.homeFeed = YouTubeFeed(
+            videos: [MockYouTubeClient.makeVideo(videoId: "grid-0")],
+            continuation: "more"
+        )
+        self.mockClient.homeShelves = [
+            YouTubeHomeSection(id: "shelf-1", title: "Breaking news", videos: [shelfVideo], kind: .shelf),
+        ]
+        // Page A is entirely shelf videos (filters to nothing) but more remains;
+        // page B has a real video. A single loadMore() must reach page B rather
+        // than stalling on the empty page (the sentinel would not re-fire).
+        self.mockClient.homeContinuationPages = [
+            YouTubeFeed(videos: [shelfVideo], continuation: "still-more"),
+            YouTubeFeed(videos: [MockYouTubeClient.makeVideo(videoId: "pageB-vid")], continuation: nil),
+        ]
+
+        await self.sut.load()
+        #expect(self.sut.videos.map(\.videoId) == ["grid-0"])
+        #expect(self.sut.hasMoreVideos)
+
+        await self.sut.loadMore()
+
+        // Walked past the fully-filtered page A to surface page B's video.
+        #expect(self.sut.videos.map(\.videoId) == ["grid-0", "pageB-vid"])
+        #expect(self.sut.hasMoreVideos == false)
+    }
+
     @Test("A failing topic fetch omits only that rail")
     func failingTopicOmitsOnlyThatRail() async {
         self.mockClient.homeChips = [

--- a/Tests/KasetTests/YouTubeHomeViewModelTests.swift
+++ b/Tests/KasetTests/YouTubeHomeViewModelTests.swift
@@ -182,6 +182,33 @@ struct YouTubeHomeViewModelTests {
         #expect(shelf?.videos.map(\.videoId) == ["shelf-vid"])
     }
 
+    @Test("Pagination stays reachable when shelves empty the first grid page")
+    func paginationReachableWithEmptyGrid() async {
+        // First page: every flat video also belongs to a shelf, so the grid is
+        // empty after dedup — but a continuation exists. hasMoreVideos must stay
+        // true so the view keeps the pagination sentinel and loadMore() works.
+        let shelfVideo = MockYouTubeClient.makeVideo(videoId: "shelf-vid")
+        self.mockClient.homeFeed = YouTubeFeed(videos: [shelfVideo], continuation: "page2")
+        self.mockClient.homeShelves = [
+            YouTubeHomeSection(id: "shelf-1", title: "Breaking news", videos: [shelfVideo], kind: .shelf),
+        ]
+        // Page 2 brings a fresh grid-only video (plus a shelf dup to verify the
+        // shelf filter also applies to continuation pages).
+        self.mockClient.homeFeedContinuation = YouTubeFeed(
+            videos: [shelfVideo, MockYouTubeClient.makeVideo(videoId: "page2-vid")],
+            continuation: nil
+        )
+
+        await self.sut.load()
+        #expect(self.sut.videos.isEmpty) // first page fully filtered into the shelf
+        #expect(self.sut.hasMoreVideos) // continuation still reachable
+
+        await self.sut.loadMore()
+        // Page 2's non-shelf video appears; the shelf dup is filtered out.
+        #expect(self.sut.videos.map(\.videoId) == ["page2-vid"])
+        #expect(self.sut.hasMoreVideos == false)
+    }
+
     @Test("A failing topic fetch omits only that rail")
     func failingTopicOmitsOnlyThatRail() async {
         self.mockClient.homeChips = [

--- a/Tests/KasetTests/YouTubeHomeViewModelTests.swift
+++ b/Tests/KasetTests/YouTubeHomeViewModelTests.swift
@@ -154,6 +154,34 @@ struct YouTubeHomeViewModelTests {
         #expect(self.sut.sections.map(\.title) == ["Continue Watching", "Breaking news", "Gaming", "Music"])
     }
 
+    @Test("Shelf videos are excluded from the For You grid (no double render)")
+    func shelfVideosExcludedFromGrid() async {
+        // The parser collects shelf videos into feed.videos too; the shelf rail
+        // surfaces them again. The grid must drop the shelf videos so they are
+        // not rendered twice (once in the rail, once under "For you").
+        let shelfVideo = MockYouTubeClient.makeVideo(videoId: "shelf-vid")
+        let gridOnly = MockYouTubeClient.makeVideo(videoId: "grid-only")
+        self.mockClient.homeFeed = YouTubeFeed(
+            videos: [shelfVideo, gridOnly], // shelf-vid appears in both feed.videos and the shelf
+            continuation: nil
+        )
+        self.mockClient.homeShelves = [
+            YouTubeHomeSection(
+                id: "shelf-1-Breaking news",
+                title: "Breaking news",
+                videos: [shelfVideo],
+                kind: .shelf
+            ),
+        ]
+
+        await self.sut.load()
+
+        // Grid keeps only the non-shelf video; the shelf rail still has it.
+        #expect(self.sut.videos.map(\.videoId) == ["grid-only"])
+        let shelf = self.sut.sections.first { $0.kind == .shelf }
+        #expect(shelf?.videos.map(\.videoId) == ["shelf-vid"])
+    }
+
     @Test("A failing topic fetch omits only that rail")
     func failingTopicOmitsOnlyThatRail() async {
         self.mockClient.homeChips = [

--- a/Tests/KasetTests/YouTubeResponseParserTests.swift
+++ b/Tests/KasetTests/YouTubeResponseParserTests.swift
@@ -103,6 +103,110 @@ struct YouTubeFeedParserTests {
         let result = YouTubeFeedParser.deduplicate([video1, video2, video1])
         #expect(result.map(\.videoId) == ["a", "b"])
     }
+
+    // MARK: - Home chips & shelves
+
+    /// A chip spec for `makeHomeResponse` (struct, not a tuple, to satisfy the
+    /// large_tuple lint rule).
+    private struct ChipFixture {
+        let title: String
+        /// InnerTube continuation cursor; `nil` models the tokenless "All" chip.
+        let continuation: String?
+        let selected: Bool
+    }
+
+    /// Builds a minimal home browse response with a filter-chip bar and
+    /// optional richShelfRenderer shelves, matching the live `FEwhat_to_watch`
+    /// shape (`richGridRenderer.header.feedFilterChipBarRenderer` and
+    /// `richGridRenderer.contents[].richSectionRenderer.content.richShelfRenderer`).
+    private func makeHomeResponse(
+        chips: [ChipFixture] = [],
+        shelves: [(title: String, videoIds: [String])] = []
+    ) -> [String: Any] {
+        func chipEntry(_ chip: ChipFixture) -> [String: Any] {
+            var renderer: [String: Any] = [
+                "text": ["simpleText": chip.title],
+                "isSelected": chip.selected,
+            ]
+            if let continuation = chip.continuation {
+                renderer["navigationEndpoint"] = [
+                    "continuationCommand": ["token": continuation],
+                ]
+            }
+            return ["chipCloudChipRenderer": renderer]
+        }
+
+        func videoRenderer(_ id: String) -> [String: Any] {
+            ["richItemRenderer": ["content": ["videoRenderer": [
+                "videoId": id,
+                "title": ["runs": [["text": "Video \(id)"]]],
+            ]]]]
+        }
+
+        func shelfEntry(_ shelf: (title: String, videoIds: [String])) -> [String: Any] {
+            ["richSectionRenderer": ["content": ["richShelfRenderer": [
+                "title": ["runs": [["text": shelf.title]]],
+                "contents": shelf.videoIds.map(videoRenderer),
+            ]]]]
+        }
+
+        return [
+            "contents": ["twoColumnBrowseResultsRenderer": ["tabs": [
+                ["tabRenderer": ["content": ["richGridRenderer": [
+                    "header": ["feedFilterChipBarRenderer": ["contents": chips.map(chipEntry)]],
+                    "contents": shelves.map(shelfEntry),
+                ]]]],
+            ]]],
+        ]
+    }
+
+    @Test("Parses filter chips and skips the selected All chip")
+    func parsesChips() {
+        let data = self.makeHomeResponse(chips: [
+            ChipFixture(title: "All", continuation: nil, selected: true),
+            ChipFixture(title: "Gaming", continuation: "tok-gaming", selected: false),
+            ChipFixture(title: "Music", continuation: "tok-music", selected: false),
+        ])
+
+        let chips = YouTubeFeedParser.parseChips(data)
+
+        #expect(chips.map(\.title) == ["Gaming", "Music"])
+        #expect(chips.map(\.continuation) == ["tok-gaming", "tok-music"])
+    }
+
+    @Test("Chips without a token are skipped")
+    func skipsTokenlessChips() {
+        let data = self.makeHomeResponse(chips: [
+            ChipFixture(title: "Gaming", continuation: "tok-gaming", selected: false),
+            ChipFixture(title: "Broken", continuation: nil, selected: false),
+        ])
+
+        let chips = YouTubeFeedParser.parseChips(data)
+
+        #expect(chips.map(\.title) == ["Gaming"])
+    }
+
+    @Test("Parses titled home shelves with their videos")
+    func parsesHomeShelves() {
+        let data = self.makeHomeResponse(shelves: [
+            (title: "Breaking news", videoIds: ["n1", "n2"]),
+        ])
+
+        let sections = YouTubeFeedParser.parseHomeShelves(data)
+
+        #expect(sections.count == 1)
+        let shelf = sections.first
+        #expect(shelf?.title == "Breaking news")
+        #expect(shelf?.kind == .shelf)
+        #expect(shelf?.videos.map(\.videoId) == ["n1", "n2"])
+    }
+
+    @Test("Empty shelves are dropped")
+    func dropsEmptyShelves() {
+        let data = self.makeHomeResponse(shelves: [(title: "Empty", videoIds: [])])
+
+        #expect(YouTubeFeedParser.parseHomeShelves(data).isEmpty)
+    }
 }
 
 // MARK: - WatchNextParserTests

--- a/docs/adr/0022-youtube-home-sections.md
+++ b/docs/adr/0022-youtube-home-sections.md
@@ -46,7 +46,7 @@ additive.**
   `parseChips` and `parseHomeShelves`, preserve the chip/shelf titles the old
   flattening walk discarded. New client methods `getHomeChips` /
   `getHomeShelves` (cache hits on the same `FEwhat_to_watch` response) and
-  `getHomeTopicFeed(token:)` (reusing `parseContinuation`) expose them. The
+  `getHomeTopicFeed(continuation:)` (reusing `parseContinuation`) expose them. The
   selected "All" chip (no token) is skipped.
 - **New models** `YouTubeHomeSection { id, title, videos, kind }` and
   `YouTubeHomeChip` live alongside the unchanged flat `YouTubeFeed`. The view

--- a/docs/adr/0022-youtube-home-sections.md
+++ b/docs/adr/0022-youtube-home-sections.md
@@ -1,0 +1,78 @@
+# ADR-0022: YouTube Home Sections — Continue Watching + Personalized Topic Rails
+
+## Status
+
+Accepted
+
+## Context
+
+The YouTube (video) Home tab rendered a single flat, vertical `LazyVGrid` of
+recommended videos. We wanted a YouTube-Music-style home: a **Continue
+Watching** rail of partially-watched videos on top, followed by several
+**side-scrolling personalized sections** with real topic labels (Gaming, AI,
+Music, …) — personalized, not arbitrary.
+
+Investigation with `api-explorer --youtube` against a signed-in account
+surfaced three facts that shaped the design:
+
+1. **`FEwhat_to_watch` is a near-flat recommendation grid.** It returns a
+   `richGridRenderer` of individual videos plus only 1–3 titled
+   `richShelfRenderer` shelves (e.g. "Breaking news"). There is **no** rich
+   set of named rails like YouTube Music's home, and **no** "Continue
+   watching" shelf.
+2. **Resume progress is per-video, not a shelf.** `YouTubeVideo.watchedPercent`
+   (0–100) is already parsed from both renderer generations and already
+   rendered as a red bar by `VideoThumbnailView`. The richest source of
+   in-progress videos is the history feed (`FEhistory`).
+3. **The home response carries a personalized filter-chip bar.** At
+   `richGridRenderer.header.feedFilterChipBarRenderer`, ~18 chips
+   (Gaming/Music/AI/News plus account-specific ones like "Bungie Inc.") each
+   carry a `navigationEndpoint.continuationCommand.token`. Browsing a chip
+   token returns a personalized, topic-filtered grid (the "Gaming" chip
+   returned 67 gaming videos, ~5/67 overlapping default home) with its own
+   pagination token. The response uses `reloadContinuationItemsCommand`, which
+   `YouTubeFeedParser.parseContinuation` already handles.
+
+## Decision
+
+**Synthesize the sections client-side from existing endpoints; keep the change
+additive.**
+
+- **Continue Watching** is `getHistory().videos` filtered to
+  `watchedPercent ∈ 1…95` (started, not effectively finished), excluding
+  Shorts and live, deduped and capped. No new endpoint, no persistence — the
+  history feed is the source of truth.
+- **Topic rails** come from the home chip bar. Two new parser entry points,
+  `parseChips` and `parseHomeShelves`, preserve the chip/shelf titles the old
+  flattening walk discarded. New client methods `getHomeChips` /
+  `getHomeShelves` (cache hits on the same `FEwhat_to_watch` response) and
+  `getHomeTopicFeed(token:)` (reusing `parseContinuation`) expose them. The
+  selected "All" chip (no token) is skipped.
+- **New models** `YouTubeHomeSection { id, title, videos, kind }` and
+  `YouTubeHomeChip` live alongside the unchanged flat `YouTubeFeed`. The view
+  model gains a `sections` array built concurrently with the existing flat
+  `videos` grid (an isolated `withTaskGroup` fetches all topic feeds in
+  parallel, preserving chip order); per-section failures are logged and the
+  section omitted, never failing the page.
+- **The view** renders `sections` as `CarouselShelfSection` rails (the same
+  generic shelf the music home uses) above the existing recommendation grid,
+  reusing `VideoCard` as-is. The grid keeps its infinite-scroll pagination.
+
+## Consequences
+
+- The existing flat home pipeline (`getHomeFeed`, `loadMore`, `videos`) and
+  its tests are untouched; the feature is purely additive, so the
+  `YouTubeClientProtocol` change is new methods only (no signature churn).
+- Topic rails depend on YouTube's chip bar, which is personalized and varies
+  per account and over time; titles are carried through verbatim rather than
+  matched against literals. Non-topic chips ("Watched", "Recently uploaded",
+  "Mixes") are kept in YouTube's own order.
+- Topic feeds re-request `FEwhat_to_watch` for chips (cache hit) then one
+  `browse` per chip — bounded to ~8 rails at first paint. Per-rail
+  continuation tokens are captured but in-rail "load more" is deferred.
+- Parser shape depends on `richGridRenderer.header.feedFilterChipBarRenderer`
+  and `richSectionRenderer.content.richShelfRenderer`; YouTube's renderer
+  migration could move these. Inline parser tests pin the confirmed shapes;
+  `api-explorer --youtube browse FEwhat_to_watch` is the re-discovery tool.
+
+See [docs/youtube.md](../youtube.md) for the full architecture.


### PR DESCRIPTION
## Summary

Restructures the YouTube (video) **Home** tab from a single flat recommendation grid into YouTube-Music-style side-scrolling sections, all sourced from **personalized** data (not random videos):

- **Continue Watching** — history videos started but not finished (`watchedPercent` 1–95, excluding Shorts/live), reusing the existing resume-bar `VideoCard`.
- **Native shelves** — titled shelves the home response itself returns (e.g. "Breaking news"), when present.
- **Topic rails** — one side-scroller per personalized home **filter chip** (Gaming, Music, AI, News, Podcasts, …), each browsing its own continuation feed. Confirmed personalized + topic-filtered via `api-explorer` (chips are derived per-account from watch history; the "Gaming" chip returned gaming-only videos largely disjoint from default home).
- **For you** — the existing recommendation grid retained as the final section, with its infinite-scroll pagination unchanged.

### How it's built (additive, low-risk)

- New `YouTubeHomeSection` / `YouTubeHomeChip` models alongside the unchanged flat `YouTubeFeed`.
- Two parser entry points — `parseChips` and `parseHomeShelves` — that preserve chip/shelf titles the previous flattening walk discarded, reusing the existing item + continuation parsing (chip feeds use `parseContinuation` as-is).
- Three client methods (`getHomeChips`, `getHomeShelves`, `getHomeTopicFeed`) that piggyback the cached `FEwhat_to_watch` response; `getHistory` is reused for Continue Watching (no new endpoint).
- Section composition in `YouTubeHomeViewModel`: rails are fetched concurrently, the recommendation grid publishes immediately (first paint never blocks on slow chip rails), task cancellation is surfaced, and stale rails are cleared on reload.
- The view reuses the generic `CarouselShelfSection` (same shelf the Music home uses) and `VideoCard`. The flat feed path, its pagination, and all prior tests are untouched. No protocol-breaking changes.

See `docs/adr/0022-youtube-home-sections.md` for the decision record.

## Test plan

- [x] `swift build` clean
- [x] `swift test --skip KasetUITests` — 1419 tests pass, incl. new coverage:
  - Continue Watching filter (1–95, excludes Shorts/live/finished/not-started)
  - section ordering (continue → shelves → topics) and per-section failure isolation
  - grid renders without waiting on slow topic rails
  - a cancelled load aborts instead of publishing empty rails
  - a reload clears stale rails before showing the new grid
  - `parseChips` / `parseHomeShelves` parsing (incl. skipping the selected "All" chip and empty shelves)
- [x] `swiftlint --strict` — 0 violations
- [x] `swiftformat .` — clean
- [x] Codex review (`$autoreview`) — clean after iterating
- [ ] Manual: open YouTube → Home; verify Continue Watching shows partially-watched videos with resume bars, topic rails are personalized and side-scroll with glass paging, and the "For you" grid still infinite-scrolls