### PR TITLE
docs: update YouTube support documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Guidance for AI coding assistants working on this repository.
 
 You are a Senior Swift Engineer specializing in SwiftUI, Swift Concurrency, and macOS development. Your code must adhere to Apple's Human Interface Guidelines. Target **Swift 6.0+** and **macOS 26.0+**.
 
-Kaset is a native macOS YouTube Music client (Swift/SwiftUI) using a hidden WebView for DRM playback and `YTMusicClient` API calls for all data fetching.
+Kaset is a native macOS client for YouTube Music and YouTube (Swift/SwiftUI). It uses WebViews only for DRM/playback/auth surfaces and uses `YTMusicClient` / `YouTubeClient` API calls for data fetching.
 
 ## Critical Rules
 
@@ -16,7 +16,7 @@ Kaset is a native macOS YouTube Music client (Swift/SwiftUI) using a hidden WebV
 
 > ⚠️ **No Third-Party Frameworks** — Do not introduce third-party dependencies without asking first.
 
-> ⚠️ **Prefer API over WebView** — Always use `YTMusicClient` API calls when functionality exists. Only use WebView for playback (DRM-protected audio) and authentication.
+> ⚠️ **Prefer API over WebView** — Always use `YTMusicClient` (YouTube Music) or `YouTubeClient` (YouTube) API calls when functionality exists. Only use WebView for playback (DRM-protected media) and authentication.
 
 > 🔧 **Improve API Explorer, Don't Write One-Off Scripts** — When exploring or debugging API-related functionality, **always enhance `Sources/APIExplorer/main.swift`** instead of writing temporary scripts.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,8 +1,24 @@
 # Kaset Domain Language
 
+## App Source
+
+The active content experience selected by the sidebar source toggle. `.music` is the YouTube Music experience and remains the default; `.video` is the regular YouTube experience. Source switches swap the visible navigation surface without merging the two data models.
+
+## Music Experience
+
+Kaset's YouTube Music surface: songs, albums, artists, playlists, podcasts, lyrics, queue management, and DRM audio playback through the hidden `SingletonPlayerWebView`. Data fetching belongs to `YTMusicClient` and music-specific parsers.
+
+## YouTube Experience
+
+Kaset's regular YouTube surface: recommendations, search, subscriptions, Shorts, channels, playlists, Watch Later, history, comments, and video playback through `YouTubeWatchWebView`. Data fetching belongs to `YouTubeClient` and YouTube-specific parsers under `Services/API/Parsers/YouTube/`.
+
+## Playback Arbiter
+
+The coordinator that keeps YouTube Music and regular YouTube from playing over each other. It pauses music when a YouTube video starts, pauses YouTube video when music starts, and lets media-key handling follow whichever source played most recently.
+
 ## Library
 
-The signed-in user's saved YouTube Music collection. Kaset surfaces Library content as playlists, followed artists, subscribed podcast shows, and uploaded songs.
+The signed-in user's saved YouTube Music collection. Kaset surfaces Music Library content as playlists, followed artists, subscribed podcast shows, and uploaded songs. Regular YouTube has separate library-like surfaces such as subscriptions, Watch Later, liked videos, history, and playlists.
 
 ## Library Content Identity
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,8 +20,8 @@ cd kaset
 # Build from command line
 swift build
 
-# Run tests
-swift test
+# Run unit tests (do not combine with UI tests)
+swift test --skip KasetUITests
 
 # Package and run the app
 Scripts/compile_and_run.sh
@@ -44,13 +44,13 @@ Sources/
   └── Kaset/            → Main app target
       ├── Models/       → Data models (Song, Playlist, Album, Artist, etc.)
       ├── Services/
-      │   ├── API/      → YTMusicClient (YouTube Music API calls)
+      │   ├── API/      → YTMusicClient + YouTubeClient (InnerTube API calls)
       │   ├── Auth/     → AuthService (login state machine)
       │   ├── Player/   → PlayerService, NowPlayingManager (playback, media keys)
       │   └── WebKit/   → WebKitManager (cookie store, persistent login)
-      ├── ViewModels/   → HomeViewModel, LibraryViewModel, SearchViewModel
+      ├── ViewModels/   → Music view models plus YouTube/ video-source view models
       ├── Utilities/    → DiagnosticsLogger, extensions
-      └── Views/        → SwiftUI views (MainWindow, Sidebar, PlayerBar, etc.)
+      └── Views/        → SwiftUI views (MainWindow, Sidebar, PlayerBar, YouTube views, etc.)
   └── APIExplorer/      → API explorer CLI tool
 Tests/                  → Unit tests (KasetTests/)
 Scripts/                → Build scripts
@@ -64,8 +64,12 @@ docs/                   → Detailed documentation
 | `Sources/Kaset/AppDelegate.swift`                   | Window lifecycle, background audio support |
 | `Sources/Kaset/Services/WebKit/WebKitManager.swift` | Cookie store & persistence                 |
 | `Sources/Kaset/Services/Auth/AuthService.swift`     | Login state machine                        |
+| `Sources/Kaset/Services/API/YTMusicClient.swift`    | YouTube Music API client                   |
+| `Sources/Kaset/Services/API/YouTubeClient.swift`    | Regular YouTube API client                 |
 | `Sources/Kaset/Services/Player/PlayerService.swift` | Playback state & control                   |
+| `Sources/Kaset/Services/Player/YouTubePlayerService.swift` | Regular YouTube playback state & control   |
 | `Sources/Kaset/Views/MiniPlayerWebView.swift`       | Singleton WebView, playback UI             |
+| `Sources/Kaset/Views/YouTube/YouTubeWatchWebView.swift` | Singleton WebView for regular YouTube watch playback |
 | `Sources/Kaset/Views/MainWindow.swift`              | Main app window                            |
 | `Sources/Kaset/Utilities/DiagnosticsLogger.swift`   | Logging                                    |
 
@@ -75,6 +79,7 @@ For detailed architecture documentation, see the `docs/` folder:
 
 - **[docs/architecture.md](docs/architecture.md)** — Services, state management, data flow
 - **[docs/playback.md](docs/playback.md)** — WebView playback system, background audio
+- **[docs/youtube.md](docs/youtube.md)** — Regular YouTube source, video playback, Shorts, comments, and parser strategy
 - **[docs/testing.md](docs/testing.md)** — Test commands, patterns, debugging
 
 ### High-Level Overview
@@ -83,10 +88,19 @@ The app uses a clean architecture with:
 
 - **Observable Pattern**: `@Observable` classes for reactive state management
 - **MainActor Isolation**: All UI and service classes are `@MainActor` for thread safety
-- **WebKit Integration**: Persistent `WKWebsiteDataStore` for cookie management
+- **Dual Source Model**: YouTube Music and regular YouTube are parallel experiences behind a sidebar source toggle
+- **WebKit Integration**: Persistent `WKWebsiteDataStore` for cookie management, authentication, and DRM playback
 - **Swift Concurrency**: `async`/`await` throughout, no `DispatchQueue`
 
 ### Playback Architecture
+
+Kaset has two playback paths. YouTube Music uses `PlayerService` plus the
+`SingletonPlayerWebView` at `music.youtube.com`; regular YouTube uses
+`YouTubePlayerService` plus `YouTubeWatchWebView` at `www.youtube.com`.
+`PlaybackArbiter` keeps one audio source active at a time and media keys route
+to the source that played most recently.
+
+#### YouTube Music
 
 ```
 User clicks Play
@@ -111,6 +125,25 @@ PlayerService.play(videoId:)
             - duration
 ```
 
+#### Regular YouTube
+
+```
+User opens a YouTube video
+    │
+    ▼
+YouTubePlayerService.play(video:)
+    │
+    ├── Sets active video metadata
+    ├── Loads www.youtube.com/watch?v={id}
+    └── Hosts YouTubeWatchWebView inline or in the floating window
+            │
+            ▼
+    JavaScript bridge sends state, captions, quality, and ad updates
+            │
+            ▼
+    YouTubePlayerService updates playback state and YouTubePlayerBar
+```
+
 ### Authentication Flow
 
 ```
@@ -128,9 +161,9 @@ Observer detects cookie → Dismiss sheet
 ### Background Audio
 
 ```
-Close window (⌘W) → Window hides → Audio continues
-Click dock icon    → Window shows → Same WebView
-Quit app (⌘Q)     → App terminates → Audio stops
+Close window (⌘W) → Window hides → active playback continues
+Click dock icon    → Window shows → same Music/YouTube WebView state
+Quit app (⌘Q)     → App terminates → playback stops
 ```
 
 ## Coding Guidelines
@@ -198,7 +231,7 @@ final class MyServiceTests: XCTestCase {
 
 1. **No Third-Party Frameworks** — Do not introduce third-party dependencies without discussion first
 2. **Build Must Pass** — Run `swift build`
-3. **Tests Must Pass** — Run `swift test`
+3. **Tests Must Pass** — Run `swift test --skip KasetUITests` for unit tests
 4. **Linting** — Run `swiftlint --strict && swiftformat .` before submitting
 5. **Small PRs** — Keep changes focused and reviewable
 6. **Share AI Prompts** — If you used AI assistance, include the prompt in your PR (see below)
@@ -255,11 +288,11 @@ Reference: Sources/Kaset/Services/HapticService.swift for existing patterns
 ## Testing
 
 ```bash
-# Run all tests
-swift test
+# Run unit tests
+swift test --skip KasetUITests
 
-# Run specific test (use --filter)
-swift test --filter PlayerServiceTests
+# Run specific unit test (use --filter)
+swift test --skip KasetUITests --filter PlayerServiceTests
 ```
 
 See [docs/testing.md](docs/testing.md) for detailed testing patterns and debugging tips.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,19 @@
 # Kaset
 
-A native macOS YouTube Music client built with Swift and SwiftUI.
+A native macOS client for YouTube Music and YouTube, built with Swift and SwiftUI.
 
 <img src="docs/screenshot.png" alt="Kaset Screenshot">
 
 ## Features
 
-- 🎵 **Native macOS Experience** — Apple Music-style UI with Liquid Glass player bar and clean sidebar navigation
-- 🎧 **YouTube Music Premium Support** — Full playback of DRM-protected content via your existing subscription
+- 🎵 **Native macOS Experience** — Apple Music-style UI with Liquid Glass player bars, clean sidebar navigation, and a source toggle for Music ↔ YouTube
+- 🎧 **YouTube Music Support** — Full playback of DRM-protected YouTube Music content via your existing Premium subscription
+- ▶️ **[YouTube Support](docs/youtube.md)** — Browse regular YouTube recommendations, search, subscriptions, Shorts, Watch Later, history, comments, and video playback with native controls, captions, quality selection, and picture in picture
 - 🎛️ **System Integration** — Now Playing in Control Center, media key support, Dock menu controls
 - 📳 **Haptic Feedback** — Tactile feedback on Force Touch trackpads for player controls and navigation
 - 🎶 **Track Notifications** — Get notified when a new track starts playing
 - 🔊 **Background Audio** — Music continues playing when the window is closed; stops on quit
-- 🎚️ **Equalizer** — System-wide 6-band parametric EQ with Spotify-style presets, applied to YouTube Music output
+- 🎚️ **Equalizer** — System-wide 6-band parametric EQ with Spotify-style presets, applied to WebKit playback output
 - ⌨️ **[Keyboard Shortcuts](docs/keyboard-shortcuts.md)** — Full keyboard control for playback, navigation, and more
 - 🧭 **Explore** — Discover new releases, charts, and moods & genres
 - 🎙️ **Podcasts** — Browse and listen to podcasts with episode progress tracking
@@ -24,8 +25,7 @@ A native macOS YouTube Music client built with Swift and SwiftUI.
 - 📜 **Lyrics** — View plain and synced lyrics with line-by-line highlighting when timing data is available, plus AI-powered explanations and mood analysis on macOS 26+
 - 📃 **Queue Management** — View, reorder, shuffle, and clear your playback queue
 - 📣 **Share** — Share songs, playlists, albums, and artists via the native macOS share sheet
-- ▶️ **[YouTube Mode](docs/youtube.md)** — Flip the sidebar source toggle for a native regular-YouTube client: recommendations, search, subscriptions, Shorts, Watch Later, history, comments, and video playback with native controls, captions, quality selection, and picture in picture
-- 🔗 **[URL Scheme](docs/url-scheme.md)** — Open songs directly with `kaset://play?v=VIDEO_ID`; YouTube watch and `youtu.be` links play in YouTube mode
+- 🔗 **[URL Scheme](docs/url-scheme.md)** — Open songs directly with `kaset://play?v=VIDEO_ID`; app-targeted YouTube watch and `youtu.be` links play in YouTube mode
 - 🤖 **[AppleScript Support](docs/applescript.md)** — Automate playback with scripts, Raycast, Alfred, and Shortcuts
 - 🧩 **[Extensions](docs/extensions.md)** — Load WebKit Web Extensions, including [uBlock Origin Lite](https://github.com/uBlockOrigin/uBOL-home)
 
@@ -33,7 +33,7 @@ A native macOS YouTube Music client built with Swift and SwiftUI.
 
 - macOS 15.4 or later
 - Apple Intelligence features require macOS 26.0 or later
-- [Google](https://accounts.google.com) account
+- [Google](https://accounts.google.com) account for YouTube Music and YouTube personalization
 
 ## Installation
 

--- a/Sources/APIExplorer/main.swift
+++ b/Sources/APIExplorer/main.swift
@@ -1,14 +1,13 @@
 #!/usr/bin/env swift
 //
 //  main.swift
-//  Standalone API Explorer for YouTube Music
+//  Standalone API Explorer for YouTube Music and YouTube
 //
-//  A unified tool for exploring both public and authenticated YouTube Music API endpoints.
+//  A unified tool for exploring public and authenticated YouTube Music and regular YouTube API endpoints.
 //  Reads cookies from the Kaset app's debug cookie export for authenticated requests.
 //
 //  Usage:
-//    chmod +x Tools/api-explorer.swift
-//    ./Tools/api-explorer.swift [command] [options]
+//    swift run api-explorer [command] [options]
 //
 //  Commands:
 //    browse <browseId> [params]    - Explore a browse endpoint
@@ -21,17 +20,17 @@
 //  Options:
 //    -v, --verbose                 - Show full raw JSON response (not truncated)
 //    -o, --output <file>           - Save raw JSON response to a file
-//    --youtube                     - Target regular YouTube (www.youtube.com, WEB client)
+//    --youtube, --yt               - Target regular YouTube (www.youtube.com, WEB client)
 //                                    instead of YouTube Music
 //
 //  Examples:
-//    ./Tools/api-explorer.swift browse FEmusic_home
-//    ./Tools/api-explorer.swift browse FEmusic_charts
-//    ./Tools/api-explorer.swift browse FEmusic_liked_playlists   # Requires auth
-//    ./Tools/api-explorer.swift action search '{"query":"never gonna give you up"}'
-//    ./Tools/api-explorer.swift continuation <token> next        # Mix queue continuation
-//    ./Tools/api-explorer.swift auth
-//    ./Tools/api-explorer.swift list
+//    swift run api-explorer browse FEmusic_home
+//    swift run api-explorer browse FEmusic_charts
+//    swift run api-explorer browse FEmusic_liked_playlists   # Requires auth
+//    swift run api-explorer action search '{"query":"never gonna give you up"}'
+//    swift run api-explorer continuation <token> next        # Mix queue continuation
+//    swift run api-explorer auth
+//    swift run api-explorer list
 //
 
 import CommonCrypto
@@ -1033,7 +1032,7 @@ func discoverAccounts(verbose: Bool) async {
         }
         print()
         print("💡 Use --authuser N to make requests as a specific account")
-        print("   Example: ./api-explorer.swift browse FEmusic_liked_playlists --authuser 1")
+        print("   Example: swift run api-explorer browse FEmusic_liked_playlists --authuser 1")
     }
 }
 
@@ -1638,7 +1637,7 @@ func discoverBrandAccounts(verbose: Bool) async {
 
         print()
         print("💡 To use a brand account, use the --brand flag with the Brand ID:")
-        print("   Example: ./api-explorer.swift browse FEmusic_liked_playlists --brand <ID>")
+        print("   Example: swift run api-explorer browse FEmusic_liked_playlists --brand <ID>")
         print()
         print("   This sets context.user.onBehalfOfUser in the request body,")
         print("   which is required for brand account access.")
@@ -1782,7 +1781,7 @@ func listEndpoints() {
         ggMGKgQIBBAA    Alphabetical Z-A
         ggMCCAE         Default Sort
 
-        Example: ./api-explorer.swift browse FEmusic_library_albums ggMGKgQIARAA
+        Example: swift run api-explorer browse FEmusic_library_albums ggMGKgQIARAA
 
         FEmusic_library_corpus_track_artists is the Library Artists chip endpoint.
         It requires sign-in for useful content but does not need sort params.
@@ -1796,7 +1795,8 @@ func listEndpoints() {
         🌐/🔐 BROWSE (auth used automatically when cookies are available)
         ───────────────────────────────────────────────────────────────────────────────
         FEwhat_to_watch               Home feed (personalized recommendations)
-        FEtrending                    Trending
+        FE{gaming,news,sports,live,fashion,learning}_destination
+                                      Explore destination feeds
         FEsubscriptions               Subscriptions feed (requires auth)
         FElibrary                     Library overview (requires auth)
         FEhistory                     Watch history (requires auth)
@@ -1820,10 +1820,10 @@ func listEndpoints() {
         💡 USAGE TIPS
         ═══════════════════════════════════════════════════════════════════════════════
 
-        Check auth status:     ./api-explorer.swift auth
-        Explore with verbose:  ./api-explorer.swift browse FEmusic_charts -v
-        Dynamic browse ID:     ./api-explorer.swift browse VLPLrAXtmErZgOeiKm4sgNOknGvNjby9efdf
-        Action with body:      ./api-explorer.swift action player '{"videoId":"dQw4w9WgXcQ"}'
+        Check auth status:     swift run api-explorer auth
+        Explore with verbose:  swift run api-explorer browse FEmusic_charts -v
+        Dynamic browse ID:     swift run api-explorer browse VLPLrAXtmErZgOeiKm4sgNOknGvNjby9efdf
+        Action with body:      swift run api-explorer action player '{"videoId":"dQw4w9WgXcQ"}'
 
         * Param-based library endpoints above return HTTP 400 without both auth AND params
 
@@ -1834,14 +1834,14 @@ func listEndpoints() {
 func showHelp() {
     print(
         """
-        YouTube Music API Explorer
-        ==========================
+        YouTube Music and YouTube API Explorer
+        ======================================
 
-        A standalone tool for exploring YouTube Music API endpoints.
-        Supports both public and authenticated endpoints (reads cookies from Kaset app).
+        A standalone tool for exploring YouTube Music and regular YouTube API endpoints.
+        Supports public and authenticated endpoints (reads cookies from Kaset app).
 
         Usage:
-          ./api-explorer.swift <command> [options]
+          swift run api-explorer <command> [options]
 
         Commands:
           browse <browseId> [params]     Explore a browse endpoint
@@ -1864,47 +1864,47 @@ func showHelp() {
           -o, --output <file>            Save raw JSON response to a file
           --authuser N                   Use Google account at index N (for multi-account)
           --brand <ID>                   Use brand account ID (21-digit number)
-          --youtube                      Target regular YouTube (www.youtube.com, WEB client)
+          --youtube, --yt                Target regular YouTube (www.youtube.com, WEB client)
                                          instead of YouTube Music
 
         YouTube mode examples:
           # Browse YouTube surfaces (auth used automatically when cookies exist)
-          ./api-explorer.swift --youtube browse FEwhat_to_watch     # Home feed
-          ./api-explorer.swift --youtube browse FEtrending          # Trending
-          ./api-explorer.swift --youtube browse FEsubscriptions     # Subscriptions feed
-          ./api-explorer.swift --youtube browse FEhistory           # Watch history
-          ./api-explorer.swift --youtube browse VLWL                # Watch Later
-          ./api-explorer.swift --youtube browse VLLL                # Liked videos
-          ./api-explorer.swift --youtube action search '{"query":"swift concurrency"}'
-          ./api-explorer.swift --youtube action next '{"videoId":"dQw4w9WgXcQ"}'
-          ./api-explorer.swift --youtube action guide '{}'          # Sidebar + subscriptions list
+          swift run api-explorer --youtube browse FEwhat_to_watch     # Home feed
+          swift run api-explorer --youtube browse FEgaming_destination # Explore destination
+          swift run api-explorer --youtube browse FEsubscriptions     # Subscriptions feed
+          swift run api-explorer --youtube browse FEhistory           # Watch history
+          swift run api-explorer --youtube browse VLWL                # Watch Later
+          swift run api-explorer --youtube browse VLLL                # Liked videos
+          swift run api-explorer --youtube action search '{"query":"swift concurrency"}'
+          swift run api-explorer --youtube action next '{"videoId":"dQw4w9WgXcQ"}'
+          swift run api-explorer --youtube action guide '{}'          # Sidebar + subscriptions list
 
         Examples:
           # Explore public endpoints
-          ./api-explorer.swift browse FEmusic_home
-          ./api-explorer.swift browse FEmusic_charts
-          ./api-explorer.swift browse FEmusic_moods_and_genres -v
+          swift run api-explorer browse FEmusic_home
+          swift run api-explorer browse FEmusic_charts
+          swift run api-explorer browse FEmusic_moods_and_genres -v
 
           # Explore authenticated endpoints (requires Kaset sign-in)
-          ./api-explorer.swift browse FEmusic_liked_playlists
-          ./api-explorer.swift browse FEmusic_history
-          ./api-explorer.swift browse FEmusic_library_corpus_track_artists
+          swift run api-explorer browse FEmusic_liked_playlists
+          swift run api-explorer browse FEmusic_history
+          swift run api-explorer browse FEmusic_library_corpus_track_artists
 
           # Discover brand accounts and use them
-          ./api-explorer.swift brandaccounts                            # List brand accounts with IDs
-          ./api-explorer.swift browse FEmusic_liked_playlists --brand <ID>  # Use brand account
+          swift run api-explorer brandaccounts                            # List brand accounts with IDs
+          swift run api-explorer browse FEmusic_liked_playlists --brand <ID>  # Use brand account
 
           # Action endpoints
-          ./api-explorer.swift action search '{"query":"never gonna give you up"}'
-          ./api-explorer.swift action player '{"videoId":"dQw4w9WgXcQ"}'
-          ./api-explorer.swift action next '{"playlistId":"RDEM...","videoId":"abc123"}'
+          swift run api-explorer action search '{"query":"never gonna give you up"}'
+          swift run api-explorer action player '{"videoId":"dQw4w9WgXcQ"}'
+          swift run api-explorer action next '{"playlistId":"RDEM...","videoId":"abc123"}'
 
           # Continuation (for pagination / infinite mix)
-          ./api-explorer.swift continuation <token>           # browse endpoint (default)
-          ./api-explorer.swift continuation <token> next      # next endpoint (for mix queues)
+          swift run api-explorer continuation <token>           # browse endpoint (default)
+          swift run api-explorer continuation <token> next      # next endpoint (for mix queues)
 
           # Check auth status
-          ./api-explorer.swift auth
+          swift run api-explorer auth
 
             Authentication:
                 For authenticated endpoints, sign in to the Kaset app first.
@@ -2065,7 +2065,7 @@ func runMain() async {
 
     default:
         print("❌ Unknown command: \(command)")
-        print("   Run './api-explorer.swift help' for usage")
+        print("   Run 'swift run api-explorer help' for usage")
     }
 }
 

--- a/Sources/Kaset/Services/URLHandler.swift
+++ b/Sources/Kaset/Services/URLHandler.swift
@@ -2,7 +2,8 @@ import Foundation
 
 // MARK: - URLHandler
 
-/// Handles parsing and routing of YouTube Music URLs.
+/// Handles parsing and routing of YouTube Music URLs, regular YouTube watch
+/// links, and Kaset custom-scheme URLs.
 ///
 /// Supports URLs like:
 /// - `https://music.youtube.com/watch?v=dQw4w9WgXcQ` - Play song
@@ -11,6 +12,8 @@ import Foundation
 /// - `https://music.youtube.com/browse/VLPLxxx` - Open playlist (browse format)
 /// - `https://music.youtube.com/channel/UCxxx` - Open artist
 /// - `https://music.youtube.com/browse/MPLAUCxxx` - Open library artist
+/// - `https://www.youtube.com/watch?v=dQw4w9WgXcQ` - Play regular YouTube video
+/// - `https://youtu.be/dQw4w9WgXcQ` - Play regular YouTube video
 /// - `kaset://play?v=dQw4w9WgXcQ` - Custom scheme for song
 /// - `kaset://playlist?list=PLxxx` - Custom scheme for playlist
 /// - `kaset://album?id=MPRExxx` - Custom scheme for album
@@ -38,7 +41,7 @@ enum URLHandler {
 
     // MARK: - URL Parsing
 
-    /// Parses a YouTube Music URL and returns the content type.
+    /// Parses a supported URL and returns the content type.
     /// - Parameter url: The URL to parse.
     /// - Returns: The parsed content, or nil if the URL is not recognized.
     static func parse(_ url: URL) -> ParsedContent? {

--- a/docs/api-discovery.md
+++ b/docs/api-discovery.md
@@ -1,8 +1,8 @@
-# YouTube Music API Reference
+# YouTube Music and YouTube API Reference
 
-> **Complete documentation of YouTube Music API endpoints for Kaset development.**
+> **Complete documentation of YouTube Music and regular YouTube InnerTube endpoints for Kaset development.**
 >
-> This document catalogs all known YouTube Music API endpoints, their authentication requirements, implementation status, and usage patterns. Use the standalone [API Explorer](../Tools/api-explorer.swift) tool for live endpoint testing.
+> This document catalogs known YouTube Music API endpoints, their authentication requirements, implementation status, and usage patterns. The same `api-explorer` tool also supports regular YouTube via `--youtube`; see [YouTube Mode](youtube.md) for the video-source architecture.
 
 ## Table of Contents
 
@@ -37,6 +37,17 @@ The YouTube Music API (`youtubei/v1`) is an internal API used by the YouTube Mus
 | Client Version | `1.20231204.01.00` |
 | Protocol | HTTPS POST with JSON body |
 
+Regular YouTube uses the same `youtubei/v1` protocol with different request identity:
+
+| Property | Value |
+|----------|-------|
+| Base URL | `https://www.youtube.com/youtubei/v1` |
+| API Key | Not required for the currently used WEB InnerTube requests |
+| Client Name | `WEB` |
+| Origin | `https://www.youtube.com` |
+
+Use `swift run api-explorer --youtube ...` to target regular YouTube. Use the default mode for YouTube Music.
+
 ### Endpoint Types
 
 1. **Browse Endpoints** - Load content pages (Home, Explore, Library, etc.)
@@ -63,6 +74,8 @@ let hash = SHA1(hashInput)
 let header = "SAPISIDHASH \(timestamp)_\(hash)"
 ```
 
+For regular YouTube requests, the hash input origin must be `https://www.youtube.com`; a `music.youtube.com` hash will fail authorization against the YouTube WEB client.
+
 ### Required Cookies
 
 | Cookie | Purpose |
@@ -81,7 +94,7 @@ Brand accounts (YouTube channels) can be accessed by setting `context.user.onBeh
 Use the `account/accounts_list` endpoint to get all accounts (primary + brand) with their IDs:
 
 ```bash
-./Tools/api-explorer.swift brandaccounts
+swift run api-explorer brandaccounts
 ```
 
 **Response Structure**:
@@ -128,10 +141,10 @@ let body: [String: Any] = [
 **API Explorer Usage**:
 ```bash
 # List brand accounts with IDs
-./Tools/api-explorer.swift brandaccounts
+swift run api-explorer brandaccounts
 
 # Access brand account library
-./Tools/api-explorer.swift browse FEmusic_liked_playlists --brand 111997145576882617490
+swift run api-explorer browse FEmusic_liked_playlists --brand 111997145576882617490
 ```
 
 #### Key Differences: authuser vs brand
@@ -1114,39 +1127,51 @@ let result = try await RetryPolicy.execute(
 
 ## Using the API Explorer
 
-The standalone [api-explorer.swift](../Tools/api-explorer.swift) tool provides comprehensive exploration of both public and authenticated API endpoints.
-
-### Setup
-
-```bash
-# Make executable (one time)
-chmod +x Tools/api-explorer.swift
-```
+The SwiftPM `api-explorer` executable (`Sources/APIExplorer/main.swift`) provides comprehensive exploration of both public and authenticated API endpoints.
 
 ### Basic Usage
 
 ```bash
 # Check authentication status
-./Tools/api-explorer.swift auth
+swift run api-explorer auth
 
 # List all known endpoints
-./Tools/api-explorer.swift list
+swift run api-explorer list
 
 # Explore a public browse endpoint
-./Tools/api-explorer.swift browse FEmusic_charts
+swift run api-explorer browse FEmusic_charts
 # Output: ✅ HTTP 200
 #         📋 Top-level keys (5): contents, frameworkUpdates, header...
 
 # Explore with verbose output (shows full raw JSON, no truncation)
-./Tools/api-explorer.swift browse FEmusic_home -v
+swift run api-explorer browse FEmusic_home -v
 
 # Save raw JSON to a file for analysis
-./Tools/api-explorer.swift action search '{"query":"manifest"}' -o /tmp/search.json
+swift run api-explorer action search '{"query":"manifest"}' -o /tmp/search.json
 
 # Explore action endpoints
-./Tools/api-explorer.swift action search '{"query":"never gonna give you up"}'
-./Tools/api-explorer.swift action player '{"videoId":"dQw4w9WgXcQ"}'
+swift run api-explorer action search '{"query":"never gonna give you up"}'
+swift run api-explorer action player '{"videoId":"dQw4w9WgXcQ"}'
 ```
+
+### Regular YouTube Mode
+
+Pass `--youtube` (or `--yt`) to target `www.youtube.com` with the WEB client instead of `music.youtube.com` with WEB_REMIX:
+
+```bash
+# Regular YouTube home recommendations
+swift run api-explorer --youtube browse FEwhat_to_watch
+
+# YouTube subscriptions and history (auth used automatically when cookies exist)
+swift run api-explorer --youtube browse FEsubscriptions
+swift run api-explorer --youtube browse FEhistory
+
+# Search and watch-next metadata
+swift run api-explorer --youtube action search '{"query":"swift concurrency"}'
+swift run api-explorer --youtube action next '{"videoId":"VIDEO_ID"}'
+```
+
+Prefer the destination feeds documented in [youtube.md](youtube.md) for Explore; YouTube's old `FEtrending` feed is no longer a reliable target.
 
 ### Authenticated Endpoints
 
@@ -1154,12 +1179,12 @@ For authenticated endpoints (🔐), sign in to the Kaset app first:
 
 ```bash
 # Check if cookies are available
-./Tools/api-explorer.swift auth
+swift run api-explorer auth
 
 # If authenticated, explore library endpoints
-./Tools/api-explorer.swift browse FEmusic_liked_playlists
-./Tools/api-explorer.swift browse FEmusic_history
-./Tools/api-explorer.swift browse FEmusic_library_albums ggMGKgQIARAA
+swift run api-explorer browse FEmusic_liked_playlists
+swift run api-explorer browse FEmusic_history
+swift run api-explorer browse FEmusic_library_albums ggMGKgQIARAA
 ```
 
 Debug builds export auth cookies for the API explorer to `~/Library/Application Support/Kaset/cookies.dat`.
@@ -1168,10 +1193,10 @@ Debug builds export auth cookies for the API explorer to `~/Library/Application 
 
 ```bash
 # List all accounts (primary + brand) with their IDs
-./Tools/api-explorer.swift brandaccounts
+swift run api-explorer brandaccounts
 
 # Access a brand account's library
-./Tools/api-explorer.swift browse FEmusic_liked_playlists --brand 111997145576882617490
+swift run api-explorer browse FEmusic_liked_playlists --brand 111997145576882617490
 ```
 
 The `--brand` flag sets `context.user.onBehalfOfUser` in the request body. See [Brand Account Support](#brand-account-support) in the Authentication section for details.
@@ -1197,6 +1222,7 @@ The `--brand` flag sets `context.user.onBehalfOfUser` in the request body. See [
 | `-o, --output <file>` | Save raw JSON to file |
 | `--authuser N` | Use Google account at index N |
 | `--brand <ID>` | Use brand account (21-digit ID) |
+| `--youtube`, `--yt` | Target regular YouTube (`www.youtube.com`, WEB client) instead of YouTube Music |
 
 ---
 
@@ -1215,6 +1241,7 @@ The `--brand` flag sets `context.user.onBehalfOfUser` in the request body. See [
 
 | Date | Changes |
 |------|---------|
+| 2026-06-24 | Documented regular YouTube `--youtube` API Explorer mode alongside YouTube Music |
 | 2026-01-16 | Added comprehensive Podcast ID Format section: MPSPP→PL conversion, L-prefix validation, double-L bug documentation |
 | 2026-01-14 | Added Brand Account Support: `account/accounts_list` endpoint, `--brand` flag, `brandaccounts` command |
 | 2026-01-06 | Added Video Feature API section: musicVideoType, streamingData quality options, related content endpoints |

--- a/docs/applescript.md
+++ b/docs/applescript.md
@@ -7,7 +7,7 @@ Kaset supports AppleScript for automation with tools like Raycast, Alfred, and S
 | Command | Description |
 | ------- | ----------- |
 | `play` | Start or resume playback |
-| `play video` | Play a YouTube video by its video ID
+| `play video` | Play a YouTube Music item by its video ID |
 | `pause` | Pause playback |
 | `playpause` | Toggle play/pause |
 | `next track` | Skip to next track |
@@ -32,11 +32,13 @@ tell application "Kaset"
 end tell
 ```
 
-### Play a video
+### Play a YouTube Music item by video ID
 
 ```applescript
 tell application "Kaset" to play video "dQw4w9WgXcQ"
 ```
+
+For regular YouTube video links, use the URL routing documented in [URL Scheme and YouTube Links](url-scheme.md), for example `open -a Kaset "https://youtu.be/VIDEO_ID"`.
 
 ### Get Player State
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture & Services
 
-This document provides detailed information about Kaset's architecture, services, and design patterns.
+This document provides detailed information about Kaset's architecture, services, and design patterns. Kaset now has two parallel content sources over the same Google login: YouTube Music (`.music`, default) and regular YouTube (`.video`). Shared infrastructure handles auth, settings, caching, images, and media keys; source-specific clients, models, parsers, view models, and playback WebViews keep the two experiences isolated.
 
 ## Core Structure
 
@@ -13,17 +13,17 @@ Sources/
       ├── AppDelegate.swift → Window lifecycle
       ├── Models/       → Data types (Song, Playlist, Album, Artist, etc.)
       ├── Services/     → Business logic
-      │   ├── API/      → YTMusicClient, Parsers/
+      │   ├── API/      → YTMusicClient, YouTubeClient, Parsers/
       │   ├── Audio/    → EqualizerService, EqualizerAudioEngine, ProcessTapHelper, BiquadFilter
       │   ├── Auth/     → AuthService (login state machine)
       │   ├── Library/  → Library identity and optimistic reconciliation modules
-      │   ├── Player/   → PlayerService, NowPlayingManager, queue metadata and album playback actions
+      │   ├── Player/   → PlayerService, YouTubePlayerService, PlaybackArbiter, NowPlayingManager, queue metadata and album playback actions
       │   ├── Scripting/→ ScriptCommands (AppleScript integration)
       │   ├── WebKit/   → WebKitManager (cookie persistence)
       │   └── HapticService.swift → Force Touch trackpad haptic feedback
-      ├── ViewModels/   → State management (HomeViewModel, etc.)
+      ├── ViewModels/   → State management (music view models plus YouTube/ video-source view models)
       ├── Utilities/    → Helpers (DiagnosticsLogger, extensions)
-      └── Views/        → SwiftUI views (MainWindow, Sidebar, PlayerBar, etc.)
+      └── Views/        → SwiftUI views (MainWindow, Sidebar, PlayerBar, YouTube views, etc.)
   └── APIExplorer/      → API explorer CLI tool
 Tests/                  → Unit tests (KasetTests/)
 docs/                   → Documentation
@@ -39,6 +39,9 @@ All major services have protocol definitions for testability:
 protocol YTMusicClientProtocol: Sendable { ... }
 protocol AuthServiceProtocol { ... }
 protocol PlayerServiceProtocol { ... }
+
+// Sources/Kaset/Services/YouTubeProtocols.swift
+protocol YouTubeClientProtocol: Sendable { ... }
 ```
 
 ViewModels accept protocols via dependency injection with default implementations:
@@ -53,6 +56,8 @@ final class HomeViewModel {
     }
 }
 ```
+
+YouTube view models follow the same pattern with `YouTubeClientProtocol` and live under `Sources/Kaset/ViewModels/YouTube/`. `YouTubeViewModelStore` keeps the YouTube navigation stack and view-model caches warm while the user switches back to Music.
 
 ## State Management
 
@@ -136,6 +141,28 @@ Makes authenticated requests to YouTube Music's internal API:
 - `addSongToPlaylist(videoId:playlistId:allowDuplicate:)` → Add one song to an existing playlist via `browse/edit_playlist`
 - `createPlaylist(title:description:privacyStatus:videoIds:)` → Create a playlist and optionally seed it with songs
 
+### YouTubeClient
+
+**File**: `Sources/Kaset/Services/API/YouTubeClient.swift`
+
+Makes authenticated requests to regular YouTube's internal InnerTube API. It deliberately mirrors `YTMusicClient`'s scaffolding while keeping the origin, client identity, models, and parsers separate:
+
+- Uses `https://www.youtube.com` for `SAPISIDHASH`, `Origin`, `Referer`, and `X-Origin`
+- Uses the `WEB` InnerTube client instead of YouTube Music's `WEB_REMIX`
+- Prefixes shared `APICache` keys with `yt:` so video-source entries do not collide with Music cache invalidation
+- Delegates response parsing to YouTube-specific parsers under `Services/API/Parsers/YouTube/`
+
+**Endpoints / surfaces**:
+- `getHomeBundle()` / `getHomeFeed()` → Recommendations, chips, shelves, and pagination
+- `search(query:filter:)` → Videos, channels, and playlists
+- `getWatchNext(videoId:)` → Watch metadata, related videos, channel state, and comment continuation
+- `getComments(continuation:)`, `postComment(...)`, `performCommentAction(...)` → Watch-page comments
+- `getChannel(channelId:)`, `getPlaylist(playlistId:)`, `getDestinationFeed(_:)`, `getShorts()` → Browse surfaces
+- `getSubscriptionsFeed()`, `getSubscribedChannels()`, `getHistory(forceRefresh:)`, `getUserPlaylists()` → Signed-in YouTube surfaces
+- `rateVideo(...)`, `setSubscribed(...)`, `addToWatchLater(...)`, `removeFromWatchLater(...)` → Mutations
+
+See [youtube.md](youtube.md) for the full source-toggle and regular YouTube architecture.
+
 ### API Parsers
 
 **Directory**: `Sources/Kaset/Services/API/Parsers/`
@@ -155,9 +182,9 @@ Response parsing is extracted into specialized modules:
 | `RadioQueueParser.swift` | Radio queue from "next" endpoint |
 | `SongMetadataParser.swift` | Full song metadata with feedback tokens |
 | `LyricsParser.swift` | Lyrics extraction |
+| `YouTube/` | Regular YouTube feed, search, watch-next, comments, channel, playlist, guide, and renderer parsers |
 
 **Design**: Static enum-based parsers with pure functions for testability.
-
 
 ### Queue Song Metadata and Album Playback
 
@@ -167,7 +194,7 @@ Response parsing is extracted into specialized modules:
 
 **File**: `Sources/Kaset/Services/Player/PlayerService.swift`
 
-Controls audio playback via singleton WebView:
+Controls YouTube Music audio playback via the singleton Music WebView:
 
 | Property | Type | Description |
 |----------|------|-------------|
@@ -188,7 +215,7 @@ Controls audio playback via singleton WebView:
 
 **File**: `Sources/Kaset/Views/MiniPlayerWebView.swift`
 
-Manages the singleton WebView for playback:
+Manages the singleton WebView for YouTube Music playback:
 
 - Creates exactly ONE WebView for app lifetime
 - Handles video loading with pause-before-load
@@ -205,6 +232,28 @@ final class SingletonPlayerWebView {
 }
 ```
 
+### YouTubePlayerService and YouTubeWatchWebView
+
+**Files**:
+- `Sources/Kaset/Services/Player/YouTubePlayerService.swift`
+- `Sources/Kaset/Views/YouTube/YouTubeWatchWebView.swift`
+
+Control regular YouTube video playback through a separate singleton watch WebView. The WebView loads `www.youtube.com/watch?v={videoId}`, extracts the video surface for inline/floating presentation, and reports playback state, captions, quality, ad state, and timing back to Swift.
+
+`YouTubePlayerService.surfaceLocation` tracks where the extracted video currently lives:
+
+| Surface | Description |
+|---------|-------------|
+| `.inline` | Docked in `YouTubeWatchView` |
+| `.floating` | Hosted by `YouTubeVideoWindowController` |
+| `.none` | No active YouTube playback surface |
+
+### PlaybackArbiter
+
+**File**: `Sources/Kaset/Services/Player/PlaybackArbiter.swift`
+
+Coordinates the two playback services so Music and YouTube do not play over each other. When one source starts, the arbiter pauses the other source; `NowPlayingManager` uses the arbiter's active/last-played source to route media keys.
+
 ### NowPlayingManager
 
 **File**: `Sources/Kaset/Services/Player/NowPlayingManager.swift`
@@ -213,9 +262,9 @@ Remote command center integration for media key support:
 
 - Registers `MPRemoteCommandCenter` handlers
 - Handles media keys (play/pause, next, previous, seek)
-- Routes commands to `PlayerService` → `SingletonPlayerWebView`
+- Routes commands to `PlayerService` / `YouTubePlayerService` based on the active source
 
-**Note**: Now Playing display (track info, album art) is handled natively by WKWebView's Media Session API. This provides better integration with album artwork from YouTube Music.
+**Note**: Now Playing display (track/video info, artwork) is handled natively by WKWebView's Media Session API. This provides better integration with YouTube Music artwork and regular YouTube video metadata.
 
 ### HapticService
 
@@ -304,12 +353,13 @@ Manages user preferences persisted via `UserDefaults`:
 |---------|------|---------|-------------|
 | `showNowPlayingNotifications` | `Bool` | `true` | Track change notifications |
 | `defaultLaunchPage` | `LaunchPage` | `.home` | Initial page on app launch |
+| `appSource` | `AppSource` | `.music` | Active source toggle (`.music` for YouTube Music, `.video` for regular YouTube) |
 | `hapticFeedbackEnabled` | `Bool` | `true` | Force Touch feedback |
 | `rememberPlaybackSettings` | `Bool` | `false` | Persist shuffle/repeat state |
 | `syncedLyricsEnabled` | `Bool` | `true` | Enable synced lyrics provider lookup before plain lyrics fallback |
 | `popOutVideoOnNavigateAway` | `Bool` | `true` | Pop a playing YouTube video into the floating window when navigating away; when off, playback stops |
 
-**LaunchPage Options**: Home, Explore, Charts, Moods & Genres, New Releases, Liked Music, Playlists, Last Used
+**Music LaunchPage Options**: Home, Explore, Charts, Moods & Genres, New Releases, Liked Music, Playlists, Last Used
 
 ### EqualizerService
 
@@ -394,7 +444,7 @@ Caches and syncs like/dislike status for songs:
 
 **File**: `Sources/Kaset/Services/URLHandler.swift`
 
-Parses YouTube Music and custom `kaset://` URLs:
+Parses YouTube Music URLs, regular YouTube watch links, and custom `kaset://` URLs:
 
 | URL Pattern | ParsedContent |
 |-------------|---------------|
@@ -402,12 +452,14 @@ Parses YouTube Music and custom `kaset://` URLs:
 | `music.youtube.com/playlist?list=xxx` | `.playlist(id:)` |
 | `music.youtube.com/browse/MPRExxx` | `.album(id:)` |
 | `music.youtube.com/channel/UCxxx` | `.artist(id:)` |
+| `youtube.com/watch?v=xxx` | `.youtubeVideo(videoId:)` |
+| `youtu.be/xxx` | `.youtubeVideo(videoId:)` |
 | `kaset://play?v=xxx` | `.song(videoId:)` |
 | `kaset://playlist?list=xxx` | `.playlist(id:)` |
 | `kaset://album?id=xxx` | `.album(id:)` |
 | `kaset://artist?id=xxx` | `.artist(id:)` |
 
-**Usage**: Called from `KasetApp.onOpenURL` to handle deep links.
+**Usage**: Called from `KasetApp.onOpenURL` to handle deep links. Music song links play through `PlayerService`; regular YouTube watch links switch to the YouTube source and open playback in the floating video window.
 
 ### ScriptCommands (AppleScript)
 
@@ -511,6 +563,8 @@ App Launch
 
 ## API Request Flow
 
+The Music and YouTube API clients share the same high-level request shape but use different origins and InnerTube client identities. The Music path looks like this:
+
 ```
 YTMusicClient.getHome()
     │
@@ -536,7 +590,11 @@ YTMusicClient.getHome()
                   → Show LoginSheet
 ```
 
+`YouTubeClient` follows the same cookie/SAPISIDHASH flow with `https://www.youtube.com`, the `WEB` client context, and `yt:`-prefixed cache keys.
+
 ## Playback Flow
+
+This diagram covers YouTube Music playback. Regular YouTube playback is documented in [youtube.md](youtube.md) and uses `YouTubePlayerService` plus `YouTubeWatchWebView`.
 
 ```
 User clicks Play

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -17,6 +17,8 @@ Kaset provides keyboard control for playback and navigation while preserving sta
 
 Mute is still available from the Playback menu and AppleScript, but Kaset intentionally does not assign a default mute shortcut so the native macOS minimize shortcut (`⌘M`) continues to work.
 
+Playback shortcuts are source-aware where both sources implement an equivalent action: play/pause, skip, seek, and volume route to regular YouTube when a YouTube video was the last active playback source. Shuffle, repeat, queue, and lyrics remain YouTube Music concepts.
+
 ## Navigation
 
 | Shortcut | Action           |

--- a/docs/playback.md
+++ b/docs/playback.md
@@ -1,6 +1,6 @@
-# Playback System
+# YouTube Music Playback System
 
-This document details the WebView-based playback system, its architecture, and implementation notes.
+This document details Kaset's YouTube Music WebView-based playback system, its architecture, and implementation notes. Regular YouTube video playback is a separate source with its own `YouTubePlayerService` and `YouTubeWatchWebView`; see [YouTube Mode](youtube.md).
 
 ## Overview
 

--- a/docs/task-planning.md
+++ b/docs/task-planning.md
@@ -65,7 +65,7 @@ Every task should be broken into phases. Each phase must have:
 ```
 Phase 1: Research
 ├── Write findings to session workspace
-├── Exit: Understand YTMusicClient pattern, confirm no existing solution
+├── Exit: Understand the relevant API client pattern (YTMusicClient for Music, YouTubeClient for YouTube), confirm no existing solution
 
 Phase 2: Interface
 ├── Create NewService.swift with protocol + stub

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -42,14 +42,16 @@ swiftlint --strict && swiftformat .
 Tests/KasetTests/
 ├── Helpers/
 │   ├── MockURLProtocol.swift    # Network mocking
-│   ├── MockYTMusicClient.swift  # API client mock
+│   ├── MockYTMusicClient.swift  # YouTube Music API client mock
+│   ├── MockYouTubeClient.swift  # Regular YouTube API client mock
 │   └── TestFixtures.swift       # Fixture loading utilities
 ├── SwiftTestingHelpers/
 │   └── Tags.swift               # Custom test tags (.api, .parser, etc.)
 ├── Fixtures/
 │   ├── home_response.json       # Sample API responses
 │   ├── search_response.json
-│   └── playlist_detail.json
+│   ├── playlist_detail.json
+│   └── YouTube/                 # Sanitized regular YouTube fixtures
 ├── *Tests.swift                 # Unit test files (Swift Testing)
 └── MusicIntentIntegrationTests.swift  # AI integration tests
 ```
@@ -62,6 +64,7 @@ New code in `Sources/Kaset/` (Services, Models, ViewModels, Utilities) must incl
 
 1. Create test file in `Tests/KasetTests/` matching the source file name
    - Example: `YTMusicClient.swift` → `YTMusicClientTests.swift`
+   - Example: `YouTubeClient.swift` / YouTube parsers → `YouTube...Tests.swift`
 2. Add the test file to the Xcode project
 3. Run tests to verify
 
@@ -283,7 +286,7 @@ func durationFormatting(seconds: Double, expected: String) {
 
 ### MockYTMusicClient
 
-The project includes a ready-to-use mock client:
+The project includes ready-to-use API client mocks for both sources. Use `MockYTMusicClient` for YouTube Music view models and services:
 
 ```swift
 // Tests/KasetTests/Helpers/MockYTMusicClient.swift
@@ -299,6 +302,25 @@ final class MockYTMusicClient: YTMusicClientProtocol, @unchecked Sendable {
     // ... other methods
 }
 ```
+
+Use `MockYouTubeClient` for the regular YouTube source:
+
+```swift
+// Tests/KasetTests/Helpers/MockYouTubeClient.swift
+final class MockYouTubeClient: YouTubeClientProtocol, @unchecked Sendable {
+    var homeFeed = YouTubeFeed(videos: [], continuation: nil)
+    var searchResponse = YouTubeSearchResponse(videos: [], channels: [], playlists: [], continuation: nil)
+    var error: Error?
+
+    func getHomeFeed() async throws -> YouTubeFeed {
+        if let error { throw error }
+        return homeFeed
+    }
+    // ... other methods
+}
+```
+
+Regular YouTube parser tests should use sanitized fixtures in `Tests/KasetTests/Fixtures/YouTube/`; re-capture with `swift run api-explorer --youtube ... -o` when YouTube renderer shapes change.
 
 **Usage in tests**:
 ```swift

--- a/docs/url-scheme.md
+++ b/docs/url-scheme.md
@@ -1,34 +1,81 @@
-# URL Scheme
+# URL Scheme and YouTube Links
 
-Kaset supports a custom URL scheme for opening content directly from other apps, scripts, or the command line.
+Kaset supports deep links for opening content directly from other apps, scripts, or the command line. There are two URL families:
 
-## Play a Song
+- `kaset://...` custom-scheme links for YouTube Music content
+- Regular YouTube watch links (`youtube.com/watch` and `youtu.be`) routed into the YouTube source
 
-Play a song by its YouTube video ID:
+## YouTube Music Custom Scheme
+
+### Play a Song
+
+Play a song by its YouTube Music video ID:
 
 ```bash
-open "kaset://play?v=dQw4w9WgXcQ"
+open "kaset://play?v=VIDEO_ID"
 ```
+
+### Open Music Content
+
+`URLHandler` can parse these custom-scheme routes:
+
+| URL | Parsed content |
+|-----|----------------|
+| `kaset://play?v=VIDEO_ID` | Song playback through YouTube Music |
+| `kaset://playlist?list=PLAYLIST_ID` | Music playlist |
+| `kaset://album?id=ALBUM_ID` | Music album |
+| `kaset://artist?id=CHANNEL_OR_LIBRARY_ARTIST_ID` | Music artist |
+
+> Current app routing starts playback for `kaset://play`. Playlist, album, and artist parsing is available for navigation flows but is not exposed as a full external-routing UI yet.
+
+## YouTube Music Web Links
+
+Kaset also recognizes common `music.youtube.com` URLs:
+
+| URL | Parsed content |
+|-----|----------------|
+| `https://music.youtube.com/watch?v=VIDEO_ID` | Song playback through YouTube Music |
+| `https://music.youtube.com/playlist?list=PLAYLIST_ID` | Music playlist |
+| `https://music.youtube.com/browse/MPRE...` / `OLAK...` | Music album |
+| `https://music.youtube.com/channel/UC...` | Music artist |
+| `https://music.youtube.com/browse/MPLAUC...` | Library artist |
+
+## Regular YouTube Links
+
+Regular YouTube watch links switch Kaset to the YouTube source and open the video in the floating YouTube player when they are delivered to Kaset. From Terminal, target the app explicitly so macOS does not hand the HTTPS URL to the default browser:
+
+```bash
+open -a Kaset "https://www.youtube.com/watch?v=VIDEO_ID"
+open -a Kaset "https://youtu.be/VIDEO_ID"
+```
+
+Recognized hosts are `youtube.com`, `www.youtube.com`, `m.youtube.com`, and `youtu.be`. Non-watch YouTube pages are ignored by the URL handler.
 
 ## Usage Examples
 
 ### From Terminal
 
 ```bash
-# Play a specific song
+# Play a YouTube Music song
 open "kaset://play?v=VIDEO_ID"
+
+# Open a regular YouTube video in YouTube mode
+open -a Kaset "https://www.youtube.com/watch?v=VIDEO_ID"
 ```
 
 ### From AppleScript
 
 ```applescript
 do shell script "open 'kaset://play?v=VIDEO_ID'"
+do shell script "open -a Kaset 'https://youtu.be/VIDEO_ID'"
 ```
 
 ### From Shortcuts
 
-Use the "Open URLs" action with `kaset://play?v=VIDEO_ID`.
+Use the "Open URLs" action with `kaset://play?v=VIDEO_ID`. For regular YouTube HTTPS links, use a "Run Shell Script" action with `open -a Kaset "https://youtu.be/VIDEO_ID"` so the link is sent to Kaset instead of the default browser.
 
 ## See Also
 
+- [YouTube Mode](youtube.md) — Regular YouTube source architecture and playback behavior
+- [Playback System](playback.md) — YouTube Music WebView playback
 - [AppleScript Support](applescript.md) — Automate playback with scripts, Raycast, Alfred, and Shortcuts

--- a/docs/video.md
+++ b/docs/video.md
@@ -1,6 +1,6 @@
-# Video Mode
+# YouTube Music Video Mode
 
-This document details the floating video window feature.
+This document details the floating video window for YouTube Music videos. Regular YouTube playback uses the YouTube source's separate watch WebView and floating window; see [YouTube Mode](youtube.md).
 
 ## Overview
 

--- a/docs/youtube.md
+++ b/docs/youtube.md
@@ -215,4 +215,6 @@ the native scrubber is disabled; YouTube Premium accounts see no ads.
 - Watch-page DOM selectors (`#movie_player`, autonav toggle) can shift;
   the extraction enforcement loop and `api-explorer --youtube` are the
   debugging tools of choice.
-- Comments on the watch page are deferred.
+- Reply posting and comment sorting controls are intentionally minimal; the
+  current watch page supports loading top-level comments, posting a top-level
+  comment, and optimistic like/dislike toggles.


### PR DESCRIPTION
## Summary

- Update README and contributor docs to describe Kaset as supporting both YouTube Music and regular YouTube.
- Expand architecture, testing, API discovery, URL scheme, playback, video, keyboard shortcut, and AppleScript docs for the dual-source model.
- Refresh `api-explorer` help text and URL handler comments to align with YouTube Music + YouTube support.

## Validation

- `swiftformat Sources/APIExplorer/main.swift Sources/Kaset/Services/URLHandler.swift`
- `swift build`
- `swift run api-explorer help`
- `git diff --check`
- Local markdown link check for README/docs links
