### PR TITLE
fix: enforce main window sizing contract

### DIFF
--- a/Sources/Kaset/AppDelegate.swift
+++ b/Sources/Kaset/AppDelegate.swift
@@ -118,16 +118,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func setupWindowDelegate() {
         DiagnosticsLogger.app.info("AppDelegate: setupWindowDelegate starting")
         for window in NSApplication.shared.windows where window.canBecomeMain {
-            // Skip auxiliary player windows; only the regular app window should be hidden-on-close.
-            if self.isAuxiliaryPlayerWindow(window) {
+            // Skip auxiliary/player and non-primary scene windows; only the regular app window should be hidden-on-close.
+            if self.isAuxiliaryPlayerWindow(window) || !MainWindowLayout.isPrimaryWindow(window) {
                 continue
             }
             window.delegate = self
-            // Enable automatic window frame persistence using autosave name
-            // This ensures window size/position is restored across app launches
-            if window.frameAutosaveName.isEmpty {
-                window.setFrameAutosaveName("KasetMainWindow")
-            }
+            MainWindowLayout.configure(window)
             // Store reference to main window for reliable reopen
             self.mainWindow = window
         }
@@ -228,7 +224,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func showMainWindowIfNeeded() {
         DiagnosticsLogger.app.info("AppDelegate: showMainWindowIfNeeded")
         // Try stored reference first
-        if let mainWindow {
+        if let mainWindow, MainWindowLayout.isPrimaryWindow(mainWindow) {
+            MainWindowLayout.configure(mainWindow)
             if !mainWindow.isVisible {
                 mainWindow.makeKeyAndOrderFront(nil)
             }
@@ -236,7 +233,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         // Fallback: find main window by frameAutosaveName
-        for window in NSApplication.shared.windows where window.frameAutosaveName == "KasetMainWindow" {
+        for window in NSApplication.shared.windows where window.frameAutosaveName == MainWindowLayout.autosaveName {
+            MainWindowLayout.configure(window)
             self.mainWindow = window
             if !window.isVisible {
                 window.makeKeyAndOrderFront(nil)
@@ -245,11 +243,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         // Last resort: find any main-capable window that's not an auxiliary player window.
+        // Do not apply the primary-window sizing contract here: a generic fallback
+        // may match Settings or another regular scene window.
         for window in NSApplication.shared.windows where window.canBecomeMain {
             if self.isAuxiliaryPlayerWindow(window) {
                 continue
             }
-            self.mainWindow = window
             if !window.isVisible {
                 window.makeKeyAndOrderFront(nil)
             }

--- a/Sources/Kaset/KasetApp.swift
+++ b/Sources/Kaset/KasetApp.swift
@@ -264,6 +264,8 @@ struct KasetApp: App {
                 }
             }
         }
+        .defaultSize(width: MainWindowLayout.defaultWidth, height: MainWindowLayout.defaultHeight)
+        .windowResizability(.contentMinSize)
 
         Settings {
             SettingsView()
@@ -503,19 +505,23 @@ struct KasetApp: App {
     @discardableResult
     private func focusExistingMainWindow() -> Bool {
         // Find and show the main window
-        for window in NSApplication.shared.windows where window.frameAutosaveName == "KasetMainWindow" {
+        for window in NSApplication.shared.windows where window.frameAutosaveName == MainWindowLayout.autosaveName {
+            MainWindowLayout.configure(window)
             window.makeKeyAndOrderFront(nil)
             NSApplication.shared.activate(ignoringOtherApps: true)
             return true
         }
 
-        for window in NSApplication.shared.windows where window.title == "Kaset" && !Self.isAuxiliaryPlayerWindow(window) {
+        for window in NSApplication.shared.windows where window.title == MainWindowLayout.windowTitle && !Self.isAuxiliaryPlayerWindow(window) {
+            MainWindowLayout.configure(window)
             window.makeKeyAndOrderFront(nil)
             NSApplication.shared.activate(ignoringOtherApps: true)
             return true
         }
 
         // Fallback: find any main-capable window that's not an auxiliary player window.
+        // Do not apply the primary-window sizing contract here: a generic fallback
+        // may match Settings or another regular scene window.
         for window in NSApplication.shared.windows where window.canBecomeMain {
             if Self.isAuxiliaryPlayerWindow(window) {
                 continue
@@ -534,7 +540,7 @@ struct KasetApp: App {
 
     /// Hides the main window while keeping playback and auxiliary windows alive.
     private func hideMainWindow() {
-        for window in NSApplication.shared.windows where window.frameAutosaveName == "KasetMainWindow" {
+        for window in NSApplication.shared.windows where window.frameAutosaveName == MainWindowLayout.autosaveName {
             window.orderOut(nil)
             return
         }

--- a/Sources/Kaset/Utilities/MainWindowLayout.swift
+++ b/Sources/Kaset/Utilities/MainWindowLayout.swift
@@ -1,0 +1,74 @@
+import AppKit
+
+// MARK: - MainWindowLayout
+
+/// Shared sizing contract for Kaset's primary app window.
+///
+/// SwiftUI's `.frame(minWidth:minHeight:)` documents the layout floor for the
+/// view hierarchy, while this helper applies the same floor to the underlying
+/// `NSWindow` so live resizing and restored autosaved frames cannot shrink the
+/// window below the point where the sidebar/player controls remain usable.
+enum MainWindowLayout {
+    static let autosaveName = "KasetMainWindow"
+    static let windowTitle = "Kaset"
+    static let minimumWidth: CGFloat = 980
+    static let minimumHeight: CGFloat = 600
+    static let defaultWidth: CGFloat = 1100
+    static let defaultHeight: CGFloat = 760
+
+    static var minimumContentSize: NSSize {
+        NSSize(width: minimumWidth, height: minimumHeight)
+    }
+
+    /// Returns true for windows that are known to be the primary app window.
+    static func isPrimaryWindowIdentity(title: String, frameAutosaveName: String) -> Bool {
+        frameAutosaveName == self.autosaveName || title == self.windowTitle
+    }
+
+    @MainActor
+    static func isPrimaryWindow(_ window: NSWindow) -> Bool {
+        self.isPrimaryWindowIdentity(title: window.title, frameAutosaveName: window.frameAutosaveName)
+    }
+
+    /// Applies the primary-window sizing contract to an AppKit window.
+    @MainActor
+    static func configure(_ window: NSWindow) {
+        guard self.isPrimaryWindow(window) else { return }
+
+        if window.frameAutosaveName.isEmpty {
+            window.setFrameAutosaveName(self.autosaveName)
+        }
+
+        window.contentMinSize = self.minimumContentSize
+        self.expandIfNeeded(window)
+    }
+
+    /// Pure clamp used by both AppKit configuration and tests.
+    static func clampedContentSize(_ contentSize: NSSize) -> NSSize {
+        NSSize(
+            width: max(contentSize.width, self.minimumWidth),
+            height: max(contentSize.height, self.minimumHeight)
+        )
+    }
+
+    @MainActor
+    private static func expandIfNeeded(_ window: NSWindow) {
+        let currentFrame = window.frame
+        let currentContentSize = window.contentRect(forFrameRect: currentFrame).size
+        let clampedContentSize = Self.clampedContentSize(currentContentSize)
+
+        guard clampedContentSize.width > currentContentSize.width
+            || clampedContentSize.height > currentContentSize.height
+        else { return }
+
+        let clampedFrameSize = window.frameRect(
+            forContentRect: NSRect(origin: .zero, size: clampedContentSize)
+        ).size
+        var clampedFrame = currentFrame
+        clampedFrame.size = clampedFrameSize
+        // Keep the titlebar/top edge anchored when expanding a stale restored
+        // frame, so the window does not jump downward on launch/reopen.
+        clampedFrame.origin.y = currentFrame.maxY - clampedFrameSize.height
+        window.setFrame(clampedFrame, display: true)
+    }
+}

--- a/Sources/Kaset/Utilities/MainWindowLayout.swift
+++ b/Sources/Kaset/Utilities/MainWindowLayout.swift
@@ -69,6 +69,8 @@ enum MainWindowLayout {
         // Keep the titlebar/top edge anchored when expanding a stale restored
         // frame, so the window does not jump downward on launch/reopen.
         clampedFrame.origin.y = currentFrame.maxY - clampedFrameSize.height
-        window.setFrame(clampedFrame, display: true)
+
+        let constrainedFrame = window.constrainFrameRect(clampedFrame, to: window.screen)
+        window.setFrame(constrainedFrame, display: true)
     }
 }

--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -192,6 +192,7 @@ struct MainWindow: View {
             AccountErrorToast()
                 .padding(.top, 60)
         }
+        .frame(minWidth: MainWindowLayout.minimumWidth, minHeight: MainWindowLayout.minimumHeight)
         .onChange(of: self.showCommandBar.wrappedValue) { _, newValue in
             if newValue {
                 self.presentCommandBarIfAvailable()
@@ -413,7 +414,7 @@ struct MainWindow: View {
         }
         .animation(.easeInOut(duration: 0.25), value: self.playerService.showLyrics)
         .animation(.easeInOut(duration: 0.25), value: self.playerService.showQueue)
-        .frame(minWidth: 980, minHeight: 600)
+        .frame(minWidth: MainWindowLayout.minimumWidth, minHeight: MainWindowLayout.minimumHeight)
         .toolbar {
             if self.supportsCommandBarUI {
                 ToolbarItem(placement: .primaryAction) {
@@ -598,7 +599,7 @@ struct MainWindow: View {
                 .controlSize(.regular)
                 .frame(width: 20, height: 20)
         }
-        .frame(minWidth: 980, minHeight: 600)
+        .frame(minWidth: MainWindowLayout.minimumWidth, minHeight: MainWindowLayout.minimumHeight)
     }
 
     private func handleAuthStateChange(oldState: AuthService.State, newState: AuthService.State) {

--- a/Tests/KasetTests/MainWindowLayoutTests.swift
+++ b/Tests/KasetTests/MainWindowLayoutTests.swift
@@ -1,0 +1,34 @@
+import AppKit
+import Testing
+@testable import Kaset
+
+@Suite("Main window layout", .serialized)
+struct MainWindowLayoutTests {
+    @Test("Clamps undersized restored content frames")
+    func clampsUndersizedContentFrames() {
+        let clamped = MainWindowLayout.clampedContentSize(NSSize(width: 640, height: 420))
+
+        #expect(clamped.width == MainWindowLayout.minimumWidth)
+        #expect(clamped.height == MainWindowLayout.minimumHeight)
+    }
+
+    @Test("Leaves larger content frames unchanged")
+    func leavesLargerContentFramesUnchanged() {
+        let size = NSSize(width: 1400, height: 900)
+
+        #expect(MainWindowLayout.clampedContentSize(size) == size)
+    }
+
+    @Test("Minimum AppKit content size matches SwiftUI content floor")
+    func minimumContentSizeMatchesSwiftUIFloor() {
+        #expect(MainWindowLayout.minimumContentSize.width == MainWindowLayout.minimumWidth)
+        #expect(MainWindowLayout.minimumContentSize.height == MainWindowLayout.minimumHeight)
+    }
+
+    @Test("Primary window identity excludes other regular scene windows")
+    func primaryWindowIdentityExcludesOtherRegularSceneWindows() {
+        #expect(MainWindowLayout.isPrimaryWindowIdentity(title: MainWindowLayout.windowTitle, frameAutosaveName: ""))
+        #expect(MainWindowLayout.isPrimaryWindowIdentity(title: "Settings", frameAutosaveName: MainWindowLayout.autosaveName))
+        #expect(!MainWindowLayout.isPrimaryWindowIdentity(title: "Settings", frameAutosaveName: ""))
+    }
+}


### PR DESCRIPTION
## Summary
- Add a shared `MainWindowLayout` helper for Kaset's primary window sizing contract.
- Apply consistent default/minimum sizing through SwiftUI and `NSWindow` configuration when discovering, focusing, reopening, or restoring the main window.
- Add unit coverage for clamping behavior and primary-window identity checks.

## Validation
- `swiftformat .`
- `swiftlint --strict`
- `swift build`
- `swift test --skip KasetUITests`
- `.agents/skills/autoreview/scripts/autoreview --mode local` — clean, no accepted/actionable findings
