### PR TITLE
Add setting to disable YouTube video pop-out on back

### DIFF
--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -156,12 +156,20 @@ final class YouTubePlayerService {
     private let playbackController: any YouTubeWatchPlaybackControlling
     private let logger = DiagnosticsLogger.player
 
+    /// Whether a playing video should pop out into the floating window when the
+    /// inline watch view disappears (navigate-away). Read live so the user's
+    /// setting takes effect mid-session; injected so tests stay deterministic
+    /// without touching global `UserDefaults`.
+    private let shouldPopOutOnNavigateAway: @MainActor () -> Bool
+
     init(
         webKitManager: WebKitManager = .shared,
-        playbackController: (any YouTubeWatchPlaybackControlling)? = nil
+        playbackController: (any YouTubeWatchPlaybackControlling)? = nil,
+        shouldPopOutOnNavigateAway: @escaping @MainActor () -> Bool = { SettingsManager.shared.popOutVideoOnNavigateAway }
     ) {
         self.webKitManager = webKitManager
         self.playbackController = playbackController ?? YouTubeWatchWebView.shared
+        self.shouldPopOutOnNavigateAway = shouldPopOutOnNavigateAway
     }
 
     // MARK: - Commands
@@ -505,9 +513,11 @@ final class YouTubePlayerService {
             return
         }
 
-        if self.isPlaying {
+        if self.isPlaying, self.shouldPopOutOnNavigateAway() {
             self.popOutToWindow()
         } else {
+            // Playing with pop-out disabled, or paused: stop instead of
+            // leaving a detached surface.
             self.stop()
         }
     }

--- a/Sources/Kaset/Services/SettingsManager.swift
+++ b/Sources/Kaset/Services/SettingsManager.swift
@@ -27,6 +27,7 @@ final class SettingsManager {
         static let keepMiniPlayerOnTop = "settings.keepMiniPlayerOnTop"
         static let ambientBackdropEnabled = "settings.ambientBackdropEnabled"
         static let ambientBackdropStyle = "settings.ambientBackdropStyle"
+        static let popOutVideoOnNavigateAway = "settings.popOutVideoOnNavigateAway"
         #if DEBUG
             static let useLegacyMacOS15UI = "settings.debug.useLegacyMacOS15UI"
         #endif
@@ -309,6 +310,16 @@ final class SettingsManager {
         }
     }
 
+    /// Whether a playing YouTube video pops out into the floating window when
+    /// the user navigates away from the inline watch view. When disabled,
+    /// playback stops instead. Applies to regular YouTube videos only, not the
+    /// Music experience.
+    var popOutVideoOnNavigateAway: Bool {
+        didSet {
+            UserDefaults.standard.set(self.popOutVideoOnNavigateAway, forKey: Keys.popOutVideoOnNavigateAway)
+        }
+    }
+
     /// The style the YouTube watch page should actually render: the chosen
     /// style when enabled, `.off` when the feature is disabled.
     var resolvedAmbientStyle: AmbientBackdropStyle {
@@ -359,6 +370,7 @@ final class SettingsManager {
         self.romanizationEnabled = UserDefaults.standard.object(forKey: Keys.romanizationEnabled) as? Bool ?? true
         self.keepMiniPlayerOnTop = UserDefaults.standard.object(forKey: Keys.keepMiniPlayerOnTop) as? Bool ?? false
         self.ambientBackdropEnabled = UserDefaults.standard.object(forKey: Keys.ambientBackdropEnabled) as? Bool ?? true
+        self.popOutVideoOnNavigateAway = UserDefaults.standard.object(forKey: Keys.popOutVideoOnNavigateAway) as? Bool ?? true
         #if DEBUG
             self.useLegacyMacOS15UI = UserDefaults.standard.object(forKey: Keys.useLegacyMacOS15UI) as? Bool ?? false
         #endif

--- a/Sources/Kaset/Views/YouTubeSettingsView.swift
+++ b/Sources/Kaset/Views/YouTubeSettingsView.swift
@@ -27,6 +27,17 @@ struct YouTubeSettingsView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
+
+            Section {
+                Toggle("Pop Out Video When Navigating Away", isOn: self.$settings.popOutVideoOnNavigateAway)
+                    .help("Keep a playing video in a floating window when you leave the page. When off, the video stops instead.")
+            } header: {
+                Text("Video Window")
+            } footer: {
+                Text("When off, navigating back from a playing video stops it instead of opening the floating player. The pop-out and full-view buttons still work.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
         }
         .formStyle(.grouped)
     }

--- a/Tests/KasetTests/SettingsManagerTests.swift
+++ b/Tests/KasetTests/SettingsManagerTests.swift
@@ -72,6 +72,27 @@ struct SettingsManagerTests {
         #expect(manager.rememberPlaybackSettings == false)
     }
 
+    @Test("Default popOutVideoOnNavigateAway is true")
+    func defaultPopOutVideoOnNavigateAway() {
+        let manager = SettingsManager.shared
+        #expect(manager.popOutVideoOnNavigateAway == true)
+    }
+
+    @Test("popOutVideoOnNavigateAway persists to UserDefaults")
+    func popOutVideoOnNavigateAwayPersists() {
+        let manager = SettingsManager.shared
+        let originalValue = manager.popOutVideoOnNavigateAway
+        defer {
+            manager.popOutVideoOnNavigateAway = originalValue
+        }
+
+        manager.popOutVideoOnNavigateAway = false
+        #expect(UserDefaults.standard.bool(forKey: SettingsManager.Keys.popOutVideoOnNavigateAway) == false)
+
+        manager.popOutVideoOnNavigateAway = true
+        #expect(UserDefaults.standard.bool(forKey: SettingsManager.Keys.popOutVideoOnNavigateAway) == true)
+    }
+
     @Test("Disabling rememberPlaybackSettings clears persisted values")
     func disablingRememberPlaybackSettingsClearsValues() {
         let manager = SettingsManager.shared

--- a/Tests/KasetTests/YouTubePlayerServiceTests.swift
+++ b/Tests/KasetTests/YouTubePlayerServiceTests.swift
@@ -96,7 +96,12 @@ struct YouTubePlayerServiceTests {
 
     init() {
         self.controller = MockYouTubeWatchPlaybackController()
-        self.sut = YouTubePlayerService(playbackController: self.controller)
+        // Pin the navigate-away pop-out gate ON so the existing pop-out
+        // assertions don't depend on the global SettingsManager.shared state.
+        self.sut = YouTubePlayerService(
+            playbackController: self.controller,
+            shouldPopOutOnNavigateAway: { true }
+        )
     }
 
     @Test("Initial state is empty")
@@ -205,6 +210,82 @@ struct YouTubePlayerServiceTests {
 
         #expect(self.sut.surfaceLocation == .inline)
         #expect(self.sut.activeInlineVideoId == "abc")
+    }
+
+    @Test("Pop-out disabled: inline disappearance while playing stops instead of floating")
+    func disappearWhilePlayingStopsWhenPopOutDisabled() {
+        let controller = MockYouTubeWatchPlaybackController()
+        let sut = YouTubePlayerService(
+            playbackController: controller,
+            shouldPopOutOnNavigateAway: { false }
+        )
+        sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        sut.activeInlineVideoId = "abc"
+        sut.updatePlaybackState(.init(
+            isPlaying: true, progress: 0, duration: 10,
+            videoId: "abc", title: nil, isAd: false
+        ))
+
+        sut.inlineSurfaceWillDisappear(videoId: "abc")
+
+        #expect(sut.surfaceLocation == .none)
+        #expect(sut.currentVideo == nil)
+        #expect(controller.tearDownCount == 1)
+    }
+
+    @Test("Pop-out disabled still yields to the one-shot source-switch suppression")
+    func sourceSwitchStillPausesInPlaceWhenPopOutDisabled() {
+        let controller = MockYouTubeWatchPlaybackController()
+        let sut = YouTubePlayerService(
+            playbackController: controller,
+            shouldPopOutOnNavigateAway: { false }
+        )
+        sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        sut.activeInlineVideoId = "abc"
+        sut.updatePlaybackState(.init(
+            isPlaying: true, progress: 5, duration: 60,
+            videoId: "abc", title: nil, isAd: false
+        ))
+
+        sut.prepareForSourceSwitch()
+        sut.inlineSurfaceWillDisappear(videoId: "abc")
+
+        // Suppression wins regardless of the setting: paused in place, not stopped.
+        #expect(controller.pauseCount == 1)
+        #expect(sut.surfaceLocation == .inline)
+        #expect(sut.currentVideo?.videoId == "abc")
+        #expect(controller.tearDownCount == 0)
+    }
+
+    @Test("Pop-out gate is read live, not captured at init")
+    func popOutGateReadLive() {
+        let controller = MockYouTubeWatchPlaybackController()
+        var popOutEnabled = false
+        let sut = YouTubePlayerService(
+            playbackController: controller,
+            shouldPopOutOnNavigateAway: { popOutEnabled }
+        )
+
+        // First navigate-away with the gate off: stops.
+        sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        sut.activeInlineVideoId = "abc"
+        sut.updatePlaybackState(.init(
+            isPlaying: true, progress: 0, duration: 10,
+            videoId: "abc", title: nil, isAd: false
+        ))
+        sut.inlineSurfaceWillDisappear(videoId: "abc")
+        #expect(sut.surfaceLocation == .none)
+
+        // Flip the gate on; a fresh playback now pops out.
+        popOutEnabled = true
+        sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        sut.activeInlineVideoId = "abc"
+        sut.updatePlaybackState(.init(
+            isPlaying: true, progress: 0, duration: 10,
+            videoId: "abc", title: nil, isAd: false
+        ))
+        sut.inlineSurfaceWillDisappear(videoId: "abc")
+        #expect(sut.surfaceLocation == .floating)
     }
 
     @Test("Video ended invokes the hook and clears isPlaying")

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -307,6 +307,7 @@ Manages user preferences persisted via `UserDefaults`:
 | `hapticFeedbackEnabled` | `Bool` | `true` | Force Touch feedback |
 | `rememberPlaybackSettings` | `Bool` | `false` | Persist shuffle/repeat state |
 | `syncedLyricsEnabled` | `Bool` | `true` | Enable synced lyrics provider lookup before plain lyrics fallback |
+| `popOutVideoOnNavigateAway` | `Bool` | `true` | Pop a playing YouTube video into the floating window when navigating away; when off, playback stops |
 
 **LaunchPage Options**: Home, Explore, Charts, Moods & Genres, New Releases, Liked Music, Playlists, Last Used
 

--- a/docs/youtube.md
+++ b/docs/youtube.md
@@ -145,7 +145,12 @@ Handoff rules:
 - Opening a watch view auto-plays (or adopts the surface if its video is
   already playing, closing the floating window).
 - Navigating away within YouTube while **playing** pops the surface out
-  to the floating window; while **paused**, playback stops.
+  to the floating window; while **paused**, playback stops. The
+  playing-case pop-out is gated by the `popOutVideoOnNavigateAway` setting
+  (Settings → YouTube, default on); when disabled, navigating away **stops**
+  playback instead of opening the floating window. The setting gates only this
+  automatic hand-off — the player-bar PiP / Full-view buttons and the
+  `kaset://` URL scheme open the floating window regardless.
 - **Toggling to Music pauses the docked video in place** — no pop-out
   appears, and toggling back restores the same watch view (the YouTube
   drill-in path lives in `YouTubeViewModelStore`, which survives source


### PR DESCRIPTION
## Summary

- Adds a **Pop Out Video When Navigating Away** toggle (Settings → YouTube, default **on**). When a playing YouTube video leaves the inline watch view (e.g. pressing the back button), it is handed off to the floating pop-out window as before — but with the toggle **off**, navigating away **stops** playback instead.
- The gate applies only to the **automatic** navigate-away branch in `YouTubePlayerService.inlineSurfaceWillDisappear`. Explicit pop-outs — the player-bar PiP / Full-view buttons and the `kaset://` URL scheme — call `popOutToWindow()` directly and are **unaffected**.
- The setting is read through an injected `@MainActor () -> Bool` closure (mirroring the existing `EqualizerService` pattern) so it stays live mid-session and is unit-testable without polluting global `UserDefaults`.

## Details

| File | Change |
|------|--------|
| `Services/SettingsManager.swift` | New persisted `popOutVideoOnNavigateAway: Bool`, default `true` (positive polarity → binds directly to the toggle) |
| `Services/Player/YouTubePlayerService.swift` | Gate the navigate-away pop-out branch behind the injected closure; falls through to the existing `stop()` when disabled |
| `Views/YouTubeSettingsView.swift` | New "Video Window" section with the toggle |
| `docs/youtube.md`, `docs/architecture.md` | Documented the gated handoff rule and the new settings row |

No ADR: small, reversible toggle reusing existing `stop()` semantics — not a significant design change per AGENTS.md.

## Test plan

- [x] `swift build`
- [x] `swift test --skip KasetUITests` — 1458 tests pass, including 5 new (disabled→stops, source-switch suppression still wins, gate read live, default value, persistence); existing pop-out assertions pinned to the gate so they stay deterministic
- [x] `swiftlint --strict` — 0 violations · `swiftformat` clean
- [ ] Manual smoke (Xcode): toggle **on** → back pops out (unchanged); toggle **off** → back stops playback, no floating window; with toggle **off**, PiP/Full-view buttons and a `kaset://youtube` deep link still open the floating window