### PR TITLE
Add ambient color backdrop to the YouTube watch page

### DIFF
--- a/Sources/Kaset/KasetApp.swift
+++ b/Sources/Kaset/KasetApp.swift
@@ -642,6 +642,11 @@ struct SettingsView: View {
                     }
             }
 
+            YouTubeSettingsView()
+                .tabItem {
+                    Label("YouTube", systemImage: "play.rectangle.fill")
+                }
+
             ScrobblingSettingsView()
                 .environment(self.scrobblingCoordinator)
                 .tabItem {

--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -21,6 +21,7 @@ protocol YouTubeWatchPlaybackControlling: AnyObject {
     func availableQualityLevels() async -> [String]
     func currentQualityLevel() async -> String?
     func setQualityLevel(_ level: String)
+    func storyboardSpec(expectedVideoId: String?) async -> String?
     func tearDown()
 }
 
@@ -118,6 +119,21 @@ final class YouTubePlayerService {
 
     /// The player's current quality level.
     private(set) var currentQuality: String?
+
+    /// YouTube storyboard spec for the current video (drives the ambient
+    /// backdrop's fine-grained live color). `nil` until fetched / unavailable.
+    private(set) var storyboardSpec: String?
+
+    /// The video id `storyboardSpec` was fetched for, so the spec is keyed to
+    /// its video rather than relying on reset ordering — a different id forces a
+    /// refetch and prevents a previous video's spec from leaking forward.
+    private var storyboardSpecVideoId: String?
+
+    /// The video id whose storyboard fetch is currently running or has already
+    /// completed (even when it produced no spec). Makes `refreshStoryboardSpec`
+    /// self-guarding so a re-trigger for the same video can't spawn overlapping
+    /// retry loops or repeated WebView evaluations.
+    private var storyboardFetchVideoId: String?
 
     /// The video whose playback options were last fetched.
     private var playbackOptionsVideoId: String?
@@ -313,6 +329,9 @@ final class YouTubePlayerService {
         self.activeCaptionLanguageCode = nil
         self.qualityLevels = []
         self.currentQuality = nil
+        self.storyboardSpec = nil
+        self.storyboardSpecVideoId = nil
+        self.storyboardFetchVideoId = nil
         self.playbackOptionsVideoId = nil
     }
 
@@ -356,6 +375,37 @@ final class YouTubePlayerService {
             if !tracks.isEmpty || attempt == 2 {
                 return
             }
+            try? await Task.sleep(for: .milliseconds(1500))
+        }
+    }
+
+    /// Fetches the storyboard spec for the ambient backdrop, keyed to its video
+    /// so a previous video's spec never leaks forward. Kept separate from
+    /// `refreshPlaybackOptions` so this cosmetic-only data never delays caption
+    /// or quality loading. Retries briefly since the player response, like the
+    /// captions module, isn't ready the instant playback starts.
+    func refreshStoryboardSpec() async {
+        let videoId = self.currentVideo?.videoId
+        // Already fetched (or fetching) for this exact video — don't spawn an
+        // overlapping retry loop, even on a no-storyboard video that resolved
+        // to nil.
+        if self.storyboardFetchVideoId == videoId {
+            return
+        }
+        self.storyboardFetchVideoId = videoId
+        // Drop any spec from a previous video before awaiting the refetch.
+        self.storyboardSpec = nil
+        self.storyboardSpecVideoId = nil
+
+        for attempt in 0 ..< 3 {
+            let spec = await self.playbackController.storyboardSpec(expectedVideoId: videoId)
+            guard self.currentVideo?.videoId == videoId else { return }
+            if let spec {
+                self.storyboardSpec = spec
+                self.storyboardSpecVideoId = videoId
+                return
+            }
+            if attempt == 2 { return }
             try? await Task.sleep(for: .milliseconds(1500))
         }
     }
@@ -481,6 +531,13 @@ final class YouTubePlayerService {
             self.playbackOptionsVideoId = videoId
             Task {
                 await self.refreshPlaybackOptions()
+            }
+            // Storyboard color is only worth fetching when the ambient backdrop
+            // is on; runs independently so it never delays caption/quality load.
+            if SettingsManager.shared.ambientBackdropEnabled {
+                Task {
+                    await self.refreshStoryboardSpec()
+                }
             }
         }
 

--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -124,16 +124,16 @@ final class YouTubePlayerService {
     /// backdrop's fine-grained live color). `nil` until fetched / unavailable.
     private(set) var storyboardSpec: String?
 
-    /// The video id `storyboardSpec` was fetched for, so the spec is keyed to
-    /// its video rather than relying on reset ordering — a different id forces a
-    /// refetch and prevents a previous video's spec from leaking forward.
-    private var storyboardSpecVideoId: String?
-
-    /// The video id whose storyboard fetch is currently running or has already
-    /// completed (even when it produced no spec). Makes `refreshStoryboardSpec`
-    /// self-guarding so a re-trigger for the same video can't spawn overlapping
-    /// retry loops or repeated WebView evaluations.
+    /// The video id whose storyboard spec has been *resolved* — either
+    /// successfully fetched, or confirmed absent after a full retry while real
+    /// content (not a preroll ad) was playing. Acts as a positive+negative cache
+    /// so a re-trigger for the same video is a no-op and storyboard-less videos
+    /// don't re-fetch on every playback update.
     private var storyboardFetchVideoId: String?
+
+    /// The video id whose storyboard fetch loop is currently running, to avoid
+    /// spawning overlapping loops / repeated WebView evaluations for one video.
+    private var storyboardFetchInFlightVideoId: String?
 
     /// The video whose playback options were last fetched.
     private var playbackOptionsVideoId: String?
@@ -330,8 +330,8 @@ final class YouTubePlayerService {
         self.qualityLevels = []
         self.currentQuality = nil
         self.storyboardSpec = nil
-        self.storyboardSpecVideoId = nil
         self.storyboardFetchVideoId = nil
+        self.storyboardFetchInFlightVideoId = nil
         self.playbackOptionsVideoId = nil
     }
 
@@ -386,26 +386,41 @@ final class YouTubePlayerService {
     /// captions module, isn't ready the instant playback starts.
     func refreshStoryboardSpec() async {
         let videoId = self.currentVideo?.videoId
-        // Already fetched (or fetching) for this exact video — don't spawn an
-        // overlapping retry loop, even on a no-storyboard video that resolved
-        // to nil.
+        // Already resolved this exact video (got a spec, or confirmed it has
+        // none after a full retry) — nothing to do. The trigger only calls this
+        // for real content, never during a preroll ad, so a resolved `nil` here
+        // is a genuine "no storyboard" and is safe to cache as a negative result
+        // instead of re-fetching on every 1 Hz playback update.
         if self.storyboardFetchVideoId == videoId {
             return
         }
-        self.storyboardFetchVideoId = videoId
+        if self.storyboardFetchInFlightVideoId == videoId {
+            return
+        }
+        self.storyboardFetchInFlightVideoId = videoId
+        defer {
+            if self.storyboardFetchInFlightVideoId == videoId {
+                self.storyboardFetchInFlightVideoId = nil
+            }
+        }
         // Drop any spec from a previous video before awaiting the refetch.
         self.storyboardSpec = nil
-        self.storyboardSpecVideoId = nil
+        self.storyboardFetchVideoId = nil
 
         for attempt in 0 ..< 3 {
             let spec = await self.playbackController.storyboardSpec(expectedVideoId: videoId)
             guard self.currentVideo?.videoId == videoId else { return }
             if let spec {
                 self.storyboardSpec = spec
-                self.storyboardSpecVideoId = videoId
+                self.storyboardFetchVideoId = videoId
                 return
             }
-            if attempt == 2 { return }
+            if attempt == 2 {
+                // Retries exhausted on real content: cache the negative result
+                // so we don't loop forever on a storyboard-less video.
+                self.storyboardFetchVideoId = videoId
+                return
+            }
             try? await Task.sleep(for: .milliseconds(1500))
         }
     }
@@ -532,12 +547,21 @@ final class YouTubePlayerService {
             Task {
                 await self.refreshPlaybackOptions()
             }
-            // Storyboard color is only worth fetching when the ambient backdrop
-            // is on; runs independently so it never delays caption/quality load.
-            if SettingsManager.shared.ambientBackdropEnabled {
-                Task {
-                    await self.refreshStoryboardSpec()
-                }
+        }
+
+        // Storyboard color drives the ambient backdrop, so only fetch it when
+        // the feature is on and real content (not a preroll ad) is playing.
+        // Not gated on the one-shot playback-options branch above, so it also
+        // fires when the user enables ambient mid-playback or when content
+        // starts after an ad. `refreshStoryboardSpec` is self-guarding, so
+        // calling it on each qualifying update is cheap.
+        if update.isPlaying,
+           !update.isAd,
+           self.currentVideo != nil,
+           SettingsManager.shared.ambientBackdropEnabled
+        {
+            Task {
+                await self.refreshStoryboardSpec()
             }
         }
 

--- a/Sources/Kaset/Services/SettingsManager.swift
+++ b/Sources/Kaset/Services/SettingsManager.swift
@@ -25,6 +25,8 @@ final class SettingsManager {
         static let romanizationEnabled = "settings.romanizationEnabled"
         static let contentLanguage = "settings.contentLanguage"
         static let keepMiniPlayerOnTop = "settings.keepMiniPlayerOnTop"
+        static let ambientBackdropEnabled = "settings.ambientBackdropEnabled"
+        static let ambientBackdropStyle = "settings.ambientBackdropStyle"
         #if DEBUG
             static let useLegacyMacOS15UI = "settings.debug.useLegacyMacOS15UI"
         #endif
@@ -292,6 +294,27 @@ final class SettingsManager {
         }
     }
 
+    /// Whether the ambient color backdrop is shown on the YouTube watch page.
+    /// Applies to regular YouTube videos only, not the Music experience.
+    var ambientBackdropEnabled: Bool {
+        didSet {
+            UserDefaults.standard.set(self.ambientBackdropEnabled, forKey: Keys.ambientBackdropEnabled)
+        }
+    }
+
+    /// The chosen ambient backdrop style when the feature is enabled.
+    var ambientBackdropStyle: AmbientBackdropStyle {
+        didSet {
+            UserDefaults.standard.set(self.ambientBackdropStyle.rawValue, forKey: Keys.ambientBackdropStyle)
+        }
+    }
+
+    /// The style the YouTube watch page should actually render: the chosen
+    /// style when enabled, `.off` when the feature is disabled.
+    var resolvedAmbientStyle: AmbientBackdropStyle {
+        self.ambientBackdropEnabled ? self.ambientBackdropStyle : .off
+    }
+
     /// The language used for the app interface and API content.
     var contentLanguage: ContentLanguage {
         didSet {
@@ -335,6 +358,7 @@ final class SettingsManager {
         self.syncedLyricsEnabled = UserDefaults.standard.object(forKey: Keys.syncedLyricsEnabled) as? Bool ?? true
         self.romanizationEnabled = UserDefaults.standard.object(forKey: Keys.romanizationEnabled) as? Bool ?? true
         self.keepMiniPlayerOnTop = UserDefaults.standard.object(forKey: Keys.keepMiniPlayerOnTop) as? Bool ?? false
+        self.ambientBackdropEnabled = UserDefaults.standard.object(forKey: Keys.ambientBackdropEnabled) as? Bool ?? true
         #if DEBUG
             self.useLegacyMacOS15UI = UserDefaults.standard.object(forKey: Keys.useLegacyMacOS15UI) as? Bool ?? false
         #endif
@@ -353,6 +377,15 @@ final class SettingsManager {
             self.playbackAudioQuality = quality
         } else {
             self.playbackAudioQuality = .auto
+        }
+
+        if let rawValue = UserDefaults.standard.string(forKey: Keys.ambientBackdropStyle),
+           let style = AmbientBackdropStyle(rawValue: rawValue),
+           style != .off
+        {
+            self.ambientBackdropStyle = style
+        } else {
+            self.ambientBackdropStyle = .live
         }
 
         if let rawValue = UserDefaults.standard.string(forKey: Keys.defaultLaunchPage),

--- a/Sources/Kaset/Views/YouTube/AmbientBackdropStyle.swift
+++ b/Sources/Kaset/Views/YouTube/AmbientBackdropStyle.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+// MARK: - AmbientBackdropStyle
+
+/// The visual style of the YouTube watch-page ambient backdrop.
+///
+/// Shared between `SettingsManager` (persistence) and `AmbientVideoBackdrop`
+/// (rendering). `off` is reached by disabling the feature rather than being a
+/// user-pickable style — see `userSelectableCases`.
+enum AmbientBackdropStyle: String, CaseIterable, Identifiable {
+    /// No ambient — the plain window background.
+    case off
+    /// A steady (non-drifting) soft version of the aurora glow.
+    case soft
+    /// Drifting multi-color aurora from the static thumbnail.
+    case glow
+    /// Drifting aurora whose colors crossfade through the storyboard
+    /// sprite-sheet cells as the video plays.
+    case live
+
+    var id: String {
+        self.rawValue
+    }
+
+    /// The styles a user can choose in Settings. `off` is excluded — turning
+    /// the feature off is the master toggle's job, so the picker never offers a
+    /// redundant second "off".
+    static var userSelectableCases: [AmbientBackdropStyle] {
+        [.soft, .glow, .live]
+    }
+
+    /// User-facing name shown in Settings.
+    var displayName: String {
+        switch self {
+        case .off: String(localized: "Off")
+        case .soft: String(localized: "Soft")
+        case .glow: String(localized: "Glow")
+        case .live: String(localized: "Live (follows video)")
+        }
+    }
+
+    /// Terse label for the DEBUG developer style picker.
+    var debugLabel: String {
+        switch self {
+        case .off: "Off"
+        case .soft: "Soft"
+        case .glow: "Glow"
+        case .live: "Live (storyboard)"
+        }
+    }
+}

--- a/Sources/Kaset/Views/YouTube/AmbientVideoBackdrop.swift
+++ b/Sources/Kaset/Views/YouTube/AmbientVideoBackdrop.swift
@@ -82,7 +82,6 @@ struct AmbientVideoBackdrop: View {
     // MARK: Ambient composition
 
     /// Branch on Reduce Motion rather than pausing the `TimelineView`, mirroring
-    /// Branch on Reduce Motion rather than pausing the `TimelineView`, mirroring
     /// the repo's `PulseModifier` pattern. `.soft` is intentionally steady (no
     /// drift) so it reads as a calm version of the same glow.
     private var ambientContent: some View {
@@ -107,7 +106,10 @@ struct AmbientVideoBackdrop: View {
         let frames = self.renderFrames
         // `.soft` is the calm style: same colors, dimmer than the drifting glow.
         let intensity: Double = self.style == .soft ? 0.7 : 1.0
-        if frames.count <= 1 {
+        // Under Reduce Motion, collapse `.live` to a single static frame: the
+        // blobs already stop drifting (time: nil) and the colors must not
+        // cross-fade as playback advances either.
+        if frames.count <= 1 || self.reduceMotion {
             Self.aurora(
                 colors: frames.first ?? self.fallbackColors,
                 size: size,

--- a/Sources/Kaset/Views/YouTube/AmbientVideoBackdrop.swift
+++ b/Sources/Kaset/Views/YouTube/AmbientVideoBackdrop.swift
@@ -1,0 +1,625 @@
+import AppKit
+import CoreGraphics
+import SwiftUI
+
+// MARK: - AmbientVideoBackdrop
+
+/// PROTOTYPE — "live ambient" glow for the YouTube watch page.
+///
+/// We cannot sample the playing video's pixels (Widevine DRM black-frames every
+/// capture path, and the surface is an opaque AppKit web view). Instead this
+/// renders the effect itself: a drifting "aurora" of luminous color blobs pulled
+/// from the video thumbnail — and, in `.live` mode, crossfading through the
+/// colors of YouTube's non-DRM storyboard sprite-sheet cells keyed to playback
+/// progress, so the color shifts as the video plays without ever touching a
+/// protected frame. The page's existing Liquid Glass chrome tints over it as a
+/// bonus, but the glow stands on its own.
+///
+/// Self-contained on purpose: it does NOT edit the shared `AccentBackground`
+/// (used by the artist/playlist/podcast pages). Revert by deleting this file and
+/// the `.ambientVideoBackdrop(...)` call in `YouTubeWatchView`.
+struct AmbientVideoBackdrop: View {
+    // MARK: Inputs
+
+    let videoId: String?
+    let thumbnailURL: URL?
+    let style: AmbientBackdropStyle
+    /// 0…1 playback position for `.live` crossfade; `nil` when this video is
+    /// not the one actively playing (the parent guards `duration > 0`).
+    var liveFraction: Double?
+    /// YouTube storyboard spec for fine-grained `.live` color. When present,
+    /// its sprite-sheet cells replace the coarse 3-still source. `nil` until the
+    /// player publishes it (or unavailable).
+    var storyboardSpec: String?
+
+    // MARK: State
+
+    @State private var palette: ColorExtractor.ColorPalette = .default
+    /// Distinct vivid colors from the thumbnail (used by `.glow` and as the
+    /// `.live` fallback when storyboard frames are unavailable).
+    @State private var thumbnailSwatches: [Color] = []
+    /// Per-storyboard-frame swatch sets for the `.live` crossfade.
+    @State private var frameSwatches: [[Color]] = []
+    /// The `videoId` the published colors belong to. The render path ignores
+    /// any state whose tag doesn't match the current `videoId`, so a previous
+    /// video's colors can never show through while a new load is in flight —
+    /// regardless of how the async fetches interleave.
+    @State private var loadedVideoId: String?
+
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+
+    // MARK: Body
+
+    var body: some View {
+        Group {
+            if self.style == .off {
+                Color.clear
+            } else if self.reduceTransparency {
+                // Reduce Transparency: flatten to a near-solid low tint, no glow.
+                self.flatTint
+            } else {
+                ZStack {
+                    Color(nsColor: .windowBackgroundColor)
+                    self.ambientContent
+                }
+            }
+        }
+        .animation(.easeInOut(duration: 0.6), value: self.palette)
+        .animation(.easeInOut(duration: 0.5), value: self.style)
+        .task(id: self.loadKey) {
+            await self.load()
+        }
+    }
+
+    /// Re-runs the loader when the video, style, or storyboard availability
+    /// changes (the spec arrives a beat after playback starts).
+    private var loadKey: String {
+        "\(self.videoId ?? "-")|\(self.style.rawValue)|\(self.storyboardSpec != nil)"
+    }
+
+    // MARK: Ambient composition
+
+    /// Branch on Reduce Motion rather than pausing the `TimelineView`, mirroring
+    /// Branch on Reduce Motion rather than pausing the `TimelineView`, mirroring
+    /// the repo's `PulseModifier` pattern. `.soft` is intentionally steady (no
+    /// drift) so it reads as a calm version of the same glow.
+    private var ambientContent: some View {
+        GeometryReader { geo in
+            if self.style == .soft || self.reduceMotion {
+                self.auroraLayer(size: geo.size, time: nil)
+            } else {
+                TimelineView(.animation) { timeline in
+                    self.auroraLayer(
+                        size: geo.size,
+                        time: timeline.date.timeIntervalSinceReferenceDate
+                    )
+                }
+            }
+        }
+    }
+
+    /// The hero: one drifting aurora, or two crossfading by playback position in
+    /// `.live` mode. Both sub-layers keep orbiting so motion never stops.
+    @ViewBuilder
+    private func auroraLayer(size: CGSize, time: TimeInterval?) -> some View {
+        let frames = self.renderFrames
+        // `.soft` is the calm style: same colors, dimmer than the drifting glow.
+        let intensity: Double = self.style == .soft ? 0.7 : 1.0
+        if frames.count <= 1 {
+            Self.aurora(
+                colors: frames.first ?? self.fallbackColors,
+                size: size,
+                time: time,
+                colorScheme: self.colorScheme,
+                intensity: intensity
+            )
+        } else {
+            let position = (self.liveFraction ?? 0) * Double(frames.count - 1)
+            let lower = min(max(Int(position.rounded(.down)), 0), frames.count - 1)
+            let upper = min(lower + 1, frames.count - 1)
+            let blend = position - Double(lower)
+            let lowerColors = frames[lower].isEmpty ? self.fallbackColors : frames[lower]
+            let upperColors = frames[upper].isEmpty ? self.fallbackColors : frames[upper]
+            ZStack {
+                Self.aurora(colors: lowerColors, size: size, time: time, colorScheme: self.colorScheme, intensity: intensity)
+                    .opacity(1 - blend)
+                Self.aurora(colors: upperColors, size: size, time: time, colorScheme: self.colorScheme, intensity: intensity)
+                    .opacity(blend)
+            }
+            .animation(.easeInOut(duration: 0.7), value: self.liveFraction)
+        }
+    }
+
+    /// Whether the published color state belongs to the current video. Stale
+    /// state (from a prior video, mid-transition) is treated as not-yet-loaded.
+    private var colorsAreCurrent: Bool {
+        self.loadedVideoId == self.videoId
+    }
+
+    /// The palette to render: the loaded one only when it belongs to the current
+    /// video, otherwise the neutral default. Every palette read goes through
+    /// this so no render path can show a prior video's colors mid-transition.
+    private var currentPalette: ColorExtractor.ColorPalette {
+        self.colorsAreCurrent ? self.palette : .default
+    }
+
+    /// The swatch set(s) feeding the aurora for the current style.
+    private var renderFrames: [[Color]] {
+        switch self.style {
+        case .live where self.colorsAreCurrent && !self.frameSwatches.isEmpty:
+            self.frameSwatches
+        default:
+            [self.fallbackColors]
+        }
+    }
+
+    /// Thumbnail swatches, or palette-derived colors if extraction found none.
+    /// Falls back to the neutral default palette until the current video's
+    /// colors have actually loaded.
+    private var fallbackColors: [Color] {
+        if self.colorsAreCurrent, !self.thumbnailSwatches.isEmpty {
+            return self.thumbnailSwatches
+        }
+        return [self.currentPalette.primary, self.currentPalette.secondary]
+    }
+
+    /// A single drifting field of additively-blended color blobs. Static when
+    /// `time` is nil (Reduce Motion or the `.soft` style). `intensity` scales
+    /// the overall brightness so `.soft` reads dimmer than the drifting glow.
+    private static func aurora(
+        colors: [Color],
+        size: CGSize,
+        time: TimeInterval?,
+        colorScheme: ColorScheme,
+        intensity: Double
+    ) -> some View {
+        let isDark = colorScheme == .dark
+        // Additive light reads as "glow" on a dark base; on a light base it
+        // blows out to white, so fall back to a softer source-over tint.
+        let blend: BlendMode = isDark ? .plusLighter : .normal
+        let coreOpacity: Double = (isDark ? 0.55 : 0.30) * intensity
+        let elapsed = time ?? 0
+
+        return ZStack {
+            ForEach(Array(colors.prefix(Self.layout.count).enumerated()), id: \.offset) { index, color in
+                let spot = Self.layout[index]
+                let period = Self.periods[index]
+                let phase = Self.phases[index]
+                let driftX = time == nil ? 0 : 0.12 * size.width * sin(elapsed / period + phase)
+                let driftY = time == nil ? 0 : 0.10 * size.height * cos(elapsed / (period + 6) + phase)
+                let diameter = size.width
+
+                RadialGradient(
+                    colors: [color.opacity(coreOpacity), .clear],
+                    center: .center,
+                    startRadius: 0,
+                    endRadius: diameter * 0.5
+                )
+                .frame(width: diameter, height: diameter)
+                .position(
+                    x: spot.x * size.width + driftX,
+                    y: spot.y * size.height + driftY
+                )
+                .blendMode(blend)
+            }
+        }
+        .compositingGroup()
+        .blur(radius: 46)
+        .frame(width: size.width, height: size.height)
+        .clipped()
+    }
+
+    /// Resting positions (unit coords) for up to five blobs — spread across the
+    /// upper-mid field with one low so color still reaches the player bar.
+    private static let layout: [(x: CGFloat, y: CGFloat)] = [
+        (0.28, 0.24), (0.74, 0.20), (0.18, 0.58), (0.82, 0.64), (0.50, 0.42),
+    ]
+
+    /// Mutually-prime orbit periods (seconds) so the drift never visibly loops.
+    private static let periods: [Double] = [19, 23, 29, 31, 37]
+    private static let phases: [Double] = [0.0, 1.7, 3.1, 4.6, 5.9]
+
+    /// Reduce Transparency fallback: a flat, low-opacity tint, no motion.
+    private var flatTint: some View {
+        ZStack {
+            Color(nsColor: .windowBackgroundColor)
+            LinearGradient(
+                colors: [self.currentPalette.primary.opacity(0.14), .clear],
+                startPoint: .top,
+                endPoint: .center
+            )
+        }
+    }
+
+    // MARK: Loading
+
+    private func load() async {
+        guard self.style != .off else { return }
+
+        // Resolve thumbnail colors, then publish — assigning defaults on
+        // failure too, so a new video whose thumbnail is missing/fails can't
+        // keep showing the previous video's colors (e.g. after SPA drift, when
+        // this view instance is reused). Guarded by cancellation so a superseded
+        // load never clobbers the current one.
+        let resolved: (palette: ColorExtractor.ColorPalette, swatches: [Color])? = if let url = self.thumbnailURL ?? self.fallbackThumbnailURL {
+            // Same URL + size the watch poster already fetches → warm cache hit,
+            // no second network download.
+            await Self.loadPaletteAndSwatches(url: url, size: CGSize(width: 1280, height: 720))
+        } else {
+            nil
+        }
+        if Task.isCancelled { return }
+        let isNewVideo = self.loadedVideoId != self.videoId
+        self.palette = resolved?.palette ?? .default
+        self.thumbnailSwatches = resolved?.swatches ?? []
+        // Drop the prior video's storyboard frames so `.live` falls back to the
+        // (current) thumbnail colors until fresh frames load, rather than
+        // briefly crossfading the old video's frames.
+        if isNewVideo {
+            self.frameSwatches = []
+        }
+        // Tag the published colors with this video. Until this runs for the
+        // current `videoId`, the render path shows the neutral default rather
+        // than a prior video's colors.
+        self.loadedVideoId = self.videoId
+
+        guard self.style == .live else {
+            self.frameSwatches = []
+            return
+        }
+
+        // Prefer the storyboard sprite sheet (dozens of timeline cells from a
+        // single fetch) for moment-to-moment color; fall back to the 3 sampled
+        // stills when no spec is available (live streams, age-gated, etc.).
+        if let spec = self.storyboardSpec,
+           let sheet = StoryboardSheet(spec: spec),
+           let sets = await Self.loadStoryboardSwatches(sheet: sheet),
+           !sets.isEmpty
+        {
+            if Task.isCancelled { return }
+            self.frameSwatches = sets
+            return
+        }
+
+        var sets: [[Color]] = []
+        for url in self.storyboardFrameURLs() {
+            if let swatches = await Self.loadSwatches(url: url, size: CGSize(width: 320, height: 180)),
+               !swatches.isEmpty
+            {
+                sets.append(swatches)
+            }
+        }
+        if Task.isCancelled { return }
+        self.frameSwatches = sets
+    }
+
+    /// `mqdefault.jpg` is the 16:9, no-letterbox thumbnail when the model has no
+    /// `thumbnailURL`.
+    private var fallbackThumbnailURL: URL? {
+        guard let videoId else { return nil }
+        return URL(string: "https://i.ytimg.com/vi/\(videoId)/mqdefault.jpg")
+    }
+
+    /// YouTube's three evenly-sampled storyboard stills (start/mid/end) — the
+    /// `.live` fallback when no full storyboard spec is available.
+    private func storyboardFrameURLs() -> [URL] {
+        guard let videoId else { return [] }
+        return (1 ... 3).compactMap { URL(string: "https://i.ytimg.com/vi/\(videoId)/\($0).jpg") }
+    }
+
+    // MARK: Off-main extraction
+
+    //
+    // `nonisolated` so the CPU-bound pixel work runs off the main actor and the
+    // non-Sendable `NSImage` never escapes into MainActor state — only the
+    // Sendable `[Color]` / `ColorPalette` cross back.
+
+    // swiftformat:disable modifierOrder
+    nonisolated private static func loadPaletteAndSwatches(
+        url: URL,
+        size: CGSize
+    ) async -> (palette: ColorExtractor.ColorPalette, swatches: [Color])? {
+        guard let nsImage = await ImageCache.shared.image(for: url, targetSize: size) else {
+            return nil
+        }
+        return (ColorExtractor.extractPalette(from: nsImage), Self.extractSwatches(from: nsImage))
+    }
+
+    nonisolated private static func loadSwatches(url: URL, size: CGSize) async -> [Color]? {
+        guard let nsImage = await ImageCache.shared.image(for: url, targetSize: size) else {
+            return nil
+        }
+        return Self.extractSwatches(from: nsImage)
+    }
+
+    /// Fetches the storyboard sheet(s) and extracts one swatch set per cell, in
+    /// timeline order, so the existing `liveFraction` crossfade walks them as
+    /// the video plays. Dark cells (no vivid color) carry the previous cell's
+    /// swatches forward so the glow never drops to black mid-timeline.
+    nonisolated private static func loadStoryboardSwatches(sheet: StoryboardSheet) async -> [[Color]]? {
+        var sets: [[Color]] = []
+        var lastNonEmpty: [Color] = []
+        for (sheetIndex, sheetURL) in sheet.sheetURLs.enumerated() {
+            // Fetch at full size (nil) — downsampling a multi-cell sheet would
+            // corrupt the per-cell crops.
+            guard let nsImage = await ImageCache.shared.image(for: sheetURL, targetSize: nil),
+                  let cgImage = nsImage.cgImage(forProposedRect: nil, context: nil, hints: nil)
+            else {
+                continue
+            }
+            let rects = sheet.cellRects(
+                forSheetAt: sheetIndex,
+                pixelWidth: cgImage.width,
+                height: cgImage.height
+            )
+            for rect in rects {
+                guard let cell = cgImage.cropping(to: rect) else { continue }
+                let swatches = Self.extractSwatches(from: NSImage(cgImage: cell, size: .zero))
+                if !swatches.isEmpty {
+                    lastNonEmpty = swatches
+                }
+                sets.append(lastNonEmpty)
+            }
+        }
+        // Drop any leading empties (dark cells before the first vivid one) so
+        // the crossfade starts on real color.
+        let trimmed = sets.drop { $0.isEmpty }
+        return trimmed.isEmpty ? nil : Array(trimmed)
+    }
+
+    /// Pulls up to five distinct, vivid colors from an image by binning pixels
+    /// by hue and keeping the most saturated-and-bright clusters. Unlike
+    /// `ColorExtractor`'s single weighted average, this preserves multiple hues
+    /// so the aurora has real color variety to move between.
+    nonisolated private static func extractSwatches(from image: NSImage, maxCount: Int = 5) -> [Color] {
+        guard let cgImage = image.cgImage(forProposedRect: nil, context: nil, hints: nil) else {
+            return []
+        }
+        let dimension = 24
+        guard let context = CGContext(
+            data: nil,
+            width: dimension,
+            height: dimension,
+            bitsPerComponent: 8,
+            bytesPerRow: dimension * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else {
+            return []
+        }
+
+        context.interpolationQuality = .medium
+        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: dimension, height: dimension))
+
+        guard let data = context.data else {
+            return []
+        }
+        let pointer = data.bindMemory(to: UInt8.self, capacity: dimension * dimension * 4)
+
+        let binCount = 12
+        var weight = [Double](repeating: 0, count: binCount)
+        var sumR = [Double](repeating: 0, count: binCount)
+        var sumG = [Double](repeating: 0, count: binCount)
+        var sumB = [Double](repeating: 0, count: binCount)
+
+        for index in 0 ..< (dimension * dimension) {
+            let offset = index * 4
+            let red = Double(pointer[offset]) / 255
+            let green = Double(pointer[offset + 1]) / 255
+            let blue = Double(pointer[offset + 2]) / 255
+
+            let maxC = max(red, green, blue)
+            let minC = min(red, green, blue)
+            let brightness = maxC
+            let saturation = maxC > 0 ? (maxC - minC) / maxC : 0
+
+            // Skip near-black, near-white, and washed-out pixels.
+            guard brightness > 0.12, brightness < 0.97, saturation > 0.18 else {
+                continue
+            }
+
+            let hue = Self.hue(red: red, green: green, blue: blue, maxC: maxC, minC: minC)
+            let bin = min(binCount - 1, Int(hue / 360 * Double(binCount)))
+            let pixelWeight = saturation * brightness
+            weight[bin] += pixelWeight
+            sumR[bin] += red * pixelWeight
+            sumG[bin] += green * pixelWeight
+            sumB[bin] += blue * pixelWeight
+        }
+
+        let clusters = (0 ..< binCount)
+            .filter { weight[$0] > 0 }
+            .map { bin in
+                (weight: weight[bin], color: Self.glowColor(
+                    red: sumR[bin] / weight[bin],
+                    green: sumG[bin] / weight[bin],
+                    blue: sumB[bin] / weight[bin]
+                ))
+            }
+            .sorted { $0.weight > $1.weight }
+            .prefix(maxCount)
+            .map(\.color)
+
+        return Array(clusters)
+    }
+
+    /// HSB hue in degrees from RGB extremes.
+    nonisolated private static func hue(
+        red: Double,
+        green: Double,
+        blue: Double,
+        maxC: Double,
+        minC: Double
+    ) -> Double {
+        let delta = maxC - minC
+        guard delta > 0 else { return 0 }
+        var hue: Double = if maxC == red {
+            ((green - blue) / delta).truncatingRemainder(dividingBy: 6)
+        } else if maxC == green {
+            (blue - red) / delta + 2
+        } else {
+            (red - green) / delta + 4
+        }
+        hue *= 60
+        return hue < 0 ? hue + 360 : hue
+    }
+
+    /// Boosts a cluster's saturation and normalizes brightness so it reads as
+    /// emitted light in the aurora rather than a muddy average.
+    nonisolated private static func glowColor(red: Double, green: Double, blue: Double) -> Color {
+        let base = NSColor(red: red, green: green, blue: blue, alpha: 1)
+        var hue: CGFloat = 0
+        var saturation: CGFloat = 0
+        var brightness: CGFloat = 0
+        var alpha: CGFloat = 0
+        base.getHue(&hue, saturation: &saturation, brightness: &brightness, alpha: &alpha)
+        let boosted = NSColor(
+            hue: hue,
+            saturation: min(saturation * 1.35, 1),
+            brightness: max(min(brightness * 1.1, 0.9), 0.55),
+            alpha: 1
+        )
+        return Color(nsColor: boosted)
+    }
+    // swiftformat:enable modifierOrder
+}
+
+// MARK: - View modifier
+
+extension View {
+    /// Applies the prototype ambient glow full-bleed behind the content.
+    func ambientVideoBackdrop(
+        videoId: String?,
+        thumbnailURL: URL?,
+        style: AmbientBackdropStyle,
+        liveFraction: Double?,
+        storyboardSpec: String?
+    ) -> some View {
+        self.background {
+            AmbientVideoBackdrop(
+                videoId: videoId,
+                thumbnailURL: thumbnailURL,
+                style: style,
+                liveFraction: liveFraction,
+                storyboardSpec: storyboardSpec
+            )
+            .ignoresSafeArea()
+        }
+    }
+}
+
+// MARK: - StoryboardSheet
+
+/// Parses a YouTube storyboard spec string into fetchable sprite-sheet URLs and
+/// per-cell crop rects. Format confirmed against yt-dlp / NewPipe and a live
+/// video: `base|level0|level1|…`, where `base` is a URL template with `$L`/`$N`
+/// placeholders and each level is `width#height#frameCount#cols#rows#interval#N#sigh`.
+///
+/// Prefers Level 0 (typically a single `default.jpg` of ~100 cells), so one HTTP
+/// fetch yields dozens of evenly-spaced timeline samples — ideal for ambient
+/// color. All grid values are parsed from the live spec, never hardcoded.
+struct StoryboardSheet {
+    let sheetURLs: [URL]
+    private let cols: Int
+    private let rows: Int
+    private let frameCount: Int
+
+    /// Sanity caps on values parsed from the (untrusted) WebView spec, so a
+    /// malformed or hostile spec can't overflow the arithmetic or trigger a
+    /// flood of image fetches. A real Level-0 sheet is ~10×10 = 100 cells in a
+    /// single image; these ceilings sit comfortably above that and fail closed.
+    private static let maxGridDimension = 50
+    private static let maxFrameCount = 10000
+    private static let maxSheets = 8
+
+    init?(spec: String) {
+        let parts = spec.components(separatedBy: "|")
+        guard parts.count >= 2 else { return nil }
+        let base = parts[0]
+
+        // Pick Level 0 — the densest single sheet (one fetch, most cells).
+        let levelIndex = 0
+        let fields = parts[1].components(separatedBy: "#")
+        guard fields.count >= 8,
+              let cols = Int(fields[3]),
+              let rows = Int(fields[4]),
+              let frameCount = Int(fields[2]),
+              cols > 0, cols <= Self.maxGridDimension,
+              rows > 0, rows <= Self.maxGridDimension,
+              frameCount > 0, frameCount <= Self.maxFrameCount
+        else {
+            return nil
+        }
+        let name = fields[6]
+        let sigh = fields[7]
+
+        let perSheet = cols * rows
+        let sheetCount = min(
+            Int((Double(frameCount) / Double(perSheet)).rounded(.up)),
+            Self.maxSheets
+        )
+        guard sheetCount > 0 else { return nil }
+
+        var urls: [URL] = []
+        for sheet in 0 ..< sheetCount {
+            let resolved = base
+                .replacingOccurrences(of: "$L", with: String(levelIndex))
+                .replacingOccurrences(of: "$N", with: name)
+                .appending("&sigh=\(sigh)")
+                .replacingOccurrences(of: "$M", with: String(sheet))
+            // The spec comes from the WebView; only fetch it natively when it
+            // resolves to an https YouTube image host, so a hostile/mutated
+            // spec can't point native requests at private/non-YouTube hosts.
+            if let url = URL(string: resolved), Self.isAllowedStoryboardURL(url) {
+                urls.append(url)
+            }
+        }
+        guard !urls.isEmpty else { return nil }
+
+        self.sheetURLs = urls
+        self.cols = cols
+        self.rows = rows
+        self.frameCount = frameCount
+    }
+
+    /// Row-major crop rects (top-left origin, matching `CGImage.cropping`) for
+    /// the real frames on the sheet at `sheetIndex`, derived from the actual
+    /// fetched sheet pixel dimensions so we don't trust the spec's nominal cell
+    /// size. The last sheet is capped to the remaining frames so padding cells
+    /// (when `frameCount` isn't an exact multiple of the grid) aren't sampled —
+    /// otherwise the tail color would stick across the padded cells.
+    func cellRects(forSheetAt sheetIndex: Int, pixelWidth width: Int, height: Int) -> [CGRect] {
+        let cellW = width / self.cols
+        let cellH = height / self.rows
+        guard cellW > 0, cellH > 0 else { return [] }
+        let perSheet = self.cols * self.rows
+        let remaining = self.frameCount - sheetIndex * perSheet
+        guard remaining > 0 else { return [] }
+        let cellsOnThisSheet = min(perSheet, remaining)
+        var rects: [CGRect] = []
+        for cell in 0 ..< cellsOnThisSheet {
+            let row = cell / self.cols
+            let col = cell % self.cols
+            rects.append(CGRect(
+                x: col * cellW,
+                y: row * cellH,
+                width: cellW,
+                height: cellH
+            ))
+        }
+        return rects
+    }
+
+    /// Whether a resolved storyboard URL is safe to fetch natively: `https`
+    /// scheme on a YouTube image host. Guards the WebView→native trust boundary.
+    private static func isAllowedStoryboardURL(_ url: URL) -> Bool {
+        guard url.scheme?.lowercased() == "https",
+              let host = url.host?.lowercased()
+        else {
+            return false
+        }
+        return host == "ytimg.com" || host.hasSuffix(".ytimg.com")
+    }
+}

--- a/Sources/Kaset/Views/YouTube/YouTubeWatchView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeWatchView.swift
@@ -24,6 +24,33 @@ struct YouTubeWatchView: View {
     }
 
     @State private var commentDraft = ""
+    @State private var settings = SettingsManager.shared
+
+    /// The ambient backdrop style to render: the user's chosen style, or `.off`
+    /// when they've disabled the feature in Settings → YouTube.
+    private var ambientStyle: AmbientBackdropStyle {
+        self.settings.resolvedAmbientStyle
+    }
+
+    /// 0…1 playback position, only while THIS view's video is the one playing,
+    /// for the `.live` storyboard crossfade. `nil` otherwise (guards NaN when
+    /// duration is still 0 at cold load).
+    private var ambientLiveFraction: Double? {
+        guard self.youtubePlayer.currentVideo?.videoId == self.video.videoId,
+              self.youtubePlayer.duration > 0
+        else { return nil }
+        return min(max(self.youtubePlayer.progress / self.youtubePlayer.duration, 0), 1)
+    }
+
+    /// Storyboard spec for the fine-grained `.live` color, but only while THIS
+    /// view's video is the one playing — so a previous video's sheets never
+    /// tint a newly-opened watch page.
+    private var ambientStoryboardSpec: String? {
+        guard self.youtubePlayer.currentVideo?.videoId == self.video.videoId else {
+            return nil
+        }
+        return self.youtubePlayer.storyboardSpec
+    }
 
     var body: some View {
         ScrollView {
@@ -49,21 +76,64 @@ struct YouTubeWatchView: View {
             .padding(.horizontal, 16)
             .padding(.vertical, 20)
         }
+        // PROTOTYPE: full-bleed ambient color behind the page. `.ignoresSafeArea`
+        // (inside the modifier) lets it bleed under the bottom player-bar inset,
+        // so the bar's Liquid Glass capsule refracts the live color.
+        .ambientVideoBackdrop(
+            videoId: self.video.videoId,
+            thumbnailURL: self.video.thumbnailURL,
+            style: self.ambientStyle,
+            liveFraction: self.ambientLiveFraction,
+            storyboardSpec: self.ambientStoryboardSpec
+        )
         // The in-page metadata shows the title; keep the bar clean.
         .navigationTitle("")
-        .task {
-            self.startOrAdoptPlayback()
-            await self.viewModel.load()
-            // Feed the related list to the player so the bar's next/previous
-            // buttons can skip between videos.
-            if self.youtubePlayer.currentVideo?.videoId == self.video.videoId {
-                self.youtubePlayer.setUpNext(self.viewModel.data.related)
+        // Let the ambient reach under the nav bar, like the other accent pages.
+        .toolbarBackgroundVisibility(.hidden, for: .automatic)
+        #if DEBUG
+            .toolbar {
+                self.ambientStylePicker
+            }
+        #endif
+            .task {
+                self.startOrAdoptPlayback()
+                await self.viewModel.load()
+                // Feed the related list to the player so the bar's next/previous
+                // buttons can skip between videos.
+                if self.youtubePlayer.currentVideo?.videoId == self.video.videoId {
+                    self.youtubePlayer.setUpNext(self.viewModel.data.related)
+                }
+            }
+            .onDisappear {
+                self.youtubePlayer.inlineSurfaceWillDisappear(videoId: self.video.videoId)
+            }
+    }
+
+    // MARK: - Ambient Style Picker (PROTOTYPE)
+
+    #if DEBUG
+        /// DEBUG-only toolbar control to switch ambient styles live on-device.
+        /// Binds to the same `SettingsManager` value as the Settings → YouTube
+        /// tab, so there is a single source of truth. The whole property is
+        /// compiled out of release builds (an empty `@ToolbarContentBuilder`
+        /// body would otherwise be invalid).
+        @ToolbarContentBuilder
+        private var ambientStylePicker: some ToolbarContent {
+            ToolbarItem(placement: .automatic) {
+                Menu {
+                    Picker("Ambient", selection: self.$settings.ambientBackdropStyle) {
+                        ForEach(AmbientBackdropStyle.allCases) { style in
+                            Text(style.debugLabel).tag(style)
+                        }
+                    }
+                    .pickerStyle(.inline)
+                } label: {
+                    Image(systemName: "paintpalette")
+                }
+                .help("Ambient backdrop style (developer)")
             }
         }
-        .onDisappear {
-            self.youtubePlayer.inlineSurfaceWillDisappear(videoId: self.video.videoId)
-        }
-    }
+    #endif
 
     // MARK: - Video Surface
 

--- a/Sources/Kaset/Views/YouTube/YouTubeWatchWebView+Scripts.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeWatchWebView+Scripts.swift
@@ -340,6 +340,18 @@ extension YouTubeWatchWebView {
         }
     }
 
+    /// Encodes a Swift string as a safe JavaScript string literal (including the
+    /// surrounding quotes) so arbitrary contents can't break out of the literal
+    /// when interpolated into an `evaluateJavaScript` payload.
+    static func jsStringLiteral(_ value: String) -> String {
+        guard let data = try? JSONEncoder().encode(value),
+              let json = String(data: data, encoding: .utf8)
+        else {
+            return "\"\""
+        }
+        return json
+    }
+
     /// Fetches the caption tracks the player offers.
     func availableCaptionTracks() async -> [YouTubeCaptionTrack] {
         let script = """
@@ -398,6 +410,49 @@ extension YouTubeWatchWebView {
             """
         }
         self.webView?.evaluateJavaScript(script, completionHandler: nil)
+    }
+
+    /// The storyboard spec string for the current video, read from the player
+    /// response. Drives the ambient backdrop's fine-grained live color.
+    ///
+    /// Only returns a spec when the player response's own `videoId` matches
+    /// `expectedVideoId` — `window.ytInitialPlayerResponse` is the page-load
+    /// global and can still describe the *previous* video after a YouTube SPA
+    /// auto-advance, which would tint the new page with the old video's colors.
+    func storyboardSpec(expectedVideoId: String?) async -> String? {
+        // JSON-encode the id into a safe JS string literal rather than raw
+        // string interpolation, so a quote/backslash/newline can't break out of
+        // the literal at the WKWebView trust boundary.
+        let expectedLiteral = Self.jsStringLiteral(expectedVideoId ?? "")
+        let script = """
+        (function() {
+            try {
+                var expected = \(expectedLiteral);
+                var response = null;
+                var player = document.getElementById('movie_player');
+                if (player && typeof player.getPlayerResponse === 'function') {
+                    response = player.getPlayerResponse();
+                }
+                if (!response || !response.storyboards) {
+                    response = window.ytInitialPlayerResponse;
+                }
+                if (!response || !response.storyboards) { return ''; }
+                // Reject a response that describes a different video than the
+                // one we're asking about (stale global after SPA navigation).
+                var details = response.videoDetails;
+                var responseId = details && details.videoId;
+                if (expected && responseId && responseId !== expected) { return ''; }
+                var sb = response.storyboards;
+                var renderer = sb.playerStoryboardSpecRenderer
+                    || sb.playerLiveStoryboardSpecRenderer;
+                return (renderer && renderer.spec) || '';
+            } catch (e) { return ''; }
+        })();
+        """
+        guard let spec = await self.evaluateForString(script), !spec.isEmpty else {
+            return nil
+        }
+        return spec
     }
 
     /// The language code of the player's active caption track (nil = off).

--- a/Sources/Kaset/Views/YouTubeSettingsView.swift
+++ b/Sources/Kaset/Views/YouTubeSettingsView.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+/// Settings for the regular YouTube video experience (distinct from the Music
+/// experience). Currently hosts the ambient backdrop controls; a natural home
+/// for future video-only preferences.
+struct YouTubeSettingsView: View {
+    @State private var settings = SettingsManager.shared
+
+    var body: some View {
+        Form {
+            Section {
+                Toggle("Ambient Color Backdrop", isOn: self.$settings.ambientBackdropEnabled)
+                    .help("Show a soft color glow, drawn from the video, behind the player")
+
+                if self.settings.ambientBackdropEnabled {
+                    Picker("Style", selection: self.$settings.ambientBackdropStyle) {
+                        ForEach(AmbientBackdropStyle.userSelectableCases) { style in
+                            Text(style.displayName).tag(style)
+                        }
+                    }
+                    .help("“Live” shifts the colors as the video plays; the others stay constant")
+                }
+            } header: {
+                Text("Ambient Backdrop")
+            } footer: {
+                Text("A soft color glow drawn from the video plays behind the player. Applies to YouTube videos, not Music.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .formStyle(.grouped)
+    }
+}

--- a/Tests/KasetTests/StoryboardSheetTests.swift
+++ b/Tests/KasetTests/StoryboardSheetTests.swift
@@ -1,0 +1,167 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+// MARK: - StoryboardSheetTests
+
+/// Tests for `StoryboardSheet`, the pure parser that turns a YouTube storyboard
+/// spec string into fetchable sprite-sheet URLs and per-cell crop rects, plus
+/// the `AmbientBackdropStyle` value type.
+@Suite(.tags(.parser))
+struct StoryboardSheetTests {
+    /// A well-formed Level-0 spec (10×10 grid, 100 frames, single `default`
+    /// sheet) shaped exactly like a real captured spec. The `sigh` token here is
+    /// a harmless placeholder — never a real credential.
+    private static let validSpec =
+        "https://i.ytimg.com/sb/VIDEOID/storyboard3_L$L/$N.jpg?sqp=TOKEN" +
+        "|48#27#100#10#10#0#default#PLACEHOLDERSIGH" +
+        "|80#45#100#10#10#5000#M$M#PLACEHOLDERSIGH2"
+
+    // MARK: - Valid parsing
+
+    @Test("Parses a valid spec into an https ytimg sheet URL")
+    func parsesValidSpec() throws {
+        let sheet = try #require(StoryboardSheet(spec: Self.validSpec))
+        #expect(sheet.sheetURLs.count == 1) // 100 frames / (10*10) = 1 sheet
+        let url = try #require(sheet.sheetURLs.first)
+        #expect(url.scheme == "https")
+        #expect(url.host == "i.ytimg.com")
+        // Level 0, $N -> default, sigh appended, $M -> 0.
+        #expect(url.absoluteString.contains("storyboard3_L0/default.jpg"))
+        #expect(url.absoluteString.contains("sigh=PLACEHOLDERSIGH"))
+        #expect(!url.absoluteString.contains("$"))
+    }
+
+    @Test("sheetCount rounds up when frameCount is not a grid multiple")
+    func sheetCountRoundsUp() throws {
+        // 5×5 = 25 per sheet, 60 frames -> ceil(60/25) = 3 sheets.
+        let spec = "https://i.ytimg.com/sb/V/storyboard3_L$L/$N.jpg?sqp=T" +
+            "|48#27#60#5#5#0#default#SIGH"
+        let sheet = try #require(StoryboardSheet(spec: spec))
+        #expect(sheet.sheetURLs.count == 3)
+    }
+
+    // MARK: - cellRects capping
+
+    @Test("cellRects caps the last sheet to the remaining real frames")
+    func cellRectsCapsLastSheet() throws {
+        // 5×5 grid, 60 frames -> sheet 2 (index 2) holds the final 10 frames.
+        let spec = "https://i.ytimg.com/sb/V/storyboard3_L$L/$N.jpg?sqp=T" +
+            "|48#27#60#5#5#0#default#SIGH"
+        let sheet = try #require(StoryboardSheet(spec: spec))
+        // A 250×250 sheet -> 50×50 cells.
+        let firstSheet = sheet.cellRects(forSheetAt: 0, pixelWidth: 250, height: 250)
+        #expect(firstSheet.count == 25) // full grid
+        let lastSheet = sheet.cellRects(forSheetAt: 2, pixelWidth: 250, height: 250)
+        #expect(lastSheet.count == 10) // 60 - 2*25 = 10 real frames, not 25 padding cells
+    }
+
+    @Test("cellRects returns nothing for a sheet index past the frame count")
+    func cellRectsEmptyPastEnd() throws {
+        let sheet = try #require(StoryboardSheet(spec: Self.validSpec))
+        #expect(sheet.cellRects(forSheetAt: 99, pixelWidth: 100, height: 100).isEmpty)
+    }
+
+    @Test("cellRects returns nothing when the sheet is too small to subdivide")
+    func cellRectsEmptyForTinySheet() throws {
+        let sheet = try #require(StoryboardSheet(spec: Self.validSpec))
+        // 10×10 grid but only a 4×4 sheet -> integer cell size 0.
+        #expect(sheet.cellRects(forSheetAt: 0, pixelWidth: 4, height: 4).isEmpty)
+    }
+
+    // MARK: - Security: host / scheme allowlist (tested via init? building URLs)
+
+    @Test(
+        "Rejects specs whose base resolves to a non-ytimg or non-https host",
+        arguments: [
+            "http://127.0.0.1/sb/V/storyboard3_L$L/$N.jpg?sqp=T|48#27#100#10#10#0#default#SIGH",
+            "https://evil.example.com/sb/V/$N.jpg?sqp=T|48#27#100#10#10#0#default#SIGH",
+            "http://i.ytimg.com/sb/V/$N.jpg?sqp=T|48#27#100#10#10#0#default#SIGH",
+            "https://notytimg.com/sb/V/$N.jpg?sqp=T|48#27#100#10#10#0#default#SIGH",
+        ]
+    )
+    func rejectsDisallowedHosts(spec: String) {
+        // No allowed URL can be built, so init? fails closed.
+        #expect(StoryboardSheet(spec: spec) == nil)
+    }
+
+    @Test("Accepts subdomains of ytimg.com over https")
+    func acceptsYtimgSubdomain() throws {
+        let spec = "https://i9.ytimg.com/sb/V/storyboard3_L$L/$N.jpg?sqp=T" +
+            "|48#27#100#10#10#0#default#SIGH"
+        let sheet = try #require(StoryboardSheet(spec: spec))
+        #expect(sheet.sheetURLs.first?.host == "i9.ytimg.com")
+    }
+
+    // MARK: - Security: bounds / malformed input
+
+    @Test("Rejects an empty or single-field spec")
+    func rejectsMalformedSpec() {
+        #expect(StoryboardSheet(spec: "") == nil)
+        #expect(StoryboardSheet(spec: "https://i.ytimg.com/sb/V/$N.jpg") == nil)
+    }
+
+    @Test("Rejects a level whose field list is too short")
+    func rejectsShortFieldList() {
+        let spec = "https://i.ytimg.com/sb/V/$N.jpg?sqp=T|48#27#100#10#10"
+        #expect(StoryboardSheet(spec: spec) == nil)
+    }
+
+    @Test(
+        "Rejects non-positive or non-numeric grid/frame values",
+        arguments: [
+            "https://i.ytimg.com/sb/V/$N.jpg?sqp=T|48#27#100#0#10#0#default#S", // cols 0
+            "https://i.ytimg.com/sb/V/$N.jpg?sqp=T|48#27#100#10#0#0#default#S", // rows 0
+            "https://i.ytimg.com/sb/V/$N.jpg?sqp=T|48#27#0#10#10#0#default#S", // frames 0
+            "https://i.ytimg.com/sb/V/$N.jpg?sqp=T|48#27#abc#10#10#0#default#S", // frames NaN
+        ]
+    )
+    func rejectsInvalidDimensions(spec: String) {
+        #expect(StoryboardSheet(spec: spec) == nil)
+    }
+
+    @Test(
+        "Rejects oversized grid/frame values that exceed the security caps",
+        arguments: [
+            "https://i.ytimg.com/sb/V/$N.jpg?sqp=T|48#27#100#9999#10#0#default#S", // cols > cap
+            "https://i.ytimg.com/sb/V/$N.jpg?sqp=T|48#27#100#10#9999#0#default#S", // rows > cap
+            "https://i.ytimg.com/sb/V/$N.jpg?sqp=T|48#27#999999999#10#10#0#default#S", // frames > cap
+        ]
+    )
+    func rejectsOversizedDimensions(spec: String) {
+        #expect(StoryboardSheet(spec: spec) == nil)
+    }
+}
+
+// MARK: - AmbientBackdropStyleTests
+
+@Suite(.tags(.model))
+struct AmbientBackdropStyleTests {
+    @Test("userSelectableCases excludes off and lists the three visible styles")
+    func userSelectableExcludesOff() {
+        let cases = AmbientBackdropStyle.userSelectableCases
+        #expect(!cases.contains(.off))
+        #expect(cases == [.soft, .glow, .live])
+    }
+
+    @Test("rawValues round-trip for every case")
+    func rawValuesRoundTrip() {
+        for style in AmbientBackdropStyle.allCases {
+            #expect(AmbientBackdropStyle(rawValue: style.rawValue) == style)
+        }
+    }
+
+    @Test("Identifiers are unique")
+    func identifiersUnique() {
+        let ids = AmbientBackdropStyle.allCases.map(\.id)
+        #expect(Set(ids).count == ids.count)
+    }
+
+    @Test("Display and debug names are non-empty for every case")
+    func namesNonEmpty() {
+        for style in AmbientBackdropStyle.allCases {
+            #expect(!style.displayName.isEmpty)
+            #expect(!style.debugLabel.isEmpty)
+        }
+    }
+}

--- a/Tests/KasetTests/YouTubePlayerServiceTests.swift
+++ b/Tests/KasetTests/YouTubePlayerServiceTests.swift
@@ -77,6 +77,10 @@ private final class MockYouTubeWatchPlaybackController: YouTubeWatchPlaybackCont
         self.selectedQuality = level
     }
 
+    func storyboardSpec(expectedVideoId _: String?) async -> String? {
+        nil
+    }
+
     func tearDown() {
         self.tearDownCount += 1
     }


### PR DESCRIPTION
## Summary

Adds a subtle, drifting **ambient color glow** ("aurora") behind the YouTube video watch page, sourced from the video's own colors — similar to the album-art backgrounds already used on the artist/playlist/podcast pages, but tuned for video.

- **Three styles** behind a master on/off toggle: **Soft** (steady glow), **Glow** (drifting), **Live** (drifting + colors follow the video as it plays).
- **Live mode** shifts color over time by sampling YouTube's non-DRM **storyboard sprite-sheet** cells keyed to playback progress. True per-frame capture is impossible here — playback is a Widevine-DRM `WKWebView`, which black-frames every capture path — so the glow is synthesized from the thumbnail/storyboard, never a protected frame.
- The backdrop renders only **app-controlled color** (no glass of its own); the page's existing Liquid Glass chrome (player bar, subscribe/comment capsules) tints over it as a bonus.

## Settings restructure

The ambient feature applies to YouTube **videos**, not Music, so a global toggle in General would be miscategorized. This adds a dedicated **"YouTube" settings tab** (icon matching the app's `AppSource.video`) as the home for video-only preferences:

- Master **Ambient Color Backdrop** toggle (default **on**)
- **Style** picker (Soft / Glow / Live), shown only when enabled — the toggle owns off, so the picker has no redundant "Off" and remembers your style across off→on
- Setting lives in `SettingsManager` (not a prototype `@AppStorage` key); a DEBUG-only toolbar picker drives the same single source of truth

## Implementation notes

- New `AmbientVideoBackdrop` view + shared `AmbientBackdropStyle`. **Self-contained** — the shared `AccentBackground` used by the music pages is untouched; revert = delete two files + one modifier call.
- Storyboard spec is read through the **existing watch-page JS bridge** (`evaluateForString`, same pattern as captions/quality), keyed to its video id, and decoupled from caption/quality loading so cosmetic data never delays functional data.
- **Hardening:** the WebView-sourced spec drives native image fetches, so it is validated — `https` + YouTube-image-host allowlist, plus dimension/sheet caps — and the video id is JSON-encoded into the JS payload rather than raw-interpolated.
- **Correctness:** published color state is tagged with its `videoId`; every render path refuses colors that don't match the current video, so a prior video's colors never show through during async navigation. Async loads check `Task.isCancelled` before publishing.
- Reuses the existing `ImageCache` (warm hit, no double fetch) and `ColorExtractor`; honors Reduce Motion (static) and Reduce Transparency (flat tint).

## Test plan

- [x] `swift build` clean (debug + release `./Scripts/compile_and_run.sh`)
- [x] `swiftlint --strict` clean, `swiftformat` applied
- [x] `swift test --skip KasetUITests` — 1438 tests pass
- [x] `$autoreview` clean (iterated through and fixed all accepted findings; JS-escaping, URL allowlist, stale-color keying, cancellation, retry decoupling)
- [ ] On-device: toggle the feature off/on in Settings → YouTube; confirm Soft / Glow / Live are visibly distinct and that Live colors shift across a video's timeline