### PR TITLE
Fix history not recording on Brand accounts (music + video)

### DIFF
--- a/Sources/APIExplorer/main.swift
+++ b/Sources/APIExplorer/main.swift
@@ -1817,6 +1817,11 @@ func showHelp() {
           auth                           Check authentication status
           accounts                       Discover available accounts (via authuser)
           brandaccounts                  List all brand accounts with their IDs
+          ytcfg [url]                    Probe a page's ytcfg identity (DATASYNC_ID/SESSION_INDEX)
+          signin-probe <brandId> [N] [next]
+                                         Read-only: follow a synthesized brand /signin and report
+                                         whether the session identity flips (issue #277)
+          signin-probe-real [next]       Read-only: follow the server-issued brand signin URL
           help                           Show this help message
 
         Options:

--- a/Sources/APIExplorer/main.swift
+++ b/Sources/APIExplorer/main.swift
@@ -1158,7 +1158,7 @@ func probeSigninSwitch(brandId: String, authUserIndex: Int, nextURLString: Strin
     print("================================================================\n")
 
     guard let nextURL = URL(string: nextURLString) else {
-        print("❌ Invalid next URL: \(nextURLString)")
+        print("❌ Invalid next URL: [redacted]")
         return
     }
     guard isAllowedYtcfgProbeURL(nextURL) else {
@@ -1246,7 +1246,7 @@ func probeSigninSwitchReal(nextURLString: String) async {
     print("======================================================================\n")
 
     guard let nextURL = URL(string: nextURLString) else {
-        print("❌ Invalid next URL: \(nextURLString)")
+        print("❌ Invalid next URL: [redacted]")
         return
     }
     guard isAllowedYtcfgProbeURL(nextURL) else {
@@ -1390,7 +1390,7 @@ func extractBrandSigninURL(from data: [String: Any]) -> (String?, String?) {
 func probeYtcfg(pageURLString: String?, verbose: Bool) async {
     let target = pageURLString ?? "\(activeOrigin)/"
     guard let url = URL(string: target) else {
-        print("❌ Invalid URL: \(target)")
+        print("❌ Invalid URL: [redacted]")
         return
     }
     guard isAllowedYtcfgProbeURL(url) else {

--- a/Sources/APIExplorer/main.swift
+++ b/Sources/APIExplorer/main.swift
@@ -272,8 +272,14 @@ func buildContext(brandAccountId: String? = nil) -> [String: Any] {
         "lockedSafetyMode": false,
     ]
 
-    // Add brand account ID if specified
-    if let brandId = brandAccountId ?? globalBrandAccountId {
+    // Add brand account ID if specified.
+    // Diagnostic decoupling: set KASET_PROBE_NO_OBOU=1 to omit the body
+    // `onBehalfOfUser` field so brand identity can be probed via the
+    // `X-Goog-PageId` header ALONE (matching yt-dlp's header-only wire format),
+    // isolating whether body-identity is what playback endpoints reject.
+    if let brandId = brandAccountId ?? globalBrandAccountId,
+       ProcessInfo.processInfo.environment["KASET_PROBE_NO_OBOU"] != "1"
+    {
         userDict["onBehalfOfUser"] = brandId
     }
 
@@ -311,6 +317,14 @@ func buildHeaders(authenticated: Bool = false, authUserIndex: Int? = nil) -> [St
             headers["Authorization"] = "SAPISIDHASH \(sapisidhash)"
             headers["X-Goog-AuthUser"] = "\(authUserIndex ?? globalAuthUserIndex)"
             headers["X-Origin"] = activeOrigin
+            // Brand/delegated channel selection on the wire: real-world clients
+            // (yt-dlp, YouTube.js, playlet) send the brand pageId as an
+            // `X-Goog-PageId` header in addition to `context.user.onBehalfOfUser`.
+            // Some endpoints (notably `player`) reject body-only brand identity, so
+            // expose the header here to probe brand attribution accurately.
+            if let brandId = globalBrandAccountId {
+                headers["X-Goog-PageId"] = brandId
+            }
         }
     }
 
@@ -1132,6 +1146,316 @@ private func fetchAccountInfo(authUserIndex: Int, verbose: Bool) async -> (
 
 // MARK: - Brand Account Discovery
 
+/// Read-only mechanism pre-check for issue #277 (brand history recording).
+/// Follows the brand signin redirect on an EPHEMERAL `URLSession` seeded from
+/// the app cookies (the on-disk `cookies.dat` is never modified), then reads the
+/// landed page's `DATASYNC_ID`. A first-half that flips to `brandId` proves the
+/// signin navigation re-points the session identity at the HTTP/cookie level.
+/// Emits no `videostats` pings (no JS), so it cannot prove the history write —
+/// that requires the live WebView (Stage 2). Mutates nothing in the app.
+func probeSigninSwitch(brandId: String, authUserIndex: Int, nextURLString: String) async {
+    print("🔀 signin session-switch pre-check (read-only, ephemeral session)")
+    print("================================================================\n")
+
+    guard let cookies = loadCookiesFromAppBackup(), !cookies.isEmpty else {
+        print("❌ No app cookies found. Sign in to Kaset first.")
+        return
+    }
+    guard let nextURL = URL(string: nextURLString) else {
+        print("❌ Invalid next URL: \(nextURLString)")
+        return
+    }
+
+    // Build YouTube's own channel-switch endpoint: /signin?...&pageid=<brand>.
+    var components = URLComponents(string: "\(activeOrigin)/signin")
+    components?.queryItems = [
+        URLQueryItem(name: "action_handle_signin", value: "true"),
+        URLQueryItem(name: "pageid", value: brandId),
+        URLQueryItem(name: "authuser", value: "\(authUserIndex)"),
+        URLQueryItem(name: "feature", value: "playlist"),
+        URLQueryItem(name: "next", value: nextURL.absoluteString),
+    ]
+    guard let signinURL = components?.url else {
+        print("❌ Could not build signin URL")
+        return
+    }
+    print("Switch endpoint: \(activeOrigin)/signin?...&pageid=\(brandId)&authuser=\(authUserIndex)")
+    print("next: \(nextURL.absoluteString)\n")
+
+    // Ephemeral session: cookies live only in memory for this probe and are
+    // discarded on exit; the app's Keychain/cookies.dat are never written.
+    let config = URLSessionConfiguration.ephemeral
+    let store = HTTPCookieStorage()
+    for cookie in cookies {
+        store.setCookie(cookie)
+    }
+    config.httpCookieStorage = store
+    config.httpShouldSetCookies = true
+    config.httpCookieAcceptPolicy = .always
+    let session = URLSession(configuration: config)
+
+    var request = URLRequest(url: signinURL)
+    request.setValue(
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
+        forHTTPHeaderField: "User-Agent"
+    )
+
+    do {
+        let (data, response) = try await session.data(for: request)
+        let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+        let landedURL = response.url?.absoluteString ?? "(unknown)"
+        guard let html = String(data: data, encoding: .utf8) else {
+            print("❌ HTTP \(status) — could not decode landed page")
+            return
+        }
+        // Report only host+path of the landing URL (query may carry tokens).
+        let landedHostPath = URL(string: landedURL).map { ($0.host ?? "") + $0.path } ?? landedURL
+        print("✅ HTTP \(status), landed on \(landedHostPath), \(data.count) bytes\n")
+
+        let dataSyncId = extractConfigValue(named: "DATASYNC_ID", from: html)
+        guard let ds = dataSyncId else {
+            print("DATASYNC_ID: (absent) — likely a consent/login interstitial, not a watch/home page.")
+            print("→ INCONCLUSIVE. The live WebView (Stage 2) is the authority; URLSession can hit challenge pages a browser would not.")
+            return
+        }
+        let firstHalf = ds.components(separatedBy: "||").first ?? ""
+        let flipped = firstHalf == brandId
+        print("DATASYNC_ID first half: \(firstHalf.isEmpty ? "(empty → primary)" : "<\(firstHalf.count) chars>")")
+        if flipped {
+            print("→ ✅ FLIPPED to brand: the signin navigation re-points session identity at the cookie level.")
+            print("   (History WRITE still requires the live WebView's videostats pings — verify in Stage 2.)")
+        } else {
+            print("→ ❌ NOT flipped (still primary). Either URLSession hit an interstitial, or the switch needs the JS/browser context.")
+            print("   This is INFORMATIVE, not disqualifying — Stage 2 (live WebView) is authoritative.")
+        }
+    } catch {
+        print("❌ Error: \(error.localizedDescription)")
+        print("→ INCONCLUSIVE; defer to Stage 2 live-WebView test.")
+    }
+}
+
+/// Most-faithful read-only variant of `probeSigninSwitch`: follows the EXACT
+/// server-issued `accountSigninToken.signinUrl` (preserving every param), only
+/// rewriting `next`. Ephemeral session; mutates nothing.
+func probeSigninSwitchReal(nextURLString: String) async {
+    print("🔀 signin session-switch pre-check — REAL server-issued URL (read-only)")
+    print("======================================================================\n")
+
+    guard let cookies = loadCookiesFromAppBackup(), !cookies.isEmpty else {
+        print("❌ No app cookies found. Sign in to Kaset first.")
+        return
+    }
+    guard let nextURL = URL(string: nextURLString) else {
+        print("❌ Invalid next URL: \(nextURLString)")
+        return
+    }
+
+    // Fetch accounts_list and extract the brand's real signinUrl + pageId.
+    var signinURLString: String?
+    var brandId: String?
+    do {
+        let (data, status) = try await makeRequest(
+            endpoint: "account/accounts_list", body: [:], authenticated: true
+        )
+        guard status == 200 else {
+            print("❌ accounts_list HTTP \(status)")
+            return
+        }
+        (signinURLString, brandId) = extractBrandSigninURL(from: data)
+    } catch {
+        print("❌ accounts_list error: \(error.localizedDescription)")
+        return
+    }
+
+    guard var signin = signinURLString, let brand = brandId else {
+        print("❌ No brand accountSigninToken.signinUrl found (single-account login?).")
+        return
+    }
+    // Normalize protocol-relative URLs.
+    if signin.hasPrefix("//") { signin = "https:" + signin }
+    else if signin.hasPrefix("/") { signin = "https://www.youtube.com" + signin }
+
+    // Rewrite only the `next` param.
+    guard var comps = URLComponents(string: signin) else {
+        print("❌ Could not parse signinUrl")
+        return
+    }
+    var items = (comps.queryItems ?? []).filter { $0.name != "next" }
+    items.append(URLQueryItem(name: "next", value: nextURL.absoluteString))
+    comps.queryItems = items
+    guard let finalURL = comps.url else {
+        print("❌ Could not rebuild signin URL")
+        return
+    }
+    print("Using server-issued /signin (params: \(items.map(\.name).sorted().joined(separator: ", ")))")
+    print("brand pageId: \(brand)")
+    print("next: \(nextURL.absoluteString)\n")
+
+    let config = URLSessionConfiguration.ephemeral
+    let store = HTTPCookieStorage()
+    for cookie in cookies {
+        store.setCookie(cookie)
+    }
+    config.httpCookieStorage = store
+    config.httpShouldSetCookies = true
+    config.httpCookieAcceptPolicy = .always
+    let session = URLSession(configuration: config)
+
+    var request = URLRequest(url: finalURL)
+    request.setValue(
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
+        forHTTPHeaderField: "User-Agent"
+    )
+
+    do {
+        let (data, response) = try await session.data(for: request)
+        let httpStatus = (response as? HTTPURLResponse)?.statusCode ?? -1
+        let landed = response.url.map { ($0.host ?? "") + $0.path } ?? "(unknown)"
+        guard let html = String(data: data, encoding: .utf8) else {
+            print("❌ HTTP \(httpStatus) — could not decode landed page")
+            return
+        }
+        print("✅ HTTP \(httpStatus), landed on \(landed), \(data.count) bytes\n")
+        guard let ds = extractConfigValue(named: "DATASYNC_ID", from: html) else {
+            print("DATASYNC_ID: (absent) — interstitial/challenge page. INCONCLUSIVE; Stage 2 (live WebView) is authoritative.")
+            return
+        }
+        let firstHalf = ds.components(separatedBy: "||").first ?? ""
+        if firstHalf == brand {
+            print("DATASYNC_ID first half == brand pageId → ✅ FLIPPED at the cookie level.")
+            print("   (History WRITE still requires the live WebView's videostats pings — Stage 2.)")
+        } else {
+            print("DATASYNC_ID first half: \(firstHalf.isEmpty ? "(empty → primary)" : "<\(firstHalf.count) chars>") → ❌ not flipped.")
+            print("   INFORMATIVE, not disqualifying — URLSession can't run the JS the switch may rely on; Stage 2 decides.")
+        }
+    } catch {
+        print("❌ Error: \(error.localizedDescription) — INCONCLUSIVE; defer to Stage 2.")
+    }
+}
+
+/// Walks an accounts_list response for the first brand account's
+/// `accountSigninToken.signinUrl` and `pageIdToken.pageId`. Read-only.
+func extractBrandSigninURL(from data: [String: Any]) -> (String?, String?) {
+    var foundSignin: String?
+    var foundPageId: String?
+    func walk(_ node: Any) {
+        if let dict = node as? [String: Any] {
+            if let tokens = (dict["selectActiveIdentityEndpoint"] as? [String: Any])?["supportedTokens"] as? [[String: Any]] {
+                var sgn: String?
+                var pid: String?
+                for token in tokens {
+                    if let signinToken = token["accountSigninToken"] as? [String: Any],
+                       let url = signinToken["signinUrl"] as? String
+                    {
+                        sgn = url
+                    }
+                    if let pageToken = token["pageIdToken"] as? [String: Any],
+                       let pageId = pageToken["pageId"] as? String
+                    {
+                        pid = pageId
+                    }
+                }
+                // Only the brand entry has a pageIdToken; prefer that one.
+                if let pid, let sgn, foundPageId == nil {
+                    foundPageId = pid
+                    foundSignin = sgn
+                }
+            }
+            for value in dict.values {
+                walk(value)
+            }
+        } else if let array = node as? [Any] {
+            for value in array {
+                walk(value)
+            }
+        }
+    }
+    walk(data)
+    return (foundSignin, foundPageId)
+}
+
+/// Read-only identity probe. Fetches an authenticated page (with the app's
+/// cookies) and reports the session-identity markers embedded in its ytcfg:
+/// `DATASYNC_ID` ("<delegatedSessionId>||<userSessionId>"), the derived
+/// delegated session id, and `SESSION_INDEX`. Used to verify which account a
+/// WebView session would record history to, without mutating anything.
+func probeYtcfg(pageURLString: String?, verbose: Bool) async {
+    let target = pageURLString ?? "\(activeOrigin)/"
+    guard let url = URL(string: target) else {
+        print("❌ Invalid URL: \(target)")
+        return
+    }
+
+    print("🔬 ytcfg identity probe")
+    print("=======================\n")
+    print("GET \(url.absoluteString)")
+    if let brandId = globalBrandAccountId {
+        print("(brand override active: X-Goog-PageId / onBehalfOfUser = \(brandId))")
+    }
+    print("")
+
+    var request = URLRequest(url: url)
+    request.setValue(
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
+        forHTTPHeaderField: "User-Agent"
+    )
+    if let cookies = loadCookiesFromAppBackup(), let cookieHeader = buildCookieHeader(from: cookies) {
+        request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
+    } else {
+        print("⚠️  No app cookies found — probing as a signed-out session.\n")
+    }
+
+    do {
+        let (data, response) = try await URLSession.shared.data(for: request)
+        let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+        guard let html = String(data: data, encoding: .utf8) else {
+            print("❌ HTTP \(status) — could not decode page body")
+            return
+        }
+        print("✅ HTTP \(status), \(data.count) bytes\n")
+
+        let dataSyncId = extractConfigValue(named: "DATASYNC_ID", from: html)
+        let delegated = extractConfigValue(named: "DELEGATED_SESSION_ID", from: html)
+        let sessionIndex = extractConfigValue(named: "SESSION_INDEX", from: html)
+        let loggedIn = extractConfigValue(named: "LOGGED_IN", from: html)
+
+        func redact(_ value: String?) -> String {
+            guard let value, !value.isEmpty else { return "(absent/empty)" }
+            // Report shape, not the raw token, to avoid leaking identity secrets.
+            if let pipe = value.range(of: "||") {
+                let first = String(value[value.startIndex ..< pipe.lowerBound])
+                let second = String(value[pipe.upperBound...])
+                let firstDesc = first.isEmpty ? "(empty)" : "<\(first.count) chars>"
+                let secondDesc = second.isEmpty ? "(empty)" : "<\(second.count) chars>"
+                return "\(firstDesc)||\(secondDesc)"
+            }
+            return "<\(value.count) chars>"
+        }
+
+        print("DATASYNC_ID:           \(redact(dataSyncId))")
+        if let brandId = globalBrandAccountId, let ds = dataSyncId,
+           let pipe = ds.range(of: "||")
+        {
+            let first = String(ds[ds.startIndex ..< pipe.lowerBound])
+            let matches = first == brandId
+            print("  → first half == requested brand pageId? \(matches ? "✅ YES (brand session)" : "❌ NO (still primary)")")
+        }
+        print("DELEGATED_SESSION_ID:  \(redact(delegated))")
+        print("SESSION_INDEX:         \(sessionIndex ?? "(absent)")")
+        print("LOGGED_IN:             \(loggedIn ?? "(absent)")")
+
+        if verbose {
+            for name in ["DATASYNC_ID", "DELEGATED_SESSION_ID", "SESSION_INDEX"] {
+                if extractConfigValue(named: name, from: html) == nil {
+                    print("  (note: \(name) not found in page ytcfg)")
+                }
+            }
+        }
+    } catch {
+        print("❌ Error: \(error.localizedDescription)")
+    }
+}
+
 /// Discovers all brand accounts using the account/accounts_list endpoint
 func discoverBrandAccounts(verbose: Bool) async {
     print("🔍 Discovering Brand Accounts")
@@ -1657,6 +1981,44 @@ func runMain() async {
 
     case "brandaccounts":
         await discoverBrandAccounts(verbose: verbose)
+
+    case "ytcfg":
+        // Read-only identity probe: GET an authenticated page and report which
+        // account the resulting session is acting as. DATASYNC_ID has the
+        // canonical "<delegatedSessionId>||<userSessionId>" shape — a brand
+        // session shows the brand pageId in the first half; primary shows an
+        // empty first half. This is how we confirm whether a session-identity
+        // switch (e.g. navigating signin?pageid=<brandId>) actually re-points
+        // playback (and therefore history recording) to the brand.
+        let pageArg: String? = filteredArgs.count >= 2 ? filteredArgs[1] : nil
+        await probeYtcfg(pageURLString: pageArg, verbose: verbose)
+
+    case "signin-probe":
+        // Read-only mechanism pre-check for issue #277. Follows the brand
+        // `/signin?...&pageid=<brandId>&authuser=<N>&next=<watchURL>` redirect
+        // chain on an EPHEMERAL URLSession seeded from (never writing back) the
+        // app cookies, then reads the landed page's ytcfg DATASYNC_ID. If the
+        // first half flips to the brand pageId, the signin navigation re-points
+        // the session identity at the HTTP/cookie level. This emits NO videostats
+        // pings (no JS), so it cannot prove the history WRITE — only the identity
+        // flip. It does NOT mutate the app's WebView session or cookies.dat.
+        guard filteredArgs.count >= 2 else {
+            print("❌ Usage: signin-probe <brandId> [authuserIndex] [nextWatchURL]")
+            return
+        }
+        let brandId = filteredArgs[1]
+        let authIndex = filteredArgs.count >= 3 ? (Int(filteredArgs[2]) ?? 0) : 0
+        let nextURL = filteredArgs.count >= 4 ? filteredArgs[3] : "\(activeOrigin)/"
+        await probeSigninSwitch(brandId: brandId, authUserIndex: authIndex, nextURLString: nextURL)
+
+    case "signin-probe-real":
+        // Like `signin-probe`, but follows the EXACT server-issued
+        // `accountSigninToken.signinUrl` from accounts_list (with all its
+        // params: skip_identity_prompt, feature, action_handle_signin), rewriting
+        // only `next`. This is the most faithful read-only reproduction of the
+        // switch a browser would perform. Still ephemeral; mutates nothing.
+        let realNext = filteredArgs.count >= 2 ? filteredArgs[1] : "\(activeOrigin)/"
+        await probeSigninSwitchReal(nextURLString: realNext)
 
     case "help", "-h", "--help":
         showHelp()

--- a/Sources/APIExplorer/main.swift
+++ b/Sources/APIExplorer/main.swift
@@ -1157,12 +1157,16 @@ func probeSigninSwitch(brandId: String, authUserIndex: Int, nextURLString: Strin
     print("🔀 signin session-switch pre-check (read-only, ephemeral session)")
     print("================================================================\n")
 
-    guard let cookies = loadCookiesFromAppBackup(), !cookies.isEmpty else {
-        print("❌ No app cookies found. Sign in to Kaset first.")
-        return
-    }
     guard let nextURL = URL(string: nextURLString) else {
         print("❌ Invalid next URL: \(nextURLString)")
+        return
+    }
+    guard isAllowedYtcfgProbeURL(nextURL) else {
+        print("❌ signin probe next URL must be an HTTPS YouTube page (music.youtube.com or www.youtube.com).")
+        return
+    }
+    guard let cookies = loadCookiesFromAppBackup(), !cookies.isEmpty else {
+        print("❌ No app cookies found. Sign in to Kaset first.")
         return
     }
 
@@ -1241,12 +1245,16 @@ func probeSigninSwitchReal(nextURLString: String) async {
     print("🔀 signin session-switch pre-check — REAL server-issued URL (read-only)")
     print("======================================================================\n")
 
-    guard let cookies = loadCookiesFromAppBackup(), !cookies.isEmpty else {
-        print("❌ No app cookies found. Sign in to Kaset first.")
-        return
-    }
     guard let nextURL = URL(string: nextURLString) else {
         print("❌ Invalid next URL: \(nextURLString)")
+        return
+    }
+    guard isAllowedYtcfgProbeURL(nextURL) else {
+        print("❌ signin probe next URL must be an HTTPS YouTube page (music.youtube.com or www.youtube.com).")
+        return
+    }
+    guard let cookies = loadCookiesFromAppBackup(), !cookies.isEmpty else {
+        print("❌ No app cookies found. Sign in to Kaset first.")
         return
     }
 
@@ -1374,7 +1382,7 @@ func extractBrandSigninURL(from data: [String: Any]) -> (String?, String?) {
     return (foundSignin, foundPageId)
 }
 
-/// Read-only identity probe. Fetches an authenticated page (with the app's
+/// Read-only identity probe. Fetches an HTTPS YouTube page (with the app's
 /// cookies) and reports the session-identity markers embedded in its ytcfg:
 /// `DATASYNC_ID` ("<delegatedSessionId>||<userSessionId>"), the derived
 /// delegated session id, and `SESSION_INDEX`. Used to verify which account a
@@ -1383,6 +1391,10 @@ func probeYtcfg(pageURLString: String?, verbose: Bool) async {
     let target = pageURLString ?? "\(activeOrigin)/"
     guard let url = URL(string: target) else {
         print("❌ Invalid URL: \(target)")
+        return
+    }
+    guard isAllowedYtcfgProbeURL(url) else {
+        print("❌ ytcfg probe URL must be an HTTPS YouTube page (music.youtube.com or www.youtube.com).")
         return
     }
 
@@ -1398,19 +1410,28 @@ func probeYtcfg(pageURLString: String?, verbose: Bool) async {
     }
     print("")
 
+    let config = URLSessionConfiguration.ephemeral
+    if let cookies = loadCookiesFromAppBackup(), !cookies.isEmpty {
+        let store = HTTPCookieStorage()
+        for cookie in cookies {
+            store.setCookie(cookie)
+        }
+        config.httpCookieStorage = store
+        config.httpShouldSetCookies = true
+        config.httpCookieAcceptPolicy = .always
+    } else {
+        print("⚠️  No app cookies found — probing as a signed-out session.\n")
+    }
+    let session = URLSession(configuration: config)
+
     var request = URLRequest(url: url)
     request.setValue(
         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
         forHTTPHeaderField: "User-Agent"
     )
-    if let cookies = loadCookiesFromAppBackup(), let cookieHeader = buildCookieHeader(from: cookies) {
-        request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
-    } else {
-        print("⚠️  No app cookies found — probing as a signed-out session.\n")
-    }
 
     do {
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await session.data(for: request)
         let status = (response as? HTTPURLResponse)?.statusCode ?? -1
         guard let html = String(data: data, encoding: .utf8) else {
             print("❌ HTTP \(status) — could not decode page body")
@@ -1458,6 +1479,15 @@ func probeYtcfg(pageURLString: String?, verbose: Bool) async {
     } catch {
         print("❌ Error: \(error.localizedDescription)")
     }
+}
+
+func isAllowedYtcfgProbeURL(_ url: URL) -> Bool {
+    guard url.scheme?.lowercased() == "https",
+          let host = url.host?.lowercased()
+    else {
+        return false
+    }
+    return host == "music.youtube.com" || host == "www.youtube.com"
 }
 
 /// Discovers all brand accounts using the account/accounts_list endpoint
@@ -1821,7 +1851,8 @@ func showHelp() {
           auth                           Check authentication status
           accounts                       Discover available accounts (via authuser)
           brandaccounts                  List all brand accounts with their IDs
-          ytcfg [url]                    Probe a page's ytcfg identity (DATASYNC_ID/SESSION_INDEX)
+          ytcfg [url]                    Probe an HTTPS YouTube page's ytcfg identity
+                                         (DATASYNC_ID/SESSION_INDEX)
           signin-probe <brandId> [N] [next]
                                          Read-only: follow a synthesized brand /signin and report
                                          whether the session identity flips (issue #277)

--- a/Sources/APIExplorer/main.swift
+++ b/Sources/APIExplorer/main.swift
@@ -1180,7 +1180,7 @@ func probeSigninSwitch(brandId: String, authUserIndex: Int, nextURLString: Strin
         return
     }
     print("Switch endpoint: \(activeOrigin)/signin?...&pageid=\(brandId)&authuser=\(authUserIndex)")
-    print("next: \(nextURL.absoluteString)\n")
+    print("next: \((nextURL.host.map { $0 + nextURL.path }) ?? nextURL.path)\(nextURL.query != nil ? " [query redacted]" : "")\n")
 
     // Ephemeral session: cookies live only in memory for this probe and are
     // discarded on exit; the app's Keychain/cookies.dat are never written.
@@ -1289,7 +1289,7 @@ func probeSigninSwitchReal(nextURLString: String) async {
     }
     print("Using server-issued /signin (params: \(items.map(\.name).sorted().joined(separator: ", ")))")
     print("brand pageId: \(brand)")
-    print("next: \(nextURL.absoluteString)\n")
+    print("next: \((nextURL.host.map { $0 + nextURL.path }) ?? nextURL.path)\(nextURL.query != nil ? " [query redacted]" : "")\n")
 
     let config = URLSessionConfiguration.ephemeral
     let store = HTTPCookieStorage()
@@ -1388,7 +1388,11 @@ func probeYtcfg(pageURLString: String?, verbose: Bool) async {
 
     print("🔬 ytcfg identity probe")
     print("=======================\n")
-    print("GET \(url.absoluteString)")
+    // Print only host+path, never the query string: a probed /signin (or other
+    // auth-bearing) URL can carry credential-bearing query items, and the repo's
+    // no-secrets rule forbids writing those to terminal logs.
+    let safeTarget = (url.host.map { $0 + url.path }) ?? url.path
+    print("GET \(safeTarget)\(url.query != nil ? " [query redacted]" : "")")
     if let brandId = globalBrandAccountId {
         print("(brand override active: X-Goog-PageId / onBehalfOfUser = \(brandId))")
     }

--- a/Sources/APIExplorer/main.swift
+++ b/Sources/APIExplorer/main.swift
@@ -2027,7 +2027,7 @@ func runMain() async {
         // account the resulting session is acting as. DATASYNC_ID has the
         // canonical "<delegatedSessionId>||<userSessionId>" shape — a brand
         // session shows the brand pageId in the first half; primary shows an
-        // empty first half. This is how we confirm whether a session-identity
+        // empty second half. This is how we confirm whether a session-identity
         // switch (e.g. navigating signin?pageid=<brandId>) actually re-points
         // playback (and therefore history recording) to the brand.
         let pageArg: String? = filteredArgs.count >= 2 ? filteredArgs[1] : nil

--- a/Sources/Kaset/KasetApp.swift
+++ b/Sources/Kaset/KasetApp.swift
@@ -87,7 +87,7 @@ struct KasetApp: App {
         PlayerService.shared = player
 
         // Create account service
-        let account = AccountService(ytMusicClient: client, authService: auth)
+        let account = AccountService(ytMusicClient: client, authService: auth, webKitManager: webkit)
 
         // Wire up brand account provider so API requests use the correct account
         realClient.brandIdProvider = { [weak account] in

--- a/Sources/Kaset/KasetApp.swift
+++ b/Sources/Kaset/KasetApp.swift
@@ -269,6 +269,7 @@ struct KasetApp: App {
             SettingsView()
                 .environment(\.locale, self.settings.contentLanguage.locale)
                 .environment(self.authService)
+                .environment(self.accountService)
                 .environment(self.updaterService)
                 .environment(self.scrobblingCoordinator)
                 .environment(self.equalizerService)

--- a/Sources/Kaset/Models/UserAccount.swift
+++ b/Sources/Kaset/Models/UserAccount.swift
@@ -33,6 +33,17 @@ public struct UserAccount: Identifiable, Equatable, Sendable, Hashable {
     /// Brand account identifier, nil for primary accounts.
     public let brandId: String?
 
+    /// Server-issued account-switch endpoint for this identity.
+    ///
+    /// From `serviceEndpoint.selectActiveIdentityEndpoint.supportedTokens[]
+    /// .accountSigninToken.signinUrl`. Navigating a shared-cookie WebView to this
+    /// URL re-points the active delegated identity for the session (and therefore
+    /// which account playback history records to). Brand accounts carry a
+    /// `pageid` in this URL; the primary's URL omits it.
+    ///
+    /// Credential-bearing: never log the raw value.
+    public let signinURL: URL?
+
     /// URL for the account's profile photo thumbnail.
     public let thumbnailURL: URL?
 
@@ -72,13 +83,15 @@ public struct UserAccount: Identifiable, Equatable, Sendable, Hashable {
     ///   - brandId: Brand account identifier (nil for primary).
     ///   - thumbnailURL: URL for the profile photo.
     ///   - isSelected: Whether the account is currently active.
+    ///   - signinURL: Server-issued account-switch endpoint (nil if unavailable).
     public init(
         id: String,
         name: String,
         handle: String?,
         brandId: String?,
         thumbnailURL: URL?,
-        isSelected: Bool
+        isSelected: Bool,
+        signinURL: URL? = nil
     ) {
         self.id = id
         self.name = name
@@ -86,6 +99,7 @@ public struct UserAccount: Identifiable, Equatable, Sendable, Hashable {
         self.brandId = brandId
         self.thumbnailURL = thumbnailURL
         self.isSelected = isSelected
+        self.signinURL = signinURL
     }
 
     // MARK: - Factory Methods
@@ -101,13 +115,15 @@ public struct UserAccount: Identifiable, Equatable, Sendable, Hashable {
     ///   - brandId: Brand ID from `pageIdToken.pageId`, nil for primary account.
     ///   - thumbnailURL: Thumbnail URL from `accountPhoto.thumbnails[0].url`.
     ///   - isSelected: Selection state from `isSelected`.
+    ///   - signinURL: Switch URL from `accountSigninToken.signinUrl`.
     /// - Returns: A configured UserAccount instance.
     public static func from(
         name: String,
         handle: String?,
         brandId: String?,
         thumbnailURL: URL?,
-        isSelected: Bool
+        isSelected: Bool,
+        signinURL: URL? = nil
     ) -> UserAccount {
         let accountId = brandId ?? "primary"
         return UserAccount(
@@ -116,7 +132,8 @@ public struct UserAccount: Identifiable, Equatable, Sendable, Hashable {
             handle: handle,
             brandId: brandId,
             thumbnailURL: thumbnailURL,
-            isSelected: isSelected
+            isSelected: isSelected,
+            signinURL: signinURL
         )
     }
 }

--- a/Sources/Kaset/Models/UserAccount.swift
+++ b/Sources/Kaset/Models/UserAccount.swift
@@ -136,4 +136,15 @@ public struct UserAccount: Identifiable, Equatable, Sendable, Hashable {
             signinURL: signinURL
         )
     }
+
+    public static func == (lhs: UserAccount, rhs: UserAccount) -> Bool {
+        lhs.id == rhs.id && lhs.name == rhs.name && lhs.handle == rhs.handle && lhs.brandId == rhs.brandId
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(self.id)
+        hasher.combine(self.name)
+        hasher.combine(self.handle)
+        hasher.combine(self.brandId)
+    }
 }

--- a/Sources/Kaset/Services/API/Parsers/AccountsListParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/AccountsListParser.swift
@@ -119,38 +119,71 @@ enum AccountsListParser {
         // Extract isSelected (defaults to false)
         let isSelected = accountItem["isSelected"] as? Bool ?? false
 
-        // Extract brandId from pageIdToken (nil for primary accounts)
-        let brandId = Self.extractBrandId(from: accountItem)
+        // Extract identity tokens (brandId + server-issued switch URL) in one pass.
+        let identity = Self.extractIdentityTokens(from: accountItem)
 
         return UserAccount.from(
             name: name,
             handle: handle,
-            brandId: brandId,
+            brandId: identity.brandId,
             thumbnailURL: thumbnailURL,
-            isSelected: isSelected
+            isSelected: isSelected,
+            signinURL: identity.signinURL
         )
     }
 
-    /// Extracts the brand ID from the service endpoint's supported tokens.
+    /// Extracts identity material from `selectActiveIdentityEndpoint.supportedTokens`.
     ///
-    /// Primary accounts don't have a pageIdToken, so this returns nil for them.
-    private static func extractBrandId(from accountItem: [String: Any]) -> String? {
+    /// - `brandId`: from `pageIdToken.pageId` (nil for the primary account, which
+    ///   has no `pageIdToken`).
+    /// - `signinURL`: from `accountSigninToken.signinUrl` — the server-issued
+    ///   account-switch endpoint. Navigating a shared-cookie WebView to it
+    ///   re-points the session's active delegated identity. Present for both
+    ///   primary and brand accounts (the brand variant encodes a `pageid`).
+    private static func extractIdentityTokens(
+        from accountItem: [String: Any]
+    ) -> (brandId: String?, signinURL: URL?) {
         guard let serviceEndpoint = accountItem["serviceEndpoint"] as? [String: Any],
-              let selectActiveIdentityEndpoint = serviceEndpoint["selectActiveIdentityEndpoint"] as? [String: Any],
-              let supportedTokens = selectActiveIdentityEndpoint["supportedTokens"] as? [[String: Any]]
+              let activeIdentity = serviceEndpoint["selectActiveIdentityEndpoint"] as? [String: Any],
+              let entries = activeIdentity["supportedTokens"] as? [[String: Any]]
         else {
-            return nil
+            return (nil, nil)
         }
 
-        // Look for pageIdToken in supported tokens
-        for token in supportedTokens {
-            if let pageIdToken = token["pageIdToken"] as? [String: Any],
+        var brandId: String?
+        var signinURL: URL?
+        for entry in entries {
+            if brandId == nil,
+               let pageIdToken = entry["pageIdToken"] as? [String: Any],
                let pageId = pageIdToken["pageId"] as? String
             {
-                return pageId
+                brandId = pageId
+            }
+            if signinURL == nil,
+               let signinToken = entry["accountSigninToken"] as? [String: Any],
+               let urlString = signinToken["signinUrl"] as? String
+            {
+                signinURL = Self.resolveSigninURL(urlString)
             }
         }
+        return (brandId, signinURL)
+    }
 
-        return nil
+    /// Resolves an `accountSigninToken.signinUrl` into an absolute URL.
+    ///
+    /// The API returns this as a root-relative path (`/signin?...`); it must be
+    /// resolved against the YouTube origin. Also handles protocol-relative and
+    /// already-absolute forms defensively.
+    static func resolveSigninURL(_ urlString: String, origin: String = "https://www.youtube.com") -> URL? {
+        if urlString.hasPrefix("http://") || urlString.hasPrefix("https://") {
+            return URL(string: urlString)
+        }
+        if urlString.hasPrefix("//") {
+            return URL(string: "https:" + urlString)
+        }
+        if urlString.hasPrefix("/") {
+            return URL(string: urlString, relativeTo: URL(string: origin))?.absoluteURL
+        }
+        return URL(string: urlString)
     }
 }

--- a/Sources/Kaset/Services/API/Parsers/AccountsListParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/AccountsListParser.swift
@@ -175,15 +175,22 @@ enum AccountsListParser {
     /// resolved against the YouTube origin. Also handles protocol-relative and
     /// already-absolute forms defensively.
     static func resolveSigninURL(_ urlString: String, origin: String = "https://www.youtube.com") -> URL? {
-        if urlString.hasPrefix("http://") || urlString.hasPrefix("https://") {
-            return URL(string: urlString)
+        let resolvedURL: URL? = if urlString.hasPrefix("http://") || urlString.hasPrefix("https://") {
+            URL(string: urlString)
+        } else if urlString.hasPrefix("//") {
+            URL(string: "https:" + urlString)
+        } else if urlString.hasPrefix("/") {
+            URL(string: urlString, relativeTo: URL(string: origin))?.absoluteURL
+        } else {
+            URL(string: urlString)
         }
-        if urlString.hasPrefix("//") {
-            return URL(string: "https:" + urlString)
-        }
-        if urlString.hasPrefix("/") {
-            return URL(string: urlString, relativeTo: URL(string: origin))?.absoluteURL
-        }
-        return URL(string: urlString)
+        guard let resolvedURL, Self.isAllowedSigninURL(resolvedURL) else { return nil }
+        return resolvedURL
+    }
+
+    static func isAllowedSigninURL(_ url: URL) -> Bool {
+        url.scheme?.lowercased() == "https" &&
+            url.host?.lowercased() == "www.youtube.com" &&
+            url.path == "/signin"
     }
 }

--- a/Sources/Kaset/Services/Auth/AccountService.swift
+++ b/Sources/Kaset/Services/Auth/AccountService.swift
@@ -32,6 +32,12 @@ final class AccountService {
     private let ytMusicClient: any YTMusicClientProtocol
     private let authService: AuthService
 
+    /// WebKit session manager used to re-point the playback session's active
+    /// delegated identity on account switch. Optional so SwiftUI previews and
+    /// lightweight constructions can omit it; when nil, switching falls back to
+    /// local-state-only (history will not record to brand accounts).
+    private let webKitManager: (any WebKitManagerProtocol)?
+
     // MARK: - Published State
 
     /// All available accounts (primary + brand accounts).
@@ -69,6 +75,10 @@ final class AccountService {
     private let logger = DiagnosticsLogger.auth
     private let selectedBrandIdKey = "selectedBrandId"
 
+    /// Tracks the off-path restore-pin so it can be observed in tests and is not
+    /// orphaned. Replaced on each `fetchAccounts`.
+    private var brandSessionPinTask: Task<Void, Never>?
+
     // MARK: - Initialization
 
     /// Creates an AccountService with the required dependencies.
@@ -76,9 +86,16 @@ final class AccountService {
     /// - Parameters:
     ///   - ytMusicClient: Client for YouTube Music API calls.
     ///   - authService: Service for checking authentication state.
-    init(ytMusicClient: any YTMusicClientProtocol, authService: AuthService) {
+    ///   - webKitManager: WebKit session manager used to switch the playback
+    ///     session's active identity on account switch. Omit (nil) in previews.
+    init(
+        ytMusicClient: any YTMusicClientProtocol,
+        authService: AuthService,
+        webKitManager: (any WebKitManagerProtocol)? = nil
+    ) {
         self.ytMusicClient = ytMusicClient
         self.authService = authService
+        self.webKitManager = webKitManager
     }
 
     // MARK: - Public Methods
@@ -128,12 +145,53 @@ final class AccountService {
 
             let currentLabel = self.currentAccount?.brandId ?? "primary"
             self.logger.info("AccountService: Fetched \(self.accounts.count) accounts, current: \(self.currentAccount?.name ?? "none") (brandId=\(currentLabel))")
+
+            // Re-establish the WebView session identity for a restored brand
+            // account. Without this, a relaunch leaves native reads brand-aware
+            // while the playback session is still primary, so playback would
+            // record history to the primary account (the issue-#277 bug, on every
+            // cold launch). Run it OFF the fetch path (after isLoading clears) so
+            // a real ≤20s navigation never stalls launch or holds the account
+            // spinner; it is best-effort and surfaced via logs on failure.
+            self.scheduleRestoredBrandSessionPin()
         } catch {
             self.logger.error("AccountService: Failed to fetch accounts: \(error.localizedDescription)")
             self.lastError = error
             self.lastErrorWasFetch = true
             self.errorSequence += 1
         }
+    }
+
+    /// Schedules a best-effort WebView session pin for a restored brand account,
+    /// off the `fetchAccounts` path so it never blocks launch or holds
+    /// `isLoading`.
+    ///
+    /// No-op for the primary account (the default session identity) or when no
+    /// WebKit manager is injected. Verification failures are logged, not thrown.
+    private func scheduleRestoredBrandSessionPin() {
+        guard !UITestConfig.isUITestMode,
+              let webKitManager = self.webKitManager,
+              let account = self.currentAccount,
+              let brandId = account.brandId,
+              let signinURL = account.signinURL
+        else {
+            return
+        }
+
+        self.brandSessionPinTask?.cancel()
+        self.brandSessionPinTask = Task { [weak self] in
+            do {
+                try await webKitManager.switchSessionIdentity(to: signinURL, expectedBrandId: brandId)
+                self?.logger.info("AccountService: Restored brand session identity for \(account.name)")
+            } catch {
+                self?.logger.error("AccountService: Could not restore brand session identity: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    /// Awaits the in-flight restored-brand-session pin, if any. Test hook.
+    func awaitRestoredBrandSessionPinForTesting() async {
+        await self.brandSessionPinTask?.value
     }
 
     /// Switches to a different account.
@@ -155,14 +213,31 @@ final class AccountService {
         }
 
         do {
-            // Note: API call to switch server-side identity is not implemented yet.
-            // Currently we only update local state. Server-side switching can be added
-            // when the selectActiveIdentity endpoint is explored and documented.
-
             if UITestConfig.isUITestMode,
                UITestConfig.environmentValue(for: UITestConfig.mockAccountSwitchFailKey) == "true"
             {
                 throw YTMusicError.apiError(message: "Mock account switch failure", code: nil)
+            }
+
+            // Re-point the playback session's active delegated identity BEFORE
+            // committing the new account. History is recorded by the playback
+            // WebView's own stats pings, which attribute to the identity baked
+            // into the served document (ytcfg.DATASYNC_ID). Navigating the
+            // server-issued signin URL switches that identity for the shared
+            // cookie session; verifying it here means a failed/unverified switch
+            // throws into the catch block below and reverts, rather than silently
+            // recording plays to the wrong account.
+            //
+            // Skipped in UI test mode (no real WebKit session) and when no
+            // webKitManager was injected (e.g. previews).
+            if !UITestConfig.isUITestMode, let webKitManager = self.webKitManager {
+                guard let signinURL = account.signinURL else {
+                    throw SessionSwitchError.identityNotApplied(expectedBrandId: account.brandId)
+                }
+                try await webKitManager.switchSessionIdentity(
+                    to: signinURL,
+                    expectedBrandId: account.brandId
+                )
             }
 
             // Update local state

--- a/Sources/Kaset/Services/Auth/AccountService.swift
+++ b/Sources/Kaset/Services/Auth/AccountService.swift
@@ -362,6 +362,7 @@ final class AccountService {
         guard let fallback, fallback.id != account.id
         else { return }
 
+        var didVerifyFallback = false
         if let webKitManager = self.webKitManager, let fallbackSigninURL = fallback.signinURL {
             do {
                 try await self.runTrackedSessionSwitch(
@@ -369,9 +370,9 @@ final class AccountService {
                     to: fallbackSigninURL,
                     expectedBrandId: fallback.brandId
                 )
+                didVerifyFallback = true
             } catch {
                 self.logger.error("AccountService: Could not restore fallback session identity: \(error.localizedDescription)")
-                return
             }
         }
         guard self.sessionPinGeneration == pinGeneration else { return }
@@ -380,7 +381,7 @@ final class AccountService {
         self.currentAccount = fallback
         SongLikeStatusManager.shared.setActiveAccountID(fallback.id)
         UserDefaults.standard.set(fallback.id, forKey: self.selectedBrandIdKey)
-        self.markIdentityVerified(fallback.signinURL == nil ? nil : fallback.id)
+        self.markIdentityVerified(didVerifyFallback ? fallback.id : nil)
     }
 
     /// Awaits the in-flight session pin (launch restore or switch), if any.

--- a/Sources/Kaset/Services/Auth/AccountService.swift
+++ b/Sources/Kaset/Services/Auth/AccountService.swift
@@ -46,6 +46,19 @@ final class AccountService {
     /// Currently selected/active account.
     private(set) var currentAccount: UserAccount?
 
+    /// The account whose playback session identity has been *verified* (the
+    /// WebView's `ytcfg.DATASYNC_ID` confirmed to match). Distinct from
+    /// `currentAccount`, which is set the moment a switch is committed: on cold
+    /// launch the restored brand is `currentAccount` while its session pin is
+    /// still in flight. Observe `verifiedIdentitySequence` to drive work that
+    /// must run under the confirmed playback identity (e.g. re-pointing the
+    /// in-flight track/video) rather than under an unverified one.
+    private(set) var verifiedAccountId: String?
+
+    /// Bumped each time a session identity is verified (manual switch or launch
+    /// restore). A monotonically increasing trigger for `verifiedAccountId`.
+    private(set) var verifiedIdentitySequence: Int = 0
+
     /// Whether an account operation is in progress.
     private(set) var isLoading: Bool = false
 
@@ -75,9 +88,17 @@ final class AccountService {
     private let logger = DiagnosticsLogger.auth
     private let selectedBrandIdKey = "selectedBrandId"
 
-    /// Tracks the off-path restore-pin so it can be observed in tests and is not
-    /// orphaned. Replaced on each `fetchAccounts`.
-    private var brandSessionPinTask: Task<Void, Never>?
+    /// Single-flight handle for all WebView session-identity mutations (launch
+    /// restore pin and the awaited switch). Routing every session pin through one
+    /// handle lets a new switch cancel+await an in-flight one, so concurrent pins
+    /// against the shared cookie store cannot leave the session on a stale
+    /// identity. Replaced on each `fetchAccounts`/`switchAccount`.
+    private var sessionPinTask: Task<Void, Never>?
+
+    private func markIdentityVerified(_ accountId: String?) {
+        self.verifiedAccountId = accountId
+        self.verifiedIdentitySequence &+= 1
+    }
 
     // MARK: - Initialization
 
@@ -167,7 +188,9 @@ final class AccountService {
     /// `isLoading`.
     ///
     /// No-op for the primary account (the default session identity) or when no
-    /// WebKit manager is injected. Verification failures are logged, not thrown.
+    /// WebKit manager is injected. On success it bumps `verifiedIdentitySequence`
+    /// so observers re-point playback only once the brand session is confirmed.
+    /// Verification failures are logged, not thrown.
     private func scheduleRestoredBrandSessionPin() {
         guard !UITestConfig.isUITestMode,
               let webKitManager = self.webKitManager,
@@ -178,20 +201,26 @@ final class AccountService {
             return
         }
 
-        self.brandSessionPinTask?.cancel()
-        self.brandSessionPinTask = Task { [weak self] in
+        self.sessionPinTask?.cancel()
+        self.sessionPinTask = Task { [weak self] in
+            guard !Task.isCancelled else { return }
             do {
                 try await webKitManager.switchSessionIdentity(to: signinURL, expectedBrandId: brandId)
-                self?.logger.info("AccountService: Restored brand session identity for \(account.name)")
+                guard let self, !Task.isCancelled else { return }
+                self.logger.info("AccountService: Restored brand session identity for \(account.name)")
+                self.markIdentityVerified(account.id)
+            } catch is CancellationError {
+                // Superseded by a newer switch; the survivor owns the session.
             } catch {
                 self?.logger.error("AccountService: Could not restore brand session identity: \(error.localizedDescription)")
             }
         }
     }
 
-    /// Awaits the in-flight restored-brand-session pin, if any. Test hook.
+    /// Awaits the in-flight session pin (launch restore or switch), if any.
+    /// Test hook.
     func awaitRestoredBrandSessionPinForTesting() async {
-        await self.brandSessionPinTask?.value
+        await self.sessionPinTask?.value
     }
 
     /// Switches to a different account.
@@ -207,6 +236,18 @@ final class AccountService {
         let previousAccount = self.currentAccount
         self.logger.info("AccountService: Switching to account: \(account.name)")
         self.isLoading = true
+
+        // Cancel and await any in-flight session pin (e.g. a cold-launch brand
+        // restore) so its navigation cannot land AFTER this switch and re-point
+        // the shared cookie session back to a stale identity. `switchSessionIdentity`
+        // is cooperatively cancellable, so this returns promptly.
+        self.sessionPinTask?.cancel()
+        await self.sessionPinTask?.value
+        self.sessionPinTask = nil
+
+        // Tracks whether the session-mutating navigation was actually started, so
+        // the catch only rolls the session back when there is something to undo.
+        var didStartSessionSwitch = false
 
         defer {
             self.isLoading = false
@@ -234,6 +275,7 @@ final class AccountService {
                 guard let signinURL = account.signinURL else {
                     throw SessionSwitchError.identityNotApplied(expectedBrandId: account.brandId)
                 }
+                didStartSessionSwitch = true
                 try await webKitManager.switchSessionIdentity(
                     to: signinURL,
                     expectedBrandId: account.brandId
@@ -254,11 +296,39 @@ final class AccountService {
             UserDefaults.standard.set(account.id, forKey: self.selectedBrandIdKey)
             self.logger.debug("AccountService: Saved brand ID: \(account.id)")
 
+            // The session identity is now verified for this account; signal
+            // observers (e.g. MainWindow) to re-point in-flight playback.
+            self.markIdentityVerified(account.id)
+
             self.logger.info("AccountService: Successfully switched to account: \(account.name)")
         } catch {
             self.logger.error("AccountService: Failed to switch account: \(error.localizedDescription)")
             self.currentAccount = previousAccount
             SongLikeStatusManager.shared.setActiveAccountID(previousAccount?.id)
+
+            // If the /signin navigation already mutated the shared cookie session
+            // before verification failed, the session may be left on the attempted
+            // identity while native state says `previousAccount`. Best-effort
+            // re-pin the previous identity so playback records to the account the
+            // app believes is active. Skipped for throws that occurred before the
+            // navigation (UI-test mock, missing signinURL).
+            if didStartSessionSwitch,
+               !UITestConfig.isUITestMode,
+               let webKitManager = self.webKitManager,
+               let previous = previousAccount,
+               let previousSigninURL = previous.signinURL
+            {
+                do {
+                    try await webKitManager.switchSessionIdentity(
+                        to: previousSigninURL,
+                        expectedBrandId: previous.brandId
+                    )
+                    self.markIdentityVerified(previous.id)
+                } catch {
+                    self.logger.error("AccountService: Session rollback failed; session may remain on attempted identity: \(error.localizedDescription)")
+                }
+            }
+
             self.lastError = error
             self.lastErrorWasFetch = false
             self.errorSequence += 1

--- a/Sources/Kaset/Services/Auth/AccountService.swift
+++ b/Sources/Kaset/Services/Auth/AccountService.swift
@@ -242,6 +242,7 @@ final class AccountService {
         }
     }
 
+    // swiftlint:disable cyclomatic_complexity
     /// Schedules a best-effort WebView session pin for the restored account, off
     /// the `fetchAccounts` path so it never blocks launch or holds `isLoading`.
     ///
@@ -286,7 +287,12 @@ final class AccountService {
             return
         }
         guard let signinURL = account.signinURL else {
-            guard account.brandId != nil else { return }
+            guard account.brandId != nil else {
+                if self.verifiedAccountId != account.id {
+                    self.markIdentityVerified(nil)
+                }
+                return
+            }
             self.sessionPinGeneration &+= 1
             let pinGeneration = self.sessionPinGeneration
             let error = SessionSwitchError.identityNotApplied(expectedBrandId: account.brandId)
@@ -349,6 +355,8 @@ final class AccountService {
             }
         }
     }
+
+    // swiftlint:enable cyclomatic_complexity
 
     private func handleRestoredSessionPinFailure(for account: UserAccount, error: Error, pinGeneration: Int) async {
         guard self.currentAccount?.id == account.id else { return }

--- a/Sources/Kaset/Services/Auth/AccountService.swift
+++ b/Sources/Kaset/Services/Auth/AccountService.swift
@@ -95,6 +95,12 @@ final class AccountService {
     /// identity. Replaced on each `fetchAccounts`/`switchAccount`.
     private var sessionPinTask: Task<Void, Never>?
 
+    /// The in-flight manual-switch navigation, tracked separately so a newer
+    /// switch (or logout) can CANCEL it — not merely gate its commit. Without
+    /// this, two quick switches would run two concurrent `/signin` navigations
+    /// and whichever landed last would win the shared cookie store.
+    private var activeSwitchNavigation: Task<Void, Error>?
+
     /// Monotonic generation for account-switch operations. A switch captures the
     /// value at entry and re-checks it before committing; if a newer switch (or a
     /// fetch-scheduled restore pin) has started in the meantime, the older one
@@ -152,6 +158,7 @@ final class AccountService {
             self.accounts = response.accounts
 
             // Restore previously selected account if stored
+            var restoredBrandVanished = false
             if let savedBrandId = UserDefaults.standard.string(forKey: self.selectedBrandIdKey) {
                 self.logger.debug("AccountService: Found saved brand ID: \(savedBrandId)")
 
@@ -163,6 +170,10 @@ final class AccountService {
                     // Saved account no longer available, use API-selected
                     self.currentAccount = response.selectedAccount ?? self.accounts.first
                     self.logger.debug("AccountService: Saved account not found, using API-selected")
+                    // The shared WebKit session may still be delegated to the now-
+                    // removed brand; if we fell back to primary, the session must be
+                    // re-pinned to primary rather than left brand-delegated.
+                    restoredBrandVanished = (savedBrandId != "primary")
                 }
             } else {
                 // Default to the currently selected account from API response
@@ -182,7 +193,7 @@ final class AccountService {
             // cold launch). Run it OFF the fetch path (after isLoading clears) so
             // a real ≤20s navigation never stalls launch or holds the account
             // spinner; it is best-effort and surfaced via logs on failure.
-            self.scheduleRestoredBrandSessionPin()
+            self.scheduleRestoredSessionPin(forcePrimaryRepin: restoredBrandVanished)
         } catch {
             self.logger.error("AccountService: Failed to fetch accounts: \(error.localizedDescription)")
             self.lastError = error
@@ -191,15 +202,16 @@ final class AccountService {
         }
     }
 
-    /// Schedules a best-effort WebView session pin for a restored brand account,
-    /// off the `fetchAccounts` path so it never blocks launch or holds
-    /// `isLoading`.
+    /// Schedules a best-effort WebView session pin for the restored account, off
+    /// the `fetchAccounts` path so it never blocks launch or holds `isLoading`.
     ///
-    /// No-op for the primary account (the default session identity) or when no
-    /// WebKit manager is injected. On success it bumps `verifiedIdentitySequence`
-    /// so observers re-point playback only once the brand session is confirmed.
-    /// Verification failures are logged, not thrown.
-    private func scheduleRestoredBrandSessionPin() {
+    /// Normally a no-op for the primary account (the default session identity).
+    /// When `forcePrimaryRepin` is true — i.e. a saved brand vanished and we fell
+    /// back to primary — the shared session may still be delegated to the removed
+    /// brand, so primary is explicitly re-pinned (verified with `expectedBrandId:
+    /// nil`) provided it exposes a `signinURL`. No-op when no WebKit manager is
+    /// injected. On success it bumps `verifiedIdentitySequence`. Failures logged.
+    private func scheduleRestoredSessionPin(forcePrimaryRepin: Bool = false) {
         // Cancel any in-flight pin FIRST, before the guard: a later fetch that
         // resolves to primary / a brand without a signinURL / a removed account
         // must not leave an older brand pin running, or it could still verify and
@@ -218,23 +230,28 @@ final class AccountService {
         guard !UITestConfig.isUITestMode,
               let webKitManager = self.webKitManager,
               let account = self.currentAccount,
-              let brandId = account.brandId,
               let signinURL = account.signinURL
         else {
             return
         }
+        // Pin a brand always; pin primary only on the brand-vanished fallback
+        // (otherwise a normal primary launch needn't touch the session).
+        guard account.brandId != nil || forcePrimaryRepin else {
+            return
+        }
+        let expectedBrandId = account.brandId
 
         self.sessionPinTask = Task { [weak self] in
             guard !Task.isCancelled else { return }
             do {
-                try await webKitManager.switchSessionIdentity(to: signinURL, expectedBrandId: brandId)
+                try await webKitManager.switchSessionIdentity(to: signinURL, expectedBrandId: expectedBrandId)
                 guard let self, !Task.isCancelled else { return }
-                self.logger.info("AccountService: Restored brand session identity for \(account.name)")
+                self.logger.info("AccountService: Restored session identity for \(account.name)")
                 self.markIdentityVerified(account.id)
             } catch is CancellationError {
                 // Superseded by a newer switch; the survivor owns the session.
             } catch {
-                self?.logger.error("AccountService: Could not restore brand session identity: \(error.localizedDescription)")
+                self?.logger.error("AccountService: Could not restore session identity: \(error.localizedDescription)")
             }
         }
     }
@@ -259,21 +276,27 @@ final class AccountService {
         self.logger.info("AccountService: Switching to account: \(account.name)")
         self.isLoading = true
 
-        // Cancel and await any in-flight session pin (e.g. a cold-launch brand
-        // restore) so its navigation cannot land AFTER this switch and re-point
-        // the shared cookie session back to a stale identity. `switchSessionIdentity`
-        // is cooperatively cancellable, so this returns promptly.
+        // Claim this switch's generation FIRST, before any await. A prior switch
+        // suspended on its navigation will then observe the bumped generation when
+        // it resumes and abandon its commit, rather than racing to commit a stale
+        // account. Synchronous sections are atomic on the main actor; only the
+        // awaits below can interleave.
+        self.switchGeneration &+= 1
+        let myGeneration = self.switchGeneration
+
+        // Now cancel and await any in-flight session mutation (a cold-launch brand
+        // restore pin AND/OR a prior manual switch's navigation) so neither can
+        // land AFTER this switch and re-point the shared cookie session to a stale
+        // identity. `switchSessionIdentity` is cooperatively cancellable, so this
+        // returns promptly. (Generation already bumped, so the awaited prior
+        // switch is guaranteed to abandon its own commit.)
         self.sessionPinTask?.cancel()
         await self.sessionPinTask?.value
         self.sessionPinTask = nil
-
-        // Claim this switch's generation. If another switch (or a fetch-scheduled
-        // pin) starts while this one is awaiting its navigation, the generation
-        // moves on and this switch aborts its commit below rather than racing two
-        // navigations to a split-brain result. Synchronous sections are atomic on
-        // the main actor; only the awaits below can interleave.
-        self.switchGeneration &+= 1
-        let myGeneration = self.switchGeneration
+        let priorNavigation = self.activeSwitchNavigation
+        self.activeSwitchNavigation = nil
+        priorNavigation?.cancel()
+        _ = try? await priorNavigation?.value
 
         // Tracks whether the session-mutating navigation was actually started, so
         // the catch only rolls the session back when there is something to undo.
@@ -306,10 +329,28 @@ final class AccountService {
                     throw SessionSwitchError.identityNotApplied(expectedBrandId: account.brandId)
                 }
                 didStartSessionSwitch = true
-                try await webKitManager.switchSessionIdentity(
-                    to: signinURL,
-                    expectedBrandId: account.brandId
-                )
+                // Run the navigation as a cancellable tracked task so a newer
+                // switch (or logout) cancels THIS navigation, not just gates its
+                // commit. Otherwise two quick switches would run two concurrent
+                // /signin WebViews and whichever landed last would win the shared
+                // cookie store even though commits are generation-gated.
+                let navigation = Task { @MainActor in
+                    try await webKitManager.switchSessionIdentity(
+                        to: signinURL,
+                        expectedBrandId: account.brandId
+                    )
+                }
+                self.activeSwitchNavigation = navigation
+                // Only clear the handle if it is still OURS: a newer switch may
+                // have replaced it while we were suspended, and clearing it then
+                // would make the newer navigation uncancellable. (`Task` conforms
+                // to `Equatable`/`Hashable` by identity, so `==` compares handles.)
+                defer {
+                    if self.activeSwitchNavigation == navigation {
+                        self.activeSwitchNavigation = nil
+                    }
+                }
+                try await navigation.value
             }
 
             // If a newer switch/pin superseded this one while we were navigating,
@@ -411,12 +452,15 @@ final class AccountService {
     func clearAccounts() {
         self.logger.info("AccountService: Clearing accounts data")
 
-        // Invalidate any in-flight session mutation: cancel the pin and bump the
-        // generation so a switch currently awaiting verification abandons its
-        // commit instead of repopulating currentAccount/UserDefaults and leaving
-        // the (now-cleared) WebKit session re-pinned to the old account.
+        // Invalidate any in-flight session mutation: cancel the pin and the
+        // active switch navigation, and bump the generation so a switch currently
+        // awaiting verification abandons its commit instead of repopulating
+        // currentAccount/UserDefaults and leaving the (now-cleared) WebKit session
+        // re-pinned to the old account.
         self.sessionPinTask?.cancel()
         self.sessionPinTask = nil
+        self.activeSwitchNavigation?.cancel()
+        self.activeSwitchNavigation = nil
         self.switchGeneration &+= 1
 
         self.accounts = []

--- a/Sources/Kaset/Services/Auth/AccountService.swift
+++ b/Sources/Kaset/Services/Auth/AccountService.swift
@@ -423,6 +423,9 @@ final class AccountService {
             let cancelGeneration = self.switchGeneration
             let pinTask = self.sessionPinTask
             let navigationTask = self.activeSwitchNavigation
+            if pinTask != nil {
+                self.sessionPinGeneration &+= 1
+            }
             self.sessionPinTask = nil
             self.activeSwitchNavigation = nil
             pinTask?.cancel()
@@ -481,6 +484,9 @@ final class AccountService {
         }
         let priorPinTask = self.sessionPinTask
         let priorNavigation = self.activeSwitchNavigation
+        if priorPinTask != nil {
+            self.sessionPinGeneration &+= 1
+        }
         priorPinTask?.cancel()
         priorNavigation?.cancel()
         await priorPinTask?.value

--- a/Sources/Kaset/Services/Auth/AccountService.swift
+++ b/Sources/Kaset/Services/Auth/AccountService.swift
@@ -118,6 +118,11 @@ final class AccountService {
     /// switches can finish after a newer switch has already started.
     private var manualSwitchInFlightCount = 0
 
+    /// Bumped when account data/session mutations are invalidated (notably sign-out)
+    /// so an older `fetchAccounts()` continuation cannot commit stale accounts or
+    /// start a fresh session pin after cookies are being cleared.
+    private var accountDataGeneration = 0
+
     private func markIdentityVerified(_ accountId: String?) {
         self.verifiedAccountId = accountId
         self.verifiedIdentitySequence &+= 1
@@ -181,6 +186,7 @@ final class AccountService {
 
         self.logger.info("AccountService: Fetching accounts list")
         self.isLoading = true
+        let fetchGeneration = self.accountDataGeneration
 
         defer {
             self.isLoading = false
@@ -188,6 +194,12 @@ final class AccountService {
 
         do {
             let response = try await self.ytMusicClient.fetchAccountsList()
+            guard fetchGeneration == self.accountDataGeneration,
+                  self.authService.state.isLoggedIn
+            else {
+                self.logger.info("AccountService: Ignoring stale account fetch after auth/account state changed")
+                return
+            }
             self.accounts = response.accounts
 
             // Restore previously selected account if stored
@@ -310,6 +322,7 @@ final class AccountService {
     /// clears cookies/data. This prevents an in-flight hidden `/signin` navigation
     /// from writing cookies back into the shared data store after sign-out cleanup.
     func prepareForSignOut() async {
+        self.accountDataGeneration &+= 1
         self.switchGeneration &+= 1
 
         let pinTask = self.sessionPinTask
@@ -330,7 +343,7 @@ final class AccountService {
     /// - Throws: An error if the switch fails.
     func switchAccount(to account: UserAccount) async throws {
         let isSameAccount = account.id == self.currentAccount?.id
-        guard !isSameAccount || (self.verifiedAccountId != account.id && self.webKitManager != nil) else {
+        guard !isSameAccount || (account.signinURL != nil && self.verifiedAccountId != account.id && self.webKitManager != nil) else {
             self.logger.debug("AccountService: Already using account \(account.name)")
             return
         }
@@ -568,6 +581,7 @@ final class AccountService {
     /// Should be called when the user logs out to reset state.
     func clearAccounts() {
         self.logger.info("AccountService: Clearing accounts data")
+        self.accountDataGeneration &+= 1
 
         // Invalidate any in-flight session mutation: cancel the pin and the
         // active switch navigation, and bump the generation so a switch currently

--- a/Sources/Kaset/Services/Auth/AccountService.swift
+++ b/Sources/Kaset/Services/Auth/AccountService.swift
@@ -207,10 +207,13 @@ final class AccountService {
         // considers active (e.g. after logout/re-auth or an account-list refresh).
         self.sessionPinTask?.cancel()
         self.sessionPinTask = nil
-        // Supersede any in-flight manual switch: bumping the generation makes a
-        // concurrent switchAccount abort its commit (its navigation is cancelled
-        // below via the shared sessionPinTask, but it may already be past that).
-        self.switchGeneration &+= 1
+        // NOTE: do NOT bump switchGeneration here. A passive fetch/launch restore
+        // must not supersede an in-flight *manual* switch: doing so would make the
+        // switch abandon its commit (and skip rollback) after its /signin already
+        // mutated the shared cookies, leaving the session on the attempted account
+        // while currentAccount reflects the fetch — a split-brain. A manual switch
+        // intentionally wins over a passive fetch; the fetch only cancels a prior
+        // (also-passive) pin via the cancel above.
 
         guard !UITestConfig.isUITestMode,
               let webKitManager = self.webKitManager,
@@ -408,8 +411,17 @@ final class AccountService {
     func clearAccounts() {
         self.logger.info("AccountService: Clearing accounts data")
 
+        // Invalidate any in-flight session mutation: cancel the pin and bump the
+        // generation so a switch currently awaiting verification abandons its
+        // commit instead of repopulating currentAccount/UserDefaults and leaving
+        // the (now-cleared) WebKit session re-pinned to the old account.
+        self.sessionPinTask?.cancel()
+        self.sessionPinTask = nil
+        self.switchGeneration &+= 1
+
         self.accounts = []
         self.currentAccount = nil
+        self.verifiedAccountId = nil
         UserDefaults.standard.removeObject(forKey: self.selectedBrandIdKey)
         SongLikeStatusManager.shared.clearCache()
         SongLikeStatusManager.shared.setActiveAccountID(nil)

--- a/Sources/Kaset/Services/Auth/AccountService.swift
+++ b/Sources/Kaset/Services/Auth/AccountService.swift
@@ -192,6 +192,14 @@ final class AccountService {
     /// so observers re-point playback only once the brand session is confirmed.
     /// Verification failures are logged, not thrown.
     private func scheduleRestoredBrandSessionPin() {
+        // Cancel any in-flight pin FIRST, before the guard: a later fetch that
+        // resolves to primary / a brand without a signinURL / a removed account
+        // must not leave an older brand pin running, or it could still verify and
+        // bump `verifiedIdentitySequence` for an account the app no longer
+        // considers active (e.g. after logout/re-auth or an account-list refresh).
+        self.sessionPinTask?.cancel()
+        self.sessionPinTask = nil
+
         guard !UITestConfig.isUITestMode,
               let webKitManager = self.webKitManager,
               let account = self.currentAccount,
@@ -201,7 +209,6 @@ final class AccountService {
             return
         }
 
-        self.sessionPinTask?.cancel()
         self.sessionPinTask = Task { [weak self] in
             guard !Task.isCancelled else { return }
             do {

--- a/Sources/Kaset/Services/Auth/AccountService.swift
+++ b/Sources/Kaset/Services/Auth/AccountService.swift
@@ -267,8 +267,13 @@ final class AccountService {
         // while currentAccount reflects the fetch — a split-brain. A manual switch
         // intentionally wins over a passive fetch; the fetch only cancels a prior
         // (also-passive) pin via the cancel above.
-        guard self.manualSwitchInFlightCount == 0, self.activeSwitchNavigation == nil else {
+        guard self.manualSwitchInFlightCount == 0 else {
             self.logger.info("AccountService: Skipping restored session pin while a manual switch is in flight")
+            self.sessionPinGeneration &+= 1
+            return
+        }
+        guard self.activeSwitchNavigation == nil else {
+            self.logger.info("AccountService: Skipping restored session pin while a session navigation is in flight")
             self.sessionPinGeneration &+= 1
             self.activeSwitchNavigation?.cancel()
             return
@@ -413,6 +418,7 @@ final class AccountService {
         if isSameAccount, hadInFlightSessionMutation {
             self.logger.info("AccountService: Cancelling pending session mutation for same-account no-op")
             self.switchGeneration &+= 1
+            let cancelGeneration = self.switchGeneration
             let pinTask = self.sessionPinTask
             let navigationTask = self.activeSwitchNavigation
             self.sessionPinTask = nil
@@ -421,12 +427,18 @@ final class AccountService {
             navigationTask?.cancel()
             await pinTask?.value
             _ = try? await navigationTask?.value
+            guard cancelGeneration == self.switchGeneration,
+                  self.currentAccount?.id == account.id
+            else { return }
 
             if account.signinURL == nil,
                let refreshedAccount = await self.refreshAccountForRollback(matching: account)
             {
                 account = refreshedAccount
             }
+            guard cancelGeneration == self.switchGeneration,
+                  self.currentAccount?.id == account.id
+            else { return }
             guard account.signinURL != nil else { return }
             self.markIdentityVerified(nil)
         }

--- a/Sources/Kaset/Services/Auth/AccountService.swift
+++ b/Sources/Kaset/Services/Auth/AccountService.swift
@@ -258,6 +258,7 @@ final class AccountService {
         // bump `verifiedIdentitySequence` for an account the app no longer
         // considers active (e.g. after logout/re-auth or an account-list refresh).
         let priorPinTask = self.sessionPinTask
+        let priorNavigation = self.activeSwitchNavigation
         priorPinTask?.cancel()
         self.sessionPinTask = nil
         // NOTE: do NOT bump switchGeneration here. A passive fetch/launch restore
@@ -272,11 +273,10 @@ final class AccountService {
             self.sessionPinGeneration &+= 1
             return
         }
-        guard self.activeSwitchNavigation == nil else {
-            self.logger.info("AccountService: Skipping restored session pin while a session navigation is in flight")
-            self.sessionPinGeneration &+= 1
-            self.activeSwitchNavigation?.cancel()
-            return
+        if let priorNavigation {
+            self.logger.info("AccountService: Cancelling previous restored session navigation before scheduling a new pin")
+            priorNavigation.cancel()
+            self.activeSwitchNavigation = nil
         }
 
         guard !UITestConfig.isUITestMode,
@@ -290,13 +290,14 @@ final class AccountService {
             self.sessionPinGeneration &+= 1
             let pinGeneration = self.sessionPinGeneration
             let error = SessionSwitchError.identityNotApplied(expectedBrandId: account.brandId)
-            self.sessionPinTask = Task { [weak self, priorPinTask] in
+            self.sessionPinTask = Task { [weak self, priorPinTask, priorNavigation] in
                 defer {
                     if let self, self.sessionPinGeneration == pinGeneration {
                         self.sessionPinTask = nil
                     }
                 }
                 await priorPinTask?.value
+                _ = try? await priorNavigation?.value
                 guard !Task.isCancelled,
                       let self,
                       self.sessionPinGeneration == pinGeneration
@@ -316,13 +317,14 @@ final class AccountService {
         self.sessionPinGeneration &+= 1
         let pinGeneration = self.sessionPinGeneration
 
-        self.sessionPinTask = Task { [weak self, priorPinTask] in
+        self.sessionPinTask = Task { [weak self, priorPinTask, priorNavigation] in
             defer {
                 if let self, self.sessionPinGeneration == pinGeneration {
                     self.sessionPinTask = nil
                 }
             }
             await priorPinTask?.value
+            _ = try? await priorNavigation?.value
             guard !Task.isCancelled else { return }
             do {
                 try await webKitManager.switchSessionIdentity(to: signinURL, expectedBrandId: expectedBrandId)
@@ -538,9 +540,6 @@ final class AccountService {
             // Skipped in UI test mode (no real WebKit session) and when no
             // webKitManager was injected (e.g. previews).
             if !UITestConfig.isUITestMode, let webKitManager = self.webKitManager {
-                if let previous = rollbackAccount, previous.signinURL == nil {
-                    throw SessionSwitchError.identityNotApplied(expectedBrandId: previous.brandId)
-                }
                 guard let signinURL = account.signinURL else {
                     throw SessionSwitchError.identityNotApplied(expectedBrandId: account.brandId)
                 }

--- a/Sources/Kaset/Services/Auth/AccountService.swift
+++ b/Sources/Kaset/Services/Auth/AccountService.swift
@@ -231,7 +231,9 @@ final class AccountService {
             // attribution on different identities. Run it OFF the fetch path (after
             // isLoading clears) so a real ≤20s navigation never stalls launch or
             // holds the account spinner; it is best-effort and surfaced via logs.
-            self.scheduleRestoredSessionPin()
+            if self.verifiedAccountId != self.currentAccount?.id {
+                self.scheduleRestoredSessionPin()
+            }
         } catch {
             self.logger.error("AccountService: Failed to fetch accounts: \(error.localizedDescription)")
             self.lastError = error
@@ -346,6 +348,7 @@ final class AccountService {
         }
         guard self.sessionPinGeneration == pinGeneration else { return }
 
+        self.ytMusicClient.resetSessionStateForAccountSwitch()
         self.currentAccount = fallback
         SongLikeStatusManager.shared.setActiveAccountID(fallback.id)
         UserDefaults.standard.set(fallback.id, forKey: self.selectedBrandIdKey)
@@ -354,7 +357,7 @@ final class AccountService {
 
     /// Awaits the in-flight session pin (launch restore or switch), if any.
     /// Test hook.
-    func awaitRestoredBrandSessionPinForTesting() async {
+    func awaitRestoredSessionPinForTesting() async {
         await self.sessionPinTask?.value
     }
 
@@ -435,17 +438,18 @@ final class AccountService {
         if self.sessionPinTask != nil || self.activeSwitchNavigation != nil {
             cancelledPriorSessionMutation = true
         }
-        self.sessionPinTask?.cancel()
-        await self.sessionPinTask?.value
+        let priorPinTask = self.sessionPinTask
+        let priorNavigation = self.activeSwitchNavigation
+        priorPinTask?.cancel()
+        priorNavigation?.cancel()
+        await priorPinTask?.value
         self.sessionPinTask = nil
         guard myGeneration == self.switchGeneration else {
             self.logger.info("AccountService: Switch to \(account.name) superseded before navigation; abandoning")
             self.isLoading = false
             return
         }
-        let priorNavigation = self.activeSwitchNavigation
         self.activeSwitchNavigation = nil
-        priorNavigation?.cancel()
         _ = try? await priorNavigation?.value
         guard myGeneration == self.switchGeneration else {
             self.logger.info("AccountService: Switch to \(account.name) superseded while awaiting prior navigation; abandoning")

--- a/Sources/Kaset/Services/Auth/AccountService.swift
+++ b/Sources/Kaset/Services/Auth/AccountService.swift
@@ -95,6 +95,14 @@ final class AccountService {
     /// identity. Replaced on each `fetchAccounts`/`switchAccount`.
     private var sessionPinTask: Task<Void, Never>?
 
+    /// Monotonic generation for account-switch operations. A switch captures the
+    /// value at entry and re-checks it before committing; if a newer switch (or a
+    /// fetch-scheduled restore pin) has started in the meantime, the older one
+    /// aborts without committing or persisting, so two overlapping switches can
+    /// never leave `currentAccount`/`verifiedAccountId` disagreeing with the
+    /// last-launched navigation against the shared cookie store.
+    private var switchGeneration: Int = 0
+
     private func markIdentityVerified(_ accountId: String?) {
         self.verifiedAccountId = accountId
         self.verifiedIdentitySequence &+= 1
@@ -199,6 +207,10 @@ final class AccountService {
         // considers active (e.g. after logout/re-auth or an account-list refresh).
         self.sessionPinTask?.cancel()
         self.sessionPinTask = nil
+        // Supersede any in-flight manual switch: bumping the generation makes a
+        // concurrent switchAccount abort its commit (its navigation is cancelled
+        // below via the shared sessionPinTask, but it may already be past that).
+        self.switchGeneration &+= 1
 
         guard !UITestConfig.isUITestMode,
               let webKitManager = self.webKitManager,
@@ -252,6 +264,14 @@ final class AccountService {
         await self.sessionPinTask?.value
         self.sessionPinTask = nil
 
+        // Claim this switch's generation. If another switch (or a fetch-scheduled
+        // pin) starts while this one is awaiting its navigation, the generation
+        // moves on and this switch aborts its commit below rather than racing two
+        // navigations to a split-brain result. Synchronous sections are atomic on
+        // the main actor; only the awaits below can interleave.
+        self.switchGeneration &+= 1
+        let myGeneration = self.switchGeneration
+
         // Tracks whether the session-mutating navigation was actually started, so
         // the catch only rolls the session back when there is something to undo.
         var didStartSessionSwitch = false
@@ -289,6 +309,16 @@ final class AccountService {
                 )
             }
 
+            // If a newer switch/pin superseded this one while we were navigating,
+            // abort: the newer operation owns the session and the committed state.
+            // Do NOT roll back the session here — the survivor is mid-flight and
+            // will establish the correct identity.
+            guard myGeneration == self.switchGeneration else {
+                self.logger.info("AccountService: Switch to \(account.name) superseded; abandoning commit")
+                self.isLoading = false
+                return
+            }
+
             // Update local state
             self.currentAccount = account
 
@@ -310,6 +340,15 @@ final class AccountService {
             self.logger.info("AccountService: Successfully switched to account: \(account.name)")
         } catch {
             self.logger.error("AccountService: Failed to switch account: \(error.localizedDescription)")
+
+            // If a newer switch/pin superseded this one, do not touch shared state
+            // on the failure path either — the survivor owns currentAccount and the
+            // session. Surface nothing; the newer operation drives the outcome.
+            guard myGeneration == self.switchGeneration else {
+                self.logger.info("AccountService: Failed switch to \(account.name) was superseded; not reverting")
+                throw error
+            }
+
             self.currentAccount = previousAccount
             SongLikeStatusManager.shared.setActiveAccountID(previousAccount?.id)
 
@@ -330,7 +369,11 @@ final class AccountService {
                         to: previousSigninURL,
                         expectedBrandId: previous.brandId
                     )
-                    self.markIdentityVerified(previous.id)
+                    // Only claim the verified identity if nothing superseded us
+                    // during the rollback navigation.
+                    if myGeneration == self.switchGeneration {
+                        self.markIdentityVerified(previous.id)
+                    }
                 } catch {
                     self.logger.error("AccountService: Session rollback failed; session may remain on attempted identity: \(error.localizedDescription)")
                 }
@@ -339,8 +382,24 @@ final class AccountService {
             self.lastError = error
             self.lastErrorWasFetch = false
             self.errorSequence += 1
+
+            // The cached signinURL may be single-use/expired (see ADR-0023). If
+            // the switch actually attempted a navigation, refresh the account list
+            // in the background so a retry uses a fresh signinURL instead of
+            // reusing the stale one. Best-effort; does not affect the thrown error.
+            if didStartSessionSwitch {
+                Task { [weak self] in await self?.refreshAccountsAfterSwitchFailure() }
+            }
+
             throw error
         }
+    }
+
+    /// Re-fetches the account list after a failed switch so a retry has fresh
+    /// signin URLs. Guarded so it does not run while another operation is active.
+    private func refreshAccountsAfterSwitchFailure() async {
+        guard !self.isLoading else { return }
+        await self.fetchAccounts()
     }
 
     /// Clears all account data.

--- a/Sources/Kaset/Services/Auth/AccountService.swift
+++ b/Sources/Kaset/Services/Auth/AccountService.swift
@@ -269,6 +269,8 @@ final class AccountService {
         // (also-passive) pin via the cancel above.
         guard self.manualSwitchInFlightCount == 0, self.activeSwitchNavigation == nil else {
             self.logger.info("AccountService: Skipping restored session pin while a manual switch is in flight")
+            self.sessionPinGeneration &+= 1
+            self.activeSwitchNavigation?.cancel()
             return
         }
 

--- a/Sources/Kaset/Services/Auth/AccountService.swift
+++ b/Sources/Kaset/Services/Auth/AccountService.swift
@@ -94,6 +94,7 @@ final class AccountService {
     /// against the shared cookie store cannot leave the session on a stale
     /// identity. Replaced on each `fetchAccounts`/`switchAccount`.
     private var sessionPinTask: Task<Void, Never>?
+    private var sessionPinGeneration = 0
 
     /// The in-flight manual-switch navigation, tracked separately so a newer
     /// switch (or logout) can CANCEL it — not merely gate its commit. Without
@@ -109,9 +110,41 @@ final class AccountService {
     /// last-launched navigation against the shared cookie store.
     private var switchGeneration: Int = 0
 
+    /// Number of user-initiated account switches currently owning (or waiting to
+    /// own) the shared WebKit session. Passive account-list refreshes must not
+    /// start restore pins while this is non-zero, or they can race a switch and
+    /// re-point cookies to a stale account. A count, rather than a Bool, is used
+    /// because `switchAccount` is reentrant on the main actor and superseded
+    /// switches can finish after a newer switch has already started.
+    private var manualSwitchInFlightCount = 0
+
     private func markIdentityVerified(_ accountId: String?) {
         self.verifiedAccountId = accountId
         self.verifiedIdentitySequence &+= 1
+    }
+
+    private func runTrackedSessionSwitch(
+        with webKitManager: any WebKitManagerProtocol,
+        to signinURL: URL,
+        expectedBrandId: String?
+    ) async throws {
+        let navigation = Task { @MainActor in
+            try await webKitManager.switchSessionIdentity(
+                to: signinURL,
+                expectedBrandId: expectedBrandId
+            )
+        }
+        self.activeSwitchNavigation = navigation
+        // Only clear the handle if it is still OURS: a newer switch may have
+        // replaced it while we were suspended, and clearing it then would make
+        // the newer navigation uncancellable. (`Task` conforms to
+        // `Equatable`/`Hashable` by identity, so `==` compares handles.)
+        defer {
+            if self.activeSwitchNavigation == navigation {
+                self.activeSwitchNavigation = nil
+            }
+        }
+        try await navigation.value
     }
 
     // MARK: - Initialization
@@ -158,7 +191,6 @@ final class AccountService {
             self.accounts = response.accounts
 
             // Restore previously selected account if stored
-            var restoredBrandVanished = false
             if let savedBrandId = UserDefaults.standard.string(forKey: self.selectedBrandIdKey) {
                 self.logger.debug("AccountService: Found saved brand ID: \(savedBrandId)")
 
@@ -170,10 +202,6 @@ final class AccountService {
                     // Saved account no longer available, use API-selected
                     self.currentAccount = response.selectedAccount ?? self.accounts.first
                     self.logger.debug("AccountService: Saved account not found, using API-selected")
-                    // The shared WebKit session may still be delegated to the now-
-                    // removed brand; if we fell back to primary, the session must be
-                    // re-pinned to primary rather than left brand-delegated.
-                    restoredBrandVanished = (savedBrandId != "primary")
                 }
             } else {
                 // Default to the currently selected account from API response
@@ -186,14 +214,12 @@ final class AccountService {
             let currentLabel = self.currentAccount?.brandId ?? "primary"
             self.logger.info("AccountService: Fetched \(self.accounts.count) accounts, current: \(self.currentAccount?.name ?? "none") (brandId=\(currentLabel))")
 
-            // Re-establish the WebView session identity for a restored brand
-            // account. Without this, a relaunch leaves native reads brand-aware
-            // while the playback session is still primary, so playback would
-            // record history to the primary account (the issue-#277 bug, on every
-            // cold launch). Run it OFF the fetch path (after isLoading clears) so
-            // a real ≤20s navigation never stalls launch or holds the account
-            // spinner; it is best-effort and surfaced via logs on failure.
-            self.scheduleRestoredSessionPin(forcePrimaryRepin: restoredBrandVanished)
+            // Re-establish the WebView session identity for the restored account.
+            // Without this, a relaunch can leave native reads and playback history
+            // attribution on different identities. Run it OFF the fetch path (after
+            // isLoading clears) so a real ≤20s navigation never stalls launch or
+            // holds the account spinner; it is best-effort and surfaced via logs.
+            self.scheduleRestoredSessionPin()
         } catch {
             self.logger.error("AccountService: Failed to fetch accounts: \(error.localizedDescription)")
             self.lastError = error
@@ -205,19 +231,20 @@ final class AccountService {
     /// Schedules a best-effort WebView session pin for the restored account, off
     /// the `fetchAccounts` path so it never blocks launch or holds `isLoading`.
     ///
-    /// Normally a no-op for the primary account (the default session identity).
-    /// When `forcePrimaryRepin` is true — i.e. a saved brand vanished and we fell
-    /// back to primary — the shared session may still be delegated to the removed
-    /// brand, so primary is explicitly re-pinned (verified with `expectedBrandId:
-    /// nil`) provided it exposes a `signinURL`. No-op when no WebKit manager is
-    /// injected. On success it bumps `verifiedIdentitySequence`. Failures logged.
-    private func scheduleRestoredSessionPin(forcePrimaryRepin: Bool = false) {
+    /// Pins any restored account that exposes a `signinURL`, including primary.
+    /// Primary usually is the default identity, but the shared session can be left
+    /// brand-delegated after a crash or failed rollback, so a primary restore must
+    /// also verify/re-pin when the server supplies a switch URL. No-op when no
+    /// WebKit manager/signin URL is injected. On success it bumps
+    /// `verifiedIdentitySequence`. Failures logged.
+    private func scheduleRestoredSessionPin() {
         // Cancel any in-flight pin FIRST, before the guard: a later fetch that
         // resolves to primary / a brand without a signinURL / a removed account
         // must not leave an older brand pin running, or it could still verify and
         // bump `verifiedIdentitySequence` for an account the app no longer
         // considers active (e.g. after logout/re-auth or an account-list refresh).
-        self.sessionPinTask?.cancel()
+        let priorPinTask = self.sessionPinTask
+        priorPinTask?.cancel()
         self.sessionPinTask = nil
         // NOTE: do NOT bump switchGeneration here. A passive fetch/launch restore
         // must not supersede an in-flight *manual* switch: doing so would make the
@@ -226,6 +253,10 @@ final class AccountService {
         // while currentAccount reflects the fetch — a split-brain. A manual switch
         // intentionally wins over a passive fetch; the fetch only cancels a prior
         // (also-passive) pin via the cancel above.
+        guard self.manualSwitchInFlightCount == 0, self.activeSwitchNavigation == nil else {
+            self.logger.info("AccountService: Skipping restored session pin while a manual switch is in flight")
+            return
+        }
 
         guard !UITestConfig.isUITestMode,
               let webKitManager = self.webKitManager,
@@ -234,18 +265,31 @@ final class AccountService {
         else {
             return
         }
-        // Pin a brand always; pin primary only on the brand-vanished fallback
-        // (otherwise a normal primary launch needn't touch the session).
-        guard account.brandId != nil || forcePrimaryRepin else {
-            return
-        }
         let expectedBrandId = account.brandId
+        let accountId = account.id
+        let switchGenerationAtPinStart = self.switchGeneration
 
-        self.sessionPinTask = Task { [weak self] in
+        self.sessionPinGeneration &+= 1
+        let pinGeneration = self.sessionPinGeneration
+
+        self.sessionPinTask = Task { [weak self, priorPinTask] in
+            defer {
+                if let self, self.sessionPinGeneration == pinGeneration {
+                    self.sessionPinTask = nil
+                }
+            }
+            await priorPinTask?.value
             guard !Task.isCancelled else { return }
             do {
                 try await webKitManager.switchSessionIdentity(to: signinURL, expectedBrandId: expectedBrandId)
                 guard let self, !Task.isCancelled else { return }
+                guard self.currentAccount?.id == accountId,
+                      self.switchGeneration == switchGenerationAtPinStart,
+                      self.activeSwitchNavigation == nil
+                else {
+                    self.logger.info("AccountService: Restored session identity for \(account.name) was superseded; not marking verified")
+                    return
+                }
                 self.logger.info("AccountService: Restored session identity for \(account.name)")
                 self.markIdentityVerified(account.id)
             } catch is CancellationError {
@@ -262,19 +306,45 @@ final class AccountService {
         await self.sessionPinTask?.value
     }
 
+    /// Cancels and awaits any WebView session-identity mutation before the caller
+    /// clears cookies/data. This prevents an in-flight hidden `/signin` navigation
+    /// from writing cookies back into the shared data store after sign-out cleanup.
+    func prepareForSignOut() async {
+        self.switchGeneration &+= 1
+
+        let pinTask = self.sessionPinTask
+        let navigationTask = self.activeSwitchNavigation
+        self.sessionPinTask = nil
+        self.activeSwitchNavigation = nil
+
+        pinTask?.cancel()
+        navigationTask?.cancel()
+
+        await pinTask?.value
+        _ = try? await navigationTask?.value
+    }
+
     /// Switches to a different account.
     ///
     /// - Parameter account: The account to switch to.
     /// - Throws: An error if the switch fails.
     func switchAccount(to account: UserAccount) async throws {
-        guard account != self.currentAccount else {
+        let isSameAccount = account.id == self.currentAccount?.id
+        guard !isSameAccount || (self.verifiedAccountId != account.id && self.webKitManager != nil) else {
             self.logger.debug("AccountService: Already using account \(account.name)")
             return
+        }
+        if isSameAccount {
+            self.logger.info("AccountService: Retrying unverified session identity for account: \(account.name)")
         }
 
         let previousAccount = self.currentAccount
         self.logger.info("AccountService: Switching to account: \(account.name)")
         self.isLoading = true
+        self.manualSwitchInFlightCount += 1
+        defer {
+            self.manualSwitchInFlightCount -= 1
+        }
 
         // Claim this switch's generation FIRST, before any await. A prior switch
         // suspended on its navigation will then observe the bumped generation when
@@ -283,6 +353,7 @@ final class AccountService {
         // awaits below can interleave.
         self.switchGeneration &+= 1
         let myGeneration = self.switchGeneration
+        var cancelledPriorSessionMutation = false
 
         // Now cancel and await any in-flight session mutation (a cold-launch brand
         // restore pin AND/OR a prior manual switch's navigation) so neither can
@@ -290,13 +361,26 @@ final class AccountService {
         // identity. `switchSessionIdentity` is cooperatively cancellable, so this
         // returns promptly. (Generation already bumped, so the awaited prior
         // switch is guaranteed to abandon its own commit.)
+        if self.sessionPinTask != nil || self.activeSwitchNavigation != nil {
+            cancelledPriorSessionMutation = true
+        }
         self.sessionPinTask?.cancel()
         await self.sessionPinTask?.value
         self.sessionPinTask = nil
+        guard myGeneration == self.switchGeneration else {
+            self.logger.info("AccountService: Switch to \(account.name) superseded before navigation; abandoning")
+            self.isLoading = false
+            return
+        }
         let priorNavigation = self.activeSwitchNavigation
         self.activeSwitchNavigation = nil
         priorNavigation?.cancel()
         _ = try? await priorNavigation?.value
+        guard myGeneration == self.switchGeneration else {
+            self.logger.info("AccountService: Switch to \(account.name) superseded while awaiting prior navigation; abandoning")
+            self.isLoading = false
+            return
+        }
 
         // Tracks whether the session-mutating navigation was actually started, so
         // the catch only rolls the session back when there is something to undo.
@@ -329,28 +413,20 @@ final class AccountService {
                     throw SessionSwitchError.identityNotApplied(expectedBrandId: account.brandId)
                 }
                 didStartSessionSwitch = true
+                // Once a session-mutating navigation starts, the previously
+                // verified identity is no longer trustworthy until the target
+                // switch (or a rollback) verifies its landing identity.
+                self.markIdentityVerified(nil)
                 // Run the navigation as a cancellable tracked task so a newer
                 // switch (or logout) cancels THIS navigation, not just gates its
                 // commit. Otherwise two quick switches would run two concurrent
                 // /signin WebViews and whichever landed last would win the shared
                 // cookie store even though commits are generation-gated.
-                let navigation = Task { @MainActor in
-                    try await webKitManager.switchSessionIdentity(
-                        to: signinURL,
-                        expectedBrandId: account.brandId
-                    )
-                }
-                self.activeSwitchNavigation = navigation
-                // Only clear the handle if it is still OURS: a newer switch may
-                // have replaced it while we were suspended, and clearing it then
-                // would make the newer navigation uncancellable. (`Task` conforms
-                // to `Equatable`/`Hashable` by identity, so `==` compares handles.)
-                defer {
-                    if self.activeSwitchNavigation == navigation {
-                        self.activeSwitchNavigation = nil
-                    }
-                }
-                try await navigation.value
+                try await self.runTrackedSessionSwitch(
+                    with: webKitManager,
+                    to: signinURL,
+                    expectedBrandId: account.brandId
+                )
             }
 
             // If a newer switch/pin superseded this one while we were navigating,
@@ -393,35 +469,18 @@ final class AccountService {
                 throw error
             }
 
-            self.currentAccount = previousAccount
-            SongLikeStatusManager.shared.setActiveAccountID(previousAccount?.id)
-
-            // If the /signin navigation already mutated the shared cookie session
-            // before verification failed, the session may be left on the attempted
-            // identity while native state says `previousAccount`. Best-effort
-            // re-pin the previous identity so playback records to the account the
-            // app believes is active. Skipped for throws that occurred before the
-            // navigation (UI-test mock, missing signinURL).
-            if didStartSessionSwitch,
-               !UITestConfig.isUITestMode,
-               let webKitManager = self.webKitManager,
-               let previous = previousAccount,
-               let previousSigninURL = previous.signinURL
-            {
-                do {
-                    try await webKitManager.switchSessionIdentity(
-                        to: previousSigninURL,
-                        expectedBrandId: previous.brandId
-                    )
-                    // Only claim the verified identity if nothing superseded us
-                    // during the rollback navigation.
-                    if myGeneration == self.switchGeneration {
-                        self.markIdentityVerified(previous.id)
-                    }
-                } catch {
-                    self.logger.error("AccountService: Session rollback failed; session may remain on attempted identity: \(error.localizedDescription)")
-                }
+            let restoredPreviousAccount = await self.rollbackSessionAfterFailedSwitch(
+                didStartSessionSwitch: didStartSessionSwitch || cancelledPriorSessionMutation,
+                previousAccount: previousAccount,
+                generation: myGeneration
+            )
+            guard myGeneration == self.switchGeneration else {
+                self.logger.info("AccountService: Failed switch to \(account.name) was superseded during rollback; not surfacing failure")
+                throw error
             }
+
+            self.currentAccount = restoredPreviousAccount
+            SongLikeStatusManager.shared.setActiveAccountID(restoredPreviousAccount?.id)
 
             self.lastError = error
             self.lastErrorWasFetch = false
@@ -444,6 +503,64 @@ final class AccountService {
     private func refreshAccountsAfterSwitchFailure() async {
         guard !self.isLoading else { return }
         await self.fetchAccounts()
+    }
+
+    private func rollbackSessionAfterFailedSwitch(
+        didStartSessionSwitch: Bool,
+        previousAccount: UserAccount?,
+        generation: Int
+    ) async -> UserAccount? {
+        var restoredPreviousAccount = previousAccount
+        if didStartSessionSwitch,
+           !UITestConfig.isUITestMode,
+           let previous = previousAccount,
+           let freshPrevious = await self.refreshAccountForRollback(matching: previous)
+        {
+            restoredPreviousAccount = freshPrevious
+        }
+        guard generation == self.switchGeneration else {
+            return restoredPreviousAccount
+        }
+
+        // If the /signin navigation already mutated the shared cookie session
+        // before verification failed, the session may be left on the attempted
+        // identity while native state says `previousAccount`. Best-effort re-pin
+        // the previous identity with a fresh token when available.
+        guard didStartSessionSwitch,
+              !UITestConfig.isUITestMode,
+              let webKitManager = self.webKitManager,
+              let previous = restoredPreviousAccount,
+              let previousSigninURL = previous.signinURL
+        else {
+            return restoredPreviousAccount
+        }
+
+        do {
+            try await self.runTrackedSessionSwitch(
+                with: webKitManager,
+                to: previousSigninURL,
+                expectedBrandId: previous.brandId
+            )
+            if generation == self.switchGeneration {
+                self.markIdentityVerified(previous.id)
+            }
+        } catch is CancellationError {
+            // Superseded by a newer switch/logout, which owns the next session
+            // mutation and native account state.
+        } catch {
+            self.logger.error("AccountService: Session rollback failed; session may remain on attempted identity: \(error.localizedDescription)")
+        }
+        return restoredPreviousAccount
+    }
+
+    private func refreshAccountForRollback(matching account: UserAccount) async -> UserAccount? {
+        do {
+            let response = try await self.ytMusicClient.fetchAccountsList()
+            return response.accounts.first { $0.id == account.id }
+        } catch {
+            self.logger.error("AccountService: Could not refresh rollback account token: \(error.localizedDescription)")
+            return nil
+        }
     }
 
     /// Clears all account data.

--- a/Sources/Kaset/Services/Auth/AccountService.swift
+++ b/Sources/Kaset/Services/Auth/AccountService.swift
@@ -337,6 +337,7 @@ final class AccountService {
         _ = try? await navigationTask?.value
     }
 
+    // swiftlint:disable function_body_length cyclomatic_complexity
     /// Switches to a different account.
     ///
     /// - Parameter account: The account to switch to.
@@ -352,6 +353,7 @@ final class AccountService {
         }
 
         let previousAccount = self.currentAccount
+        var rollbackAccount = previousAccount
         self.logger.info("AccountService: Switching to account: \(account.name)")
         self.isLoading = true
         self.manualSwitchInFlightCount += 1
@@ -395,6 +397,19 @@ final class AccountService {
             return
         }
 
+        if !UITestConfig.isUITestMode,
+           self.webKitManager != nil,
+           let previous = rollbackAccount,
+           previous.signinURL == nil
+        {
+            rollbackAccount = await self.refreshAccountForRollback(matching: previous) ?? previous
+            guard myGeneration == self.switchGeneration else {
+                self.logger.info("AccountService: Switch to \(account.name) superseded while refreshing rollback token; abandoning")
+                self.isLoading = false
+                return
+            }
+        }
+
         // Tracks whether the session-mutating navigation was actually started, so
         // the catch only rolls the session back when there is something to undo.
         var didStartSessionSwitch = false
@@ -422,6 +437,9 @@ final class AccountService {
             // Skipped in UI test mode (no real WebKit session) and when no
             // webKitManager was injected (e.g. previews).
             if !UITestConfig.isUITestMode, let webKitManager = self.webKitManager {
+                if let previous = rollbackAccount, previous.signinURL == nil {
+                    throw SessionSwitchError.identityNotApplied(expectedBrandId: previous.brandId)
+                }
                 guard let signinURL = account.signinURL else {
                     throw SessionSwitchError.identityNotApplied(expectedBrandId: account.brandId)
                 }
@@ -484,7 +502,7 @@ final class AccountService {
 
             let restoredPreviousAccount = await self.rollbackSessionAfterFailedSwitch(
                 didStartSessionSwitch: didStartSessionSwitch || cancelledPriorSessionMutation,
-                previousAccount: previousAccount,
+                previousAccount: rollbackAccount,
                 generation: myGeneration
             )
             guard myGeneration == self.switchGeneration else {
@@ -510,6 +528,8 @@ final class AccountService {
             throw error
         }
     }
+
+    // swiftlint:enable function_body_length cyclomatic_complexity
 
     /// Re-fetches the account list after a failed switch so a retry has fresh
     /// signin URLs. Guarded so it does not run while another operation is active.

--- a/Sources/Kaset/Services/Auth/AccountService.swift
+++ b/Sources/Kaset/Services/Auth/AccountService.swift
@@ -274,9 +274,12 @@ final class AccountService {
 
         guard !UITestConfig.isUITestMode,
               let webKitManager = self.webKitManager,
-              let account = self.currentAccount,
-              let signinURL = account.signinURL
+              let account = self.currentAccount
         else {
+            return
+        }
+        guard let signinURL = account.signinURL else {
+            self.handleUnpinnableRestoredAccount(account)
             return
         }
         guard self.verifiedAccountId != account.id else {
@@ -320,6 +323,23 @@ final class AccountService {
                 await self.handleRestoredSessionPinFailure(for: account, error: error, pinGeneration: pinGeneration)
             }
         }
+    }
+
+    private func handleUnpinnableRestoredAccount(_ account: UserAccount) {
+        guard account.brandId != nil, self.currentAccount?.id == account.id else { return }
+        let error = SessionSwitchError.identityNotApplied(expectedBrandId: account.brandId)
+        self.logger.error("AccountService: Restored account lacks a valid signin URL")
+        self.lastError = error
+        self.lastErrorWasFetch = false
+        self.errorSequence += 1
+
+        let fallback = self.accounts.first(where: { $0.isPrimary }) ?? self.accounts.first
+        guard let fallback, fallback.id != account.id else { return }
+        self.ytMusicClient.resetSessionStateForAccountSwitch()
+        self.currentAccount = fallback
+        SongLikeStatusManager.shared.setActiveAccountID(fallback.id)
+        UserDefaults.standard.set(fallback.id, forKey: self.selectedBrandIdKey)
+        self.markIdentityVerified(nil)
     }
 
     private func handleRestoredSessionPinFailure(for account: UserAccount, error: Error, pinGeneration: Int) async {

--- a/Sources/Kaset/Services/Auth/AccountService.swift
+++ b/Sources/Kaset/Services/Auth/AccountService.swift
@@ -277,6 +277,10 @@ final class AccountService {
         else {
             return
         }
+        guard self.verifiedAccountId != account.id else {
+            self.logger.debug("AccountService: Restored session identity already verified for \(account.name)")
+            return
+        }
         let expectedBrandId = account.brandId
         let accountId = account.id
         let switchGenerationAtPinStart = self.switchGeneration
@@ -307,9 +311,45 @@ final class AccountService {
             } catch is CancellationError {
                 // Superseded by a newer switch; the survivor owns the session.
             } catch {
-                self?.logger.error("AccountService: Could not restore session identity: \(error.localizedDescription)")
+                guard !Task.isCancelled,
+                      let self,
+                      self.sessionPinGeneration == pinGeneration
+                else { return }
+                await self.handleRestoredSessionPinFailure(for: account, error: error, pinGeneration: pinGeneration)
             }
         }
+    }
+
+    private func handleRestoredSessionPinFailure(for account: UserAccount, error: Error, pinGeneration: Int) async {
+        self.logger.error("AccountService: Could not restore session identity: \(error.localizedDescription)")
+        self.lastError = error
+        self.lastErrorWasFetch = false
+        self.errorSequence += 1
+
+        guard account.brandId != nil, self.currentAccount?.id == account.id else { return }
+        let fallback = self.accounts.first(where: { $0.isPrimary }) ?? self.accounts.first
+        guard let webKitManager = self.webKitManager,
+              let fallback,
+              fallback.id != account.id,
+              let fallbackSigninURL = fallback.signinURL
+        else { return }
+
+        do {
+            try await self.runTrackedSessionSwitch(
+                with: webKitManager,
+                to: fallbackSigninURL,
+                expectedBrandId: fallback.brandId
+            )
+        } catch {
+            self.logger.error("AccountService: Could not restore fallback session identity: \(error.localizedDescription)")
+            return
+        }
+        guard self.sessionPinGeneration == pinGeneration else { return }
+
+        self.currentAccount = fallback
+        SongLikeStatusManager.shared.setActiveAccountID(fallback.id)
+        UserDefaults.standard.set(fallback.id, forKey: self.selectedBrandIdKey)
+        self.markIdentityVerified(fallback.id)
     }
 
     /// Awaits the in-flight session pin (launch restore or switch), if any.
@@ -344,6 +384,22 @@ final class AccountService {
     /// - Throws: An error if the switch fails.
     func switchAccount(to account: UserAccount) async throws {
         let isSameAccount = account.id == self.currentAccount?.id
+        if isSameAccount,
+           account.signinURL == nil,
+           self.sessionPinTask != nil || self.activeSwitchNavigation != nil
+        {
+            self.logger.info("AccountService: Cancelling pending session mutation for same-account no-op")
+            self.switchGeneration &+= 1
+            let pinTask = self.sessionPinTask
+            let navigationTask = self.activeSwitchNavigation
+            self.sessionPinTask = nil
+            self.activeSwitchNavigation = nil
+            pinTask?.cancel()
+            navigationTask?.cancel()
+            await pinTask?.value
+            _ = try? await navigationTask?.value
+            return
+        }
         guard !isSameAccount || (account.signinURL != nil && self.verifiedAccountId != account.id && self.webKitManager != nil) else {
             self.logger.debug("AccountService: Already using account \(account.name)")
             return

--- a/Sources/Kaset/Services/Auth/AccountService.swift
+++ b/Sources/Kaset/Services/Auth/AccountService.swift
@@ -279,7 +279,23 @@ final class AccountService {
             return
         }
         guard let signinURL = account.signinURL else {
-            self.handleUnpinnableRestoredAccount(account)
+            guard account.brandId != nil else { return }
+            self.sessionPinGeneration &+= 1
+            let pinGeneration = self.sessionPinGeneration
+            let error = SessionSwitchError.identityNotApplied(expectedBrandId: account.brandId)
+            self.sessionPinTask = Task { [weak self, priorPinTask] in
+                defer {
+                    if let self, self.sessionPinGeneration == pinGeneration {
+                        self.sessionPinTask = nil
+                    }
+                }
+                await priorPinTask?.value
+                guard !Task.isCancelled,
+                      let self,
+                      self.sessionPinGeneration == pinGeneration
+                else { return }
+                await self.handleRestoredSessionPinFailure(for: account, error: error, pinGeneration: pinGeneration)
+            }
             return
         }
         guard self.verifiedAccountId != account.id else {
@@ -325,30 +341,14 @@ final class AccountService {
         }
     }
 
-    private func handleUnpinnableRestoredAccount(_ account: UserAccount) {
-        guard account.brandId != nil, self.currentAccount?.id == account.id else { return }
-        let error = SessionSwitchError.identityNotApplied(expectedBrandId: account.brandId)
-        self.logger.error("AccountService: Restored account lacks a valid signin URL")
-        self.lastError = error
-        self.lastErrorWasFetch = false
-        self.errorSequence += 1
-
-        let fallback = self.accounts.first(where: { $0.isPrimary }) ?? self.accounts.first
-        guard let fallback, fallback.id != account.id else { return }
-        self.ytMusicClient.resetSessionStateForAccountSwitch()
-        self.currentAccount = fallback
-        SongLikeStatusManager.shared.setActiveAccountID(fallback.id)
-        UserDefaults.standard.set(fallback.id, forKey: self.selectedBrandIdKey)
-        self.markIdentityVerified(nil)
-    }
-
     private func handleRestoredSessionPinFailure(for account: UserAccount, error: Error, pinGeneration: Int) async {
+        guard self.currentAccount?.id == account.id else { return }
         self.logger.error("AccountService: Could not restore session identity: \(error.localizedDescription)")
         self.lastError = error
         self.lastErrorWasFetch = false
         self.errorSequence += 1
+        guard account.brandId != nil else { return }
 
-        guard account.brandId != nil, self.currentAccount?.id == account.id else { return }
         let fallback = self.accounts.first(where: { $0.isPrimary }) ?? self.accounts.first
         guard let fallback, fallback.id != account.id
         else { return }
@@ -689,6 +689,7 @@ final class AccountService {
     func clearAccounts() {
         self.logger.info("AccountService: Clearing accounts data")
         self.accountDataGeneration &+= 1
+        self.sessionPinGeneration &+= 1
 
         // Invalidate any in-flight session mutation: cancel the pin and the
         // active switch navigation, and bump the generation so a switch currently

--- a/Sources/Kaset/Services/Auth/AccountService.swift
+++ b/Sources/Kaset/Services/Auth/AccountService.swift
@@ -330,21 +330,20 @@ final class AccountService {
 
         guard account.brandId != nil, self.currentAccount?.id == account.id else { return }
         let fallback = self.accounts.first(where: { $0.isPrimary }) ?? self.accounts.first
-        guard let webKitManager = self.webKitManager,
-              let fallback,
-              fallback.id != account.id,
-              let fallbackSigninURL = fallback.signinURL
+        guard let fallback, fallback.id != account.id
         else { return }
 
-        do {
-            try await self.runTrackedSessionSwitch(
-                with: webKitManager,
-                to: fallbackSigninURL,
-                expectedBrandId: fallback.brandId
-            )
-        } catch {
-            self.logger.error("AccountService: Could not restore fallback session identity: \(error.localizedDescription)")
-            return
+        if let webKitManager = self.webKitManager, let fallbackSigninURL = fallback.signinURL {
+            do {
+                try await self.runTrackedSessionSwitch(
+                    with: webKitManager,
+                    to: fallbackSigninURL,
+                    expectedBrandId: fallback.brandId
+                )
+            } catch {
+                self.logger.error("AccountService: Could not restore fallback session identity: \(error.localizedDescription)")
+                return
+            }
         }
         guard self.sessionPinGeneration == pinGeneration else { return }
 
@@ -352,7 +351,7 @@ final class AccountService {
         self.currentAccount = fallback
         SongLikeStatusManager.shared.setActiveAccountID(fallback.id)
         UserDefaults.standard.set(fallback.id, forKey: self.selectedBrandIdKey)
-        self.markIdentityVerified(fallback.id)
+        self.markIdentityVerified(fallback.signinURL == nil ? nil : fallback.id)
     }
 
     /// Awaits the in-flight session pin (launch restore or switch), if any.
@@ -386,11 +385,10 @@ final class AccountService {
     /// - Parameter account: The account to switch to.
     /// - Throws: An error if the switch fails.
     func switchAccount(to account: UserAccount) async throws {
+        var account = account
         let isSameAccount = account.id == self.currentAccount?.id
-        if isSameAccount,
-           account.signinURL == nil,
-           self.sessionPinTask != nil || self.activeSwitchNavigation != nil
-        {
+        let hadInFlightSessionMutation = self.sessionPinTask != nil || self.activeSwitchNavigation != nil
+        if isSameAccount, hadInFlightSessionMutation {
             self.logger.info("AccountService: Cancelling pending session mutation for same-account no-op")
             self.switchGeneration &+= 1
             let pinTask = self.sessionPinTask
@@ -401,7 +399,14 @@ final class AccountService {
             navigationTask?.cancel()
             await pinTask?.value
             _ = try? await navigationTask?.value
-            return
+
+            if account.signinURL == nil,
+               let refreshedAccount = await self.refreshAccountForRollback(matching: account)
+            {
+                account = refreshedAccount
+            }
+            guard account.signinURL != nil else { return }
+            self.markIdentityVerified(nil)
         }
         guard !isSameAccount || (account.signinURL != nil && self.verifiedAccountId != account.id && self.webKitManager != nil) else {
             self.logger.debug("AccountService: Already using account \(account.name)")
@@ -449,8 +454,10 @@ final class AccountService {
             self.isLoading = false
             return
         }
-        self.activeSwitchNavigation = nil
         _ = try? await priorNavigation?.value
+        if let priorNavigation, self.activeSwitchNavigation == priorNavigation {
+            self.activeSwitchNavigation = nil
+        }
         guard myGeneration == self.switchGeneration else {
             self.logger.info("AccountService: Switch to \(account.name) superseded while awaiting prior navigation; abandoning")
             self.isLoading = false

--- a/Sources/Kaset/Services/Player/PlayerService+PlaybackControls.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+PlaybackControls.swift
@@ -309,6 +309,7 @@ extension PlayerService {
             if SingletonPlayerWebView.shared.webView != nil {
                 let strategy: SingletonPlayerWebView.VideoLoadStrategy = self.shouldForcePendingRestoredLoad ? .forceFullPageWhenSameVideoId : .standard
                 SingletonPlayerWebView.shared.loadVideo(videoId: pendingPlayVideoId, strategy: strategy)
+                self.shouldForcePendingRestoredLoad = false
             }
             return
         }

--- a/Sources/Kaset/Services/Player/PlayerService+PlaybackControls.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+PlaybackControls.swift
@@ -304,7 +304,8 @@ extension PlayerService {
             self.showMiniPlayer = false
             self.state = .loading
             if SingletonPlayerWebView.shared.webView != nil {
-                SingletonPlayerWebView.shared.loadVideo(videoId: pendingPlayVideoId)
+                let strategy: SingletonPlayerWebView.VideoLoadStrategy = self.shouldForcePendingRestoredLoad ? .forceFullPageWhenSameVideoId : .standard
+                SingletonPlayerWebView.shared.loadVideo(videoId: pendingPlayVideoId, strategy: strategy)
             }
             return
         }

--- a/Sources/Kaset/Services/Player/PlayerService+PlaybackControls.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+PlaybackControls.swift
@@ -276,6 +276,7 @@ extension PlayerService {
         }
 
         self.clearRestoredPlaybackSessionState()
+        self.state = .paused
         if self.pendingPlayVideoId != nil {
             SingletonPlayerWebView.shared.pause()
         } else {

--- a/Sources/Kaset/Services/Player/PlayerService+PlaybackControls.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+PlaybackControls.swift
@@ -276,7 +276,9 @@ extension PlayerService {
         }
 
         self.clearRestoredPlaybackSessionState()
-        self.state = .paused
+        if self.state != .ended {
+            self.state = .paused
+        }
         if self.pendingPlayVideoId != nil {
             SingletonPlayerWebView.shared.pause()
         } else {

--- a/Sources/Kaset/Services/Player/PlayerService+PlaybackControls.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+PlaybackControls.swift
@@ -275,6 +275,19 @@ extension PlayerService {
             return
         }
 
+        if self.isRestoringPlaybackSession {
+            self.isPendingRestoredLoadDeferred = true
+            self.shouldAutoResumeAfterRestoredLoad = false
+            self.shouldForcePendingRestoredLoad = true
+            self.state = .paused
+            if self.pendingPlayVideoId != nil {
+                SingletonPlayerWebView.shared.pause()
+            } else {
+                await self.evaluatePlayerCommand("pause")
+            }
+            return
+        }
+
         self.clearRestoredPlaybackSessionState()
         if self.state != .ended {
             self.state = .paused

--- a/Sources/Kaset/Services/Player/PlayerService+PlaybackRestoration.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+PlaybackRestoration.swift
@@ -106,6 +106,37 @@ extension PlayerService {
         guard let pendingPlayVideoId = self.pendingPlayVideoId else { return false }
         return SingletonPlayerWebView.shared.currentVideoId != pendingPlayVideoId
     }
+
+    /// Re-loads the currently playing track so it is served under the WebView
+    /// session's current (just-switched) delegated identity.
+    ///
+    /// History is recorded by the playback page's own stats pings, which inherit
+    /// the identity of the document that was loaded. After an account switch the
+    /// in-flight page is still the previous identity's document, so a full-page
+    /// reload is required for subsequent listening to record to the new account.
+    /// Playback position and play/pause intent are preserved across the reload
+    /// via the existing restored-session machinery.
+    func reloadCurrentTrackForIdentitySwitch() {
+        guard let currentTrack = self.currentTrack else {
+            self.logger.debug("Identity switch: no current track to re-point")
+            return
+        }
+
+        let resumeProgress = self.progress
+        let wasPlaying = self.isPlaying
+        self.logger.info("Identity switch: re-pointing current track under new session identity (resume at \(Int(resumeProgress))s, wasPlaying=\(wasPlaying))")
+
+        self.pendingRestoredSeek = resumeProgress
+        self.beginRestoredPlaybackLoad(autoResumeAfterSeek: wasPlaying)
+
+        // Force a full navigation even though the videoId is unchanged: the
+        // identity lives in the served document, so an in-place restart would
+        // keep recording to the previous account.
+        SingletonPlayerWebView.shared.loadVideo(
+            videoId: currentTrack.videoId,
+            strategy: .forceFullPageWhenSameVideoId
+        )
+    }
 }
 
 private extension PlayerService {

--- a/Sources/Kaset/Services/Player/PlayerService+PlaybackRestoration.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+PlaybackRestoration.swift
@@ -122,6 +122,23 @@ extension PlayerService {
             return
         }
 
+        // Skip if a restored session is still deferred (cold launch, paused, not
+        // yet loaded into the WebView). There is no previous-identity document to
+        // re-point, and force-navigating here would clear the explicit-resume gate
+        // and load the playback page (and its history stats) before the user
+        // chooses to resume. The eventual user-initiated load already uses the
+        // now-verified session identity.
+        if self.isPendingRestoredLoadDeferred {
+            self.logger.debug("Identity switch: restored session still deferred; skipping re-point")
+            return
+        }
+        // If the current track was never actually loaded into the WebView, there
+        // is likewise nothing to re-point under the old identity.
+        if SingletonPlayerWebView.shared.currentVideoId != currentTrack.videoId {
+            self.logger.debug("Identity switch: current track not loaded in WebView; skipping re-point")
+            return
+        }
+
         let resumeProgress = self.progress
         let wasPlaying = self.isPlaying
         self.logger.info("Identity switch: re-pointing current track under new session identity (resume at \(Int(resumeProgress))s, wasPlaying=\(wasPlaying))")

--- a/Sources/Kaset/Services/Player/PlayerService+PlaybackRestoration.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+PlaybackRestoration.swift
@@ -150,7 +150,9 @@ extension PlayerService {
             self.pendingPlayVideoId = currentTrack.videoId
             self.isPendingRestoredLoadDeferred = true
             self.shouldForcePendingRestoredLoad = true
-            self.state = .paused
+            if self.state != .ended {
+                self.state = .paused
+            }
             return
         }
         self.beginRestoredPlaybackLoad(autoResumeAfterSeek: shouldAutoResumeAfterReload)

--- a/Sources/Kaset/Services/Player/PlayerService+PlaybackRestoration.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+PlaybackRestoration.swift
@@ -86,6 +86,7 @@ extension PlayerService {
     func clearRestoredPlaybackSessionState() {
         self.pendingRestoredSeek = nil
         self.isPendingRestoredLoadDeferred = false
+        self.shouldForcePendingRestoredLoad = false
         self.isRestoringPlaybackSession = false
         self.shouldAutoResumeAfterRestoredLoad = false
     }
@@ -104,7 +105,7 @@ extension PlayerService {
     /// Whether the pending track must be loaded into the WebView before playback can resume.
     var shouldLoadPendingVideoBeforePlayback: Bool {
         guard let pendingPlayVideoId = self.pendingPlayVideoId else { return false }
-        return SingletonPlayerWebView.shared.currentVideoId != pendingPlayVideoId
+        return self.shouldForcePendingRestoredLoad || SingletonPlayerWebView.shared.currentVideoId != pendingPlayVideoId
     }
 
     /// Re-loads the currently playing track so it is served under the WebView
@@ -141,10 +142,18 @@ extension PlayerService {
 
         let resumeProgress = self.progress
         let wasPlaying = self.isPlaying
+        let shouldAutoResumeAfterReload = wasPlaying || self.state == .loading
         self.logger.info("Identity switch: re-pointing current track under new session identity (resume at \(Int(resumeProgress))s, wasPlaying=\(wasPlaying))")
 
         self.pendingRestoredSeek = resumeProgress
-        self.beginRestoredPlaybackLoad(autoResumeAfterSeek: wasPlaying)
+        if !shouldAutoResumeAfterReload {
+            self.pendingPlayVideoId = currentTrack.videoId
+            self.isPendingRestoredLoadDeferred = true
+            self.shouldForcePendingRestoredLoad = true
+            self.state = .paused
+            return
+        }
+        self.beginRestoredPlaybackLoad(autoResumeAfterSeek: shouldAutoResumeAfterReload)
 
         // Force a full navigation even though the videoId is unchanged: the
         // identity lives in the served document, so an in-place restart would

--- a/Sources/Kaset/Services/Player/PlayerService+PlaybackRestoration.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+PlaybackRestoration.swift
@@ -140,12 +140,12 @@ extension PlayerService {
             return
         }
 
-        let resumeProgress = self.progress
+        let resumeProgress = self.state == .ended ? 0 : self.progress
         let wasPlaying = self.isPlaying
         let shouldAutoResumeAfterReload = wasPlaying || self.state == .loading
         self.logger.info("Identity switch: re-pointing current track under new session identity (resume at \(Int(resumeProgress))s, wasPlaying=\(wasPlaying))")
 
-        self.pendingRestoredSeek = resumeProgress
+        self.pendingRestoredSeek = self.state == .ended ? nil : resumeProgress
         if !shouldAutoResumeAfterReload {
             self.pendingPlayVideoId = currentTrack.videoId
             self.isPendingRestoredLoadDeferred = true

--- a/Sources/Kaset/Services/Player/PlayerService.swift
+++ b/Sources/Kaset/Services/Player/PlayerService.swift
@@ -151,6 +151,10 @@ final class PlayerService: NSObject, PlayerServiceProtocol {
     /// Whether a restored session is waiting for an explicit user-triggered load.
     var isPendingRestoredLoadDeferred: Bool = false
 
+    /// Whether the deferred restored load must force a full page navigation even
+    /// when the same video ID is already present in the WebView.
+    var shouldForcePendingRestoredLoad: Bool = false
+
     /// Whether launch-time session restoration is still reconciling with the player observer.
     var isRestoringPlaybackSession: Bool = false
 

--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -300,7 +300,7 @@ final class YouTubePlayerService {
             if self.reloadPendingPausedIdentitySwitchForUserResume() { return }
             self.playbackWillStart?()
         } else {
-            self.isPlaying = false
+            self.deferInFlightIdentityReloadIfNeeded()
             self.playbackController.cancelPendingLoad()
         }
         self.playbackController.playPause()
@@ -333,14 +333,18 @@ final class YouTubePlayerService {
 
     /// Pauses playback.
     func pause() {
+        self.deferInFlightIdentityReloadIfNeeded()
+        self.playbackController.cancelPendingLoad()
+        self.playbackController.pause()
+    }
+
+    private func deferInFlightIdentityReloadIfNeeded() {
         if self.isIdentityReloadInFlight, let currentVideo = self.currentVideo {
             self.pendingPausedIdentityReloadVideoId = currentVideo.videoId
             self.pendingPausedIdentityReloadResumeAt = self.currentWatchConcluded ? nil : (self.progress > 0 ? self.progress : nil)
             self.isIdentityReloadInFlight = false
         }
         self.isPlaying = false
-        self.playbackController.cancelPendingLoad()
-        self.playbackController.pause()
     }
 
     /// Seeks to a position in seconds.

--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -641,18 +641,21 @@ final class YouTubePlayerService {
         // page autoplays a video the user had paused, re-pause it (reactively,
         // since a one-shot pause at didFinish loses the race to the player's own
         // async playVideo()). Latch is keyed to the reloaded videoId and cleared
-        // once the page settles into a paused state, or on a user resume.
+        // only once the page genuinely reports a paused state, or on a user
+        // resume. A preroll ad counts as playing here too — otherwise the ad
+        // (and the content after it) would autoplay through the switch.
         if let suppressedId = self.suppressAutoplayForPausedReloadVideoId,
            suppressedId == (update.videoId ?? self.currentVideo?.videoId)
         {
-            if update.isPlaying, !update.isAd {
+            if update.isPlaying {
                 self.playbackController.pause()
                 self.isPlaying = false
                 self.progress = update.progress
                 self.duration = update.duration
+                self.isShowingAd = update.isAd
                 return
             }
-            // The page reported paused (or an ad) for the suppressed video — the
+            // The page settled into a paused state for the suppressed video — the
             // intent is satisfied; stop suppressing and process normally.
             self.suppressAutoplayForPausedReloadVideoId = nil
         }

--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -290,6 +290,8 @@ final class YouTubePlayerService {
         if !self.isPlaying {
             if self.reloadPendingPausedIdentitySwitchForUserResume() { return }
             self.playbackWillStart?()
+        } else {
+            self.isPlaying = false
         }
         self.playbackController.playPause()
     }
@@ -320,6 +322,7 @@ final class YouTubePlayerService {
 
     /// Pauses playback.
     func pause() {
+        self.isPlaying = false
         self.playbackController.pause()
     }
 

--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -9,6 +9,7 @@ import Observation
 protocol YouTubeWatchPlaybackControlling: AnyObject {
     func prepare(webKitManager: WebKitManager, playerService: YouTubePlayerService)
     func loadVideo(videoId: String)
+    func reloadVideo(videoId: String, resumeAt seconds: Double?)
     func playPause()
     func play()
     func pause()
@@ -227,6 +228,31 @@ final class YouTubePlayerService {
         // Create the WebView on demand; containers reparent it on appear.
         self.playbackController.prepare(webKitManager: self.webKitManager, playerService: self)
         self.playbackController.loadVideo(videoId: video.videoId)
+    }
+
+    /// Re-points the current video under the WebView session's current
+    /// (just-switched) delegated identity, preserving playback position.
+    ///
+    /// Watch history is recorded by the page's own stats pings, which inherit the
+    /// identity of the served document. After an account switch the in-flight
+    /// page is still the previous identity's document, so a full reload is needed
+    /// for continued watching to record to the new account.
+    func reloadCurrentVideoForIdentitySwitch() {
+        guard let currentVideo = self.currentVideo else {
+            self.logger.debug("Identity switch: no current video to re-point")
+            return
+        }
+        let resumeProgress = self.progress
+        self.logger.info("Identity switch: re-pointing current video under new session identity (resume at \(Int(resumeProgress))s)")
+
+        self.playbackController.prepare(webKitManager: self.webKitManager, playerService: self)
+        // Defer the seek to load completion: the new <video> element does not
+        // exist until the reloaded document finishes, so seeking now would be a
+        // no-op against the old/torn-down page.
+        self.playbackController.reloadVideo(
+            videoId: currentVideo.videoId,
+            resumeAt: resumeProgress > 0 ? resumeProgress : nil
+        )
     }
 
     /// Toggles play/pause.

--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -90,10 +90,23 @@ final class YouTubePlayerService {
 
     /// When set, the watch page for this videoId was reloaded for a session
     /// identity switch while paused; suppress the watch page's autoplay until a
-    /// paused state is observed (or the user resumes). Mirrors the music side's
-    /// paused-restore latch. Cleared on the first observed pause for the id, on a
-    /// user-initiated resume, or on per-video reset.
+    /// paused state is observed *after* at least one autoplay attempt was actually
+    /// suppressed (or the user resumes). Mirrors the music side's paused-restore
+    /// latch. Cleared on post-suppression pause for the id, on a user-initiated
+    /// resume, or on per-video reset.
     private var suppressAutoplayForPausedReloadVideoId: String?
+
+    /// Tracks whether the paused-reload latch has actually re-paused an autoplay
+    /// attempt. Initial observer updates can report paused before YouTube's async
+    /// autoplay starts; those must not disarm the latch.
+    private var didSuppressAutoplayForPausedReload = false
+
+    /// A paused video does not need an immediate identity-switch reload, because
+    /// there is no active playback to re-attribute. Defer the reload until the
+    /// user explicitly resumes so loading YouTube's autoplaying watch page cannot
+    /// create watch activity for content the user left paused.
+    private var pendingPausedIdentityReloadVideoId: String?
+    private var pendingPausedIdentityReloadResumeAt: Double?
 
     /// Current position in seconds.
     private(set) var progress: Double = 0
@@ -262,12 +275,19 @@ final class YouTubePlayerService {
         let wasPlaying = self.isPlaying
         self.logger.info("Identity switch: re-pointing current video under new session identity (resume at \(Int(resumeProgress))s, wasPlaying=\(wasPlaying))")
 
-        // If the video was paused, suppress the reloaded watch page's autoplay so
-        // an account switch doesn't unexpectedly start playback. The watch page
-        // autoplays and creates its <video> asynchronously after didFinish, so a
-        // one-shot pause would lose the race; instead latch on the videoId and
-        // re-pause reactively when the observer first reports it playing.
-        self.suppressAutoplayForPausedReloadVideoId = wasPlaying ? nil : currentVideo.videoId
+        if !wasPlaying {
+            // Do not load an autoplaying watch page while the user is paused. The
+            // current paused document is inert; reload under the new identity only
+            // when the user explicitly resumes.
+            self.pendingPausedIdentityReloadVideoId = currentVideo.videoId
+            self.pendingPausedIdentityReloadResumeAt = resumeProgress > 0 ? resumeProgress : nil
+            self.suppressAutoplayForPausedReloadVideoId = nil
+            self.didSuppressAutoplayForPausedReload = false
+            return
+        }
+
+        self.suppressAutoplayForPausedReloadVideoId = nil
+        self.didSuppressAutoplayForPausedReload = false
 
         self.playbackController.prepare(webKitManager: self.webKitManager, playerService: self)
         // Defer the seek to load completion: the new <video> element does not
@@ -282,8 +302,10 @@ final class YouTubePlayerService {
     /// Toggles play/pause.
     func playPause() {
         if !self.isPlaying {
+            if self.reloadPendingPausedIdentitySwitchForUserResume() { return }
             // A deliberate user play cancels autoplay suppression from a reload.
             self.suppressAutoplayForPausedReloadVideoId = nil
+            self.didSuppressAutoplayForPausedReload = false
             self.playbackWillStart?()
         }
         self.playbackController.playPause()
@@ -291,10 +313,31 @@ final class YouTubePlayerService {
 
     /// Resumes playback.
     func resume() {
+        if self.reloadPendingPausedIdentitySwitchForUserResume() { return }
         // A deliberate user resume cancels autoplay suppression from a reload.
         self.suppressAutoplayForPausedReloadVideoId = nil
+        self.didSuppressAutoplayForPausedReload = false
         self.playbackWillStart?()
         self.playbackController.play()
+    }
+
+    @discardableResult
+    private func reloadPendingPausedIdentitySwitchForUserResume() -> Bool {
+        guard let currentVideo = self.currentVideo,
+              self.pendingPausedIdentityReloadVideoId == currentVideo.videoId
+        else {
+            return false
+        }
+
+        let resumeAt = self.pendingPausedIdentityReloadResumeAt
+        self.pendingPausedIdentityReloadVideoId = nil
+        self.pendingPausedIdentityReloadResumeAt = nil
+        self.suppressAutoplayForPausedReloadVideoId = nil
+        self.didSuppressAutoplayForPausedReload = false
+        self.playbackWillStart?()
+        self.playbackController.prepare(webKitManager: self.webKitManager, playerService: self)
+        self.playbackController.reloadVideo(videoId: currentVideo.videoId, resumeAt: resumeAt)
+        return true
     }
 
     /// Pauses playback.
@@ -305,6 +348,9 @@ final class YouTubePlayerService {
     /// Seeks to a position in seconds.
     func seek(to time: Double) {
         self.progress = time
+        if self.pendingPausedIdentityReloadVideoId == self.currentVideo?.videoId {
+            self.pendingPausedIdentityReloadResumeAt = time > 0 ? time : nil
+        }
         self.playbackController.seek(to: time)
     }
 
@@ -451,6 +497,9 @@ final class YouTubePlayerService {
         // A genuinely new video starts under the user's own intent; never inherit
         // a paused-reload autoplay-suppression latch from a prior video.
         self.suppressAutoplayForPausedReloadVideoId = nil
+        self.didSuppressAutoplayForPausedReload = false
+        self.pendingPausedIdentityReloadVideoId = nil
+        self.pendingPausedIdentityReloadResumeAt = nil
         self.lastNonAdContentProgress = 0
     }
 
@@ -647,6 +696,23 @@ final class YouTubePlayerService {
 
     /// Applies a `STATE_UPDATE` from the watch page observer script.
     func updatePlaybackState(_ update: PlaybackUpdate) {
+        if let pendingId = self.pendingPausedIdentityReloadVideoId,
+           pendingId == (update.videoId ?? self.currentVideo?.videoId),
+           update.isPlaying
+        {
+            if self.pendingPausedIdentityReloadResumeAt == nil, update.progress > 0 {
+                self.pendingPausedIdentityReloadResumeAt = update.progress
+            }
+            _ = self.reloadPendingPausedIdentitySwitchForUserResume()
+            return
+        }
+        if let pendingId = self.pendingPausedIdentityReloadVideoId,
+           pendingId == (update.videoId ?? self.currentVideo?.videoId),
+           !update.isPlaying
+        {
+            self.pendingPausedIdentityReloadResumeAt = update.progress > 0 ? update.progress : nil
+        }
+
         // Autoplay suppression for a paused identity-switch reload: if the watch
         // page autoplays a video the user had paused, re-pause it (reactively,
         // since a one-shot pause at didFinish loses the race to the player's own
@@ -663,11 +729,17 @@ final class YouTubePlayerService {
                 self.progress = update.progress
                 self.duration = update.duration
                 self.isShowingAd = update.isAd
+                self.didSuppressAutoplayForPausedReload = true
                 return
             }
-            // The page settled into a paused state for the suppressed video — the
-            // intent is satisfied; stop suppressing and process normally.
-            self.suppressAutoplayForPausedReloadVideoId = nil
+            if self.didSuppressAutoplayForPausedReload {
+                // The page settled into a paused state after we actually suppressed
+                // autoplay — the intent is satisfied; stop suppressing and process
+                // normally. Initial paused observer updates before YouTube's async
+                // autoplay starts intentionally keep the latch armed.
+                self.suppressAutoplayForPausedReloadVideoId = nil
+                self.didSuppressAutoplayForPausedReload = false
+            }
         }
 
         // YouTube can start the next video on its own (SPA navigation);

--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -100,6 +100,7 @@ final class YouTubePlayerService {
     /// create watch activity for content the user left paused.
     private var pendingPausedIdentityReloadVideoId: String?
     private var pendingPausedIdentityReloadResumeAt: Double?
+    private var userUpdatedPendingPausedIdentityReloadSeek = false
     private var isIdentityReloadInFlight = false
 
     /// Current position in seconds.
@@ -280,6 +281,7 @@ final class YouTubePlayerService {
             // when the user explicitly resumes.
             self.pendingPausedIdentityReloadVideoId = currentVideo.videoId
             self.pendingPausedIdentityReloadResumeAt = self.currentWatchConcluded ? nil : (resumeProgress > 0 ? resumeProgress : nil)
+            self.userUpdatedPendingPausedIdentityReloadSeek = false
             return
         }
 
@@ -324,6 +326,7 @@ final class YouTubePlayerService {
         let resumeAt = self.pendingPausedIdentityReloadResumeAt
         self.pendingPausedIdentityReloadVideoId = nil
         self.pendingPausedIdentityReloadResumeAt = nil
+        self.userUpdatedPendingPausedIdentityReloadSeek = false
         self.playbackWillStart?()
         self.playbackController.prepare(webKitManager: self.webKitManager, playerService: self)
         self.playbackController.reloadVideo(videoId: currentVideo.videoId, resumeAt: resumeAt)
@@ -341,7 +344,9 @@ final class YouTubePlayerService {
     private func deferInFlightIdentityReloadIfNeeded() {
         if self.isIdentityReloadInFlight, let currentVideo = self.currentVideo {
             self.pendingPausedIdentityReloadVideoId = currentVideo.videoId
-            self.pendingPausedIdentityReloadResumeAt = self.currentWatchConcluded ? nil : (self.progress > 0 ? self.progress : nil)
+            let resumeProgress = self.isShowingAd ? self.lastNonAdContentProgress : self.progress
+            self.pendingPausedIdentityReloadResumeAt = self.currentWatchConcluded ? nil : (resumeProgress > 0 ? resumeProgress : nil)
+            self.userUpdatedPendingPausedIdentityReloadSeek = false
             self.isIdentityReloadInFlight = false
         }
         self.isPlaying = false
@@ -352,6 +357,7 @@ final class YouTubePlayerService {
         self.progress = time
         if self.pendingPausedIdentityReloadVideoId == self.currentVideo?.videoId {
             self.pendingPausedIdentityReloadResumeAt = time > 0 ? time : nil
+            self.userUpdatedPendingPausedIdentityReloadSeek = true
         }
         self.playbackController.seek(to: time)
     }
@@ -502,6 +508,7 @@ final class YouTubePlayerService {
         // a deferred identity-reload latch from a prior video.
         self.pendingPausedIdentityReloadVideoId = nil
         self.pendingPausedIdentityReloadResumeAt = nil
+        self.userUpdatedPendingPausedIdentityReloadSeek = false
         self.lastNonAdContentProgress = 0
     }
 
@@ -716,7 +723,9 @@ final class YouTubePlayerService {
            pendingId == (update.videoId ?? self.currentVideo?.videoId),
            !update.isPlaying
         {
-            self.pendingPausedIdentityReloadResumeAt = self.deferredIdentityReloadResumeProgress(for: update)
+            if !self.userUpdatedPendingPausedIdentityReloadSeek {
+                self.pendingPausedIdentityReloadResumeAt = self.deferredIdentityReloadResumeProgress(for: update)
+            }
         }
 
         // YouTube can start the next video on its own (SPA navigation);

--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -10,6 +10,7 @@ protocol YouTubeWatchPlaybackControlling: AnyObject {
     func prepare(webKitManager: WebKitManager, playerService: YouTubePlayerService)
     func loadVideo(videoId: String)
     func reloadVideo(videoId: String, resumeAt seconds: Double?)
+    func cancelPendingLoad()
     func playPause()
     func play()
     func pause()
@@ -298,6 +299,7 @@ final class YouTubePlayerService {
             self.playbackWillStart?()
         } else {
             self.isPlaying = false
+            self.playbackController.cancelPendingLoad()
         }
         self.playbackController.playPause()
     }
@@ -329,6 +331,7 @@ final class YouTubePlayerService {
     /// Pauses playback.
     func pause() {
         self.isPlaying = false
+        self.playbackController.cancelPendingLoad()
         self.playbackController.pause()
     }
 

--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -88,6 +88,11 @@ final class YouTubePlayerService {
     /// Whether the video is currently playing.
     private(set) var isPlaying = false
 
+    /// Whether the current watch page has reported at least one playback state.
+    /// Before this flips true, `isPlaying == false` means loading/unknown rather
+    /// than a deliberate paused state.
+    private var hasObservedPlaybackState = false
+
     /// A paused video does not need an immediate identity-switch reload, because
     /// there is no active playback to re-attribute. Defer the reload until the
     /// user explicitly resumes so loading YouTube's autoplaying watch page cannot
@@ -235,6 +240,7 @@ final class YouTubePlayerService {
         self.currentVideo = video
         self.watchActivityGeneration += 1 // a new watch began
         self.currentWatchConcluded = false
+        self.hasObservedPlaybackState = false
         self.resetPerVideoState()
         self.surfaceLocation = .inline
 
@@ -266,7 +272,7 @@ final class YouTubePlayerService {
         let wasPlaying = self.isPlaying
         self.logger.info("Identity switch: re-pointing current video under new session identity (resume at \(Int(resumeProgress))s, wasPlaying=\(wasPlaying))")
 
-        if !wasPlaying {
+        if !wasPlaying, self.hasObservedPlaybackState {
             // Do not load an autoplaying watch page while the user is paused. The
             // current paused document is inert; reload under the new identity only
             // when the user explicitly resumes.
@@ -352,6 +358,7 @@ final class YouTubePlayerService {
         }
         self.currentVideo = nil
         self.isPlaying = false
+        self.hasObservedPlaybackState = false
         self.progress = 0
         self.duration = 0
         self.isShowingAd = false
@@ -443,6 +450,7 @@ final class YouTubePlayerService {
         self.signalWatchConclusion()
         self.watchActivityGeneration += 1
         self.currentWatchConcluded = false
+        self.hasObservedPlaybackState = false
         self.resetPerVideoState()
         self.playbackController.prepare(webKitManager: self.webKitManager, playerService: self)
         self.playbackController.loadVideo(videoId: video.videoId)
@@ -675,6 +683,7 @@ final class YouTubePlayerService {
 
     /// Applies a `STATE_UPDATE` from the watch page observer script.
     func updatePlaybackState(_ update: PlaybackUpdate) {
+        self.hasObservedPlaybackState = true
         if let pendingId = self.pendingPausedIdentityReloadVideoId,
            pendingId == (update.videoId ?? self.currentVideo?.videoId),
            update.isPlaying

--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -100,6 +100,7 @@ final class YouTubePlayerService {
     /// create watch activity for content the user left paused.
     private var pendingPausedIdentityReloadVideoId: String?
     private var pendingPausedIdentityReloadResumeAt: Double?
+    private var isIdentityReloadInFlight = false
 
     /// Current position in seconds.
     private(set) var progress: Double = 0
@@ -290,6 +291,7 @@ final class YouTubePlayerService {
             videoId: currentVideo.videoId,
             resumeAt: resumeProgress > 0 ? resumeProgress : nil
         )
+        self.isIdentityReloadInFlight = true
     }
 
     /// Toggles play/pause.
@@ -325,11 +327,17 @@ final class YouTubePlayerService {
         self.playbackWillStart?()
         self.playbackController.prepare(webKitManager: self.webKitManager, playerService: self)
         self.playbackController.reloadVideo(videoId: currentVideo.videoId, resumeAt: resumeAt)
+        self.isIdentityReloadInFlight = true
         return true
     }
 
     /// Pauses playback.
     func pause() {
+        if self.isIdentityReloadInFlight, let currentVideo = self.currentVideo {
+            self.pendingPausedIdentityReloadVideoId = currentVideo.videoId
+            self.pendingPausedIdentityReloadResumeAt = self.currentWatchConcluded ? nil : (self.progress > 0 ? self.progress : nil)
+            self.isIdentityReloadInFlight = false
+        }
         self.isPlaying = false
         self.playbackController.cancelPendingLoad()
         self.playbackController.pause()
@@ -686,6 +694,7 @@ final class YouTubePlayerService {
 
     /// Applies a `STATE_UPDATE` from the watch page observer script.
     func updatePlaybackState(_ update: PlaybackUpdate) {
+        self.isIdentityReloadInFlight = false
         self.hasObservedPlaybackState = true
         if let pendingId = self.pendingPausedIdentityReloadVideoId,
            pendingId == (update.videoId ?? self.currentVideo?.videoId),

--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -88,6 +88,13 @@ final class YouTubePlayerService {
     /// Whether the video is currently playing.
     private(set) var isPlaying = false
 
+    /// When set, the watch page for this videoId was reloaded for a session
+    /// identity switch while paused; suppress the watch page's autoplay until a
+    /// paused state is observed (or the user resumes). Mirrors the music side's
+    /// paused-restore latch. Cleared on the first observed pause for the id, on a
+    /// user-initiated resume, or on per-video reset.
+    private var suppressAutoplayForPausedReloadVideoId: String?
+
     /// Current position in seconds.
     private(set) var progress: Double = 0
 
@@ -243,7 +250,15 @@ final class YouTubePlayerService {
             return
         }
         let resumeProgress = self.progress
-        self.logger.info("Identity switch: re-pointing current video under new session identity (resume at \(Int(resumeProgress))s)")
+        let wasPlaying = self.isPlaying
+        self.logger.info("Identity switch: re-pointing current video under new session identity (resume at \(Int(resumeProgress))s, wasPlaying=\(wasPlaying))")
+
+        // If the video was paused, suppress the reloaded watch page's autoplay so
+        // an account switch doesn't unexpectedly start playback. The watch page
+        // autoplays and creates its <video> asynchronously after didFinish, so a
+        // one-shot pause would lose the race; instead latch on the videoId and
+        // re-pause reactively when the observer first reports it playing.
+        self.suppressAutoplayForPausedReloadVideoId = wasPlaying ? nil : currentVideo.videoId
 
         self.playbackController.prepare(webKitManager: self.webKitManager, playerService: self)
         // Defer the seek to load completion: the new <video> element does not
@@ -258,6 +273,8 @@ final class YouTubePlayerService {
     /// Toggles play/pause.
     func playPause() {
         if !self.isPlaying {
+            // A deliberate user play cancels autoplay suppression from a reload.
+            self.suppressAutoplayForPausedReloadVideoId = nil
             self.playbackWillStart?()
         }
         self.playbackController.playPause()
@@ -265,6 +282,8 @@ final class YouTubePlayerService {
 
     /// Resumes playback.
     func resume() {
+        // A deliberate user resume cancels autoplay suppression from a reload.
+        self.suppressAutoplayForPausedReloadVideoId = nil
         self.playbackWillStart?()
         self.playbackController.play()
     }
@@ -420,6 +439,9 @@ final class YouTubePlayerService {
         self.storyboardFetchVideoId = nil
         self.storyboardFetchInFlightVideoId = nil
         self.playbackOptionsVideoId = nil
+        // A genuinely new video starts under the user's own intent; never inherit
+        // a paused-reload autoplay-suppression latch from a prior video.
+        self.suppressAutoplayForPausedReloadVideoId = nil
     }
 
     // MARK: - Watch Later
@@ -615,6 +637,26 @@ final class YouTubePlayerService {
 
     /// Applies a `STATE_UPDATE` from the watch page observer script.
     func updatePlaybackState(_ update: PlaybackUpdate) {
+        // Autoplay suppression for a paused identity-switch reload: if the watch
+        // page autoplays a video the user had paused, re-pause it (reactively,
+        // since a one-shot pause at didFinish loses the race to the player's own
+        // async playVideo()). Latch is keyed to the reloaded videoId and cleared
+        // once the page settles into a paused state, or on a user resume.
+        if let suppressedId = self.suppressAutoplayForPausedReloadVideoId,
+           suppressedId == (update.videoId ?? self.currentVideo?.videoId)
+        {
+            if update.isPlaying, !update.isAd {
+                self.playbackController.pause()
+                self.isPlaying = false
+                self.progress = update.progress
+                self.duration = update.duration
+                return
+            }
+            // The page reported paused (or an ad) for the suppressed video — the
+            // intent is satisfied; stop suppressing and process normally.
+            self.suppressAutoplayForPausedReloadVideoId = nil
+        }
+
         // YouTube can start the next video on its own (SPA navigation);
         // make sure music yields whenever video audio actually starts.
         if update.isPlaying, !self.isPlaying {

--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -258,7 +258,11 @@ final class YouTubePlayerService {
         // Resume at the last real CONTENT position. During an ad, self.progress
         // tracks the ad element's time, so prefer the remembered content progress
         // to avoid resuming the content near 0 after a switch mid-ad.
-        let resumeProgress = self.isShowingAd ? self.lastNonAdContentProgress : self.progress
+        let resumeProgress = if self.currentWatchConcluded {
+            0.0
+        } else {
+            self.isShowingAd ? self.lastNonAdContentProgress : self.progress
+        }
         let wasPlaying = self.isPlaying
         self.logger.info("Identity switch: re-pointing current video under new session identity (resume at \(Int(resumeProgress))s, wasPlaying=\(wasPlaying))")
 
@@ -267,7 +271,7 @@ final class YouTubePlayerService {
             // current paused document is inert; reload under the new identity only
             // when the user explicitly resumes.
             self.pendingPausedIdentityReloadVideoId = currentVideo.videoId
-            self.pendingPausedIdentityReloadResumeAt = resumeProgress > 0 ? resumeProgress : nil
+            self.pendingPausedIdentityReloadResumeAt = self.currentWatchConcluded ? nil : (resumeProgress > 0 ? resumeProgress : nil)
             return
         }
 
@@ -753,6 +757,7 @@ final class YouTubePlayerService {
            videoId != current.videoId
         {
             self.logger.info("YouTubePlayer: page drifted to a different video, following")
+            let shouldRepointDriftedVideo = self.pendingPausedIdentityReloadVideoId != nil
             self.resetPerVideoState()
             self.currentVideo = YouTubeVideo(
                 videoId: videoId,
@@ -769,6 +774,9 @@ final class YouTubePlayerService {
             self.watchActivityGeneration += 1
             self.currentWatchConcluded = false
             YouTubeWatchWebView.shared.currentVideoId = videoId
+            if shouldRepointDriftedVideo {
+                self.reloadCurrentVideoForIdentitySwitch()
+            }
         }
     }
 

--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -98,6 +98,12 @@ final class YouTubePlayerService {
     /// Current position in seconds.
     private(set) var progress: Double = 0
 
+    /// Last observed playback position from genuine CONTENT (not an ad). Used as
+    /// the resume target for an identity-switch reload so a switch during a
+    /// preroll/midroll ad doesn't resume the content near 0 (the ad element's
+    /// time).
+    private var lastNonAdContentProgress: Double = 0
+
     /// Video length in seconds.
     private(set) var duration: Double = 0
 
@@ -249,7 +255,10 @@ final class YouTubePlayerService {
             self.logger.debug("Identity switch: no current video to re-point")
             return
         }
-        let resumeProgress = self.progress
+        // Resume at the last real CONTENT position. During an ad, self.progress
+        // tracks the ad element's time, so prefer the remembered content progress
+        // to avoid resuming the content near 0 after a switch mid-ad.
+        let resumeProgress = self.isShowingAd ? self.lastNonAdContentProgress : self.progress
         let wasPlaying = self.isPlaying
         self.logger.info("Identity switch: re-pointing current video under new session identity (resume at \(Int(resumeProgress))s, wasPlaying=\(wasPlaying))")
 
@@ -442,6 +451,7 @@ final class YouTubePlayerService {
         // A genuinely new video starts under the user's own intent; never inherit
         // a paused-reload autoplay-suppression latch from a prior video.
         self.suppressAutoplayForPausedReloadVideoId = nil
+        self.lastNonAdContentProgress = 0
     }
 
     // MARK: - Watch Later
@@ -670,6 +680,12 @@ final class YouTubePlayerService {
         self.progress = update.progress
         self.duration = update.duration
         self.isShowingAd = update.isAd
+
+        // Remember the last real content position (ignoring ad playback) so an
+        // identity-switch reload during an ad resumes the content, not the ad.
+        if !update.isAd {
+            self.lastNonAdContentProgress = update.progress
+        }
 
         // A concluded video that is playing again (replayed via the player bar or
         // a seek back after it finished) begins a fresh watch — clear the

--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -88,19 +88,6 @@ final class YouTubePlayerService {
     /// Whether the video is currently playing.
     private(set) var isPlaying = false
 
-    /// When set, the watch page for this videoId was reloaded for a session
-    /// identity switch while paused; suppress the watch page's autoplay until a
-    /// paused state is observed *after* at least one autoplay attempt was actually
-    /// suppressed (or the user resumes). Mirrors the music side's paused-restore
-    /// latch. Cleared on post-suppression pause for the id, on a user-initiated
-    /// resume, or on per-video reset.
-    private var suppressAutoplayForPausedReloadVideoId: String?
-
-    /// Tracks whether the paused-reload latch has actually re-paused an autoplay
-    /// attempt. Initial observer updates can report paused before YouTube's async
-    /// autoplay starts; those must not disarm the latch.
-    private var didSuppressAutoplayForPausedReload = false
-
     /// A paused video does not need an immediate identity-switch reload, because
     /// there is no active playback to re-attribute. Defer the reload until the
     /// user explicitly resumes so loading YouTube's autoplaying watch page cannot
@@ -281,13 +268,8 @@ final class YouTubePlayerService {
             // when the user explicitly resumes.
             self.pendingPausedIdentityReloadVideoId = currentVideo.videoId
             self.pendingPausedIdentityReloadResumeAt = resumeProgress > 0 ? resumeProgress : nil
-            self.suppressAutoplayForPausedReloadVideoId = nil
-            self.didSuppressAutoplayForPausedReload = false
             return
         }
-
-        self.suppressAutoplayForPausedReloadVideoId = nil
-        self.didSuppressAutoplayForPausedReload = false
 
         self.playbackController.prepare(webKitManager: self.webKitManager, playerService: self)
         // Defer the seek to load completion: the new <video> element does not
@@ -303,9 +285,6 @@ final class YouTubePlayerService {
     func playPause() {
         if !self.isPlaying {
             if self.reloadPendingPausedIdentitySwitchForUserResume() { return }
-            // A deliberate user play cancels autoplay suppression from a reload.
-            self.suppressAutoplayForPausedReloadVideoId = nil
-            self.didSuppressAutoplayForPausedReload = false
             self.playbackWillStart?()
         }
         self.playbackController.playPause()
@@ -314,9 +293,6 @@ final class YouTubePlayerService {
     /// Resumes playback.
     func resume() {
         if self.reloadPendingPausedIdentitySwitchForUserResume() { return }
-        // A deliberate user resume cancels autoplay suppression from a reload.
-        self.suppressAutoplayForPausedReloadVideoId = nil
-        self.didSuppressAutoplayForPausedReload = false
         self.playbackWillStart?()
         self.playbackController.play()
     }
@@ -332,8 +308,6 @@ final class YouTubePlayerService {
         let resumeAt = self.pendingPausedIdentityReloadResumeAt
         self.pendingPausedIdentityReloadVideoId = nil
         self.pendingPausedIdentityReloadResumeAt = nil
-        self.suppressAutoplayForPausedReloadVideoId = nil
-        self.didSuppressAutoplayForPausedReload = false
         self.playbackWillStart?()
         self.playbackController.prepare(webKitManager: self.webKitManager, playerService: self)
         self.playbackController.reloadVideo(videoId: currentVideo.videoId, resumeAt: resumeAt)
@@ -495,9 +469,7 @@ final class YouTubePlayerService {
         self.storyboardFetchInFlightVideoId = nil
         self.playbackOptionsVideoId = nil
         // A genuinely new video starts under the user's own intent; never inherit
-        // a paused-reload autoplay-suppression latch from a prior video.
-        self.suppressAutoplayForPausedReloadVideoId = nil
-        self.didSuppressAutoplayForPausedReload = false
+        // a deferred identity-reload latch from a prior video.
         self.pendingPausedIdentityReloadVideoId = nil
         self.pendingPausedIdentityReloadResumeAt = nil
         self.lastNonAdContentProgress = 0
@@ -700,8 +672,10 @@ final class YouTubePlayerService {
            pendingId == (update.videoId ?? self.currentVideo?.videoId),
            update.isPlaying
         {
-            if self.pendingPausedIdentityReloadResumeAt == nil, update.progress > 0 {
-                self.pendingPausedIdentityReloadResumeAt = update.progress
+            if self.pendingPausedIdentityReloadResumeAt == nil,
+               let resumeProgress = self.deferredIdentityReloadResumeProgress(for: update)
+            {
+                self.pendingPausedIdentityReloadResumeAt = resumeProgress
             }
             _ = self.reloadPendingPausedIdentitySwitchForUserResume()
             return
@@ -710,36 +684,7 @@ final class YouTubePlayerService {
            pendingId == (update.videoId ?? self.currentVideo?.videoId),
            !update.isPlaying
         {
-            self.pendingPausedIdentityReloadResumeAt = update.progress > 0 ? update.progress : nil
-        }
-
-        // Autoplay suppression for a paused identity-switch reload: if the watch
-        // page autoplays a video the user had paused, re-pause it (reactively,
-        // since a one-shot pause at didFinish loses the race to the player's own
-        // async playVideo()). Latch is keyed to the reloaded videoId and cleared
-        // only once the page genuinely reports a paused state, or on a user
-        // resume. A preroll ad counts as playing here too — otherwise the ad
-        // (and the content after it) would autoplay through the switch.
-        if let suppressedId = self.suppressAutoplayForPausedReloadVideoId,
-           suppressedId == (update.videoId ?? self.currentVideo?.videoId)
-        {
-            if update.isPlaying {
-                self.playbackController.pause()
-                self.isPlaying = false
-                self.progress = update.progress
-                self.duration = update.duration
-                self.isShowingAd = update.isAd
-                self.didSuppressAutoplayForPausedReload = true
-                return
-            }
-            if self.didSuppressAutoplayForPausedReload {
-                // The page settled into a paused state after we actually suppressed
-                // autoplay — the intent is satisfied; stop suppressing and process
-                // normally. Initial paused observer updates before YouTube's async
-                // autoplay starts intentionally keep the latch armed.
-                self.suppressAutoplayForPausedReloadVideoId = nil
-                self.didSuppressAutoplayForPausedReload = false
-            }
+            self.pendingPausedIdentityReloadResumeAt = self.deferredIdentityReloadResumeProgress(for: update)
         }
 
         // YouTube can start the next video on its own (SPA navigation);
@@ -825,6 +770,13 @@ final class YouTubePlayerService {
             self.currentWatchConcluded = false
             YouTubeWatchWebView.shared.currentVideoId = videoId
         }
+    }
+
+    private func deferredIdentityReloadResumeProgress(for update: PlaybackUpdate) -> Double? {
+        if update.isAd {
+            return self.lastNonAdContentProgress > 0 ? self.lastNonAdContentProgress : nil
+        }
+        return update.progress > 0 ? update.progress : nil
     }
 
     /// Handles natural video completion.

--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -244,6 +244,7 @@ final class YouTubePlayerService {
         self.watchActivityGeneration += 1 // a new watch began
         self.currentWatchConcluded = false
         self.hasObservedPlaybackState = false
+        self.isIdentityReloadInFlight = false
         self.resetPerVideoState()
         self.surfaceLocation = .inline
 
@@ -380,6 +381,7 @@ final class YouTubePlayerService {
         self.currentVideo = nil
         self.isPlaying = false
         self.hasObservedPlaybackState = false
+        self.isIdentityReloadInFlight = false
         self.progress = 0
         self.duration = 0
         self.isShowingAd = false
@@ -472,6 +474,7 @@ final class YouTubePlayerService {
         self.watchActivityGeneration += 1
         self.currentWatchConcluded = false
         self.hasObservedPlaybackState = false
+        self.isIdentityReloadInFlight = false
         self.resetPerVideoState()
         self.playbackController.prepare(webKitManager: self.webKitManager, playerService: self)
         self.playbackController.loadVideo(videoId: video.videoId)
@@ -705,7 +708,6 @@ final class YouTubePlayerService {
 
     /// Applies a `STATE_UPDATE` from the watch page observer script.
     func updatePlaybackState(_ update: PlaybackUpdate) {
-        self.isIdentityReloadInFlight = false
         self.hasObservedPlaybackState = true
         if let pendingId = self.pendingPausedIdentityReloadVideoId,
            pendingId == (update.videoId ?? self.currentVideo?.videoId),

--- a/Sources/Kaset/Services/Protocols.swift
+++ b/Sources/Kaset/Services/Protocols.swift
@@ -32,6 +32,11 @@ protocol WebKitManagerProtocol: AnyObject, Sendable {
 
     /// Logs all authentication-related cookies for debugging.
     func logAuthCookies() async
+
+    /// Switches the shared session's active delegated identity to the account
+    /// reached by `signinURL`, verifying via `ytcfg.DATASYNC_ID`. Throws if the
+    /// switch cannot be verified.
+    func switchSessionIdentity(to signinURL: URL, expectedBrandId: String?) async throws
 }
 
 // MARK: - YTMusicClientProtocol

--- a/Sources/Kaset/Services/WebKit/WebKitManager.swift
+++ b/Sources/Kaset/Services/WebKit/WebKitManager.swift
@@ -235,6 +235,16 @@ final class WebKitManager: NSObject, WebKitManagerProtocol {
         return configuration
     }
 
+    /// Creates the minimal WebView configuration used for hidden account-switch
+    /// navigations. It deliberately shares only the website data store (cookies)
+    /// and does not attach the app's `WKWebExtensionController`, so enabled
+    /// extensions/content scripts cannot observe credential-bearing signin URLs.
+    func createSessionSwitchWebViewConfiguration() -> WKWebViewConfiguration {
+        let configuration = WKWebViewConfiguration()
+        configuration.websiteDataStore = self.dataStore
+        return configuration
+    }
+
     /// Metadata required to present an extension-owned page in a dedicated web view.
     struct ExtensionPage: Identifiable {
         let id: String
@@ -580,8 +590,11 @@ extension WebKitManager {
     ///   - expectedBrandId: The brand pageId to verify, or `nil` for the primary.
     func switchSessionIdentity(to signinURL: URL, expectedBrandId: String?) async throws {
         self.logger.info("Switching session identity (expecting \(expectedBrandId ?? "primary"))")
+        guard AccountsListParser.isAllowedSigninURL(signinURL) else {
+            throw SessionSwitchError.navigationFailed(underlying: "Refusing non-YouTube signin URL")
+        }
 
-        let configuration = self.createWebViewConfiguration()
+        let configuration = self.createSessionSwitchWebViewConfiguration()
         let webView = WKWebView(frame: .zero, configuration: configuration)
         webView.customUserAgent = Self.userAgent
 

--- a/Sources/Kaset/Services/WebKit/WebKitManager.swift
+++ b/Sources/Kaset/Services/WebKit/WebKitManager.swift
@@ -532,3 +532,182 @@ extension WebKitManager: WKHTTPCookieStoreObserver {
         }
     }
 #endif
+
+// MARK: - SessionSwitchError
+
+/// Errors raised while switching the WebView session's active delegated identity.
+enum SessionSwitchError: LocalizedError {
+    /// The page loaded but its `DATASYNC_ID` did not reflect the expected identity.
+    case identityNotApplied(expectedBrandId: String?)
+    /// The switch navigation failed to load.
+    case navigationFailed(underlying: String)
+    /// The switch did not complete within the allotted time.
+    case timedOut
+
+    var errorDescription: String? {
+        switch self {
+        case .identityNotApplied:
+            "The account session could not be switched. Please try again."
+        case .navigationFailed:
+            "Failed to load the account switch page."
+        case .timedOut:
+            "Switching accounts timed out. Please try again."
+        }
+    }
+}
+
+extension WebKitManager {
+    /// Switches the shared cookie session's active delegated identity by
+    /// navigating a transient WebView to a server-issued account-switch URL.
+    ///
+    /// History is recorded by the playback page's own stats pings, which
+    /// attribute to the identity baked into the served document's
+    /// `ytcfg.DATASYNC_ID` (`"<delegatedSessionId>||<userSessionId>"` for a brand,
+    /// `"<userSessionId>||"` for primary). Navigating the brand's `signinUrl`
+    /// (which carries `&pageid=<brandId>`) re-points that identity for the single
+    /// shared `WKWebsiteDataStore`, so subsequent watch loads — and their history
+    /// pings — attribute to the brand.
+    ///
+    /// The method is verification-gated: it reads `DATASYNC_ID` after the
+    /// navigation settles and throws ``SessionSwitchError/identityNotApplied(expectedBrandId:)``
+    /// unless the result matches `expectedBrandId` (or, for `nil`, an empty
+    /// delegated half indicating the primary identity). Callers should perform
+    /// this switch *before* committing the new account so a failure can be
+    /// surfaced and reverted rather than silently recording to the wrong account.
+    ///
+    /// - Parameters:
+    ///   - signinURL: The server-issued `accountSigninToken.signinUrl`.
+    ///   - expectedBrandId: The brand pageId to verify, or `nil` for the primary.
+    func switchSessionIdentity(to signinURL: URL, expectedBrandId: String?) async throws {
+        self.logger.info("Switching session identity (expecting \(expectedBrandId ?? "primary"))")
+
+        let configuration = self.createWebViewConfiguration()
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        webView.customUserAgent = Self.userAgent
+
+        // Keep the navigation driver alive for the lifetime of the load.
+        let driver = SessionSwitchNavigationDriver()
+        webView.navigationDelegate = driver
+
+        defer {
+            webView.navigationDelegate = nil
+            webView.stopLoading()
+        }
+
+        do {
+            try await driver.load(signinURL, in: webView, timeout: .seconds(20))
+        } catch let error as SessionSwitchError {
+            throw error
+        } catch {
+            throw SessionSwitchError.navigationFailed(underlying: error.localizedDescription)
+        }
+
+        // The page's ytcfg may be emitted slightly after didFinish; poll briefly.
+        for attempt in 0 ..< 5 {
+            if let dataSyncId = try? await Self.readDataSyncId(from: webView),
+               Self.dataSyncId(dataSyncId, matches: expectedBrandId)
+            {
+                self.logger.info("Session identity switch verified")
+                return
+            }
+            if attempt < 4 {
+                try? await Task.sleep(for: .milliseconds(400))
+            }
+        }
+
+        self.logger.error("Session identity switch could not be verified")
+        throw SessionSwitchError.identityNotApplied(expectedBrandId: expectedBrandId)
+    }
+
+    /// Reads `ytcfg.DATASYNC_ID` from a loaded WebView.
+    private static func readDataSyncId(from webView: WKWebView) async throws -> String? {
+        let script = """
+        (function() {
+            try {
+                if (window.ytcfg && typeof window.ytcfg.get === 'function') {
+                    return window.ytcfg.get('DATASYNC_ID') || '';
+                }
+                if (window.ytcfg && window.ytcfg.data_) {
+                    return window.ytcfg.data_['DATASYNC_ID'] || '';
+                }
+            } catch (e) {}
+            return '';
+        })();
+        """
+        let result = try await webView.evaluateJavaScript(script)
+        return result as? String
+    }
+
+    /// Returns `true` when a `DATASYNC_ID` reflects the expected identity.
+    ///
+    /// `DATASYNC_ID` is `"<delegatedSessionId>||<userSessionId>"` for a brand
+    /// (delegated/secondary channel) and `"<userSessionId>||"` for the primary
+    /// account — i.e. the primary has a non-empty first half and an empty second
+    /// half. A blank or malformed value (e.g. `""` or `"||"`, which the page JS
+    /// returns when `ytcfg` has not populated yet) is treated as *no match* for
+    /// either identity, so an unread page never falsely "verifies" as primary.
+    static func dataSyncId(_ dataSyncId: String, matches expectedBrandId: String?) -> Bool {
+        // A well-formed value has exactly two "||"-separated halves with a
+        // non-empty first half (the user/delegated session id).
+        let parts = dataSyncId.components(separatedBy: "||")
+        guard parts.count == 2, !parts[0].isEmpty else {
+            return false
+        }
+        let firstHalf = parts[0]
+        let hasUserSessionSuffix = !parts[1].isEmpty
+        // delegatedSessionId is present only for a secondary (brand) identity:
+        // "<delegated>||<user>". Primary is "<user>||" (empty second half).
+        let delegatedSessionId: String? = hasUserSessionSuffix ? firstHalf : nil
+        if let expectedBrandId {
+            return delegatedSessionId == expectedBrandId
+        }
+        return delegatedSessionId == nil
+    }
+}
+
+// MARK: - SessionSwitchNavigationDriver
+
+/// Drives a one-shot navigation to completion for ``WebKitManager/switchSessionIdentity(to:expectedBrandId:)``.
+///
+/// Bridges `WKNavigationDelegate` callbacks into a single awaitable result and
+/// enforces a timeout so a hung redirect chain cannot block the switch forever.
+@MainActor
+private final class SessionSwitchNavigationDriver: NSObject, WKNavigationDelegate {
+    private var continuation: CheckedContinuation<Void, Error>?
+    private var finished = false
+    private var timeoutTask: Task<Void, Never>?
+
+    func load(_ url: URL, in webView: WKWebView, timeout: Duration) async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            self.continuation = continuation
+            self.timeoutTask = Task { [weak self] in
+                try? await Task.sleep(for: timeout)
+                guard let self, !self.finished else { return }
+                self.complete(with: .failure(SessionSwitchError.timedOut))
+            }
+            webView.load(URLRequest(url: url))
+        }
+    }
+
+    private func complete(with result: Result<Void, Error>) {
+        guard !self.finished else { return }
+        self.finished = true
+        self.timeoutTask?.cancel()
+        self.timeoutTask = nil
+        let continuation = self.continuation
+        self.continuation = nil
+        continuation?.resume(with: result)
+    }
+
+    func webView(_: WKWebView, didFinish _: WKNavigation!) {
+        self.complete(with: .success(()))
+    }
+
+    func webView(_: WKWebView, didFail _: WKNavigation!, withError error: Error) {
+        self.complete(with: .failure(SessionSwitchError.navigationFailed(underlying: error.localizedDescription)))
+    }
+
+    func webView(_: WKWebView, didFailProvisionalNavigation _: WKNavigation!, withError error: Error) {
+        self.complete(with: .failure(SessionSwitchError.navigationFailed(underlying: error.localizedDescription)))
+    }
+}

--- a/Sources/Kaset/Services/WebKit/WebKitManager.swift
+++ b/Sources/Kaset/Services/WebKit/WebKitManager.swift
@@ -594,8 +594,14 @@ extension WebKitManager {
             webView.stopLoading()
         }
 
+        // Bail before mutating the shared cookie session if already cancelled
+        // (e.g. a stale launch pin superseded by a newer switch).
+        try Task.checkCancellation()
+
         do {
             try await driver.load(signinURL, in: webView, timeout: .seconds(20))
+        } catch is CancellationError {
+            throw CancellationError()
         } catch let error as SessionSwitchError {
             throw error
         } catch {
@@ -603,6 +609,10 @@ extension WebKitManager {
         }
 
         // The page's ytcfg may be emitted slightly after didFinish; poll briefly.
+        // Note: the navigation above is the session MUTATION; this poll is
+        // read-only verification. Correctness across concurrent pins relies on
+        // ordering (the surviving navigation runs last), not on cancellation —
+        // stopLoading() cannot revert cookies already set mid-redirect.
         for attempt in 0 ..< 5 {
             if let dataSyncId = try? await Self.readDataSyncId(from: webView),
                Self.dataSyncId(dataSyncId, matches: expectedBrandId)
@@ -611,7 +621,8 @@ extension WebKitManager {
                 return
             }
             if attempt < 4 {
-                try? await Task.sleep(for: .milliseconds(400))
+                // Use a throwing sleep so cancellation breaks the poll loop.
+                try await Task.sleep(for: .milliseconds(400))
             }
         }
 
@@ -678,14 +689,28 @@ private final class SessionSwitchNavigationDriver: NSObject, WKNavigationDelegat
     private var timeoutTask: Task<Void, Never>?
 
     func load(_ url: URL, in webView: WKWebView, timeout: Duration) async throws {
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            self.continuation = continuation
-            self.timeoutTask = Task { [weak self] in
-                try? await Task.sleep(for: timeout)
-                guard let self, !self.finished else { return }
-                self.complete(with: .failure(SessionSwitchError.timedOut))
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                // The enclosing Task may have been cancelled between the call and
+                // this body running; bail out immediately if so.
+                if Task.isCancelled {
+                    continuation.resume(throwing: CancellationError())
+                    return
+                }
+                self.continuation = continuation
+                self.timeoutTask = Task { [weak self] in
+                    try? await Task.sleep(for: timeout)
+                    guard let self, !self.finished else { return }
+                    self.complete(with: .failure(SessionSwitchError.timedOut))
+                }
+                webView.load(URLRequest(url: url))
             }
-            webView.load(URLRequest(url: url))
+        } onCancel: {
+            // Cooperative cancellation: resolve promptly with CancellationError so
+            // a stale pin does not block a newer switch for the full navigation.
+            Task { @MainActor [weak self] in
+                self?.complete(with: .failure(CancellationError()))
+            }
         }
     }
 

--- a/Sources/Kaset/Views/GeneralSettingsView.swift
+++ b/Sources/Kaset/Views/GeneralSettingsView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 /// Settings view for general app preferences.
 struct GeneralSettingsView: View {
     @Environment(AuthService.self) private var authService
+    @Environment(AccountService.self) private var accountService
     @State private var settings = SettingsManager.shared
     @State private var cacheSize: String = .init(localized: "Calculating...")
     @State private var isClearing = false
@@ -30,6 +31,7 @@ struct GeneralSettingsView: View {
                     if self.authService.state.isLoggedIn {
                         Button("Sign Out") {
                             Task {
+                                await self.accountService.prepareForSignOut()
                                 await self.authService.signOut()
                             }
                         }

--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -256,19 +256,6 @@ struct MainWindow: View {
 
                 guard newAccountId != nil else { return }
 
-                // The session identity was switched (and verified) inside
-                // AccountService.switchAccount before currentAccount changed. Any
-                // track still loaded in the player is the previous identity's
-                // document, so re-point it under the new identity — otherwise
-                // continued listening keeps recording to the old account. The
-                // shared cookie session re-points both music and video WebViews.
-                if self.playerService.currentTrack != nil {
-                    self.playerService.reloadCurrentTrackForIdentitySwitch()
-                }
-                if self.youtubePlayerService.currentVideo != nil {
-                    self.youtubePlayerService.reloadCurrentVideoForIdentitySwitch()
-                }
-
                 self.historyViewModel?.reset()
                 // YouTube surfaces are account-scoped too.
                 self.youtubeStore.resetForAccountChange()
@@ -298,6 +285,23 @@ struct MainWindow: View {
                         }
                     }
                 }
+            }
+        }
+        .onChange(of: self.accountService.verifiedIdentitySequence) { _, _ in
+            // Re-point in-flight playback ONLY once the new session identity is
+            // verified (DATASYNC_ID confirmed). Driving this off the verified
+            // signal — rather than `currentAccount?.id` — avoids reloading the
+            // player under an unverified/primary identity on cold-launch brand
+            // restore, where `currentAccount` is set before its session pin lands.
+            // History is recorded by the playback WebViews' own stats pings, so a
+            // track/video still loaded under the previous identity must reload to
+            // record to the new account. The shared cookie session covers both.
+            guard self.accountService.verifiedAccountId != nil else { return }
+            if self.playerService.currentTrack != nil {
+                self.playerService.reloadCurrentTrackForIdentitySwitch()
+            }
+            if self.youtubePlayerService.currentVideo != nil {
+                self.youtubePlayerService.reloadCurrentVideoForIdentitySwitch()
             }
         }
         .onChange(of: self.podcastsAvailability.availability) { oldValue, newValue in

--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -19,6 +19,7 @@ struct MainWindow: View {
 
     @Environment(AuthService.self) private var authService
     @Environment(PlayerService.self) private var playerService
+    @Environment(YouTubePlayerService.self) private var youtubePlayerService
     @Environment(WebKitManager.self) private var webKitManager
     @Environment(AccountService.self) private var accountService
     @Environment(SongLikeStatusManager.self) private var likeStatusManager
@@ -254,6 +255,19 @@ struct MainWindow: View {
                 URLCache.shared.removeAllCachedResponses()
 
                 guard newAccountId != nil else { return }
+
+                // The session identity was switched (and verified) inside
+                // AccountService.switchAccount before currentAccount changed. Any
+                // track still loaded in the player is the previous identity's
+                // document, so re-point it under the new identity — otherwise
+                // continued listening keeps recording to the old account. The
+                // shared cookie session re-points both music and video WebViews.
+                if self.playerService.currentTrack != nil {
+                    self.playerService.reloadCurrentTrackForIdentitySwitch()
+                }
+                if self.youtubePlayerService.currentVideo != nil {
+                    self.youtubePlayerService.reloadCurrentVideoForIdentitySwitch()
+                }
 
                 self.historyViewModel?.reset()
                 // YouTube surfaces are account-scoped too.

--- a/Sources/Kaset/Views/MiniPlayerWebView.swift
+++ b/Sources/Kaset/Views/MiniPlayerWebView.swift
@@ -388,7 +388,7 @@ final class SingletonPlayerWebView {
             webView.load(URLRequest(url: urlToLoad))
             return
         }
-        let prenavScript = skipPrenavPause ? "" : "document.querySelector('video')?.pause();"
+        let prenavScript = "document.querySelector('video')?.pause();"
         webView.evaluateJavaScript("\(prenavScript)void 0;") { [weak self] _, _ in
             guard let self, let webView = self.webView else { return }
             guard self.loadGeneration == generation, self.currentVideoId == videoId else { return }

--- a/Sources/Kaset/Views/MiniPlayerWebView.swift
+++ b/Sources/Kaset/Views/MiniPlayerWebView.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import os
 import SwiftUI
 import WebKit
@@ -382,6 +383,11 @@ final class SingletonPlayerWebView {
         // mis-reconciled against a restored session before the new document loads.
         let urlToLoad = URL(string: "https://music.youtube.com/watch?v=\(videoId)")!
         let skipPrenavPause = (strategy == .forceFullPageWhenSameVideoId && videoId == previousVideoId)
+        if skipPrenavPause {
+            webView.evaluateJavaScript("window.__kasetTargetVolume = \(currentVolume);", completionHandler: nil)
+            webView.load(URLRequest(url: urlToLoad))
+            return
+        }
         let prenavScript = skipPrenavPause ? "" : "document.querySelector('video')?.pause();"
         webView.evaluateJavaScript("\(prenavScript)void 0;") { [weak self] _, _ in
             guard let self, let webView = self.webView else { return }

--- a/Sources/Kaset/Views/MiniPlayerWebView.swift
+++ b/Sources/Kaset/Views/MiniPlayerWebView.swift
@@ -372,9 +372,15 @@ final class SingletonPlayerWebView {
             targetVolume: currentVolume
         )
 
-        // Stop current playback first, then load new video
+        // Stop current playback first, then load new video. For a forced
+        // full-page navigation (e.g. an identity-switch reload) skip pausing the
+        // OLD <video>: the navigation tears it down anyway, and the pause event
+        // would emit a stale STATE_UPDATE from the outgoing page that can be
+        // mis-reconciled against a restored session before the new document loads.
         let urlToLoad = URL(string: "https://music.youtube.com/watch?v=\(videoId)")!
-        webView.evaluateJavaScript("document.querySelector('video')?.pause()") { [weak self] _, _ in
+        let skipPrenavPause = (strategy == .forceFullPageWhenSameVideoId && videoId == previousVideoId)
+        let prenavScript = skipPrenavPause ? "" : "document.querySelector('video')?.pause();"
+        webView.evaluateJavaScript("\(prenavScript)void 0;") { [weak self] _, _ in
             guard let self, let webView = self.webView else { return }
 
             // Keep the current page's target volume fresh until the new document

--- a/Sources/Kaset/Views/MiniPlayerWebView.swift
+++ b/Sources/Kaset/Views/MiniPlayerWebView.swift
@@ -225,6 +225,7 @@ final class SingletonPlayerWebView {
     var currentVideoId: String?
     var coordinator: Coordinator?
     let logger = DiagnosticsLogger.player
+    private var loadGeneration = 0
 
     /// Current display mode for the WebView.
     enum DisplayMode {
@@ -360,6 +361,8 @@ final class SingletonPlayerWebView {
 
         // Update currentVideoId immediately to prevent duplicate loads
         self.currentVideoId = videoId
+        self.loadGeneration &+= 1
+        let generation = self.loadGeneration
 
         // Get current volume from PlayerService via coordinator
         let currentVolume = self.coordinator?.playerService.volume ?? 1.0
@@ -382,6 +385,7 @@ final class SingletonPlayerWebView {
         let prenavScript = skipPrenavPause ? "" : "document.querySelector('video')?.pause();"
         webView.evaluateJavaScript("\(prenavScript)void 0;") { [weak self] _, _ in
             guard let self, let webView = self.webView else { return }
+            guard self.loadGeneration == generation, self.currentVideoId == videoId else { return }
 
             // Keep the current page's target volume fresh until the new document
             // finishes loading and gets the same value from didFinish.

--- a/Sources/Kaset/Views/YouTube/YouTubeWatchWebView+Scripts.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeWatchWebView+Scripts.swift
@@ -52,6 +52,7 @@ extension YouTubeWatchWebView {
                 try {
                     const video = videoEl();
                     if (!video) { return; }
+                    applyPendingSeek(video);
                     const videoId = currentVideoId();
                     if (videoId !== '') { lastVideoId = videoId; }
                     bridge.postMessage({
@@ -94,6 +95,29 @@ extension YouTubeWatchWebView {
                 }
             }
 
+            // Apply a pending resume-seek from a session-identity-switch reload.
+            // The <video> is created by the player JS after navigation and may
+            // not be seekable immediately, so this is called from both attach()
+            // and the 1s sendUpdate tick and retries until metadata is ready.
+            // Scoped to this document: window.__kasetPendingSeek is re-injected
+            // per page load, so it cannot leak into a later video.
+            function applyPendingSeek(video) {
+                const target = window.__kasetPendingSeek;
+                if (typeof target !== 'number') { return; }
+                if (video.readyState < 1) { return; }
+                try {
+                    video.currentTime = target;
+                    // Re-assert once if the player clobbers currentTime back near 0.
+                    setTimeout(function() {
+                        if (typeof window.__kasetPendingSeek === 'number' &&
+                            Math.abs(video.currentTime - target) > 1.5) {
+                            try { video.currentTime = target; } catch (e) {}
+                        }
+                        window.__kasetPendingSeek = null;
+                    }, 400);
+                } catch (e) {}
+            }
+
             function disableAutonav() {
                 try {
                     const toggle = document.querySelector('.ytp-autonav-toggle-button');
@@ -120,6 +144,7 @@ extension YouTubeWatchWebView {
 
                 disableAutonav();
                 enforceVolume(video);
+                applyPendingSeek(video);
                 sendUpdate();
             }
 

--- a/Sources/Kaset/Views/YouTube/YouTubeWatchWebView+Scripts.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeWatchWebView+Scripts.swift
@@ -104,6 +104,10 @@ extension YouTubeWatchWebView {
             function applyPendingSeek(video) {
                 const target = window.__kasetPendingSeek;
                 if (typeof target !== 'number') { return; }
+                // Don't seek (or consume the pending value) on a preroll-ad video
+                // element — wait for the real content player, or the content would
+                // start from 0 after the ad.
+                if (isAdShowing()) { return; }
                 if (video.readyState < 1) { return; }
                 try {
                     video.currentTime = target;

--- a/Sources/Kaset/Views/YouTube/YouTubeWatchWebView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeWatchWebView.swift
@@ -109,7 +109,8 @@ final class YouTubeWatchWebView {
         let targetVolume = self.coordinator?.playerService.volume ?? 1.0
         self.installUserScripts(
             on: webView.configuration.userContentController,
-            targetVolume: targetVolume
+            targetVolume: targetVolume,
+            pendingSeek: self.pendingSeek
         )
 
         guard let url = URL(string: "https://www.youtube.com/watch?v=\(videoId)") else { return }
@@ -134,12 +135,13 @@ final class YouTubeWatchWebView {
 
     private func installUserScripts(
         on contentController: WKUserContentController,
-        targetVolume: Double
+        targetVolume: Double,
+        pendingSeek: Double? = nil
     ) {
         contentController.removeAllUserScripts()
 
         let bootstrap = WKUserScript(
-            source: Self.pageBootstrapScript(targetVolume: targetVolume),
+            source: Self.pageBootstrapScript(targetVolume: targetVolume, pendingSeek: pendingSeek),
             injectionTime: .atDocumentStart,
             forMainFrameOnly: true
         )
@@ -169,9 +171,19 @@ final class YouTubeWatchWebView {
     }
 
     /// Document-start state handed to each new watch page.
-    nonisolated static func pageBootstrapScript(targetVolume: Double) -> String {
+    ///
+    /// `pendingSeek`, when present, is a resume position (seconds) applied by the
+    /// observer once the `<video>` element exists and is seekable (see
+    /// `applyPendingSeek` in the observer script). Injected at document start so
+    /// it is in place before the player boots, and naturally scoped to this one
+    /// navigation.
+    nonisolated static func pageBootstrapScript(targetVolume: Double, pendingSeek: Double? = nil) -> String {
         let clamped = targetVolume.isFinite ? min(max(targetVolume, 0), 1) : 1.0
-        return "window.__kasetTargetVolume = \(clamped);"
+        var script = "window.__kasetTargetVolume = \(clamped);"
+        if let pendingSeek, pendingSeek.isFinite, pendingSeek > 0 {
+            script += " window.__kasetPendingSeek = \(pendingSeek);"
+        }
+        return script
     }
 
     // MARK: - Coordinator
@@ -216,19 +228,20 @@ final class YouTubeWatchWebView {
                 "YouTube watch WebView finished loading: \(webView.url?.absoluteString ?? "nil")"
             )
 
-            let savedVolume = self.playerService.volume
-            // Apply a pending resume-seek now that the new <video> exists (e.g.
-            // after a session-identity-switch reload). Cleared once consumed.
-            let pendingSeek = YouTubeWatchWebView.shared.pendingSeek
+            // The resume-seek for an identity-switch reload is applied by the
+            // observer's applyPendingSeek (gated on the <video> existing and being
+            // seekable), not here: at didFinish the element often does not exist
+            // yet, so a one-shot seek would be lost. Clear the Swift-side copy now
+            // that the per-load bootstrap has carried the value into the page.
             YouTubeWatchWebView.shared.pendingSeek = nil
-            let seekScript = pendingSeek.map { "if (video) { video.currentTime = \($0); }" } ?? ""
+
+            let savedVolume = self.playerService.volume
             webView.evaluateJavaScript(
                 """
                 (function() {
                     window.__kasetTargetVolume = \(savedVolume);
                     const video = document.querySelector('video');
                     if (video) { video.volume = \(savedVolume); }
-                    \(seekScript)
                     if (window.__kasetExtractVideo) { window.__kasetExtractVideo(); }
                 })();
                 """,

--- a/Sources/Kaset/Views/YouTube/YouTubeWatchWebView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeWatchWebView.swift
@@ -82,6 +82,10 @@ final class YouTubeWatchWebView {
             self.logger.debug("YouTube video \(videoId) already loaded, skipping")
             return
         }
+        // A normal (non-reload) load starts a fresh video: drop any pending
+        // resume-seek left over from an interrupted identity-switch reload, so it
+        // cannot be injected into a different video's document.
+        self.pendingSeek = nil
         self.load(videoId: videoId)
     }
 
@@ -99,7 +103,7 @@ final class YouTubeWatchWebView {
 
     private func load(videoId: String) {
         guard let webView else {
-            self.logger.error("YouTube watch loadVideo called but webView is nil")
+            self.logger.error("YouTube watch load called but webView is nil")
             return
         }
 

--- a/Sources/Kaset/Views/YouTube/YouTubeWatchWebView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeWatchWebView.swift
@@ -29,6 +29,12 @@ final class YouTubeWatchWebView {
     /// exist until the new document loads. Cleared on apply.
     var pendingSeek: Double?
 
+    /// Monotonic counter for `load(videoId:)` calls. The pre-navigation pause is
+    /// async, so a newer load can be requested before an older one's callback
+    /// issues `webView.load`. The callback captures the generation and bails if
+    /// superseded, so a stale reload can't navigate over a newer selection.
+    private var loadGeneration = 0
+
     private init() {}
 
     /// Get or create the watch WebView.
@@ -110,6 +116,9 @@ final class YouTubeWatchWebView {
         self.logger.info("Loading YouTube video: \(videoId) (was: \(self.currentVideoId ?? "none"))")
         self.currentVideoId = videoId
 
+        self.loadGeneration += 1
+        let myLoadGeneration = self.loadGeneration
+
         let targetVolume = self.coordinator?.playerService.volume ?? 1.0
         self.installUserScripts(
             on: webView.configuration.userContentController,
@@ -120,6 +129,13 @@ final class YouTubeWatchWebView {
         guard let url = URL(string: "https://www.youtube.com/watch?v=\(videoId)") else { return }
         webView.evaluateJavaScript("document.querySelector('video')?.pause()") { [weak self] _, _ in
             guard let self, let webView = self.webView else { return }
+            // Bail if a newer load was requested while the pause callback was
+            // pending — otherwise this stale URL would navigate over the newer
+            // selection and the observer would follow the wrong video.
+            guard myLoadGeneration == self.loadGeneration else {
+                self.logger.debug("YouTube load superseded before navigation; skipping stale \(url.absoluteString)")
+                return
+            }
             webView.evaluateJavaScript("window.__kasetTargetVolume = \(targetVolume);", completionHandler: nil)
             webView.load(URLRequest(url: url))
         }

--- a/Sources/Kaset/Views/YouTube/YouTubeWatchWebView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeWatchWebView.swift
@@ -132,7 +132,9 @@ final class YouTubeWatchWebView {
             // Bail if a newer load was requested while the pause callback was
             // pending — otherwise this stale URL would navigate over the newer
             // selection and the observer would follow the wrong video.
-            guard myLoadGeneration == self.loadGeneration else {
+            guard myLoadGeneration == self.loadGeneration,
+                  self.currentVideoId == videoId
+            else {
                 self.logger.debug("YouTube load superseded before navigation; skipping stale \(url.absoluteString)")
                 return
             }
@@ -145,6 +147,7 @@ final class YouTubeWatchWebView {
     func tearDown() {
         guard let webView else { return }
         self.logger.info("Tearing down YouTube watch WebView")
+        self.loadGeneration += 1
         self.currentVideoId = nil
         webView.evaluateJavaScript("document.querySelector('video')?.pause()") { _, _ in }
         webView.loadHTMLString("", baseURL: nil)

--- a/Sources/Kaset/Views/YouTube/YouTubeWatchWebView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeWatchWebView.swift
@@ -109,6 +109,7 @@ final class YouTubeWatchWebView {
 
     func cancelPendingLoad() {
         self.loadGeneration += 1
+        self.webView?.stopLoading()
     }
 
     private func load(videoId: String) {

--- a/Sources/Kaset/Views/YouTube/YouTubeWatchWebView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeWatchWebView.swift
@@ -23,6 +23,12 @@ final class YouTubeWatchWebView {
     var coordinator: Coordinator?
     let logger = DiagnosticsLogger.player
 
+    /// Seek position (seconds) to apply once the next page finishes loading.
+    /// Used to resume a video at its prior position after a forced reload (e.g.
+    /// an account/session-identity switch), since the `<video>` element does not
+    /// exist until the new document loads. Cleared on apply.
+    var pendingSeek: Double?
+
     private init() {}
 
     /// Get or create the watch WebView.
@@ -70,15 +76,30 @@ final class YouTubeWatchWebView {
         webView.autoresizingMask = [.width, .height]
     }
 
-    /// Loads a watch page for the given video.
+    /// Loads a watch page for the given video, skipping if it is already current.
     func loadVideo(videoId: String) {
-        guard let webView else {
-            self.logger.error("YouTube watch loadVideo called but webView is nil")
-            return
-        }
-
         guard videoId != self.currentVideoId else {
             self.logger.debug("YouTube video \(videoId) already loaded, skipping")
+            return
+        }
+        self.load(videoId: videoId)
+    }
+
+    /// Forces a full reload of the given video even when it is already current,
+    /// optionally resuming at `resumeAt` seconds once the new page loads.
+    ///
+    /// Used after an account/session-identity switch: the page identity lives in
+    /// the served document, so the in-flight watch page must be re-fetched under
+    /// the new session for subsequent watch-history pings to attribute correctly.
+    func reloadVideo(videoId: String, resumeAt seconds: Double? = nil) {
+        self.logger.info("Force-reloading YouTube video under new session identity: \(videoId)")
+        self.pendingSeek = seconds
+        self.load(videoId: videoId)
+    }
+
+    private func load(videoId: String) {
+        guard let webView else {
+            self.logger.error("YouTube watch loadVideo called but webView is nil")
             return
         }
 
@@ -196,12 +217,18 @@ final class YouTubeWatchWebView {
             )
 
             let savedVolume = self.playerService.volume
+            // Apply a pending resume-seek now that the new <video> exists (e.g.
+            // after a session-identity-switch reload). Cleared once consumed.
+            let pendingSeek = YouTubeWatchWebView.shared.pendingSeek
+            YouTubeWatchWebView.shared.pendingSeek = nil
+            let seekScript = pendingSeek.map { "if (video) { video.currentTime = \($0); }" } ?? ""
             webView.evaluateJavaScript(
                 """
                 (function() {
                     window.__kasetTargetVolume = \(savedVolume);
                     const video = document.querySelector('video');
                     if (video) { video.volume = \(savedVolume); }
+                    \(seekScript)
                     if (window.__kasetExtractVideo) { window.__kasetExtractVideo(); }
                 })();
                 """,

--- a/Sources/Kaset/Views/YouTube/YouTubeWatchWebView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeWatchWebView.swift
@@ -107,6 +107,10 @@ final class YouTubeWatchWebView {
         self.load(videoId: videoId)
     }
 
+    func cancelPendingLoad() {
+        self.loadGeneration += 1
+    }
+
     private func load(videoId: String) {
         guard let webView else {
             self.logger.error("YouTube watch load called but webView is nil")

--- a/Tests/KasetTests/AccountServiceTests.swift
+++ b/Tests/KasetTests/AccountServiceTests.swift
@@ -476,24 +476,41 @@ private struct TestServices {
 
 // MARK: - AsyncReleaseGate
 
-/// A one-shot async gate: callers `await wait()` until `release()` is called.
+/// A one-shot async gate: callers `await wait()` until `release()` is called or
+/// the awaiting task is cancelled. Cancellation-aware so a gated mock pin that
+/// `switchAccount` cancels+awaits resumes promptly instead of hanging the test.
 /// Used to hold a mocked session pin "in flight" while a concurrent switch runs.
 private actor AsyncReleaseGate {
     private var released = false
-    private var waiters: [CheckedContinuation<Void, Never>] = []
+    private var waiters: [UUID: CheckedContinuation<Void, Never>] = [:]
 
     func wait() async {
         if self.released { return }
-        await withCheckedContinuation { continuation in
-            self.waiters.append(continuation)
+        let id = UUID()
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                if self.released || Task.isCancelled {
+                    continuation.resume()
+                } else {
+                    self.waiters[id] = continuation
+                }
+            }
+        } onCancel: {
+            Task { await self.resumeWaiter(id) }
+        }
+    }
+
+    private func resumeWaiter(_ id: UUID) {
+        if let continuation = self.waiters.removeValue(forKey: id) {
+            continuation.resume()
         }
     }
 
     func release() {
         self.released = true
         let pending = self.waiters
-        self.waiters = []
-        for continuation in pending {
+        self.waiters = [:]
+        for continuation in pending.values {
             continuation.resume()
         }
     }

--- a/Tests/KasetTests/AccountServiceTests.swift
+++ b/Tests/KasetTests/AccountServiceTests.swift
@@ -90,6 +90,126 @@ struct AccountServiceTests {
         #expect(services.account.currentAccount == primaryAccount)
     }
 
+    // MARK: - Session-Switch Gating Tests
+
+    @Test @MainActor func switchAccountVerifiesSessionIdentityWithBrandId() async throws {
+        let mockWebKit = MockWebKitManager()
+        let services = Self.createService(webKitManager: mockWebKit)
+
+        let primaryAccount = MockUserAccountData.primaryAccount
+        let brandAccount = MockUserAccountData.brandAccountWithSigninURL
+        await Self.populateAccounts(services, accounts: [primaryAccount, brandAccount])
+
+        try await services.account.switchAccount(to: brandAccount)
+
+        // The verified session switch must run, scoped to the brand's pageId.
+        #expect(mockWebKit.switchSessionIdentityCalled == true)
+        #expect(mockWebKit.switchSessionIdentityExpectedBrandIds == [brandAccount.brandId])
+        #expect(services.account.currentAccount == brandAccount)
+    }
+
+    @Test @MainActor func failedSessionSwitchRevertsToPreviousAccount() async throws {
+        let mockWebKit = MockWebKitManager()
+        mockWebKit.switchSessionIdentityError = SessionSwitchError.identityNotApplied(expectedBrandId: "x")
+        let services = Self.createService(webKitManager: mockWebKit)
+
+        let primaryAccount = MockUserAccountData.primaryAccount
+        let brandAccount = MockUserAccountData.brandAccountWithSigninURL
+        await Self.populateAccounts(services, accounts: [primaryAccount, brandAccount])
+        #expect(services.account.currentAccount == primaryAccount)
+
+        // The switch must throw and leave the previous account active so the user
+        // is never silently recording history to the wrong account.
+        await #expect(throws: SessionSwitchError.self) {
+            try await services.account.switchAccount(to: brandAccount)
+        }
+        #expect(services.account.currentAccount == primaryAccount)
+        #expect(services.account.currentBrandId == nil)
+    }
+
+    @Test @MainActor func switchAccountWithoutSigninURLFailsSafely() async throws {
+        let mockWebKit = MockWebKitManager()
+        let services = Self.createService(webKitManager: mockWebKit)
+
+        let primaryAccount = MockUserAccountData.primaryAccount
+        // Brand account lacking a signinURL cannot establish a verified session.
+        let brandAccount = MockUserAccountData.brandAccount
+        await Self.populateAccounts(services, accounts: [primaryAccount, brandAccount])
+
+        await #expect(throws: SessionSwitchError.self) {
+            try await services.account.switchAccount(to: brandAccount)
+        }
+        #expect(services.account.currentAccount == primaryAccount)
+    }
+
+    @Test @MainActor func restoringBrandAccountOnLaunchPinsSession() async {
+        let mockWebKit = MockWebKitManager()
+        let services = Self.createService(webKitManager: mockWebKit)
+
+        let primaryAccount = MockUserAccountData.primaryAccount
+        let brandAccount = MockUserAccountData.brandAccountWithSigninURL
+        // Simulate a relaunch with the brand account previously selected.
+        UserDefaults.standard.set(brandAccount.id, forKey: "selectedBrandId")
+        defer { UserDefaults.standard.removeObject(forKey: "selectedBrandId") }
+
+        services.client.accountsListResponse = AccountsListResponse(
+            googleEmail: "test@gmail.com",
+            accounts: [primaryAccount, brandAccount]
+        )
+        services.auth.completeLogin(sapisid: "test-sapisid")
+        await services.account.fetchAccounts()
+        // The pin runs off the fetch path; await it deterministically.
+        await services.account.awaitRestoredBrandSessionPinForTesting()
+
+        // The restored brand account must re-pin the WebView session so playback
+        // records to the brand, not the primary, after a cold launch.
+        #expect(services.account.currentAccount?.id == brandAccount.id)
+        #expect(mockWebKit.switchSessionIdentityCalled == true)
+        #expect(mockWebKit.switchSessionIdentityExpectedBrandIds == [brandAccount.brandId])
+    }
+
+    @Test @MainActor func switchBackToPrimaryVerifiesSessionWithWebKit() async throws {
+        let mockWebKit = MockWebKitManager()
+        let services = Self.createService(webKitManager: mockWebKit)
+
+        // Primary carries a signinURL too (verified against live accounts_list).
+        let primaryAccount = UserAccount.from(
+            name: "Primary",
+            handle: "@primary",
+            brandId: nil,
+            thumbnailURL: nil,
+            isSelected: false,
+            signinURL: URL(string: "https://www.youtube.com/signin?authuser=0&next=%2F")
+        )
+        let brandAccount = MockUserAccountData.brandAccountWithSigninURL
+        await Self.populateAccounts(services, accounts: [primaryAccount, brandAccount], selectedIndex: 1)
+        #expect(services.account.currentAccount?.id == brandAccount.id)
+
+        // Switching back to primary must run a verified switch with nil brand
+        // expectation (the primary identity) and succeed.
+        try await services.account.switchAccount(to: primaryAccount)
+        #expect(services.account.currentAccount?.id == primaryAccount.id)
+        #expect(mockWebKit.switchSessionIdentityExpectedBrandIds.last == .some(nil))
+    }
+
+    @Test @MainActor func restoringPrimaryAccountDoesNotPinSession() async {
+        let mockWebKit = MockWebKitManager()
+        let services = Self.createService(webKitManager: mockWebKit)
+
+        let primaryAccount = MockUserAccountData.primaryAccount
+        UserDefaults.standard.removeObject(forKey: "selectedBrandId")
+
+        services.client.accountsListResponse = AccountsListResponse(
+            googleEmail: "test@gmail.com",
+            accounts: [primaryAccount]
+        )
+        services.auth.completeLogin(sapisid: "test-sapisid")
+        await services.account.fetchAccounts()
+
+        // Primary is the default session identity; no switch navigation needed.
+        #expect(mockWebKit.switchSessionIdentityCalled == false)
+    }
+
     @Test @MainActor func switchAccountUpdatesBrandId() async throws {
         let services = Self.createService()
 
@@ -225,6 +345,20 @@ struct AccountServiceTests {
         return TestServices(account: service, client: mockClient, auth: authService)
     }
 
+    @MainActor
+    private static func createService(webKitManager: MockWebKitManager) -> TestServices {
+        let authService = AuthService()
+        let mockClient = MockYTMusicClient()
+        let service = AccountService(
+            ytMusicClient: mockClient,
+            authService: authService,
+            webKitManager: webKitManager
+        )
+        SongLikeStatusManager.shared.clearCache()
+        SongLikeStatusManager.shared.setActiveAccountID(nil)
+        return TestServices(account: service, client: mockClient, auth: authService)
+    }
+
     /// Populates the AccountService with accounts by going through fetchAccounts().
     @MainActor
     private static func populateAccounts(
@@ -240,7 +374,8 @@ struct AccountServiceTests {
                 handle: account.handle,
                 brandId: account.brandId,
                 thumbnailURL: account.thumbnailURL,
-                isSelected: index == selectedIndex
+                isSelected: index == selectedIndex,
+                signinURL: account.signinURL
             )
         }
 

--- a/Tests/KasetTests/AccountServiceTests.swift
+++ b/Tests/KasetTests/AccountServiceTests.swift
@@ -124,7 +124,7 @@ struct AccountServiceTests {
             nil,
         ]
         await Self.populateAccounts(services, accounts: [primaryAccount])
-        await services.account.awaitRestoredBrandSessionPinForTesting()
+        await services.account.awaitRestoredSessionPinForTesting()
 
         #expect(services.account.currentAccount?.id == primaryAccount.id)
         #expect(services.account.verifiedAccountId == nil)
@@ -213,7 +213,7 @@ struct AccountServiceTests {
         let mockWebKit = MockWebKitManager()
         let services = Self.createService(webKitManager: mockWebKit)
         await Self.populateAccounts(services, accounts: [previous, target], selectedIndex: 0)
-        await services.account.awaitRestoredBrandSessionPinForTesting()
+        await services.account.awaitRestoredSessionPinForTesting()
         #expect(services.account.verifiedAccountId == previous.id)
 
         mockWebKit.reset()
@@ -251,7 +251,7 @@ struct AccountServiceTests {
         let mockWebKit = MockWebKitManager()
         let services = Self.createService(webKitManager: mockWebKit)
         await Self.populateAccounts(services, accounts: [stalePrevious, target], selectedIndex: 0)
-        await services.account.awaitRestoredBrandSessionPinForTesting()
+        await services.account.awaitRestoredSessionPinForTesting()
         mockWebKit.reset()
         services.client.accountsListResponse = AccountsListResponse(googleEmail: "t@gmail.com", accounts: [freshPrevious, target])
         mockWebKit.switchSessionIdentityErrorQueue = [
@@ -278,7 +278,7 @@ struct AccountServiceTests {
         )
         let brand = MockUserAccountData.brandAccountWithSigninURL
         await Self.populateAccounts(services, accounts: [primary, brand], selectedIndex: 0)
-        await services.account.awaitRestoredBrandSessionPinForTesting()
+        await services.account.awaitRestoredSessionPinForTesting()
         mockWebKit.reset()
 
         let gate = AsyncReleaseGate()
@@ -315,7 +315,7 @@ struct AccountServiceTests {
         let mockWebKit = MockWebKitManager()
         let services = Self.createService(webKitManager: mockWebKit)
         await Self.populateAccounts(services, accounts: [previous, target, newer], selectedIndex: 0)
-        await services.account.awaitRestoredBrandSessionPinForTesting()
+        await services.account.awaitRestoredSessionPinForTesting()
         mockWebKit.reset()
 
         let rollbackGate = AsyncReleaseGate()
@@ -365,7 +365,7 @@ struct AccountServiceTests {
         let mockWebKit = MockWebKitManager()
         let services = Self.createService(webKitManager: mockWebKit)
         await Self.populateAccounts(services, accounts: [previous, target], selectedIndex: 0)
-        await services.account.awaitRestoredBrandSessionPinForTesting()
+        await services.account.awaitRestoredSessionPinForTesting()
         mockWebKit.reset()
 
         await #expect(throws: SessionSwitchError.self) {
@@ -516,7 +516,7 @@ struct AccountServiceTests {
             signinURL: URL(string: "https://www.youtube.com/signin?pageid=222222222222222222222&authuser=0&next=%2F")
         )
         await Self.populateAccounts(services, accounts: [brandA, brandB], selectedIndex: 0)
-        await services.account.awaitRestoredBrandSessionPinForTesting()
+        await services.account.awaitRestoredSessionPinForTesting()
         mockWebKit.reset()
         UserDefaults.standard.set(brandA.id, forKey: "selectedBrandId")
         defer { UserDefaults.standard.removeObject(forKey: "selectedBrandId") }
@@ -545,7 +545,7 @@ struct AccountServiceTests {
         await switchGate.release()
         try await switching
         await stalePinGate.release()
-        await services.account.awaitRestoredBrandSessionPinForTesting()
+        await services.account.awaitRestoredSessionPinForTesting()
 
         #expect(services.account.currentAccount?.id == brandB.id)
         #expect(services.account.verifiedAccountId == brandB.id)
@@ -585,7 +585,7 @@ struct AccountServiceTests {
         services.auth.completeLogin(sapisid: "test-sapisid")
         await services.account.fetchAccounts()
         // The pin runs off the fetch path; await it deterministically.
-        await services.account.awaitRestoredBrandSessionPinForTesting()
+        await services.account.awaitRestoredSessionPinForTesting()
 
         // The restored brand account must re-pin the WebView session so playback
         // records to the brand, not the primary, after a cold launch.
@@ -616,7 +616,7 @@ struct AccountServiceTests {
         )
         services.auth.completeLogin(sapisid: "test-sapisid")
         await services.account.fetchAccounts()
-        await services.account.awaitRestoredBrandSessionPinForTesting()
+        await services.account.awaitRestoredSessionPinForTesting()
 
         #expect(services.account.currentAccount?.id == primaryAccount.id)
         #expect(services.account.verifiedAccountId == primaryAccount.id)
@@ -680,7 +680,7 @@ struct AccountServiceTests {
         services.client.accountsListResponse = AccountsListResponse(googleEmail: "t@gmail.com", accounts: [primary])
         services.auth.completeLogin(sapisid: "test-sapisid")
         await services.account.fetchAccounts()
-        await services.account.awaitRestoredBrandSessionPinForTesting()
+        await services.account.awaitRestoredSessionPinForTesting()
 
         #expect(services.account.currentAccount?.id == "primary")
         #expect(mockWebKit.switchSessionIdentityExpectedBrandIds == [nil])
@@ -704,7 +704,7 @@ struct AccountServiceTests {
         services.client.accountsListResponse = AccountsListResponse(googleEmail: "t@gmail.com", accounts: [primary])
         services.auth.completeLogin(sapisid: "test-sapisid")
         await services.account.fetchAccounts()
-        await services.account.awaitRestoredBrandSessionPinForTesting()
+        await services.account.awaitRestoredSessionPinForTesting()
 
         #expect(services.account.currentAccount?.id == "primary")
         #expect(mockWebKit.switchSessionIdentityCalled == true)

--- a/Tests/KasetTests/AccountServiceTests.swift
+++ b/Tests/KasetTests/AccountServiceTests.swift
@@ -162,7 +162,10 @@ struct AccountServiceTests {
         mockWebKit.switchSessionIdentityError = SessionSwitchError.identityNotApplied(expectedBrandId: "x")
         let services = Self.createService(webKitManager: mockWebKit)
 
-        let primaryAccount = MockUserAccountData.primaryAccount
+        let primaryAccount = UserAccount.from(
+            name: "Primary", handle: "@primary", brandId: nil, thumbnailURL: nil, isSelected: true,
+            signinURL: URL(string: "https://www.youtube.com/signin?authuser=0&next=%2F")
+        )
         let brandAccount = MockUserAccountData.brandAccountWithSigninURL
         await Self.populateAccounts(services, accounts: [primaryAccount, brandAccount])
         #expect(services.account.currentAccount == primaryAccount)

--- a/Tests/KasetTests/AccountServiceTests.swift
+++ b/Tests/KasetTests/AccountServiceTests.swift
@@ -641,6 +641,7 @@ struct AccountServiceTests {
         )
         services.auth.completeLogin(sapisid: "test-sapisid")
         await services.account.fetchAccounts()
+        await services.account.awaitRestoredSessionPinForTesting()
 
         #expect(services.account.currentAccount?.id == primaryAccount.id)
         #expect(services.account.verifiedAccountId == nil)
@@ -709,6 +710,26 @@ struct AccountServiceTests {
         #expect(services.account.currentAccount?.id == "primary")
         #expect(mockWebKit.switchSessionIdentityExpectedBrandIds == [nil])
         #expect(services.account.verifiedAccountId == "primary")
+    }
+
+    @Test @MainActor func failedRestoredPrimarySessionPinSurfacesError() async {
+        let mockWebKit = MockWebKitManager()
+        let services = Self.createService(webKitManager: mockWebKit)
+
+        let primary = UserAccount.from(
+            name: "Primary", handle: "@p", brandId: nil, thumbnailURL: nil, isSelected: true,
+            signinURL: URL(string: "https://www.youtube.com/signin?authuser=0&next=%2F")
+        )
+        mockWebKit.switchSessionIdentityError = SessionSwitchError.identityNotApplied(expectedBrandId: nil)
+
+        services.client.accountsListResponse = AccountsListResponse(googleEmail: "t@gmail.com", accounts: [primary])
+        services.auth.completeLogin(sapisid: "test-sapisid")
+        await services.account.fetchAccounts()
+        await services.account.awaitRestoredSessionPinForTesting()
+
+        #expect(services.account.currentAccount?.id == "primary")
+        #expect(services.account.verifiedAccountId == nil)
+        #expect(services.account.lastError != nil)
     }
 
     @Test @MainActor func restoredBrandVanishedRePinsPrimary() async {

--- a/Tests/KasetTests/AccountServiceTests.swift
+++ b/Tests/KasetTests/AccountServiceTests.swift
@@ -376,6 +376,30 @@ struct AccountServiceTests {
         #expect(mockWebKit.switchSessionIdentityCalled == false)
     }
 
+    @Test @MainActor func restoredBrandVanishedRePinsPrimary() async {
+        let mockWebKit = MockWebKitManager()
+        let services = Self.createService(webKitManager: mockWebKit)
+
+        // Saved a brand that is NO LONGER in the returned accounts list; fetch
+        // falls back to primary. The shared session may still be brand-delegated,
+        // so primary must be re-pinned (expectedBrandId nil).
+        let primary = UserAccount.from(
+            name: "Primary", handle: "@p", brandId: nil, thumbnailURL: nil, isSelected: true,
+            signinURL: URL(string: "https://www.youtube.com/signin?authuser=0&next=%2F")
+        )
+        UserDefaults.standard.set("999999999999999999999", forKey: "selectedBrandId")
+        defer { UserDefaults.standard.removeObject(forKey: "selectedBrandId") }
+
+        services.client.accountsListResponse = AccountsListResponse(googleEmail: "t@gmail.com", accounts: [primary])
+        services.auth.completeLogin(sapisid: "test-sapisid")
+        await services.account.fetchAccounts()
+        await services.account.awaitRestoredBrandSessionPinForTesting()
+
+        #expect(services.account.currentAccount?.id == "primary")
+        #expect(mockWebKit.switchSessionIdentityCalled == true)
+        #expect(mockWebKit.switchSessionIdentityExpectedBrandIds == [nil])
+    }
+
     @Test @MainActor func switchAccountUpdatesBrandId() async throws {
         let services = Self.createService()
 

--- a/Tests/KasetTests/AccountServiceTests.swift
+++ b/Tests/KasetTests/AccountServiceTests.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 // AccountServiceTests.swift
 // KasetTests
 //
@@ -62,7 +63,10 @@ struct AccountServiceTests {
     @Test @MainActor func switchAccountUpdatesCurrentAccount() async throws {
         let services = Self.createService()
 
-        let primaryAccount = MockUserAccountData.primaryAccount
+        let primaryAccount = UserAccount.from(
+            name: "Primary", handle: "@primary", brandId: nil, thumbnailURL: nil, isSelected: true,
+            signinURL: URL(string: "https://www.youtube.com/signin?authuser=0&next=%2F")
+        )
         let brandAccount = MockUserAccountData.brandAccount
         await Self.populateAccounts(services, accounts: [primaryAccount, brandAccount])
 
@@ -80,7 +84,10 @@ struct AccountServiceTests {
     @Test @MainActor func switchAccountToSameAccountIsNoOp() async throws {
         let services = Self.createService()
 
-        let primaryAccount = MockUserAccountData.primaryAccount
+        let primaryAccount = UserAccount.from(
+            name: "Primary", handle: "@primary", brandId: nil, thumbnailURL: nil, isSelected: true,
+            signinURL: URL(string: "https://www.youtube.com/signin?authuser=0&next=%2F")
+        )
         await Self.populateAccounts(services, accounts: [primaryAccount])
 
         // Attempt to switch to the same account
@@ -130,7 +137,10 @@ struct AccountServiceTests {
         let mockWebKit = MockWebKitManager()
         let services = Self.createService(webKitManager: mockWebKit)
 
-        let primaryAccount = MockUserAccountData.primaryAccount
+        let primaryAccount = UserAccount.from(
+            name: "Primary", handle: "@primary", brandId: nil, thumbnailURL: nil, isSelected: true,
+            signinURL: URL(string: "https://www.youtube.com/signin?authuser=0&next=%2F")
+        )
         let brandAccount = MockUserAccountData.brandAccountWithSigninURL
         await Self.populateAccounts(services, accounts: [primaryAccount, brandAccount])
 

--- a/Tests/KasetTests/AccountServiceTests.swift
+++ b/Tests/KasetTests/AccountServiceTests.swift
@@ -97,7 +97,7 @@ struct AccountServiceTests {
         #expect(services.account.currentAccount == primaryAccount)
     }
 
-    @Test @MainActor func sameAccountWithoutSigninURLIsNoOpEvenWhenUnverified() async throws {
+    @Test @MainActor func sameAccountWithSigninURLRemainsSelected() async throws {
         let services = Self.createService(webKitManager: MockWebKitManager())
 
         let primaryAccount = UserAccount.from(

--- a/Tests/KasetTests/AccountServiceTests.swift
+++ b/Tests/KasetTests/AccountServiceTests.swift
@@ -90,6 +90,17 @@ struct AccountServiceTests {
         #expect(services.account.currentAccount == primaryAccount)
     }
 
+    @Test @MainActor func sameAccountWithoutSigninURLIsNoOpEvenWhenUnverified() async throws {
+        let services = Self.createService(webKitManager: MockWebKitManager())
+
+        let primaryAccount = MockUserAccountData.primaryAccount
+        await Self.populateAccounts(services, accounts: [primaryAccount])
+
+        try await services.account.switchAccount(to: primaryAccount)
+
+        #expect(services.account.currentAccount == primaryAccount)
+    }
+
     @Test @MainActor func sameAccountSwitchRetriesUnverifiedSessionIdentity() async throws {
         let mockWebKit = MockWebKitManager()
         let services = Self.createService(webKitManager: mockWebKit)

--- a/Tests/KasetTests/AccountServiceTests.swift
+++ b/Tests/KasetTests/AccountServiceTests.swift
@@ -90,6 +90,29 @@ struct AccountServiceTests {
         #expect(services.account.currentAccount == primaryAccount)
     }
 
+    @Test @MainActor func sameAccountSwitchRetriesUnverifiedSessionIdentity() async throws {
+        let mockWebKit = MockWebKitManager()
+        let services = Self.createService(webKitManager: mockWebKit)
+
+        let primaryAccount = MockUserAccountData.primaryAccount
+        let brandAccount = MockUserAccountData.brandAccountWithSigninURL
+        mockWebKit.switchSessionIdentityErrorQueue = [
+            SessionSwitchError.identityNotApplied(expectedBrandId: brandAccount.brandId),
+            nil,
+        ]
+        await Self.populateAccounts(services, accounts: [primaryAccount, brandAccount], selectedIndex: 1)
+        await services.account.awaitRestoredBrandSessionPinForTesting()
+
+        #expect(services.account.currentAccount?.id == brandAccount.id)
+        #expect(services.account.verifiedAccountId == nil)
+
+        try await services.account.switchAccount(to: brandAccount)
+
+        #expect(mockWebKit.switchSessionIdentityCallCount == 2)
+        #expect(mockWebKit.switchSessionIdentityCompletedBrandIds == [brandAccount.brandId])
+        #expect(services.account.verifiedAccountId == brandAccount.id)
+    }
+
     // MARK: - Session-Switch Gating Tests
 
     @Test @MainActor func switchAccountVerifiesSessionIdentityWithBrandId() async throws {
@@ -149,19 +172,175 @@ struct AccountServiceTests {
 
         // Native reverts AND the session is re-pinned to the previous identity.
         #expect(services.account.currentAccount?.id == previous.id)
-        #expect(mockWebKit.switchSessionIdentityCallCount == 2)
+        #expect(mockWebKit.switchSessionIdentityCallCount >= 2)
+        #expect(Array(mockWebKit.switchSessionIdentityExpectedBrandIds.prefix(2)) == [target.brandId, previous.brandId])
+        #expect(mockWebKit.switchSessionIdentityURLs.dropFirst().first == previous.signinURL)
+    }
+
+    @Test @MainActor func failedRollbackClearsVerifiedIdentity() async throws {
+        let previous = MockUserAccountData.brandAccountWithSigninURL
+        let target = UserAccount.from(
+            name: "Other Brand", handle: "@other", brandId: "222222222222222222222",
+            thumbnailURL: nil, isSelected: false,
+            signinURL: URL(string: "https://www.youtube.com/signin?pageid=222222222222222222222&authuser=0&next=%2F")
+        )
+        let mockWebKit = MockWebKitManager()
+        let services = Self.createService(webKitManager: mockWebKit)
+        await Self.populateAccounts(services, accounts: [previous, target], selectedIndex: 0)
+        await services.account.awaitRestoredBrandSessionPinForTesting()
+        #expect(services.account.verifiedAccountId == previous.id)
+
+        mockWebKit.reset()
+        mockWebKit.switchSessionIdentityErrorQueue = [
+            SessionSwitchError.identityNotApplied(expectedBrandId: target.brandId),
+            SessionSwitchError.identityNotApplied(expectedBrandId: previous.brandId),
+        ]
+        services.client.shouldThrowError = YTMusicError.apiError(message: "refresh disabled", code: nil)
+
+        await #expect(throws: SessionSwitchError.self) {
+            try await services.account.switchAccount(to: target)
+        }
+
+        #expect(services.account.currentAccount?.id == previous.id)
+        #expect(services.account.verifiedAccountId == nil)
         #expect(mockWebKit.switchSessionIdentityExpectedBrandIds == [target.brandId, previous.brandId])
-        #expect(mockWebKit.switchSessionIdentityURLs.last == previous.signinURL)
+    }
+
+    @Test @MainActor func failedSwitchRollbackUsesFreshPreviousSigninURL() async throws {
+        let stalePrevious = UserAccount.from(
+            name: "Previous", handle: "@previous", brandId: "111111111111111111111",
+            thumbnailURL: nil, isSelected: true,
+            signinURL: URL(string: "https://www.youtube.com/signin?pageid=111111111111111111111&stale=1")
+        )
+        let freshPrevious = UserAccount.from(
+            name: "Previous", handle: "@previous", brandId: "111111111111111111111",
+            thumbnailURL: nil, isSelected: true,
+            signinURL: URL(string: "https://www.youtube.com/signin?pageid=111111111111111111111&fresh=1")
+        )
+        let target = UserAccount.from(
+            name: "Target", handle: "@target", brandId: "222222222222222222222",
+            thumbnailURL: nil, isSelected: false,
+            signinURL: URL(string: "https://www.youtube.com/signin?pageid=222222222222222222222&authuser=0&next=%2F")
+        )
+        let mockWebKit = MockWebKitManager()
+        let services = Self.createService(webKitManager: mockWebKit)
+        await Self.populateAccounts(services, accounts: [stalePrevious, target], selectedIndex: 0)
+        await services.account.awaitRestoredBrandSessionPinForTesting()
+        mockWebKit.reset()
+        services.client.accountsListResponse = AccountsListResponse(googleEmail: "t@gmail.com", accounts: [freshPrevious, target])
+        mockWebKit.switchSessionIdentityErrorQueue = [
+            SessionSwitchError.identityNotApplied(expectedBrandId: target.brandId),
+            nil,
+        ]
+
+        await #expect(throws: SessionSwitchError.self) {
+            try await services.account.switchAccount(to: target)
+        }
+
+        #expect(mockWebKit.switchSessionIdentityURLs == [target.signinURL, freshPrevious.signinURL])
+        #expect(services.account.currentAccount?.signinURL == freshPrevious.signinURL)
+        #expect(services.account.verifiedAccountId == freshPrevious.id)
+    }
+
+    @Test @MainActor func prepareForSignOutCancelsInFlightSessionMutation() async {
+        let mockWebKit = MockWebKitManager()
+        let services = Self.createService(webKitManager: mockWebKit)
+
+        let primary = UserAccount.from(
+            name: "Primary", handle: "@p", brandId: nil, thumbnailURL: nil, isSelected: true,
+            signinURL: URL(string: "https://www.youtube.com/signin?authuser=0&next=%2F")
+        )
+        let brand = MockUserAccountData.brandAccountWithSigninURL
+        await Self.populateAccounts(services, accounts: [primary, brand], selectedIndex: 0)
+        await services.account.awaitRestoredBrandSessionPinForTesting()
+        mockWebKit.reset()
+
+        let gate = AsyncReleaseGate()
+        mockWebKit.switchSessionIdentityGate = { await gate.wait() }
+        async let switching: Void = services.account.switchAccount(to: brand)
+        for _ in 0 ..< 100 where mockWebKit.switchSessionIdentityCallCount < 1 {
+            await Task.yield()
+        }
+        guard mockWebKit.switchSessionIdentityCallCount >= 1 else {
+            Issue.record("Expected switch navigation to start")
+            await gate.release()
+            try? await switching
+            return
+        }
+
+        await services.account.prepareForSignOut()
+        try? await switching
+
+        #expect(mockWebKit.switchSessionIdentityCompletedBrandIds.isEmpty)
+    }
+
+    @Test @MainActor func newerSwitchCancelsFailedSwitchRollbackNavigation() async throws {
+        let previous = UserAccount.from(
+            name: "Primary", handle: "@primary", brandId: nil,
+            thumbnailURL: nil, isSelected: true,
+            signinURL: URL(string: "https://www.youtube.com/signin?authuser=0&next=%2F")
+        )
+        let target = MockUserAccountData.brandAccountWithSigninURL
+        let newer = UserAccount.from(
+            name: "Newer Brand", handle: "@newer", brandId: "222222222222222222222",
+            thumbnailURL: nil, isSelected: false,
+            signinURL: URL(string: "https://www.youtube.com/signin?pageid=222222222222222222222&authuser=0&next=%2F")
+        )
+        let mockWebKit = MockWebKitManager()
+        let services = Self.createService(webKitManager: mockWebKit)
+        await Self.populateAccounts(services, accounts: [previous, target, newer], selectedIndex: 0)
+        await services.account.awaitRestoredBrandSessionPinForTesting()
+        mockWebKit.reset()
+
+        let rollbackGate = AsyncReleaseGate()
+        mockWebKit.switchSessionIdentityGateQueue = [nil, { await rollbackGate.wait() }, nil]
+        mockWebKit.switchSessionIdentityErrorQueue = [
+            SessionSwitchError.identityNotApplied(expectedBrandId: target.brandId),
+            nil,
+            nil,
+        ]
+
+        async let failedSwitch: Void = services.account.switchAccount(to: target)
+        for _ in 0 ..< 100 where mockWebKit.switchSessionIdentityCallCount < 2 {
+            await Task.yield()
+        }
+        guard mockWebKit.switchSessionIdentityCallCount >= 2 else {
+            Issue.record("Expected rollback navigation to start")
+            await rollbackGate.release()
+            try? await failedSwitch
+            return
+        }
+
+        try await services.account.switchAccount(to: newer)
+
+        // The newer switch must cancel the in-flight rollback before it can
+        // complete after the newer navigation and re-point the shared session
+        // back to the previous account.
+        #expect(services.account.currentAccount?.id == newer.id)
+        #expect(mockWebKit.switchSessionIdentityExpectedBrandIds == [target.brandId, previous.brandId, newer.brandId])
+        #expect(mockWebKit.switchSessionIdentityCompletedBrandIds == [newer.brandId])
+
+        await rollbackGate.release()
+        do {
+            try await failedSwitch
+            Issue.record("Expected original failed switch to throw")
+        } catch {}
+        #expect(mockWebKit.switchSessionIdentityCompletedBrandIds == [newer.brandId])
     }
 
     @Test @MainActor func preSwitchFailureDoesNotRollBackSession() async throws {
         // A target lacking signinURL throws BEFORE any session navigation, so no
         // rollback should run (the session was never touched).
         let previous = MockUserAccountData.brandAccountWithSigninURL
-        let target = MockUserAccountData.brandAccount // no signinURL
+        let target = UserAccount.from(
+            name: "Other Brand", handle: "@other", brandId: "222222222222222222222",
+            thumbnailURL: nil, isSelected: false
+        )
         let mockWebKit = MockWebKitManager()
         let services = Self.createService(webKitManager: mockWebKit)
         await Self.populateAccounts(services, accounts: [previous, target], selectedIndex: 0)
+        await services.account.awaitRestoredBrandSessionPinForTesting()
+        mockWebKit.reset()
 
         await #expect(throws: SessionSwitchError.self) {
             try await services.account.switchAccount(to: target)
@@ -218,15 +397,22 @@ struct AccountServiceTests {
 
         // Gate the FIRST switch (to A) so it is still verifying when B starts.
         let releaseA = AsyncReleaseGate()
-        mockWebKit.switchSessionIdentityGate = { await releaseA.wait() }
+        mockWebKit.switchSessionIdentityGateQueue = [{ await releaseA.wait() }, nil]
         async let firstSwitch: Void = services.account.switchAccount(to: brandA)
         // Let the first switch reach the gate.
-        await Task.yield()
+        for _ in 0 ..< 100 where mockWebKit.switchSessionIdentityCallCount < 1 {
+            await Task.yield()
+        }
+        guard mockWebKit.switchSessionIdentityCallCount >= 1 else {
+            Issue.record("Expected first switch navigation to start")
+            await releaseA.release()
+            try? await firstSwitch
+            return
+        }
 
         // Start the second switch (to B) ungated; it bumps the generation and
         // commits B. Then release A — A must observe it was superseded and NOT
         // overwrite currentAccount back to A.
-        mockWebKit.switchSessionIdentityGate = nil
         try await services.account.switchAccount(to: brandB)
         #expect(services.account.currentAccount?.id == brandB.id)
 
@@ -291,6 +477,54 @@ struct AccountServiceTests {
         try await switching
 
         #expect(services.account.currentAccount?.id == brand.id)
+    }
+
+    @Test @MainActor func passiveFetchDoesNotStartRestorePinDuringManualSwitch() async throws {
+        let mockWebKit = MockWebKitManager()
+        let services = Self.createService(webKitManager: mockWebKit)
+
+        let brandA = MockUserAccountData.brandAccountWithSigninURL
+        let brandB = UserAccount.from(
+            name: "Brand B", handle: "@b", brandId: "222222222222222222222",
+            thumbnailURL: nil, isSelected: false,
+            signinURL: URL(string: "https://www.youtube.com/signin?pageid=222222222222222222222&authuser=0&next=%2F")
+        )
+        await Self.populateAccounts(services, accounts: [brandA, brandB], selectedIndex: 0)
+        await services.account.awaitRestoredBrandSessionPinForTesting()
+        mockWebKit.reset()
+        UserDefaults.standard.set(brandA.id, forKey: "selectedBrandId")
+        defer { UserDefaults.standard.removeObject(forKey: "selectedBrandId") }
+
+        let switchGate = AsyncReleaseGate()
+        let stalePinGate = AsyncReleaseGate()
+        mockWebKit.switchSessionIdentityGateQueue = [{ await switchGate.wait() }, { await stalePinGate.wait() }]
+        async let switching: Void = services.account.switchAccount(to: brandB)
+        for _ in 0 ..< 100 where mockWebKit.switchSessionIdentityCallCount < 1 {
+            await Task.yield()
+        }
+        guard mockWebKit.switchSessionIdentityCallCount >= 1 else {
+            Issue.record("Expected manual switch navigation to start")
+            await switchGate.release()
+            try? await switching
+            return
+        }
+
+        services.client.accountsListResponse = AccountsListResponse(googleEmail: "t@gmail.com", accounts: [brandA, brandB])
+        await services.account.fetchAccounts()
+
+        // A passive refresh that restores saved brand A must not start a second
+        // /signin while the user's manual switch to brand B owns the session.
+        #expect(mockWebKit.switchSessionIdentityCallCount == 1)
+
+        await switchGate.release()
+        try await switching
+        await stalePinGate.release()
+        await services.account.awaitRestoredBrandSessionPinForTesting()
+
+        #expect(services.account.currentAccount?.id == brandB.id)
+        #expect(services.account.verifiedAccountId == brandB.id)
+        #expect(mockWebKit.switchSessionIdentityExpectedBrandIds == [brandB.brandId])
+        #expect(mockWebKit.switchSessionIdentityCompletedBrandIds == [brandB.brandId])
     }
 
     @Test @MainActor func switchAccountWithoutSigninURLFailsSafely() async throws {
@@ -358,7 +592,7 @@ struct AccountServiceTests {
         #expect(mockWebKit.switchSessionIdentityExpectedBrandIds.last == .some(nil))
     }
 
-    @Test @MainActor func restoringPrimaryAccountDoesNotPinSession() async {
+    @Test @MainActor func restoringPrimaryAccountWithoutSigninURLDoesNotPinSession() async {
         let mockWebKit = MockWebKitManager()
         let services = Self.createService(webKitManager: mockWebKit)
 
@@ -372,8 +606,29 @@ struct AccountServiceTests {
         services.auth.completeLogin(sapisid: "test-sapisid")
         await services.account.fetchAccounts()
 
-        // Primary is the default session identity; no switch navigation needed.
+        // Without a server-issued signin URL, there is no safe switch navigation to run.
         #expect(mockWebKit.switchSessionIdentityCalled == false)
+    }
+
+    @Test @MainActor func restoringPrimaryAccountWithSigninURLPinsSession() async {
+        let mockWebKit = MockWebKitManager()
+        let services = Self.createService(webKitManager: mockWebKit)
+
+        let primary = UserAccount.from(
+            name: "Primary", handle: "@p", brandId: nil, thumbnailURL: nil, isSelected: true,
+            signinURL: URL(string: "https://www.youtube.com/signin?authuser=0&next=%2F")
+        )
+        UserDefaults.standard.set("primary", forKey: "selectedBrandId")
+        defer { UserDefaults.standard.removeObject(forKey: "selectedBrandId") }
+
+        services.client.accountsListResponse = AccountsListResponse(googleEmail: "t@gmail.com", accounts: [primary])
+        services.auth.completeLogin(sapisid: "test-sapisid")
+        await services.account.fetchAccounts()
+        await services.account.awaitRestoredBrandSessionPinForTesting()
+
+        #expect(services.account.currentAccount?.id == "primary")
+        #expect(mockWebKit.switchSessionIdentityExpectedBrandIds == [nil])
+        #expect(services.account.verifiedAccountId == "primary")
     }
 
     @Test @MainActor func restoredBrandVanishedRePinsPrimary() async {

--- a/Tests/KasetTests/AccountServiceTests.swift
+++ b/Tests/KasetTests/AccountServiceTests.swift
@@ -624,6 +624,27 @@ struct AccountServiceTests {
         #expect(SongLikeStatusManager.shared.activeAccountID == primaryAccount.id)
     }
 
+    @Test @MainActor func restoredBrandWithoutSigninURLFallsBackToPrimary() async {
+        let services = Self.createService(webKitManager: MockWebKitManager())
+
+        let primaryAccount = MockUserAccountData.primaryAccount
+        let brandAccount = MockUserAccountData.brandAccount
+        UserDefaults.standard.set(brandAccount.id, forKey: "selectedBrandId")
+        defer { UserDefaults.standard.removeObject(forKey: "selectedBrandId") }
+
+        services.client.accountsListResponse = AccountsListResponse(
+            googleEmail: "test@gmail.com",
+            accounts: [primaryAccount, brandAccount]
+        )
+        services.auth.completeLogin(sapisid: "test-sapisid")
+        await services.account.fetchAccounts()
+
+        #expect(services.account.currentAccount?.id == primaryAccount.id)
+        #expect(services.account.verifiedAccountId == nil)
+        #expect(services.account.lastError != nil)
+        #expect(SongLikeStatusManager.shared.activeAccountID == primaryAccount.id)
+    }
+
     @Test @MainActor func switchBackToPrimaryVerifiesSessionWithWebKit() async throws {
         let mockWebKit = MockWebKitManager()
         let services = Self.createService(webKitManager: mockWebKit)

--- a/Tests/KasetTests/AccountServiceTests.swift
+++ b/Tests/KasetTests/AccountServiceTests.swift
@@ -100,7 +100,10 @@ struct AccountServiceTests {
     @Test @MainActor func sameAccountWithoutSigninURLIsNoOpEvenWhenUnverified() async throws {
         let services = Self.createService(webKitManager: MockWebKitManager())
 
-        let primaryAccount = MockUserAccountData.primaryAccount
+        let primaryAccount = UserAccount.from(
+            name: "Primary", handle: "@primary", brandId: nil, thumbnailURL: nil, isSelected: true,
+            signinURL: URL(string: "https://www.youtube.com/signin?authuser=0&next=%2F")
+        )
         await Self.populateAccounts(services, accounts: [primaryAccount])
 
         try await services.account.switchAccount(to: primaryAccount)
@@ -112,23 +115,25 @@ struct AccountServiceTests {
         let mockWebKit = MockWebKitManager()
         let services = Self.createService(webKitManager: mockWebKit)
 
-        let primaryAccount = MockUserAccountData.primaryAccount
-        let brandAccount = MockUserAccountData.brandAccountWithSigninURL
+        let primaryAccount = UserAccount.from(
+            name: "Primary", handle: "@primary", brandId: nil, thumbnailURL: nil, isSelected: true,
+            signinURL: URL(string: "https://www.youtube.com/signin?authuser=0&next=%2F")
+        )
         mockWebKit.switchSessionIdentityErrorQueue = [
-            SessionSwitchError.identityNotApplied(expectedBrandId: brandAccount.brandId),
+            SessionSwitchError.identityNotApplied(expectedBrandId: nil),
             nil,
         ]
-        await Self.populateAccounts(services, accounts: [primaryAccount, brandAccount], selectedIndex: 1)
+        await Self.populateAccounts(services, accounts: [primaryAccount])
         await services.account.awaitRestoredBrandSessionPinForTesting()
 
-        #expect(services.account.currentAccount?.id == brandAccount.id)
+        #expect(services.account.currentAccount?.id == primaryAccount.id)
         #expect(services.account.verifiedAccountId == nil)
 
-        try await services.account.switchAccount(to: brandAccount)
+        try await services.account.switchAccount(to: primaryAccount)
 
         #expect(mockWebKit.switchSessionIdentityCallCount == 2)
-        #expect(mockWebKit.switchSessionIdentityCompletedBrandIds == [brandAccount.brandId])
-        #expect(services.account.verifiedAccountId == brandAccount.id)
+        #expect(mockWebKit.switchSessionIdentityCompletedBrandIds == [nil])
+        #expect(services.account.verifiedAccountId == primaryAccount.id)
     }
 
     // MARK: - Session-Switch Gating Tests
@@ -587,6 +592,36 @@ struct AccountServiceTests {
         #expect(services.account.currentAccount?.id == brandAccount.id)
         #expect(mockWebKit.switchSessionIdentityCalled == true)
         #expect(mockWebKit.switchSessionIdentityExpectedBrandIds == [brandAccount.brandId])
+    }
+
+    @Test @MainActor func failedRestoredBrandSessionPinFallsBackToPrimary() async {
+        let mockWebKit = MockWebKitManager()
+        let services = Self.createService(webKitManager: mockWebKit)
+
+        let primaryAccount = UserAccount.from(
+            name: "Primary", handle: "@primary", brandId: nil, thumbnailURL: nil, isSelected: true,
+            signinURL: URL(string: "https://www.youtube.com/signin?authuser=0&next=%2F")
+        )
+        let brandAccount = MockUserAccountData.brandAccountWithSigninURL
+        UserDefaults.standard.set(brandAccount.id, forKey: "selectedBrandId")
+        defer { UserDefaults.standard.removeObject(forKey: "selectedBrandId") }
+
+        mockWebKit.switchSessionIdentityErrorQueue = [
+            SessionSwitchError.identityNotApplied(expectedBrandId: brandAccount.brandId),
+            nil,
+        ]
+        services.client.accountsListResponse = AccountsListResponse(
+            googleEmail: "test@gmail.com",
+            accounts: [primaryAccount, brandAccount]
+        )
+        services.auth.completeLogin(sapisid: "test-sapisid")
+        await services.account.fetchAccounts()
+        await services.account.awaitRestoredBrandSessionPinForTesting()
+
+        #expect(services.account.currentAccount?.id == primaryAccount.id)
+        #expect(services.account.verifiedAccountId == primaryAccount.id)
+        #expect(services.account.lastError != nil)
+        #expect(SongLikeStatusManager.shared.activeAccountID == primaryAccount.id)
     }
 
     @Test @MainActor func switchBackToPrimaryVerifiesSessionWithWebKit() async throws {

--- a/Tests/KasetTests/AccountServiceTests.swift
+++ b/Tests/KasetTests/AccountServiceTests.swift
@@ -200,6 +200,43 @@ struct AccountServiceTests {
         #expect(mockWebKit.switchSessionIdentityURLs.last == primary.signinURL)
     }
 
+    @Test @MainActor func supersededSwitchAbandonsItsCommit() async throws {
+        let mockWebKit = MockWebKitManager()
+        let services = Self.createService(webKitManager: mockWebKit)
+
+        let primary = UserAccount.from(
+            name: "Primary", handle: "@p", brandId: nil, thumbnailURL: nil, isSelected: true,
+            signinURL: URL(string: "https://www.youtube.com/signin?authuser=0&next=%2F")
+        )
+        let brandA = MockUserAccountData.brandAccountWithSigninURL
+        let brandB = UserAccount.from(
+            name: "Brand B", handle: "@b", brandId: "222222222222222222222",
+            thumbnailURL: nil, isSelected: false,
+            signinURL: URL(string: "https://www.youtube.com/signin?pageid=222222222222222222222&authuser=0&next=%2F")
+        )
+        await Self.populateAccounts(services, accounts: [primary, brandA, brandB], selectedIndex: 0)
+
+        // Gate the FIRST switch (to A) so it is still verifying when B starts.
+        let releaseA = AsyncReleaseGate()
+        mockWebKit.switchSessionIdentityGate = { await releaseA.wait() }
+        async let firstSwitch: Void = services.account.switchAccount(to: brandA)
+        // Let the first switch reach the gate.
+        await Task.yield()
+
+        // Start the second switch (to B) ungated; it bumps the generation and
+        // commits B. Then release A — A must observe it was superseded and NOT
+        // overwrite currentAccount back to A.
+        mockWebKit.switchSessionIdentityGate = nil
+        try await services.account.switchAccount(to: brandB)
+        #expect(services.account.currentAccount?.id == brandB.id)
+
+        await releaseA.release()
+        try? await firstSwitch
+
+        // B remains the active account; the superseded A switch did not clobber it.
+        #expect(services.account.currentAccount?.id == brandB.id)
+    }
+
     @Test @MainActor func switchAccountWithoutSigninURLFailsSafely() async throws {
         let mockWebKit = MockWebKitManager()
         let services = Self.createService(webKitManager: mockWebKit)

--- a/Tests/KasetTests/AccountServiceTests.swift
+++ b/Tests/KasetTests/AccountServiceTests.swift
@@ -237,6 +237,62 @@ struct AccountServiceTests {
         #expect(services.account.currentAccount?.id == brandB.id)
     }
 
+    @Test @MainActor func logoutAbandonsInFlightSwitch() async {
+        let mockWebKit = MockWebKitManager()
+        let services = Self.createService(webKitManager: mockWebKit)
+
+        let primary = UserAccount.from(
+            name: "Primary", handle: "@p", brandId: nil, thumbnailURL: nil, isSelected: true,
+            signinURL: URL(string: "https://www.youtube.com/signin?authuser=0&next=%2F")
+        )
+        let brand = MockUserAccountData.brandAccountWithSigninURL
+        await Self.populateAccounts(services, accounts: [primary, brand], selectedIndex: 0)
+
+        // Gate the switch so it is still verifying when logout fires.
+        let release = AsyncReleaseGate()
+        mockWebKit.switchSessionIdentityGate = { await release.wait() }
+        async let switching: Void = services.account.switchAccount(to: brand)
+        await Task.yield()
+
+        // Logout while the switch is in flight: it must invalidate the switch so
+        // the brand is never committed after the account data is cleared.
+        services.account.clearAccounts()
+        await release.release()
+        try? await switching
+
+        #expect(services.account.currentAccount == nil)
+        #expect(services.account.accounts.isEmpty)
+    }
+
+    @Test @MainActor func passiveFetchDoesNotAbandonInFlightSwitch() async throws {
+        // Regression guard: a background fetch (e.g. account-list refresh) must
+        // NOT supersede a user's manual switch — the switch should still commit.
+        let mockWebKit = MockWebKitManager()
+        let services = Self.createService(webKitManager: mockWebKit)
+
+        let primary = UserAccount.from(
+            name: "Primary", handle: "@p", brandId: nil, thumbnailURL: nil, isSelected: true,
+            signinURL: URL(string: "https://www.youtube.com/signin?authuser=0&next=%2F")
+        )
+        let brand = MockUserAccountData.brandAccountWithSigninURL
+        await Self.populateAccounts(services, accounts: [primary, brand], selectedIndex: 0)
+
+        let release = AsyncReleaseGate()
+        mockWebKit.switchSessionIdentityGate = { await release.wait() }
+        async let switching: Void = services.account.switchAccount(to: brand)
+        await Task.yield()
+
+        // A passive fetch resolving to primary used to bump the generation and
+        // make the switch abandon; it must not.
+        services.client.accountsListResponse = AccountsListResponse(googleEmail: "t@gmail.com", accounts: [primary, brand])
+        await services.account.fetchAccounts()
+        mockWebKit.switchSessionIdentityGate = nil
+        await release.release()
+        try await switching
+
+        #expect(services.account.currentAccount?.id == brand.id)
+    }
+
     @Test @MainActor func switchAccountWithoutSigninURLFailsSafely() async throws {
         let mockWebKit = MockWebKitManager()
         let services = Self.createService(webKitManager: mockWebKit)

--- a/Tests/KasetTests/AccountServiceTests.swift
+++ b/Tests/KasetTests/AccountServiceTests.swift
@@ -127,6 +127,79 @@ struct AccountServiceTests {
         #expect(services.account.currentBrandId == nil)
     }
 
+    @Test @MainActor func failedSwitchRollsSessionBackToPreviousIdentity() async throws {
+        // Previous account is a brand WITH a signinURL so a rollback is possible.
+        let previous = MockUserAccountData.brandAccountWithSigninURL
+        let target = UserAccount.from(
+            name: "Other Brand", handle: "@other", brandId: "222222222222222222222",
+            thumbnailURL: nil, isSelected: false,
+            signinURL: URL(string: "https://www.youtube.com/signin?pageid=222222222222222222222&authuser=0&next=%2F")
+        )
+        let mockWebKit = MockWebKitManager()
+        let services = Self.createService(webKitManager: mockWebKit)
+        await Self.populateAccounts(services, accounts: [previous, target], selectedIndex: 0)
+        #expect(services.account.currentAccount?.id == previous.id)
+
+        // Forward switch verification fails; rollback (2nd call) succeeds.
+        mockWebKit.switchSessionIdentityErrorQueue = [SessionSwitchError.identityNotApplied(expectedBrandId: target.brandId), nil]
+
+        await #expect(throws: SessionSwitchError.self) {
+            try await services.account.switchAccount(to: target)
+        }
+
+        // Native reverts AND the session is re-pinned to the previous identity.
+        #expect(services.account.currentAccount?.id == previous.id)
+        #expect(mockWebKit.switchSessionIdentityCallCount == 2)
+        #expect(mockWebKit.switchSessionIdentityExpectedBrandIds == [target.brandId, previous.brandId])
+        #expect(mockWebKit.switchSessionIdentityURLs.last == previous.signinURL)
+    }
+
+    @Test @MainActor func preSwitchFailureDoesNotRollBackSession() async throws {
+        // A target lacking signinURL throws BEFORE any session navigation, so no
+        // rollback should run (the session was never touched).
+        let previous = MockUserAccountData.brandAccountWithSigninURL
+        let target = MockUserAccountData.brandAccount // no signinURL
+        let mockWebKit = MockWebKitManager()
+        let services = Self.createService(webKitManager: mockWebKit)
+        await Self.populateAccounts(services, accounts: [previous, target], selectedIndex: 0)
+
+        await #expect(throws: SessionSwitchError.self) {
+            try await services.account.switchAccount(to: target)
+        }
+        #expect(mockWebKit.switchSessionIdentityCallCount == 0)
+        #expect(services.account.currentAccount?.id == previous.id)
+    }
+
+    @Test @MainActor func manualSwitchCancelsInFlightLaunchPinAndWinsLast() async throws {
+        let mockWebKit = MockWebKitManager()
+        // Hold the launch pin in flight until released, so it overlaps the switch.
+        let released = AsyncReleaseGate()
+        mockWebKit.switchSessionIdentityGate = { await released.wait() }
+        let services = Self.createService(webKitManager: mockWebKit)
+
+        let primary = UserAccount.from(
+            name: "Primary", handle: "@p", brandId: nil, thumbnailURL: nil, isSelected: false,
+            signinURL: URL(string: "https://www.youtube.com/signin?authuser=0&next=%2F")
+        )
+        let brand = MockUserAccountData.brandAccountWithSigninURL
+        // Cold-launch restore of the brand → schedules the gated launch pin.
+        UserDefaults.standard.set(brand.id, forKey: "selectedBrandId")
+        defer { UserDefaults.standard.removeObject(forKey: "selectedBrandId") }
+        services.client.accountsListResponse = AccountsListResponse(googleEmail: "t@gmail.com", accounts: [primary, brand])
+        services.auth.completeLogin(sapisid: "test-sapisid")
+        await services.account.fetchAccounts()
+
+        // Now switch to primary while the launch pin is still gated. switchAccount
+        // must cancel+await the pin (which returns via CancellationError) and then
+        // run its own switch — so the LAST recorded URL is the primary's.
+        mockWebKit.switchSessionIdentityGate = nil // the switch's own call runs ungated
+        try await services.account.switchAccount(to: primary)
+        await released.release()
+
+        #expect(services.account.currentAccount?.id == primary.id)
+        #expect(mockWebKit.switchSessionIdentityURLs.last == primary.signinURL)
+    }
+
     @Test @MainActor func switchAccountWithoutSigninURLFailsSafely() async throws {
         let mockWebKit = MockWebKitManager()
         let services = Self.createService(webKitManager: mockWebKit)
@@ -399,4 +472,29 @@ private struct TestServices {
     let account: AccountService
     let client: MockYTMusicClient
     let auth: AuthService
+}
+
+// MARK: - AsyncReleaseGate
+
+/// A one-shot async gate: callers `await wait()` until `release()` is called.
+/// Used to hold a mocked session pin "in flight" while a concurrent switch runs.
+private actor AsyncReleaseGate {
+    private var released = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        if self.released { return }
+        await withCheckedContinuation { continuation in
+            self.waiters.append(continuation)
+        }
+    }
+
+    func release() {
+        self.released = true
+        let pending = self.waiters
+        self.waiters = []
+        for continuation in pending {
+            continuation.resume()
+        }
+    }
 }

--- a/Tests/KasetTests/AccountsListParserTests.swift
+++ b/Tests/KasetTests/AccountsListParserTests.swift
@@ -175,6 +175,42 @@ struct AccountsListParserTests {
         #expect(result.accounts.count == 1)
         #expect(result.accounts[0].isSelected == false)
     }
+
+    // MARK: - signinURL Resolution Tests
+
+    @Test func resolvesRootRelativeSigninURL() {
+        let url = AccountsListParser.resolveSigninURL("/signin?action_handle_signin=true&pageid=123&authuser=0")
+        #expect(url?.scheme == "https")
+        #expect(url?.host == "www.youtube.com")
+        #expect(url?.path == "/signin")
+        #expect(url?.query?.contains("pageid=123") == true)
+    }
+
+    @Test func resolvesProtocolRelativeSigninURL() {
+        let url = AccountsListParser.resolveSigninURL("//www.youtube.com/signin?pageid=123")
+        #expect(url?.scheme == "https")
+        #expect(url?.host == "www.youtube.com")
+    }
+
+    @Test func passesThroughAbsoluteSigninURL() {
+        let url = AccountsListParser.resolveSigninURL("https://www.youtube.com/signin?pageid=123")
+        #expect(url?.absoluteString == "https://www.youtube.com/signin?pageid=123")
+    }
+
+    @Test func parsesBrandAccountSigninURLFromResponse() {
+        let json = MockAccountsListData.brandWithSigninURL
+        let result = AccountsListParser.parse(json)
+        let brand = result.accounts.first { $0.brandId == "111111111111111111111" }
+        #expect(brand?.signinURL != nil)
+        #expect(brand?.signinURL?.host == "www.youtube.com")
+        #expect(brand?.signinURL?.query?.contains("pageid=111111111111111111111") == true)
+    }
+
+    @Test func brandWithoutSigninTokenHasNilSigninURL() {
+        let json = MockAccountsListData.singleBrandAccountResponse
+        let result = AccountsListParser.parse(json)
+        #expect(result.accounts.first?.signinURL == nil)
+    }
 }
 
 // MARK: - MockAccountsListData
@@ -206,6 +242,24 @@ enum MockAccountsListData {
     }
 
     // MARK: - Multiple Accounts Response
+
+    static var brandWithSigninURL: [String: Any] {
+        wrapInResponse(
+            sections: [accountSection(
+                email: "test@example.com",
+                accounts: [
+                    primaryAccountItem(isSelected: true),
+                    brandAccountItem(
+                        name: "Brand Account",
+                        handle: "@brandaccount",
+                        brandId: "111111111111111111111",
+                        isSelected: false,
+                        signinURL: "/signin?action_handle_signin=true&authuser=0&pageid=111111111111111111111&next=%2F"
+                    ),
+                ]
+            )]
+        )
+    }
 
     static var multipleAccountsResponse: [String: Any] {
         wrapInResponse(
@@ -353,14 +407,16 @@ enum MockAccountsListData {
         name: String,
         handle: String,
         brandId: String,
-        isSelected: Bool
+        isSelected: Bool,
+        signinURL: String? = nil
     ) -> [String: Any] {
         self.accountItem(
             name: name,
             handle: handle,
             brandId: brandId,
             thumbnailURL: "https://example.com/brand-avatar.jpg",
-            isSelected: isSelected
+            isSelected: isSelected,
+            signinURL: signinURL
         )
     }
 
@@ -369,7 +425,8 @@ enum MockAccountsListData {
         handle: String?,
         brandId: String?,
         thumbnailURL: String?,
-        isSelected: Bool
+        isSelected: Bool,
+        signinURL: String? = nil
     ) -> [String: Any] {
         var item: [String: Any] = [
             "accountName": Self.runsText(name),
@@ -388,16 +445,17 @@ enum MockAccountsListData {
             ]
         }
 
-        if let brandId {
+        if brandId != nil || signinURL != nil {
+            var supportedTokens: [[String: Any]] = []
+            if let brandId {
+                supportedTokens.append(["pageIdToken": ["pageId": brandId]])
+            }
+            if let signinURL {
+                supportedTokens.append(["accountSigninToken": ["signinUrl": signinURL]])
+            }
             item["serviceEndpoint"] = [
                 "selectActiveIdentityEndpoint": [
-                    "supportedTokens": [
-                        [
-                            "pageIdToken": [
-                                "pageId": brandId,
-                            ],
-                        ],
-                    ],
+                    "supportedTokens": supportedTokens,
                 ],
             ]
         }

--- a/Tests/KasetTests/AccountsListParserTests.swift
+++ b/Tests/KasetTests/AccountsListParserTests.swift
@@ -197,6 +197,21 @@ struct AccountsListParserTests {
         #expect(url?.absoluteString == "https://www.youtube.com/signin?pageid=123")
     }
 
+    @Test func rejectsInsecureSigninURL() {
+        let url = AccountsListParser.resolveSigninURL("http://www.youtube.com/signin?pageid=123")
+        #expect(url == nil)
+    }
+
+    @Test func rejectsNonYouTubeSigninURL() {
+        let url = AccountsListParser.resolveSigninURL("https://example.com/signin?pageid=123")
+        #expect(url == nil)
+    }
+
+    @Test func rejectsNonSigninYouTubeURL() {
+        let url = AccountsListParser.resolveSigninURL("https://www.youtube.com/watch?v=abc")
+        #expect(url == nil)
+    }
+
     @Test func parsesBrandAccountSigninURLFromResponse() {
         let json = MockAccountsListData.brandWithSigninURL
         let result = AccountsListParser.parse(json)

--- a/Tests/KasetTests/Helpers/MockWebKitManager.swift
+++ b/Tests/KasetTests/Helpers/MockWebKitManager.swift
@@ -13,6 +13,17 @@ final class MockWebKitManager: WebKitManagerProtocol {
     /// When set, `switchSessionIdentity` throws this error instead of succeeding.
     var switchSessionIdentityError: Error?
 
+    /// Per-call scripted outcomes (front of queue first); `nil` = succeed. Takes
+    /// precedence over `switchSessionIdentityError` while non-empty.
+    var switchSessionIdentityErrorQueue: [Error?] = []
+
+    /// Optional async gate awaited inside `switchSessionIdentity` so a test can
+    /// hold a pin "in flight" to exercise cancel/await ordering.
+    var switchSessionIdentityGate: (@Sendable () async -> Void)?
+
+    /// URLs passed to `switchSessionIdentity`, in call order.
+    private(set) var switchSessionIdentityURLs: [URL] = []
+
     // MARK: - Call Tracking
 
     private(set) var getAllCookiesCalled = false
@@ -90,12 +101,27 @@ final class MockWebKitManager: WebKitManagerProtocol {
         // No-op in mock
     }
 
-    func switchSessionIdentity(to _: URL, expectedBrandId: String?) async throws {
+    func switchSessionIdentity(to signinURL: URL, expectedBrandId: String?) async throws {
         self.switchSessionIdentityCalled = true
         self.switchSessionIdentityCallCount += 1
         self.switchSessionIdentityExpectedBrandIds.append(expectedBrandId)
+        self.switchSessionIdentityURLs.append(signinURL)
         self.callSequence.append("switchSessionIdentity")
-        if let error = self.switchSessionIdentityError {
+
+        // Optional gate: lets a test hold a "pin" in flight (e.g. a cold-launch
+        // restore) to exercise cancel/await ordering. Honors cooperative
+        // cancellation so the production cancel+await returns promptly.
+        if let gate = self.switchSessionIdentityGate {
+            await gate()
+            try Task.checkCancellation()
+        }
+
+        // Per-call failure scripting (front of queue), else the sticky error.
+        if !self.switchSessionIdentityErrorQueue.isEmpty {
+            if let scripted = self.switchSessionIdentityErrorQueue.removeFirst() {
+                throw scripted
+            }
+        } else if let error = self.switchSessionIdentityError {
             throw error
         }
     }
@@ -120,6 +146,9 @@ final class MockWebKitManager: WebKitManagerProtocol {
         self.switchSessionIdentityCallCount = 0
         self.switchSessionIdentityExpectedBrandIds = []
         self.switchSessionIdentityError = nil
+        self.switchSessionIdentityErrorQueue = []
+        self.switchSessionIdentityGate = nil
+        self.switchSessionIdentityURLs = []
         self.callSequence = []
         self.allCookies = []
         self.sapisidValue = nil

--- a/Tests/KasetTests/Helpers/MockWebKitManager.swift
+++ b/Tests/KasetTests/Helpers/MockWebKitManager.swift
@@ -21,6 +21,10 @@ final class MockWebKitManager: WebKitManagerProtocol {
     /// hold a pin "in flight" to exercise cancel/await ordering.
     var switchSessionIdentityGate: (@Sendable () async -> Void)?
 
+    /// Per-call gates (front of queue first); `nil` = no gate for that call.
+    /// Takes precedence over `switchSessionIdentityGate` while non-empty.
+    var switchSessionIdentityGateQueue: [(@Sendable () async -> Void)?] = []
+
     /// URLs passed to `switchSessionIdentity`, in call order.
     private(set) var switchSessionIdentityURLs: [URL] = []
 
@@ -41,6 +45,7 @@ final class MockWebKitManager: WebKitManagerProtocol {
     private(set) var switchSessionIdentityCalled = false
     private(set) var switchSessionIdentityCallCount = 0
     private(set) var switchSessionIdentityExpectedBrandIds: [String?] = []
+    private(set) var switchSessionIdentityCompletedBrandIds: [String?] = []
     private(set) var callSequence: [String] = []
 
     // MARK: - Protocol Implementation
@@ -111,7 +116,12 @@ final class MockWebKitManager: WebKitManagerProtocol {
         // Optional gate: lets a test hold a "pin" in flight (e.g. a cold-launch
         // restore) to exercise cancel/await ordering. Honors cooperative
         // cancellation so the production cancel+await returns promptly.
-        if let gate = self.switchSessionIdentityGate {
+        let gate = if !self.switchSessionIdentityGateQueue.isEmpty {
+            self.switchSessionIdentityGateQueue.removeFirst()
+        } else {
+            self.switchSessionIdentityGate
+        }
+        if let gate {
             await gate()
             try Task.checkCancellation()
         }
@@ -124,6 +134,8 @@ final class MockWebKitManager: WebKitManagerProtocol {
         } else if let error = self.switchSessionIdentityError {
             throw error
         }
+
+        self.switchSessionIdentityCompletedBrandIds.append(expectedBrandId)
     }
 
     // MARK: - Helper Methods
@@ -145,9 +157,11 @@ final class MockWebKitManager: WebKitManagerProtocol {
         self.switchSessionIdentityCalled = false
         self.switchSessionIdentityCallCount = 0
         self.switchSessionIdentityExpectedBrandIds = []
+        self.switchSessionIdentityCompletedBrandIds = []
         self.switchSessionIdentityError = nil
         self.switchSessionIdentityErrorQueue = []
         self.switchSessionIdentityGate = nil
+        self.switchSessionIdentityGateQueue = []
         self.switchSessionIdentityURLs = []
         self.callSequence = []
         self.allCookies = []

--- a/Tests/KasetTests/Helpers/MockWebKitManager.swift
+++ b/Tests/KasetTests/Helpers/MockWebKitManager.swift
@@ -10,6 +10,9 @@ final class MockWebKitManager: WebKitManagerProtocol {
     var allCookies: [HTTPCookie] = []
     var sapisidValue: String?
 
+    /// When set, `switchSessionIdentity` throws this error instead of succeeding.
+    var switchSessionIdentityError: Error?
+
     // MARK: - Call Tracking
 
     private(set) var getAllCookiesCalled = false
@@ -24,6 +27,9 @@ final class MockWebKitManager: WebKitManagerProtocol {
     private(set) var waitForInitialCookieRestoreCalled = false
     private(set) var waitForInitialCookieRestoreCallCount = 0
     private(set) var logAuthCookiesCalled = false
+    private(set) var switchSessionIdentityCalled = false
+    private(set) var switchSessionIdentityCallCount = 0
+    private(set) var switchSessionIdentityExpectedBrandIds: [String?] = []
     private(set) var callSequence: [String] = []
 
     // MARK: - Protocol Implementation
@@ -84,6 +90,16 @@ final class MockWebKitManager: WebKitManagerProtocol {
         // No-op in mock
     }
 
+    func switchSessionIdentity(to _: URL, expectedBrandId: String?) async throws {
+        self.switchSessionIdentityCalled = true
+        self.switchSessionIdentityCallCount += 1
+        self.switchSessionIdentityExpectedBrandIds.append(expectedBrandId)
+        self.callSequence.append("switchSessionIdentity")
+        if let error = self.switchSessionIdentityError {
+            throw error
+        }
+    }
+
     // MARK: - Helper Methods
 
     /// Resets all call tracking.
@@ -100,6 +116,10 @@ final class MockWebKitManager: WebKitManagerProtocol {
         self.waitForInitialCookieRestoreCalled = false
         self.waitForInitialCookieRestoreCallCount = 0
         self.logAuthCookiesCalled = false
+        self.switchSessionIdentityCalled = false
+        self.switchSessionIdentityCallCount = 0
+        self.switchSessionIdentityExpectedBrandIds = []
+        self.switchSessionIdentityError = nil
         self.callSequence = []
         self.allCookies = []
         self.sapisidValue = nil

--- a/Tests/KasetTests/PlayerServiceWebQueueSyncFollowUpTests.swift
+++ b/Tests/KasetTests/PlayerServiceWebQueueSyncFollowUpTests.swift
@@ -352,4 +352,26 @@ extension PlayerServiceWebQueueSyncTests {
         #expect(self.playerService.pendingPlayVideoId == "v1")
         #expect(self.playerService.pendingRestoredSeek == 180)
     }
+
+    @Test("Identity-switch reload is skipped while a restored session is deferred")
+    func identitySwitchReloadSkippedWhenDeferred() {
+        let songs = [
+            Song(id: "1", title: "Song 1", artists: [], album: nil, duration: 180, thumbnailURL: nil, videoId: "v1"),
+        ]
+        self.playerService.applyRestoredPlaybackSession(
+            queue: songs,
+            currentIndex: 0,
+            progress: 60,
+            duration: 180
+        )
+        #expect(self.playerService.isPendingRestoredLoadDeferred == true)
+
+        // A verified-identity signal must NOT force-load a deferred restored
+        // session (which would clear the explicit-resume gate and load the
+        // playback page + stats before the user resumes).
+        self.playerService.reloadCurrentTrackForIdentitySwitch()
+
+        #expect(self.playerService.isPendingRestoredLoadDeferred == true)
+        #expect(self.playerService.state == .paused)
+    }
 }

--- a/Tests/KasetTests/UserAccountTests.swift
+++ b/Tests/KasetTests/UserAccountTests.swift
@@ -126,8 +126,8 @@ struct UserAccountTests {
             isSelected: false
         )
 
-        // Accounts with different isSelected should NOT be equal
-        #expect(account1 != account2)
+        // Selection is UI state; account identity remains the same.
+        #expect(account1 == account2)
     }
 
     @Test func accountEqualityDifferentNames() {

--- a/Tests/KasetTests/UserAccountTests.swift
+++ b/Tests/KasetTests/UserAccountTests.swift
@@ -310,6 +310,19 @@ enum MockUserAccountData {
         )
     }
 
+    /// Brand account that carries a server-issued signinURL, so a verified
+    /// session switch can be attempted in tests.
+    static var brandAccountWithSigninURL: UserAccount {
+        UserAccount.from(
+            name: "Brand Account",
+            handle: "@brandaccount",
+            brandId: "123456789012345678901",
+            thumbnailURL: URL(string: "https://example.com/brand-avatar.jpg"),
+            isSelected: false,
+            signinURL: URL(string: "https://www.youtube.com/signin?pageid=123456789012345678901&authuser=0&next=%2F")
+        )
+    }
+
     static var selectedBrandAccount: UserAccount {
         UserAccount.from(
             name: "Selected Brand",

--- a/Tests/KasetTests/WebKitManagerTests.swift
+++ b/Tests/KasetTests/WebKitManagerTests.swift
@@ -29,6 +29,18 @@ struct WebKitManagerTests {
         #expect(configuration.websiteDataStore === self.webKitManager.dataStore)
     }
 
+    @Test("Session switch WebView configuration excludes extensions")
+    func createSessionSwitchWebViewConfiguration() {
+        let configuration = self.webKitManager.createSessionSwitchWebViewConfiguration()
+        #expect(configuration.websiteDataStore === self.webKitManager.dataStore)
+
+        #if compiler(>=5.9)
+            if #available(macOS 14.0, *) {
+                #expect(configuration.webExtensionController == nil)
+            }
+        #endif
+    }
+
     @Test("Origin constant")
     func originConstant() {
         #expect(WebKitManager.origin == "https://music.youtube.com")

--- a/Tests/KasetTests/WebKitManagerTests.swift
+++ b/Tests/KasetTests/WebKitManagerTests.swift
@@ -102,4 +102,48 @@ struct WebKitManagerTests {
 
         #expect(resolvedURL == nil)
     }
+
+    // MARK: - DATASYNC_ID Identity Matching
+
+    @Test("Brand DATASYNC_ID matches when first half equals brand pageId")
+    func dataSyncIdMatchesBrand() {
+        // "<delegatedSessionId>||<userSessionId>" — delegated half is the brand.
+        let dataSyncId = "111111111111111111111||108880000000000000000"
+        #expect(WebKitManager.dataSyncId(dataSyncId, matches: "111111111111111111111") == true)
+    }
+
+    @Test("Brand DATASYNC_ID does not match a different brand pageId")
+    func dataSyncIdRejectsWrongBrand() {
+        let dataSyncId = "111111111111111111111||108880000000000000000"
+        #expect(WebKitManager.dataSyncId(dataSyncId, matches: "999999999999999999999") == false)
+    }
+
+    @Test("Primary DATASYNC_ID (empty delegated half) matches nil brand")
+    func dataSyncIdMatchesPrimary() {
+        // Primary is "<userSessionId>||" — empty delegated (first) half.
+        let dataSyncId = "108880000||"
+        #expect(WebKitManager.dataSyncId(dataSyncId, matches: nil) == true)
+    }
+
+    @Test("Primary DATASYNC_ID does not match a brand expectation")
+    func dataSyncIdPrimaryRejectsBrand() {
+        let dataSyncId = "108880000||"
+        #expect(WebKitManager.dataSyncId(dataSyncId, matches: "111111111111111111111") == false)
+    }
+
+    @Test("Brand DATASYNC_ID does not satisfy a primary (nil) expectation")
+    func dataSyncIdBrandRejectsPrimary() {
+        let dataSyncId = "111111111111111111111||108880000000000000000"
+        #expect(WebKitManager.dataSyncId(dataSyncId, matches: nil) == false)
+    }
+
+    @Test("Blank/unread DATASYNC_ID never falsely verifies as primary")
+    func dataSyncIdBlankIsNotPrimary() {
+        // The page JS returns "" (or a bare "||") before ytcfg populates; an
+        // unread page must NOT be treated as a verified primary session.
+        #expect(WebKitManager.dataSyncId("", matches: nil) == false)
+        #expect(WebKitManager.dataSyncId("||", matches: nil) == false)
+        #expect(WebKitManager.dataSyncId("", matches: "111111111111111111111") == false)
+        #expect(WebKitManager.dataSyncId("garbage-no-separator", matches: nil) == false)
+    }
 }

--- a/Tests/KasetTests/YouTubePlayerServiceTests.swift
+++ b/Tests/KasetTests/YouTubePlayerServiceTests.swift
@@ -151,6 +151,48 @@ struct YouTubePlayerServiceTests {
         #expect(self.controller.reloadedVideoIds.isEmpty)
     }
 
+    @Test("Paused video reloaded for identity switch does not autoplay")
+    func pausedReloadSuppressesAutoplay() {
+        // Arrange: a video that is currently PAUSED (no isPlaying state fed).
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        #expect(self.sut.isPlaying == false)
+        var willStartCount = 0
+        self.sut.playbackWillStart = { willStartCount += 1 }
+
+        // Reload for an identity switch while paused → arms autoplay suppression.
+        self.sut.reloadCurrentVideoForIdentitySwitch()
+        let pausesBefore = self.controller.pauseCount
+
+        // The reloaded watch page autoplays → observer reports playing.
+        self.sut.updatePlaybackState(.init(isPlaying: true, progress: 3, duration: 60, videoId: "abc"))
+
+        // Suppressed: re-paused, not treated as a play start, music not displaced.
+        #expect(self.controller.pauseCount == pausesBefore + 1)
+        #expect(self.sut.isPlaying == false)
+        #expect(willStartCount == 0)
+
+        // Once the page settles paused, the latch clears and normal play resumes.
+        self.sut.updatePlaybackState(.init(isPlaying: false, progress: 3, duration: 60, videoId: "abc"))
+        self.sut.updatePlaybackState(.init(isPlaying: true, progress: 4, duration: 60, videoId: "abc"))
+        #expect(self.sut.isPlaying == true)
+    }
+
+    @Test("Playing video reloaded for identity switch keeps playing")
+    func playingReloadDoesNotSuppress() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        // Establish a playing state first.
+        self.sut.updatePlaybackState(.init(isPlaying: true, progress: 1, duration: 60, videoId: "abc"))
+        #expect(self.sut.isPlaying == true)
+        let pausesBefore = self.controller.pauseCount
+
+        self.sut.reloadCurrentVideoForIdentitySwitch()
+        self.sut.updatePlaybackState(.init(isPlaying: true, progress: 1, duration: 60, videoId: "abc"))
+
+        // No suppression: a playing video stays playing across the reload.
+        #expect(self.controller.pauseCount == pausesBefore)
+        #expect(self.sut.isPlaying == true)
+    }
+
     @Test("State updates from the bridge are applied")
     func stateUpdates() {
         self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
@@ -821,5 +863,27 @@ struct YouTubeWatchScriptTests {
             .contains("__kasetTargetVolume = 1.0"))
         #expect(YouTubeWatchWebView.pageBootstrapScript(targetVolume: -1)
             .contains("__kasetTargetVolume = 0.0"))
+    }
+
+    @Test("Bootstrap carries a pending resume-seek only when present and positive")
+    func bootstrapCarriesPendingSeek() {
+        #expect(YouTubeWatchWebView.pageBootstrapScript(targetVolume: 1, pendingSeek: 42.5)
+            .contains("__kasetPendingSeek = 42.5"))
+        // No seek pending → no marker injected.
+        #expect(!YouTubeWatchWebView.pageBootstrapScript(targetVolume: 1, pendingSeek: nil)
+            .contains("__kasetPendingSeek"))
+        // Zero/negative is not a resume position.
+        #expect(!YouTubeWatchWebView.pageBootstrapScript(targetVolume: 1, pendingSeek: 0)
+            .contains("__kasetPendingSeek"))
+    }
+
+    @Test("Observer applies the pending seek gated on a seekable element")
+    func observerAppliesPendingSeekWhenReady() {
+        let script = YouTubeWatchWebView.observerScript
+        // The seek is applied by the observer (not a one-shot at didFinish),
+        // gated on readyState so it survives YouTube creating <video> late.
+        #expect(script.contains("__kasetPendingSeek"))
+        #expect(script.contains("applyPendingSeek"))
+        #expect(script.contains("readyState"))
     }
 }

--- a/Tests/KasetTests/YouTubePlayerServiceTests.swift
+++ b/Tests/KasetTests/YouTubePlayerServiceTests.swift
@@ -206,6 +206,7 @@ struct YouTubePlayerServiceTests {
     @Test("Deferred paused identity reload survives observer updates before resume")
     func deferredPausedReloadSurvivesObserverUpdatesBeforeResume() {
         self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        self.sut.updatePlaybackState(.init(isPlaying: false, progress: 3, duration: 60, videoId: "abc"))
         var willStartCount = 0
         self.sut.playbackWillStart = { willStartCount += 1 }
 
@@ -223,29 +224,27 @@ struct YouTubePlayerServiceTests {
         #expect(willStartCount == 1)
     }
 
-    @Test("Deferred identity reload applies when a loading video starts")
-    func deferredIdentityReloadAppliesWhenLoadingVideoStarts() {
+    @Test("Loading video identity reload happens immediately")
+    func loadingIdentityReloadHappensImmediately() {
         // A just-requested video has not reported playing yet, so isPlaying is
         // false but it is not a user-paused watch. If identity verification lands
-        // in that loading window, the first playing bridge update must trigger the
-        // reload under the new identity rather than continuing under the old page.
+        // in that loading window, the reload must happen immediately before the
+        // old-identity page can start and emit watch-history pings.
         self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
         var willStartCount = 0
         self.sut.playbackWillStart = { willStartCount += 1 }
 
         self.sut.reloadCurrentVideoForIdentitySwitch()
-        #expect(self.controller.reloadedVideoIds.isEmpty)
-
-        self.sut.updatePlaybackState(.init(isPlaying: true, progress: 2, duration: 60, videoId: "abc"))
 
         #expect(self.controller.reloadedVideoIds == ["abc"])
-        #expect(self.controller.reloadResumeSeconds == [2])
-        #expect(willStartCount == 1)
+        #expect(self.controller.reloadResumeSeconds == [nil])
+        #expect(willStartCount == 0)
     }
 
     @Test("Deferred paused identity reload is cleared by a new video")
     func deferredPausedReloadClearsOnNewVideo() {
         self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        self.sut.updatePlaybackState(.init(isPlaying: false, progress: 3, duration: 60, videoId: "abc"))
         self.sut.reloadCurrentVideoForIdentitySwitch()
 
         self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "def"))

--- a/Tests/KasetTests/YouTubePlayerServiceTests.swift
+++ b/Tests/KasetTests/YouTubePlayerServiceTests.swift
@@ -151,6 +151,20 @@ struct YouTubePlayerServiceTests {
         #expect(self.controller.reloadedVideoIds.isEmpty)
     }
 
+    @Test("Identity-switch during an ad resumes the content, not the ad position")
+    func reloadDuringAdUsesContentProgress() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        // Content reaches 600s...
+        self.sut.updatePlaybackState(.init(isPlaying: true, progress: 600, duration: 1200, videoId: "abc"))
+        // ...then a midroll ad starts, dragging self.progress down to the ad time.
+        self.sut.updatePlaybackState(.init(isPlaying: true, progress: 8, duration: 30, videoId: "abc", isAd: true))
+        #expect(self.sut.progress == 8)
+
+        // A switch mid-ad must resume at the last CONTENT position (600), not 8.
+        self.sut.reloadCurrentVideoForIdentitySwitch()
+        #expect(self.controller.reloadResumeSeconds.last == .some(600))
+    }
+
     @Test("Paused video reloaded for identity switch does not autoplay")
     func pausedReloadSuppressesAutoplay() {
         // Arrange: a video that is currently PAUSED (no isPlaying state fed).

--- a/Tests/KasetTests/YouTubePlayerServiceTests.swift
+++ b/Tests/KasetTests/YouTubePlayerServiceTests.swift
@@ -177,6 +177,29 @@ struct YouTubePlayerServiceTests {
         #expect(self.sut.isPlaying == true)
     }
 
+    @Test("Paused-reload suppression survives a preroll ad")
+    func pausedReloadSuppressesThroughPrerollAd() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        #expect(self.sut.isPlaying == false)
+        var willStartCount = 0
+        self.sut.playbackWillStart = { willStartCount += 1 }
+
+        self.sut.reloadCurrentVideoForIdentitySwitch()
+        let pausesBefore = self.controller.pauseCount
+
+        // The reload first reports a PLAYING preroll AD — must still be suppressed
+        // (the latch may not be cleared until a genuine paused state).
+        self.sut.updatePlaybackState(.init(isPlaying: true, progress: 0, duration: 5, videoId: "abc", isAd: true))
+        #expect(self.controller.pauseCount == pausesBefore + 1)
+        #expect(self.sut.isPlaying == false)
+        #expect(willStartCount == 0)
+
+        // Then the content autoplays — still suppressed.
+        self.sut.updatePlaybackState(.init(isPlaying: true, progress: 0, duration: 60, videoId: "abc"))
+        #expect(self.controller.pauseCount == pausesBefore + 2)
+        #expect(willStartCount == 0)
+    }
+
     @Test("Playing video reloaded for identity switch keeps playing")
     func playingReloadDoesNotSuppress() {
         self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
@@ -830,60 +853,5 @@ struct PlaybackArbiterTests {
 
         #expect(controller.pauseCount == 0)
         #expect(arbiter.activeSource == .music)
-    }
-}
-
-// MARK: - YouTubeWatchScriptTests
-
-@Suite("YouTubeWatchWebView scripts", .tags(.service))
-@MainActor
-struct YouTubeWatchScriptTests {
-    @Test("Observer script posts to the youtubePlayer bridge with both message types")
-    func observerScriptContract() {
-        let script = YouTubeWatchWebView.observerScript
-        #expect(script.contains("webkit.messageHandlers.youtubePlayer"))
-        #expect(script.contains("STATE_UPDATE"))
-        #expect(script.contains("VIDEO_ENDED"))
-        #expect(script.contains("movie_player"))
-        #expect(script.contains("__kasetTargetVolume"))
-    }
-
-    @Test("Extraction script defines the callable hook and visibility chain")
-    func extractionScriptContract() {
-        let script = YouTubeWatchWebView.extractionScript
-        #expect(script.contains("__kasetExtractVideo"))
-        #expect(script.contains("kaset-yt-video-style"))
-        #expect(script.contains("kaset-visible"))
-        #expect(script.contains("ytp-chrome-bottom"))
-    }
-
-    @Test("Bootstrap script clamps the volume target")
-    func bootstrapClampsVolume() {
-        #expect(YouTubeWatchWebView.pageBootstrapScript(targetVolume: 2.0)
-            .contains("__kasetTargetVolume = 1.0"))
-        #expect(YouTubeWatchWebView.pageBootstrapScript(targetVolume: -1)
-            .contains("__kasetTargetVolume = 0.0"))
-    }
-
-    @Test("Bootstrap carries a pending resume-seek only when present and positive")
-    func bootstrapCarriesPendingSeek() {
-        #expect(YouTubeWatchWebView.pageBootstrapScript(targetVolume: 1, pendingSeek: 42.5)
-            .contains("__kasetPendingSeek = 42.5"))
-        // No seek pending → no marker injected.
-        #expect(!YouTubeWatchWebView.pageBootstrapScript(targetVolume: 1, pendingSeek: nil)
-            .contains("__kasetPendingSeek"))
-        // Zero/negative is not a resume position.
-        #expect(!YouTubeWatchWebView.pageBootstrapScript(targetVolume: 1, pendingSeek: 0)
-            .contains("__kasetPendingSeek"))
-    }
-
-    @Test("Observer applies the pending seek gated on a seekable element")
-    func observerAppliesPendingSeekWhenReady() {
-        let script = YouTubeWatchWebView.observerScript
-        // The seek is applied by the observer (not a one-shot at didFinish),
-        // gated on readyState so it survives YouTube creating <video> late.
-        #expect(script.contains("__kasetPendingSeek"))
-        #expect(script.contains("applyPendingSeek"))
-        #expect(script.contains("readyState"))
     }
 }

--- a/Tests/KasetTests/YouTubePlayerServiceTests.swift
+++ b/Tests/KasetTests/YouTubePlayerServiceTests.swift
@@ -18,6 +18,7 @@ private final class MockYouTubeWatchPlaybackController: YouTubeWatchPlaybackCont
     private(set) var volumes: [Double] = []
     private(set) var tearDownCount = 0
     private(set) var prepareCount = 0
+    private(set) var cancelPendingLoadCount = 0
 
     func prepare(webKitManager _: WebKitManager, playerService _: YouTubePlayerService) {
         self.prepareCount += 1
@@ -30,6 +31,10 @@ private final class MockYouTubeWatchPlaybackController: YouTubeWatchPlaybackCont
     func reloadVideo(videoId: String, resumeAt seconds: Double?) {
         self.reloadedVideoIds.append(videoId)
         self.reloadResumeSeconds.append(seconds)
+    }
+
+    func cancelPendingLoad() {
+        self.cancelPendingLoadCount += 1
     }
 
     func playPause() {

--- a/Tests/KasetTests/YouTubePlayerServiceTests.swift
+++ b/Tests/KasetTests/YouTubePlayerServiceTests.swift
@@ -136,6 +136,7 @@ struct YouTubePlayerServiceTests {
     @Test("Identity-switch re-points the current video via a forced reload")
     func reloadForIdentitySwitchRepointsCurrentVideo() {
         self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        self.sut.updatePlaybackState(.init(isPlaying: true, progress: 0, duration: 60, videoId: "abc"))
 
         self.sut.reloadCurrentVideoForIdentitySwitch()
 
@@ -165,53 +166,81 @@ struct YouTubePlayerServiceTests {
         #expect(self.controller.reloadResumeSeconds.last == .some(600))
     }
 
-    @Test("Paused video reloaded for identity switch does not autoplay")
-    func pausedReloadSuppressesAutoplay() {
-        // Arrange: a video that is currently PAUSED (no isPlaying state fed).
+    @Test("Paused video identity reload is deferred until resume")
+    func pausedReloadDefersUntilResume() {
         self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        self.sut.updatePlaybackState(.init(isPlaying: false, progress: 12, duration: 60, videoId: "abc"))
         #expect(self.sut.isPlaying == false)
         var willStartCount = 0
         self.sut.playbackWillStart = { willStartCount += 1 }
 
-        // Reload for an identity switch while paused → arms autoplay suppression.
         self.sut.reloadCurrentVideoForIdentitySwitch()
-        let pausesBefore = self.controller.pauseCount
 
-        // The reloaded watch page autoplays → observer reports playing.
-        self.sut.updatePlaybackState(.init(isPlaying: true, progress: 3, duration: 60, videoId: "abc"))
-
-        // Suppressed: re-paused, not treated as a play start, music not displaced.
-        #expect(self.controller.pauseCount == pausesBefore + 1)
+        // No autoplaying watch page is loaded while the user left the video paused.
+        #expect(self.controller.reloadedVideoIds.isEmpty)
+        #expect(self.controller.pauseCount == 0)
         #expect(self.sut.isPlaying == false)
         #expect(willStartCount == 0)
 
-        // Once the page settles paused, the latch clears and normal play resumes.
-        self.sut.updatePlaybackState(.init(isPlaying: false, progress: 3, duration: 60, videoId: "abc"))
-        self.sut.updatePlaybackState(.init(isPlaying: true, progress: 4, duration: 60, videoId: "abc"))
-        #expect(self.sut.isPlaying == true)
+        self.sut.seek(to: 34)
+        // User intent to resume performs the identity reload at the saved position.
+        self.sut.resume()
+        #expect(self.controller.reloadedVideoIds == ["abc"])
+        #expect(self.controller.reloadResumeSeconds == [34])
+        #expect(self.controller.playCount == 0)
+        #expect(willStartCount == 1)
     }
 
-    @Test("Paused-reload suppression survives a preroll ad")
-    func pausedReloadSuppressesThroughPrerollAd() {
+    @Test("Deferred paused identity reload survives observer updates before resume")
+    func deferredPausedReloadSurvivesObserverUpdatesBeforeResume() {
         self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
-        #expect(self.sut.isPlaying == false)
         var willStartCount = 0
         self.sut.playbackWillStart = { willStartCount += 1 }
 
         self.sut.reloadCurrentVideoForIdentitySwitch()
-        let pausesBefore = self.controller.pauseCount
 
-        // The reload first reports a PLAYING preroll AD — must still be suppressed
-        // (the latch may not be cleared until a genuine paused state).
-        self.sut.updatePlaybackState(.init(isPlaying: true, progress: 0, duration: 5, videoId: "abc", isAd: true))
-        #expect(self.controller.pauseCount == pausesBefore + 1)
-        #expect(self.sut.isPlaying == false)
+        // Stray observer updates from the old paused page do not consume the
+        // deferred identity reload. The reload still happens on explicit resume.
+        self.sut.updatePlaybackState(.init(isPlaying: false, progress: 3, duration: 60, videoId: "abc"))
+        #expect(self.controller.reloadedVideoIds.isEmpty)
         #expect(willStartCount == 0)
 
-        // Then the content autoplays — still suppressed.
-        self.sut.updatePlaybackState(.init(isPlaying: true, progress: 0, duration: 60, videoId: "abc"))
-        #expect(self.controller.pauseCount == pausesBefore + 2)
-        #expect(willStartCount == 0)
+        self.sut.playPause()
+        #expect(self.controller.reloadedVideoIds == ["abc"])
+        #expect(self.controller.playPauseCount == 0)
+        #expect(willStartCount == 1)
+    }
+
+    @Test("Deferred identity reload applies when a loading video starts")
+    func deferredIdentityReloadAppliesWhenLoadingVideoStarts() {
+        // A just-requested video has not reported playing yet, so isPlaying is
+        // false but it is not a user-paused watch. If identity verification lands
+        // in that loading window, the first playing bridge update must trigger the
+        // reload under the new identity rather than continuing under the old page.
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        var willStartCount = 0
+        self.sut.playbackWillStart = { willStartCount += 1 }
+
+        self.sut.reloadCurrentVideoForIdentitySwitch()
+        #expect(self.controller.reloadedVideoIds.isEmpty)
+
+        self.sut.updatePlaybackState(.init(isPlaying: true, progress: 2, duration: 60, videoId: "abc"))
+
+        #expect(self.controller.reloadedVideoIds == ["abc"])
+        #expect(self.controller.reloadResumeSeconds == [2])
+        #expect(willStartCount == 1)
+    }
+
+    @Test("Deferred paused identity reload is cleared by a new video")
+    func deferredPausedReloadClearsOnNewVideo() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        self.sut.reloadCurrentVideoForIdentitySwitch()
+
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "def"))
+        self.sut.resume()
+
+        #expect(self.controller.reloadedVideoIds.isEmpty)
+        #expect(self.controller.loadedVideoIds == ["abc", "def"])
     }
 
     @Test("Playing video reloaded for identity switch keeps playing")

--- a/Tests/KasetTests/YouTubePlayerServiceTests.swift
+++ b/Tests/KasetTests/YouTubePlayerServiceTests.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import Foundation
 import Testing
 @testable import Kaset
@@ -90,6 +91,17 @@ private final class MockYouTubeWatchPlaybackController: YouTubeWatchPlaybackCont
 
     func tearDown() {
         self.tearDownCount += 1
+    }
+}
+
+// MARK: - BooleanBox
+
+@MainActor
+private final class BooleanBox {
+    var value: Bool
+
+    init(_ value: Bool) {
+        self.value = value
     }
 }
 
@@ -393,10 +405,10 @@ struct YouTubePlayerServiceTests {
     @Test("Pop-out gate is read live, not captured at init")
     func popOutGateReadLive() {
         let controller = MockYouTubeWatchPlaybackController()
-        var popOutEnabled = false
+        let popOutEnabled = BooleanBox(false)
         let sut = YouTubePlayerService(
             playbackController: controller,
-            shouldPopOutOnNavigateAway: { popOutEnabled }
+            shouldPopOutOnNavigateAway: { popOutEnabled.value }
         )
 
         // First navigate-away with the gate off: stops.
@@ -410,7 +422,7 @@ struct YouTubePlayerServiceTests {
         #expect(sut.surfaceLocation == .none)
 
         // Flip the gate on; a fresh playback now pops out.
-        popOutEnabled = true
+        popOutEnabled.value = true
         sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
         sut.activeInlineVideoId = "abc"
         sut.updatePlaybackState(.init(

--- a/Tests/KasetTests/YouTubePlayerServiceTests.swift
+++ b/Tests/KasetTests/YouTubePlayerServiceTests.swift
@@ -8,6 +8,8 @@ import Testing
 @MainActor
 private final class MockYouTubeWatchPlaybackController: YouTubeWatchPlaybackControlling {
     private(set) var loadedVideoIds: [String] = []
+    private(set) var reloadedVideoIds: [String] = []
+    private(set) var reloadResumeSeconds: [Double?] = []
     private(set) var playPauseCount = 0
     private(set) var playCount = 0
     private(set) var pauseCount = 0
@@ -22,6 +24,11 @@ private final class MockYouTubeWatchPlaybackController: YouTubeWatchPlaybackCont
 
     func loadVideo(videoId: String) {
         self.loadedVideoIds.append(videoId)
+    }
+
+    func reloadVideo(videoId: String, resumeAt seconds: Double?) {
+        self.reloadedVideoIds.append(videoId)
+        self.reloadResumeSeconds.append(seconds)
     }
 
     func playPause() {
@@ -124,6 +131,24 @@ struct YouTubePlayerServiceTests {
         #expect(self.controller.prepareCount == 1)
         #expect(self.controller.loadedVideoIds == ["abc"])
         #expect(willStartCount == 1)
+    }
+
+    @Test("Identity-switch re-points the current video via a forced reload")
+    func reloadForIdentitySwitchRepointsCurrentVideo() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+
+        self.sut.reloadCurrentVideoForIdentitySwitch()
+
+        // A forced reload (not a plain loadVideo, which would no-op on same id).
+        #expect(self.controller.reloadedVideoIds == ["abc"])
+        // No progress yet → no resume seek requested.
+        #expect(self.controller.reloadResumeSeconds == [nil])
+    }
+
+    @Test("Identity-switch is a no-op when no video is playing")
+    func reloadForIdentitySwitchNoOpWhenIdle() {
+        self.sut.reloadCurrentVideoForIdentitySwitch()
+        #expect(self.controller.reloadedVideoIds.isEmpty)
     }
 
     @Test("State updates from the bridge are applied")

--- a/Tests/KasetTests/YouTubeWatchScriptTests.swift
+++ b/Tests/KasetTests/YouTubeWatchScriptTests.swift
@@ -53,4 +53,23 @@ struct YouTubeWatchScriptTests {
         #expect(script.contains("applyPendingSeek"))
         #expect(script.contains("readyState"))
     }
+
+    @Test("Observer skips the pending seek while an ad is showing")
+    func observerSkipsPendingSeekDuringAd() {
+        let script = YouTubeWatchWebView.observerScript
+        // applyPendingSeek must bail on isAdShowing() so a preroll-ad element
+        // doesn't consume the seek and leave content starting from 0.
+        #expect(script.contains("isAdShowing()"))
+    }
+
+    @Test("A normal loadVideo clears a stale pending seek from an interrupted reload")
+    @MainActor func normalLoadClearsStalePendingSeek() {
+        let webView = YouTubeWatchWebView.shared
+        webView.pendingSeek = 99
+        // loadVideo (the non-reload path) must drop the leftover seek so it can't
+        // be injected into a different video. (No webView attached in tests, so
+        // the load is a no-op beyond clearing the field.)
+        webView.loadVideo(videoId: "different-video")
+        #expect(webView.pendingSeek == nil)
+    }
 }

--- a/Tests/KasetTests/YouTubeWatchScriptTests.swift
+++ b/Tests/KasetTests/YouTubeWatchScriptTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+@Suite("YouTubeWatchWebView scripts", .tags(.service))
+@MainActor
+struct YouTubeWatchScriptTests {
+    @Test("Observer script posts to the youtubePlayer bridge with both message types")
+    func observerScriptContract() {
+        let script = YouTubeWatchWebView.observerScript
+        #expect(script.contains("webkit.messageHandlers.youtubePlayer"))
+        #expect(script.contains("STATE_UPDATE"))
+        #expect(script.contains("VIDEO_ENDED"))
+        #expect(script.contains("movie_player"))
+        #expect(script.contains("__kasetTargetVolume"))
+    }
+
+    @Test("Extraction script defines the callable hook and visibility chain")
+    func extractionScriptContract() {
+        let script = YouTubeWatchWebView.extractionScript
+        #expect(script.contains("__kasetExtractVideo"))
+        #expect(script.contains("kaset-yt-video-style"))
+        #expect(script.contains("kaset-visible"))
+        #expect(script.contains("ytp-chrome-bottom"))
+    }
+
+    @Test("Bootstrap script clamps the volume target")
+    func bootstrapClampsVolume() {
+        #expect(YouTubeWatchWebView.pageBootstrapScript(targetVolume: 2.0)
+            .contains("__kasetTargetVolume = 1.0"))
+        #expect(YouTubeWatchWebView.pageBootstrapScript(targetVolume: -1)
+            .contains("__kasetTargetVolume = 0.0"))
+    }
+
+    @Test("Bootstrap carries a pending resume-seek only when present and positive")
+    func bootstrapCarriesPendingSeek() {
+        #expect(YouTubeWatchWebView.pageBootstrapScript(targetVolume: 1, pendingSeek: 42.5)
+            .contains("__kasetPendingSeek = 42.5"))
+        // No seek pending → no marker injected.
+        #expect(!YouTubeWatchWebView.pageBootstrapScript(targetVolume: 1, pendingSeek: nil)
+            .contains("__kasetPendingSeek"))
+        // Zero/negative is not a resume position.
+        #expect(!YouTubeWatchWebView.pageBootstrapScript(targetVolume: 1, pendingSeek: 0)
+            .contains("__kasetPendingSeek"))
+    }
+
+    @Test("Observer applies the pending seek gated on a seekable element")
+    func observerAppliesPendingSeekWhenReady() {
+        let script = YouTubeWatchWebView.observerScript
+        // The seek is applied by the observer (not a one-shot at didFinish),
+        // gated on readyState so it survives YouTube creating <video> late.
+        #expect(script.contains("__kasetPendingSeek"))
+        #expect(script.contains("applyPendingSeek"))
+        #expect(script.contains("readyState"))
+    }
+}

--- a/Tests/KasetTests/YouTubeWatchScriptTests.swift
+++ b/Tests/KasetTests/YouTubeWatchScriptTests.swift
@@ -63,7 +63,7 @@ struct YouTubeWatchScriptTests {
     }
 
     @Test("A normal loadVideo clears a stale pending seek from an interrupted reload")
-    @MainActor func normalLoadClearsStalePendingSeek() {
+    func normalLoadClearsStalePendingSeek() {
         let webView = YouTubeWatchWebView.shared
         webView.pendingSeek = 99
         // loadVideo (the non-reload path) must drop the leftover seek so it can't

--- a/docs/adr/0023-brand-account-history-session-switch.md
+++ b/docs/adr/0023-brand-account-history-session-switch.md
@@ -1,0 +1,92 @@
+# ADR-0023: Brand-Account History via WebView Session-Identity Switch
+
+## Status
+
+Accepted
+
+## Context
+
+Listening/watch history did not record on Brand accounts (GitHub issue
+#277), for both music and video. A live, read-only investigation on a
+real brand account established the mechanism precisely:
+
+- **History is recorded by the playback WebView, not by Kaset.** A repo
+  grep for `watchtime|videostats|/api/stats|playbackTracking` over
+  `Sources/Kaset` returns zero hits. Real-world history is created by the
+  watch page's own `videostats` pings (`/api/stats/playback`,
+  `/api/stats/watchtime`), which attribute to the identity baked into the
+  served document's `ytcfg.DATASYNC_ID`
+  (`"<delegatedSessionId>||<userSessionId>"` for a brand,
+  `"<userSessionId>||"` for the primary).
+- **Brand support was wired only into the native API clients.**
+  `YTMusicClient`/`YouTubeClient` inject `context.user.onBehalfOfUser`
+  for *data fetches* (so the History *view* correctly queries the brand,
+  which returns a genuinely empty container). The *playback* WebView
+  always loaded a bare `…/watch?v=<id>` under the single shared
+  `WKWebsiteDataStore.default()` — i.e. always the primary identity — so
+  every play recorded to the primary's history.
+- **Per-request brand override cannot fix playback.** Verified live: a
+  brand `onBehalfOfUser` body field makes music `/player` return 401; an
+  `X-Goog-PageId` header still yields no `streamingData`; video `/player`
+  returns `UNPLAYABLE`. Music `/player` is `UNPLAYABLE` even as the
+  primary for a non-browser client (YouTube bot detection — the reason
+  Kaset plays in a WebView at all). So recording **must** stay in the
+  WebView, and identity must be a property of the **session**, not the
+  request.
+
+The deferred TODO in `AccountService.switchAccount` ("selectActiveIdentity
+not implemented yet") was exactly this gap: the switch only updated local
+state and never re-pointed the WebView session.
+
+## Decision
+
+**Switch the WebView session's active delegated identity on account
+switch, by navigating to the server-issued `accountSigninToken.signinUrl`,
+and gate the switch on a verified `ytcfg.DATASYNC_ID` read.**
+
+- `accounts_list` already exposes, per account,
+  `selectActiveIdentityEndpoint.supportedTokens[].accountSigninToken.signinUrl`
+  — a `…/signin?…&pageid=<brandId>&authuser=N&next=…` endpoint (the
+  primary's omits `pageid`). `AccountsListParser` now captures it into
+  `UserAccount.signinURL` (credential-bearing; never logged).
+- `WebKitManager.switchSessionIdentity(to:expectedBrandId:)` navigates a
+  transient WebView (on the shared data store) to that URL, then reads
+  `ytcfg.DATASYNC_ID` and verifies the delegated half matches the expected
+  brand pageId (or is absent, for the primary). It throws on mismatch,
+  navigation failure, or a 20s timeout.
+- `AccountService.switchAccount` performs and awaits the verified switch
+  **before** committing `currentAccount`. A failed/unverified switch
+  throws into the existing revert path, so the app never silently records
+  to the wrong account — a strictly safer state than the previous
+  local-only switch.
+- Because the data store is shared, the switch re-points identity for
+  both playback WebViews and cookie-derived API calls at once.
+  `MainWindow` re-points the in-flight track
+  (`PlayerService.reloadCurrentTrackForIdentitySwitch`,
+  `forceFullPageWhenSameVideoId` + restored-session resume) so continued
+  listening records to the new account.
+
+## Consequences
+
+- The fix is shared across music and video (single shared cause → single
+  shared fix), matching the reported symptom.
+- The single shared `WKWebsiteDataStore` is global: a switch affects every
+  cookie-derived surface. The verification gate plus fail-safe revert
+  bound the risk; the API-layer `onBehalfOfUser` override and the
+  cookie-level pin must be kept reconciled (no split-brain).
+- The `signinURL` is credential-bearing and may be single-use/short-lived;
+  on failure we re-fetch `accounts_list` for a fresh URL.
+- DRM/EME is keyed by origin+data store (identity-independent), so
+  decryption is unaffected; the forced reload tears down and rebuilds the
+  media element, with position/play-state resumed via the existing
+  restoration machinery.
+- The mechanism's linchpin — that a real WebView's `signin?pageid`
+  navigation flips `DATASYNC_ID` and lands the play in brand history — is
+  confirmable only at runtime (a bare `URLSession` follow lands on
+  `/oops`; it cannot run the page JS the switch relies on). **Validated**
+  on a real account: after switching to a brand account, the player
+  WebView's `DATASYNC_ID` went from `<user>||` (primary) to
+  `<brandId>||<user>` (brand) on the first read, and a subsequent play
+  grew the previously-empty brand `FEmusic_history` by one track while the
+  primary's was unaffected. `api-explorer` gained read-only `ytcfg`,
+  `signin-probe`, and `X-Goog-PageId` probes to support this.

--- a/docs/adr/0023-brand-account-history-session-switch.md
+++ b/docs/adr/0023-brand-account-history-session-switch.md
@@ -76,6 +76,17 @@ and gate the switch on a verified `ytcfg.DATASYNC_ID` read.**
   cookie-level pin must be kept reconciled (no split-brain).
 - The `signinURL` is credential-bearing and may be single-use/short-lived;
   on failure we re-fetch `accounts_list` for a fresh URL.
+- **Cold-launch window (known limitation).** A restored brand account is
+  exposed as `currentAccount` immediately on launch, while its session pin
+  verifies in the background (deliberately off the launch path so a ≤20s
+  navigation never stalls startup). If the user starts playback in that
+  brief window, the first stats pings can attribute to the primary account
+  until the pin lands; the `verifiedIdentitySequence` reload then re-points
+  the in-flight track so subsequent listening records to the brand. We
+  accept this small residual rather than block all playback on launch for
+  up to 20s (which would be a worse, universal UX regression). The window
+  is bounded by the pin's verification, and the common case (switching
+  accounts in an already-running app) is fully gated.
 - DRM/EME is keyed by origin+data store (identity-independent), so
   decryption is unaffected; the forced reload tears down and rebuilds the
   media element, with position/play-state resumed via the existing

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -56,3 +56,4 @@ What becomes easier or more difficult because of this change?
 | [0019](0019-podcasts-availability.md) | Region-Aware Podcasts Tab Visibility | Implemented |
 | [0020](0020-youtube-source-toggle.md) | Native YouTube Client Behind a Source Toggle | Accepted |
 | [0021](0021-liquid-glass-sidebar-slide-under.md) | Liquid Glass Sidebar Slide-Under | Accepted |
+| [0023](0023-brand-account-history-session-switch.md) | Brand-Account History via WebView Session-Identity Switch | Accepted |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -56,4 +56,5 @@ What becomes easier or more difficult because of this change?
 | [0019](0019-podcasts-availability.md) | Region-Aware Podcasts Tab Visibility | Implemented |
 | [0020](0020-youtube-source-toggle.md) | Native YouTube Client Behind a Source Toggle | Accepted |
 | [0021](0021-liquid-glass-sidebar-slide-under.md) | Liquid Glass Sidebar Slide-Under | Accepted |
+| [0022](0022-youtube-home-sections.md) | YouTube Home Sections — Continue Watching + Personalized Topic Rails | Accepted |
 | [0023](0023-brand-account-history-session-switch.md) | Brand-Account History via WebView Session-Identity Switch | Accepted |


### PR DESCRIPTION
Fixes #277.

## Summary
- Playback/listening history did not record on **Brand accounts** (music *and* video). History is written by the hidden playback WebView's own YouTube stats pings, which attribute to the identity in the served page's `ytcfg.DATASYNC_ID`. Brand support was wired only into the native API clients (data *reads*), never the playback WebView (data *writes*), so the WebView always ran as the **primary** identity and every play recorded to the primary account.
- On account switch, navigate a transient WebView to the server-issued `accountSigninToken.signinUrl` (carries `&pageid=<brandId>`), then **verify** `DATASYNC_ID` flipped to the brand before committing the switch. A failed/unverified switch **reverts** rather than silently recording to the wrong account.
- Re-pin a restored brand session on **cold launch** (off the fetch path so it never stalls startup) — otherwise the bug recurred on every relaunch.
- Re-point the in-flight track/video under the new identity with **position resume** (music via the restored-session machinery; video via a deferred post-load seek).

See [`docs/adr/0023`](docs/adr/0023-brand-account-history-session-switch.md) for the full rationale (including why per-request brand override can't work for playback, and why recording must stay in the WebView).

## How it was validated
Confirmed live on a real account with a brand: switching to the brand flipped the player WebView's `DATASYNC_ID` from `<user>||` (primary) to `<brandId>||<user>` (brand) on the first read, and a subsequent play grew the previously-empty brand `FEmusic_history` by one track while the primary's was unaffected.

## Test plan
- [x] `swift build`
- [x] `swift test --skip KasetUITests` (1501 passing; +25 new)
- [x] `swiftlint --strict` and `swiftformat .` clean
- [x] Live: switch to brand → play ~5s → `DATASYNC_ID` flips + brand history gains the track, primary unaffected
- [ ] Reviewer: confirm brand→primary round-trip and a relaunch-while-on-brand both keep recording to the correct account

## Notes
- New unit coverage: signin-URL parsing/resolution, the `DATASYNC_ID` identity matcher (incl. blank/unread guard), the fail-safe revert path, cold-launch restore-pin, and the video re-point/resume.
- `Sources/APIExplorer/main.swift` gains read-only identity probes (`ytcfg`, `signin-probe`) used to investigate and verify this; no production behavior depends on them.