### PR TITLE
Fix YouTube Home load (stuck skeleton, latency) + floating window drag/crash

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,14 @@ Default local workflow is CLI-first: use the commands above for day-to-day verif
 >
 > Always run `swiftformat .` before completing work to auto-fix these issues.
 
+## Debugging & Measurement
+
+> 🔬 **Measure before you fix — never guess at runtime behavior.** For any bug about *timing, lifecycle, or "why didn't this run/load/update"* (SwiftUI `.task`/state churn, cold-launch ordering, perceived latency), instrument the real code path and observe before changing anything. Reasoning about SwiftUI lifecycle or async ordering from the source alone is unreliable; a 10-line timestamped trace settles in one launch what hours of hypothesizing cannot. Add the trace → reproduce → read the evidence → fix the thing the data points at → re-measure to confirm → remove the instrumentation.
+
+> ⚠️ **The app is sandboxed — most ad-hoc logging silently fails.** `Logger`/`os_log` `.info`/`.debug` lines do **not** reliably surface in `log stream`/`log show`, and a hardcoded `/tmp/...` file write is blocked by the sandbox and fails with no error. For throwaway diagnostics, write to **`NSTemporaryDirectory()`** (the app's container tmp), `synchronize()` after each line, and read it from `~/Library/Containers/com.sertacozercan.Kaset/Data/tmp/`. Macro-level: window-screenshot automation is also unreliable here, so prefer file traces over visual capture. Always strip diagnostic instrumentation before commit.
+
+See `docs/common-bug-patterns.md` for the timestamped-trace template, the sandbox tmp path, and the single-flight load pattern that resolves the `.task`-restart cancellation deadlock.
+
 ## Continuous Review
 
 For non-trivial code changes, run `$autoreview` (`.agents/skills/autoreview/SKILL.md`) before final/commit/ship and keep going until there are no accepted/actionable findings, unless the change is trivial/docs-only, equivalent manual review already happened, or the human opts out.

--- a/Sources/Kaset/Models/YouTube/YouTubeFeed.swift
+++ b/Sources/Kaset/Models/YouTube/YouTubeFeed.swift
@@ -60,6 +60,18 @@ struct YouTubeHomeChip: Identifiable {
     let continuation: String
 }
 
+// MARK: - YouTubeHomeBundle
+
+/// The three surfaces carried by a single home `FEwhat_to_watch` response: the
+/// flat recommendation feed, the personalized filter chips, and the response's
+/// own titled shelves. Produced by one fetch + one parse pass so the ~2 MB blob
+/// is deserialized and walked once rather than three times.
+struct YouTubeHomeBundle {
+    let feed: YouTubeFeed
+    let chips: [YouTubeHomeChip]
+    let shelves: [YouTubeHomeSection]
+}
+
 // MARK: - YouTubeSearchResponse
 
 /// Results of a YouTube search, split by result kind.

--- a/Sources/Kaset/Services/API/APICache.swift
+++ b/Sources/Kaset/Services/API/APICache.swift
@@ -87,6 +87,21 @@ final class APICache {
         self.cache[key] = CacheEntry(data: data, timestamp: now, ttl: ttl)
     }
 
+    /// Key under which raw `Data` payloads are boxed inside a `CacheEntry`, so
+    /// raw-bytes caching reuses the same TTL / LRU / eviction machinery as the
+    /// deserialized-dict cache instead of a parallel store.
+    private static let rawDataBoxKey = "__APICacheRawData__"
+
+    /// Gets cached raw bytes if available and not expired.
+    func getData(key: String) -> Data? {
+        self.get(key: key)?[Self.rawDataBoxKey] as? Data
+    }
+
+    /// Stores raw bytes in the cache with the specified TTL.
+    func setData(key: String, data: Data, ttl: TimeInterval) {
+        self.set(key: key, data: [Self.rawDataBoxKey: data], ttl: ttl)
+    }
+
     private static let logger = DiagnosticsLogger.api
 
     /// Generates a stable, deterministic cache key from endpoint, request body, and brand ID.

--- a/Sources/Kaset/Services/API/APICache.swift
+++ b/Sources/Kaset/Services/API/APICache.swift
@@ -134,9 +134,17 @@ final class APICache {
         return "\(endpoint):\(hashString)"
     }
 
+    /// Monotonic counter bumped on every full invalidation (account switch,
+    /// sign-out, session expiry). Callers that fetch across an `await` can
+    /// capture it before the fetch and refuse to write a now-stale response —
+    /// e.g. bytes fetched for a user who signed out mid-flight, whose cache
+    /// scope key may be unchanged (the account-unknown `pending` scope).
+    private(set) var generation = 0
+
     /// Invalidates all cached entries.
     func invalidateAll() {
         self.cache.removeAll()
+        self.generation &+= 1
     }
 
     /// Invalidates entries matching the given prefix.

--- a/Sources/Kaset/Services/API/MockUITestYouTubeClient.swift
+++ b/Sources/Kaset/Services/API/MockUITestYouTubeClient.swift
@@ -12,6 +12,14 @@ final class MockUITestYouTubeClient: YouTubeClientProtocol {
         YouTubeFeed(videos: Self.sampleVideos, continuation: nil)
     }
 
+    func getHomeBundle() async throws -> YouTubeHomeBundle {
+        try await YouTubeHomeBundle(
+            feed: self.getHomeFeed(),
+            chips: self.getHomeChips(),
+            shelves: self.getHomeShelves()
+        )
+    }
+
     func getHomeFeedContinuation() async throws -> YouTubeFeed? {
         nil
     }

--- a/Sources/Kaset/Services/API/Parsers/YouTube/YouTubeFeedParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/YouTube/YouTubeFeedParser.swift
@@ -54,6 +54,25 @@ enum YouTubeFeedParser {
 
     // MARK: - Home Sections (Chips & Shelves)
 
+    /// One deserialize + parse of the home `FEwhat_to_watch` response into all
+    /// three of its surfaces: the flat feed, the personalized chips, and the
+    /// titled shelves. The home response carries all three, so callers fetch and
+    /// walk it once here instead of three separate `parse`/`parseChips`/
+    /// `parseHomeShelves` passes over the same ~2 MB blob.
+    ///
+    /// `Data` in, value types out — safe to run off the main actor (the
+    /// intermediate `[String: Any]` never escapes this function).
+    static func parseHomeBundle(from data: Data) throws -> YouTubeHomeBundle {
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw YTMusicError.parseError(message: "Response is not a JSON object")
+        }
+        return YouTubeHomeBundle(
+            feed: Self.parse(json),
+            chips: Self.parseChips(json),
+            shelves: Self.parseHomeShelves(json)
+        )
+    }
+
     /// Parses the home feed's personalized filter-chip bar into browsable
     /// topic chips. The selected "All" chip (which has no continuation token)
     /// is skipped so callers get only the topic rails.

--- a/Sources/Kaset/Services/API/YouTubeClient.swift
+++ b/Sources/Kaset/Services/API/YouTubeClient.swift
@@ -96,12 +96,7 @@ final class YouTubeClient: YouTubeClientProtocol {
     func getHomeBundle() async throws -> YouTubeHomeBundle {
         self.logger.info("Fetching YouTube home bundle (feed + chips + shelves)")
 
-        // Shared raw `FEwhat_to_watch` bytes (cache-read validated + cache-write
-        // after parse). Shorts reads the same bytes so the two surfaces share one
-        // cached 2 MB response.
-        let data = try await self.homeResponseData()
-        let bundle = try await Self.parseHomeBundle(from: data)
-
+        let bundle = try await self.homeBundle()
         // The detached parse is not cancelled when the Home view model is
         // discarded (account switch). Don't mutate shared client state after
         // cancellation — the providers may already have moved to the new account.
@@ -113,41 +108,39 @@ final class YouTubeClient: YouTubeClientProtocol {
         return bundle
     }
 
-    /// The raw `FEwhat_to_watch` response bytes, served from cache (after auth
-    /// validation) or fetched. Cached only after the bytes are confirmed to be a
-    /// JSON object, under a single key shared by Home and Shorts so navigating
-    /// between them reuses the same 2 MB response.
-    private func homeResponseData() async throws -> Data {
+    /// Loads + parses the shared `FEwhat_to_watch` bundle. The 2 MB deserialize
+    /// + walk always runs OFF the main actor (`parseHomeBundle` on a detached
+    /// task), which also validates the payload — it throws on non-JSON — so the
+    /// raw bytes are cached only after a successful parse, with no main-actor
+    /// deserialize and no redundant second parse. Home and Shorts share this so
+    /// the response and its cache entry are reused.
+    private func homeBundle() async throws -> YouTubeHomeBundle {
         let homeBody: [String: Any] = ["browseId": "FEwhat_to_watch"]
-        // Capture the cache key for the CURRENT (authenticated) account scope and
-        // the cache generation BEFORE any network await. If the user signs out
-        // mid-flight, recomputing the key later would resolve to the same
-        // account-unknown `pending` scope (a pending->pending transition the key
-        // comparison alone can't catch), so we also require the cache generation
-        // to be unchanged — `invalidateAll()` (account switch / sign-out /
-        // session expiry) bumps it and rejects the stale write.
+        // Capture the cache key (current authenticated scope) and the cache
+        // generation BEFORE any network await. A sign-out mid-flight keeps the
+        // `pending` key unchanged, so the generation (bumped by invalidateAll)
+        // is what rejects a stale write.
         let cacheKey = self.homeDataCacheKey(body: homeBody)
         let cacheGeneration = APICache.shared.generation
+
         if let cacheKey, let cached = try await self.cachedHomeData(key: cacheKey) {
-            return cached
+            return try await Self.parseHomeBundle(from: cached)
         }
 
         let data = try await self.requestData("browse", body: homeBody)
-        // Validate it parses BEFORE caching: a transient non-JSON 200 must not
-        // poison the 5-minute Home cache (retries/refresh would re-read the bad
-        // bytes and fail without re-fetching).
-        guard (try? JSONSerialization.jsonObject(with: data)) is [String: Any] else {
-            throw YTMusicError.parseError(message: "Home response is not a JSON object")
-        }
-        // Only write if neither the scope key NOR the cache generation changed
-        // during the fetch — i.e. no account switch / sign-out happened.
+        // Parse off-main; this throws on a non-JSON 200, so we never cache bytes
+        // that don't parse.
+        let bundle = try await Self.parseHomeBundle(from: data)
+
+        // Cache only if no account switch / sign-out happened during the fetch
+        // (key AND generation unchanged).
         if let cacheKey,
            cacheKey == self.homeDataCacheKey(body: homeBody),
            cacheGeneration == APICache.shared.generation
         {
             APICache.shared.setData(key: cacheKey, data: data, ttl: APICache.TTL.home)
         }
-        return data
+        return bundle
     }
 
     /// Off-actor parse of the home bundle, kept on a detached task so the 2 MB
@@ -322,12 +315,11 @@ final class YouTubeClient: YouTubeClientProtocol {
     func getShorts() async throws -> [YouTubeVideo] {
         self.logger.info("Fetching YouTube Shorts")
 
-        // Shorts ride along in the home `FEwhat_to_watch` response. Read the same
-        // shared raw bytes as getHomeBundle so loading one warms the other (no
-        // second 2 MB fetch when navigating Home <-> Shorts).
-        let data = try await self.homeResponseData()
-        let parsed = try await Self.parseHomeBundle(from: data)
-        return parsed.feed.shorts
+        // Shorts ride along in the home `FEwhat_to_watch` response. Share the
+        // same loader as getHomeBundle so loading one warms the other (no second
+        // 2 MB fetch/parse when navigating Home <-> Shorts).
+        let bundle = try await self.homeBundle()
+        return bundle.feed.shorts
     }
 
     // MARK: - Subscriptions & Library
@@ -488,6 +480,11 @@ final class YouTubeClient: YouTubeClientProtocol {
         fullBody["context"] = self.buildContext()
 
         let cacheKey = self.cacheKey(forEndpoint: Self.cachePrefix + endpoint, body: fullBody, ttl: ttl)
+        // Captured before the network await so a sign-out / account switch during
+        // the request rejects a stale write (e.g. an in-flight getHistory or
+        // topic-rail call whose `pending` scope key is unchanged across a nil->nil
+        // sign-out). `invalidateAll()` bumps the generation.
+        let cacheGeneration = APICache.shared.generation
 
         // Validate the current auth session before serving any cached
         // personalized YouTube response: if the cookies/SAPISID were cleared or
@@ -509,7 +506,10 @@ final class YouTubeClient: YouTubeClientProtocol {
             try await self.performRequest(endpoint, fullBody: fullBody)
         }
 
-        if let ttl, let cacheKey {
+        // Only cache if no account switch / sign-out happened during the request
+        // (the cache generation is unchanged); otherwise this could write the
+        // previous account's private data under a still-`pending` scope.
+        if let ttl, let cacheKey, cacheGeneration == APICache.shared.generation {
             APICache.shared.set(key: cacheKey, data: json, ttl: ttl)
         }
 

--- a/Sources/Kaset/Services/API/YouTubeClient.swift
+++ b/Sources/Kaset/Services/API/YouTubeClient.swift
@@ -93,6 +93,29 @@ final class YouTubeClient: YouTubeClientProtocol {
         return feed
     }
 
+    func getHomeBundle() async throws -> YouTubeHomeBundle {
+        self.logger.info("Fetching YouTube home bundle (feed + chips + shelves)")
+
+        // One request for the raw response bytes, then one deserialize + parse
+        // pass off the main actor producing all three home surfaces. Replaces
+        // three separate getHomeFeed/getHomeChips/getHomeShelves calls that each
+        // re-walked the same ~2 MB blob on the main thread.
+        let data = try await self.requestData(
+            "browse",
+            body: ["browseId": "FEwhat_to_watch"],
+            ttl: APICache.TTL.home
+        )
+        let bundle = try await Task.detached(priority: .userInitiated) {
+            try YouTubeFeedParser.parseHomeBundle(from: data)
+        }.value
+
+        self.homeContinuation = bundle.feed.continuation
+        self.logger.info(
+            "YouTube home bundle: \(bundle.feed.videos.count) videos, \(bundle.chips.count) chips, \(bundle.shelves.count) shelves"
+        )
+        return bundle
+    }
+
     func getHomeFeedContinuation() async throws -> YouTubeFeed? {
         guard let continuation = self.homeContinuation else {
             return nil
@@ -133,8 +156,15 @@ final class YouTubeClient: YouTubeClientProtocol {
     func getHomeTopicFeed(continuation: String) async throws -> YouTubeFeed {
         // A chip browse uses the same `browse` continuation wire shape as
         // pagination, but returns a fresh topic-filtered grid (reload
-        // semantics) with its own trailing continuation token.
-        let data = try await self.request("browse", body: ["continuation": continuation])
+        // semantics) with its own trailing continuation token. Cached (keyed on
+        // the continuation token via the request body) so returning to Home
+        // shows its rails immediately instead of re-fetching every topic over
+        // the network — which made the rows "snap" in well after the grid.
+        let data = try await self.request(
+            "browse",
+            body: ["continuation": continuation],
+            ttl: APICache.TTL.home
+        )
         return YouTubeFeedParser.parseContinuation(data)
     }
 
@@ -417,27 +447,14 @@ final class YouTubeClient: YouTubeClientProtocol {
         var fullBody = body
         fullBody["context"] = self.buildContext()
 
-        let brandId = self.brandIdProvider?() ?? ""
-        let accountScope = self.accountCacheIdentityProvider?()
-        let cacheKey: String? = if ttl != nil, let accountScope, !accountScope.isEmpty {
-            APICache.stableCacheKey(
-                endpoint: Self.cachePrefix + endpoint,
-                body: fullBody,
-                brandId: Self.cacheScope(accountIdentity: accountScope, brandId: brandId)
-            )
-        } else {
-            nil
-        }
+        let cacheKey = self.cacheKey(forEndpoint: Self.cachePrefix + endpoint, body: fullBody, ttl: ttl)
 
-        // Validate the current auth session before returning any cached
-        // personalized YouTube response. If the account identity is not loaded
-        // yet, skip caching rather than falling back to a generic primary scope.
-        if let cacheKey {
-            _ = try await self.buildAuthHeaders()
-            if let cached = APICache.shared.get(key: cacheKey) {
-                self.logger.debug("Cache hit for \(Self.cachePrefix)\(endpoint)")
-                return cached
-            }
+        // Check the cache BEFORE building auth headers: a warm hit should not
+        // pay the cookie-store / SAPISIDHASH cost (several WebKit cookie-store
+        // hops). Auth is still validated below before any network request.
+        if let cacheKey, let cached = APICache.shared.get(key: cacheKey) {
+            self.logger.debug("Cache hit for \(Self.cachePrefix)\(endpoint)")
+            return cached
         }
 
         let json: [String: Any] = if retry {
@@ -458,6 +475,68 @@ final class YouTubeClient: YouTubeClientProtocol {
     private static func cacheScope(accountIdentity: String, brandId: String) -> String {
         let brand = brandId.isEmpty ? "primary" : brandId
         return "account=\(accountIdentity);brand=\(brand)"
+    }
+
+    /// Stable account identity used to scope cache keys before the real account
+    /// loads. On cold launch `accountCacheIdentityProvider` is empty until
+    /// `fetchAccounts()` (a network call) resolves — previously that disabled
+    /// caching entirely, so the home feed/chips/shelves all ran as cold ~2 MB
+    /// misses. Scoping to a fixed `"pending"` identity instead lets the cold
+    /// window reuse its own responses. It cannot leak across accounts: the
+    /// `nil → resolved` account transition runs `APICache.invalidateAll()` and
+    /// rebuilds the YouTube view models (`MainWindow` account `onChange`), so the
+    /// pending entries are cleared the moment a real identity lands.
+    private static let pendingAccountScope = "pending"
+
+    /// Derives the cache key for an endpoint+body, scoping to the resolved
+    /// account identity when available and to `pendingAccountScope` otherwise.
+    /// Returns `nil` only when the call is not cacheable (`ttl == nil`).
+    private func cacheKey(forEndpoint endpoint: String, body: [String: Any], ttl: TimeInterval?) -> String? {
+        guard ttl != nil else { return nil }
+        let brandId = self.brandIdProvider?() ?? ""
+        let scopeIdentity = self.accountCacheIdentityProvider?().flatMap { $0.isEmpty ? nil : $0 }
+            ?? Self.pendingAccountScope
+        return APICache.stableCacheKey(
+            endpoint: endpoint,
+            body: body,
+            brandId: Self.cacheScope(accountIdentity: scopeIdentity, brandId: brandId)
+        )
+    }
+
+    /// Like `request()`, but returns the raw response bytes instead of a
+    /// deserialized `[String: Any]`. Used for large responses (the ~2 MB home
+    /// feed) so the caller can deserialize and parse off the main actor. The
+    /// raw `Data` is cached (keyed identically) so a warm hit skips both the
+    /// network and the main-thread deserialize.
+    private func requestData(
+        _ endpoint: String,
+        body: [String: Any],
+        ttl: TimeInterval? = nil,
+        retry: Bool = true
+    ) async throws -> Data {
+        var fullBody = body
+        fullBody["context"] = self.buildContext()
+
+        let cacheKey = self.cacheKey(forEndpoint: Self.cachePrefix + "data:" + endpoint, body: fullBody, ttl: ttl)
+
+        if let cacheKey, let cached = APICache.shared.getData(key: cacheKey) {
+            self.logger.debug("Cache hit (data) for \(Self.cachePrefix)\(endpoint)")
+            return cached
+        }
+
+        let data: Data = if retry {
+            try await RetryPolicy.default.execute { [self] in
+                try await self.performRequestData(endpoint, fullBody: fullBody)
+            }
+        } else {
+            try await self.performRequestData(endpoint, fullBody: fullBody)
+        }
+
+        if let ttl, let cacheKey {
+            APICache.shared.setData(key: cacheKey, data: data, ttl: ttl)
+        }
+
+        return data
     }
 
     /// Performs the actual network request.
@@ -493,6 +572,49 @@ final class YouTubeClient: YouTubeClientProtocol {
                 throw YTMusicError.parseError(message: "Response is not a JSON object")
             }
             return json
+        case let .authError(statusCode):
+            self.logger.error("YouTube auth error: HTTP \(statusCode)")
+            self.authService.sessionExpired()
+            throw YTMusicError.authExpired
+        case let .httpError(statusCode):
+            self.logger.error("YouTube API error: HTTP \(statusCode)")
+            throw YTMusicError.apiError(message: "HTTP \(statusCode)", code: statusCode)
+        case let .networkError(error):
+            throw YTMusicError.networkError(underlying: error)
+        }
+    }
+
+    /// Like `performRequest`, but returns the raw response bytes (no
+    /// deserialize) so the caller can parse off the main actor.
+    private func performRequestData(
+        _ endpoint: String,
+        fullBody: [String: Any]
+    ) async throws -> Data {
+        var components = URLComponents(string: "\(Self.baseURL)/\(endpoint)")
+        components?.queryItems = [
+            URLQueryItem(name: "prettyPrint", value: "false"),
+        ]
+        guard let url = components?.url else {
+            throw YTMusicError.unknown(message: "Invalid API URL for endpoint: \(endpoint)")
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+
+        let headers = try await self.buildAuthHeaders()
+        for (key, value) in headers {
+            request.setValue(value, forHTTPHeaderField: key)
+        }
+
+        request.httpBody = try JSONSerialization.data(withJSONObject: fullBody)
+
+        self.logger.debug("Making YouTube request (data) to \(endpoint)")
+
+        let result = try await Self.performNetworkRequest(request: request, session: self.session)
+
+        switch result {
+        case let .success(data):
+            return data
         case let .authError(statusCode):
             self.logger.error("YouTube auth error: HTTP \(statusCode)")
             self.authService.sessionExpired()

--- a/Sources/Kaset/Services/API/YouTubeClient.swift
+++ b/Sources/Kaset/Services/API/YouTubeClient.swift
@@ -449,12 +449,16 @@ final class YouTubeClient: YouTubeClientProtocol {
 
         let cacheKey = self.cacheKey(forEndpoint: Self.cachePrefix + endpoint, body: fullBody, ttl: ttl)
 
-        // Check the cache BEFORE building auth headers: a warm hit should not
-        // pay the cookie-store / SAPISIDHASH cost (several WebKit cookie-store
-        // hops). Auth is still validated below before any network request.
-        if let cacheKey, let cached = APICache.shared.get(key: cacheKey) {
-            self.logger.debug("Cache hit for \(Self.cachePrefix)\(endpoint)")
-            return cached
+        // Validate the current auth session before serving any cached
+        // personalized YouTube response: if the cookies/SAPISID were cleared or
+        // the session expired while a cache entry is still warm, we must not keep
+        // rendering private cached data — fall through to reauth instead.
+        if let cacheKey {
+            _ = try await self.buildAuthHeaders()
+            if let cached = APICache.shared.get(key: cacheKey) {
+                self.logger.debug("Cache hit for \(Self.cachePrefix)\(endpoint)")
+                return cached
+            }
         }
 
         let json: [String: Any] = if retry {
@@ -519,9 +523,14 @@ final class YouTubeClient: YouTubeClientProtocol {
 
         let cacheKey = self.cacheKey(forEndpoint: Self.cachePrefix + "data:" + endpoint, body: fullBody, ttl: ttl)
 
-        if let cacheKey, let cached = APICache.shared.getData(key: cacheKey) {
-            self.logger.debug("Cache hit (data) for \(Self.cachePrefix)\(endpoint)")
-            return cached
+        // Validate the session before serving cached personalized data (see
+        // `request`); the home bundle is account-scoped private data.
+        if let cacheKey {
+            _ = try await self.buildAuthHeaders()
+            if let cached = APICache.shared.getData(key: cacheKey) {
+                self.logger.debug("Cache hit (data) for \(Self.cachePrefix)\(endpoint)")
+                return cached
+            }
         }
 
         let data: Data = if retry {

--- a/Sources/Kaset/Services/API/YouTubeClient.swift
+++ b/Sources/Kaset/Services/API/YouTubeClient.swift
@@ -119,11 +119,15 @@ final class YouTubeClient: YouTubeClientProtocol {
     /// between them reuses the same 2 MB response.
     private func homeResponseData() async throws -> Data {
         let homeBody: [String: Any] = ["browseId": "FEwhat_to_watch"]
-        // Capture the cache key for the CURRENT (authenticated) account scope up
-        // front, before any network await. If the user signs out mid-flight,
-        // recomputing it later would resolve to the account-unknown `pending`
-        // scope and store this user's bytes there — readable after a re-login.
+        // Capture the cache key for the CURRENT (authenticated) account scope and
+        // the cache generation BEFORE any network await. If the user signs out
+        // mid-flight, recomputing the key later would resolve to the same
+        // account-unknown `pending` scope (a pending->pending transition the key
+        // comparison alone can't catch), so we also require the cache generation
+        // to be unchanged — `invalidateAll()` (account switch / sign-out /
+        // session expiry) bumps it and rejects the stale write.
         let cacheKey = self.homeDataCacheKey(body: homeBody)
+        let cacheGeneration = APICache.shared.generation
         if let cacheKey, let cached = try await self.cachedHomeData(key: cacheKey) {
             return cached
         }
@@ -135,9 +139,12 @@ final class YouTubeClient: YouTubeClientProtocol {
         guard (try? JSONSerialization.jsonObject(with: data)) is [String: Any] else {
             throw YTMusicError.parseError(message: "Home response is not a JSON object")
         }
-        // Re-validate the scope (a sign-out mid-flight changes the key); only
-        // write if it still matches the authenticated request.
-        if let cacheKey, cacheKey == self.homeDataCacheKey(body: homeBody) {
+        // Only write if neither the scope key NOR the cache generation changed
+        // during the fetch — i.e. no account switch / sign-out happened.
+        if let cacheKey,
+           cacheKey == self.homeDataCacheKey(body: homeBody),
+           cacheGeneration == APICache.shared.generation
+        {
             APICache.shared.setData(key: cacheKey, data: data, ttl: APICache.TTL.home)
         }
         return data

--- a/Sources/Kaset/Services/API/YouTubeClient.swift
+++ b/Sources/Kaset/Services/API/YouTubeClient.swift
@@ -96,10 +96,28 @@ final class YouTubeClient: YouTubeClientProtocol {
     func getHomeBundle() async throws -> YouTubeHomeBundle {
         self.logger.info("Fetching YouTube home bundle (feed + chips + shelves)")
 
-        // One request for the raw response bytes, then one deserialize + parse
-        // pass off the main actor producing all three home surfaces. Replaces
-        // three separate getHomeFeed/getHomeChips/getHomeShelves calls that each
-        // re-walked the same ~2 MB blob on the main thread.
+        // Shared raw `FEwhat_to_watch` bytes (cache-read validated + cache-write
+        // after parse). Shorts reads the same bytes so the two surfaces share one
+        // cached 2 MB response.
+        let data = try await self.homeResponseData()
+        let bundle = try await Self.parseHomeBundle(from: data)
+
+        // The detached parse is not cancelled when the Home view model is
+        // discarded (account switch). Don't mutate shared client state after
+        // cancellation — the providers may already have moved to the new account.
+        try Task.checkCancellation()
+        self.homeContinuation = bundle.feed.continuation
+        self.logger.info(
+            "YouTube home bundle: \(bundle.feed.videos.count) videos, \(bundle.chips.count) chips, \(bundle.shelves.count) shelves"
+        )
+        return bundle
+    }
+
+    /// The raw `FEwhat_to_watch` response bytes, served from cache (after auth
+    /// validation) or fetched. Cached only after the bytes are confirmed to be a
+    /// JSON object, under a single key shared by Home and Shorts so navigating
+    /// between them reuses the same 2 MB response.
+    private func homeResponseData() async throws -> Data {
         let homeBody: [String: Any] = ["browseId": "FEwhat_to_watch"]
         // Capture the cache key for the CURRENT (authenticated) account scope up
         // front, before any network await. If the user signs out mid-flight,
@@ -107,32 +125,22 @@ final class YouTubeClient: YouTubeClientProtocol {
         // scope and store this user's bytes there — readable after a re-login.
         let cacheKey = self.homeDataCacheKey(body: homeBody)
         if let cacheKey, let cached = try await self.cachedHomeData(key: cacheKey) {
-            let bundle = try await Self.parseHomeBundle(from: cached)
-            try Task.checkCancellation()
-            self.homeContinuation = bundle.feed.continuation
-            return bundle
+            return cached
         }
 
         let data = try await self.requestData("browse", body: homeBody)
-        // Parse BEFORE caching: a transient non-JSON 200 must not poison the
-        // 5-minute Home cache (retries/refresh would re-read the bad bytes and
-        // fail without re-fetching).
-        let bundle = try await Self.parseHomeBundle(from: data)
-
-        // The detached parse is not cancelled when the Home view model is
-        // discarded (account switch). Don't mutate shared client state or
-        // populate the cache after cancellation — the cache scope/providers may
-        // have already moved to the new account. Re-validate the scope too: only
-        // write if the key still matches the current account.
-        try Task.checkCancellation()
+        // Validate it parses BEFORE caching: a transient non-JSON 200 must not
+        // poison the 5-minute Home cache (retries/refresh would re-read the bad
+        // bytes and fail without re-fetching).
+        guard (try? JSONSerialization.jsonObject(with: data)) is [String: Any] else {
+            throw YTMusicError.parseError(message: "Home response is not a JSON object")
+        }
+        // Re-validate the scope (a sign-out mid-flight changes the key); only
+        // write if it still matches the authenticated request.
         if let cacheKey, cacheKey == self.homeDataCacheKey(body: homeBody) {
             APICache.shared.setData(key: cacheKey, data: data, ttl: APICache.TTL.home)
         }
-        self.homeContinuation = bundle.feed.continuation
-        self.logger.info(
-            "YouTube home bundle: \(bundle.feed.videos.count) videos, \(bundle.chips.count) chips, \(bundle.shelves.count) shelves"
-        )
-        return bundle
+        return data
     }
 
     /// Off-actor parse of the home bundle, kept on a detached task so the 2 MB
@@ -307,14 +315,12 @@ final class YouTubeClient: YouTubeClientProtocol {
     func getShorts() async throws -> [YouTubeVideo] {
         self.logger.info("Fetching YouTube Shorts")
 
-        // Shorts ride along in the home feed response; the shared TTL means
-        // this is a cache hit right after the home grid loads.
-        let data = try await self.request(
-            "browse",
-            body: ["browseId": "FEwhat_to_watch"],
-            ttl: APICache.TTL.home
-        )
-        return YouTubeFeedParser.parse(data).shorts
+        // Shorts ride along in the home `FEwhat_to_watch` response. Read the same
+        // shared raw bytes as getHomeBundle so loading one warms the other (no
+        // second 2 MB fetch when navigating Home <-> Shorts).
+        let data = try await self.homeResponseData()
+        let parsed = try await Self.parseHomeBundle(from: data)
+        return parsed.feed.shorts
     }
 
     // MARK: - Subscriptions & Library

--- a/Sources/Kaset/Services/API/YouTubeClient.swift
+++ b/Sources/Kaset/Services/API/YouTubeClient.swift
@@ -101,7 +101,12 @@ final class YouTubeClient: YouTubeClientProtocol {
         // three separate getHomeFeed/getHomeChips/getHomeShelves calls that each
         // re-walked the same ~2 MB blob on the main thread.
         let homeBody: [String: Any] = ["browseId": "FEwhat_to_watch"]
-        if let cached = try await self.cachedHomeData(body: homeBody) {
+        // Capture the cache key for the CURRENT (authenticated) account scope up
+        // front, before any network await. If the user signs out mid-flight,
+        // recomputing it later would resolve to the account-unknown `pending`
+        // scope and store this user's bytes there — readable after a re-login.
+        let cacheKey = self.homeDataCacheKey(body: homeBody)
+        if let cacheKey, let cached = try await self.cachedHomeData(key: cacheKey) {
             let bundle = try await Self.parseHomeBundle(from: cached)
             try Task.checkCancellation()
             self.homeContinuation = bundle.feed.continuation
@@ -117,9 +122,12 @@ final class YouTubeClient: YouTubeClientProtocol {
         // The detached parse is not cancelled when the Home view model is
         // discarded (account switch). Don't mutate shared client state or
         // populate the cache after cancellation — the cache scope/providers may
-        // have already moved to the new account.
+        // have already moved to the new account. Re-validate the scope too: only
+        // write if the key still matches the current account.
         try Task.checkCancellation()
-        self.cacheHomeData(data, body: homeBody)
+        if let cacheKey, cacheKey == self.homeDataCacheKey(body: homeBody) {
+            APICache.shared.setData(key: cacheKey, data: data, ttl: APICache.TTL.home)
+        }
         self.homeContinuation = bundle.feed.continuation
         self.logger.info(
             "YouTube home bundle: \(bundle.feed.videos.count) videos, \(bundle.chips.count) chips, \(bundle.shelves.count) shelves"
@@ -554,22 +562,17 @@ final class YouTubeClient: YouTubeClientProtocol {
         return self.cacheKey(forEndpoint: Self.cachePrefix + "data:browse", body: fullBody, ttl: APICache.TTL.home)
     }
 
-    /// Returns cached raw home bytes if present, after validating the auth
-    /// session (a cleared/expired session must not serve private cached data).
-    private func cachedHomeData(body: [String: Any]) async throws -> Data? {
-        guard let cacheKey = self.homeDataCacheKey(body: body) else { return nil }
+    /// Returns cached raw home bytes for `key` if present, after validating the
+    /// auth session (a cleared/expired session must not serve private cached
+    /// data). `key` is captured by the caller before any network await so it
+    /// reflects the authenticated request scope, not a later signed-out one.
+    private func cachedHomeData(key: String) async throws -> Data? {
         _ = try await self.buildAuthHeaders()
-        if let cached = APICache.shared.getData(key: cacheKey) {
+        if let cached = APICache.shared.getData(key: key) {
             self.logger.debug("Cache hit (data) for \(Self.cachePrefix)browse")
             return cached
         }
         return nil
-    }
-
-    /// Caches raw home bytes (called only after a successful parse).
-    private func cacheHomeData(_ data: Data, body: [String: Any]) {
-        guard let cacheKey = self.homeDataCacheKey(body: body) else { return }
-        APICache.shared.setData(key: cacheKey, data: data, ttl: APICache.TTL.home)
     }
 
     /// Performs the actual network request.

--- a/Sources/Kaset/Services/API/YouTubeClient.swift
+++ b/Sources/Kaset/Services/API/YouTubeClient.swift
@@ -100,20 +100,39 @@ final class YouTubeClient: YouTubeClientProtocol {
         // pass off the main actor producing all three home surfaces. Replaces
         // three separate getHomeFeed/getHomeChips/getHomeShelves calls that each
         // re-walked the same ~2 MB blob on the main thread.
-        let data = try await self.requestData(
-            "browse",
-            body: ["browseId": "FEwhat_to_watch"],
-            ttl: APICache.TTL.home
-        )
-        let bundle = try await Task.detached(priority: .userInitiated) {
-            try YouTubeFeedParser.parseHomeBundle(from: data)
-        }.value
+        let homeBody: [String: Any] = ["browseId": "FEwhat_to_watch"]
+        if let cached = try await self.cachedHomeData(body: homeBody) {
+            let bundle = try await Self.parseHomeBundle(from: cached)
+            try Task.checkCancellation()
+            self.homeContinuation = bundle.feed.continuation
+            return bundle
+        }
 
+        let data = try await self.requestData("browse", body: homeBody)
+        // Parse BEFORE caching: a transient non-JSON 200 must not poison the
+        // 5-minute Home cache (retries/refresh would re-read the bad bytes and
+        // fail without re-fetching).
+        let bundle = try await Self.parseHomeBundle(from: data)
+
+        // The detached parse is not cancelled when the Home view model is
+        // discarded (account switch). Don't mutate shared client state or
+        // populate the cache after cancellation — the cache scope/providers may
+        // have already moved to the new account.
+        try Task.checkCancellation()
+        self.cacheHomeData(data, body: homeBody)
         self.homeContinuation = bundle.feed.continuation
         self.logger.info(
             "YouTube home bundle: \(bundle.feed.videos.count) videos, \(bundle.chips.count) chips, \(bundle.shelves.count) shelves"
         )
         return bundle
+    }
+
+    /// Off-actor parse of the home bundle, kept on a detached task so the 2 MB
+    /// deserialize + walk does not block the main actor.
+    private static func parseHomeBundle(from data: Data) async throws -> YouTubeHomeBundle {
+        try await Task.detached(priority: .userInitiated) {
+            try YouTubeFeedParser.parseHomeBundle(from: data)
+        }.value
     }
 
     func getHomeFeedContinuation() async throws -> YouTubeFeed? {
@@ -508,44 +527,49 @@ final class YouTubeClient: YouTubeClientProtocol {
     }
 
     /// Like `request()`, but returns the raw response bytes instead of a
-    /// deserialized `[String: Any]`. Used for large responses (the ~2 MB home
-    /// feed) so the caller can deserialize and parse off the main actor. The
-    /// raw `Data` is cached (keyed identically) so a warm hit skips both the
-    /// network and the main-thread deserialize.
+    /// deserialized `[String: Any]`. Used for the ~2 MB home feed so the caller
+    /// can deserialize and parse off the main actor. Caching is the caller's
+    /// responsibility (it caches the bytes only after a successful parse, so a
+    /// transient non-JSON 200 can't poison the cache).
     private func requestData(
         _ endpoint: String,
         body: [String: Any],
-        ttl: TimeInterval? = nil,
         retry: Bool = true
     ) async throws -> Data {
         var fullBody = body
         fullBody["context"] = self.buildContext()
 
-        let cacheKey = self.cacheKey(forEndpoint: Self.cachePrefix + "data:" + endpoint, body: fullBody, ttl: ttl)
-
-        // Validate the session before serving cached personalized data (see
-        // `request`); the home bundle is account-scoped private data.
-        if let cacheKey {
-            _ = try await self.buildAuthHeaders()
-            if let cached = APICache.shared.getData(key: cacheKey) {
-                self.logger.debug("Cache hit (data) for \(Self.cachePrefix)\(endpoint)")
-                return cached
-            }
-        }
-
-        let data: Data = if retry {
-            try await RetryPolicy.default.execute { [self] in
+        if retry {
+            return try await RetryPolicy.default.execute { [self] in
                 try await self.performRequestData(endpoint, fullBody: fullBody)
             }
-        } else {
-            try await self.performRequestData(endpoint, fullBody: fullBody)
         }
+        return try await self.performRequestData(endpoint, fullBody: fullBody)
+    }
 
-        if let ttl, let cacheKey {
-            APICache.shared.setData(key: cacheKey, data: data, ttl: ttl)
+    /// Cache key for the raw home-bundle bytes.
+    private func homeDataCacheKey(body: [String: Any]) -> String? {
+        var fullBody = body
+        fullBody["context"] = self.buildContext()
+        return self.cacheKey(forEndpoint: Self.cachePrefix + "data:browse", body: fullBody, ttl: APICache.TTL.home)
+    }
+
+    /// Returns cached raw home bytes if present, after validating the auth
+    /// session (a cleared/expired session must not serve private cached data).
+    private func cachedHomeData(body: [String: Any]) async throws -> Data? {
+        guard let cacheKey = self.homeDataCacheKey(body: body) else { return nil }
+        _ = try await self.buildAuthHeaders()
+        if let cached = APICache.shared.getData(key: cacheKey) {
+            self.logger.debug("Cache hit (data) for \(Self.cachePrefix)browse")
+            return cached
         }
+        return nil
+    }
 
-        return data
+    /// Caches raw home bytes (called only after a successful parse).
+    private func cacheHomeData(_ data: Data, body: [String: Any]) {
+        guard let cacheKey = self.homeDataCacheKey(body: body) else { return }
+        APICache.shared.setData(key: cacheKey, data: data, ttl: APICache.TTL.home)
     }
 
     /// Performs the actual network request.

--- a/Sources/Kaset/Services/Auth/AuthService.swift
+++ b/Sources/Kaset/Services/Auth/AuthService.swift
@@ -99,6 +99,10 @@ final class AuthService: AuthServiceProtocol {
         self.logger.warning("Session expired, requiring re-authentication")
         self.state = .loggedOut
         self.needsReauth = true
+        // Drop cached personalized responses so a later login in the same
+        // session can't be served the previous user's data (incl. the
+        // account-unknown "pending" cache scope) before its TTL expires.
+        APICache.shared.invalidateAll()
     }
 
     /// Signs out the user by clearing all cookies and data.
@@ -106,6 +110,7 @@ final class AuthService: AuthServiceProtocol {
         self.logger.info("Signing out user")
 
         await self.webKitManager.clearAllData()
+        APICache.shared.invalidateAll()
 
         self.state = .loggedOut
         self.needsReauth = false

--- a/Sources/Kaset/Services/YouTubeProtocols.swift
+++ b/Sources/Kaset/Services/YouTubeProtocols.swift
@@ -14,6 +14,12 @@ protocol YouTubeClientProtocol: Sendable {
     /// Fetches the recommended home feed (`FEwhat_to_watch`).
     func getHomeFeed() async throws -> YouTubeFeed
 
+    /// Fetches the home feed, its filter chips, and its titled shelves from a
+    /// single `FEwhat_to_watch` request, parsed off the main actor. Preferred
+    /// over calling `getHomeFeed`/`getHomeChips`/`getHomeShelves` separately:
+    /// the ~2 MB response is fetched and walked once instead of three times.
+    func getHomeBundle() async throws -> YouTubeHomeBundle
+
     /// Fetches the next page of the home feed, or `nil` when exhausted.
     func getHomeFeedContinuation() async throws -> YouTubeFeed?
 

--- a/Sources/Kaset/Utilities/ImageCache.swift
+++ b/Sources/Kaset/Utilities/ImageCache.swift
@@ -15,7 +15,10 @@ actor ImageCache {
     private static let maxDiskCacheSize: Int64 = 200 * 1024 * 1024
 
     private let memoryCache = NSCache<NSString, NSImage>()
-    private var inFlight: [URL: Task<NSImage?, Never>] = [:]
+    /// Keyed by URL + target size (the memory-cache key), so an in-flight
+    /// 320×180 fetch is not awaited by a 1280×720 request and handed back the
+    /// small downsampled image.
+    private var inFlight: [NSString: Task<NSImage?, Never>] = [:]
     private let fileManager = FileManager.default
     private let diskCacheURL: URL
 
@@ -85,8 +88,9 @@ actor ImageCache {
             return diskImage
         }
 
-        // Check if already fetching
-        if let existing = inFlight[url] {
+        // Check if already fetching (keyed by URL + size, so a smaller in-flight
+        // decode is not returned to a larger request).
+        if let existing = inFlight[memoryKey] {
             return await existing.value
         }
 
@@ -105,9 +109,9 @@ actor ImageCache {
             }
         }
 
-        self.inFlight[url] = task
+        self.inFlight[memoryKey] = task
         let result = await task.value
-        self.inFlight.removeValue(forKey: url)
+        self.inFlight.removeValue(forKey: memoryKey)
         return result
     }
 

--- a/Sources/Kaset/Utilities/ImageCache.swift
+++ b/Sources/Kaset/Utilities/ImageCache.swift
@@ -75,27 +75,29 @@ actor ImageCache {
             return cached
         }
 
-        // Check disk cache off the actor so concurrent decodes (every visible
-        // card on first paint) run in parallel across cores instead of
-        // serializing here. loadFromDisk is nonisolated and reads only
-        // immutable state; only the memory-cache write below is back on-actor.
-        // Disk holds the raw bytes (URL-keyed) and re-decodes at the requested
-        // size, so different sizes share one download but get distinct decodes.
-        if let diskImage = await Task.detached(priority: .userInitiated, operation: { [self] in
-            self.loadFromDisk(url: url, targetSize: targetSize)
-        }).value {
-            self.memoryCache.setObject(diskImage, forKey: memoryKey)
-            return diskImage
-        }
-
-        // Check if already fetching (keyed by URL + size, so a smaller in-flight
-        // decode is not returned to a larger request).
+        // Coalesce concurrent cold requests for the same URL+size BEFORE any
+        // suspension point. The disk read runs off the actor (so decodes
+        // parallelize across cores), but registering the in-flight task first
+        // means two callers — e.g. the first-screen prefetch and a visible card
+        // — share one disk read + at most one network download instead of
+        // racing past each other and both downloading.
         if let existing = inFlight[memoryKey] {
             return await existing.value
         }
 
-        // Fetch from network
-        let task = Task<NSImage?, Never> {
+        let task = Task<NSImage?, Never> { [self] in
+            // Disk holds the raw bytes (URL-keyed) and re-decodes at the
+            // requested size, so different sizes share one download but get
+            // distinct decodes. loadFromDisk is nonisolated (immutable state),
+            // run detached so the decode does not serialize on the actor.
+            if let diskImage = await Task.detached(priority: .userInitiated, operation: {
+                self.loadFromDisk(url: url, targetSize: targetSize)
+            }).value {
+                self.memoryCache.setObject(diskImage, forKey: memoryKey)
+                return diskImage
+            }
+
+            // Cold miss: download once, decode, and cache the raw bytes.
             do {
                 let (data, response) = try await URLSession.shared.data(from: url)
                 guard Self.isSuccessfulResponse(response) else { return nil }

--- a/Sources/Kaset/Utilities/ImageCache.swift
+++ b/Sources/Kaset/Utilities/ImageCache.swift
@@ -14,7 +14,7 @@ actor ImageCache {
     /// Maximum disk cache size in bytes (200MB).
     private static let maxDiskCacheSize: Int64 = 200 * 1024 * 1024
 
-    private let memoryCache = NSCache<NSURL, NSImage>()
+    private let memoryCache = NSCache<NSString, NSImage>()
     private var inFlight: [URL: Task<NSImage?, Never>] = [:]
     private let fileManager = FileManager.default
     private let diskCacheURL: URL
@@ -63,8 +63,12 @@ actor ImageCache {
     ///   - targetSize: Optional target size for downsampling. If provided, the image will be
     ///                 downsampled to fit this size, significantly reducing memory usage.
     func image(for url: URL, targetSize: CGSize? = nil) async -> NSImage? {
-        // Check memory cache
-        if let cached = memoryCache.object(forKey: url as NSURL) {
+        // Memory cache is keyed by URL *and* target size: the same thumbnail is
+        // requested at different sizes (Home cards at 320×180, the watch
+        // placeholder at 1280×720). Keying by URL alone let the first small
+        // decode satisfy a later large request, leaving the large view blurry.
+        let memoryKey = Self.memoryKey(for: url, targetSize: targetSize)
+        if let cached = memoryCache.object(forKey: memoryKey) {
             return cached
         }
 
@@ -72,10 +76,12 @@ actor ImageCache {
         // card on first paint) run in parallel across cores instead of
         // serializing here. loadFromDisk is nonisolated and reads only
         // immutable state; only the memory-cache write below is back on-actor.
+        // Disk holds the raw bytes (URL-keyed) and re-decodes at the requested
+        // size, so different sizes share one download but get distinct decodes.
         if let diskImage = await Task.detached(priority: .userInitiated, operation: { [self] in
             self.loadFromDisk(url: url, targetSize: targetSize)
         }).value {
-            self.memoryCache.setObject(diskImage, forKey: url as NSURL)
+            self.memoryCache.setObject(diskImage, forKey: memoryKey)
             return diskImage
         }
 
@@ -91,7 +97,7 @@ actor ImageCache {
                 guard Self.isSuccessfulResponse(response) else { return nil }
                 guard let image = Self.createImage(from: data, targetSize: targetSize) else { return nil }
                 let cost = targetSize != nil ? Int(image.size.width * image.size.height * 4) : data.count
-                self.memoryCache.setObject(image, forKey: url as NSURL, cost: cost)
+                self.memoryCache.setObject(image, forKey: memoryKey, cost: cost)
                 self.saveToDisk(url: url, data: data)
                 return image
             } catch {
@@ -103,6 +109,13 @@ actor ImageCache {
         let result = await task.value
         self.inFlight.removeValue(forKey: url)
         return result
+    }
+
+    /// Memory-cache key combining the URL with the requested decode size, so
+    /// decodes at different sizes for the same URL do not evict one another.
+    private static func memoryKey(for url: URL, targetSize: CGSize?) -> NSString {
+        guard let targetSize else { return url.absoluteString as NSString }
+        return "\(url.absoluteString)@\(Int(targetSize.width))x\(Int(targetSize.height))" as NSString
     }
 
     private static func isSuccessfulResponse(_ response: URLResponse) -> Bool {
@@ -126,7 +139,7 @@ actor ImageCache {
                 guard !Task.isCancelled else { break }
 
                 // Skip if already in memory cache
-                if self.memoryCache.object(forKey: url as NSURL) != nil {
+                if self.memoryCache.object(forKey: Self.memoryKey(for: url, targetSize: targetSize)) != nil {
                     continue
                 }
 

--- a/Sources/Kaset/Utilities/ImageCache.swift
+++ b/Sources/Kaset/Utilities/ImageCache.swift
@@ -68,8 +68,13 @@ actor ImageCache {
             return cached
         }
 
-        // Check disk cache
-        if let diskImage = loadFromDisk(url: url, targetSize: targetSize) {
+        // Check disk cache off the actor so concurrent decodes (every visible
+        // card on first paint) run in parallel across cores instead of
+        // serializing here. loadFromDisk is nonisolated and reads only
+        // immutable state; only the memory-cache write below is back on-actor.
+        if let diskImage = await Task.detached(priority: .userInitiated, operation: { [self] in
+            self.loadFromDisk(url: url, targetSize: targetSize)
+        }).value {
             self.memoryCache.setObject(diskImage, forKey: url as NSURL)
             return diskImage
         }
@@ -210,23 +215,31 @@ actor ImageCache {
 
     // MARK: - Disk Cache Helpers
 
-    private func cacheKey(for url: URL) -> String {
+    // swiftformat:disable modifierOrder
+    nonisolated private func cacheKey(for url: URL) -> String {
         let data = Data(url.absoluteString.utf8)
         let hash = SHA256.hash(data: data)
         return hash.compactMap { String(format: "%02x", $0) }.joined()
     }
 
-    private func diskCachePath(for url: URL) -> URL {
+    nonisolated private func diskCachePath(for url: URL) -> URL {
         self.diskCacheURL.appendingPathComponent(self.cacheKey(for: url))
     }
 
-    private func loadFromDisk(url: URL, targetSize: CGSize? = nil) -> NSImage? {
+    /// Reads and decodes a cached image off the actor. `nonisolated` so warm
+    /// disk hits — `Data(contentsOf:)` plus the ImageIO downsample in
+    /// `createImage` — run concurrently across cores instead of serializing on
+    /// the `ImageCache` actor (every visible card used to queue its decode
+    /// behind the others). Touches only immutable state (`diskCacheURL`).
+    nonisolated private func loadFromDisk(url: URL, targetSize: CGSize? = nil) -> NSImage? {
         let path = self.diskCachePath(for: url)
         guard let data = try? Data(contentsOf: path) else {
             return nil
         }
         return Self.createImage(from: data, targetSize: targetSize)
     }
+
+    // swiftformat:enable modifierOrder
 
     private func saveToDisk(url: URL, data: Data) {
         let path = self.diskCachePath(for: url)

--- a/Sources/Kaset/ViewModels/YouTube/YouTubeHomeViewModel.swift
+++ b/Sources/Kaset/ViewModels/YouTube/YouTubeHomeViewModel.swift
@@ -90,10 +90,6 @@ final class YouTubeHomeViewModel {
         let generation = token
         self.loadingState = .loading
         do {
-            // Continue Watching reads history (a different endpoint), so start
-            // it concurrently with the home bundle.
-            async let continueWatching = self.continueWatchingSection()
-
             // One request + one off-main parse yields the grid, the filter
             // chips, and the titled shelves together (they all live in the same
             // ~2 MB `FEwhat_to_watch` response). Replaces three separate
@@ -127,26 +123,32 @@ final class YouTubeHomeViewModel {
                 self.loadingState = .loaded
             }
 
-            // Continue Watching (history) and the shelves are ready now, so
-            // publish them with the grid instead of waiting on the topic rails.
-            var head: [YouTubeHomeSection] = []
-            if let cw = await continueWatching {
-                head.append(cw)
-            }
-            head.append(contentsOf: shelves)
-
-            try Task.checkCancellation()
-            guard generation == self.loadGeneration else { return }
-            if !head.isEmpty {
-                self.sections = head
+            // Publish the shelves immediately and start the topic rails now —
+            // do NOT block on the watch-history request (it can be slow/retrying
+            // and would otherwise delay the rails and keep an empty grid stuck on
+            // the skeleton). The Continue Watching rail is inserted at the front
+            // once history resolves.
+            if !shelves.isEmpty {
+                self.sections = shelves
                 if !gridReady {
                     self.loadingState = .loaded // any content clears the skeleton
                 }
             }
 
-            // Stream the topic rails in as each resolves (see streamTopicRails).
+            // Stream the rails in as each resolves; the streamer is the single
+            // writer of `sections` and prepends Continue Watching when its
+            // (concurrent) history fetch lands. See streamTopicRails.
             let chips = Array(bundle.chips.prefix(Self.topicRailCap))
-            await self.streamTopicRails(chips: chips, head: head, gridReady: gridReady, generation: generation)
+            await self.streamTopicRails(
+                chips: chips,
+                shelves: shelves,
+                continueWatching: { [weak self] in
+                    guard let self else { return nil }
+                    return await self.continueWatchingSection()
+                },
+                gridReady: gridReady,
+                generation: generation
+            )
 
             // Empty grid with no rails at all: flip `.loaded` so the
             // "No recommendations" placeholder can show instead of a stuck
@@ -172,35 +174,53 @@ final class YouTubeHomeViewModel {
     /// Streams the topic rails into `sections` as each browse resolves.
     ///
     /// Measured: the fast rails finish ~350 ms after they start, but the old
-    /// atomic publish waited for the slowest (~800 ms). Reveal each rail at its
-    /// chip-ordered slot the moment it lands — gaps fill in as earlier-index
-    /// rails arrive — so rows appear as soon as ANY rail resolves rather than
-    /// gating on the (possibly slow) first chip. The published array always
-    /// honors chip order; a later rail may slot in above an already-shown one,
-    /// but that is a small upward settle, not an ~800 ms blank wait.
+    /// Streams the rails into `sections` as each resolves, as the single writer.
+    ///
+    /// Continue Watching (watch history, a separate and sometimes slow request)
+    /// and the topic-chip browses all run concurrently here. Shelves are already
+    /// known; each rail is revealed at its ordered slot the moment it lands, so
+    /// rows appear as soon as ANY rail resolves rather than gating on the slowest
+    /// (or on history). Final order is always: Continue Watching, shelves, then
+    /// topic rails in chip order — a later rail may slot in above an
+    /// already-shown one (a small upward settle), never an ~800 ms blank wait.
     private func streamTopicRails(
         chips: [YouTubeHomeChip],
-        head: [YouTubeHomeSection],
+        shelves: [YouTubeHomeSection],
+        continueWatching: @escaping @Sendable () async -> YouTubeHomeSection?,
         gridReady: Bool,
         generation: Int
     ) async {
-        guard !chips.isEmpty else { return }
-        var slot = [YouTubeHomeSection?](repeating: nil, count: chips.count)
+        // One result channel for both rail kinds: the history rail (index -1,
+        // pinned to the front) and the topic rails (chip index >= 0).
+        var topicSlot = [YouTubeHomeSection?](repeating: nil, count: chips.count)
+        var continueWatchingRail: YouTubeHomeSection?
+
+        func publish() {
+            guard generation == self.loadGeneration else { return }
+            var next: [YouTubeHomeSection] = []
+            if let continueWatchingRail { next.append(continueWatchingRail) }
+            next.append(contentsOf: shelves)
+            next.append(contentsOf: topicSlot.compactMap(\.self))
+            self.sections = next
+            if !gridReady, self.loadingState != .loaded {
+                self.loadingState = .loaded
+            }
+        }
+
         await withTaskGroup(of: (Int, YouTubeHomeSection?).self) { group in
+            group.addTask { await (-1, continueWatching()) }
             for (index, chip) in chips.enumerated() {
                 group.addTask {
                     await (index, self.topicSection(for: chip))
                 }
             }
             for await (index, section) in group {
-                slot[index] = section
-                guard generation == self.loadGeneration else { continue }
-                // Publish every resolved rail in chip order (compacting the
-                // not-yet-resolved and dropped/empty slots).
-                self.sections = head + slot.compactMap(\.self)
-                if !gridReady, self.loadingState != .loaded {
-                    self.loadingState = .loaded
+                if index == -1 {
+                    continueWatchingRail = section
+                } else {
+                    topicSlot[index] = section
                 }
+                publish()
             }
         }
     }

--- a/Sources/Kaset/ViewModels/YouTube/YouTubeHomeViewModel.swift
+++ b/Sources/Kaset/ViewModels/YouTube/YouTubeHomeViewModel.swift
@@ -150,12 +150,13 @@ final class YouTubeHomeViewModel {
                 generation: generation
             )
 
-            // Empty grid with no rails at all: flip `.loaded` so the
-            // "No recommendations" placeholder can show instead of a stuck
-            // skeleton. (`loadMore`'s `.loadingMore` is never active here.)
+            // Empty grid: flip the initial-load skeleton to `.loaded` so the
+            // "No recommendations" placeholder can show. Only from `.loading` —
+            // if `loadMore()` started a continuation (empty first page with
+            // `hasMoreVideos`), don't clobber its `.loadingMore`.
             try Task.checkCancellation()
             guard generation == self.loadGeneration else { return }
-            if !gridReady {
+            if !gridReady, self.loadingState == .loading {
                 self.loadingState = .loaded
             }
         } catch {
@@ -204,8 +205,11 @@ final class YouTubeHomeViewModel {
             // history); flipping `.loaded` then — with topics still pending and
             // `next` empty — would flash the "No recommendations" state. The
             // genuinely-empty case is handled by the terminal `.loaded` in
-            // performLoad after all rail work finishes.
-            if !gridReady, !next.isEmpty, self.loadingState != .loaded {
+            // performLoad after all rail work finishes. Only flip from the
+            // initial-load `.loading` skeleton; never clobber a concurrent
+            // `loadMore()`'s `.loadingMore` (that would let a second continuation
+            // start before the first finishes).
+            if !gridReady, !next.isEmpty, self.loadingState == .loading {
                 self.loadingState = .loaded
             }
         }

--- a/Sources/Kaset/ViewModels/YouTube/YouTubeHomeViewModel.swift
+++ b/Sources/Kaset/ViewModels/YouTube/YouTubeHomeViewModel.swift
@@ -171,9 +171,6 @@ final class YouTubeHomeViewModel {
         }
     }
 
-    /// Streams the topic rails into `sections` as each browse resolves.
-    ///
-    /// Measured: the fast rails finish ~350 ms after they start, but the old
     /// Streams the rails into `sections` as each resolves, as the single writer.
     ///
     /// Continue Watching (watch history, a separate and sometimes slow request)

--- a/Sources/Kaset/ViewModels/YouTube/YouTubeHomeViewModel.swift
+++ b/Sources/Kaset/ViewModels/YouTube/YouTubeHomeViewModel.swift
@@ -199,7 +199,13 @@ final class YouTubeHomeViewModel {
             next.append(contentsOf: shelves)
             next.append(contentsOf: topicSlot.compactMap(\.self))
             self.sections = next
-            if !gridReady, self.loadingState != .loaded {
+            // Only clear the skeleton once there is actual content. The first
+            // group result is often history returning nil (no resumable watch
+            // history); flipping `.loaded` then — with topics still pending and
+            // `next` empty — would flash the "No recommendations" state. The
+            // genuinely-empty case is handled by the terminal `.loaded` in
+            // performLoad after all rail work finishes.
+            if !gridReady, !next.isEmpty, self.loadingState != .loaded {
                 self.loadingState = .loaded
             }
         }

--- a/Sources/Kaset/ViewModels/YouTube/YouTubeHomeViewModel.swift
+++ b/Sources/Kaset/ViewModels/YouTube/YouTubeHomeViewModel.swift
@@ -68,15 +68,26 @@ final class YouTubeHomeViewModel {
             await existing.value
             return
         }
-        let task = Task { await self.performLoad() }
+        // Tag this run so only it clears the shared handle. Without the tag, a
+        // cancelled earlier run resuming after refresh() started a new one would
+        // null out the new run's handle (breaking single-flight: a concurrent
+        // load() would see nil and start a duplicate fetch).
+        self.loadGeneration += 1
+        let token = self.loadGeneration
+        let task = Task { await self.performLoad(token: token) }
         self.loadTask = task
         await task.value
     }
 
-    private func performLoad() async {
-        defer { self.loadTask = nil }
-        self.loadGeneration += 1
-        let generation = self.loadGeneration
+    private func performLoad(token: Int) async {
+        defer {
+            // Only clear the handle if it still points at THIS run. A stale run
+            // resuming late must not wipe a newer run's task.
+            if self.loadGeneration == token {
+                self.loadTask = nil
+            }
+        }
+        let generation = token
         self.loadingState = .loading
         do {
             // Continue Watching reads history (a different endpoint), so start
@@ -205,6 +216,17 @@ final class YouTubeHomeViewModel {
         self.sections = []
         self.shelfVideoIDs = []
         await self.load()
+    }
+
+    /// Cancels any in-flight load when this view model is being discarded (e.g.
+    /// an account switch replaces it). The load runs in an unstructured `Task`
+    /// that survives `.task` teardown, so without this the discarded model would
+    /// keep using the shared `YouTubeClient` after the cache scope and providers
+    /// moved to the new account — repopulating caches or clobbering
+    /// `homeContinuation` with stale, wrong-account responses.
+    func cancelLoad() {
+        self.loadTask?.cancel()
+        self.loadTask = nil
     }
 
     /// Loads the next feed page when the user nears the end of the grid.

--- a/Sources/Kaset/ViewModels/YouTube/YouTubeHomeViewModel.swift
+++ b/Sources/Kaset/ViewModels/YouTube/YouTubeHomeViewModel.swift
@@ -41,6 +41,10 @@ final class YouTubeHomeViewModel {
     /// (SwiftUI restarts .task during launch/layout churn; latest wins).
     private var loadGeneration = 0
 
+    /// The single in-flight load, shared by concurrent `load()` callers so
+    /// SwiftUI `.task` restarts coalesce onto one run instead of cancelling it.
+    private var loadTask: Task<Void, Never>?
+
     let client: any YouTubeClientProtocol
     private let logger = DiagnosticsLogger.api
 
@@ -48,27 +52,45 @@ final class YouTubeHomeViewModel {
         self.client = client
     }
 
-    /// Loads the home feed if not already loaded.
+    /// Loads the home feed once and keeps it. Safe to call repeatedly: SwiftUI
+    /// restarts `.task` during launch/layout churn (the trace showed two fires
+    /// ~18 ms apart on first paint), and a structured load would be cancelled by
+    /// the restart while the next call bailed — leaving the model stuck at
+    /// `.idle` with nothing running. Running the work in a stored UNSTRUCTURED
+    /// `Task` decouples it from `.task` cancellation: the first call starts it,
+    /// concurrent calls await the same task, and it runs to completion once.
     func load() async {
+        if case .loaded = self.loadingState {
+            return // Already loaded — a repeat is a no-op (don't refetch/wipe rails).
+        }
+        // Coalesce concurrent callers (rapid `.task` restarts) onto one run.
+        if let existing = self.loadTask {
+            await existing.value
+            return
+        }
+        let task = Task { await self.performLoad() }
+        self.loadTask = task
+        await task.value
+    }
+
+    private func performLoad() async {
+        defer { self.loadTask = nil }
         self.loadGeneration += 1
         let generation = self.loadGeneration
         self.loadingState = .loading
         do {
             // Continue Watching reads history (a different endpoint), so start
-            // it concurrently with the home feed. Chips and shelves come from
-            // the SAME `FEwhat_to_watch` response, so await the home feed first
-            // to warm the cache, then read them as cache hits rather than
-            // racing three identical network requests.
+            // it concurrently with the home bundle.
             async let continueWatching = self.continueWatchingSection()
-            let feed = try await client.getHomeFeed()
 
-            // Shelves and topics both read the now-cached home response for
-            // their chip/shelf data; their topic browses (slow) fan out from
-            // there. Shelves are a cache hit, so awaiting them before first
-            // paint is cheap and lets us de-duplicate the grid (below).
-            async let shelvesTask = self.shelfSections()
-            async let topics = self.topicSections()
-            let shelves = await shelvesTask
+            // One request + one off-main parse yields the grid, the filter
+            // chips, and the titled shelves together (they all live in the same
+            // ~2 MB `FEwhat_to_watch` response). Replaces three separate
+            // getHomeFeed/getHomeShelves/getHomeChips calls that each re-fetched
+            // and re-walked the same blob on the main thread.
+            let bundle = try await client.getHomeBundle()
+
+            let shelves = bundle.shelves
 
             try Task.checkCancellation()
             guard generation == self.loadGeneration else { return }
@@ -79,7 +101,7 @@ final class YouTubeHomeViewModel {
             // its rail, once under "For you"). Stored so continuation pages
             // apply the same filter.
             self.shelfVideoIDs = Set(shelves.flatMap { section in section.videos.map(\.videoId) })
-            let gridVideos = feed.videos.filter { !self.shelfVideoIDs.contains($0.videoId) }
+            let gridVideos = bundle.feed.videos.filter { !self.shelfVideoIDs.contains($0.videoId) }
 
             // Publish the recommendation grid immediately so first paint does
             // not wait on the optional topic rails (chips fan out to several
@@ -91,39 +113,42 @@ final class YouTubeHomeViewModel {
             self.hasMoreVideos = self.client.hasMoreHomeFeed
             let gridReady = !gridVideos.isEmpty
             if gridReady {
-                // Publish the new grid with a cleared rail set so a reload (a
-                // `.task` restart after a prior load) never renders the previous
-                // load's Continue Watching/topic rails above the fresh grid
-                // while the new rail fetches are still in flight. The new rails
-                // populate below once they resolve.
-                self.sections = []
                 self.loadingState = .loaded
             }
 
-            var sections: [YouTubeHomeSection] = []
-            if let continueWatching = await continueWatching {
-                sections.append(continueWatching)
+            // Continue Watching (history) and the shelves are ready now, so
+            // publish them with the grid instead of waiting on the topic rails.
+            var head: [YouTubeHomeSection] = []
+            if let cw = await continueWatching {
+                head.append(cw)
             }
-            sections.append(contentsOf: shelves)
-            await sections.append(contentsOf: topics)
+            head.append(contentsOf: shelves)
 
-            // The section helpers isolate per-rail failures by resolving to
-            // empty rather than throwing — including when a cancelled `.task`
-            // makes their requests fail. Surface that cancellation here so a
-            // cancelled load aborts instead of publishing empty rails (or
-            // marking an empty grid `.loaded`) as if it had succeeded.
             try Task.checkCancellation()
             guard generation == self.loadGeneration else { return }
-            self.sections = sections
-            // Only flip the state here when the grid did not already publish it,
-            // so a concurrent loadMore()'s `.loadingMore` is not clobbered.
+            if !head.isEmpty {
+                self.sections = head
+                if !gridReady {
+                    self.loadingState = .loaded // any content clears the skeleton
+                }
+            }
+
+            // Stream the topic rails in as each resolves (see streamTopicRails).
+            let chips = Array(bundle.chips.prefix(Self.topicRailCap))
+            await self.streamTopicRails(chips: chips, head: head, gridReady: gridReady, generation: generation)
+
+            // Empty grid with no rails at all: flip `.loaded` so the
+            // "No recommendations" placeholder can show instead of a stuck
+            // skeleton. (`loadMore`'s `.loadingMore` is never active here.)
+            try Task.checkCancellation()
+            guard generation == self.loadGeneration else { return }
             if !gridReady {
                 self.loadingState = .loaded
             }
         } catch {
             guard generation == self.loadGeneration else { return }
-            // A cancelled load (view went away mid-flight) is not an
-            // error; reset so the next task run reloads.
+            // A cancelled load (e.g. refresh() cancelled the in-flight task) is
+            // not an error; reset so a subsequent load runs cleanly.
             if error is CancellationError {
                 self.loadingState = .idle
                 return
@@ -133,8 +158,48 @@ final class YouTubeHomeViewModel {
         }
     }
 
+    /// Streams the topic rails into `sections` as each browse resolves.
+    ///
+    /// Measured: the fast rails finish ~350 ms after they start, but the old
+    /// atomic publish waited for the slowest (~800 ms). Reveal each rail at its
+    /// chip-ordered slot the moment it lands — gaps fill in as earlier-index
+    /// rails arrive — so rows appear as soon as ANY rail resolves rather than
+    /// gating on the (possibly slow) first chip. The published array always
+    /// honors chip order; a later rail may slot in above an already-shown one,
+    /// but that is a small upward settle, not an ~800 ms blank wait.
+    private func streamTopicRails(
+        chips: [YouTubeHomeChip],
+        head: [YouTubeHomeSection],
+        gridReady: Bool,
+        generation: Int
+    ) async {
+        guard !chips.isEmpty else { return }
+        var slot = [YouTubeHomeSection?](repeating: nil, count: chips.count)
+        await withTaskGroup(of: (Int, YouTubeHomeSection?).self) { group in
+            for (index, chip) in chips.enumerated() {
+                group.addTask {
+                    await (index, self.topicSection(for: chip))
+                }
+            }
+            for await (index, section) in group {
+                slot[index] = section
+                guard generation == self.loadGeneration else { continue }
+                // Publish every resolved rail in chip order (compacting the
+                // not-yet-resolved and dropped/empty slots).
+                self.sections = head + slot.compactMap(\.self)
+                if !gridReady, self.loadingState != .loaded {
+                    self.loadingState = .loaded
+                }
+            }
+        }
+    }
+
     /// Forces a fresh reload (e.g. after account switches).
     func refresh() async {
+        // Cancel and drop any in-flight load so `load()` starts a fresh one
+        // rather than awaiting the stale task.
+        self.loadTask?.cancel()
+        self.loadTask = nil
         self.loadingState = .idle
         self.videos = []
         self.sections = []
@@ -219,51 +284,6 @@ final class YouTubeHomeViewModel {
             }
             return nil
         }
-    }
-
-    /// The home response's own titled shelves (e.g. "Breaking news").
-    private func shelfSections() async -> [YouTubeHomeSection] {
-        do {
-            return try await self.client.getHomeShelves()
-        } catch {
-            if !(error is CancellationError) {
-                self.logger.error("Home shelves unavailable: \(error.localizedDescription)")
-            }
-            return []
-        }
-    }
-
-    /// One rail per personalized filter-chip topic, fetched concurrently and
-    /// returned in chip order. Empty topic feeds are dropped.
-    private func topicSections() async -> [YouTubeHomeSection] {
-        let chips: [YouTubeHomeChip]
-        do {
-            chips = try await Array(self.client.getHomeChips().prefix(Self.topicRailCap))
-        } catch {
-            if !(error is CancellationError) {
-                self.logger.error("Home chips unavailable: \(error.localizedDescription)")
-            }
-            return []
-        }
-        guard !chips.isEmpty else { return [] }
-
-        // Fetch all topic feeds concurrently, preserving chip order via index.
-        let indexed = await withTaskGroup(of: (Int, YouTubeHomeSection?).self) { group in
-            for (index, chip) in chips.enumerated() {
-                group.addTask {
-                    await (index, self.topicSection(for: chip))
-                }
-            }
-            var collected: [(Int, YouTubeHomeSection?)] = []
-            for await result in group {
-                collected.append(result)
-            }
-            return collected
-        }
-
-        return indexed
-            .sorted { $0.0 < $1.0 }
-            .compactMap(\.1)
     }
 
     /// Browses a single chip token into a topic section, or `nil` on

--- a/Sources/Kaset/Views/YouTube/VideoCard.swift
+++ b/Sources/Kaset/Views/YouTube/VideoCard.swift
@@ -71,7 +71,12 @@ struct VideoThumbnailView: View {
     var body: some View {
         CachedAsyncImage(
             url: self.video.thumbnailURL,
-            targetSize: CGSize(width: 640, height: 360)
+            // Cards render at ≤320 pt wide (~640 px @2x). ImageCache doubles
+            // targetSize for Retina, so 320×180 → a 640 px decode that matches
+            // the displayed size. The previous 640×360 decoded at 1280 px — ~4×
+            // the pixels — wasting CPU on first paint and thrashing the 50 MB
+            // memory cache (fewer images fit → re-decode on scroll).
+            targetSize: CGSize(width: 320, height: 180)
         ) { image in
             image
                 .resizable()

--- a/Sources/Kaset/Views/YouTube/YouTubeHistoryView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeHistoryView.swift
@@ -32,7 +32,10 @@ struct YouTubeHistoryView: View {
             }
         }
         .navigationTitle(Text("History", comment: "YouTube history title"))
-        .task {
+        // Keyed on the view-model identity so a cold-launch account swap (which
+        // rebuilds the model) re-fires the load instead of leaving the fresh,
+        // idle model stuck. See YouTubeHomeView for the full rationale.
+        .task(id: ObjectIdentifier(self.viewModel)) {
             await self.viewModel.load()
         }
     }

--- a/Sources/Kaset/Views/YouTube/YouTubeHomeView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeHomeView.swift
@@ -46,7 +46,13 @@ struct YouTubeHomeView: View {
         }
         .navigationTitle(Text("Home", comment: "YouTube home feed title"))
         .accessibilityIdentifier(AccessibilityID.YouTubeContent.homeGrid)
-        .task {
+        // Key on the view-model identity, not a bare `.task`. On cold launch the
+        // account resolves after first paint and `resetForAccountChange()` swaps
+        // in a fresh view model; a bare `.task` would not re-fire for that
+        // property swap, leaving the new (idle) model stuck on the skeleton until
+        // a navigation changed the view identity. Re-keying reloads the new model
+        // immediately. (Same shape as YouTubeExploreView.)
+        .task(id: ObjectIdentifier(self.viewModel)) {
             await self.viewModel.load()
         }
     }
@@ -55,11 +61,17 @@ struct YouTubeHomeView: View {
     /// the "For you" recommendation grid. The ScrollView track stays
     /// edge-to-edge so rails slide under the floating glass sidebar; each rail
     /// and the grid restore their own resting inset.
+    ///
+    /// The grid publishes first (fast cached feed) and the rails arrive a moment
+    /// later (slow topic/history browses). Animating on the rails' identities
+    /// makes them fade in and the grid ease down, so the late arrival reads as
+    /// intentional motion instead of an abrupt snap.
     private var feedContent: some View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 32) {
                 ForEach(self.viewModel.sections) { section in
                     self.sectionRail(section)
+                        .transition(.opacity)
                 }
 
                 // Render the grid whenever there are flat videos OR more pages
@@ -72,6 +84,10 @@ struct YouTubeHomeView: View {
                 }
             }
             .padding(.vertical, 20)
+            // Key on the rail identities (the array isn't Equatable). When the
+            // late rails land, this animates their insertion and the grid's
+            // downward shift in one smooth move.
+            .animation(AppAnimation.smooth, value: self.viewModel.sections.map(\.id))
         }
     }
 
@@ -131,6 +147,25 @@ struct YouTubeHomeView: View {
             // own edge-to-edge track so they slide under the glass sidebar.
             .padding(.horizontal, DetailContentLayout.horizontalInset)
         }
+        // Warm the first screenful of thumbnails as soon as the grid publishes
+        // so they decode ahead of scroll instead of popping in one-by-one. Keyed
+        // on the first batch's IDs so a fresh load re-warms; ImageCache.prefetch
+        // caps concurrency and skips already-cached URLs.
+        .task(id: self.firstThumbnailBatchKey) {
+            let urls = self.viewModel.videos.prefix(12).compactMap(\.thumbnailURL)
+            guard !urls.isEmpty else { return }
+            await ImageCache.shared.prefetch(
+                urls: Array(urls),
+                targetSize: CGSize(width: 320, height: 180)
+            )
+        }
+    }
+
+    /// Identity for the prefetch task: the first batch of grid video IDs. Drives
+    /// a re-warm when the grid's first page changes (a fresh load), not on every
+    /// pagination append.
+    private var firstThumbnailBatchKey: String {
+        self.viewModel.videos.prefix(12).map(\.videoId).joined(separator: ",")
     }
 
     private var loadingGrid: some View {

--- a/Sources/Kaset/Views/YouTube/YouTubePlaylistsView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubePlaylistsView.swift
@@ -32,7 +32,10 @@ struct YouTubePlaylistsView: View {
             }
         }
         .navigationTitle(Text("Playlists", comment: "YouTube playlists title"))
-        .task {
+        // Keyed on the view-model identity so a cold-launch account swap (which
+        // rebuilds the model) re-fires the load instead of leaving the fresh,
+        // idle model stuck. See YouTubeHomeView for the full rationale.
+        .task(id: ObjectIdentifier(self.viewModel)) {
             await self.viewModel.load()
         }
     }

--- a/Sources/Kaset/Views/YouTube/YouTubeShortsView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeShortsView.swift
@@ -45,6 +45,11 @@ struct YouTubeShortsView: View {
         // rebuilds the model) re-fires the load instead of leaving the fresh,
         // idle model stuck. See YouTubeHomeView for the full rationale.
         .task(id: ObjectIdentifier(self.viewModel)) {
+            // The view model is swapped on an account change; this @State is from
+            // the previous account. Reset it so the autoplay guard below selects
+            // the new model's first short instead of keeping a stale ID that is
+            // not in the new pager.
+            self.currentShortId = nil
             await self.viewModel.load()
             // Autoplay the first short on entry.
             if self.currentShortId == nil, let first = self.viewModel.shorts.first {

--- a/Sources/Kaset/Views/YouTube/YouTubeShortsView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeShortsView.swift
@@ -41,7 +41,10 @@ struct YouTubeShortsView: View {
             }
         }
         .navigationTitle(Text("Shorts", comment: "YouTube Shorts title"))
-        .task {
+        // Keyed on the view-model identity so a cold-launch account swap (which
+        // rebuilds the model) re-fires the load instead of leaving the fresh,
+        // idle model stuck. See YouTubeHomeView for the full rationale.
+        .task(id: ObjectIdentifier(self.viewModel)) {
             await self.viewModel.load()
             // Autoplay the first short on entry.
             if self.currentShortId == nil, let first = self.viewModel.shorts.first {

--- a/Sources/Kaset/Views/YouTube/YouTubeSubscriptionsView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeSubscriptionsView.swift
@@ -31,7 +31,10 @@ struct YouTubeSubscriptionsView: View {
             }
         }
         .navigationTitle(Text("Subscriptions", comment: "YouTube subscriptions title"))
-        .task {
+        // Keyed on the view-model identity so a cold-launch account swap (which
+        // rebuilds the model) re-fires the load instead of leaving the fresh,
+        // idle model stuck. See YouTubeHomeView for the full rationale.
+        .task(id: ObjectIdentifier(self.viewModel)) {
             await self.viewModel.load()
         }
     }

--- a/Sources/Kaset/Views/YouTube/YouTubeVideoWindowController.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeVideoWindowController.swift
@@ -253,10 +253,33 @@ final class YouTubeVideoWindowResizeGuard: NSObject, NSWindowDelegate {
 
     /// Floors a proposed content size and snaps it to 16:9. Pure function so
     /// both interactive resizes and programmatic frame restores share it.
-    static func normalizedContentSize(for proposed: NSSize, minContentSize: NSSize) -> NSSize {
-        // Drive off width, then derive a 16:9 height; if that height would fall
-        // under the floor, drive off the floor height instead. Guarantees both
-        // axes stay at or above the floor.
+    ///
+    /// `current` lets the clamp follow whichever axis the user is dragging: a
+    /// vertical-edge drag changes height but not width, so deriving width from
+    /// the changed height keeps that drag responsive instead of snapping back.
+    /// Pass `nil` (the default) to always drive off width.
+    static func normalizedContentSize(
+        for proposed: NSSize,
+        minContentSize: NSSize,
+        current: NSSize? = nil
+    ) -> NSSize {
+        // Pick the driving axis: the one that changed more relative to `current`
+        // (width by default). Height-driven keeps vertical-edge drags working.
+        let heightDriven: Bool = if let current {
+            abs(proposed.height - current.height) > abs(proposed.width - current.width)
+        } else {
+            false
+        }
+
+        if heightDriven {
+            let height = max(proposed.height, minContentSize.height)
+            var width = (height * 16 / 9).rounded()
+            if width < minContentSize.width {
+                width = minContentSize.width
+            }
+            return NSSize(width: width, height: height)
+        }
+
         let width = max(proposed.width, minContentSize.width)
         var height = (width * 9 / 16).rounded()
         if height < minContentSize.height {
@@ -272,12 +295,15 @@ final class YouTubeVideoWindowResizeGuard: NSObject, NSWindowDelegate {
         // clamp.
         guard !sender.styleMask.contains(.fullScreen) else { return frameSize }
         // frameSize is a FRAME size; convert to content, clamp, convert back so
-        // the titlebar inset is preserved.
+        // the titlebar inset is preserved. Pass the current content size so a
+        // vertical-edge drag (height changes, width doesn't) follows the height.
         let proposedFrame = NSRect(origin: .zero, size: frameSize)
         let proposedContent = sender.contentRect(forFrameRect: proposedFrame).size
+        let currentContent = sender.contentRect(forFrameRect: sender.frame).size
         let clampedContent = Self.normalizedContentSize(
             for: proposedContent,
-            minContentSize: self.minContentSize
+            minContentSize: self.minContentSize,
+            current: currentContent
         )
         let clampedFrame = sender.frameRect(forContentRect: NSRect(origin: .zero, size: clampedContent))
         return clampedFrame.size
@@ -380,10 +406,18 @@ private final class WindowDragNSView: NSView {
     }
 
     override func mouseDown(with event: NSEvent) {
-        // Preserve the standard titlebar gesture: double-click zooms (or
-        // miniaturizes, per System Settings) rather than starting a drag.
+        // Preserve the standard titlebar gesture: a double-click performs the
+        // user's configured "double-click a window's title bar to" action
+        // (Zoom / Minimize / None); a single click starts the window drag.
         if event.clickCount == 2 {
-            self.window?.performZoom(nil)
+            switch UserDefaults.standard.string(forKey: "AppleActionOnDoubleClick") {
+            case "Minimize":
+                self.window?.miniaturize(nil)
+            case "None":
+                break
+            default: // "Maximize" (zoom) is the macOS default.
+                self.window?.performZoom(nil)
+            }
         } else {
             self.window?.performDrag(with: event)
         }

--- a/Sources/Kaset/Views/YouTube/YouTubeVideoWindowController.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeVideoWindowController.swift
@@ -19,6 +19,17 @@ final class YouTubeVideoWindowController {
     private var isClosing = false
     private let frameAutosaveKey = "KasetYouTubeVideoWindow"
 
+    /// Floor for the video content area. Below roughly this size the macOS 26
+    /// `NSHostingView` safe-area corner-inset recompute can raise an uncaught
+    /// `NSException` during the display-cycle commit and abort the app, so the
+    /// resize guard never lets the content shrink past it.
+    private static let minContentSize = NSSize(width: 512, height: 288)
+
+    /// Enforces the 16:9 ratio and the `minContentSize` floor on every resize.
+    /// Strong reference because `NSWindow.delegate` is weak; kept for the
+    /// window's lifetime and torn down in `performCleanup`.
+    private var resizeGuard: YouTubeVideoWindowResizeGuard?
+
     /// When fullscreen was entered from the inline watch view, exiting it
     /// docks the video back inline instead of leaving the small pop-out.
     private var returnInlineOnExitFullscreen = false
@@ -60,12 +71,19 @@ final class YouTubeVideoWindowController {
         // fullScreenPrimary so the green traffic light enters fullscreen
         // (not just zoom).
         window.collectionBehavior = [.fullScreenPrimary]
-        // Lock resizing to the video's aspect ratio so the surface can't be
-        // misshapen (controls overlay inside the video, so content == video).
-        window.contentAspectRatio = NSSize(width: 16, height: 9)
-        // Generous floor: the full player bar needs the width, and very
-        // small WebView surfaces have crashed during live resizes.
-        window.contentMinSize = NSSize(width: 512, height: 288)
+        // Aspect + floor are enforced by the resize-guard delegate below, NOT
+        // by contentAspectRatio. With both contentAspectRatio and
+        // contentMinSize set, AppKit honors the aspect lock on the dragged axis
+        // during live resize and lets the OTHER axis slip below the floor; the
+        // resulting degenerate content rect makes the macOS 26 NSHostingView
+        // safe-area corner-inset update raise an uncaught NSException in the
+        // display-cycle commit (SIGABRT). A windowWillResize clamp is the single
+        // sizing authority, so the two constraints can't fight.
+        let resizeGuard = YouTubeVideoWindowResizeGuard(minContentSize: Self.minContentSize)
+        self.resizeGuard = resizeGuard
+        window.delegate = resizeGuard
+        // Harmless backstop now that nothing competes with it.
+        window.contentMinSize = Self.minContentSize
         window.backgroundColor = .black
         window.setFrameAutosaveName(self.frameAutosaveKey)
         window.identifier = NSUserInterfaceItemIdentifier(AccessibilityID.YouTubeContent.videoWindow)
@@ -73,13 +91,18 @@ final class YouTubeVideoWindowController {
         if !window.setFrameUsingName(self.frameAutosaveKey) {
             self.positionAtDefaultLocation(window: window)
         }
-        // Saved frames from earlier layouts may not be 16:9; the aspect lock
-        // only constrains user resizes, so normalize the content explicitly.
-        var contentSize = window.contentRect(forFrameRect: window.frame).size
-        contentSize.width = max(contentSize.width, 512)
-        let expectedHeight = contentSize.width * 9 / 16
-        if abs(contentSize.height - expectedHeight) > 1 || contentSize.width < 512 {
-            window.setContentSize(NSSize(width: contentSize.width, height: expectedHeight))
+        // A saved frame from an earlier layout may not be 16:9 (or may be below
+        // the floor); windowWillResize only fires for interactive resizes, so
+        // normalize the restored frame explicitly through the same clamp.
+        let currentContent = window.contentRect(forFrameRect: window.frame).size
+        let normalized = YouTubeVideoWindowResizeGuard.normalizedContentSize(
+            for: currentContent,
+            minContentSize: Self.minContentSize
+        )
+        if abs(currentContent.width - normalized.width) > 1
+            || abs(currentContent.height - normalized.height) > 1
+        {
+            window.setContentSize(normalized)
         }
 
         window.orderFront(nil)
@@ -170,6 +193,24 @@ final class YouTubeVideoWindowController {
     private func performCleanup() {
         self.youtubePlayerService?.isWindowFullscreen = false
         self.returnInlineOnExitFullscreen = false
+        // Remove the fullscreen observers registered in show() so they don't
+        // stack on the shared singleton across show/close cycles. (The willClose
+        // observer is removed on the close paths before cleanup runs.) Scoped to
+        // the window object, mirroring how show() registered them.
+        if let window = self.window {
+            NotificationCenter.default.removeObserver(
+                self,
+                name: NSWindow.didEnterFullScreenNotification,
+                object: window
+            )
+            NotificationCenter.default.removeObserver(
+                self,
+                name: NSWindow.didExitFullScreenNotification,
+                object: window
+            )
+        }
+        self.window?.delegate = nil
+        self.resizeGuard = nil
         self.window = nil
         self.hostingView = nil
         self.isClosing = false
@@ -189,6 +230,60 @@ final class YouTubeVideoWindowController {
     }
 }
 
+// MARK: - YouTubeVideoWindowResizeGuard
+
+/// Window delegate that keeps the floating video window at 16:9 and never lets
+/// it shrink below a safe floor.
+///
+/// Replaces `NSWindow.contentAspectRatio` + `contentMinSize`: when both are
+/// set, AppKit reconciles the aspect lock on the dragged axis during a live
+/// resize and lets the other axis slip below the floor. The degenerate content
+/// rect then makes the macOS 26 `NSHostingView` safe-area corner-inset recompute
+/// raise an uncaught `NSException` inside the display-cycle commit, aborting the
+/// app. Clamping every proposed frame in `windowWillResize(_:to:)` — before the
+/// geometry is applied — keeps a single sizing authority, so nothing competes.
+@MainActor
+final class YouTubeVideoWindowResizeGuard: NSObject, NSWindowDelegate {
+    private let minContentSize: NSSize
+
+    init(minContentSize: NSSize) {
+        self.minContentSize = minContentSize
+        super.init()
+    }
+
+    /// Floors a proposed content size and snaps it to 16:9. Pure function so
+    /// both interactive resizes and programmatic frame restores share it.
+    static func normalizedContentSize(for proposed: NSSize, minContentSize: NSSize) -> NSSize {
+        // Drive off width, then derive a 16:9 height; if that height would fall
+        // under the floor, drive off the floor height instead. Guarantees both
+        // axes stay at or above the floor.
+        let width = max(proposed.width, minContentSize.width)
+        var height = (width * 9 / 16).rounded()
+        if height < minContentSize.height {
+            height = minContentSize.height
+        }
+        return NSSize(width: width, height: height)
+    }
+
+    func windowWillResize(_ sender: NSWindow, to frameSize: NSSize) -> NSSize {
+        // Never reshape a fullscreen transition: the animation drives the window
+        // to screen size (far above the floor), and returning a width-derived
+        // 16:9 size would distort it. Only interactive/standard resizes need the
+        // clamp.
+        guard !sender.styleMask.contains(.fullScreen) else { return frameSize }
+        // frameSize is a FRAME size; convert to content, clamp, convert back so
+        // the titlebar inset is preserved.
+        let proposedFrame = NSRect(origin: .zero, size: frameSize)
+        let proposedContent = sender.contentRect(forFrameRect: proposedFrame).size
+        let clampedContent = Self.normalizedContentSize(
+            for: proposedContent,
+            minContentSize: self.minContentSize
+        )
+        let clampedFrame = sender.frameRect(forContentRect: NSRect(origin: .zero, size: clampedContent))
+        return clampedFrame.size
+    }
+}
+
 // MARK: - YouTubeVideoWindowContent
 
 /// Floating window content: corner-to-corner video with hover-revealed
@@ -199,6 +294,11 @@ private struct YouTubeVideoWindowContent: View {
     @Environment(YouTubePlayerService.self) private var youtubePlayer
 
     @State private var isHovering = false
+
+    /// Height of the top strip that moves the window. Generous enough to be
+    /// an easy grab target; the top of the video carries no YouTube controls
+    /// (the scrubber lives at the bottom), so it costs no native click area.
+    private static let dragStripHeight: CGFloat = 36
 
     var body: some View {
         ZStack(alignment: .topLeading) {
@@ -212,6 +312,28 @@ private struct YouTubeVideoWindowContent: View {
                         .transition(.opacity)
                 }
             }
+
+            // Top drag strip: the corner-to-corner WebView reports
+            // mouseDownCanMoveWindow == false and swallows mouseDown, so the
+            // window's isMovableByWindowBackground is dead everywhere the
+            // WebView covers — leaving only the hidden titlebar sliver to grab.
+            // This native strip sits above the WebView and moves the window
+            // explicitly via NSWindow.performDrag.
+            WindowDragHandle()
+                .frame(maxWidth: .infinity)
+                .frame(height: Self.dragStripHeight)
+                .overlay(alignment: .top) {
+                    if self.isHovering {
+                        // Subtle grab affordance so the drag region is
+                        // discoverable without cluttering the chrome-free look.
+                        Capsule()
+                            .fill(.white.opacity(0.35))
+                            .frame(width: 36, height: 5)
+                            .padding(.top, 7)
+                            .transition(.opacity)
+                            .allowsHitTesting(false)
+                    }
+                }
         }
         .background(.black)
         .ignoresSafeArea()
@@ -220,6 +342,50 @@ private struct YouTubeVideoWindowContent: View {
                 self.isHovering = hovering
             }
             YouTubeVideoWindowController.shared.setWindowChromeVisible(hovering)
+        }
+    }
+}
+
+// MARK: - WindowDragHandle
+
+/// Transparent native strip that lets the user move the floating window by
+/// dragging along the top. The hosted WebView reports
+/// `mouseDownCanMoveWindow == false` and consumes `mouseDown`, defeating the
+/// window's `isMovableByWindowBackground` everywhere it covers; this strip sits
+/// above the WebView and drives the move explicitly through
+/// `NSWindow.performDrag(with:)`. Scoped to the floating window only — the
+/// shared `YouTubeWatchSurfaceView` is untouched.
+private struct WindowDragHandle: NSViewRepresentable {
+    func makeNSView(context _: Context) -> NSView {
+        WindowDragNSView()
+    }
+
+    func updateNSView(_: NSView, context _: Context) {}
+}
+
+// MARK: - WindowDragNSView
+
+/// Backing view for `WindowDragHandle`.
+private final class WindowDragNSView: NSView {
+    /// Take `mouseDown` ourselves instead of letting AppKit's background-drag
+    /// heuristics intercept it, so the move is driven deterministically.
+    override var mouseDownCanMoveWindow: Bool {
+        false
+    }
+
+    /// Drag even when the floating window is not key — it is ordered front
+    /// without stealing focus, so a first click must move it, not just activate.
+    override func acceptsFirstMouse(for _: NSEvent?) -> Bool {
+        true
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        // Preserve the standard titlebar gesture: double-click zooms (or
+        // miniaturizes, per System Settings) rather than starting a drag.
+        if event.clickCount == 2 {
+            self.window?.performZoom(nil)
+        } else {
+            self.window?.performDrag(with: event)
         }
     }
 }

--- a/Sources/Kaset/Views/YouTube/YouTubeViewModelStore.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeViewModelStore.swift
@@ -36,6 +36,11 @@ final class YouTubeViewModelStore {
 
     /// Resets account-scoped state after an account switch.
     func resetForAccountChange() {
+        // Cancel the outgoing Home model's in-flight load before discarding it:
+        // its unstructured load task survives view teardown and would otherwise
+        // keep using the shared client after the cache scope moved to the new
+        // account (stale continuation / cache contamination).
+        self.home.cancelLoad()
         self.home = YouTubeHomeViewModel(client: self.client)
         self.search = YouTubeSearchViewModel(client: self.client)
         self.explore = YouTubeExploreViewModel(client: self.client)

--- a/Tests/KasetTests/APICacheTests.swift
+++ b/Tests/KasetTests/APICacheTests.swift
@@ -30,6 +30,18 @@ struct APICacheTests {
         #expect(retrieved == nil)
     }
 
+    @Test("Raw data set and get round-trips")
+    func cacheDataSetAndGet() {
+        let bytes = Data("a 2MB-ish home response would go here".utf8)
+        self.cache.setData(key: "raw_key", data: bytes, ttl: 60)
+
+        #expect(self.cache.getData(key: "raw_key") == bytes)
+        // Missing key is nil, and a dict-typed entry is not mistaken for data.
+        #expect(self.cache.getData(key: "nonexistent_raw") == nil)
+        self.cache.set(key: "dict_key", data: ["k": 1], ttl: 60)
+        #expect(self.cache.getData(key: "dict_key") == nil)
+    }
+
     @Test("Cache invalidate all")
     func cacheInvalidateAll() {
         self.cache.set(key: "key1", data: ["a": 1], ttl: 60)

--- a/Tests/KasetTests/APICacheTests.swift
+++ b/Tests/KasetTests/APICacheTests.swift
@@ -42,6 +42,18 @@ struct APICacheTests {
         #expect(self.cache.getData(key: "dict_key") == nil)
     }
 
+    @Test("invalidateAll bumps the generation counter")
+    func invalidateAllBumpsGeneration() {
+        // Callers capture the generation before an async fetch and refuse to
+        // write a stale response if it changed (account switch / sign-out /
+        // session expiry), even when the cache-scope key is unchanged.
+        let before = self.cache.generation
+        self.cache.invalidateAll()
+        #expect(self.cache.generation == before + 1)
+        self.cache.invalidateAll()
+        #expect(self.cache.generation == before + 2)
+    }
+
     @Test("Cache invalidate all")
     func cacheInvalidateAll() {
         self.cache.set(key: "key1", data: ["a": 1], ttl: 60)

--- a/Tests/KasetTests/Helpers/MockYouTubeClient.swift
+++ b/Tests/KasetTests/Helpers/MockYouTubeClient.swift
@@ -210,8 +210,16 @@ final class MockYouTubeClient: YouTubeClientProtocol {
         return self.subscribedChannels
     }
 
+    /// Awaited inside `getHistory` before it returns, so a test can hold the
+    /// Continue Watching (history) request open and verify topic rails publish
+    /// without waiting for it.
+    var beforeHistoryReturn: (@Sendable () async -> Void)?
+
     func getHistory() async throws -> YouTubeFeed {
         if let error { throw error }
+        if let beforeHistoryReturn {
+            await beforeHistoryReturn()
+        }
         return self.historyFeed
     }
 

--- a/Tests/KasetTests/Helpers/MockYouTubeClient.swift
+++ b/Tests/KasetTests/Helpers/MockYouTubeClient.swift
@@ -53,6 +53,19 @@ final class MockYouTubeClient: YouTubeClientProtocol {
         return self.homeFeed
     }
 
+    func getHomeBundle() async throws -> YouTubeHomeBundle {
+        if let error { throw error }
+        // One call stands in for the single coalesced fetch: count it like a
+        // home-feed fetch so call-count assertions read naturally, and assemble
+        // the bundle from the same fixtures the individual getters use.
+        self.homeFeedCallCount += 1
+        return YouTubeHomeBundle(
+            feed: self.homeFeed,
+            chips: self.homeChips,
+            shelves: self.homeShelves
+        )
+    }
+
     func getHomeFeedContinuation() async throws -> YouTubeFeed? {
         if let error { throw error }
         if !self.homeContinuationPages.isEmpty {

--- a/Tests/KasetTests/VideoSupportTests.swift
+++ b/Tests/KasetTests/VideoSupportTests.swift
@@ -2,6 +2,8 @@ import Foundation
 import Testing
 @testable import Kaset
 
+// MARK: - VideoSupportTests
+
 /// Tests for Video Support functionality.
 @Suite(.serialized, .tags(.service))
 @MainActor
@@ -132,5 +134,57 @@ struct VideoSupportTests {
         #expect(hidden == .hidden)
         #expect(miniPlayer == .miniPlayer)
         #expect(video == .video)
+    }
+}
+
+// MARK: - YouTubeVideoWindowResizeGuardTests
+
+@Suite(.tags(.service))
+@MainActor
+struct YouTubeVideoWindowResizeGuardTests {
+    private let floor = NSSize(width: 512, height: 288)
+
+    @Test("Width-driven resize snaps height to 16:9 (default)")
+    func widthDrivenSnapsHeight() {
+        let result = YouTubeVideoWindowResizeGuard.normalizedContentSize(
+            for: NSSize(width: 800, height: 999),
+            minContentSize: self.floor
+        )
+        #expect(result == NSSize(width: 800, height: 450)) // 800 * 9/16
+    }
+
+    @Test("Floor is enforced on both axes")
+    func floorEnforced() {
+        let result = YouTubeVideoWindowResizeGuard.normalizedContentSize(
+            for: NSSize(width: 100, height: 100),
+            minContentSize: self.floor
+        )
+        #expect(result == self.floor)
+    }
+
+    @Test("Vertical-edge drag follows the proposed height")
+    func heightDrivenFollowsHeight() {
+        // Current 800x450; user drags the bottom edge to make it taller. Width is
+        // unchanged, height grew — the clamp must follow the height, not snap it
+        // back to the old width-derived value.
+        let result = YouTubeVideoWindowResizeGuard.normalizedContentSize(
+            for: NSSize(width: 800, height: 700),
+            minContentSize: self.floor,
+            current: NSSize(width: 800, height: 450)
+        )
+        #expect(result.height == 700)
+        #expect(result.width == (700.0 * 16 / 9).rounded()) // 1244
+        #expect(result.width > 800) // followed the height, did not snap back
+    }
+
+    @Test("Horizontal-edge drag still follows the proposed width")
+    func widthDrivenWithCurrent() {
+        let result = YouTubeVideoWindowResizeGuard.normalizedContentSize(
+            for: NSSize(width: 1000, height: 450),
+            minContentSize: self.floor,
+            current: NSSize(width: 800, height: 450)
+        )
+        #expect(result.width == 1000)
+        #expect(result.height == (1000.0 * 9 / 16).rounded()) // 563
     }
 }

--- a/Tests/KasetTests/VideoSupportTests.swift
+++ b/Tests/KasetTests/VideoSupportTests.swift
@@ -166,25 +166,26 @@ struct YouTubeVideoWindowResizeGuardTests {
     func heightDrivenFollowsHeight() {
         // Current 800x450; user drags the bottom edge to make it taller. Width is
         // unchanged, height grew — the clamp must follow the height, not snap it
-        // back to the old width-derived value.
+        // back to the old width-derived value. width = round(700 * 16/9) = 1244.
         let result = YouTubeVideoWindowResizeGuard.normalizedContentSize(
             for: NSSize(width: 800, height: 700),
             minContentSize: self.floor,
             current: NSSize(width: 800, height: 450)
         )
         #expect(result.height == 700)
-        #expect(result.width == (700.0 * 16 / 9).rounded()) // 1244
-        #expect(result.width > 800) // followed the height, did not snap back
+        #expect(result.width == 1244) // followed the height, not snapped to 800
     }
 
     @Test("Horizontal-edge drag still follows the proposed width")
     func widthDrivenWithCurrent() {
+        // width unchanged-axis is the bigger delta, so drive off width:
+        // height = round(1000 * 9/16) = round(562.5) = 563.
         let result = YouTubeVideoWindowResizeGuard.normalizedContentSize(
             for: NSSize(width: 1000, height: 450),
             minContentSize: self.floor,
             current: NSSize(width: 800, height: 450)
         )
         #expect(result.width == 1000)
-        #expect(result.height == (1000.0 * 9 / 16).rounded()) // 563
+        #expect(result.height == 563)
     }
 }

--- a/Tests/KasetTests/YouTubeHomeViewModelTests.swift
+++ b/Tests/KasetTests/YouTubeHomeViewModelTests.swift
@@ -154,6 +154,76 @@ struct YouTubeHomeViewModelTests {
         #expect(self.sut.sections.map(\.title) == ["Continue Watching", "Breaking news", "Gaming", "Music"])
     }
 
+    @Test("Topic rails publish incrementally and still end in chip order")
+    func railsPublishIncrementallyInOrder() async {
+        // Perceived-latency fix: rails stream in as each browse resolves (a row
+        // shows as soon as ANY topic lands, not after the slowest), but the
+        // published array always honors chip order. Here the FIRST chip resolves
+        // LAST, so the second chip's rail must appear first and the first chip's
+        // rail must slot in above it once it lands.
+        self.mockClient.homeChips = [
+            YouTubeHomeChip(title: "Gaming", continuation: "tok-gaming"), // chip index 0
+            YouTubeHomeChip(title: "Music", continuation: "tok-music"), // chip index 1
+        ]
+        self.mockClient.homeTopicFeeds = [
+            "tok-gaming": YouTubeFeed(videos: MockYouTubeClient.makeVideos(count: 3), continuation: nil),
+            "tok-music": YouTubeFeed(videos: MockYouTubeClient.makeVideos(count: 3), continuation: nil),
+        ]
+
+        // Hold the FIRST chip (Gaming) open until Music has been published, so
+        // completion order is the reverse of chip order.
+        let gamingGate = AsyncGate()
+        self.mockClient.beforeTopicReturn = { continuation in
+            if continuation == "tok-gaming" {
+                await gamingGate.wait()
+            }
+        }
+
+        async let loadDone: Void = self.sut.load()
+
+        // Wait until Music has been published as the sole (out-of-order) rail.
+        while self.sut.sections.first(where: { $0.kind == .topic })?.title != "Music" {
+            await Task.yield()
+        }
+        #expect(self.sut.sections.map(\.title) == ["Music"]) // later chip shown first
+
+        // Release Gaming; it must slot ABOVE Music to restore chip order.
+        await gamingGate.open()
+        await loadDone
+        #expect(self.sut.sections.map(\.title) == ["Gaming", "Music"])
+    }
+
+    @Test("Grid, shelves, and chips come from a single coalesced home fetch")
+    func homeFetchedOncePerLoad() async {
+        // The grid, the titled shelves, and the chips that drive the topic rails
+        // all live in one FEwhat_to_watch response; load() must fetch+parse it
+        // once (getHomeBundle), not three times. Regression guard for the
+        // load-time fix.
+        self.mockClient.homeFeed = YouTubeFeed(
+            videos: MockYouTubeClient.makeVideos(count: 3),
+            continuation: nil
+        )
+        self.mockClient.homeShelves = [
+            YouTubeHomeSection(
+                id: "shelf-1-Breaking news",
+                title: "Breaking news",
+                videos: MockYouTubeClient.makeVideos(count: 2),
+                kind: .shelf
+            ),
+        ]
+        self.mockClient.homeChips = [YouTubeHomeChip(title: "Gaming", continuation: "tok-gaming")]
+        self.mockClient.homeTopicFeeds = [
+            "tok-gaming": YouTubeFeed(videos: MockYouTubeClient.makeVideos(count: 2), continuation: nil),
+        ]
+
+        await self.sut.load()
+
+        // One coalesced home fetch produced the grid, the shelf, and the chips.
+        #expect(self.mockClient.homeFeedCallCount == 1)
+        #expect(self.mockClient.homeChipsCallCount == 0) // chips came from the bundle, not a separate call
+        #expect(self.sut.sections.map(\.kind) == [.shelf, .topic])
+    }
+
     @Test("Shelf videos are excluded from the For You grid (no double render)")
     func shelfVideosExcludedFromGrid() async {
         // The parser collects shelf videos into feed.videos too; the shelf rail
@@ -321,23 +391,27 @@ struct YouTubeHomeViewModelTests {
         #expect(self.sut.sections.map(\.kind) == [.topic])
     }
 
-    @Test("A cancelled load aborts instead of publishing empty rails")
-    func cancelledLoadAbortsRails() async {
-        // Empty grid so the worst case is exercised: a cancelled load must not
-        // mark the empty grid `.loaded` or publish empty sections.
+    @Test("Cancelling the load task does not abort the persistent load")
+    func cancellingTaskDoesNotAbortLoad() async {
+        // The view model outlives the view (it lives in YouTubeViewModelStore),
+        // and SwiftUI restarts/cancels `.task` during launch/layout churn. A
+        // cancelled `.task` closure must NOT abort the load — otherwise the
+        // model is left stuck at `.idle` with nothing running (the cold-launch
+        // stuck-skeleton bug). The load runs in an unstructured task that
+        // survives outer cancellation and completes once.
         self.mockClient.homeFeed = .empty
         self.mockClient.homeChips = [YouTubeHomeChip(title: "Gaming", continuation: "tok-gaming")]
         self.mockClient.homeTopicFeeds = [
             "tok-gaming": YouTubeFeed(videos: MockYouTubeClient.makeVideos(count: 2), continuation: nil),
         ]
 
-        // Hold the topic rail open until the test cancels the load.
+        // Hold the topic rail open until the test cancels the outer task.
         let gate = AsyncGate()
         self.mockClient.beforeTopicReturn = { _ in await gate.wait() }
 
         let task = Task { await self.sut.load() }
 
-        // Wait until the rail fetch is in flight, then cancel mid-load.
+        // Wait until the rail fetch is in flight, then cancel the outer task.
         while self.mockClient.requestedTopicContinuations.isEmpty {
             await Task.yield()
         }
@@ -345,14 +419,52 @@ struct YouTubeHomeViewModelTests {
         await gate.open()
         await task.value
 
-        // The load was cancelled: it must reset to idle and publish nothing,
-        // rather than leaving an empty grid `.loaded` with no rails.
-        #expect(self.sut.loadingState == .idle)
-        #expect(self.sut.sections.isEmpty)
+        // The persistent load completed despite the outer cancellation: the
+        // topic rail is published and the model is loaded, so returning to Home
+        // shows content immediately instead of a stuck skeleton.
+        #expect(self.sut.loadingState == .loaded)
+        #expect(self.sut.sections.map(\.kind) == [.topic])
     }
 
-    @Test("A reload clears stale rails before showing the new grid")
-    func reloadClearsStaleRailsBeforeNewGrid() async {
+    @Test("refresh() cancels the in-flight load and reloads from scratch")
+    func refreshCancelsInFlightAndReloads() async {
+        self.mockClient.homeFeed = YouTubeFeed(
+            videos: MockYouTubeClient.makeVideos(count: 3),
+            continuation: nil
+        )
+        self.mockClient.homeChips = [YouTubeHomeChip(title: "Gaming", continuation: "tok-gaming")]
+        self.mockClient.homeTopicFeeds = [
+            "tok-gaming": YouTubeFeed(videos: MockYouTubeClient.makeVideos(count: 2), continuation: nil),
+        ]
+
+        // Hold the first load's rail open, then refresh() while it is in flight.
+        let gate = AsyncGate()
+        self.mockClient.beforeTopicReturn = { _ in await gate.wait() }
+        let first = Task { await self.sut.load() }
+        while self.mockClient.requestedTopicContinuations.isEmpty {
+            await Task.yield()
+        }
+
+        // refresh() must cancel the stalled in-flight load and start fresh.
+        self.mockClient.beforeTopicReturn = nil // second load's rail returns immediately
+        await self.sut.refresh()
+        await gate.open() // release the abandoned first load
+        _ = await first.value
+
+        #expect(self.sut.loadingState == .loaded)
+        #expect(self.sut.videos.count == 3)
+        #expect(self.sut.sections.map(\.kind) == [.topic])
+    }
+
+    @Test("A repeated load (task restart) preserves the rails without refetching")
+    func repeatedLoadPreservesRails() async {
+        // Regression: SwiftUI restarts `.task` whenever the Home view's identity
+        // changes (the YouTube detail column is `.id(selection)`, so navigating
+        // away and back recreates the view while the view model persists). A
+        // re-entrant load used to wipe the just-loaded rails and refetch them
+        // slowly while the cached grid won instantly, so the rails never showed.
+        // load() must now be idempotent: a restart is a no-op that keeps the
+        // rails in place.
         self.mockClient.homeFeed = YouTubeFeed(
             videos: MockYouTubeClient.makeVideos(count: 3),
             continuation: nil
@@ -365,24 +477,55 @@ struct YouTubeHomeViewModelTests {
         // First load fully populates a topic rail.
         await self.sut.load()
         #expect(self.sut.sections.map(\.kind) == [.topic])
+        #expect(self.mockClient.homeFeedCallCount == 1)
 
-        // Second load (e.g. a `.task` restart) with the rail held open: the new
-        // grid must publish with the stale rail already cleared, not lingering.
+        // A second load (e.g. a `.task` restart) is a no-op: the rails and grid
+        // stay put and nothing is refetched. `refresh()` is the explicit reload.
+        await self.sut.load()
+        #expect(self.sut.sections.map(\.kind) == [.topic]) // rails preserved, not wiped
+        #expect(self.sut.videos.count == 3)
+        #expect(self.sut.loadingState == .loaded)
+        #expect(self.mockClient.homeFeedCallCount == 1) // no refetch
+    }
+
+    @Test("Concurrent loads with the first cancelled still finish loaded (no stuck skeleton)")
+    func concurrentLoadsFirstCancelledStillLoads() async {
+        // Reproduces the cold-launch deadlock the trace exposed: SwiftUI fired
+        // `.task` twice ~18 ms apart; the restart cancelled the first load while
+        // the second bailed on the old idle-guard, and the first's cancellation
+        // reset state to `.idle` — leaving the model stuck with nothing running.
+        // The single-flight load must survive: both callers coalesce onto one
+        // run that completes regardless of the first task's cancellation.
+        self.mockClient.homeFeed = YouTubeFeed(
+            videos: MockYouTubeClient.makeVideos(count: 3),
+            continuation: nil
+        )
+        self.mockClient.homeChips = [YouTubeHomeChip(title: "Gaming", continuation: "tok-gaming")]
+        self.mockClient.homeTopicFeeds = [
+            "tok-gaming": YouTubeFeed(videos: MockYouTubeClient.makeVideos(count: 2), continuation: nil),
+        ]
+
+        // Hold the rail open so both `.task` firings overlap the in-flight load.
         let gate = AsyncGate()
         self.mockClient.beforeTopicReturn = { _ in await gate.wait() }
 
-        async let reloadDone: Void = self.sut.load()
-        while self.mockClient.requestedTopicContinuations.count < 2 {
+        let first = Task { await self.sut.load() } // .task fire #1
+        while self.mockClient.requestedTopicContinuations.isEmpty {
             await Task.yield()
         }
-
-        #expect(self.sut.loadingState == .loaded)
-        #expect(self.sut.videos.count == 3)
-        #expect(self.sut.sections.isEmpty) // stale rail cleared, not shown above the new grid
+        let second = Task { await self.sut.load() } // .task fire #2 (the restart)
+        await Task.yield()
+        first.cancel() // SwiftUI cancels the superseded first closure
 
         await gate.open()
-        await reloadDone
-        #expect(self.sut.sections.map(\.kind) == [.topic]) // fresh rail repopulates
+        _ = await first.value
+        await second.value
+
+        // Not stuck: the load completed and published grid + rail.
+        #expect(self.sut.loadingState == .loaded)
+        #expect(self.sut.videos.count == 3)
+        #expect(self.sut.sections.map(\.kind) == [.topic])
+        #expect(self.mockClient.homeFeedCallCount == 1) // coalesced to one fetch
     }
 }
 

--- a/Tests/KasetTests/YouTubeHomeViewModelTests.swift
+++ b/Tests/KasetTests/YouTubeHomeViewModelTests.swift
@@ -390,6 +390,41 @@ struct YouTubeHomeViewModelTests {
         #expect(self.sut.sections.map(\.kind) == [.topic])
     }
 
+    @Test("Empty grid does not flash loaded before the topic rails arrive")
+    func emptyGridDoesNotFlashLoadedEarly() async {
+        // Regression: the first group result is often history returning nil (no
+        // resumable watch history). With an empty grid and no shelves, flipping
+        // `.loaded` on that empty first result would flash the "No
+        // recommendations" state before the topic rows arrive. The skeleton must
+        // stay until there is real content.
+        self.mockClient.homeFeed = .empty // empty grid, no shelves
+        self.mockClient.historyFeed = .empty // history resolves to nil (not resumable)
+        self.mockClient.homeChips = [YouTubeHomeChip(title: "Gaming", continuation: "tok-gaming")]
+        self.mockClient.homeTopicFeeds = [
+            "tok-gaming": YouTubeFeed(videos: MockYouTubeClient.makeVideos(count: 2), continuation: nil),
+        ]
+
+        // Hold the topic rail open so we can observe the pre-rail state.
+        let gate = AsyncGate()
+        self.mockClient.beforeTopicReturn = { _ in await gate.wait() }
+
+        async let loadDone: Void = self.sut.load()
+
+        // Wait until the topic fetch is in flight (history has resolved to nil).
+        while self.mockClient.requestedTopicContinuations.isEmpty {
+            await Task.yield()
+        }
+        // The empty history result must NOT have cleared the skeleton.
+        #expect(self.sut.loadingState != .loaded)
+        #expect(self.sut.sections.isEmpty)
+
+        // Release the rail; now content exists and the model loads.
+        await gate.open()
+        await loadDone
+        #expect(self.sut.loadingState == .loaded)
+        #expect(self.sut.sections.map(\.kind) == [.topic])
+    }
+
     @Test("The recommendation grid renders without waiting on slow topic rails")
     func gridRendersBeforeSlowRails() async {
         self.mockClient.homeFeed = YouTubeFeed(

--- a/Tests/KasetTests/YouTubeHomeViewModelTests.swift
+++ b/Tests/KasetTests/YouTubeHomeViewModelTests.swift
@@ -154,6 +154,39 @@ struct YouTubeHomeViewModelTests {
         #expect(self.sut.sections.map(\.title) == ["Continue Watching", "Breaking news", "Gaming", "Music"])
     }
 
+    @Test("Topic rails publish without waiting for a slow history fetch")
+    func railsDoNotWaitForHistory() async {
+        // Regression: Continue Watching reads watch history (a separate, possibly
+        // slow/retrying request). It must NOT gate the topic rails — otherwise a
+        // slow history call delays every row and, with an empty grid, keeps the
+        // skeleton up. The history rail slots in at the front once it resolves.
+        self.mockClient.historyFeed = YouTubeFeed(
+            videos: [MockYouTubeClient.makeVideo(videoId: "resume", watchedPercent: 30)],
+            continuation: nil
+        )
+        self.mockClient.homeChips = [YouTubeHomeChip(title: "Gaming", continuation: "tok-gaming")]
+        self.mockClient.homeTopicFeeds = [
+            "tok-gaming": YouTubeFeed(videos: MockYouTubeClient.makeVideos(count: 2), continuation: nil),
+        ]
+
+        // Hold history open until the test releases it.
+        let historyGate = AsyncGate()
+        self.mockClient.beforeHistoryReturn = { await historyGate.wait() }
+
+        async let loadDone: Void = self.sut.load()
+
+        // The topic rail must appear while history is still blocked.
+        while !self.sut.sections.contains(where: { $0.kind == .topic }) {
+            await Task.yield()
+        }
+        #expect(self.sut.sections.map(\.kind) == [.topic]) // no Continue Watching yet
+
+        // Release history; it slots in at the front.
+        await historyGate.open()
+        await loadDone
+        #expect(self.sut.sections.map(\.kind) == [.continueWatching, .topic])
+    }
+
     @Test("Topic rails publish incrementally and still end in chip order")
     func railsPublishIncrementallyInOrder() async {
         // Perceived-latency fix: rails stream in as each browse resolves (a row

--- a/Tests/KasetTests/YouTubeHomeViewModelTests.swift
+++ b/Tests/KasetTests/YouTubeHomeViewModelTests.swift
@@ -456,6 +456,48 @@ struct YouTubeHomeViewModelTests {
         #expect(self.sut.sections.map(\.kind) == [.topic])
     }
 
+    @Test("A stale run resuming after refresh does not break single-flight")
+    func staleRunResumeKeepsSingleFlight() async {
+        // Regression for the unconditional `defer { loadTask = nil }`: when
+        // refresh() cancels run #1 and starts run #2, run #1 resuming (its
+        // network await throws on cancel) must NOT null run #2's handle. If it
+        // did, a later load() would see loadTask == nil and start a DUPLICATE
+        // getHomeBundle fetch. We assert exactly one extra fetch after the new
+        // run settles and a subsequent load() is a no-op.
+        self.mockClient.homeFeed = YouTubeFeed(
+            videos: MockYouTubeClient.makeVideos(count: 3),
+            continuation: nil
+        )
+        self.mockClient.homeChips = [YouTubeHomeChip(title: "Gaming", continuation: "tok-gaming")]
+        self.mockClient.homeTopicFeeds = [
+            "tok-gaming": YouTubeFeed(videos: MockYouTubeClient.makeVideos(count: 2), continuation: nil),
+        ]
+
+        // Hold run #1's rail open so it is mid-flight when refresh() cancels it.
+        let gate = AsyncGate()
+        self.mockClient.beforeTopicReturn = { _ in await gate.wait() }
+        let first = Task { await self.sut.load() }
+        while self.mockClient.requestedTopicContinuations.isEmpty {
+            await Task.yield()
+        }
+
+        // refresh() cancels run #1 and runs #2 to completion (rail unblocked).
+        self.mockClient.beforeTopicReturn = nil
+        await self.sut.refresh()
+        let fetchesAfterRefresh = self.mockClient.homeFeedCallCount
+
+        // Release the abandoned run #1; its late `defer` must not clear run #2's
+        // handle (token-gated). loadingState is now `.loaded`.
+        await gate.open()
+        _ = await first.value
+
+        // A subsequent load() must be a no-op (state is .loaded) — no duplicate
+        // fetch slips through from a nulled handle.
+        await self.sut.load()
+        #expect(self.sut.loadingState == .loaded)
+        #expect(self.mockClient.homeFeedCallCount == fetchesAfterRefresh)
+    }
+
     @Test("A repeated load (task restart) preserves the rails without refetching")
     func repeatedLoadPreservesRails() async {
         // Regression: SwiftUI restarts `.task` whenever the Home view's identity

--- a/Tests/KasetTests/YouTubeResponseParserTests.swift
+++ b/Tests/KasetTests/YouTubeResponseParserTests.swift
@@ -207,6 +207,39 @@ struct YouTubeFeedParserTests {
 
         #expect(YouTubeFeedParser.parseHomeShelves(data).isEmpty)
     }
+
+    @Test("parseHomeBundle parses feed, chips, and shelves from one Data response")
+    func parsesHomeBundle() throws {
+        let response = self.makeHomeResponse(
+            chips: [
+                ChipFixture(title: "All", continuation: nil, selected: true),
+                ChipFixture(title: "Gaming", continuation: "tok-gaming", selected: false),
+            ],
+            shelves: [(title: "Breaking news", videoIds: ["n1", "n2"])]
+        )
+        let data = try JSONSerialization.data(withJSONObject: response)
+
+        let bundle = try YouTubeFeedParser.parseHomeBundle(from: data)
+
+        // Chips: the selected "All" chip is dropped.
+        #expect(bundle.chips.map(\.title) == ["Gaming"])
+        #expect(bundle.chips.map(\.continuation) == ["tok-gaming"])
+        // Shelves: the titled shelf with its videos.
+        #expect(bundle.shelves.map(\.title) == ["Breaking news"])
+        #expect(bundle.shelves.first?.videos.map(\.videoId) == ["n1", "n2"])
+        // Feed: the flat walk collects the shelf videos too (the view model
+        // dedupes them against the shelf rail).
+        #expect(bundle.feed.videos.map(\.videoId).sorted() == ["n1", "n2"])
+    }
+
+    @Test("parseHomeBundle throws when the bytes are not a JSON object")
+    func homeBundleThrowsOnNonJSON() {
+        let data = Data("not json".utf8)
+
+        #expect(throws: (any Error).self) {
+            _ = try YouTubeFeedParser.parseHomeBundle(from: data)
+        }
+    }
 }
 
 // MARK: - WatchNextParserTests

--- a/docs/common-bug-patterns.md
+++ b/docs/common-bug-patterns.md
@@ -189,6 +189,109 @@ have no hyphens and pass naive `!contains("-")` checks, but fail when used as
 API parameters. Always use `hasNavigableId` which validates the `UC` prefix for
 artists (or `MPRE`/`OLAK` for albums, `MPSPP` for podcasts).
 
+## ❌ Guessing at Runtime Behavior Instead of Measuring
+
+When a bug is about *timing, lifecycle, or "why didn't this run/load/update"*
+(SwiftUI `.task`/state churn, cold-launch ordering, perceived latency),
+**instrument and observe before changing code.** Reasoning about SwiftUI
+lifecycle or async ordering from the source alone repeatedly produces wrong
+fixes; a timestamped trace settles it in one launch.
+
+**The app is sandboxed**, so most ad-hoc logging fails silently:
+
+- `Logger`/`os_log` `.info`/`.debug` lines do **not** reliably appear in
+  `log stream` / `log show`.
+- A hardcoded `/tmp/...` file write is **blocked by the sandbox** and throws
+  nothing — the file just never appears in the real `/tmp`.
+- Window-screenshot automation (`screencapture` + AX bounds) is unreliable
+  here too — prefer file traces over visual capture.
+
+Use a throwaway file tracer in the app's **container** tmp
+(`NSTemporaryDirectory()`), `synchronize()` after each line, and read it from
+`~/Library/Containers/com.sertacozercan.Kaset/Data/tmp/`:
+
+```swift
+// TEMPORARY DIAGNOSTIC — remove before commit.
+enum LoadTrace {
+    nonisolated(unsafe) private static let path =
+        NSTemporaryDirectory() + "kaset_trace.log"        // container tmp, NOT /tmp
+    nonisolated(unsafe) private static let handle: FileHandle? = {
+        FileManager.default.createFile(atPath: path, contents: nil)
+        return FileHandle(forWritingAtPath: path)
+    }()
+    nonisolated(unsafe) private static let start = ProcessInfo.processInfo.systemUptime
+
+    static func log(_ message: String) {
+        let ms = (ProcessInfo.processInfo.systemUptime - start) * 1000
+        if let d = String(format: "%8.1fms %@\n", ms, message).data(using: .utf8) {
+            handle?.write(d)
+            try? handle?.synchronize()   // flush so a crash/hang still leaves the line
+        }
+    }
+}
+```
+
+Workflow: add traces at each phase boundary → rebuild (`Scripts/build-app.sh`)
+→ launch fresh, bring frontmost so the view mounts → read the trace → fix what
+the data points at → **re-measure to confirm** → delete the tracer. This is how
+the ~840ms Home "rows-lag" was localized to 8 uncached topic-rail browses
+publishing atomically after the slowest one (not to parsing or the grid fetch,
+which were the intuitive-but-wrong guesses).
+
+## ❌ Idle-Guarded Load That Deadlocks on `.task` Restart
+
+SwiftUI restarts a view's `.task` during launch/layout churn — observed firing
+**twice ~18 ms apart** on first paint. A load guarded by `loadingState == .idle`
+plus a cancellation-resets-to-`.idle` catch creates a lost-update deadlock:
+
+```swift
+// ❌ BAD: restart cancels load #1; load #2 bails on the guard; #1's
+// cancellation resets to .idle → stuck on the skeleton, nothing running.
+func load() async {
+    guard loadingState == .idle else { return }     // load #2 bails here
+    loadingState = .loading
+    do {
+        let data = try await client.fetch()          // load #1 cancelled by restart
+        // ...publish...
+    } catch {
+        if error is CancellationError { loadingState = .idle; return }  // → stuck
+    }
+}
+```
+
+Fix with a **single-flight** load: run the work in a stored *unstructured* `Task`
+so it survives `.task` cancellation; concurrent callers coalesce onto it.
+
+```swift
+// ✅ GOOD: the work is decoupled from .task cancellation; restarts coalesce.
+private var loadTask: Task<Void, Never>?
+
+func load() async {
+    if case .loaded = loadingState { return }   // a repeat after load is a no-op
+    if let existing = loadTask { await existing.value; return }   // coalesce
+    let task = Task { await performLoad() }
+    loadTask = task
+    await task.value
+}
+
+private func performLoad() async {
+    defer { loadTask = nil }
+    // ...do the load; set .loaded on success...
+}
+
+func refresh() async {            // explicit reload must cancel + restart
+    loadTask?.cancel(); loadTask = nil
+    loadingState = .idle
+    await load()
+}
+```
+
+Test the race directly: two concurrent `load()` calls with the first cancelled
+must still end `.loaded` (not stuck `.idle`). And remember a cancelled *outer*
+`.task` must NOT abort a persistent view-model load (the VM outlives the view in
+the store) — only `refresh()` aborts. When a test encodes the old
+"cancellation aborts the load" behavior, it was protecting the bug; rewrite it.
+
 ## Pre-Submit Checklists
 
 ### Performance
@@ -213,3 +316,5 @@ artists (or `MPRE`/`OLAK` for albums, `MPSPP` for podcasts).
 - [ ] No `static var shared` pattern with mutable assignment in `init`
 - [ ] WebView message handlers removed in `dismantleNSView`
 - [ ] `WKNavigationDelegate` implements `webViewWebContentProcessDidTerminate`
+- [ ] View-model loads are single-flight (survive `.task` restart) — not idle-guarded in a way that deadlocks on cancellation
+- [ ] Timing/lifecycle bugs were **measured** with a trace, not guessed; all diagnostic instrumentation removed before commit


### PR DESCRIPTION
## Summary

A batch of YouTube-mode fixes, mostly on the Home feed, plus the pop-out video window. Each fix was verified by tests and — for the runtime/timing bugs — by live measurement on a cold launch.

**Home feed**
- **Stuck skeleton on cold launch** (loaded only after navigating away/back). SwiftUI restarts the load `.task` twice ~18 ms apart on first paint; the restart cancelled load #1, load #2 bailed on the idle-guard, and #1's cancellation reset state to `.idle` with nothing running. Fixed by making `load()` **single-flight** via a stored unstructured `Task` that survives `.task` cancellation; concurrent callers coalesce onto it.
- **Rows snapped in ~840 ms after the grid.** All 8 topic rails published atomically after the slowest (~770 ms) even though fast rails finished at ~300 ms. Now each rail **streams into `sections` as it resolves**, slotted in chip order — first row ~480 ms sooner, progressive fill instead of a snap.
- **Slow time-to-first-grid.** The 2 MB `FEwhat_to_watch` response was fetched + walked up to 3×; coalesced into one `getHomeBundle()` that parses **off the main actor**. Cold-launch caching was disabled until the account identity resolved (forcing a second serial 2 MB fetch on the critical path) — scoped to a stable `pending` identity, cache-before-auth, and topic rails are now cached.
- **Thumbnails** decoded ~4× oversized and serially; right-sized, made the decode nonisolated (parallel), and prefetch the first screenful.
- The bare `.task { load() }` on Home/Shorts/Subscriptions/History/Playlists didn't re-fire when an account swap rebuilds the view model — keyed on `ObjectIdentifier(viewModel)`.

**Floating video window**
- **Hard to drag**: the corner-to-corner WKWebView defeats `isMovableByWindowBackground`; added a native top drag strip driving `NSWindow.performDrag`.
- **SIGABRT when resized very small**: `contentAspectRatio` + `contentMinSize` were competing constraints; replaced with a single `windowWillResize` clamp.

**Docs**
- Captured the measurement-first debugging lesson and the sandbox logging gotcha (os_log/`/tmp` writes fail silently → use `NSTemporaryDirectory()` file traces) in `AGENTS.md` + `docs/common-bug-patterns.md`.

## Test plan

- [x] `swift build` clean
- [x] `swiftformat .` and `swiftlint --strict` clean
- [x] `swift test --skip KasetUITests` — **1428 tests pass** (added: single-flight survival, refresh restart, incremental ordered publish, raw-Data cache round-trip, single coalesced home fetch)
- [x] Cold-launch measured live: stuck-skeleton gone (load completes on first paint); first row ~358 ms after grid vs ~840 ms before
- [ ] Reviewer: cold-launch YouTube Home and confirm rows fade in shortly after the grid (no snap); shrink the pop-out window to the corner (no crash) and drag it from the top