### PR TITLE
feat(youtube): add 30-second seek controls

### DIFF
--- a/Sources/Kaset/Services/Player/YouTubePlayerService+Seeking.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService+Seeking.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+@MainActor
+extension YouTubePlayerService {
+    /// Distance from the known duration at which a manual seek is treated as a
+    /// completed watch. Seeking a WebKit video element to exactly `duration`
+    /// does not reliably emit `ended`, so terminal seeks must not depend on the
+    /// page's natural ended event to refresh Continue Watching state.
+    private static let seekToEndThreshold: TimeInterval = 0.5
+
+    /// Window during which repeated relative-seek button presses should build
+    /// from the last requested target instead of the last observer-reported
+    /// progress. YouTube's `STATE_UPDATE` observer is coarse and can briefly
+    /// report pre-seek progress after a button press.
+    private static let relativeSeekTargetCoalescingWindow: Duration = .seconds(1)
+
+    /// Seeks to a position in seconds.
+    func seek(to time: Double) {
+        self.clearRelativeSeekCoalescingTarget()
+        self.performSeek(to: time)
+    }
+
+    private func performSeek(to time: Double) {
+        guard time.isFinite else { return }
+        let target = self.clampedSeekTarget(time)
+        if self.duration > 0, target >= self.duration - Self.seekToEndThreshold {
+            self.handleManualSeekToEnd()
+            return
+        }
+
+        self.progress = target
+        if self.pendingPausedIdentityReloadVideoId == self.currentVideo?.videoId {
+            self.pendingPausedIdentityReloadResumeAt = target > 0 ? target : nil
+            self.userUpdatedPendingPausedIdentityReloadSeek = true
+        }
+        self.playbackController.seek(to: target)
+    }
+
+    private func clampedSeekTarget(_ time: Double) -> Double {
+        if self.duration > 0 {
+            return min(max(time, 0), self.duration)
+        }
+        return max(time, 0)
+    }
+
+    private func handleManualSeekToEnd() {
+        guard self.currentVideo != nil, self.duration > 0 else { return }
+        let terminalSeekTime = max(0, self.duration - Self.seekToEndThreshold)
+        self.progress = self.duration
+        self.lastNonAdContentProgress = self.duration
+        self.clearRelativeSeekCoalescingTarget()
+        if self.pendingPausedIdentityReloadVideoId == self.currentVideo?.videoId {
+            self.pendingPausedIdentityReloadResumeAt = nil
+            self.userUpdatedPendingPausedIdentityReloadSeek = true
+        }
+
+        // Keep the WebView away from exact-duration seeks and pause it so a
+        // follow-up state update cannot look like a fresh replay of the just-
+        // concluded watch.
+        self.playbackController.seek(to: terminalSeekTime)
+        self.playbackController.pause()
+        self.handleVideoEnded(videoId: self.currentVideo?.videoId)
+    }
+
+    /// Seeks backward by a fixed interval, clamping to the beginning.
+    func seekBackward(by seconds: Double = 30) {
+        guard seconds.isFinite, seconds > 0 else { return }
+        self.seekRelative(by: -seconds)
+    }
+
+    /// Seeks forward by a fixed interval, clamping to the known duration.
+    func seekForward(by seconds: Double = 30) {
+        guard seconds.isFinite, seconds > 0 else { return }
+        self.seekRelative(by: seconds)
+    }
+
+    private func seekRelative(by delta: Double) {
+        guard delta.isFinite, delta != 0, self.currentVideo != nil else { return }
+        let now = ContinuousClock.now
+        let currentVideoId = self.currentVideo?.videoId
+        if self.lastRelativeSeekVideoId != currentVideoId {
+            self.clearRelativeSeekCoalescingTarget()
+        }
+        self.lastRelativeSeekVideoId = currentVideoId
+
+        // Bridge progress can lag behind rapid button repeats. Briefly use the
+        // last command target so repeated clicks accumulate from user intent
+        // instead of from a stale 1 Hz observer tick.
+        let baseProgress = if self.canCoalesceRelativeSeekTarget(at: now),
+                              let lastRelativeSeekTarget = self.lastRelativeSeekTarget
+        {
+            lastRelativeSeekTarget
+        } else {
+            self.progress
+        }
+
+        let target = self.clampedSeekTarget(baseProgress + delta)
+        self.lastRelativeSeekTarget = target
+        self.lastRelativeSeekIssuedAt = now
+        self.performSeek(to: target)
+    }
+
+    private func canCoalesceRelativeSeekTarget(at now: ContinuousClock.Instant) -> Bool {
+        guard let lastRelativeSeekIssuedAt = self.lastRelativeSeekIssuedAt else { return false }
+        return now - lastRelativeSeekIssuedAt <= Self.relativeSeekTargetCoalescingWindow
+    }
+
+    func clearRelativeSeekCoalescingTarget() {
+        self.lastRelativeSeekTarget = nil
+        self.lastRelativeSeekIssuedAt = nil
+        self.lastRelativeSeekVideoId = nil
+    }
+}

--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -46,6 +46,18 @@ extension YouTubeWatchWebView: YouTubeWatchPlaybackControlling {
 @MainActor
 @Observable
 final class YouTubePlayerService {
+    /// Distance from the known duration at which a manual seek is treated as a
+    /// completed watch. Seeking a WebKit video element to exactly `duration`
+    /// does not reliably emit `ended`, so terminal seeks must not depend on the
+    /// page's natural ended event to refresh Continue Watching state.
+    private static let seekToEndThreshold: TimeInterval = 0.5
+
+    /// Window during which repeated relative-seek button presses should build
+    /// from the last requested target instead of the last observer-reported
+    /// progress. YouTube's `STATE_UPDATE` observer is coarse and can briefly
+    /// report pre-seek progress after a button press.
+    private static let relativeSeekTargetCoalescingWindow: Duration = .seconds(1)
+
     // MARK: - State
 
     /// The video currently loaded for playback (nil when playback is closed).
@@ -114,6 +126,12 @@ final class YouTubePlayerService {
 
     /// Video length in seconds.
     private(set) var duration: Double = 0
+
+    /// Last requested relative-seek target used to coalesce rapid repeated
+    /// button presses while bridge state updates lag behind WebView commands.
+    private var lastRelativeSeekTarget: Double?
+    private var lastRelativeSeekIssuedAt: ContinuousClock.Instant?
+    private var lastRelativeSeekVideoId: String?
 
     /// Whether an ad is currently showing on the watch page.
     private(set) var isShowingAd = false
@@ -355,29 +373,99 @@ final class YouTubePlayerService {
 
     /// Seeks to a position in seconds.
     func seek(to time: Double) {
-        self.progress = time
+        self.clearRelativeSeekCoalescingTarget()
+        self.performSeek(to: time)
+    }
+
+    private func performSeek(to time: Double) {
+        guard time.isFinite else { return }
+        let target = self.clampedSeekTarget(time)
+        if self.duration > 0, target >= self.duration - Self.seekToEndThreshold {
+            self.handleManualSeekToEnd()
+            return
+        }
+
+        self.progress = target
         if self.pendingPausedIdentityReloadVideoId == self.currentVideo?.videoId {
-            self.pendingPausedIdentityReloadResumeAt = time > 0 ? time : nil
+            self.pendingPausedIdentityReloadResumeAt = target > 0 ? target : nil
             self.userUpdatedPendingPausedIdentityReloadSeek = true
         }
-        self.playbackController.seek(to: time)
+        self.playbackController.seek(to: target)
+    }
+
+    private func clampedSeekTarget(_ time: Double) -> Double {
+        if self.duration > 0 {
+            return min(max(time, 0), self.duration)
+        }
+        return max(time, 0)
+    }
+
+    private func handleManualSeekToEnd() {
+        guard self.currentVideo != nil, self.duration > 0 else { return }
+        let terminalSeekTime = max(0, self.duration - Self.seekToEndThreshold)
+        self.progress = self.duration
+        self.lastNonAdContentProgress = self.duration
+        self.clearRelativeSeekCoalescingTarget()
+        if self.pendingPausedIdentityReloadVideoId == self.currentVideo?.videoId {
+            self.pendingPausedIdentityReloadResumeAt = nil
+            self.userUpdatedPendingPausedIdentityReloadSeek = true
+        }
+
+        // Keep the WebView away from exact-duration seeks and pause it so a
+        // follow-up state update cannot look like a fresh replay of the just-
+        // concluded watch.
+        self.playbackController.seek(to: terminalSeekTime)
+        self.playbackController.pause()
+        self.handleVideoEnded(videoId: self.currentVideo?.videoId)
     }
 
     /// Seeks backward by a fixed interval, clamping to the beginning.
     func seekBackward(by seconds: Double = 30) {
         guard seconds.isFinite, seconds > 0 else { return }
-        self.seek(to: max(0, self.progress - seconds))
+        self.seekRelative(by: -seconds)
     }
 
     /// Seeks forward by a fixed interval, clamping to the known duration.
     func seekForward(by seconds: Double = 30) {
         guard seconds.isFinite, seconds > 0 else { return }
-        let target = self.progress + seconds
-        if self.duration > 0 {
-            self.seek(to: min(target, self.duration))
-        } else {
-            self.seek(to: target)
+        self.seekRelative(by: seconds)
+    }
+
+    private func seekRelative(by delta: Double) {
+        guard delta.isFinite, delta != 0, self.currentVideo != nil else { return }
+        let now = ContinuousClock.now
+        let currentVideoId = self.currentVideo?.videoId
+        if self.lastRelativeSeekVideoId != currentVideoId {
+            self.clearRelativeSeekCoalescingTarget()
         }
+        self.lastRelativeSeekVideoId = currentVideoId
+
+        // Bridge progress can lag behind rapid button repeats. Briefly use the
+        // last command target so repeated clicks accumulate from user intent
+        // instead of from a stale 1 Hz observer tick.
+        let baseProgress = if self.canCoalesceRelativeSeekTarget(at: now),
+                              let lastRelativeSeekTarget = self.lastRelativeSeekTarget
+        {
+            lastRelativeSeekTarget
+        } else {
+            self.progress
+        }
+
+        let target = self.clampedSeekTarget(baseProgress + delta)
+        self.lastRelativeSeekTarget = target
+        self.lastRelativeSeekIssuedAt = now
+        self.performSeek(to: target)
+    }
+
+    private func canCoalesceRelativeSeekTarget(at now: ContinuousClock.Instant) -> Bool {
+        guard let lastRelativeSeekIssuedAt = self.lastRelativeSeekIssuedAt else { return false }
+        return now - lastRelativeSeekIssuedAt <= Self.relativeSeekTargetCoalescingWindow
+    }
+
+    private func clearRelativeSeekCoalescingTarget() {
+        self.lastRelativeSeekTarget = nil
+        self.lastRelativeSeekIssuedAt = nil
+        self.lastRelativeSeekVideoId = nil
     }
 
     /// Stops playback entirely and releases the surface.
@@ -530,6 +618,7 @@ final class YouTubePlayerService {
         self.pendingPausedIdentityReloadResumeAt = nil
         self.userUpdatedPendingPausedIdentityReloadSeek = false
         self.lastNonAdContentProgress = 0
+        self.clearRelativeSeekCoalescingTarget()
     }
 
     // MARK: - Watch Later

--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -363,6 +363,23 @@ final class YouTubePlayerService {
         self.playbackController.seek(to: time)
     }
 
+    /// Seeks backward by a fixed interval, clamping to the beginning.
+    func seekBackward(by seconds: Double = 30) {
+        guard seconds.isFinite, seconds > 0 else { return }
+        self.seek(to: max(0, self.progress - seconds))
+    }
+
+    /// Seeks forward by a fixed interval, clamping to the known duration.
+    func seekForward(by seconds: Double = 30) {
+        guard seconds.isFinite, seconds > 0 else { return }
+        let target = self.progress + seconds
+        if self.duration > 0 {
+            self.seek(to: min(target, self.duration))
+        } else {
+            self.seek(to: target)
+        }
+    }
+
     /// Stops playback entirely and releases the surface.
     func stop() {
         self.logger.info("YouTubePlayer: stop")

--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -46,18 +46,6 @@ extension YouTubeWatchWebView: YouTubeWatchPlaybackControlling {
 @MainActor
 @Observable
 final class YouTubePlayerService {
-    /// Distance from the known duration at which a manual seek is treated as a
-    /// completed watch. Seeking a WebKit video element to exactly `duration`
-    /// does not reliably emit `ended`, so terminal seeks must not depend on the
-    /// page's natural ended event to refresh Continue Watching state.
-    private static let seekToEndThreshold: TimeInterval = 0.5
-
-    /// Window during which repeated relative-seek button presses should build
-    /// from the last requested target instead of the last observer-reported
-    /// progress. YouTube's `STATE_UPDATE` observer is coarse and can briefly
-    /// report pre-seek progress after a button press.
-    private static let relativeSeekTargetCoalescingWindow: Duration = .seconds(1)
-
     // MARK: - State
 
     /// The video currently loaded for playback (nil when playback is closed).
@@ -110,28 +98,28 @@ final class YouTubePlayerService {
     /// there is no active playback to re-attribute. Defer the reload until the
     /// user explicitly resumes so loading YouTube's autoplaying watch page cannot
     /// create watch activity for content the user left paused.
-    private var pendingPausedIdentityReloadVideoId: String?
-    private var pendingPausedIdentityReloadResumeAt: Double?
-    private var userUpdatedPendingPausedIdentityReloadSeek = false
+    var pendingPausedIdentityReloadVideoId: String?
+    var pendingPausedIdentityReloadResumeAt: Double?
+    var userUpdatedPendingPausedIdentityReloadSeek = false
     private var isIdentityReloadInFlight = false
 
     /// Current position in seconds.
-    private(set) var progress: Double = 0
+    var progress: Double = 0
 
     /// Last observed playback position from genuine CONTENT (not an ad). Used as
     /// the resume target for an identity-switch reload so a switch during a
     /// preroll/midroll ad doesn't resume the content near 0 (the ad element's
     /// time).
-    private var lastNonAdContentProgress: Double = 0
+    var lastNonAdContentProgress: Double = 0
 
     /// Video length in seconds.
     private(set) var duration: Double = 0
 
     /// Last requested relative-seek target used to coalesce rapid repeated
     /// button presses while bridge state updates lag behind WebView commands.
-    private var lastRelativeSeekTarget: Double?
-    private var lastRelativeSeekIssuedAt: ContinuousClock.Instant?
-    private var lastRelativeSeekVideoId: String?
+    @ObservationIgnored var lastRelativeSeekTarget: Double?
+    @ObservationIgnored var lastRelativeSeekIssuedAt: ContinuousClock.Instant?
+    @ObservationIgnored var lastRelativeSeekVideoId: String?
 
     /// Whether an ad is currently showing on the watch page.
     private(set) var isShowingAd = false
@@ -228,7 +216,7 @@ final class YouTubePlayerService {
     // MARK: - Dependencies
 
     private let webKitManager: WebKitManager
-    private let playbackController: any YouTubeWatchPlaybackControlling
+    let playbackController: any YouTubeWatchPlaybackControlling
     private let logger = DiagnosticsLogger.player
 
     /// Whether a playing video should pop out into the floating window when the
@@ -369,103 +357,6 @@ final class YouTubePlayerService {
             self.isIdentityReloadInFlight = false
         }
         self.isPlaying = false
-    }
-
-    /// Seeks to a position in seconds.
-    func seek(to time: Double) {
-        self.clearRelativeSeekCoalescingTarget()
-        self.performSeek(to: time)
-    }
-
-    private func performSeek(to time: Double) {
-        guard time.isFinite else { return }
-        let target = self.clampedSeekTarget(time)
-        if self.duration > 0, target >= self.duration - Self.seekToEndThreshold {
-            self.handleManualSeekToEnd()
-            return
-        }
-
-        self.progress = target
-        if self.pendingPausedIdentityReloadVideoId == self.currentVideo?.videoId {
-            self.pendingPausedIdentityReloadResumeAt = target > 0 ? target : nil
-            self.userUpdatedPendingPausedIdentityReloadSeek = true
-        }
-        self.playbackController.seek(to: target)
-    }
-
-    private func clampedSeekTarget(_ time: Double) -> Double {
-        if self.duration > 0 {
-            return min(max(time, 0), self.duration)
-        }
-        return max(time, 0)
-    }
-
-    private func handleManualSeekToEnd() {
-        guard self.currentVideo != nil, self.duration > 0 else { return }
-        let terminalSeekTime = max(0, self.duration - Self.seekToEndThreshold)
-        self.progress = self.duration
-        self.lastNonAdContentProgress = self.duration
-        self.clearRelativeSeekCoalescingTarget()
-        if self.pendingPausedIdentityReloadVideoId == self.currentVideo?.videoId {
-            self.pendingPausedIdentityReloadResumeAt = nil
-            self.userUpdatedPendingPausedIdentityReloadSeek = true
-        }
-
-        // Keep the WebView away from exact-duration seeks and pause it so a
-        // follow-up state update cannot look like a fresh replay of the just-
-        // concluded watch.
-        self.playbackController.seek(to: terminalSeekTime)
-        self.playbackController.pause()
-        self.handleVideoEnded(videoId: self.currentVideo?.videoId)
-    }
-
-    /// Seeks backward by a fixed interval, clamping to the beginning.
-    func seekBackward(by seconds: Double = 30) {
-        guard seconds.isFinite, seconds > 0 else { return }
-        self.seekRelative(by: -seconds)
-    }
-
-    /// Seeks forward by a fixed interval, clamping to the known duration.
-    func seekForward(by seconds: Double = 30) {
-        guard seconds.isFinite, seconds > 0 else { return }
-        self.seekRelative(by: seconds)
-    }
-
-    private func seekRelative(by delta: Double) {
-        guard delta.isFinite, delta != 0, self.currentVideo != nil else { return }
-        let now = ContinuousClock.now
-        let currentVideoId = self.currentVideo?.videoId
-        if self.lastRelativeSeekVideoId != currentVideoId {
-            self.clearRelativeSeekCoalescingTarget()
-        }
-        self.lastRelativeSeekVideoId = currentVideoId
-
-        // Bridge progress can lag behind rapid button repeats. Briefly use the
-        // last command target so repeated clicks accumulate from user intent
-        // instead of from a stale 1 Hz observer tick.
-        let baseProgress = if self.canCoalesceRelativeSeekTarget(at: now),
-                              let lastRelativeSeekTarget = self.lastRelativeSeekTarget
-        {
-            lastRelativeSeekTarget
-        } else {
-            self.progress
-        }
-
-        let target = self.clampedSeekTarget(baseProgress + delta)
-        self.lastRelativeSeekTarget = target
-        self.lastRelativeSeekIssuedAt = now
-        self.performSeek(to: target)
-    }
-
-    private func canCoalesceRelativeSeekTarget(at now: ContinuousClock.Instant) -> Bool {
-        guard let lastRelativeSeekIssuedAt = self.lastRelativeSeekIssuedAt else { return false }
-        return now - lastRelativeSeekIssuedAt <= Self.relativeSeekTargetCoalescingWindow
-    }
-
-    private func clearRelativeSeekCoalescingTarget() {
-        self.lastRelativeSeekTarget = nil
-        self.lastRelativeSeekIssuedAt = nil
-        self.lastRelativeSeekVideoId = nil
     }
 
     /// Stops playback entirely and releases the surface.

--- a/Sources/Kaset/Views/YouTube/YouTubePlayerBar.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubePlayerBar.swift
@@ -7,8 +7,8 @@ import SwiftUI
 /// Same capsule, sizing, and interaction patterns as the music `PlayerBar`
 /// (which is untouched); shown instead of it while a YouTube video is
 /// loaded. Differences per the YouTube content model:
-/// - No shuffle/repeat — previous/next skip between videos
-///   (session history / the watch page's related list).
+/// - No shuffle/repeat — left/right transport controls seek 30 seconds
+///   back/forward within the current video.
 /// - Center shows the video thumbnail, title, and channel · views.
 /// - No lyrics/queue buttons.
 /// - The minimize button drives the video pop-out (picture in picture);
@@ -91,18 +91,18 @@ struct YouTubePlayerBar: View {
 
     private var playbackControls: some View {
         HStack(spacing: 16) {
-            // Previous video (session history; restarts when none)
+            // Back 30 seconds
             Button {
                 HapticService.playback()
-                self.youtubePlayer.skipBackward()
+                self.youtubePlayer.seekBackward()
             } label: {
-                Image(systemName: "backward.fill")
+                Image(systemName: "gobackward.30")
                     .font(.system(size: 17, weight: .medium))
                     .foregroundStyle(.primary)
             }
             .buttonStyle(.pressable)
-            .disabled(self.youtubePlayer.currentVideo == nil)
-            .accessibilityLabel(String(localized: "Previous video"))
+            .disabled(!self.canSeek)
+            .accessibilityLabel(String(localized: "Back 30 seconds"))
 
             // Play/Pause
             Button {
@@ -124,20 +124,18 @@ struct YouTubePlayerBar: View {
                     : String(localized: "Play")
             )
 
-            // Next video (up next from the watch page)
+            // Forward 30 seconds
             Button {
                 HapticService.playback()
-                Task {
-                    await self.youtubePlayer.skipForward()
-                }
+                self.youtubePlayer.seekForward()
             } label: {
-                Image(systemName: "forward.fill")
+                Image(systemName: "goforward.30")
                     .font(.system(size: 17, weight: .medium))
                     .foregroundStyle(.primary)
             }
             .buttonStyle(.pressable)
-            .disabled(self.youtubePlayer.currentVideo == nil)
-            .accessibilityLabel(String(localized: "Next video"))
+            .disabled(!self.canSeek)
+            .accessibilityLabel(String(localized: "Forward 30 seconds"))
         }
     }
 

--- a/Tests/KasetTests/YouTubePlayerServiceTests.swift
+++ b/Tests/KasetTests/YouTubePlayerServiceTests.swift
@@ -208,7 +208,7 @@ struct YouTubePlayerServiceTests {
         #expect(willStartCount == 1)
     }
 
-    @Test("Relative video seeks move by 30 seconds and clamp to bounds")
+    @Test("Relative video seeks move by 30 seconds and clamp backward to start")
     func relativeSeeksClampToBounds() {
         self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
 
@@ -217,15 +217,48 @@ struct YouTubePlayerServiceTests {
         #expect(self.sut.progress == 0)
         #expect(self.controller.seeks == [0])
 
-        self.sut.updatePlaybackState(.init(isPlaying: true, progress: 90, duration: 100, videoId: "abc"))
-        self.sut.seekForward()
-        #expect(self.sut.progress == 100)
-        #expect(self.controller.seeks == [0, 100])
-
-        self.sut.updatePlaybackState(.init(isPlaying: true, progress: 45, duration: 100, videoId: "abc"))
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "def"))
+        self.sut.updatePlaybackState(.init(isPlaying: true, progress: 45, duration: 100, videoId: "def"))
         self.sut.seekBackward()
         self.sut.seekForward()
-        #expect(self.controller.seeks == [0, 100, 15, 45])
+        #expect(self.controller.seeks == [0, 15, 45])
+    }
+
+    @Test("Rapid relative seeks accumulate from the last requested target")
+    func relativeSeeksAccumulateAcrossStaleObserverUpdates() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        self.sut.updatePlaybackState(.init(isPlaying: true, progress: 10, duration: 100, videoId: "abc"))
+
+        self.sut.seekForward()
+        // A stale observer tick reports the pre-seek position before the next
+        // button press. The second seek must build from 40, not from 10.
+        self.sut.updatePlaybackState(.init(isPlaying: true, progress: 10, duration: 100, videoId: "abc"))
+        self.sut.seekForward()
+
+        #expect(self.sut.progress == 70)
+        #expect(self.controller.seeks == [40, 70])
+    }
+
+    @Test("Forward relative seek near the end manually concludes without exact-duration seek")
+    func relativeSeekToEndConcludesWithoutExactDurationSeek() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        self.sut.updatePlaybackState(.init(isPlaying: true, progress: 90, duration: 100, videoId: "abc"))
+        var endedVideoId: String?
+        self.sut.onVideoEnded = { endedVideoId = $0 }
+        let activityBefore = self.sut.watchActivityGeneration
+        let conclusionBefore = self.sut.watchConclusionGeneration
+
+        self.sut.seekForward()
+
+        #expect(self.sut.progress == 100)
+        #expect(self.sut.isPlaying == false)
+        #expect(endedVideoId == "abc")
+        #expect(self.sut.watchActivityGeneration == activityBefore + 1)
+        #expect(self.sut.watchConclusionGeneration == conclusionBefore + 1)
+        #expect(self.controller.pauseCount == 1)
+        #expect(self.controller.seeks.count == 1)
+        #expect(self.controller.seeks[0] < 100)
+        #expect(self.controller.seeks[0] >= 99)
     }
 
     @Test("Deferred paused identity reload survives observer updates before resume")

--- a/Tests/KasetTests/YouTubePlayerServiceTests.swift
+++ b/Tests/KasetTests/YouTubePlayerServiceTests.swift
@@ -208,6 +208,26 @@ struct YouTubePlayerServiceTests {
         #expect(willStartCount == 1)
     }
 
+    @Test("Relative video seeks move by 30 seconds and clamp to bounds")
+    func relativeSeeksClampToBounds() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+
+        self.sut.updatePlaybackState(.init(isPlaying: true, progress: 20, duration: 100, videoId: "abc"))
+        self.sut.seekBackward()
+        #expect(self.sut.progress == 0)
+        #expect(self.controller.seeks == [0])
+
+        self.sut.updatePlaybackState(.init(isPlaying: true, progress: 90, duration: 100, videoId: "abc"))
+        self.sut.seekForward()
+        #expect(self.sut.progress == 100)
+        #expect(self.controller.seeks == [0, 100])
+
+        self.sut.updatePlaybackState(.init(isPlaying: true, progress: 45, duration: 100, videoId: "abc"))
+        self.sut.seekBackward()
+        self.sut.seekForward()
+        #expect(self.controller.seeks == [0, 100, 15, 45])
+    }
+
     @Test("Deferred paused identity reload survives observer updates before resume")
     func deferredPausedReloadSurvivesObserverUpdatesBeforeResume() {
         self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))

--- a/docs/youtube.md
+++ b/docs/youtube.md
@@ -90,11 +90,10 @@ currently serves.
 The bottom Liquid Glass bar adapts to the active source. In YouTube mode
 (`YouTubePlayerBar`, visually identical to the music `PlayerBar`):
 
-- Previous/next skip between videos: back through session history,
-  forward through the watch page's related list (fetched lazily when
-  popped out). Skips while docked open the new video's watch view.
 - The center shows the video thumbnail, title, and channel · views, with
   the same hover-to-seek behavior.
+- Player bar transport buttons seek 30 seconds back/forward within the
+  current video.
 - Actions: like/dislike, Watch Later, AirPlay (video picker), closed
   captions menu (player tracks + Off), quality menu, full view, and
   picture in picture (pop out / pop in; hidden in fullscreen).


### PR DESCRIPTION
## Summary
- Replace YouTube video player bar previous/next buttons with 30-second back/forward seek controls.
- Add clamped relative seek helpers to `YouTubePlayerService`.
- Cover the relative seek behavior with unit tests and update YouTube player bar docs.

## Validation
- `swiftformat .`
- `swiftlint --strict`
- `swift build`
- `swift test --skip KasetUITests --filter YouTubePlayerServiceTests`
- `swift test --skip KasetUITests --filter PlayerServiceLibraryTests`
- `.agents/skills/autoreview/scripts/autoreview --mode local --parallel-tests "swift test --skip KasetUITests --filter YouTubePlayerServiceTests"`

Note: a full `swift test --skip KasetUITests` run hit an unrelated `PlayerServiceLibraryTests.swift:93` failure, and that suite passed when rerun in isolation.
