### PR TITLE
Redesign player bar into an Apple Music-style scrubber

### DIFF
--- a/Sources/Kaset/Views/AppleMusicScrubber.swift
+++ b/Sources/Kaset/Views/AppleMusicScrubber.swift
@@ -1,0 +1,175 @@
+import SwiftUI
+
+// MARK: - AppleMusicScrubber
+
+/// Apple Music-style hover scrubber: a row of elapsed / remaining timestamps at
+/// the far edges, above a long full-width draggable progress bar. Shown (by the
+/// parent) over the blurred track info while the now-playing area is hovered, so
+/// it is always in its full form — the parent controls visibility (opacity) and
+/// interactivity (`isInteractive`).
+struct AppleMusicScrubber: View {
+    /// Outer height reserved for the two-row lane (timestamps + bar).
+    static let laneHeight: CGFloat = 30
+
+    /// Current playback fraction (0...1) to render as the filled portion.
+    let fraction: Double
+    /// Accent colour for the filled track and thumb.
+    let accent: Color
+    /// Pre-formatted elapsed time (e.g. "1:23").
+    let elapsedText: String
+    /// Pre-formatted remaining time (e.g. "-2:05").
+    let remainingText: String
+    /// Whether the control accepts pointer/keyboard input (true while hovered).
+    let isInteractive: Bool
+    /// Called continuously while dragging with the new fraction (0...1).
+    let onScrub: (Double) -> Void
+    /// Called when the drag ends, to commit the seek.
+    let onCommit: () -> Void
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @FocusState private var isFocused: Bool
+
+    /// Fraction nudge per arrow-key press / accessibility adjustment.
+    private var keyboardStep: Double {
+        0.02
+    }
+
+    private var barHeight: CGFloat {
+        5
+    }
+
+    private var thumbDiameter: CGFloat {
+        11
+    }
+
+    private var clampedFraction: CGFloat {
+        CGFloat(min(max(0, self.fraction), 1))
+    }
+
+    var body: some View {
+        VStack(spacing: 4) {
+            // Timestamps at the far edges.
+            HStack(spacing: 8) {
+                Text(self.elapsedText)
+                    .frame(alignment: .leading)
+
+                Spacer(minLength: 8)
+
+                Text(self.remainingText)
+                    .frame(alignment: .trailing)
+            }
+            .font(.system(size: 11))
+            .monospacedDigit()
+            .foregroundStyle(.secondary)
+
+            // Long, full-width draggable bar.
+            GeometryReader { proxy in
+                let width = proxy.size.width
+                let fillWidth = width * self.clampedFraction
+
+                ZStack(alignment: .leading) {
+                    // Background track.
+                    Capsule()
+                        .fill(.primary.opacity(0.22))
+                        .frame(height: self.barHeight)
+
+                    // Elapsed fill.
+                    Capsule()
+                        .fill(self.accent)
+                        .frame(width: fillWidth, height: self.barHeight)
+
+                    // Draggable thumb.
+                    Circle()
+                        .fill(self.accent)
+                        .frame(width: self.thumbDiameter, height: self.thumbDiameter)
+                        .shadow(color: .black.opacity(0.25), radius: 1.5, y: 0.5)
+                        .offset(x: min(max(0, fillWidth - self.thumbDiameter / 2), max(0, width - self.thumbDiameter)))
+                }
+                .frame(maxHeight: .infinity, alignment: .center)
+                .contentShape(Rectangle())
+                .gesture(
+                    DragGesture(minimumDistance: 0)
+                        .onChanged { value in
+                            guard width > 0 else { return }
+                            let fraction = Double(min(max(0, value.location.x / width), 1))
+                            self.onScrub(fraction)
+                        }
+                        .onEnded { _ in
+                            self.onCommit()
+                        }
+                )
+            }
+            .frame(height: 12)
+        }
+        .frame(height: Self.laneHeight)
+        .focusable(self.isInteractive)
+        .focused(self.$isFocused)
+        .onKeyPress(.leftArrow) {
+            guard self.isInteractive else { return .ignored }
+            self.nudge(by: -self.keyboardStep)
+            return .handled
+        }
+        .onKeyPress(.rightArrow) {
+            guard self.isInteractive else { return .ignored }
+            self.nudge(by: self.keyboardStep)
+            return .handled
+        }
+        .accessibilityElement()
+        .accessibilityLabel(String(localized: "Playback position"))
+        .accessibilityValue("\(self.elapsedText), \(self.remainingText)")
+        .accessibilityAdjustableAction { direction in
+            guard self.isInteractive else { return }
+            switch direction {
+            case .increment:
+                self.nudge(by: self.keyboardStep)
+            case .decrement:
+                self.nudge(by: -self.keyboardStep)
+            @unknown default:
+                break
+            }
+        }
+        // When idle the scrubber is visually hidden behind the track info; keep
+        // it out of the accessibility tree too so VoiceOver can't seek invisibly.
+        .accessibilityHidden(!self.isInteractive)
+    }
+
+    /// Move the playback fraction by `delta` (clamped) and commit the seek.
+    private func nudge(by delta: Double) {
+        self.onScrub(min(1, max(0, self.fraction + delta)))
+        self.onCommit()
+    }
+}
+
+// MARK: - IdleProgressLine
+
+/// A slim, low-contrast full-width progress indicator shown in the player bar
+/// when the now-playing area is idle (not hovered). Purely decorative — the
+/// interactive seeking lives in `AppleMusicScrubber`.
+struct IdleProgressLine: View {
+    /// Current playback fraction (0...1).
+    let fraction: Double
+
+    private var clampedFraction: CGFloat {
+        CGFloat(min(max(0, self.fraction), 1))
+    }
+
+    var body: some View {
+        GeometryReader { proxy in
+            let width = proxy.size.width
+            let fillWidth = width * self.clampedFraction
+
+            ZStack(alignment: .leading) {
+                Capsule()
+                    .fill(.primary.opacity(0.5))
+                    .frame(height: 4)
+
+                Capsule()
+                    .fill(.primary)
+                    .frame(width: fillWidth, height: 4)
+            }
+            .frame(maxHeight: .infinity, alignment: .center)
+        }
+        .frame(height: 4)
+        .accessibilityHidden(true)
+    }
+}

--- a/Sources/Kaset/Views/AppleMusicScrubber.swift
+++ b/Sources/Kaset/Views/AppleMusicScrubber.swift
@@ -26,7 +26,6 @@ struct AppleMusicScrubber: View {
     /// Called when the drag ends, to commit the seek.
     let onCommit: () -> Void
 
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @FocusState private var isFocused: Bool
 
     /// Fraction nudge per arrow-key press / accessibility adjustment.
@@ -51,12 +50,10 @@ struct AppleMusicScrubber: View {
             // Timestamps at the far edges.
             HStack(spacing: 8) {
                 Text(self.elapsedText)
-                    .frame(alignment: .leading)
 
                 Spacer(minLength: 8)
 
                 Text(self.remainingText)
-                    .frame(alignment: .trailing)
             }
             .font(.system(size: 11))
             .monospacedDigit()

--- a/Sources/Kaset/Views/PlayerBar.swift
+++ b/Sources/Kaset/Views/PlayerBar.swift
@@ -11,6 +11,7 @@ struct PlayerBar: View {
     @Environment(WebKitManager.self) private var webKitManager
     @Environment(FavoritesManager.self) private var favoritesManager
     @Environment(SongLikeStatusManager.self) private var likeStatusManager
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     /// Namespace for glass effect morphing and unioning.
     @Namespace private var playerNamespace
@@ -41,7 +42,7 @@ struct PlayerBar: View {
 
                 Spacer()
 
-                // Center section: Track info OR seek bar (on hover)
+                // Center section: Track info ⇄ full-width seek scrubber on hover
                 self.centerSection
 
                 Spacer()
@@ -50,7 +51,7 @@ struct PlayerBar: View {
                 self.volumeControl
             }
             .padding(.horizontal, 20)
-            .padding(.vertical, 8)
+            .padding(.vertical, 6)
             .frame(height: 52)
             .compatGlass(interactive: true, in: .capsule)
             .compatGlassID("playerBar", in: self.playerNamespace)
@@ -156,7 +157,7 @@ struct PlayerBar: View {
         .accessibilityHidden(true)
     }
 
-    // MARK: - Center Section (track info blurs, seek bar appears on hover)
+    // MARK: - Center Section (track info ⇄ full-width seek scrubber on hover)
 
     private var centerSection: some View {
         ZStack {
@@ -164,20 +165,27 @@ struct PlayerBar: View {
             if case let .error(message) = playerService.state {
                 self.errorView(message: message)
             } else {
-                // Track info (blurred when hovering and track is playing)
-                self.trackInfoView
-                    .blur(radius: self.showsSeekControls ? 8 : 0)
-                    .opacity(self.showsSeekControls ? 0 : 1)
+                // Track info — top-aligned so it lifts off the bottom progress line.
+                VStack(spacing: 0) {
+                    self.trackInfoView
+                    Spacer(minLength: 0)
+                }
+                .blur(radius: self.showsSeekControls ? 8 : 0)
+                .opacity(self.showsSeekControls ? 0 : 1)
 
+                // Thin idle progress line ⇄ full-width hover scrubber, filling the section.
                 if self.playerService.currentTrack != nil {
-                    VStack(spacing: 0) {
-                        Spacer(minLength: 0)
-                        self.seekInteractionLayer
-                    }
+                    self.seekOverlay
                 }
             }
         }
-        .frame(maxWidth: 400, minHeight: 36)
+        .frame(maxWidth: 540, minHeight: 38)
+        .contentShape(Rectangle())
+        .onHover { hovering in
+            withAnimation(self.hoverAnimation) {
+                self.isHoveringSeekBar = hovering
+            }
+        }
         .contextMenu {
             if let track = self.playerService.currentTrack {
                 self.currentSongContextMenu(for: track)
@@ -185,43 +193,107 @@ struct PlayerBar: View {
         }
     }
 
+    /// Whether the expanded scrubber (timestamps + thumb) is shown.
     private var showsSeekControls: Bool {
         self.isHoveringSeekBar && self.playerService.currentTrack != nil
+    }
+
+    /// Hover grow/shrink animation, honouring Reduce Motion.
+    private var hoverAnimation: Animation {
+        self.reduceMotion ? .easeInOut(duration: 0.12) : AppAnimation.snappy
     }
 
     private var isCompactLayout: Bool {
         self.playerBarWidth > 0 && self.playerBarWidth < Self.compactLayoutThreshold
     }
 
-    private var seekInteractionLayer: some View {
+    /// Fraction (0...1) to render: the live drag value while seeking, otherwise actual progress.
+    private var displayFraction: Double {
+        if self.isSeeking {
+            return min(max(0, self.seekValue), 1)
+        }
+        guard self.playerService.duration > 0 else { return 0 }
+        return min(max(0, self.playerService.progress / self.playerService.duration), 1)
+    }
+
+    // MARK: - Track Info View (thumbnail + title/artist)
+
+    private var trackInfoView: some View {
+        HStack(spacing: 8) {
+            // Thumbnail
+            if let track = self.playerService.currentTrack {
+                SongThumbnailView(song: track, size: 32, cornerRadius: 4)
+            } else {
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(.quaternary)
+                    .overlay {
+                        CassetteIcon(size: 18)
+                            .foregroundStyle(.secondary)
+                    }
+                    .frame(width: 32, height: 32)
+            }
+
+            // Track info
+            if let track = self.playerService.currentTrack {
+                VStack(alignment: .leading, spacing: 0) {
+                    Text(track.title)
+                        .font(.system(size: 11, weight: .medium))
+                        .lineLimit(1)
+                        .foregroundStyle(.primary)
+
+                    Text(track.artistsDisplay.isEmpty ? String(localized: "Unknown Artist") : track.artistsDisplay)
+                        .font(.system(size: 10))
+                        .lineLimit(1)
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: 240, alignment: .leading)
+            }
+        }
+        .fixedSize(horizontal: true, vertical: false)
+        .frame(maxWidth: .infinity, alignment: .center)
+    }
+
+    // MARK: - Seek Overlay (full-width: thin idle line ⇄ edge-to-edge hover scrubber)
+
+    private var seekOverlay: some View {
         ZStack {
             if self.playerService.isCurrentItemLive {
                 self.liveIndicatorView
                     .opacity(self.showsSeekControls ? 1 : 0)
                     .transition(.opacity)
+                    .allowsHitTesting(false)
             } else {
-                self.seekBarView
-                    .opacity(self.showsSeekControls ? 1 : 0)
-                    .allowsHitTesting(self.showsSeekControls)
+                // Full-width hover scrubber (elapsed · long bar · remaining).
+                AppleMusicScrubber(
+                    fraction: self.displayFraction,
+                    accent: Self.brandAccent,
+                    elapsedText: self.isSeeking
+                        ? self.formatTime(self.seekValue * self.playerService.duration)
+                        : self.formattedProgress,
+                    remainingText: self.isSeeking
+                        ? "-\(self.formatTime(max(0, self.playerService.duration - self.seekValue * self.playerService.duration)))"
+                        : self.formattedRemaining,
+                    isInteractive: self.showsSeekControls,
+                    onScrub: { fraction in
+                        self.isSeeking = true
+                        self.seekValue = fraction
+                    },
+                    onCommit: {
+                        self.performSeek()
+                    }
+                )
+                .opacity(self.showsSeekControls ? 1 : 0)
+                .allowsHitTesting(self.showsSeekControls)
 
-                self.compactProgressView
-                    .opacity(self.showsSeekControls ? 0 : 1)
+                // Thin idle progress line shown when not hovering.
+                VStack(spacing: 0) {
+                    Spacer(minLength: 0)
+                    IdleProgressLine(fraction: self.displayFraction)
+                }
+                .opacity(self.showsSeekControls ? 0 : 1)
+                .allowsHitTesting(false)
             }
         }
-        .frame(height: self.showsSeekControls ? 28 : 10, alignment: .bottom)
-        .contentShape(Rectangle())
-        .onHover { hovering in
-            withAnimation(.easeInOut(duration: 0.15)) {
-                self.isHoveringSeekBar = hovering
-            }
-        }
-    }
-
-    private var compactProgressView: some View {
-        Rectangle()
-            .fill(.clear)
-            .frame(height: 10)
-            .accessibilityHidden(true)
     }
 
     // MARK: - Current Song Context Menu
@@ -338,73 +410,7 @@ struct PlayerBar: View {
         }
     }
 
-    // MARK: - Track Info View
-
-    private var trackInfoView: some View {
-        HStack(spacing: 10) {
-            // Thumbnail
-            if let track = self.playerService.currentTrack {
-                SongThumbnailView(song: track, size: 36, cornerRadius: 4)
-            } else {
-                RoundedRectangle(cornerRadius: 4)
-                    .fill(.quaternary)
-                    .overlay {
-                        CassetteIcon(size: 20)
-                            .foregroundStyle(.secondary)
-                    }
-                    .frame(width: 36, height: 36)
-            }
-
-            // Track info
-            if let track = playerService.currentTrack {
-                VStack(alignment: .leading, spacing: 1) {
-                    Text(track.title)
-                        .font(.system(size: 12, weight: .medium))
-                        .lineLimit(1)
-                        .foregroundStyle(.primary)
-
-                    Text(track.artistsDisplay.isEmpty ? String(localized: "Unknown Artist") : track.artistsDisplay)
-                        .font(.system(size: 10))
-                        .lineLimit(1)
-                        .foregroundStyle(.secondary)
-                }
-                .frame(maxWidth: 200, alignment: .leading)
-            }
-        }
-    }
-
-    // MARK: - Seek Bar View (replaces track info on hover)
-
-    private var seekBarView: some View {
-        HStack(spacing: 10) {
-            // Elapsed time - use cached formatted string when not seeking
-            Text(self.isSeeking ? self.formatTime(self.seekValue * self.playerService.duration) : self.formattedProgress)
-                .font(.system(size: 11))
-                .foregroundStyle(.secondary)
-                .frame(minWidth: 45, alignment: .trailing)
-                .monospacedDigit()
-
-            // Seek slider
-            Slider(value: self.$seekValue, in: 0 ... 1) { editing in
-                if editing {
-                    // User started dragging
-                    self.isSeeking = true
-                } else {
-                    // User finished dragging - perform seek
-                    self.performSeek()
-                }
-            }
-            .controlSize(.small)
-            .tint(Self.brandAccent)
-
-            // Remaining time - use cached formatted string when not seeking
-            Text(self.isSeeking ? "-\(self.formatTime(self.playerService.duration - self.seekValue * self.playerService.duration))" : self.formattedRemaining)
-                .font(.system(size: 11))
-                .foregroundStyle(.secondary)
-                .frame(minWidth: 45, alignment: .leading)
-                .monospacedDigit()
-        }
-    }
+    // MARK: - Seek
 
     /// Performs the actual seek operation after slider interaction ends.
     private func performSeek() {

--- a/Sources/Kaset/Views/YouTube/YouTubePlayerBar.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubePlayerBar.swift
@@ -17,6 +17,7 @@ struct YouTubePlayerBar: View {
     private static let brandAccent = PackageResourceLookup.brandAccent
 
     @Environment(YouTubePlayerService.self) private var youtubePlayer
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     /// Namespace for glass effect morphing.
     @Namespace private var playerNamespace
@@ -41,7 +42,7 @@ struct YouTubePlayerBar: View {
                 self.rightSection
             }
             .padding(.horizontal, 20)
-            .padding(.vertical, 8)
+            .padding(.vertical, 6)
             .frame(height: 52)
             .compatGlass(interactive: true, in: .capsule)
             .compatGlassID("youtubePlayerBar", in: self.playerNamespace)
@@ -140,30 +141,52 @@ struct YouTubePlayerBar: View {
         }
     }
 
-    // MARK: - Center Section (video info, seek bar on hover)
+    // MARK: - Center Section (video info ⇄ full-width seek scrubber on hover)
 
     private var centerSection: some View {
         ZStack {
-            self.videoInfoView
-                .blur(radius: self.showsSeekControls ? 8 : 0)
-                .opacity(self.showsSeekControls ? 0 : 1)
+            // Video info — top-aligned so it lifts off the bottom progress line.
+            VStack(spacing: 0) {
+                self.videoInfoView
+                Spacer(minLength: 0)
+            }
+            .blur(radius: self.showsSeekControls ? 8 : 0)
+            .opacity(self.showsSeekControls ? 0 : 1)
 
+            // Thin idle progress line ⇄ full-width hover scrubber.
             if self.youtubePlayer.currentVideo != nil {
-                VStack(spacing: 0) {
-                    Spacer(minLength: 0)
-                    self.seekInteractionLayer
-                }
+                self.seekOverlay
             }
         }
-        .frame(maxWidth: 400, minHeight: 36)
+        .frame(maxWidth: 540, minHeight: 38)
+        .contentShape(Rectangle())
+        .onHover { hovering in
+            withAnimation(self.hoverAnimation) {
+                self.isHoveringSeekBar = hovering
+            }
+        }
     }
 
     private var showsSeekControls: Bool {
         self.isHoveringSeekBar && self.youtubePlayer.currentVideo != nil
     }
 
+    /// Hover grow/shrink animation, honouring Reduce Motion.
+    private var hoverAnimation: Animation {
+        self.reduceMotion ? .easeInOut(duration: 0.12) : AppAnimation.snappy
+    }
+
+    /// Fraction (0...1) to render: the live drag value while seeking, otherwise actual progress.
+    private var displayFraction: Double {
+        if self.isSeeking {
+            return min(max(0, self.seekValue), 1)
+        }
+        guard self.youtubePlayer.duration > 0 else { return 0 }
+        return min(max(0, self.youtubePlayer.progress / self.youtubePlayer.duration), 1)
+    }
+
     private var videoInfoView: some View {
-        HStack(spacing: 10) {
+        HStack(spacing: 8) {
             // 16:9 video thumbnail
             CachedAsyncImage(
                 url: self.youtubePlayer.currentVideo?.thumbnailURL,
@@ -177,83 +200,71 @@ struct YouTubePlayerBar: View {
                     .fill(.quaternary)
                     .overlay {
                         Image(systemName: "play.rectangle")
-                            .font(.system(size: 14))
+                            .font(.system(size: 13))
                             .foregroundStyle(.secondary)
                     }
             }
-            .frame(width: 64, height: 36)
+            .frame(width: 57, height: 32)
             .clipShape(.rect(cornerRadius: 4))
 
             if let video = self.youtubePlayer.currentVideo {
-                VStack(alignment: .leading, spacing: 1) {
+                VStack(alignment: .leading, spacing: 0) {
                     Text(video.title)
-                        .font(.system(size: 12, weight: .medium))
+                        .font(.system(size: 11, weight: .medium))
                         .lineLimit(1)
                         .foregroundStyle(.primary)
 
-                    let detail = [video.channelName, video.viewCountText]
-                        .compactMap(\.self)
-                        .joined(separator: " · ")
-                    if !detail.isEmpty {
-                        Text(detail)
+                    if let channelName = video.channelName, !channelName.isEmpty {
+                        Text(channelName)
                             .font(.system(size: 10))
                             .lineLimit(1)
                             .foregroundStyle(.secondary)
                     }
                 }
-                .frame(maxWidth: 200, alignment: .leading)
+                .frame(maxWidth: 240, alignment: .leading)
             }
         }
+        .fixedSize(horizontal: true, vertical: false)
+        .frame(maxWidth: .infinity, alignment: .center)
     }
 
-    private var seekInteractionLayer: some View {
+    // MARK: - Seek Overlay (full-width: thin idle line ⇄ hover scrubber)
+
+    private var seekOverlay: some View {
         ZStack {
-            self.seekBarView
-                .opacity(self.showsSeekControls ? 1 : 0)
-                .allowsHitTesting(self.showsSeekControls)
-
-            Rectangle()
-                .fill(.clear)
-                .frame(height: 10)
-                .accessibilityHidden(true)
-                .opacity(self.showsSeekControls ? 0 : 1)
-        }
-        .frame(height: self.showsSeekControls ? 28 : 10, alignment: .bottom)
-        .contentShape(Rectangle())
-        .onHover { hovering in
-            withAnimation(.easeInOut(duration: 0.15)) {
-                self.isHoveringSeekBar = hovering
-            }
-        }
-    }
-
-    private var seekBarView: some View {
-        HStack(spacing: 10) {
-            Text(Self.formatTime(self.isSeeking
+            // Full-width hover scrubber (elapsed · long bar · remaining).
+            AppleMusicScrubber(
+                fraction: self.displayFraction,
+                accent: Self.brandAccent,
+                elapsedText: Self.formatTime(self.isSeeking
                     ? self.seekValue * self.youtubePlayer.duration
-                    : self.youtubePlayer.progress))
-                .font(.system(size: 11))
-                .foregroundStyle(.secondary)
-                .frame(minWidth: 45, alignment: .trailing)
-                .monospacedDigit()
-
-            Slider(value: self.$seekValue, in: 0 ... 1) { editing in
-                if editing {
+                    : self.youtubePlayer.progress),
+                remainingText: "-\(Self.formatTime(self.youtubePlayer.duration - (self.isSeeking ? self.seekValue * self.youtubePlayer.duration : self.youtubePlayer.progress)))",
+                isInteractive: self.showsSeekControls && self.canSeek,
+                onScrub: { fraction in
                     self.isSeeking = true
-                } else {
+                    self.seekValue = fraction
+                },
+                onCommit: {
                     self.performSeek()
                 }
-            }
-            .controlSize(.small)
-            .tint(Self.brandAccent)
-            .disabled(self.youtubePlayer.duration <= 0 || self.youtubePlayer.isShowingAd)
+            )
+            .opacity(self.showsSeekControls ? 1 : 0)
+            .allowsHitTesting(self.showsSeekControls && self.canSeek)
 
-            Text("-\(Self.formatTime(self.youtubePlayer.duration - (self.isSeeking ? self.seekValue * self.youtubePlayer.duration : self.youtubePlayer.progress)))")
-                .font(.system(size: 11))
-                .foregroundStyle(.secondary)
-                .frame(minWidth: 45, alignment: .leading)
-                .monospacedDigit()
+            // Thin idle progress line shown when not hovering.
+            VStack(spacing: 0) {
+                Spacer(minLength: 0)
+                IdleProgressLine(fraction: self.displayFraction)
+            }
+            .opacity(self.showsSeekControls ? 0 : 1)
+            .allowsHitTesting(false)
         }
+    }
+
+    /// Seeking is unavailable during ads or before a duration is known.
+    private var canSeek: Bool {
+        self.youtubePlayer.duration > 0 && !self.youtubePlayer.isShowingAd
     }
 
     private func performSeek() {


### PR DESCRIPTION
## Summary
- Reworks the now-playing progress UI on **both** the music (`PlayerBar`) and YouTube (`YouTubePlayerBar`) bars to match Apple Music: an always-on, high-contrast thin progress line when idle that morphs into a **full-width draggable scrubber** (elapsed / −remaining timestamps) on hover, while the track/video info blurs back and the transport/volume controls stay put.
- Adds a shared `AppleMusicScrubber` + `IdleProgressLine` (new `AppleMusicScrubber.swift`) used by both bars, so the music and YouTube sides stay in sync.
- Now-playing info is centered, slightly smaller, and **top-aligned** so it sits clear of the progress line.
- Drops the view count from the YouTube bar subtitle (channel name only); view count is unchanged everywhere else.

### Preserved behavior
- Existing seek plumbing (`seek`/`performSeek`/`displayFraction`), live-stream and error states, and the YouTube **ad / unknown-duration seek-lock** (`canSeek` gates interactivity + hit-testing).
- Accessibility: custom scrubber exposes label/value + adjustable action and arrow-key seeking, gated so the hidden idle line isn't reachable by VoiceOver.
- Respects Reduce Motion; preserves the Liquid Glass capsule, namespace IDs, and compact-layout handling.

## Test plan
- [x] `swift build`
- [x] `swift test --skip KasetUITests` (1458 tests pass)
- [x] `swiftlint --strict` + `swiftformat .` clean
- [x] Structured code review (`$autoreview`) clean
- [ ] Visual check in-app: idle thin line visible (music + YouTube), hover expands to full-width scrubber, drag seeks, timestamps update live
- [ ] Confirm info sits clear of the progress line and the line is easily visible
- [ ] Live stream still shows the LIVE indicator; YouTube seek disabled during ads