### PR TITLE
Refresh YouTube Home Continue Watching after watching a video

### DIFF
--- a/Sources/Kaset/Services/API/MockUITestYouTubeClient.swift
+++ b/Sources/Kaset/Services/API/MockUITestYouTubeClient.swift
@@ -161,7 +161,7 @@ final class MockUITestYouTubeClient: YouTubeClientProtocol {
         [Self.sampleChannel]
     }
 
-    func getHistory() async throws -> YouTubeFeed {
+    func getHistory(forceRefresh _: Bool) async throws -> YouTubeFeed {
         YouTubeFeed(videos: Self.sampleHistoryVideos, continuation: nil)
     }
 

--- a/Sources/Kaset/Services/API/YouTubeClient.swift
+++ b/Sources/Kaset/Services/API/YouTubeClient.swift
@@ -342,7 +342,7 @@ final class YouTubeClient: YouTubeClientProtocol {
         return GuideParser.subscribedChannels(data)
     }
 
-    func getHistory(forceRefresh: Bool = false) async throws -> YouTubeFeed {
+    func getHistory(forceRefresh: Bool) async throws -> YouTubeFeed {
         self.logger.info("Fetching YouTube watch history\(forceRefresh ? " (forced)" : "")")
 
         let data = try await self.request(

--- a/Sources/Kaset/Services/API/YouTubeClient.swift
+++ b/Sources/Kaset/Services/API/YouTubeClient.swift
@@ -342,13 +342,14 @@ final class YouTubeClient: YouTubeClientProtocol {
         return GuideParser.subscribedChannels(data)
     }
 
-    func getHistory() async throws -> YouTubeFeed {
-        self.logger.info("Fetching YouTube watch history")
+    func getHistory(forceRefresh: Bool = false) async throws -> YouTubeFeed {
+        self.logger.info("Fetching YouTube watch history\(forceRefresh ? " (forced)" : "")")
 
         let data = try await self.request(
             "browse",
             body: ["browseId": "FEhistory"],
-            ttl: APICache.TTL.search
+            ttl: APICache.TTL.search,
+            bypassCache: forceRefresh
         )
         return YouTubeFeedParser.parse(data)
     }
@@ -474,7 +475,8 @@ final class YouTubeClient: YouTubeClientProtocol {
         _ endpoint: String,
         body: [String: Any],
         ttl: TimeInterval? = nil,
-        retry: Bool = true
+        retry: Bool = true,
+        bypassCache: Bool = false
     ) async throws -> [String: Any] {
         var fullBody = body
         fullBody["context"] = self.buildContext()
@@ -492,7 +494,12 @@ final class YouTubeClient: YouTubeClientProtocol {
         // rendering private cached data — fall through to reauth instead.
         if let cacheKey {
             _ = try await self.buildAuthHeaders()
-            if let cached = APICache.shared.get(key: cacheKey) {
+            // `bypassCache` forces a fresh network read even on a warm entry —
+            // used when refreshing watch history right after a video was watched,
+            // where the 2 min TTL entry would otherwise re-serve the pre-watch
+            // resume percent. The fresh response is still written below, so
+            // subsequent reads stay warm.
+            if !bypassCache, let cached = APICache.shared.get(key: cacheKey) {
                 self.logger.debug("Cache hit for \(Self.cachePrefix)\(endpoint)")
                 return cached
             }

--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -76,6 +76,14 @@ final class YouTubePlayerService {
     /// by the time the user navigates back, progress has accrued.)
     private(set) var watchConclusionGeneration = 0
 
+    /// True once the current video has already signalled its conclusion (a
+    /// natural finish via `handleVideoEnded`). It prevents `stop()` — which often
+    /// follows a finish when the user closes the floating window — from
+    /// re-signalling the same already-finished video as a fresh partial-watch
+    /// conclusion (a double bump that would cancel/restart the refresh the finish
+    /// just scheduled). Reset whenever a new video becomes current.
+    private var currentWatchConcluded = false
+
     /// Whether the video is currently playing.
     private(set) var isPlaying = false
 
@@ -212,6 +220,7 @@ final class YouTubePlayerService {
         self.upNext = []
         self.currentVideo = video
         self.watchActivityGeneration += 1 // a new watch began
+        self.currentWatchConcluded = false
         self.resetPerVideoState()
         self.surfaceLocation = .inline
 
@@ -252,8 +261,11 @@ final class YouTubePlayerService {
         // state in history, so signal it before clearing — this covers closing
         // the floating window (windowWillClose -> stop) and navigating away with
         // pop-out disabled (inlineSurfaceWillDisappear -> stop) after a partial
-        // watch, neither of which emits a skip or finish event.
-        if self.currentVideo != nil, self.progress > 0 {
+        // watch, neither of which emits a skip or finish event. Skip it when the
+        // video already signalled a finish (handleVideoEnded): a close right after
+        // a natural end must not re-signal the same finished video as a fresh
+        // partial-watch conclusion.
+        if self.currentVideo != nil, self.progress > 0, !self.currentWatchConcluded {
             self.watchActivityGeneration += 1
             self.watchConclusionGeneration += 1 // a partial watch concluded
         }
@@ -348,6 +360,7 @@ final class YouTubePlayerService {
         self.currentVideo = video
         self.watchActivityGeneration += 1 // a skip concludes the prior watch and begins a new one
         self.watchConclusionGeneration += 1
+        self.currentWatchConcluded = false
         self.resetPerVideoState()
         self.playbackController.prepare(webKitManager: self.webKitManager, playerService: self)
         self.playbackController.loadVideo(videoId: video.videoId)
@@ -632,6 +645,7 @@ final class YouTubePlayerService {
             // signal it like an explicit skip.
             self.watchActivityGeneration += 1
             self.watchConclusionGeneration += 1
+            self.currentWatchConcluded = false // the drifted-to video is a fresh, unconcluded watch
             YouTubeWatchWebView.shared.currentVideoId = videoId
         }
     }
@@ -646,6 +660,7 @@ final class YouTubePlayerService {
         // user was already sitting on Home (no navigation fires).
         self.watchActivityGeneration += 1
         self.watchConclusionGeneration += 1
+        self.currentWatchConcluded = true // a later stop() must not re-signal this
         self.onVideoEnded?(videoId)
     }
 }

--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -258,9 +258,6 @@ final class YouTubePlayerService {
     func stop() {
         self.logger.info("YouTubePlayer: stop")
         // Closing/stopping a video that accrued progress changes its resume
-        // state in history, so signal it before clearing — this covers closing
-        // the floating window (windowWillClose -> stop) and navigating away with
-        // Closing/stopping a video that accrued progress changes its resume
         // state in history, so signal the conclusion before clearing — this
         // covers closing the floating window (windowWillClose -> stop) and
         // navigating away with pop-out disabled (inlineSurfaceWillDisappear ->

--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -48,6 +48,14 @@ final class YouTubePlayerService {
     /// The video currently loaded for playback (nil when playback is closed).
     private(set) var currentVideo: YouTubeVideo?
 
+    /// Monotonic count of playback starts, bumped on every `play(video:)`. Home
+    /// reads it when the user returns to rebuild Continue Watching: it tells a
+    /// genuine new watch — including re-watching the SAME video, which a videoId
+    /// alone cannot distinguish — from an incidental return where nothing was
+    /// played. Not reset by `stop()`, so a return after a finished or closed
+    /// video still carries the watch that just happened.
+    private(set) var playbackStartCount = 0
+
     /// Whether the video is currently playing.
     private(set) var isPlaying = false
 
@@ -160,6 +168,7 @@ final class YouTubePlayerService {
         }
         self.upNext = []
         self.currentVideo = video
+        self.playbackStartCount += 1
         self.resetPerVideoState()
         self.surfaceLocation = .inline
 

--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -50,14 +50,23 @@ final class YouTubePlayerService {
 
     /// Monotonic count of playback-activity events that can change watch
     /// history: a new video starting (`play`), a skip to another video
-    /// (`advance`), and a video finishing (`handleVideoEnded`). Home reads it
-    /// when the user returns (or while sitting on Home with a floating video) to
-    /// decide whether to rebuild Continue Watching: a count that advanced since
-    /// the last rebuild means new watch progress to reflect, even when the
-    /// videoId is unchanged (a re-watch) — which the id alone can't tell from an
-    /// idle return. Not reset by `stop()`, so a return after a finished or closed
-    /// video still carries the activity that just happened.
+    /// (`advance`), and a video finishing (`handleVideoEnded`). Home's
+    /// navigation-return paths read it to decide whether to rebuild Continue
+    /// Watching: a count that advanced since the last rebuild means new watch
+    /// activity to reflect, even when the videoId is unchanged (a re-watch) —
+    /// which the id alone can't tell from an idle return. Not reset by `stop()`,
+    /// so a return after a finished or closed video still carries the activity.
     private(set) var playbackActivityCount = 0
+
+    /// Monotonic count of playback events that conclude a watch session with
+    /// accrued progress — a skip away (`advance`) or a finish
+    /// (`handleVideoEnded`). Deliberately EXCLUDES a bare `play` start (which has
+    /// no progress yet). The Home-root observer keys on this so a floating video
+    /// finishing/skipping while the user sits on Home refreshes the rail, without
+    /// a fresh start prematurely consuming the activity gate (which would suppress
+    /// a later partial-watch refresh). The gate value passed to the view model is
+    /// still `playbackActivityCount`; this only decides *when* that observer fires.
+    private(set) var playbackProgressEventCount = 0
 
     /// Whether the video is currently playing.
     private(set) var isPlaying = false
@@ -298,6 +307,7 @@ final class YouTubePlayerService {
         self.playbackWillStart?()
         self.currentVideo = video
         self.playbackActivityCount += 1
+        self.playbackProgressEventCount += 1 // a skip concludes the prior watch
         self.resetPerVideoState()
         self.playbackController.prepare(webKitManager: self.webKitManager, playerService: self)
         self.playbackController.loadVideo(videoId: video.videoId)
@@ -519,10 +529,11 @@ final class YouTubePlayerService {
         self.logger.info("YouTubePlayer: video ended")
         self.isPlaying = false
         // A finish changes watch history (the video crosses into "finished"), so
-        // advance the activity counter — this lets Home drop a just-finished
-        // video from Continue Watching even when the video ended in the floating
-        // window while the user was already sitting on Home (no navigation fires).
+        // advance both counters — this lets Home drop a just-finished video from
+        // Continue Watching even when the video ended in the floating window while
+        // the user was already sitting on Home (no navigation fires).
         self.playbackActivityCount += 1
+        self.playbackProgressEventCount += 1
         self.onVideoEnded?(videoId)
     }
 }

--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -63,6 +63,19 @@ final class YouTubePlayerService {
     /// watch path needed a matching "remember to bump / don't consume early" fix.
     private(set) var watchActivityGeneration = 0
 
+    /// Like `watchActivityGeneration` but bumped only when a watch CONCLUDES with
+    /// progress to reflect — a skip (`advance`), finish (`handleVideoEnded`),
+    /// drift (`updatePlaybackState`), or `stop()` of a video with accrued
+    /// progress — NOT on a bare `play` start. The Home-root observer (which fires
+    /// without any navigation, e.g. a floating video finishing while the user
+    /// sits on Home) keys on THIS so a bare start, which has no new resume state
+    /// yet, can't trigger a premature rebuild that advances the watermark and
+    /// then swallows the real progress. The value passed to the view model is
+    /// still `watchActivityGeneration`; this only decides *when* that observer
+    /// fires. (Navigation-return observers use `watchActivityGeneration` directly:
+    /// by the time the user navigates back, progress has accrued.)
+    private(set) var watchConclusionGeneration = 0
+
     /// Whether the video is currently playing.
     private(set) var isPlaying = false
 
@@ -242,6 +255,7 @@ final class YouTubePlayerService {
         // watch, neither of which emits a skip or finish event.
         if self.currentVideo != nil, self.progress > 0 {
             self.watchActivityGeneration += 1
+            self.watchConclusionGeneration += 1 // a partial watch concluded
         }
         self.currentVideo = nil
         self.isPlaying = false
@@ -333,6 +347,7 @@ final class YouTubePlayerService {
         self.playbackWillStart?()
         self.currentVideo = video
         self.watchActivityGeneration += 1 // a skip concludes the prior watch and begins a new one
+        self.watchConclusionGeneration += 1
         self.resetPerVideoState()
         self.playbackController.prepare(webKitManager: self.webKitManager, playerService: self)
         self.playbackController.loadVideo(videoId: video.videoId)
@@ -616,6 +631,7 @@ final class YouTubePlayerService {
             // window) — the prior video concluded and a new watch began, so
             // signal it like an explicit skip.
             self.watchActivityGeneration += 1
+            self.watchConclusionGeneration += 1
             YouTubeWatchWebView.shared.currentVideoId = videoId
         }
     }
@@ -629,6 +645,7 @@ final class YouTubePlayerService {
         // Watching even when the video ended in the floating window while the
         // user was already sitting on Home (no navigation fires).
         self.watchActivityGeneration += 1
+        self.watchConclusionGeneration += 1
         self.onVideoEnded?(videoId)
     }
 }

--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -260,14 +260,17 @@ final class YouTubePlayerService {
         // Closing/stopping a video that accrued progress changes its resume
         // state in history, so signal it before clearing — this covers closing
         // the floating window (windowWillClose -> stop) and navigating away with
-        // pop-out disabled (inlineSurfaceWillDisappear -> stop) after a partial
-        // watch, neither of which emits a skip or finish event. Skip it when the
-        // video already signalled a finish (handleVideoEnded): a close right after
-        // a natural end must not re-signal the same finished video as a fresh
-        // partial-watch conclusion.
-        if self.currentVideo != nil, self.progress > 0, !self.currentWatchConcluded {
-            self.watchActivityGeneration += 1
-            self.watchConclusionGeneration += 1 // a partial watch concluded
+        // Closing/stopping a video that accrued progress changes its resume
+        // state in history, so signal the conclusion before clearing — this
+        // covers closing the floating window (windowWillClose -> stop) and
+        // navigating away with pop-out disabled (inlineSurfaceWillDisappear ->
+        // stop) after a partial watch, neither of which emits a skip or finish
+        // event. `signalWatchConclusion` de-dupes, so a close right after a
+        // natural end (already signalled) does not re-signal the finished video.
+        if self.currentVideo != nil, self.progress > 0 {
+            if self.signalWatchConclusion() {
+                self.watchActivityGeneration += 1
+            }
         }
         self.currentVideo = nil
         self.isPlaying = false
@@ -358,8 +361,9 @@ final class YouTubePlayerService {
 
         self.playbackWillStart?()
         self.currentVideo = video
-        self.watchActivityGeneration += 1 // a skip concludes the prior watch and begins a new one
-        self.watchConclusionGeneration += 1
+        // A skip concludes the prior watch (deduped) and begins a new one.
+        self.signalWatchConclusion()
+        self.watchActivityGeneration += 1
         self.currentWatchConcluded = false
         self.resetPerVideoState()
         self.playbackController.prepare(webKitManager: self.webKitManager, playerService: self)
@@ -641,11 +645,13 @@ final class YouTubePlayerService {
                 channelId: current.channelId
             )
             // The page autoplayed/navigated to a new video (e.g. in the floating
-            // window) — the prior video concluded and a new watch began, so
-            // signal it like an explicit skip.
+            // window) — the prior video concluded and a new watch began. Signal
+            // the conclusion (unless it already finished, to avoid double-bumping
+            // a natural end that auto-advances), then mark the new video as a
+            // fresh, unconcluded watch.
+            self.signalWatchConclusion()
             self.watchActivityGeneration += 1
-            self.watchConclusionGeneration += 1
-            self.currentWatchConcluded = false // the drifted-to video is a fresh, unconcluded watch
+            self.currentWatchConcluded = false
             YouTubeWatchWebView.shared.currentVideoId = videoId
         }
     }
@@ -658,9 +664,27 @@ final class YouTubePlayerService {
         // signal it — this lets Home drop a just-finished video from Continue
         // Watching even when the video ended in the floating window while the
         // user was already sitting on Home (no navigation fires).
-        self.watchActivityGeneration += 1
-        self.watchConclusionGeneration += 1
-        self.currentWatchConcluded = true // a later stop() must not re-signal this
+        if self.signalWatchConclusion() {
+            self.watchActivityGeneration += 1
+        }
         self.onVideoEnded?(videoId)
+    }
+
+    /// Marks the CURRENT watch as concluded with resume state to reflect and
+    /// advances `watchConclusionGeneration` — de-duplicated, so a watch is only
+    /// signalled once no matter how many conclusion paths fire for it (a natural
+    /// finish followed by an auto-advance drift or a window close would otherwise
+    /// double-bump and make Home cancel/restart the refresh the first conclusion
+    /// scheduled). Does NOT touch `watchActivityGeneration`: callers bump that
+    /// once per watch-state transition (a skip/drift bumps it for the new watch;
+    /// a finish/stop bumps it here). Callers that begin a NEW watch (`advance`,
+    /// drift) clear `currentWatchConcluded` afterward so the next watch can
+    /// signal.
+    @discardableResult
+    private func signalWatchConclusion() -> Bool {
+        guard !self.currentWatchConcluded else { return false }
+        self.watchConclusionGeneration += 1
+        self.currentWatchConcluded = true
+        return true
     }
 }

--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -603,6 +603,21 @@ final class YouTubePlayerService {
         self.duration = update.duration
         self.isShowingAd = update.isAd
 
+        // A concluded video that is playing again (replayed via the player bar or
+        // a seek back after it finished) begins a fresh watch — clear the
+        // conclusion flag so its later stop/finish signals the new partial
+        // rewatch instead of being deduped. Only when it's the same current video
+        // still playing real content (drift to a different id is handled below
+        // and starts its own unconcluded watch).
+        if self.currentWatchConcluded,
+           update.isPlaying,
+           !update.isAd,
+           let videoId = update.videoId,
+           videoId == self.currentVideo?.videoId
+        {
+            self.currentWatchConcluded = false
+        }
+
         // Fetch captions/quality options once per video, after playback starts
         // (the player APIs aren't ready before that).
         if update.isPlaying,
@@ -659,6 +674,18 @@ final class YouTubePlayerService {
     /// Handles natural video completion.
     func handleVideoEnded(videoId: String?) {
         self.logger.info("YouTubePlayer: video ended")
+        // Ignore an ended event that is not for the CURRENT content watch:
+        //   - a late `VIDEO_ENDED` for the previous video arriving after a skip
+        //     or SPA drift already made another video current (stale id), and
+        //   - an ad's video element firing `VIDEO_ENDED` while an ad is showing.
+        // Either would wrongly mark the active watch concluded and dedupe its
+        // real conclusion. When the bridge supplies no id we fall back to the
+        // current video (the common floating-window finish).
+        let isStaleId = videoId != nil && videoId != self.currentVideo?.videoId
+        guard !isStaleId, !self.isShowingAd else {
+            self.logger.debug("YouTubePlayer: ignoring ended event (stale id or ad)")
+            return
+        }
         self.isPlaying = false
         // A finish changes watch history (the video crosses into "finished"), so
         // signal it — this lets Home drop a just-finished video from Continue

--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -49,25 +49,19 @@ final class YouTubePlayerService {
     /// The video currently loaded for playback (nil when playback is closed).
     private(set) var currentVideo: YouTubeVideo?
 
-    /// Monotonic count of playback-activity events that can change watch
-    /// history: a new video starting (`play`), a skip to another video
-    /// (`advance`), and a video finishing (`handleVideoEnded`). Home's
-    /// navigation-return paths read it to decide whether to rebuild Continue
-    /// Watching: a count that advanced since the last rebuild means new watch
-    /// activity to reflect, even when the videoId is unchanged (a re-watch) —
-    /// which the id alone can't tell from an idle return. Not reset by `stop()`,
-    /// so a return after a finished or closed video still carries the activity.
-    private(set) var playbackActivityCount = 0
-
-    /// Monotonic count of playback events that conclude a watch session with
-    /// accrued progress — a skip away (`advance`) or a finish
-    /// (`handleVideoEnded`). Deliberately EXCLUDES a bare `play` start (which has
-    /// no progress yet). The Home-root observer keys on this so a floating video
-    /// finishing/skipping while the user sits on Home refreshes the rail, without
-    /// a fresh start prematurely consuming the activity gate (which would suppress
-    /// a later partial-watch refresh). The gate value passed to the view model is
-    /// still `playbackActivityCount`; this only decides *when* that observer fires.
-    private(set) var playbackProgressEventCount = 0
+    /// Monotonic generation bumped by EVERY change to what/how-much was watched:
+    /// a video starting (`play`), a skip to another (`advance`), a finish
+    /// (`handleVideoEnded`), the page drifting to a different video
+    /// (`updatePlaybackState`), and `stop()` tearing down a video that had
+    /// accrued progress. It is a pure SIGNAL — set-only here, never consumed by
+    /// readers. Home keeps its OWN watermark of the last generation it reflected
+    /// and rebuilds Continue Watching whenever this is ahead of that watermark.
+    ///
+    /// Deliberately over-signals: a redundant rebuild is cheap and correct, while
+    /// a missed signal leaves the rail stale. This inverts the old fragile model
+    /// (multiple counters, eagerly consumed at the wrong moment) where every new
+    /// watch path needed a matching "remember to bump / don't consume early" fix.
+    private(set) var watchActivityGeneration = 0
 
     /// Whether the video is currently playing.
     private(set) var isPlaying = false
@@ -204,7 +198,7 @@ final class YouTubePlayerService {
         }
         self.upNext = []
         self.currentVideo = video
-        self.playbackActivityCount += 1
+        self.watchActivityGeneration += 1 // a new watch began
         self.resetPerVideoState()
         self.surfaceLocation = .inline
 
@@ -241,6 +235,14 @@ final class YouTubePlayerService {
     /// Stops playback entirely and releases the surface.
     func stop() {
         self.logger.info("YouTubePlayer: stop")
+        // Closing/stopping a video that accrued progress changes its resume
+        // state in history, so signal it before clearing — this covers closing
+        // the floating window (windowWillClose -> stop) and navigating away with
+        // pop-out disabled (inlineSurfaceWillDisappear -> stop) after a partial
+        // watch, neither of which emits a skip or finish event.
+        if self.currentVideo != nil, self.progress > 0 {
+            self.watchActivityGeneration += 1
+        }
         self.currentVideo = nil
         self.isPlaying = false
         self.progress = 0
@@ -330,8 +332,7 @@ final class YouTubePlayerService {
 
         self.playbackWillStart?()
         self.currentVideo = video
-        self.playbackActivityCount += 1
-        self.playbackProgressEventCount += 1 // a skip concludes the prior watch
+        self.watchActivityGeneration += 1 // a skip concludes the prior watch and begins a new one
         self.resetPerVideoState()
         self.playbackController.prepare(webKitManager: self.webKitManager, playerService: self)
         self.playbackController.loadVideo(videoId: video.videoId)
@@ -611,6 +612,10 @@ final class YouTubePlayerService {
                 channelName: current.channelName,
                 channelId: current.channelId
             )
+            // The page autoplayed/navigated to a new video (e.g. in the floating
+            // window) — the prior video concluded and a new watch began, so
+            // signal it like an explicit skip.
+            self.watchActivityGeneration += 1
             YouTubeWatchWebView.shared.currentVideoId = videoId
         }
     }
@@ -620,11 +625,10 @@ final class YouTubePlayerService {
         self.logger.info("YouTubePlayer: video ended")
         self.isPlaying = false
         // A finish changes watch history (the video crosses into "finished"), so
-        // advance both counters — this lets Home drop a just-finished video from
-        // Continue Watching even when the video ended in the floating window while
-        // the user was already sitting on Home (no navigation fires).
-        self.playbackActivityCount += 1
-        self.playbackProgressEventCount += 1
+        // signal it — this lets Home drop a just-finished video from Continue
+        // Watching even when the video ended in the floating window while the
+        // user was already sitting on Home (no navigation fires).
+        self.watchActivityGeneration += 1
         self.onVideoEnded?(videoId)
     }
 }

--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -48,13 +48,16 @@ final class YouTubePlayerService {
     /// The video currently loaded for playback (nil when playback is closed).
     private(set) var currentVideo: YouTubeVideo?
 
-    /// Monotonic count of playback starts, bumped on every `play(video:)`. Home
-    /// reads it when the user returns to rebuild Continue Watching: it tells a
-    /// genuine new watch — including re-watching the SAME video, which a videoId
-    /// alone cannot distinguish — from an incidental return where nothing was
-    /// played. Not reset by `stop()`, so a return after a finished or closed
-    /// video still carries the watch that just happened.
-    private(set) var playbackStartCount = 0
+    /// Monotonic count of playback-activity events that can change watch
+    /// history: a new video starting (`play`), a skip to another video
+    /// (`advance`), and a video finishing (`handleVideoEnded`). Home reads it
+    /// when the user returns (or while sitting on Home with a floating video) to
+    /// decide whether to rebuild Continue Watching: a count that advanced since
+    /// the last rebuild means new watch progress to reflect, even when the
+    /// videoId is unchanged (a re-watch) — which the id alone can't tell from an
+    /// idle return. Not reset by `stop()`, so a return after a finished or closed
+    /// video still carries the activity that just happened.
+    private(set) var playbackActivityCount = 0
 
     /// Whether the video is currently playing.
     private(set) var isPlaying = false
@@ -168,7 +171,7 @@ final class YouTubePlayerService {
         }
         self.upNext = []
         self.currentVideo = video
-        self.playbackStartCount += 1
+        self.playbackActivityCount += 1
         self.resetPerVideoState()
         self.surfaceLocation = .inline
 
@@ -294,6 +297,7 @@ final class YouTubePlayerService {
 
         self.playbackWillStart?()
         self.currentVideo = video
+        self.playbackActivityCount += 1
         self.resetPerVideoState()
         self.playbackController.prepare(webKitManager: self.webKitManager, playerService: self)
         self.playbackController.loadVideo(videoId: video.videoId)
@@ -514,6 +518,11 @@ final class YouTubePlayerService {
     func handleVideoEnded(videoId: String?) {
         self.logger.info("YouTubePlayer: video ended")
         self.isPlaying = false
+        // A finish changes watch history (the video crosses into "finished"), so
+        // advance the activity counter — this lets Home drop a just-finished
+        // video from Continue Watching even when the video ended in the floating
+        // window while the user was already sitting on Home (no navigation fires).
+        self.playbackActivityCount += 1
         self.onVideoEnded?(videoId)
     }
 }

--- a/Sources/Kaset/Services/YouTubeProtocols.swift
+++ b/Sources/Kaset/Services/YouTubeProtocols.swift
@@ -85,8 +85,11 @@ protocol YouTubeClientProtocol: Sendable {
     /// Fetches the signed-in user's subscribed channels (from `guide`).
     func getSubscribedChannels() async throws -> [YouTubeChannel]
 
-    /// Fetches watch history (`FEhistory`).
-    func getHistory() async throws -> YouTubeFeed
+    /// Fetches watch history (`FEhistory`). Pass `forceRefresh: true` to bypass
+    /// the cached response — used to rebuild Continue Watching right after a
+    /// video is watched, where the warm 2 min entry would re-serve the
+    /// pre-watch resume percent.
+    func getHistory(forceRefresh: Bool) async throws -> YouTubeFeed
 
     /// Fetches the signed-in user's playlists.
     func getUserPlaylists() async throws -> [YouTubePlaylist]
@@ -104,4 +107,13 @@ protocol YouTubeClientProtocol: Sendable {
 
     /// Removes a video from Watch Later.
     func removeFromWatchLater(videoId: String) async throws
+}
+
+// MARK: - YouTubeClientProtocol Convenience
+
+extension YouTubeClientProtocol {
+    /// Fetches watch history using the cache (the default for normal loads).
+    func getHistory() async throws -> YouTubeFeed {
+        try await self.getHistory(forceRefresh: false)
+    }
 }

--- a/Sources/Kaset/ViewModels/YouTube/YouTubeHomeViewModel.swift
+++ b/Sources/Kaset/ViewModels/YouTube/YouTubeHomeViewModel.swift
@@ -83,6 +83,14 @@ final class YouTubeHomeViewModel {
     /// the triggering view's teardown.
     private var continueWatchingRefreshTask: Task<Void, Never>?
 
+    /// The target generation of `continueWatchingRefreshTask` while it is in
+    /// flight (e.g. sitting in its propagation delay), else `nil`. `refresh()`
+    /// folds this back into `pendingGeneration` before cancelling the task, so a
+    /// pull-to-refresh/error-retry that interrupts a still-delayed post-watch
+    /// rebuild doesn't lose it — the ensuing `performLoad` drains it and rebuilds
+    /// from fresh history instead of leaving the rail on pre-watch progress.
+    private var inFlightRefreshGeneration: Int?
+
     let client: any YouTubeClientProtocol
     private let logger = DiagnosticsLogger.api
 
@@ -304,6 +312,15 @@ final class YouTubeHomeViewModel {
         // rather than awaiting the stale task.
         self.loadTask?.cancel()
         self.loadTask = nil
+        // A still-delayed post-watch refresh is about to be cancelled; fold its
+        // target generation into `pendingGeneration` so the ensuing `performLoad`
+        // drains it and rebuilds from fresh history. Without this, a
+        // pull-to-refresh/error-retry that interrupts the propagation delay would
+        // lose the post-watch trigger and leave the rail on pre-watch progress.
+        if let inFlight = self.inFlightRefreshGeneration {
+            self.pendingGeneration = max(self.pendingGeneration ?? 0, inFlight)
+            self.inFlightRefreshGeneration = nil
+        }
         self.continueWatchingRefreshTask?.cancel()
         self.continueWatchingRefreshTask = nil
         // Deliberately preserve `pendingGeneration`: this is also the
@@ -330,6 +347,7 @@ final class YouTubeHomeViewModel {
         self.continueWatchingRefreshTask?.cancel()
         self.continueWatchingRefreshTask = nil
         self.pendingGeneration = nil
+        self.inFlightRefreshGeneration = nil
     }
 
     /// Loads the next feed page when the user nears the end of the grid.
@@ -469,12 +487,20 @@ final class YouTubeHomeViewModel {
         }
 
         self.continueWatchingRefreshTask?.cancel()
+        self.inFlightRefreshGeneration = generation
         self.continueWatchingRefreshTask = Task { [weak self] in
             await self?.performContinueWatchingRefresh(targetGeneration: generation)
         }
     }
 
     private func performContinueWatchingRefresh(targetGeneration: Int) async {
+        defer {
+            // Clear the in-flight marker only if it still points at THIS run, so a
+            // newer scheduled refresh (which overwrote it) keeps its marker.
+            if self.inFlightRefreshGeneration == targetGeneration {
+                self.inFlightRefreshGeneration = nil
+            }
+        }
         do {
             try await Task.sleep(for: Self.continueWatchingRefreshDelay)
         } catch {

--- a/Sources/Kaset/ViewModels/YouTube/YouTubeHomeViewModel.swift
+++ b/Sources/Kaset/ViewModels/YouTube/YouTubeHomeViewModel.swift
@@ -37,6 +37,16 @@ final class YouTubeHomeViewModel {
     /// videos already shown) can't spin indefinitely.
     private static let maxEmptyContinuationPages = 5
 
+    /// Delay before rebuilding Continue Watching after a video is watched, so
+    /// YouTube's server-side history (which the embedded player updates, not
+    /// Kaset) has a moment to record the new resume percent. Injectable so tests
+    /// don't wait. Mirrors `HistoryViewModel.playbackRefreshDelay`.
+    static var continueWatchingRefreshDelay: Duration = .seconds(3)
+
+    /// Retry delay when the first post-watch rebuild sees unchanged history
+    /// (server lag); a single retry catches the common case.
+    static var continueWatchingRefreshRetryDelay: Duration = .seconds(2)
+
     /// Invalidates stale in-flight loads when a newer one starts
     /// (SwiftUI restarts .task during launch/layout churn; latest wins).
     private var loadGeneration = 0
@@ -44,6 +54,25 @@ final class YouTubeHomeViewModel {
     /// The single in-flight load, shared by concurrent `load()` callers so
     /// SwiftUI `.task` restarts coalesce onto one run instead of cancelling it.
     private var loadTask: Task<Void, Never>?
+
+    /// The player's `playbackStartCount` the last time a Continue Watching
+    /// rebuild was triggered, so a return to Home with no new playback since is a
+    /// no-op. A count (not a videoId) so re-watching the SAME video still counts
+    /// as new — videoId alone can't tell a fresh re-watch from an idle return.
+    private var lastRefreshedPlaybackCount = 0
+
+    /// A post-watch playback count that arrived before Home finished loading, so
+    /// the scoped refresh couldn't run yet. `performLoad` consumes it once the
+    /// feed is `.loaded`, forcing a cache-bypassed Continue Watching rebuild —
+    /// otherwise a cold Home opened right after watching (with a warm `FEhistory`
+    /// cache, e.g. from the History screen) would build the rail from stale
+    /// pre-watch progress. Decouples the fix from `.task`/`.onChange` ordering.
+    private var pendingPlaybackCount: Int?
+
+    /// The in-flight post-watch Continue Watching rebuild, cancelled/replaced
+    /// when a newer watch supersedes it. Stored (unstructured) so it survives
+    /// the triggering view's teardown.
+    private var continueWatchingRefreshTask: Task<Void, Never>?
 
     let client: any YouTubeClientProtocol
     private let logger = DiagnosticsLogger.api
@@ -159,6 +188,17 @@ final class YouTubeHomeViewModel {
             if !gridReady, self.loadingState == .loading {
                 self.loadingState = .loaded
             }
+
+            // A watch happened while Home was still loading (opened cold right
+            // after watching). The rail just built above may have come from a
+            // warm pre-watch `FEhistory` cache, so run the scoped, cache-bypassed
+            // refresh now that we're `.loaded`. Consuming the pending count here
+            // (rather than in the view) makes the fix independent of whether
+            // `.task` or the selection/path `.onChange` fired first.
+            if case .loaded = self.loadingState, let pending = self.pendingPlaybackCount {
+                self.pendingPlaybackCount = nil
+                self.refreshContinueWatching(afterPlaybackCount: pending)
+            }
         } catch {
             guard generation == self.loadGeneration else { return }
             // A cancelled load (e.g. refresh() cancelled the in-flight task) is
@@ -238,6 +278,9 @@ final class YouTubeHomeViewModel {
         // rather than awaiting the stale task.
         self.loadTask?.cancel()
         self.loadTask = nil
+        self.continueWatchingRefreshTask?.cancel()
+        self.continueWatchingRefreshTask = nil
+        self.pendingPlaybackCount = nil
         self.loadingState = .idle
         self.videos = []
         self.sections = []
@@ -254,6 +297,9 @@ final class YouTubeHomeViewModel {
     func cancelLoad() {
         self.loadTask?.cancel()
         self.loadTask = nil
+        self.continueWatchingRefreshTask?.cancel()
+        self.continueWatchingRefreshTask = nil
+        self.pendingPlaybackCount = nil
     }
 
     /// Loads the next feed page when the user nears the end of the grid.
@@ -303,37 +349,165 @@ final class YouTubeHomeViewModel {
 
     // MARK: - Sections
 
-    /// Started-but-unfinished videos from watch history (deduped, capped).
-    private func continueWatchingSection() async -> YouTubeHomeSection? {
-        do {
-            let history = try await self.client.getHistory()
-            var seen = Set<String>()
-            let resumable = history.videos.filter { video in
-                guard let percent = video.watchedPercent,
-                      Self.continueWatchingRange.contains(percent),
-                      !video.isShort,
-                      !video.isLive
-                else {
-                    return false
-                }
-                return seen.insert(video.videoId).inserted
-            }
-            .prefix(Self.continueWatchingCap)
+    /// Started-but-unfinished videos from watch history (deduped, capped), or
+    /// `nil` on failure / when nothing is resumable. Used by the initial load,
+    /// where a failed history fetch should simply omit the rail.
+    private func continueWatchingSection(forceRefresh: Bool = false) async -> YouTubeHomeSection? {
+        try? await self.fetchContinueWatchingSection(forceRefresh: forceRefresh)
+    }
 
-            guard !resumable.isEmpty else { return nil }
-            return YouTubeHomeSection(
-                id: "continue-watching",
-                title: String(localized: "Continue Watching", comment: "YouTube home rail of partially-watched videos"),
-                videos: Array(resumable),
-                kind: .continueWatching
-            )
-        } catch {
-            if !(error is CancellationError) {
-                self.logger.error("Continue Watching unavailable: \(error.localizedDescription)")
+    /// Fetches watch history and builds the Continue Watching section, throwing
+    /// on fetch failure and returning `nil` only when the (successful) response
+    /// has nothing resumable. The post-watch rebuild needs this distinction: a
+    /// transient failure must keep the existing rail, not clear it.
+    private func fetchContinueWatchingSection(forceRefresh: Bool) async throws -> YouTubeHomeSection? {
+        let history = try await self.client.getHistory(forceRefresh: forceRefresh)
+        var seen = Set<String>()
+        let resumable = history.videos.filter { video in
+            guard let percent = video.watchedPercent,
+                  Self.continueWatchingRange.contains(percent),
+                  !video.isShort,
+                  !video.isLive
+            else {
+                return false
             }
-            return nil
+            return seen.insert(video.videoId).inserted
+        }
+        .prefix(Self.continueWatchingCap)
+
+        guard !resumable.isEmpty else { return nil }
+        return YouTubeHomeSection(
+            id: "continue-watching",
+            title: String(localized: "Continue Watching", comment: "YouTube home rail of partially-watched videos"),
+            videos: Array(resumable),
+            kind: .continueWatching
+        )
+    }
+
+    // MARK: - Continue Watching Refresh
+
+    /// Outcome of one cache-bypassed Continue Watching rebuild attempt, so the
+    /// retry logic can tell "history changed" from "history was unchanged" from
+    /// "the fetch failed" — three cases that need different handling.
+    private enum RailRefreshOutcome {
+        /// Fresh history differed; the rail was updated.
+        case updated
+        /// Fresh history fetched successfully but matched what was shown.
+        case unchanged
+        /// The history fetch failed (network/auth/API); the rail was left as-is.
+        case failed
+    }
+
+    /// Rebuilds only the Continue Watching rail after the user watches a video
+    /// and returns to Home, so a finished video drops out and a partially-watched
+    /// one appears — without the full `refresh()` that wipes the grid and flashes
+    /// the skeleton.
+    ///
+    /// `playbackCount` is the player's monotonic `playbackStartCount`; the
+    /// rebuild is a no-op when it hasn't advanced since the last rebuild, so
+    /// incidental returns to Home (opening then backing out of a channel, say)
+    /// don't re-fetch history, while re-watching the same video — which a videoId
+    /// alone could not distinguish from an idle return — still triggers one. The
+    /// work runs after a short delay (YouTube records watch progress server-side
+    /// via the embedded player, not Kaset) and bypasses the 2 min history cache,
+    /// retrying once if the first fetch shows no change or fails.
+    func refreshContinueWatching(afterPlaybackCount playbackCount: Int) {
+        // Only rebuild after at least one playback, for a genuinely new watch.
+        guard playbackCount > 0 else { return }
+        guard playbackCount != self.lastRefreshedPlaybackCount else { return }
+
+        // Home not loaded yet (the user opened it cold right after watching).
+        // Don't drop the trigger — record it so `performLoad` forces a
+        // cache-bypassed rail rebuild on completion. Without this, the initial
+        // load could build Continue Watching from a warm, pre-watch `FEhistory`
+        // cache and show stale progress until the TTL expires.
+        guard case .loaded = self.loadingState else {
+            self.pendingPlaybackCount = playbackCount
+            return
+        }
+
+        self.continueWatchingRefreshTask?.cancel()
+        self.continueWatchingRefreshTask = Task { [weak self] in
+            await self?.performContinueWatchingRefresh(targetCount: playbackCount)
         }
     }
+
+    private func performContinueWatchingRefresh(targetCount: Int) async {
+        do {
+            try await Task.sleep(for: Self.continueWatchingRefreshDelay)
+        } catch {
+            return // cancelled before any work; leave the count unconsumed so a later return retries
+        }
+
+        var outcome = await self.rebuildContinueWatchingRail()
+        // An unchanged result may mean server-side history hasn't caught up yet,
+        // and a failure may be a transient blip — both warrant the single retry.
+        if !Task.isCancelled, outcome != .updated {
+            do {
+                try await Task.sleep(for: Self.continueWatchingRefreshRetryDelay)
+                if !Task.isCancelled {
+                    outcome = await self.rebuildContinueWatchingRail()
+                }
+            } catch {
+                // cancelled during the retry delay; fall through with the first outcome
+            }
+        }
+
+        // Record this playback as handled ONLY when the refresh actually reached
+        // the server (updated or unchanged) and was not cancelled. A cancellation
+        // (e.g. refresh()/account switch during the delay) or a hard failure
+        // leaves `lastRefreshedPlaybackCount` unchanged, so the next return to
+        // Home retries this same playback instead of silently skipping it.
+        guard !Task.isCancelled, outcome == .updated || outcome == .unchanged else { return }
+        self.lastRefreshedPlaybackCount = targetCount
+    }
+
+    /// Fetches fresh history (cache-bypassed) and splices the resulting Continue
+    /// Watching section into `sections` in place, leaving the grid, shelves, and
+    /// topic rails untouched. On a fetch failure the existing rail is preserved.
+    @discardableResult
+    private func rebuildContinueWatchingRail() async -> RailRefreshOutcome {
+        guard case .loaded = self.loadingState else { return .unchanged }
+
+        let fresh: YouTubeHomeSection?
+        do {
+            fresh = try await self.fetchContinueWatchingSection(forceRefresh: true)
+        } catch {
+            // A transient network/auth/API failure must NOT clear an existing
+            // rail; leave it untouched and let the caller retry.
+            if !(error is CancellationError) {
+                self.logger.error("Continue Watching refresh failed: \(error.localizedDescription)")
+            }
+            return .failed
+        }
+        guard !Task.isCancelled else { return .unchanged }
+
+        let existing = self.sections.first { $0.kind == .continueWatching }
+        // No change: same videos AND the same resume progress, in the same
+        // order (or still absent). Comparing the percent — not just the id — is
+        // load-bearing: the common case is the just-watched video staying in the
+        // rail with a higher `watchedPercent` (e.g. 30 → 55). An id-only check
+        // would treat that as unchanged and keep showing the stale progress bar.
+        if existing.map(Self.railIdentity) == fresh.map(Self.railIdentity) {
+            return .unchanged
+        }
+
+        var rebuilt = self.sections.filter { $0.kind != .continueWatching }
+        if let fresh {
+            rebuilt.insert(fresh, at: 0) // Continue Watching always leads.
+        }
+        self.sections = rebuilt
+        return .updated
+    }
+
+    /// Change-detection key for the Continue Watching rail: each video's id
+    /// paired with its resume percent, so a progress-only update still registers
+    /// as a change.
+    private static func railIdentity(_ section: YouTubeHomeSection) -> [String] {
+        section.videos.map { video in "\(video.videoId):\(video.watchedPercent ?? 0)" }
+    }
+
+    // MARK: - Topic Rails
 
     /// Browses a single chip token into a topic section, or `nil` on
     /// failure / empty result.

--- a/Sources/Kaset/ViewModels/YouTube/YouTubeHomeViewModel.swift
+++ b/Sources/Kaset/ViewModels/YouTube/YouTubeHomeViewModel.swift
@@ -55,19 +55,27 @@ final class YouTubeHomeViewModel {
     /// SwiftUI `.task` restarts coalesce onto one run instead of cancelling it.
     private var loadTask: Task<Void, Never>?
 
-    /// The player's `playbackStartCount` the last time a Continue Watching
-    /// rebuild was triggered, so a return to Home with no new playback since is a
+    /// The player's `playbackActivityCount` the last time a Continue Watching
+    /// rebuild was triggered, so a return to Home with no new activity since is a
     /// no-op. A count (not a videoId) so re-watching the SAME video still counts
     /// as new — videoId alone can't tell a fresh re-watch from an idle return.
     private var lastRefreshedPlaybackCount = 0
 
-    /// A post-watch playback count that arrived before Home finished loading, so
-    /// the scoped refresh couldn't run yet. `performLoad` consumes it once the
-    /// feed is `.loaded`, forcing a cache-bypassed Continue Watching rebuild —
+    /// A post-watch playback count that arrived before Home could rebuild the
+    /// rail in place (still loading, or the initial rail streamer is mid-flight
+    /// and would clobber a separate refresh). `performLoad` consumes it once the
+    /// feed has settled, forcing a cache-bypassed Continue Watching rebuild —
     /// otherwise a cold Home opened right after watching (with a warm `FEhistory`
     /// cache, e.g. from the History screen) would build the rail from stale
     /// pre-watch progress. Decouples the fix from `.task`/`.onChange` ordering.
     private var pendingPlaybackCount: Int?
+
+    /// True while `performLoad` is streaming the initial rails (Continue Watching
+    /// + topics) into `sections`. The streamer is the sole writer of `sections`
+    /// during that window, so a concurrent post-watch refresh must defer (park as
+    /// pending) rather than race it as a second writer and risk being overwritten
+    /// by a late streamer publish.
+    private var isStreamingInitialRails = false
 
     /// The in-flight post-watch Continue Watching rebuild, cancelled/replaced
     /// when a newer watch supersedes it. Stored (unstructured) so it survives
@@ -115,6 +123,9 @@ final class YouTubeHomeViewModel {
             if self.loadGeneration == token {
                 self.loadTask = nil
             }
+            // Always clear the streaming flag, even on cancellation/error, so a
+            // later post-watch refresh isn't permanently parked as pending.
+            self.isStreamingInitialRails = false
         }
         let generation = token
         self.loadingState = .loading
@@ -166,8 +177,11 @@ final class YouTubeHomeViewModel {
 
             // Stream the rails in as each resolves; the streamer is the single
             // writer of `sections` and prepends Continue Watching when its
-            // (concurrent) history fetch lands. See streamTopicRails.
+            // (concurrent) history fetch lands. See streamTopicRails. Mark the
+            // window so a concurrent post-watch refresh defers instead of racing
+            // the streamer (which would otherwise overwrite a refreshed rail).
             let chips = Array(bundle.chips.prefix(Self.topicRailCap))
+            self.isStreamingInitialRails = true
             await self.streamTopicRails(
                 chips: chips,
                 shelves: shelves,
@@ -178,6 +192,9 @@ final class YouTubeHomeViewModel {
                 gridReady: gridReady,
                 generation: generation
             )
+            // Streaming is done — `sections` is now stable, so a deferred
+            // post-watch refresh can safely rebuild the rail in place.
+            self.isStreamingInitialRails = false
 
             // Empty grid: flip the initial-load skeleton to `.loaded` so the
             // "No recommendations" placeholder can show. Only from `.loading` —
@@ -189,13 +206,14 @@ final class YouTubeHomeViewModel {
                 self.loadingState = .loaded
             }
 
-            // A watch happened while Home was still loading (opened cold right
-            // after watching). The rail just built above may have come from a
-            // warm pre-watch `FEhistory` cache, so run the scoped, cache-bypassed
-            // refresh now that we're `.loaded`. Consuming the pending count here
-            // (rather than in the view) makes the fix independent of whether
-            // `.task` or the selection/path `.onChange` fired first.
-            if case .loaded = self.loadingState, let pending = self.pendingPlaybackCount {
+            // A watch happened while Home was still loading or streaming its
+            // rails (opened cold right after watching, or returned mid-stream).
+            // The rail just built above may have come from a warm pre-watch
+            // `FEhistory` cache, so run the scoped, cache-bypassed refresh now
+            // that the feed has settled. Consuming the pending count here (rather
+            // than in the view) makes the fix independent of whether `.task` or
+            // the selection/path `.onChange` fired first.
+            if let pending = self.pendingPlaybackCount {
                 self.pendingPlaybackCount = nil
                 self.refreshContinueWatching(afterPlaybackCount: pending)
             }
@@ -280,7 +298,11 @@ final class YouTubeHomeViewModel {
         self.loadTask = nil
         self.continueWatchingRefreshTask?.cancel()
         self.continueWatchingRefreshTask = nil
-        self.pendingPlaybackCount = nil
+        // Deliberately preserve `pendingPlaybackCount`: this is also the
+        // error-retry path, and a post-watch trigger queued during a failed cold
+        // load must survive the retry so the ensuing `performLoad` rebuilds
+        // Continue Watching from fresh (not warm pre-watch) history. An account
+        // switch clears it separately via `cancelLoad()`.
         self.loadingState = .idle
         self.videos = []
         self.sections = []
@@ -351,9 +373,11 @@ final class YouTubeHomeViewModel {
 
     /// Started-but-unfinished videos from watch history (deduped, capped), or
     /// `nil` on failure / when nothing is resumable. Used by the initial load,
-    /// where a failed history fetch should simply omit the rail.
-    private func continueWatchingSection(forceRefresh: Bool = false) async -> YouTubeHomeSection? {
-        try? await self.fetchContinueWatchingSection(forceRefresh: forceRefresh)
+    /// where a failed history fetch should simply omit the rail (the cached
+    /// path). The post-watch rebuild calls `fetchContinueWatchingSection`
+    /// directly so it can both force-refresh and distinguish failure from empty.
+    private func continueWatchingSection() async -> YouTubeHomeSection? {
+        try? await self.fetchContinueWatchingSection(forceRefresh: false)
     }
 
     /// Fetches watch history and builds the Continue Watching section, throwing
@@ -403,7 +427,7 @@ final class YouTubeHomeViewModel {
     /// one appears — without the full `refresh()` that wipes the grid and flashes
     /// the skeleton.
     ///
-    /// `playbackCount` is the player's monotonic `playbackStartCount`; the
+    /// `playbackCount` is the player's monotonic `playbackActivityCount`; the
     /// rebuild is a no-op when it hasn't advanced since the last rebuild, so
     /// incidental returns to Home (opening then backing out of a channel, say)
     /// don't re-fetch history, while re-watching the same video — which a videoId
@@ -416,12 +440,22 @@ final class YouTubeHomeViewModel {
         guard playbackCount > 0 else { return }
         guard playbackCount != self.lastRefreshedPlaybackCount else { return }
 
-        // Home not loaded yet (the user opened it cold right after watching).
-        // Don't drop the trigger — record it so `performLoad` forces a
-        // cache-bypassed rail rebuild on completion. Without this, the initial
-        // load could build Continue Watching from a warm, pre-watch `FEhistory`
-        // cache and show stale progress until the TTL expires.
-        guard case .loaded = self.loadingState else {
+        // Defer (park as pending) when the rail can't be safely rebuilt in place
+        // yet, so the trigger is never dropped:
+        //   - the initial load hasn't produced a rail (`idle`/`loading`/`error`)
+        //   - the initial rail streamer is mid-flight and is the sole writer of
+        //     `sections` (a concurrent rebuild would race it)
+        // `performLoad` drains the pending count once the feed settles. A
+        // populated `.loaded` or a `.loadingMore` (pagination over an existing
+        // grid) is fine to rebuild in place — pagination only appends grid
+        // videos and never writes the Continue Watching rail.
+        let canRebuildInPlace: Bool = switch self.loadingState {
+        case .loaded, .loadingMore:
+            !self.isStreamingInitialRails
+        case .idle, .loading, .error:
+            false
+        }
+        guard canRebuildInPlace else {
             self.pendingPlaybackCount = playbackCount
             return
         }
@@ -467,7 +501,14 @@ final class YouTubeHomeViewModel {
     /// topic rails untouched. On a fetch failure the existing rail is preserved.
     @discardableResult
     private func rebuildContinueWatchingRail() async -> RailRefreshOutcome {
-        guard case .loaded = self.loadingState else { return .unchanged }
+        // The grid/shelves must already be published (loaded, or paginating over
+        // an existing grid). Anything earlier means there's no rail to splice.
+        switch self.loadingState {
+        case .loaded, .loadingMore:
+            break
+        case .idle, .loading, .error:
+            return .unchanged
+        }
 
         let fresh: YouTubeHomeSection?
         do {

--- a/Sources/Kaset/ViewModels/YouTube/YouTubeHomeViewModel.swift
+++ b/Sources/Kaset/ViewModels/YouTube/YouTubeHomeViewModel.swift
@@ -118,14 +118,15 @@ final class YouTubeHomeViewModel {
 
     private func performLoad(token: Int) async {
         defer {
-            // Only clear the handle if it still points at THIS run. A stale run
-            // resuming late must not wipe a newer run's task.
+            // Only clear shared handles if they still point at THIS run. A stale
+            // run resuming late must not wipe a newer run's task OR clear the
+            // newer run's streaming guard (which would drop the guard while the
+            // newer streamer is still the sole writer of `sections`, reopening the
+            // refresh-vs-streamer race).
             if self.loadGeneration == token {
                 self.loadTask = nil
+                self.isStreamingInitialRails = false
             }
-            // Always clear the streaming flag, even on cancellation/error, so a
-            // later post-watch refresh isn't permanently parked as pending.
-            self.isStreamingInitialRails = false
         }
         let generation = token
         self.loadingState = .loading
@@ -180,7 +181,9 @@ final class YouTubeHomeViewModel {
             // (concurrent) history fetch lands. See streamTopicRails. Mark the
             // window so a concurrent post-watch refresh defers instead of racing
             // the streamer (which would otherwise overwrite a refreshed rail).
+            // Only the current generation may own the guard.
             let chips = Array(bundle.chips.prefix(Self.topicRailCap))
+            guard generation == self.loadGeneration else { return }
             self.isStreamingInitialRails = true
             await self.streamTopicRails(
                 chips: chips,
@@ -193,8 +196,12 @@ final class YouTubeHomeViewModel {
                 generation: generation
             )
             // Streaming is done — `sections` is now stable, so a deferred
-            // post-watch refresh can safely rebuild the rail in place.
-            self.isStreamingInitialRails = false
+            // post-watch refresh can safely rebuild the rail in place. Only clear
+            // the guard if this run still owns it (a newer load may have taken
+            // over while we were streaming); the defer is the backstop.
+            if generation == self.loadGeneration {
+                self.isStreamingInitialRails = false
+            }
 
             // Empty grid: flip the initial-load skeleton to `.loaded` so the
             // "No recommendations" placeholder can show. Only from `.loading` —

--- a/Sources/Kaset/ViewModels/YouTube/YouTubeHomeViewModel.swift
+++ b/Sources/Kaset/ViewModels/YouTube/YouTubeHomeViewModel.swift
@@ -55,20 +55,21 @@ final class YouTubeHomeViewModel {
     /// SwiftUI `.task` restarts coalesce onto one run instead of cancelling it.
     private var loadTask: Task<Void, Never>?
 
-    /// The player's `playbackActivityCount` the last time a Continue Watching
-    /// rebuild was triggered, so a return to Home with no new activity since is a
-    /// no-op. A count (not a videoId) so re-watching the SAME video still counts
-    /// as new — videoId alone can't tell a fresh re-watch from an idle return.
-    private var lastRefreshedPlaybackCount = 0
+    /// The player's `watchActivityGeneration` the last time Continue Watching
+    /// was successfully rebuilt. A return/observe with no newer generation is a
+    /// no-op. This is a VM-LOCAL watermark — the player's generation is never
+    /// "consumed"; this only advances after a confirmed rebuild, so a refresh
+    /// firing for one event can't suppress a refresh for a genuinely later one.
+    private var lastReflectedGeneration = 0
 
-    /// A post-watch playback count that arrived before Home could rebuild the
+    /// A watch-activity generation that arrived before Home could rebuild the
     /// rail in place (still loading, or the initial rail streamer is mid-flight
     /// and would clobber a separate refresh). `performLoad` consumes it once the
     /// feed has settled, forcing a cache-bypassed Continue Watching rebuild —
     /// otherwise a cold Home opened right after watching (with a warm `FEhistory`
     /// cache, e.g. from the History screen) would build the rail from stale
     /// pre-watch progress. Decouples the fix from `.task`/`.onChange` ordering.
-    private var pendingPlaybackCount: Int?
+    private var pendingGeneration: Int?
 
     /// True while `performLoad` is streaming the initial rails (Continue Watching
     /// + topics) into `sections`. The streamer is the sole writer of `sections`
@@ -217,12 +218,12 @@ final class YouTubeHomeViewModel {
             // rails (opened cold right after watching, or returned mid-stream).
             // The rail just built above may have come from a warm pre-watch
             // `FEhistory` cache, so run the scoped, cache-bypassed refresh now
-            // that the feed has settled. Consuming the pending count here (rather
-            // than in the view) makes the fix independent of whether `.task` or
-            // the selection/path `.onChange` fired first.
-            if let pending = self.pendingPlaybackCount {
-                self.pendingPlaybackCount = nil
-                self.refreshContinueWatching(afterPlaybackCount: pending)
+            // that the feed has settled. Consuming the pending generation here
+            // (rather than in the view) makes the fix independent of whether
+            // `.task` or the selection/path `.onChange` fired first.
+            if let pending = self.pendingGeneration {
+                self.pendingGeneration = nil
+                self.refreshContinueWatching(forGeneration: pending)
             }
         } catch {
             guard generation == self.loadGeneration else { return }
@@ -305,7 +306,7 @@ final class YouTubeHomeViewModel {
         self.loadTask = nil
         self.continueWatchingRefreshTask?.cancel()
         self.continueWatchingRefreshTask = nil
-        // Deliberately preserve `pendingPlaybackCount`: this is also the
+        // Deliberately preserve `pendingGeneration`: this is also the
         // error-retry path, and a post-watch trigger queued during a failed cold
         // load must survive the retry so the ensuing `performLoad` rebuilds
         // Continue Watching from fresh (not warm pre-watch) history. An account
@@ -328,7 +329,7 @@ final class YouTubeHomeViewModel {
         self.loadTask = nil
         self.continueWatchingRefreshTask?.cancel()
         self.continueWatchingRefreshTask = nil
-        self.pendingPlaybackCount = nil
+        self.pendingGeneration = nil
     }
 
     /// Loads the next feed page when the user nears the end of the grid.
@@ -429,30 +430,29 @@ final class YouTubeHomeViewModel {
         case failed
     }
 
-    /// Rebuilds only the Continue Watching rail after the user watches a video
-    /// and returns to Home, so a finished video drops out and a partially-watched
-    /// one appears — without the full `refresh()` that wipes the grid and flashes
-    /// the skeleton.
+    /// Rebuilds only the Continue Watching rail after watch activity occurs and
+    /// the user is (or returns) on Home, so a finished video drops out and a
+    /// partially-watched one appears — without the full `refresh()` that wipes
+    /// the grid and flashes the skeleton.
     ///
-    /// `playbackCount` is the player's monotonic `playbackActivityCount`; the
-    /// rebuild is a no-op when it hasn't advanced since the last rebuild, so
-    /// incidental returns to Home (opening then backing out of a channel, say)
-    /// don't re-fetch history, while re-watching the same video — which a videoId
-    /// alone could not distinguish from an idle return — still triggers one. The
-    /// work runs after a short delay (YouTube records watch progress server-side
-    /// via the embedded player, not Kaset) and bypasses the 2 min history cache,
-    /// retrying once if the first fetch shows no change or fails.
-    func refreshContinueWatching(afterPlaybackCount playbackCount: Int) {
-        // Only rebuild after at least one playback, for a genuinely new watch.
-        guard playbackCount > 0 else { return }
-        guard playbackCount != self.lastRefreshedPlaybackCount else { return }
+    /// `generation` is the player's monotonic `watchActivityGeneration`; the
+    /// rebuild is a no-op when it isn't ahead of the last reflected generation,
+    /// so incidental returns to Home (opening then backing out of a channel, say)
+    /// don't re-fetch history, while ANY new watch activity — re-watching the
+    /// same video, a skip, a finish, a drift — still triggers one. The work runs
+    /// after a short delay (YouTube records watch progress server-side via the
+    /// embedded player, not Kaset) and bypasses the 2 min history cache, retrying
+    /// once if the first fetch shows no change or fails.
+    func refreshContinueWatching(forGeneration generation: Int) {
+        // Only rebuild for activity strictly newer than what's already reflected.
+        guard generation > self.lastReflectedGeneration else { return }
 
         // Defer (park as pending) when the rail can't be safely rebuilt in place
         // yet, so the trigger is never dropped:
         //   - the initial load hasn't produced a rail (`idle`/`loading`/`error`)
         //   - the initial rail streamer is mid-flight and is the sole writer of
         //     `sections` (a concurrent rebuild would race it)
-        // `performLoad` drains the pending count once the feed settles. A
+        // `performLoad` drains the pending generation once the feed settles. A
         // populated `.loaded` or a `.loadingMore` (pagination over an existing
         // grid) is fine to rebuild in place — pagination only appends grid
         // videos and never writes the Continue Watching rail.
@@ -463,21 +463,22 @@ final class YouTubeHomeViewModel {
             false
         }
         guard canRebuildInPlace else {
-            self.pendingPlaybackCount = playbackCount
+            // Keep the highest pending generation if several arrive while loading.
+            self.pendingGeneration = max(self.pendingGeneration ?? 0, generation)
             return
         }
 
         self.continueWatchingRefreshTask?.cancel()
         self.continueWatchingRefreshTask = Task { [weak self] in
-            await self?.performContinueWatchingRefresh(targetCount: playbackCount)
+            await self?.performContinueWatchingRefresh(targetGeneration: generation)
         }
     }
 
-    private func performContinueWatchingRefresh(targetCount: Int) async {
+    private func performContinueWatchingRefresh(targetGeneration: Int) async {
         do {
             try await Task.sleep(for: Self.continueWatchingRefreshDelay)
         } catch {
-            return // cancelled before any work; leave the count unconsumed so a later return retries
+            return // cancelled before any work; leave the watermark so a later return retries
         }
 
         var outcome = await self.rebuildContinueWatchingRail()
@@ -494,13 +495,13 @@ final class YouTubeHomeViewModel {
             }
         }
 
-        // Record this playback as handled ONLY when the refresh actually reached
-        // the server (updated or unchanged) and was not cancelled. A cancellation
-        // (e.g. refresh()/account switch during the delay) or a hard failure
-        // leaves `lastRefreshedPlaybackCount` unchanged, so the next return to
-        // Home retries this same playback instead of silently skipping it.
+        // Advance the watermark ONLY when the refresh actually reached the server
+        // (updated or unchanged) and was not cancelled. A cancellation (e.g.
+        // refresh()/account switch during the delay) or a hard failure leaves it
+        // unchanged, so the next return to Home retries. `max` guards against a
+        // late-finishing earlier task lowering a watermark a newer task advanced.
         guard !Task.isCancelled, outcome == .updated || outcome == .unchanged else { return }
-        self.lastRefreshedPlaybackCount = targetCount
+        self.lastReflectedGeneration = max(self.lastReflectedGeneration, targetGeneration)
     }
 
     /// Fetches fresh history (cache-bypassed) and splices the resulting Continue

--- a/Sources/Kaset/Views/YouTube/YouTubeContentView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeContentView.swift
@@ -45,23 +45,33 @@ struct YouTubeContentView: View {
             // watching (watch from any section, then pick Home). The path is
             // already — or just reset to — empty, so the count-based trigger
             // below won't fire; fire the same gated refresh here. It's a no-op
-            // when no new playback happened (count unchanged) or on cold launch
+            // when no new activity happened (count unchanged) or on cold launch
             // (count 0), so this never double-fetches with the count trigger.
             if newSelection == .home {
-                self.store.home.refreshContinueWatching(afterPlaybackCount: self.youtubePlayer.playbackStartCount)
+                self.store.home.refreshContinueWatching(afterPlaybackCount: self.youtubePlayer.playbackActivityCount)
             }
         }
         // Returning to the Home root by popping the drill-in stack (Back from a
         // video opened on Home) rebuilds the Continue Watching rail (a finished
         // video drops out; a partially-watched one appears). Home's reload is
         // keyed on view-model identity, so a navigation pop never re-runs it on
-        // its own. The player's monotonic `playbackStartCount` gates the rebuild,
-        // so incidental returns from other drill-ins (where nothing was played)
-        // don't re-fetch history, while re-watching the same video still counts
-        // as a new watch.
+        // its own. The player's monotonic `playbackActivityCount` gates the
+        // rebuild, so incidental returns from other drill-ins (where nothing was
+        // played) don't re-fetch history, while re-watching the same video still
+        // counts as new activity.
         .onChange(of: self.store.navigationPath.count) { oldDepth, newDepth in
             guard self.selection == .home, newDepth == 0, oldDepth > 0 else { return }
-            self.store.home.refreshContinueWatching(afterPlaybackCount: self.youtubePlayer.playbackStartCount)
+            self.store.home.refreshContinueWatching(afterPlaybackCount: self.youtubePlayer.playbackActivityCount)
+        }
+        // The user can also be sitting ON the Home root while a video plays in
+        // the floating window (it pops out there when navigating away mid-play)
+        // and then skips or finishes — no selection/path change fires, but the
+        // activity counter advances. Observe it directly so Continue Watching
+        // still updates without requiring a navigation. Gated to the Home root so
+        // it doesn't fetch while the user is on another section or drilled in.
+        .onChange(of: self.youtubePlayer.playbackActivityCount) { _, newCount in
+            guard self.selection == .home, self.store.navigationPath.isEmpty else { return }
+            self.store.home.refreshContinueWatching(afterPlaybackCount: newCount)
         }
     }
 

--- a/Sources/Kaset/Views/YouTube/YouTubeContentView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeContentView.swift
@@ -65,13 +65,16 @@ struct YouTubeContentView: View {
         }
         // The user can also be sitting ON the Home root while a video plays in
         // the floating window (it pops out there when navigating away mid-play)
-        // and then skips or finishes — no selection/path change fires, but the
-        // activity counter advances. Observe it directly so Continue Watching
-        // still updates without requiring a navigation. Gated to the Home root so
-        // it doesn't fetch while the user is on another section or drilled in.
-        .onChange(of: self.youtubePlayer.playbackActivityCount) { _, newCount in
+        // and then skips or finishes — no selection/path change fires. Observe
+        // `playbackProgressEventCount`, which advances only on a skip or finish
+        // (NOT a bare start), so a video started from Home doesn't prematurely
+        // consume the activity gate and suppress a later partial-watch refresh.
+        // The gate value passed to the model stays `playbackActivityCount`.
+        // Gated to the Home root so it doesn't fetch while drilled in or on
+        // another section.
+        .onChange(of: self.youtubePlayer.playbackProgressEventCount) { _, _ in
             guard self.selection == .home, self.store.navigationPath.isEmpty else { return }
-            self.store.home.refreshContinueWatching(afterPlaybackCount: newCount)
+            self.store.home.refreshContinueWatching(afterPlaybackCount: self.youtubePlayer.playbackActivityCount)
         }
     }
 

--- a/Sources/Kaset/Views/YouTube/YouTubeContentView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeContentView.swift
@@ -41,40 +41,37 @@ struct YouTubeContentView: View {
         }
         .onChange(of: self.selection) { _, newSelection in
             self.store.navigationPath = NavigationPath()
-            // Returning to Home via the sidebar is the other way back after
-            // watching (watch from any section, then pick Home). The path is
-            // already — or just reset to — empty, so the count-based trigger
-            // below won't fire; fire the same gated refresh here. It's a no-op
-            // when no new activity happened (count unchanged) or on cold launch
-            // (count 0), so this never double-fetches with the count trigger.
+            // Returning to Home via the sidebar is one way back after watching
+            // (watch from any section, then pick Home). The path is already — or
+            // just reset to — empty, so the depth trigger below won't fire; drive
+            // the same gated refresh here. The view-model watermark makes it a
+            // no-op when no newer watch activity occurred, so the three observers
+            // coalesce safely.
             if newSelection == .home {
-                self.store.home.refreshContinueWatching(afterPlaybackCount: self.youtubePlayer.playbackActivityCount)
+                self.store.home.refreshContinueWatching(forGeneration: self.youtubePlayer.watchActivityGeneration)
             }
         }
         // Returning to the Home root by popping the drill-in stack (Back from a
         // video opened on Home) rebuilds the Continue Watching rail (a finished
         // video drops out; a partially-watched one appears). Home's reload is
         // keyed on view-model identity, so a navigation pop never re-runs it on
-        // its own. The player's monotonic `playbackActivityCount` gates the
-        // rebuild, so incidental returns from other drill-ins (where nothing was
-        // played) don't re-fetch history, while re-watching the same video still
-        // counts as new activity.
+        // its own. The view model gates on the player's monotonic
+        // `watchActivityGeneration` against its own watermark, so incidental
+        // returns (no new activity) don't re-fetch.
         .onChange(of: self.store.navigationPath.count) { oldDepth, newDepth in
             guard self.selection == .home, newDepth == 0, oldDepth > 0 else { return }
-            self.store.home.refreshContinueWatching(afterPlaybackCount: self.youtubePlayer.playbackActivityCount)
+            self.store.home.refreshContinueWatching(forGeneration: self.youtubePlayer.watchActivityGeneration)
         }
         // The user can also be sitting ON the Home root while a video plays in
         // the floating window (it pops out there when navigating away mid-play)
-        // and then skips or finishes — no selection/path change fires. Observe
-        // `playbackProgressEventCount`, which advances only on a skip or finish
-        // (NOT a bare start), so a video started from Home doesn't prematurely
-        // consume the activity gate and suppress a later partial-watch refresh.
-        // The gate value passed to the model stays `playbackActivityCount`.
-        // Gated to the Home root so it doesn't fetch while drilled in or on
-        // another section.
-        .onChange(of: self.youtubePlayer.playbackProgressEventCount) { _, _ in
+        // and then skips, finishes, drifts, or is closed — no selection/path
+        // change fires. Observe `watchActivityGeneration` directly: it advances
+        // on every watch-state change, and the view-model watermark prevents a
+        // bare start from suppressing a later partial-watch refresh. Gated to the
+        // Home root so it doesn't fetch while drilled in or on another section.
+        .onChange(of: self.youtubePlayer.watchActivityGeneration) { _, newGeneration in
             guard self.selection == .home, self.store.navigationPath.isEmpty else { return }
-            self.store.home.refreshContinueWatching(afterPlaybackCount: self.youtubePlayer.playbackActivityCount)
+            self.store.home.refreshContinueWatching(forGeneration: newGeneration)
         }
     }
 

--- a/Sources/Kaset/Views/YouTube/YouTubeContentView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeContentView.swift
@@ -39,8 +39,29 @@ struct YouTubeContentView: View {
         .onChange(of: self.youtubePlayer.skipNavigationRequest) { _, request in
             self.handleSkipNavigationRequest(request)
         }
-        .onChange(of: self.selection) { _, _ in
+        .onChange(of: self.selection) { _, newSelection in
             self.store.navigationPath = NavigationPath()
+            // Returning to Home via the sidebar is the other way back after
+            // watching (watch from any section, then pick Home). The path is
+            // already — or just reset to — empty, so the count-based trigger
+            // below won't fire; fire the same gated refresh here. It's a no-op
+            // when no new playback happened (count unchanged) or on cold launch
+            // (count 0), so this never double-fetches with the count trigger.
+            if newSelection == .home {
+                self.store.home.refreshContinueWatching(afterPlaybackCount: self.youtubePlayer.playbackStartCount)
+            }
+        }
+        // Returning to the Home root by popping the drill-in stack (Back from a
+        // video opened on Home) rebuilds the Continue Watching rail (a finished
+        // video drops out; a partially-watched one appears). Home's reload is
+        // keyed on view-model identity, so a navigation pop never re-runs it on
+        // its own. The player's monotonic `playbackStartCount` gates the rebuild,
+        // so incidental returns from other drill-ins (where nothing was played)
+        // don't re-fetch history, while re-watching the same video still counts
+        // as a new watch.
+        .onChange(of: self.store.navigationPath.count) { oldDepth, newDepth in
+            guard self.selection == .home, newDepth == 0, oldDepth > 0 else { return }
+            self.store.home.refreshContinueWatching(afterPlaybackCount: self.youtubePlayer.playbackStartCount)
         }
     }
 

--- a/Sources/Kaset/Views/YouTube/YouTubeContentView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeContentView.swift
@@ -65,13 +65,16 @@ struct YouTubeContentView: View {
         // The user can also be sitting ON the Home root while a video plays in
         // the floating window (it pops out there when navigating away mid-play)
         // and then skips, finishes, drifts, or is closed — no selection/path
-        // change fires. Observe `watchActivityGeneration` directly: it advances
-        // on every watch-state change, and the view-model watermark prevents a
-        // bare start from suppressing a later partial-watch refresh. Gated to the
-        // Home root so it doesn't fetch while drilled in or on another section.
-        .onChange(of: self.youtubePlayer.watchActivityGeneration) { _, newGeneration in
+        // change fires. Observe `watchConclusionGeneration`, which advances only
+        // when a watch CONCLUDES with progress (skip/finish/drift/stop), NOT on a
+        // bare start: a video merely starting while Home is visible has no new
+        // resume state, and refreshing then would advance the watermark and
+        // swallow the progress that accrues afterward. The value passed to the
+        // model stays `watchActivityGeneration` (the gate). Gated to the Home
+        // root so it doesn't fetch while drilled in or on another section.
+        .onChange(of: self.youtubePlayer.watchConclusionGeneration) { _, _ in
             guard self.selection == .home, self.store.navigationPath.isEmpty else { return }
-            self.store.home.refreshContinueWatching(forGeneration: newGeneration)
+            self.store.home.refreshContinueWatching(forGeneration: self.youtubePlayer.watchActivityGeneration)
         }
     }
 

--- a/Sources/Kaset/Views/YouTube/YouTubeContentView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeContentView.swift
@@ -33,6 +33,17 @@ struct YouTubeContentView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        // Reconcile on (re)mount: switching to the Music source unmounts this
+        // view, so the observers below can't see a floating video that finishes
+        // or is closed while away. On switching back to YouTube with Home already
+        // selected and the path empty, neither `selection` nor the path changes
+        // and `YouTubeHomeView.load()` is a no-op — so without this, a conclusion
+        // missed during the Music detour would leave the rail stale. The
+        // view-model watermark makes this a no-op when nothing was missed.
+        .onAppear {
+            guard self.selection == .home, self.store.navigationPath.isEmpty else { return }
+            self.store.home.refreshContinueWatching(forGeneration: self.youtubePlayer.watchActivityGeneration)
+        }
         .onChange(of: self.youtubePlayer.popInRequest) { _, request in
             self.handlePopInRequest(request)
         }

--- a/Tests/KasetTests/Helpers/MockYouTubeClient.swift
+++ b/Tests/KasetTests/Helpers/MockYouTubeClient.swift
@@ -66,8 +66,16 @@ final class MockYouTubeClient: YouTubeClientProtocol {
         )
     }
 
+    /// Awaited inside `getHomeFeedContinuation` before it returns, so a test can
+    /// hold a pagination request open and assert behaviour while the model sits
+    /// in `.loadingMore`.
+    var beforeContinuationReturn: (@Sendable () async -> Void)?
+
     func getHomeFeedContinuation() async throws -> YouTubeFeed? {
         if let error { throw error }
+        if let beforeContinuationReturn {
+            await beforeContinuationReturn()
+        }
         if !self.homeContinuationPages.isEmpty {
             return self.homeContinuationPages.removeFirst()
         }

--- a/Tests/KasetTests/Helpers/MockYouTubeClient.swift
+++ b/Tests/KasetTests/Helpers/MockYouTubeClient.swift
@@ -215,10 +215,36 @@ final class MockYouTubeClient: YouTubeClientProtocol {
     /// without waiting for it.
     var beforeHistoryReturn: (@Sendable () async -> Void)?
 
-    func getHistory() async throws -> YouTubeFeed {
+    /// Number of `getHistory` calls and how many requested a forced refresh,
+    /// so tests can assert the Continue Watching rebuild bypasses the cache.
+    private(set) var getHistoryCallCount = 0
+    private(set) var getHistoryForceRefreshCount = 0
+
+    /// When set, `getHistory(forceRefresh: true)` throws this — without failing
+    /// the cached (initial-load) path — so a test can simulate a transient
+    /// failure of only the post-watch refresh.
+    var historyForceRefreshError: Error?
+
+    /// When set, `getHistory(forceRefresh: true)` returns this instead of
+    /// `historyFeed`, so a test can give the forced (post-watch) refresh
+    /// different data than the cached initial load — making the rebuild a
+    /// deterministic single `.updated` (no retry).
+    var historyForceRefreshFeed: YouTubeFeed?
+
+    func getHistory(forceRefresh: Bool) async throws -> YouTubeFeed {
         if let error { throw error }
+        self.getHistoryCallCount += 1
+        if forceRefresh {
+            self.getHistoryForceRefreshCount += 1
+            if let historyForceRefreshError {
+                throw historyForceRefreshError
+            }
+        }
         if let beforeHistoryReturn {
             await beforeHistoryReturn()
+        }
+        if forceRefresh, let historyForceRefreshFeed {
+            return historyForceRefreshFeed
         }
         return self.historyFeed
     }

--- a/Tests/KasetTests/YouTubeHomeContinueWatchingRefreshTests.swift
+++ b/Tests/KasetTests/YouTubeHomeContinueWatchingRefreshTests.swift
@@ -7,7 +7,7 @@ import Testing
 /// Covers the post-watch Continue Watching rail refresh: returning to Home after
 /// watching a video rebuilds only that rail (a finished video drops out, a
 /// partially-watched one appears or updates its progress), gated on the player's
-/// playback count, cache-bypassed, and resilient to transient fetch failures.
+/// watch-activity generation, cache-bypassed, and resilient to transient fetch failures.
 @Suite("YouTubeHome Continue Watching refresh", .serialized, .tags(.viewModel), .timeLimit(.minutes(1)))
 @MainActor
 struct YouTubeHomeContinueWatchingRefreshTests {
@@ -72,7 +72,7 @@ struct YouTubeHomeContinueWatchingRefreshTests {
             continuation: nil
         )
 
-        self.sut.refreshContinueWatching(afterPlaybackCount: 1)
+        self.sut.refreshContinueWatching(forGeneration: 1)
         await self.waitForCondition {
             self.sut.sections.first { $0.kind == .continueWatching }?.videos.map(\.videoId) == ["other"]
         }
@@ -95,7 +95,7 @@ struct YouTubeHomeContinueWatchingRefreshTests {
             continuation: nil
         )
 
-        self.sut.refreshContinueWatching(afterPlaybackCount: 1)
+        self.sut.refreshContinueWatching(forGeneration: 1)
         await self.waitForCondition {
             self.sut.sections.contains { $0.kind == .continueWatching }
         }
@@ -123,7 +123,7 @@ struct YouTubeHomeContinueWatchingRefreshTests {
             videos: [MockYouTubeClient.makeVideo(videoId: "resume", watchedPercent: 55)],
             continuation: nil
         )
-        self.sut.refreshContinueWatching(afterPlaybackCount: 1)
+        self.sut.refreshContinueWatching(forGeneration: 1)
         await self.waitForCondition {
             self.sut.sections.first { $0.kind == .continueWatching }?.videos.first?.watchedPercent == 55
         }
@@ -167,7 +167,7 @@ struct YouTubeHomeContinueWatchingRefreshTests {
             ],
             continuation: nil
         )
-        self.sut.refreshContinueWatching(afterPlaybackCount: 1)
+        self.sut.refreshContinueWatching(forGeneration: 1)
         await self.waitForCondition {
             (self.sut.sections.first { $0.kind == .continueWatching }?.videos.count ?? 0) == 2
         }
@@ -180,7 +180,7 @@ struct YouTubeHomeContinueWatchingRefreshTests {
         #expect(self.sut.sections.first { $0.kind == .topic }?.title == "Gaming")
     }
 
-    @Test("Refresh is gated on the playback count advancing")
+    @Test("Refresh is gated on the watch-activity generation advancing")
     func refreshGatesOnPlaybackCount() async {
         self.makeRefreshDelaysInstant()
         self.mockClient.historyFeed = YouTubeFeed(
@@ -189,12 +189,12 @@ struct YouTubeHomeContinueWatchingRefreshTests {
         )
         await self.sut.load()
 
-        // No playback yet (count 0): nothing was watched, so no fetch.
-        self.sut.refreshContinueWatching(afterPlaybackCount: 0)
+        // No activity yet (generation 0): nothing was watched, so no fetch.
+        self.sut.refreshContinueWatching(forGeneration: 0)
         await Task.yield()
         #expect(self.mockClient.getHistoryForceRefreshCount == 0)
 
-        // First watch (count 1) updates the rail (a new resumable video appears),
+        // First watch (generation 1) updates the rail (a new resumable video appears),
         // so the rebuild sees a change on its first try and does not retry.
         self.mockClient.historyFeed = YouTubeFeed(
             videos: [
@@ -203,21 +203,22 @@ struct YouTubeHomeContinueWatchingRefreshTests {
             ],
             continuation: nil
         )
-        self.sut.refreshContinueWatching(afterPlaybackCount: 1)
+        self.sut.refreshContinueWatching(forGeneration: 1)
         await self.waitForCondition {
             (self.sut.sections.first { $0.kind == .continueWatching }?.videos.count ?? 0) == 2
         }
         #expect(self.mockClient.getHistoryForceRefreshCount == 1)
 
-        // Returning again with no new playback (same count) does not re-fetch.
-        self.sut.refreshContinueWatching(afterPlaybackCount: 1)
+        // Returning again with no new activity (same generation) does not re-fetch.
+        self.sut.refreshContinueWatching(forGeneration: 1)
         await Task.yield()
         #expect(self.mockClient.getHistoryForceRefreshCount == 1)
 
-        // A strictly higher count (e.g. a partial watch followed by a return,
-        // after an earlier count was already consumed) must still fire. This is
-        // the invariant the view's start-vs-progress observer split relies on:
-        // consuming one count never blocks a later, larger one.
+        // A strictly higher generation (e.g. a later partial watch, after an
+        // earlier generation was already reflected) must still fire. This is the
+        // invariant that makes the single set-only generation safe: reflecting
+        // one generation never blocks a later one — so a bare start followed by a
+        // partial watch always refreshes.
         self.mockClient.historyForceRefreshFeed = YouTubeFeed(
             videos: [
                 MockYouTubeClient.makeVideo(videoId: "resume", watchedPercent: 30),
@@ -225,12 +226,12 @@ struct YouTubeHomeContinueWatchingRefreshTests {
             ],
             continuation: nil
         )
-        self.sut.refreshContinueWatching(afterPlaybackCount: 2)
+        self.sut.refreshContinueWatching(forGeneration: 2)
         await self.waitForCondition { self.mockClient.getHistoryForceRefreshCount == 2 }
         #expect(self.mockClient.getHistoryForceRefreshCount == 2)
     }
 
-    @Test("Re-watching the same video still refreshes when the playback count advances")
+    @Test("Re-watching the same video still refreshes when the generation advances")
     func refreshFiresOnSameVideoRewatch() async {
         self.makeRefreshDelaysInstant()
         self.mockClient.historyFeed = YouTubeFeed(
@@ -244,20 +245,20 @@ struct YouTubeHomeContinueWatchingRefreshTests {
             videos: [MockYouTubeClient.makeVideo(videoId: "resume", watchedPercent: 55)],
             continuation: nil
         )
-        self.sut.refreshContinueWatching(afterPlaybackCount: 1)
+        self.sut.refreshContinueWatching(forGeneration: 1)
         await self.waitForCondition {
             self.sut.sections.first { $0.kind == .continueWatching }?.videos.first?.watchedPercent == 55
         }
         #expect(self.mockClient.getHistoryForceRefreshCount == 1)
 
         // The user opens the SAME video again and finishes it. The videoId is
-        // unchanged, but the playback count advanced (2), so the rail must still
+        // unchanged, but the generation advanced (2), so the rail must still
         // refresh — and the now-finished video drops out.
         self.mockClient.historyFeed = YouTubeFeed(
             videos: [MockYouTubeClient.makeVideo(videoId: "resume", watchedPercent: 100)],
             continuation: nil
         )
-        self.sut.refreshContinueWatching(afterPlaybackCount: 2)
+        self.sut.refreshContinueWatching(forGeneration: 2)
         await self.waitForCondition {
             self.sut.sections.contains { $0.kind == .continueWatching } == false
         }
@@ -281,7 +282,7 @@ struct YouTubeHomeContinueWatchingRefreshTests {
         self.mockClient.historyForceRefreshError = YTMusicError.networkError(
             underlying: URLError(.timedOut)
         )
-        self.sut.refreshContinueWatching(afterPlaybackCount: 1)
+        self.sut.refreshContinueWatching(forGeneration: 1)
         // Two forced attempts: the first fails, the retry fires and also fails.
         await self.waitForCondition { self.mockClient.getHistoryForceRefreshCount == 2 }
 
@@ -289,7 +290,7 @@ struct YouTubeHomeContinueWatchingRefreshTests {
         #expect(self.sut.loadingState == .loaded) // no skeleton flash
     }
 
-    @Test("A failed refresh does not consume the playback count, so a later return retries")
+    @Test("A failed refresh does not advance the watermark, so a later return retries")
     func failedRefreshLeavesPlaybackCountRetryable() async {
         self.makeRefreshDelaysInstant()
         self.mockClient.historyFeed = YouTubeFeed(
@@ -302,10 +303,10 @@ struct YouTubeHomeContinueWatchingRefreshTests {
         self.mockClient.historyForceRefreshError = YTMusicError.networkError(
             underlying: URLError(.timedOut)
         )
-        self.sut.refreshContinueWatching(afterPlaybackCount: 1)
+        self.sut.refreshContinueWatching(forGeneration: 1)
         await self.waitForCondition { self.mockClient.getHistoryForceRefreshCount == 2 }
 
-        // The user returns again with the SAME playback count. Because the failed
+        // The user returns again with the SAME generation. Because the failed
         // refresh did not consume the count, this must fetch again (not skip), and
         // now it succeeds and updates the rail.
         self.mockClient.historyForceRefreshError = nil
@@ -313,7 +314,7 @@ struct YouTubeHomeContinueWatchingRefreshTests {
             videos: [MockYouTubeClient.makeVideo(videoId: "resume", watchedPercent: 70)],
             continuation: nil
         )
-        self.sut.refreshContinueWatching(afterPlaybackCount: 1)
+        self.sut.refreshContinueWatching(forGeneration: 1)
         await self.waitForCondition {
             self.sut.sections.first { $0.kind == .continueWatching }?.videos.first?.watchedPercent == 70
         }
@@ -321,7 +322,7 @@ struct YouTubeHomeContinueWatchingRefreshTests {
         #expect(self.mockClient.getHistoryForceRefreshCount == 3) // 2 failed + 1 successful
     }
 
-    @Test("Cancelling the refresh mid-delay does not consume the playback count")
+    @Test("Cancelling the refresh mid-delay does not advance the watermark")
     func cancelledRefreshLeavesPlaybackCountRetryable() async {
         // Non-zero delay so the refresh is cancellable while still sleeping.
         YouTubeHomeViewModel.continueWatchingRefreshDelay = .seconds(60)
@@ -334,7 +335,7 @@ struct YouTubeHomeContinueWatchingRefreshTests {
 
         // Trigger a refresh, then cancel it (e.g. account switch / discard) while
         // it is still in its propagation delay — before any fetch happened.
-        self.sut.refreshContinueWatching(afterPlaybackCount: 1)
+        self.sut.refreshContinueWatching(forGeneration: 1)
         self.sut.cancelLoad()
         await Task.yield()
         #expect(self.mockClient.getHistoryForceRefreshCount == 0) // never reached the fetch
@@ -346,7 +347,7 @@ struct YouTubeHomeContinueWatchingRefreshTests {
             videos: [MockYouTubeClient.makeVideo(videoId: "resume", watchedPercent: 80)],
             continuation: nil
         )
-        self.sut.refreshContinueWatching(afterPlaybackCount: 1)
+        self.sut.refreshContinueWatching(forGeneration: 1)
         await self.waitForCondition {
             self.sut.sections.first { $0.kind == .continueWatching }?.videos.first?.watchedPercent == 80
         }
@@ -359,7 +360,7 @@ struct YouTubeHomeContinueWatchingRefreshTests {
         self.makeRefreshDelaysInstant()
         // No load() yet — loadingState is .idle. The trigger is queued as
         // pending rather than fetching now (or being dropped).
-        self.sut.refreshContinueWatching(afterPlaybackCount: 1)
+        self.sut.refreshContinueWatching(forGeneration: 1)
         await Task.yield()
         #expect(self.mockClient.getHistoryForceRefreshCount == 0)
         #expect(self.sut.sections.isEmpty)
@@ -384,7 +385,7 @@ struct YouTubeHomeContinueWatchingRefreshTests {
 
         // The user watched the video, then opened Home cold — the trigger fires
         // while Home is still idle, so it is queued as pending (no fetch yet).
-        self.sut.refreshContinueWatching(afterPlaybackCount: 1)
+        self.sut.refreshContinueWatching(forGeneration: 1)
         #expect(self.mockClient.getHistoryForceRefreshCount == 0)
 
         // Loading the feed must, on completion, consume the pending count and run
@@ -400,7 +401,7 @@ struct YouTubeHomeContinueWatchingRefreshTests {
 
         // The pending count is consumed: a later return with the same count is a
         // no-op (no second forced fetch).
-        self.sut.refreshContinueWatching(afterPlaybackCount: 1)
+        self.sut.refreshContinueWatching(forGeneration: 1)
         await Task.yield()
         #expect(self.mockClient.getHistoryForceRefreshCount == 1)
     }
@@ -440,7 +441,7 @@ struct YouTubeHomeContinueWatchingRefreshTests {
             videos: [MockYouTubeClient.makeVideo(videoId: "resume", watchedPercent: 80)],
             continuation: nil
         )
-        self.sut.refreshContinueWatching(afterPlaybackCount: 1)
+        self.sut.refreshContinueWatching(forGeneration: 1)
         await self.waitForCondition {
             self.sut.sections.first { $0.kind == .continueWatching }?.videos.first?.watchedPercent == 80
         }
@@ -476,7 +477,7 @@ struct YouTubeHomeContinueWatchingRefreshTests {
 
         // The trigger arrives mid-stream — it must defer (no forced fetch yet)
         // rather than race the streamer as a second writer to `sections`.
-        self.sut.refreshContinueWatching(afterPlaybackCount: 1)
+        self.sut.refreshContinueWatching(forGeneration: 1)
         await Task.yield()
         #expect(self.mockClient.getHistoryForceRefreshCount == 0)
 

--- a/Tests/KasetTests/YouTubeHomeContinueWatchingRefreshTests.swift
+++ b/Tests/KasetTests/YouTubeHomeContinueWatchingRefreshTests.swift
@@ -491,6 +491,41 @@ struct YouTubeHomeContinueWatchingRefreshTests {
         #expect(self.sut.sections.first { $0.kind == .continueWatching }?.videos.first?.watchedPercent == 90)
         #expect(self.mockClient.getHistoryForceRefreshCount == 1)
     }
+
+    @Test("refresh() preserves a still-delayed post-watch refresh so the reload reflects it")
+    func refreshPreservesInFlightPostWatchRefresh() async {
+        // Non-zero delay so the post-watch refresh is still in its propagation
+        // delay (in flight) when refresh() interrupts it.
+        YouTubeHomeViewModel.continueWatchingRefreshDelay = .seconds(60)
+        YouTubeHomeViewModel.continueWatchingRefreshRetryDelay = .zero
+        self.mockClient.historyFeed = YouTubeFeed(
+            videos: [MockYouTubeClient.makeVideo(videoId: "resume", watchedPercent: 30)],
+            continuation: nil
+        )
+        await self.sut.load()
+
+        // A post-watch refresh is scheduled (generation 1) but sits in its delay.
+        self.sut.refreshContinueWatching(forGeneration: 1)
+        await Task.yield()
+        #expect(self.mockClient.getHistoryForceRefreshCount == 0) // still delayed
+
+        // Fresh post-watch history; the reload's drained pending refresh must use
+        // the forced (cache-bypassed) path and reflect it.
+        YouTubeHomeViewModel.continueWatchingRefreshDelay = .zero
+        self.mockClient.historyForceRefreshFeed = YouTubeFeed(
+            videos: [MockYouTubeClient.makeVideo(videoId: "resume", watchedPercent: 75)],
+            continuation: nil
+        )
+
+        // A pull-to-refresh / error-retry interrupts the still-delayed refresh.
+        // Its target generation must survive into the reload, which then drains it.
+        await self.sut.refresh()
+        await self.waitForCondition {
+            self.sut.sections.first { $0.kind == .continueWatching }?.videos.first?.watchedPercent == 75
+        }
+        #expect(self.sut.sections.first { $0.kind == .continueWatching }?.videos.first?.watchedPercent == 75)
+        #expect(self.mockClient.getHistoryForceRefreshCount == 1) // the preserved generation forced a refetch
+    }
 }
 
 // MARK: - RefreshTestGate

--- a/Tests/KasetTests/YouTubeHomeContinueWatchingRefreshTests.swift
+++ b/Tests/KasetTests/YouTubeHomeContinueWatchingRefreshTests.swift
@@ -1,0 +1,392 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+// MARK: - YouTubeHomeContinueWatchingRefreshTests
+
+/// Covers the post-watch Continue Watching rail refresh: returning to Home after
+/// watching a video rebuilds only that rail (a finished video drops out, a
+/// partially-watched one appears or updates its progress), gated on the player's
+/// playback count, cache-bypassed, and resilient to transient fetch failures.
+@Suite("YouTubeHome Continue Watching refresh", .serialized, .tags(.viewModel), .timeLimit(.minutes(1)))
+@MainActor
+struct YouTubeHomeContinueWatchingRefreshTests {
+    let mockClient: MockYouTubeClient
+    let sut: YouTubeHomeViewModel
+
+    init() {
+        self.mockClient = MockYouTubeClient()
+        self.sut = YouTubeHomeViewModel(client: self.mockClient)
+        // The refresh delays are global statics; reset them to instant on every
+        // test so a test that sets a long delay (e.g. the cancellation test)
+        // can't leak it into another test running in parallel.
+        Self.resetRefreshDelays()
+    }
+
+    /// Resets the post-watch refresh delays to instant so tests don't wait real
+    /// seconds and never inherit another test's delay override.
+    private static func resetRefreshDelays() {
+        YouTubeHomeViewModel.continueWatchingRefreshDelay = .zero
+        YouTubeHomeViewModel.continueWatchingRefreshRetryDelay = .zero
+    }
+
+    /// Shrinks the post-watch refresh delays so tests don't wait real seconds.
+    /// Idempotent with the `init()` reset; kept for explicit intent at call sites.
+    private func makeRefreshDelaysInstant() {
+        Self.resetRefreshDelays()
+    }
+
+    /// Awaits the view model's in-flight Continue Watching rebuild (if any) by
+    /// polling for the expected state. Uses short real sleeps (not bare yields)
+    /// so a refresh task that suspends on `Task.sleep` reliably completes even
+    /// under load, bounded (~2s) so a genuine bug still fails fast.
+    private func waitForCondition(_ condition: () -> Bool) async {
+        for _ in 0 ..< 200 {
+            if condition() { return }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+    }
+
+    @Test("Watching a video to completion removes it from Continue Watching on return")
+    func refreshRemovesFinishedVideo() async {
+        self.makeRefreshDelaysInstant()
+        // Initial load: two resumable videos, including the one about to finish.
+        self.mockClient.historyFeed = YouTubeFeed(
+            videos: [
+                MockYouTubeClient.makeVideo(videoId: "watching", watchedPercent: 40),
+                MockYouTubeClient.makeVideo(videoId: "other", watchedPercent: 20),
+            ],
+            continuation: nil
+        )
+        await self.sut.load()
+        #expect(self.sut.sections.first { $0.kind == .continueWatching }?.videos.map(\.videoId)
+            == ["watching", "other"])
+
+        // The user watches "watching" to the end; fresh history now reports it
+        // finished (>=96), so it should drop out of the rail.
+        self.mockClient.historyFeed = YouTubeFeed(
+            videos: [
+                MockYouTubeClient.makeVideo(videoId: "watching", watchedPercent: 100),
+                MockYouTubeClient.makeVideo(videoId: "other", watchedPercent: 20),
+            ],
+            continuation: nil
+        )
+
+        self.sut.refreshContinueWatching(afterPlaybackCount: 1)
+        await self.waitForCondition {
+            self.sut.sections.first { $0.kind == .continueWatching }?.videos.map(\.videoId) == ["other"]
+        }
+
+        #expect(self.sut.sections.first { $0.kind == .continueWatching }?.videos.map(\.videoId) == ["other"])
+        #expect(self.mockClient.getHistoryForceRefreshCount == 1) // bypassed the cache
+    }
+
+    @Test("Watching a video partway adds it to Continue Watching on return")
+    func refreshAddsPartiallyWatchedVideo() async {
+        self.makeRefreshDelaysInstant()
+        // Initial load: nothing resumable yet, so no Continue Watching rail.
+        self.mockClient.historyFeed = .empty
+        await self.sut.load()
+        #expect(self.sut.sections.contains { $0.kind == .continueWatching } == false)
+
+        // The user watches "fresh" partway; fresh history now reports progress.
+        self.mockClient.historyFeed = YouTubeFeed(
+            videos: [MockYouTubeClient.makeVideo(videoId: "fresh", watchedPercent: 35)],
+            continuation: nil
+        )
+
+        self.sut.refreshContinueWatching(afterPlaybackCount: 1)
+        await self.waitForCondition {
+            self.sut.sections.contains { $0.kind == .continueWatching }
+        }
+
+        let rail = self.sut.sections.first { $0.kind == .continueWatching }
+        #expect(rail?.videos.map(\.videoId) == ["fresh"])
+        // Continue Watching must lead the section list.
+        #expect(self.sut.sections.first?.kind == .continueWatching)
+    }
+
+    @Test("Watching more of a still-unfinished video updates its progress in the rail")
+    func refreshUpdatesProgressForSameVideo() async {
+        self.makeRefreshDelaysInstant()
+        // Initial load: one resumable video at 30%.
+        self.mockClient.historyFeed = YouTubeFeed(
+            videos: [MockYouTubeClient.makeVideo(videoId: "resume", watchedPercent: 30)],
+            continuation: nil
+        )
+        await self.sut.load()
+        #expect(self.sut.sections.first { $0.kind == .continueWatching }?.videos.first?.watchedPercent == 30)
+
+        // The user watches more without finishing: same video, same position,
+        // higher percent. An id-only change check would miss this.
+        self.mockClient.historyFeed = YouTubeFeed(
+            videos: [MockYouTubeClient.makeVideo(videoId: "resume", watchedPercent: 55)],
+            continuation: nil
+        )
+        self.sut.refreshContinueWatching(afterPlaybackCount: 1)
+        await self.waitForCondition {
+            self.sut.sections.first { $0.kind == .continueWatching }?.videos.first?.watchedPercent == 55
+        }
+
+        #expect(self.sut.sections.first { $0.kind == .continueWatching }?.videos.first?.watchedPercent == 55)
+        #expect(self.mockClient.getHistoryForceRefreshCount == 1) // updated on the first try, no retry
+    }
+
+    @Test("Refresh rebuilds only Continue Watching, leaving grid, shelves, and topics intact")
+    func refreshLeavesOtherSectionsUntouched() async {
+        self.makeRefreshDelaysInstant()
+        self.mockClient.homeFeed = YouTubeFeed(
+            videos: MockYouTubeClient.makeVideos(count: 4),
+            continuation: nil
+        )
+        self.mockClient.homeShelves = [
+            YouTubeHomeSection(
+                id: "shelf-1-Breaking news",
+                title: "Breaking news",
+                videos: MockYouTubeClient.makeVideos(count: 2),
+                kind: .shelf
+            ),
+        ]
+        self.mockClient.homeChips = [YouTubeHomeChip(title: "Gaming", continuation: "tok-gaming")]
+        self.mockClient.homeTopicFeeds = [
+            "tok-gaming": YouTubeFeed(videos: MockYouTubeClient.makeVideos(count: 3), continuation: nil),
+        ]
+        self.mockClient.historyFeed = YouTubeFeed(
+            videos: [MockYouTubeClient.makeVideo(videoId: "resume", watchedPercent: 30)],
+            continuation: nil
+        )
+        await self.sut.load()
+        let gridBefore = self.sut.videos.map(\.videoId)
+        #expect(self.sut.sections.map(\.kind) == [.continueWatching, .shelf, .topic])
+
+        // A new watch updates history; only the rail should change.
+        self.mockClient.historyFeed = YouTubeFeed(
+            videos: [
+                MockYouTubeClient.makeVideo(videoId: "resume", watchedPercent: 30),
+                MockYouTubeClient.makeVideo(videoId: "new-resume", watchedPercent: 60),
+            ],
+            continuation: nil
+        )
+        self.sut.refreshContinueWatching(afterPlaybackCount: 1)
+        await self.waitForCondition {
+            (self.sut.sections.first { $0.kind == .continueWatching }?.videos.count ?? 0) == 2
+        }
+
+        // Grid, shelf, topic untouched and still in order; no skeleton flash.
+        #expect(self.sut.loadingState == .loaded)
+        #expect(self.sut.videos.map(\.videoId) == gridBefore)
+        #expect(self.sut.sections.map(\.kind) == [.continueWatching, .shelf, .topic])
+        #expect(self.sut.sections.first { $0.kind == .shelf }?.title == "Breaking news")
+        #expect(self.sut.sections.first { $0.kind == .topic }?.title == "Gaming")
+    }
+
+    @Test("Refresh is gated on the playback count advancing")
+    func refreshGatesOnPlaybackCount() async {
+        self.makeRefreshDelaysInstant()
+        self.mockClient.historyFeed = YouTubeFeed(
+            videos: [MockYouTubeClient.makeVideo(videoId: "resume", watchedPercent: 30)],
+            continuation: nil
+        )
+        await self.sut.load()
+
+        // No playback yet (count 0): nothing was watched, so no fetch.
+        self.sut.refreshContinueWatching(afterPlaybackCount: 0)
+        await Task.yield()
+        #expect(self.mockClient.getHistoryForceRefreshCount == 0)
+
+        // First watch (count 1) updates the rail (a new resumable video appears),
+        // so the rebuild sees a change on its first try and does not retry.
+        self.mockClient.historyFeed = YouTubeFeed(
+            videos: [
+                MockYouTubeClient.makeVideo(videoId: "resume", watchedPercent: 30),
+                MockYouTubeClient.makeVideo(videoId: "newly", watchedPercent: 45),
+            ],
+            continuation: nil
+        )
+        self.sut.refreshContinueWatching(afterPlaybackCount: 1)
+        await self.waitForCondition {
+            (self.sut.sections.first { $0.kind == .continueWatching }?.videos.count ?? 0) == 2
+        }
+        #expect(self.mockClient.getHistoryForceRefreshCount == 1)
+
+        // Returning again with no new playback (same count) does not re-fetch.
+        self.sut.refreshContinueWatching(afterPlaybackCount: 1)
+        await Task.yield()
+        #expect(self.mockClient.getHistoryForceRefreshCount == 1)
+    }
+
+    @Test("Re-watching the same video still refreshes when the playback count advances")
+    func refreshFiresOnSameVideoRewatch() async {
+        self.makeRefreshDelaysInstant()
+        self.mockClient.historyFeed = YouTubeFeed(
+            videos: [MockYouTubeClient.makeVideo(videoId: "resume", watchedPercent: 30)],
+            continuation: nil
+        )
+        await self.sut.load()
+
+        // First watch of "resume" advances it to 55%.
+        self.mockClient.historyFeed = YouTubeFeed(
+            videos: [MockYouTubeClient.makeVideo(videoId: "resume", watchedPercent: 55)],
+            continuation: nil
+        )
+        self.sut.refreshContinueWatching(afterPlaybackCount: 1)
+        await self.waitForCondition {
+            self.sut.sections.first { $0.kind == .continueWatching }?.videos.first?.watchedPercent == 55
+        }
+        #expect(self.mockClient.getHistoryForceRefreshCount == 1)
+
+        // The user opens the SAME video again and finishes it. The videoId is
+        // unchanged, but the playback count advanced (2), so the rail must still
+        // refresh — and the now-finished video drops out.
+        self.mockClient.historyFeed = YouTubeFeed(
+            videos: [MockYouTubeClient.makeVideo(videoId: "resume", watchedPercent: 100)],
+            continuation: nil
+        )
+        self.sut.refreshContinueWatching(afterPlaybackCount: 2)
+        await self.waitForCondition {
+            self.sut.sections.contains { $0.kind == .continueWatching } == false
+        }
+        #expect(self.sut.sections.contains { $0.kind == .continueWatching } == false)
+        #expect(self.mockClient.getHistoryForceRefreshCount == 2)
+    }
+
+    @Test("A failed refresh keeps the existing Continue Watching rail")
+    func refreshFailurePreservesRail() async {
+        self.makeRefreshDelaysInstant()
+        // Initial load builds a rail from cached history (no forced refresh).
+        self.mockClient.historyFeed = YouTubeFeed(
+            videos: [MockYouTubeClient.makeVideo(videoId: "resume", watchedPercent: 30)],
+            continuation: nil
+        )
+        await self.sut.load()
+        #expect(self.sut.sections.first { $0.kind == .continueWatching }?.videos.map(\.videoId) == ["resume"])
+
+        // The post-watch forced refresh fails (transient network/auth/API). The
+        // existing rail must be preserved, not wiped.
+        self.mockClient.historyForceRefreshError = YTMusicError.networkError(
+            underlying: URLError(.timedOut)
+        )
+        self.sut.refreshContinueWatching(afterPlaybackCount: 1)
+        // Two forced attempts: the first fails, the retry fires and also fails.
+        await self.waitForCondition { self.mockClient.getHistoryForceRefreshCount == 2 }
+
+        #expect(self.sut.sections.first { $0.kind == .continueWatching }?.videos.map(\.videoId) == ["resume"])
+        #expect(self.sut.loadingState == .loaded) // no skeleton flash
+    }
+
+    @Test("A failed refresh does not consume the playback count, so a later return retries")
+    func failedRefreshLeavesPlaybackCountRetryable() async {
+        self.makeRefreshDelaysInstant()
+        self.mockClient.historyFeed = YouTubeFeed(
+            videos: [MockYouTubeClient.makeVideo(videoId: "resume", watchedPercent: 30)],
+            continuation: nil
+        )
+        await self.sut.load()
+
+        // First post-watch refresh fails on both the attempt and the retry.
+        self.mockClient.historyForceRefreshError = YTMusicError.networkError(
+            underlying: URLError(.timedOut)
+        )
+        self.sut.refreshContinueWatching(afterPlaybackCount: 1)
+        await self.waitForCondition { self.mockClient.getHistoryForceRefreshCount == 2 }
+
+        // The user returns again with the SAME playback count. Because the failed
+        // refresh did not consume the count, this must fetch again (not skip), and
+        // now it succeeds and updates the rail.
+        self.mockClient.historyForceRefreshError = nil
+        self.mockClient.historyFeed = YouTubeFeed(
+            videos: [MockYouTubeClient.makeVideo(videoId: "resume", watchedPercent: 70)],
+            continuation: nil
+        )
+        self.sut.refreshContinueWatching(afterPlaybackCount: 1)
+        await self.waitForCondition {
+            self.sut.sections.first { $0.kind == .continueWatching }?.videos.first?.watchedPercent == 70
+        }
+        #expect(self.sut.sections.first { $0.kind == .continueWatching }?.videos.first?.watchedPercent == 70)
+        #expect(self.mockClient.getHistoryForceRefreshCount == 3) // 2 failed + 1 successful
+    }
+
+    @Test("Cancelling the refresh mid-delay does not consume the playback count")
+    func cancelledRefreshLeavesPlaybackCountRetryable() async {
+        // Non-zero delay so the refresh is cancellable while still sleeping.
+        YouTubeHomeViewModel.continueWatchingRefreshDelay = .seconds(60)
+        YouTubeHomeViewModel.continueWatchingRefreshRetryDelay = .zero
+        self.mockClient.historyFeed = YouTubeFeed(
+            videos: [MockYouTubeClient.makeVideo(videoId: "resume", watchedPercent: 30)],
+            continuation: nil
+        )
+        await self.sut.load()
+
+        // Trigger a refresh, then cancel it (e.g. account switch / discard) while
+        // it is still in its propagation delay — before any fetch happened.
+        self.sut.refreshContinueWatching(afterPlaybackCount: 1)
+        self.sut.cancelLoad()
+        await Task.yield()
+        #expect(self.mockClient.getHistoryForceRefreshCount == 0) // never reached the fetch
+
+        // A later return with the SAME count must NOT be skipped: the cancelled
+        // attempt didn't consume the count. Use instant delays now so it lands.
+        YouTubeHomeViewModel.continueWatchingRefreshDelay = .zero
+        self.mockClient.historyFeed = YouTubeFeed(
+            videos: [MockYouTubeClient.makeVideo(videoId: "resume", watchedPercent: 80)],
+            continuation: nil
+        )
+        self.sut.refreshContinueWatching(afterPlaybackCount: 1)
+        await self.waitForCondition {
+            self.sut.sections.first { $0.kind == .continueWatching }?.videos.first?.watchedPercent == 80
+        }
+        #expect(self.sut.sections.first { $0.kind == .continueWatching }?.videos.first?.watchedPercent == 80)
+        #expect(self.mockClient.getHistoryForceRefreshCount == 1)
+    }
+
+    @Test("Refresh before the home feed has loaded does not fetch immediately")
+    func refreshBeforeLoadDefersFetch() async {
+        self.makeRefreshDelaysInstant()
+        // No load() yet — loadingState is .idle. The trigger is queued as
+        // pending rather than fetching now (or being dropped).
+        self.sut.refreshContinueWatching(afterPlaybackCount: 1)
+        await Task.yield()
+        #expect(self.mockClient.getHistoryForceRefreshCount == 0)
+        #expect(self.sut.sections.isEmpty)
+    }
+
+    @Test("A watch during cold Home load forces a cache-bypassed rail refresh once loaded")
+    func pendingRefreshRunsAfterColdLoad() async {
+        self.makeRefreshDelaysInstant()
+        // Warm, PRE-watch history that the cached initial load would build the
+        // rail from (30%).
+        self.mockClient.historyFeed = YouTubeFeed(
+            videos: [MockYouTubeClient.makeVideo(videoId: "resume", watchedPercent: 30)],
+            continuation: nil
+        )
+        // The forced (post-watch) refresh returns DIFFERENT data (65%), so the
+        // rebuild is a single deterministic `.updated` with no retry — the
+        // assertions below are not observing a transient pre-retry count.
+        self.mockClient.historyForceRefreshFeed = YouTubeFeed(
+            videos: [MockYouTubeClient.makeVideo(videoId: "resume", watchedPercent: 65)],
+            continuation: nil
+        )
+
+        // The user watched the video, then opened Home cold — the trigger fires
+        // while Home is still idle, so it is queued as pending (no fetch yet).
+        self.sut.refreshContinueWatching(afterPlaybackCount: 1)
+        #expect(self.mockClient.getHistoryForceRefreshCount == 0)
+
+        // Loading the feed must, on completion, consume the pending count and run
+        // the cache-bypassed refetch, so the rail shows post-watch progress (65%)
+        // rather than the warm cached 30%.
+        await self.sut.load()
+        await self.waitForCondition {
+            self.sut.sections.first { $0.kind == .continueWatching }?.videos.first?.watchedPercent == 65
+        }
+
+        #expect(self.sut.sections.first { $0.kind == .continueWatching }?.videos.first?.watchedPercent == 65)
+        #expect(self.mockClient.getHistoryForceRefreshCount == 1) // single updated fetch, no retry
+
+        // The pending count is consumed: a later return with the same count is a
+        // no-op (no second forced fetch).
+        self.sut.refreshContinueWatching(afterPlaybackCount: 1)
+        await Task.yield()
+        #expect(self.mockClient.getHistoryForceRefreshCount == 1)
+    }
+}

--- a/Tests/KasetTests/YouTubeHomeContinueWatchingRefreshTests.swift
+++ b/Tests/KasetTests/YouTubeHomeContinueWatchingRefreshTests.swift
@@ -181,7 +181,7 @@ struct YouTubeHomeContinueWatchingRefreshTests {
     }
 
     @Test("Refresh is gated on the watch-activity generation advancing")
-    func refreshGatesOnPlaybackCount() async {
+    func refreshGatesOnWatchActivityGeneration() async {
         self.makeRefreshDelaysInstant()
         self.mockClient.historyFeed = YouTubeFeed(
             videos: [MockYouTubeClient.makeVideo(videoId: "resume", watchedPercent: 30)],
@@ -291,7 +291,7 @@ struct YouTubeHomeContinueWatchingRefreshTests {
     }
 
     @Test("A failed refresh does not advance the watermark, so a later return retries")
-    func failedRefreshLeavesPlaybackCountRetryable() async {
+    func failedRefreshLeavesWatermarkRetryable() async {
         self.makeRefreshDelaysInstant()
         self.mockClient.historyFeed = YouTubeFeed(
             videos: [MockYouTubeClient.makeVideo(videoId: "resume", watchedPercent: 30)],
@@ -307,7 +307,7 @@ struct YouTubeHomeContinueWatchingRefreshTests {
         await self.waitForCondition { self.mockClient.getHistoryForceRefreshCount == 2 }
 
         // The user returns again with the SAME generation. Because the failed
-        // refresh did not consume the count, this must fetch again (not skip), and
+        // refresh did not advance the watermark, this must fetch again (not skip), and
         // now it succeeds and updates the rail.
         self.mockClient.historyForceRefreshError = nil
         self.mockClient.historyFeed = YouTubeFeed(
@@ -323,7 +323,7 @@ struct YouTubeHomeContinueWatchingRefreshTests {
     }
 
     @Test("Cancelling the refresh mid-delay does not advance the watermark")
-    func cancelledRefreshLeavesPlaybackCountRetryable() async {
+    func cancelledRefreshLeavesWatermarkRetryable() async {
         // Non-zero delay so the refresh is cancellable while still sleeping.
         YouTubeHomeViewModel.continueWatchingRefreshDelay = .seconds(60)
         YouTubeHomeViewModel.continueWatchingRefreshRetryDelay = .zero
@@ -341,7 +341,7 @@ struct YouTubeHomeContinueWatchingRefreshTests {
         #expect(self.mockClient.getHistoryForceRefreshCount == 0) // never reached the fetch
 
         // A later return with the SAME count must NOT be skipped: the cancelled
-        // attempt didn't consume the count. Use instant delays now so it lands.
+        // attempt didn't advance the watermark. Use instant delays now so it lands.
         YouTubeHomeViewModel.continueWatchingRefreshDelay = .zero
         self.mockClient.historyFeed = YouTubeFeed(
             videos: [MockYouTubeClient.makeVideo(videoId: "resume", watchedPercent: 80)],
@@ -399,7 +399,7 @@ struct YouTubeHomeContinueWatchingRefreshTests {
         #expect(self.sut.sections.first { $0.kind == .continueWatching }?.videos.first?.watchedPercent == 65)
         #expect(self.mockClient.getHistoryForceRefreshCount == 1) // single updated fetch, no retry
 
-        // The pending count is consumed: a later return with the same count is a
+        // The pending generation is consumed: a later return with the same generation is a
         // no-op (no second forced fetch).
         self.sut.refreshContinueWatching(forGeneration: 1)
         await Task.yield()

--- a/Tests/KasetTests/YouTubeHomeContinueWatchingRefreshTests.swift
+++ b/Tests/KasetTests/YouTubeHomeContinueWatchingRefreshTests.swift
@@ -213,6 +213,21 @@ struct YouTubeHomeContinueWatchingRefreshTests {
         self.sut.refreshContinueWatching(afterPlaybackCount: 1)
         await Task.yield()
         #expect(self.mockClient.getHistoryForceRefreshCount == 1)
+
+        // A strictly higher count (e.g. a partial watch followed by a return,
+        // after an earlier count was already consumed) must still fire. This is
+        // the invariant the view's start-vs-progress observer split relies on:
+        // consuming one count never blocks a later, larger one.
+        self.mockClient.historyForceRefreshFeed = YouTubeFeed(
+            videos: [
+                MockYouTubeClient.makeVideo(videoId: "resume", watchedPercent: 30),
+                MockYouTubeClient.makeVideo(videoId: "newly", watchedPercent: 70),
+            ],
+            continuation: nil
+        )
+        self.sut.refreshContinueWatching(afterPlaybackCount: 2)
+        await self.waitForCondition { self.mockClient.getHistoryForceRefreshCount == 2 }
+        #expect(self.mockClient.getHistoryForceRefreshCount == 2)
     }
 
     @Test("Re-watching the same video still refreshes when the playback count advances")

--- a/Tests/KasetTests/YouTubeHomeContinueWatchingRefreshTests.swift
+++ b/Tests/KasetTests/YouTubeHomeContinueWatchingRefreshTests.swift
@@ -389,4 +389,115 @@ struct YouTubeHomeContinueWatchingRefreshTests {
         await Task.yield()
         #expect(self.mockClient.getHistoryForceRefreshCount == 1)
     }
+
+    @Test("A refresh during pagination (.loadingMore) rebuilds the rail in place")
+    func refreshDuringLoadingMoreRunsInPlace() async {
+        self.makeRefreshDelaysInstant()
+        self.mockClient.homeFeed = YouTubeFeed(
+            videos: MockYouTubeClient.makeVideos(count: 3),
+            continuation: nil
+        )
+        self.mockClient.historyFeed = YouTubeFeed(
+            videos: [MockYouTubeClient.makeVideo(videoId: "resume", watchedPercent: 30)],
+            continuation: nil
+        )
+        // A continuation page is available so `loadMore()` can run. The mock
+        // reports "has more" from `homeFeedContinuation`, so set it before load.
+        self.mockClient.homeFeedContinuation = YouTubeFeed(
+            videos: MockYouTubeClient.makeVideos(count: 2),
+            continuation: nil
+        )
+        await self.sut.load()
+        #expect(self.sut.loadingState == .loaded)
+        #expect(self.sut.hasMoreVideos)
+
+        // Hold the pagination request open so the model sits in `.loadingMore`.
+        let gate = RefreshTestGate()
+        self.mockClient.beforeContinuationReturn = { await gate.wait() }
+        let paging = Task { await self.sut.loadMore() }
+        await self.waitForCondition { self.sut.loadingState == .loadingMore }
+        #expect(self.sut.loadingState == .loadingMore)
+
+        // A return-to-Home refresh during pagination must rebuild the rail in
+        // place (pagination only appends grid videos, never the rail) — not park
+        // as pending and get stranded until the next navigation.
+        self.mockClient.historyForceRefreshFeed = YouTubeFeed(
+            videos: [MockYouTubeClient.makeVideo(videoId: "resume", watchedPercent: 80)],
+            continuation: nil
+        )
+        self.sut.refreshContinueWatching(afterPlaybackCount: 1)
+        await self.waitForCondition {
+            self.sut.sections.first { $0.kind == .continueWatching }?.videos.first?.watchedPercent == 80
+        }
+        #expect(self.sut.sections.first { $0.kind == .continueWatching }?.videos.first?.watchedPercent == 80)
+        #expect(self.mockClient.getHistoryForceRefreshCount == 1)
+
+        await gate.open()
+        await paging.value
+    }
+
+    @Test("A refresh while the initial rails are streaming defers, then runs once settled")
+    func refreshDuringInitialStreamingDefers() async {
+        self.makeRefreshDelaysInstant()
+        self.mockClient.homeFeed = YouTubeFeed(
+            videos: MockYouTubeClient.makeVideos(count: 3),
+            continuation: nil
+        )
+        // Hold the Continue Watching history fetch open so `performLoad` stays in
+        // its rail-streaming window when the refresh trigger arrives.
+        let gate = RefreshTestGate()
+        self.mockClient.beforeHistoryReturn = { await gate.wait() }
+        self.mockClient.historyFeed = YouTubeFeed(
+            videos: [MockYouTubeClient.makeVideo(videoId: "resume", watchedPercent: 30)],
+            continuation: nil
+        )
+        self.mockClient.historyForceRefreshFeed = YouTubeFeed(
+            videos: [MockYouTubeClient.makeVideo(videoId: "resume", watchedPercent: 90)],
+            continuation: nil
+        )
+
+        let loading = Task { await self.sut.load() }
+        await self.waitForCondition { self.sut.loadingState == .loaded } // grid published, still streaming
+
+        // The trigger arrives mid-stream — it must defer (no forced fetch yet)
+        // rather than race the streamer as a second writer to `sections`.
+        self.sut.refreshContinueWatching(afterPlaybackCount: 1)
+        await Task.yield()
+        #expect(self.mockClient.getHistoryForceRefreshCount == 0)
+
+        // Let streaming finish; `performLoad` then drains the pending count and
+        // runs the cache-bypassed refresh, landing the post-watch progress (90%).
+        await gate.open()
+        await loading.value
+        await self.waitForCondition {
+            self.sut.sections.first { $0.kind == .continueWatching }?.videos.first?.watchedPercent == 90
+        }
+        #expect(self.sut.sections.first { $0.kind == .continueWatching }?.videos.first?.watchedPercent == 90)
+        #expect(self.mockClient.getHistoryForceRefreshCount == 1)
+    }
+}
+
+// MARK: - RefreshTestGate
+
+/// A one-shot async gate: `wait()` suspends until `open()` is called. Local to
+/// this suite (the one in YouTubeHomeViewModelTests is file-private there).
+private actor RefreshTestGate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        if self.isOpen { return }
+        await withCheckedContinuation { continuation in
+            self.waiters.append(continuation)
+        }
+    }
+
+    func open() {
+        self.isOpen = true
+        let pending = self.waiters
+        self.waiters.removeAll()
+        for continuation in pending {
+            continuation.resume()
+        }
+    }
 }

--- a/Tests/KasetTests/YouTubePlayerServiceTests.swift
+++ b/Tests/KasetTests/YouTubePlayerServiceTests.swift
@@ -219,6 +219,31 @@ struct YouTubePlayerServiceTests {
         #expect(endedVideoId == "abc")
     }
 
+    @Test("Playback activity count advances on play, skip, and end, and survives stop")
+    func playbackActivityCountTracksWatchActivity() async {
+        #expect(self.sut.playbackActivityCount == 0)
+
+        // Starting a video counts.
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        #expect(self.sut.playbackActivityCount == 1)
+
+        // Skipping to another video counts (a distinct watch).
+        self.sut.setUpNext([MockYouTubeClient.makeVideo(videoId: "b")])
+        await self.sut.skipForward()
+        #expect(self.sut.currentVideo?.videoId == "b")
+        #expect(self.sut.playbackActivityCount == 2)
+
+        // A natural finish counts (the video crosses into "finished").
+        self.sut.handleVideoEnded(videoId: "b")
+        #expect(self.sut.playbackActivityCount == 3)
+
+        // stop() must NOT reset the counter: Home still needs to know activity
+        // happened when the user returns after closing the player.
+        self.sut.stop()
+        #expect(self.sut.currentVideo == nil)
+        #expect(self.sut.playbackActivityCount == 3)
+    }
+
     @Test("Volume changes forward to the playback controller")
     func volumeForwards() {
         self.sut.volume = 0.4

--- a/Tests/KasetTests/YouTubePlayerServiceTests.swift
+++ b/Tests/KasetTests/YouTubePlayerServiceTests.swift
@@ -307,42 +307,51 @@ struct YouTubePlayerServiceTests {
     @Test("Watch-activity generation advances on every watch-state change and survives stop")
     func watchActivityGenerationTracksEveryChange() async {
         #expect(self.sut.watchActivityGeneration == 0)
+        #expect(self.sut.watchConclusionGeneration == 0)
 
-        // Starting a video is a watch-state change.
+        // Starting a video advances the ACTIVITY generation, but NOT the
+        // CONCLUSION generation (a bare start has no accrued progress to reflect).
         self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
         #expect(self.sut.watchActivityGeneration == 1)
+        #expect(self.sut.watchConclusionGeneration == 0)
 
-        // Skipping to another video advances it (concludes one watch, begins another).
+        // Skipping concludes one watch, begins another — advances BOTH.
         self.sut.setUpNext([MockYouTubeClient.makeVideo(videoId: "b")])
         await self.sut.skipForward()
         #expect(self.sut.currentVideo?.videoId == "b")
         #expect(self.sut.watchActivityGeneration == 2)
+        #expect(self.sut.watchConclusionGeneration == 1)
 
-        // SPA drift to a different video advances it (autoplay/next in the page).
+        // SPA drift to a different video (autoplay/next) — advances BOTH.
         self.sut.updatePlaybackState(.init(
             isPlaying: true, progress: 5, duration: 60,
             videoId: "c", title: "Drifted", isAd: false
         ))
         #expect(self.sut.currentVideo?.videoId == "c")
         #expect(self.sut.watchActivityGeneration == 3)
+        #expect(self.sut.watchConclusionGeneration == 2)
 
-        // A natural finish advances it (the video crosses into "finished").
+        // A natural finish — advances BOTH.
         self.sut.handleVideoEnded(videoId: "c")
         #expect(self.sut.watchActivityGeneration == 4)
+        #expect(self.sut.watchConclusionGeneration == 3)
 
-        // stop() must NOT reset the generation: Home still needs to know activity
-        // happened when the user returns after closing the player.
+        // stop() must NOT reset either generation: Home still needs to know
+        // activity happened when the user returns after closing the player.
         self.sut.stop()
         #expect(self.sut.currentVideo == nil)
         #expect(self.sut.watchActivityGeneration == 4)
+        #expect(self.sut.watchConclusionGeneration == 3)
     }
 
-    @Test("Stopping a video with accrued progress advances the watch-activity generation")
+    @Test("Stopping a video with accrued progress advances both generations")
     func stopWithProgressAdvancesGeneration() {
         // Closing the floating window or navigating away with pop-out disabled
-        // both route through stop(); a partial watch must still signal Home.
+        // both route through stop(); a partial watch must still signal Home — and
+        // it is a CONCLUSION, so the Home-root observer's signal advances too.
         self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
         #expect(self.sut.watchActivityGeneration == 1)
+        #expect(self.sut.watchConclusionGeneration == 0)
         self.sut.updatePlaybackState(.init(
             isPlaying: true, progress: 42, duration: 120,
             videoId: "a", title: nil, isAd: false
@@ -350,17 +359,20 @@ struct YouTubePlayerServiceTests {
 
         self.sut.stop()
         #expect(self.sut.watchActivityGeneration == 2) // progress > 0 → signalled
+        #expect(self.sut.watchConclusionGeneration == 1)
     }
 
-    @Test("Stopping a video with no progress does not advance the generation")
+    @Test("Stopping a video with no progress does not advance either generation")
     func stopWithoutProgressDoesNotAdvance() {
         // A video that never started playing (progress 0) has no resume state to
         // reflect, so closing it shouldn't trigger a redundant rail refresh.
         self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
         #expect(self.sut.watchActivityGeneration == 1)
+        #expect(self.sut.watchConclusionGeneration == 0)
 
         self.sut.stop() // progress is still 0
         #expect(self.sut.watchActivityGeneration == 1)
+        #expect(self.sut.watchConclusionGeneration == 0)
     }
 
     @Test("Volume changes forward to the playback controller")

--- a/Tests/KasetTests/YouTubePlayerServiceTests.swift
+++ b/Tests/KasetTests/YouTubePlayerServiceTests.swift
@@ -222,26 +222,32 @@ struct YouTubePlayerServiceTests {
     @Test("Playback activity count advances on play, skip, and end, and survives stop")
     func playbackActivityCountTracksWatchActivity() async {
         #expect(self.sut.playbackActivityCount == 0)
+        #expect(self.sut.playbackProgressEventCount == 0)
 
-        // Starting a video counts.
+        // Starting a video advances the activity count, but NOT the
+        // progress-event count (a start has no accrued progress yet).
         self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
         #expect(self.sut.playbackActivityCount == 1)
+        #expect(self.sut.playbackProgressEventCount == 0)
 
-        // Skipping to another video counts (a distinct watch).
+        // Skipping to another video advances BOTH (it concludes the prior watch).
         self.sut.setUpNext([MockYouTubeClient.makeVideo(videoId: "b")])
         await self.sut.skipForward()
         #expect(self.sut.currentVideo?.videoId == "b")
         #expect(self.sut.playbackActivityCount == 2)
+        #expect(self.sut.playbackProgressEventCount == 1)
 
-        // A natural finish counts (the video crosses into "finished").
+        // A natural finish advances BOTH (the video crosses into "finished").
         self.sut.handleVideoEnded(videoId: "b")
         #expect(self.sut.playbackActivityCount == 3)
+        #expect(self.sut.playbackProgressEventCount == 2)
 
-        // stop() must NOT reset the counter: Home still needs to know activity
+        // stop() must NOT reset either counter: Home still needs to know activity
         // happened when the user returns after closing the player.
         self.sut.stop()
         #expect(self.sut.currentVideo == nil)
         #expect(self.sut.playbackActivityCount == 3)
+        #expect(self.sut.playbackProgressEventCount == 2)
     }
 
     @Test("Volume changes forward to the playback controller")

--- a/Tests/KasetTests/YouTubePlayerServiceTests.swift
+++ b/Tests/KasetTests/YouTubePlayerServiceTests.swift
@@ -367,6 +367,34 @@ struct YouTubePlayerServiceTests {
         #expect(self.sut.watchConclusionGeneration == conclusionAfterFinish)
     }
 
+    @Test("Auto-advance drift right after a finish does not double-signal the conclusion")
+    func driftAfterFinishDoesNotDoubleConclude() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true, progress: 119, duration: 120,
+            videoId: "a", title: nil, isAd: false
+        ))
+        self.sut.handleVideoEnded(videoId: "a")
+        let conclusionAfterFinish = self.sut.watchConclusionGeneration
+        let activityAfterFinish = self.sut.watchActivityGeneration
+
+        // The page auto-advances to the next video (playlist). The drift begins a
+        // NEW watch (activity advances) but must NOT re-conclude the already
+        // finished "a" (conclusion stays put).
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true, progress: 0, duration: 200,
+            videoId: "b", title: "Next", isAd: false
+        ))
+        #expect(self.sut.currentVideo?.videoId == "b")
+        #expect(self.sut.watchConclusionGeneration == conclusionAfterFinish) // no double-conclude
+        #expect(self.sut.watchActivityGeneration == activityAfterFinish + 1) // new watch began
+
+        // The new video then concludes (e.g. finishes) — that DOES signal, since
+        // it is a different, unconcluded watch.
+        self.sut.handleVideoEnded(videoId: "b")
+        #expect(self.sut.watchConclusionGeneration == conclusionAfterFinish + 1)
+    }
+
     @Test("Stopping a video with accrued progress advances both generations")
     func stopWithProgressAdvancesGeneration() {
         // Closing the floating window or navigating away with pop-out disabled

--- a/Tests/KasetTests/YouTubePlayerServiceTests.swift
+++ b/Tests/KasetTests/YouTubePlayerServiceTests.swift
@@ -304,35 +304,63 @@ struct YouTubePlayerServiceTests {
         #expect(endedVideoId == "abc")
     }
 
-    @Test("Playback activity count advances on play, skip, and end, and survives stop")
-    func playbackActivityCountTracksWatchActivity() async {
-        #expect(self.sut.playbackActivityCount == 0)
-        #expect(self.sut.playbackProgressEventCount == 0)
+    @Test("Watch-activity generation advances on every watch-state change and survives stop")
+    func watchActivityGenerationTracksEveryChange() async {
+        #expect(self.sut.watchActivityGeneration == 0)
 
-        // Starting a video advances the activity count, but NOT the
-        // progress-event count (a start has no accrued progress yet).
+        // Starting a video is a watch-state change.
         self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
-        #expect(self.sut.playbackActivityCount == 1)
-        #expect(self.sut.playbackProgressEventCount == 0)
+        #expect(self.sut.watchActivityGeneration == 1)
 
-        // Skipping to another video advances BOTH (it concludes the prior watch).
+        // Skipping to another video advances it (concludes one watch, begins another).
         self.sut.setUpNext([MockYouTubeClient.makeVideo(videoId: "b")])
         await self.sut.skipForward()
         #expect(self.sut.currentVideo?.videoId == "b")
-        #expect(self.sut.playbackActivityCount == 2)
-        #expect(self.sut.playbackProgressEventCount == 1)
+        #expect(self.sut.watchActivityGeneration == 2)
 
-        // A natural finish advances BOTH (the video crosses into "finished").
-        self.sut.handleVideoEnded(videoId: "b")
-        #expect(self.sut.playbackActivityCount == 3)
-        #expect(self.sut.playbackProgressEventCount == 2)
+        // SPA drift to a different video advances it (autoplay/next in the page).
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true, progress: 5, duration: 60,
+            videoId: "c", title: "Drifted", isAd: false
+        ))
+        #expect(self.sut.currentVideo?.videoId == "c")
+        #expect(self.sut.watchActivityGeneration == 3)
 
-        // stop() must NOT reset either counter: Home still needs to know activity
+        // A natural finish advances it (the video crosses into "finished").
+        self.sut.handleVideoEnded(videoId: "c")
+        #expect(self.sut.watchActivityGeneration == 4)
+
+        // stop() must NOT reset the generation: Home still needs to know activity
         // happened when the user returns after closing the player.
         self.sut.stop()
         #expect(self.sut.currentVideo == nil)
-        #expect(self.sut.playbackActivityCount == 3)
-        #expect(self.sut.playbackProgressEventCount == 2)
+        #expect(self.sut.watchActivityGeneration == 4)
+    }
+
+    @Test("Stopping a video with accrued progress advances the watch-activity generation")
+    func stopWithProgressAdvancesGeneration() {
+        // Closing the floating window or navigating away with pop-out disabled
+        // both route through stop(); a partial watch must still signal Home.
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        #expect(self.sut.watchActivityGeneration == 1)
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true, progress: 42, duration: 120,
+            videoId: "a", title: nil, isAd: false
+        ))
+
+        self.sut.stop()
+        #expect(self.sut.watchActivityGeneration == 2) // progress > 0 → signalled
+    }
+
+    @Test("Stopping a video with no progress does not advance the generation")
+    func stopWithoutProgressDoesNotAdvance() {
+        // A video that never started playing (progress 0) has no resume state to
+        // reflect, so closing it shouldn't trigger a redundant rail refresh.
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        #expect(self.sut.watchActivityGeneration == 1)
+
+        self.sut.stop() // progress is still 0
+        #expect(self.sut.watchActivityGeneration == 1)
     }
 
     @Test("Volume changes forward to the playback controller")

--- a/Tests/KasetTests/YouTubePlayerServiceTests.swift
+++ b/Tests/KasetTests/YouTubePlayerServiceTests.swift
@@ -331,17 +331,40 @@ struct YouTubePlayerServiceTests {
         #expect(self.sut.watchActivityGeneration == 3)
         #expect(self.sut.watchConclusionGeneration == 2)
 
-        // A natural finish — advances BOTH.
+        // A natural finish on a video that accrued real progress — advances BOTH.
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true, progress: 58, duration: 60,
+            videoId: "c", title: nil, isAd: false
+        ))
         self.sut.handleVideoEnded(videoId: "c")
         #expect(self.sut.watchActivityGeneration == 4)
         #expect(self.sut.watchConclusionGeneration == 3)
 
-        // stop() must NOT reset either generation: Home still needs to know
-        // activity happened when the user returns after closing the player.
+        // Closing the player after a finish (progress still nonzero, currentVideo
+        // still set) must NOT re-signal the already-finished video as a fresh
+        // conclusion — neither generation advances, and stop() doesn't reset them.
         self.sut.stop()
         #expect(self.sut.currentVideo == nil)
         #expect(self.sut.watchActivityGeneration == 4)
         #expect(self.sut.watchConclusionGeneration == 3)
+    }
+
+    @Test("Closing the window right after a finish does not double-signal the conclusion")
+    func stopAfterFinishDoesNotDoubleSignal() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true, progress: 119, duration: 120,
+            videoId: "a", title: nil, isAd: false
+        ))
+        self.sut.handleVideoEnded(videoId: "a")
+        let activityAfterFinish = self.sut.watchActivityGeneration
+        let conclusionAfterFinish = self.sut.watchConclusionGeneration
+
+        // The user closes the floating window; progress is still 119 and
+        // currentVideo is still "a", but the finish already signalled.
+        self.sut.stop()
+        #expect(self.sut.watchActivityGeneration == activityAfterFinish)
+        #expect(self.sut.watchConclusionGeneration == conclusionAfterFinish)
     }
 
     @Test("Stopping a video with accrued progress advances both generations")

--- a/Tests/KasetTests/YouTubePlayerServiceTests.swift
+++ b/Tests/KasetTests/YouTubePlayerServiceTests.swift
@@ -304,6 +304,51 @@ struct YouTubePlayerServiceTests {
         #expect(endedVideoId == "abc")
     }
 
+    @Test("A stale ended event for a no-longer-current video does not conclude the new watch")
+    func endedEventForStaleVideoIdIgnored() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        // The page drifts to "b" (now the current watch).
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true, progress: 3, duration: 60,
+            videoId: "b", title: "B", isAd: false
+        ))
+        #expect(self.sut.currentVideo?.videoId == "b")
+        let conclusionBefore = self.sut.watchConclusionGeneration
+
+        // A late VIDEO_ENDED for the previous video "a" arrives — it must be
+        // ignored so it doesn't conclude (and dedupe) the current watch of "b".
+        self.sut.handleVideoEnded(videoId: "a")
+        #expect(self.sut.watchConclusionGeneration == conclusionBefore)
+
+        // The real end of "b" still concludes it.
+        self.sut.handleVideoEnded(videoId: "b")
+        #expect(self.sut.watchConclusionGeneration == conclusionBefore + 1)
+    }
+
+    @Test("An ended event while an ad is showing does not conclude the watch")
+    func endedEventDuringAdIgnored() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        // An ad is playing (last STATE_UPDATE set isShowingAd).
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true, progress: 2, duration: 15,
+            videoId: "a", title: nil, isAd: true
+        ))
+        #expect(self.sut.isShowingAd)
+        let conclusionBefore = self.sut.watchConclusionGeneration
+
+        // The ad element fires VIDEO_ENDED — must NOT conclude the content watch.
+        self.sut.handleVideoEnded(videoId: "a")
+        #expect(self.sut.watchConclusionGeneration == conclusionBefore)
+
+        // Once the real content plays and ends, it concludes normally.
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true, progress: 100, duration: 120,
+            videoId: "a", title: nil, isAd: false
+        ))
+        self.sut.handleVideoEnded(videoId: "a")
+        #expect(self.sut.watchConclusionGeneration == conclusionBefore + 1)
+    }
+
     @Test("Watch-activity generation advances on every watch-state change and survives stop")
     func watchActivityGenerationTracksEveryChange() async {
         #expect(self.sut.watchActivityGeneration == 0)
@@ -392,6 +437,29 @@ struct YouTubePlayerServiceTests {
         // The new video then concludes (e.g. finishes) — that DOES signal, since
         // it is a different, unconcluded watch.
         self.sut.handleVideoEnded(videoId: "b")
+        #expect(self.sut.watchConclusionGeneration == conclusionAfterFinish + 1)
+    }
+
+    @Test("Replaying a finished video lets its later stop signal the new partial watch")
+    func replayAfterFinishReSignalsOnStop() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true, progress: 119, duration: 120,
+            videoId: "a", title: nil, isAd: false
+        ))
+        self.sut.handleVideoEnded(videoId: "a") // finished → concluded
+        let conclusionAfterFinish = self.sut.watchConclusionGeneration
+
+        // The user replays the SAME video (seek back / play again): it's playing
+        // with fresh progress, which clears the concluded flag.
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true, progress: 8, duration: 120,
+            videoId: "a", title: nil, isAd: false
+        ))
+
+        // Closing after the partial rewatch must signal again (not be deduped),
+        // so Home reflects the new resume position.
+        self.sut.stop()
         #expect(self.sut.watchConclusionGeneration == conclusionAfterFinish + 1)
     }
 


### PR DESCRIPTION
## Summary

Returning to Home after watching a YouTube video did not update the **Continue Watching** rail: a fully-watched video stayed in place and a partially-watched one never appeared. Three compounding gaps caused it:

- Home's only reload trigger is keyed on view-model **identity** (changes only on account switch), so a navigation return never re-ran it.
- `load()` is a deliberate no-op once `.loaded`.
- The `FEhistory` cache (2 min TTL) is never invalidated by playback, so even a forced reload re-served the pre-watch resume percent.

The diagnosis was confirmed against a real `FEhistory` response (the parser correctly surfaces resume progress for 177/179 history items; the pipeline was healthy — only the refresh path was missing).

## Changes

- **`getHistory(forceRefresh:)`** — adds a cache-bypass on the YouTube client (protocol + impl + mocks) so a post-watch refresh hits the network instead of the warm 2-min history cache.
- **`YouTubeHomeViewModel.refreshContinueWatching(forGeneration:)`** — rebuilds **only** the Continue Watching rail (grid, shelves, and topic rails untouched; no skeleton flash), after a short propagation delay (YouTube records watch progress server-side) plus one retry. Change detection compares `(videoId, watchedPercent)` so a progress-only update still registers. A transient fetch failure preserves the existing rail. While the initial rails are still streaming (or the feed is loading), the trigger is parked as a pending generation and drained once the feed settles; `.loadingMore` is rebuild-eligible.
- **Player `watchActivityGeneration`** — a single monotonic, **set-only** signal bumped by every watch-state change: starting a video (`play`), skipping (`advance`), finishing (`handleVideoEnded`), the page drifting to a different video (`updatePlaybackState`), and `stop()` when a video with accrued progress is torn down (covers closing the floating window and navigating away with pop-out disabled). The generation is never "consumed" by observers — the view model keeps its own `lastReflectedGeneration` watermark and advances it (via `max`) **only after a confirmed rebuild**, so a refresh for one event can never suppress a refresh for a genuinely later one.
- **`YouTubeContentView`** — drives the gated refresh from three Home-root triggers that coalesce safely on the watermark: popping back to the Home root, selecting Home from the sidebar, and observing `watchActivityGeneration` directly (so a video finishing/skipping/drifting/closing in the floating window while the user sits on Home still updates the rail). A pending-generation path handles opening Home **cold** right after watching.

## Test plan

- [x] `swift build` clean
- [x] `swift test --skip KasetUITests` — full suite passes (multiple consecutive clean runs; fixed a test-isolation flake from injectable static delays)
- [x] `YouTubeHomeContinueWatchingRefreshTests`: finished → removed; partial → added; progress-only update; grid/shelves/topics untouched; generation gating (strictly-higher always fires); same-video re-watch; failure preserves rail; failure/cancel leave the watermark retryable; cold-open pending refresh; refresh during `.loadingMore`; refresh deferred during initial streaming
- [x] `YouTubePlayerServiceTests`: `watchActivityGeneration` advances on play/skip/drift/finish and on stop-with-progress (not stop-without-progress), and survives `stop()`
- [x] `swiftlint --strict` 0 violations · `swiftformat` stable
- [x] Structured code review (Codex) — clean verdict on the redesign
