### PR TITLE
Fix media-key next replaying same song in background

### DIFF
--- a/Sources/Kaset/AppDelegate.swift
+++ b/Sources/Kaset/AppDelegate.swift
@@ -92,7 +92,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         DiagnosticsLogger.player.info("System woke from sleep, wasPlayingBeforeSleep: \(self.wasPlayingBeforeSleep)")
     }
 
+    func applicationDidResignActive(_: Notification) {
+        // WebKit freezes the page's requestAnimationFrame loop in the background, so the
+        // media-key override (nexttrack/previoustrack) is no longer re-applied and YouTube
+        // can reclaim it. Drive re-assertion from a native timer instead.
+        SingletonPlayerWebView.shared.beginBackgroundMediaControlReassertion()
+    }
+
     func applicationDidBecomeActive(_: Notification) {
+        // Foreground: the page's requestAnimationFrame loop resumes ownership of the
+        // override. Stop the native timer and re-assert once immediately.
+        SingletonPlayerWebView.shared.endBackgroundMediaControlReassertion()
+        SingletonPlayerWebView.shared.reassertMediaControlOverride()
         // When app becomes active (e.g., dock icon clicked), ensure main window is visible.
         // This handles the case where video window is visible but main window is hidden.
         if self.isSwitchedToMiniPlayer {

--- a/Sources/Kaset/Views/MiniPlayerWebView.swift
+++ b/Sources/Kaset/Views/MiniPlayerWebView.swift
@@ -247,6 +247,10 @@ final class SingletonPlayerWebView {
     var mediaControlUsesNextPrev: Bool
     var playbackAudioQuality: SettingsManager.PlaybackAudioQuality
 
+    /// Native timer that re-asserts the media-key override while backgrounded.
+    /// See `beginBackgroundMediaControlReassertion()`.
+    var mediaControlReassertTimer: Timer?
+
     /// Tracks if lyrics high-frequency polling should be active
     /// Used to restore polling after full-page navigation
     var isLyricsPollActive = false

--- a/Sources/Kaset/Views/SingletonPlayerWebView+PlaybackPreferences.swift
+++ b/Sources/Kaset/Views/SingletonPlayerWebView+PlaybackPreferences.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 // MARK: - SingletonPlayerWebView Media Controls
 
 extension SingletonPlayerWebView {
@@ -13,6 +15,45 @@ extension SingletonPlayerWebView {
 
     func mediaControlBootstrapScript() -> String {
         Self.mediaControlStyleBootstrapScript(useNextPrev: self.mediaControlUsesNextPrev)
+    }
+
+    /// Re-asserts Kaset's `nexttrack`/`previoustrack` media-session override immediately.
+    ///
+    /// YouTube Music periodically re-registers its own handlers. In `nextPreviousTrack`
+    /// mode the page keeps ownership via a `requestAnimationFrame` re-apply loop — but
+    /// WebKit freezes `requestAnimationFrame` while the app is backgrounded, so the
+    /// override is lost and a media-key press falls through to YouTube (which jumps to its
+    /// own recommendation; queue-drift recovery then restarts the current song from 0).
+    /// Driving the re-apply from a native timer keeps the override alive in the background.
+    func reassertMediaControlOverride() {
+        guard self.mediaControlUsesNextPrev, let webView = self.webView else { return }
+        webView.evaluateJavaScript(
+            "if (typeof window.__kasetRefreshMediaControlStyle === 'function') { window.__kasetRefreshMediaControlStyle(); }",
+            completionHandler: nil
+        )
+    }
+
+    /// Starts a native timer that re-asserts the media-key override while the app is
+    /// backgrounded. Native run-loop timers keep firing in the background (active audio
+    /// playback prevents App Nap), unlike the page's frozen `requestAnimationFrame` loop.
+    func beginBackgroundMediaControlReassertion() {
+        guard self.mediaControlUsesNextPrev else { return }
+        self.reassertMediaControlOverride()
+        guard self.mediaControlReassertTimer == nil else { return }
+        let timer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { [weak self] (_: Timer) in
+            MainActor.assumeIsolated {
+                self?.reassertMediaControlOverride()
+            }
+        }
+        timer.tolerance = 0.5
+        self.mediaControlReassertTimer = timer
+    }
+
+    /// Stops the background re-assertion timer. The page's `requestAnimationFrame` loop
+    /// resumes ownership once the app is foreground again.
+    func endBackgroundMediaControlReassertion() {
+        self.mediaControlReassertTimer?.invalidate()
+        self.mediaControlReassertTimer = nil
     }
 
     static func mediaControlStyleBootstrapScript(useNextPrev: Bool) -> String {


### PR DESCRIPTION
## Problem

Pressing the macOS media **next** key while the app is in the background sometimes restarts the **same** song from the beginning instead of advancing to the next track in the queue.

## Root cause

In `nextPreviousTrack` mode, Kaset overrides the WebView's `navigator.mediaSession` `nexttrack`/`previoustrack` handlers so media keys advance the native queue (via the `REMOTE_NEXT` message). YouTube Music periodically re-registers its own handlers, and Kaset re-asserts its override through a `requestAnimationFrame` loop on the page.

**WebKit freezes `requestAnimationFrame` while the app is backgrounded**, so the override was never re-applied. After some time backgrounded, a media-key press fell through to YouTube's own handler, which jumped to YouTube's recommended video. Queue-drift recovery (`handleUnexpectedQueueDriftIfNeeded`) then saw a video that wasn't in the native queue and force-reloaded the current queue song from 0 — the same song appeared to restart.

## Fix

Drive the override re-assertion from a native run-loop `Timer` instead of relying solely on the page's `requestAnimationFrame` loop:
- Starts on `applicationDidResignActive`.
- Stops on `applicationDidBecomeActive` (where the page's rAF loop resumes ownership), plus one immediate re-assert.

Native timers keep firing in the background (active audio playback prevents App Nap), so the override stays installed and media keys continue to advance the native queue. This extends the existing override-maintenance mechanism (`__kasetRefreshMediaControlStyle`) rather than introducing a new path.

## Verification

Confirmed at runtime with a file tracer (since removed): 5 `next` presses over 60+ seconds backgrounded each routed through `REMOTE_NEXT` → `next()` and advanced to the following queue track, with **zero** drift-recovery restarts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)