### PR TITLE
Expose .agents/skills to Claude Code via .claude/skills symlink

### DIFF
--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills


### PR DESCRIPTION
## Summary
- Add a relative symlink `.claude/skills -> ../.agents/skills` so the repo's existing skills are discoverable by Claude Code (which looks under `.claude/skills/`), without duplicating or moving any files.
- Non-destructive: all skills continue to live in `.agents/skills/` and the `.agents/skills/...` paths referenced throughout `AGENTS.md`/`CLAUDE.md` remain valid.

## Notes
- Relative target keeps the link valid across clones/checkouts.
- Only the symlink is committed. Local-only `.claude/` contents (`settings.local.json`, `worktrees/`, etc.) remain untracked and are intentionally excluded.

## Test plan
- [ ] `ls -la .claude/skills` resolves to `../.agents/skills`
- [ ] `ls .claude/skills/` lists: agent-transcript, api-exploration, autoreview, dev-loop-packaging, playback-webview-debugging
- [ ] Skills appear/usable in Claude Code