### PR TITLE
Update appcast to v0.12.0

### DIFF
--- a/appcast.xml
+++ b/appcast.xml
@@ -7,16 +7,16 @@
         <language>en</language>
 
         <item>
-            <title>Version 0.11.0</title>
-            <sparkle:releaseNotesLink>https://github.com/sozercan/kaset/releases/tag/v0.11.0</sparkle:releaseNotesLink>
-            <pubDate>Mon, 08 Jun 2026 03:08:13 +0000</pubDate>
+            <title>Version 0.12.0</title>
+            <sparkle:releaseNotesLink>https://github.com/sozercan/kaset/releases/tag/v0.12.0</sparkle:releaseNotesLink>
+            <pubDate>Wed, 24 Jun 2026 04:55:17 +0000</pubDate>
             <enclosure
-                url="https://github.com/sozercan/kaset/releases/download/v0.11.0/kaset-v0.11.0.dmg"
-                sparkle:version="20"
-                sparkle:shortVersionString="0.11.0"
-                length="11088925"
+                url="https://github.com/sozercan/kaset/releases/download/v0.12.0/kaset-v0.12.0.dmg"
+                sparkle:version="21"
+                sparkle:shortVersionString="0.12.0"
+                length="13147978"
                 type="application/octet-stream"
-                sparkle:edSignature="UP86NarTurXZztNd/cwPDuPQVcaX8J0qrRp5BylDz8Wk1l5e6SiOfDL+ZvG1xSA00jiQTg3yX1jzW/69f1MfDg=="/>
+                sparkle:edSignature="kw+M7HiXclVlmPaxpMEMOnK3/HMubDaLKyvUl1kuZHQVXeoHSdfCfjG6tFF4UGvu77xG5vjhozF6lmE8SccgCw=="/>
             <sparkle:minimumSystemVersion>15.4</sparkle:minimumSystemVersion>
         </item>
 


### PR DESCRIPTION
## Summary

Publishes the Sparkle appcast entry for **v0.12.0**, which the release workflow failed to commit.

The `Update Appcast` step in [the v0.12.0 release run](https://github.com/sozercan/kaset/actions/runs/28075528071/job/83118875923) tried to `git push origin main` directly, but the `default` branch ruleset now requires all changes to go through a pull request (`GH013: Changes must be made through a pull request`). The push was rejected, so `appcast.xml` on `main` was still pinned to v0.11.0 and existing users were not being offered the v0.12.0 auto-update.

This PR lands the exact entry the workflow generated, using the signature and length from the release build:

- `sparkle:version="21"`, `sparkle:shortVersionString="0.12.0"`
- `length="13147978"`
- `sparkle:edSignature` and download URL for `kaset-v0.12.0.dmg`

The rest of the v0.12.0 release (DMG, notarization, GitHub Release, Homebrew Cask) completed successfully — only this step failed.

> Note: a separate follow-up will fix the workflow so future releases don't fail here (granting the GitHub Actions bot bypass on the ruleset).

## Test plan

- [ ] Confirm `appcast.xml` validates and points at the v0.12.0 DMG
- [ ] After merge, verify Sparkle offers v0.12.0 to an existing v0.11.0 install