### PR TITLE
feat(ui): Player interaction improvements

### DIFF
--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -124,6 +124,9 @@ final class YouTubePlayerService {
     /// Whether an ad is currently showing on the watch page.
     private(set) var isShowingAd = false
 
+    /// Whether the current video is waiting for the WebView to report playable media.
+    private(set) var isPlaybackLoading = false
+
     /// Playback volume (0...1).
     var volume: Double = 1.0 {
         didSet {
@@ -252,6 +255,7 @@ final class YouTubePlayerService {
         self.hasObservedPlaybackState = false
         self.isIdentityReloadInFlight = false
         self.resetPerVideoState()
+        self.isPlaybackLoading = true
         self.surfaceLocation = .inline
 
         // Create the WebView on demand; containers reparent it on appear.
@@ -301,6 +305,7 @@ final class YouTubePlayerService {
             resumeAt: resumeProgress > 0 ? resumeProgress : nil
         )
         self.isIdentityReloadInFlight = true
+        self.isPlaybackLoading = true
     }
 
     /// Toggles play/pause.
@@ -338,6 +343,7 @@ final class YouTubePlayerService {
         self.playbackController.prepare(webKitManager: self.webKitManager, playerService: self)
         self.playbackController.reloadVideo(videoId: currentVideo.videoId, resumeAt: resumeAt)
         self.isIdentityReloadInFlight = true
+        self.isPlaybackLoading = true
         return true
     }
 
@@ -357,6 +363,7 @@ final class YouTubePlayerService {
             self.isIdentityReloadInFlight = false
         }
         self.isPlaying = false
+        self.isPlaybackLoading = false
     }
 
     /// Stops playback entirely and releases the surface.
@@ -376,6 +383,7 @@ final class YouTubePlayerService {
         }
         self.currentVideo = nil
         self.isPlaying = false
+        self.isPlaybackLoading = false
         self.hasObservedPlaybackState = false
         self.isIdentityReloadInFlight = false
         self.progress = 0
@@ -472,6 +480,7 @@ final class YouTubePlayerService {
         self.hasObservedPlaybackState = false
         self.isIdentityReloadInFlight = false
         self.resetPerVideoState()
+        self.isPlaybackLoading = true
         self.playbackController.prepare(webKitManager: self.webKitManager, playerService: self)
         self.playbackController.loadVideo(videoId: video.videoId)
 
@@ -737,6 +746,7 @@ final class YouTubePlayerService {
         self.progress = update.progress
         self.duration = update.duration
         self.isShowingAd = update.isAd
+        self.isPlaybackLoading = false
 
         // Remember the last real content position (ignoring ad playback) so an
         // identity-switch reload during an ad resumes the content, not the ad.
@@ -839,6 +849,7 @@ final class YouTubePlayerService {
             return
         }
         self.isPlaying = false
+        self.isPlaybackLoading = false
         // A finish changes watch history (the video crosses into "finished"), so
         // signal it — this lets Home drop a just-finished video from Continue
         // Watching even when the video ended in the floating window while the

--- a/Sources/Kaset/Views/ArtistDetailView.swift
+++ b/Sources/Kaset/Views/ArtistDetailView.swift
@@ -5,10 +5,21 @@ import SwiftUI
 /// Detail view for an artist showing their songs and albums.
 struct ArtistDetailView: View { // swiftlint:disable:this type_body_length
     let artist: Artist
+    var playerBarNavigationAction: PlayerBarNavigationAction = .disabled
     @State var viewModel: ArtistDetailViewModel
     @Environment(PlayerService.self) private var playerService
     @Environment(FavoritesManager.self) private var favoritesManager
     @Environment(SongLikeStatusManager.self) private var likeStatusManager
+
+    init(
+        artist: Artist,
+        viewModel: ArtistDetailViewModel,
+        playerBarNavigationAction: PlayerBarNavigationAction = .disabled
+    ) {
+        self.artist = artist
+        self.playerBarNavigationAction = playerBarNavigationAction
+        _viewModel = State(initialValue: viewModel)
+    }
 
     var body: some View {
         Group {
@@ -35,6 +46,8 @@ struct ArtistDetailView: View { // swiftlint:disable:this type_body_length
         .safeAreaInset(edge: .bottom, spacing: 0) {
             if case .error = self.viewModel.loadingState {} else {
                 PlayerBar()
+                    .environment(\.playerBarNavigationAction, self.playerBarNavigationAction)
+                    .environment(\.playerBarCurrentArtistID, self.artist.id)
             }
         }
         .task {

--- a/Sources/Kaset/Views/ChartsView.swift
+++ b/Sources/Kaset/Views/ChartsView.swift
@@ -32,10 +32,16 @@ struct ChartsView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .localizedNavigationTitle("Charts")
-            .navigationDestinations(client: self.viewModel.client)
+            .navigationDestinations(
+                client: self.viewModel.client,
+                playerBarNavigationAction: self.playerBarNavigationAction
+            )
+            .playerBarMusicNavigation(path: self.$navigationPath)
         }
+        .playerBarMusicNavigation(path: self.$navigationPath)
         .safeAreaInset(edge: .bottom, spacing: 0) {
             PlayerBar()
+                .playerBarMusicNavigation(path: self.$navigationPath)
         }
         .onAppear {
             if self.viewModel.loadingState == .idle {
@@ -47,6 +53,13 @@ struct ChartsView: View {
         .refreshable {
             await self.viewModel.refresh()
         }
+    }
+
+    private var playerBarNavigationAction: PlayerBarNavigationAction {
+        PlayerBarNavigationAction(
+            openArtist: { self.navigationPath.append($0) },
+            openAlbum: { self.navigationPath.append($0) }
+        )
     }
 
     // MARK: - Views

--- a/Sources/Kaset/Views/ExploreView.swift
+++ b/Sources/Kaset/Views/ExploreView.swift
@@ -32,10 +32,16 @@ struct ExploreView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .localizedNavigationTitle("Explore")
-            .navigationDestinations(client: self.viewModel.client)
+            .navigationDestinations(
+                client: self.viewModel.client,
+                playerBarNavigationAction: self.playerBarNavigationAction
+            )
+            .playerBarMusicNavigation(path: self.$navigationPath)
         }
+        .playerBarMusicNavigation(path: self.$navigationPath)
         .safeAreaInset(edge: .bottom, spacing: 0) {
             PlayerBar()
+                .playerBarMusicNavigation(path: self.$navigationPath)
         }
         .onAppear {
             if self.viewModel.loadingState == .idle {
@@ -47,6 +53,13 @@ struct ExploreView: View {
         .refreshable {
             await self.viewModel.refresh()
         }
+    }
+
+    private var playerBarNavigationAction: PlayerBarNavigationAction {
+        PlayerBarNavigationAction(
+            openArtist: { self.navigationPath.append($0) },
+            openAlbum: { self.navigationPath.append($0) }
+        )
     }
 
     // MARK: - Views

--- a/Sources/Kaset/Views/HistoryView.swift
+++ b/Sources/Kaset/Views/HistoryView.swift
@@ -51,10 +51,16 @@ struct HistoryView: View {
                     .disabled(self.isRefreshing)
                 }
             }
-            .navigationDestinations(client: self.viewModel.client)
+            .navigationDestinations(
+                client: self.viewModel.client,
+                playerBarNavigationAction: self.playerBarNavigationAction
+            )
+            .playerBarMusicNavigation(path: self.$navigationPath)
         }
+        .playerBarMusicNavigation(path: self.$navigationPath)
         .safeAreaInset(edge: .bottom, spacing: 0) {
             PlayerBar()
+                .playerBarMusicNavigation(path: self.$navigationPath)
         }
         .task {
             if self.viewModel.loadingState == .idle {
@@ -71,6 +77,13 @@ struct HistoryView: View {
         .refreshable {
             await self.performRefresh()
         }
+    }
+
+    private var playerBarNavigationAction: PlayerBarNavigationAction {
+        PlayerBarNavigationAction(
+            openArtist: { self.navigationPath.append($0) },
+            openAlbum: { self.navigationPath.append($0) }
+        )
     }
 
     /// Refreshes with visual feedback: spinning icon → data swap.

--- a/Sources/Kaset/Views/HomeView.swift
+++ b/Sources/Kaset/Views/HomeView.swift
@@ -34,10 +34,16 @@ struct HomeView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .localizedNavigationTitle("Home")
-            .navigationDestinations(client: self.viewModel.client)
+            .navigationDestinations(
+                client: self.viewModel.client,
+                playerBarNavigationAction: self.playerBarNavigationAction
+            )
+            .playerBarMusicNavigation(path: self.$navigationPath)
         }
+        .playerBarMusicNavigation(path: self.$navigationPath)
         .safeAreaInset(edge: .bottom, spacing: 0) {
             PlayerBar()
+                .playerBarMusicNavigation(path: self.$navigationPath)
         }
         .onAppear {
             if self.viewModel.loadingState == .idle {
@@ -49,6 +55,13 @@ struct HomeView: View {
         .refreshable {
             await self.viewModel.refresh()
         }
+    }
+
+    private var playerBarNavigationAction: PlayerBarNavigationAction {
+        PlayerBarNavigationAction(
+            openArtist: { self.navigationPath.append($0) },
+            openAlbum: { self.navigationPath.append($0) }
+        )
     }
 
     // MARK: - Views

--- a/Sources/Kaset/Views/LegacyFallbackViews.swift
+++ b/Sources/Kaset/Views/LegacyFallbackViews.swift
@@ -12,12 +12,18 @@ import SwiftUI
 /// Minimal playlist view used on macOS 15 (no Liquid Glass, no AI refine).
 struct SimplePlaylistDetailView: View {
     let playlist: Playlist
+    let playerBarNavigationAction: PlayerBarNavigationAction
     @State var viewModel: PlaylistDetailViewModel
     @Environment(PlayerService.self) private var playerService
     @Environment(SongLikeStatusManager.self) private var likeStatusManager
 
-    init(playlist: Playlist, viewModel: PlaylistDetailViewModel) {
+    init(
+        playlist: Playlist,
+        viewModel: PlaylistDetailViewModel,
+        playerBarNavigationAction: PlayerBarNavigationAction = .disabled
+    ) {
         self.playlist = playlist
+        self.playerBarNavigationAction = playerBarNavigationAction
         self._viewModel = State(initialValue: viewModel)
     }
 
@@ -48,6 +54,8 @@ struct SimplePlaylistDetailView: View {
             if case .error = self.viewModel.loadingState {
             } else {
                 PlayerBar()
+                    .environment(\.playerBarNavigationAction, self.playerBarNavigationAction)
+                    .environment(\.playerBarCurrentAlbumID, self.playlist.isAlbum ? self.playlist.id : nil)
             }
         }
         .task {

--- a/Sources/Kaset/Views/LibraryView.swift
+++ b/Sources/Kaset/Views/LibraryView.swift
@@ -89,7 +89,8 @@ struct LibraryView: View {
                         viewModel: PlaylistDetailViewModel(
                             playlist: playlist,
                             client: self.viewModel.client
-                        )
+                        ),
+                        playerBarNavigationAction: self.playerBarNavigationAction
                     )
                 } else {
                     SimplePlaylistDetailView(
@@ -97,7 +98,8 @@ struct LibraryView: View {
                         viewModel: PlaylistDetailViewModel(
                             playlist: playlist,
                             client: self.viewModel.client
-                        )
+                        ),
+                        playerBarNavigationAction: self.playerBarNavigationAction
                     )
                 }
             }
@@ -108,7 +110,8 @@ struct LibraryView: View {
                         artist: artist,
                         client: self.viewModel.client,
                         libraryViewModel: self.viewModel
-                    )
+                    ),
+                    playerBarNavigationAction: self.playerBarNavigationAction
                 )
             }
             .navigationDestination(for: TopSongsDestination.self) { destination in
@@ -122,10 +125,13 @@ struct LibraryView: View {
             .navigationDestination(for: PodcastShow.self) { show in
                 PodcastShowView(show: show, client: self.viewModel.client)
             }
+            .playerBarMusicNavigation(path: self.$navigationPath)
         }
+        .playerBarMusicNavigation(path: self.$navigationPath)
         .environment(self.viewModel)
         .safeAreaInset(edge: .bottom, spacing: 0) {
             PlayerBar()
+                .playerBarMusicNavigation(path: self.$navigationPath)
         }
         .task {
             if self.viewModel.loadingState == .idle {
@@ -140,6 +146,13 @@ struct LibraryView: View {
         .refreshable {
             await self.viewModel.refresh()
         }
+    }
+
+    private var playerBarNavigationAction: PlayerBarNavigationAction {
+        PlayerBarNavigationAction(
+            openArtist: { self.navigationPath.append($0) },
+            openAlbum: { self.navigationPath.append($0) }
+        )
     }
 
     // MARK: - Views

--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -539,16 +539,22 @@ struct MainWindow: View {
                             if !self.usesLegacyMacOS15UI, #available(macOS 26.0, *) {
                                 PlaylistDetailView(
                                     playlist: LikedMusicPlaylist.playlist,
-                                    viewModel: vm
+                                    viewModel: vm,
+                                    playerBarNavigationAction: self.likedMusicPlayerBarNavigationAction
                                 )
                             } else {
                                 SimplePlaylistDetailView(
                                     playlist: LikedMusicPlaylist.playlist,
-                                    viewModel: vm
+                                    viewModel: vm,
+                                    playerBarNavigationAction: self.likedMusicPlayerBarNavigationAction
                                 )
                             }
                         }
-                        .navigationDestinations(client: self.client)
+                        .navigationDestinations(
+                            client: self.client,
+                            playerBarNavigationAction: self.likedMusicPlayerBarNavigationAction
+                        )
+                        .playerBarMusicNavigation(path: self.$likedMusicNavigationPath)
                     }
                 }
             case .library:
@@ -558,6 +564,13 @@ struct MainWindow: View {
             }
         }
         .environment(self.libraryViewModel)
+    }
+
+    private var likedMusicPlayerBarNavigationAction: PlayerBarNavigationAction {
+        PlayerBarNavigationAction(
+            openArtist: { self.likedMusicNavigationPath.append($0) },
+            openAlbum: { self.likedMusicNavigationPath.append($0) }
+        )
     }
 
     private func viewForSidebarPinnedItem(

--- a/Sources/Kaset/Views/MiniPlayerViews.swift
+++ b/Sources/Kaset/Views/MiniPlayerViews.swift
@@ -843,11 +843,11 @@ struct MiniPlayerWindow: View { // swiftlint:disable:this type_body_length
     private func performSeek() {
         guard self.playerService.duration > 0 else { return }
         let target = self.seekValue * self.playerService.duration
-        let holdToken = self.seekHold.begin(target: target)
+        let holdID = self.seekHold.begin(target: target)
         Task { await self.playerService.seek(to: target) }
         Task { @MainActor in
             try? await Task.sleep(for: PlayerBarSeekHold.timeout)
-            if self.seekHold.clearIfCurrent(holdToken) {
+            if self.seekHold.clearIfCurrent(holdID) {
                 self.syncSeekValue()
             }
         }

--- a/Sources/Kaset/Views/MiniPlayerViews.swift
+++ b/Sources/Kaset/Views/MiniPlayerViews.swift
@@ -85,7 +85,7 @@ struct MiniPlayerToast: View {
 
 // MARK: - MiniPlayerWindow
 
-struct MiniPlayerWindow: View {
+struct MiniPlayerWindow: View { // swiftlint:disable:this type_body_length
     private enum Layout {
         static let chromeTopInset: CGFloat = 12
         static let trafficLightSize: CGFloat = 13
@@ -105,6 +105,7 @@ struct MiniPlayerWindow: View {
     @State private var settings = SettingsManager.shared
     @State private var seekValue: Double = 0
     @State private var isSeeking = false
+    @State private var seekHold = PlayerBarSeekHold()
     @State private var volumeValue: Double = 1
     @State private var isAdjustingVolume = false
     @State private var detailPane: DetailPane = .lyrics
@@ -127,14 +128,19 @@ struct MiniPlayerWindow: View {
         .clipShape(.rect(cornerRadius: self.cornerRadius))
         .accessibilityIdentifier(AccessibilityID.MiniPlayer.container)
         .onChange(of: self.playerService.progress) { _, newValue in
-            if !self.isSeeking, self.playerService.duration > 0 {
-                self.seekValue = newValue / self.playerService.duration
+            self.seekHold.reconcile(observedProgress: newValue)
+            if !self.isSeeking, !self.seekHold.isActive, self.playerService.duration > 0 {
+                self.seekValue = self.displayedPlaybackProgress / self.playerService.duration
             }
         }
         .onChange(of: self.playerService.duration) { _, _ in
-            if !self.isSeeking {
+            self.seekHold.reconcile(observedProgress: self.playerService.progress)
+            if !self.isSeeking, !self.seekHold.isActive {
                 self.syncSeekValue()
             }
+        }
+        .onChange(of: self.currentTrackIdentity) { _, _ in
+            self.clearSeekHold()
         }
         .onChange(of: self.playerService.volume) { _, newValue in
             if !self.isAdjustingVolume {
@@ -656,7 +662,7 @@ struct MiniPlayerWindow: View {
             .accessibilityIdentifier(AccessibilityID.MiniPlayer.seekSlider)
 
             HStack {
-                Text(self.formatTime(self.isSeeking ? self.seekValue * self.playerService.duration : self.playerService.progress))
+                Text(self.formatTime(self.isSeeking ? self.seekValue * self.playerService.duration : self.displayedPlaybackProgress))
                 Spacer()
                 Text(self.playerService.isCurrentItemLive ? String(localized: "LIVE") : self.remainingTimeText)
             }
@@ -795,7 +801,15 @@ struct MiniPlayerWindow: View {
     }
 
     private var remainingTimeText: String {
-        "-\(self.formatTime(max(0, self.playerService.duration - self.playerService.progress)))"
+        "-\(self.formatTime(max(0, self.playerService.duration - self.displayedPlaybackProgress)))"
+    }
+
+    private var displayedPlaybackProgress: TimeInterval {
+        self.seekHold.displayProgress(observedProgress: self.playerService.progress)
+    }
+
+    private var currentTrackIdentity: String {
+        self.playerService.currentTrack?.videoId ?? "none"
     }
 
     private var repeatIcon: String {
@@ -820,7 +834,7 @@ struct MiniPlayerWindow: View {
 
     private func syncSeekValue() {
         if self.playerService.duration > 0 {
-            self.seekValue = self.playerService.progress / self.playerService.duration
+            self.seekValue = self.displayedPlaybackProgress / self.playerService.duration
         } else {
             self.seekValue = 0
         }
@@ -829,7 +843,20 @@ struct MiniPlayerWindow: View {
     private func performSeek() {
         guard self.playerService.duration > 0 else { return }
         let target = self.seekValue * self.playerService.duration
+        let holdToken = self.seekHold.begin(target: target)
         Task { await self.playerService.seek(to: target) }
+        Task { @MainActor in
+            try? await Task.sleep(for: PlayerBarSeekHold.timeout)
+            if self.seekHold.clearIfCurrent(holdToken) {
+                self.syncSeekValue()
+            }
+        }
+    }
+
+    private func clearSeekHold() {
+        self.seekHold.clear()
+        self.isSeeking = false
+        self.syncSeekValue()
     }
 
     private func formatTime(_ seconds: TimeInterval) -> String {

--- a/Sources/Kaset/Views/MoodsAndGenresView.swift
+++ b/Sources/Kaset/Views/MoodsAndGenresView.swift
@@ -32,10 +32,16 @@ struct MoodsAndGenresView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .localizedNavigationTitle("Moods & Genres")
-            .navigationDestinations(client: self.viewModel.client)
+            .navigationDestinations(
+                client: self.viewModel.client,
+                playerBarNavigationAction: self.playerBarNavigationAction
+            )
+            .playerBarMusicNavigation(path: self.$navigationPath)
         }
+        .playerBarMusicNavigation(path: self.$navigationPath)
         .safeAreaInset(edge: .bottom, spacing: 0) {
             PlayerBar()
+                .playerBarMusicNavigation(path: self.$navigationPath)
         }
         .onAppear {
             if self.viewModel.loadingState == .idle {
@@ -47,6 +53,13 @@ struct MoodsAndGenresView: View {
         .refreshable {
             await self.viewModel.refresh()
         }
+    }
+
+    private var playerBarNavigationAction: PlayerBarNavigationAction {
+        PlayerBarNavigationAction(
+            openArtist: { self.navigationPath.append($0) },
+            openAlbum: { self.navigationPath.append($0) }
+        )
     }
 
     // MARK: - Views

--- a/Sources/Kaset/Views/NewReleasesView.swift
+++ b/Sources/Kaset/Views/NewReleasesView.swift
@@ -32,10 +32,16 @@ struct NewReleasesView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .localizedNavigationTitle("New Releases")
-            .navigationDestinations(client: self.viewModel.client)
+            .navigationDestinations(
+                client: self.viewModel.client,
+                playerBarNavigationAction: self.playerBarNavigationAction
+            )
+            .playerBarMusicNavigation(path: self.$navigationPath)
         }
+        .playerBarMusicNavigation(path: self.$navigationPath)
         .safeAreaInset(edge: .bottom, spacing: 0) {
             PlayerBar()
+                .playerBarMusicNavigation(path: self.$navigationPath)
         }
         .onAppear {
             if self.viewModel.loadingState == .idle {
@@ -47,6 +53,13 @@ struct NewReleasesView: View {
         .refreshable {
             await self.viewModel.refresh()
         }
+    }
+
+    private var playerBarNavigationAction: PlayerBarNavigationAction {
+        PlayerBarNavigationAction(
+            openArtist: { self.navigationPath.append($0) },
+            openAlbum: { self.navigationPath.append($0) }
+        )
     }
 
     // MARK: - Views

--- a/Sources/Kaset/Views/PlayerBar.swift
+++ b/Sources/Kaset/Views/PlayerBar.swift
@@ -25,6 +25,7 @@ struct PlayerBar: View { // swiftlint:disable:this type_body_length
     /// Local seek value for smooth slider dragging without network calls on every change.
     @State private var seekValue: Double = 0
     @State private var isSeeking = false
+    @State private var seekHold = PlayerBarSeekHold()
 
     /// Local volume value for smooth slider dragging.
     @State private var volumeValue: Double = 1.0
@@ -79,22 +80,29 @@ struct PlayerBar: View { // swiftlint:disable:this type_body_length
             await self.prepareCurrentNavigationTargets()
         }
         .onChange(of: self.playerService.progress) { _, newValue in
-            if !self.isSeeking, self.playerService.duration > 0 {
-                self.seekValue = newValue / self.playerService.duration
+            self.seekHold.reconcile(observedProgress: newValue)
+            let displayProgress = self.displayProgress(observedProgress: newValue)
+
+            if !self.isSeeking, !self.seekHold.isActive, self.playerService.duration > 0 {
+                self.seekValue = displayProgress / self.playerService.duration
             }
 
-            let currentSecond = Int(newValue)
+            let currentSecond = Int(displayProgress)
             if currentSecond != self.lastProgressSecond {
                 self.lastProgressSecond = currentSecond
-                self.formattedProgress = self.formatTime(newValue)
-                self.formattedRemaining = "-\(self.formatTime(max(0, self.playerService.duration - newValue)))"
+                self.updateFormattedTimes(progress: displayProgress, duration: self.playerService.duration)
             }
         }
         .onChange(of: self.playerService.duration) { _, newValue in
-            if !self.isSeeking, newValue > 0 {
-                self.seekValue = self.playerService.progress / newValue
+            self.seekHold.reconcile(observedProgress: self.playerService.progress)
+            let displayProgress = self.displayedPlaybackProgress
+            if !self.isSeeking, !self.seekHold.isActive, newValue > 0 {
+                self.seekValue = displayProgress / newValue
             }
-            self.formattedRemaining = "-\(self.formatTime(max(0, newValue - self.playerService.progress)))"
+            self.updateFormattedTimes(progress: displayProgress, duration: newValue)
+        }
+        .onChange(of: self.currentSeekIdentity) { _, _ in
+            self.clearSeekHold()
         }
         .onChange(of: self.playerService.volume) { _, newValue in
             if !self.isAdjustingVolume {
@@ -630,7 +638,19 @@ struct PlayerBar: View { // swiftlint:disable:this type_body_length
             return min(max(0, self.seekValue), 1)
         }
         guard self.playerService.duration > 0 else { return 0 }
-        return min(max(0, self.playerService.progress / self.playerService.duration), 1)
+        return min(max(0, self.displayedPlaybackProgress / self.playerService.duration), 1)
+    }
+
+    private var displayedPlaybackProgress: TimeInterval {
+        self.displayProgress(observedProgress: self.playerService.progress)
+    }
+
+    private func displayProgress(observedProgress: TimeInterval) -> TimeInterval {
+        self.seekHold.displayProgress(observedProgress: observedProgress)
+    }
+
+    private var currentSeekIdentity: String {
+        self.playerService.currentTrack?.videoId ?? "none"
     }
 
     // MARK: - Playback Options
@@ -1060,10 +1080,46 @@ struct PlayerBar: View { // swiftlint:disable:this type_body_length
     private func performSeek() {
         guard self.isSeeking, self.playerService.duration > 0 else { return }
         let seekTime = self.seekValue * self.playerService.duration
+        let holdToken = self.seekHold.begin(target: seekTime)
+        self.updateFormattedTimes(progress: seekTime, duration: self.playerService.duration)
+        self.isSeeking = false
+
         Task {
             await self.playerService.seek(to: seekTime)
-            self.isSeeking = false
         }
+        Task { @MainActor in
+            try? await Task.sleep(for: PlayerBarSeekHold.timeout)
+            if self.seekHold.clearIfCurrent(holdToken) {
+                self.syncSeekValueFromDisplayedProgress()
+                self.updateFormattedTimes(
+                    progress: self.displayedPlaybackProgress,
+                    duration: self.playerService.duration
+                )
+            }
+        }
+    }
+
+    private func clearSeekHold() {
+        self.seekHold.clear()
+        self.isSeeking = false
+        self.syncSeekValueFromDisplayedProgress()
+        self.updateFormattedTimes(
+            progress: self.displayedPlaybackProgress,
+            duration: self.playerService.duration
+        )
+    }
+
+    private func syncSeekValueFromDisplayedProgress() {
+        if self.playerService.duration > 0 {
+            self.seekValue = self.displayedPlaybackProgress / self.playerService.duration
+        } else {
+            self.seekValue = 0
+        }
+    }
+
+    private func updateFormattedTimes(progress: TimeInterval, duration: TimeInterval) {
+        self.formattedProgress = self.formatTime(progress)
+        self.formattedRemaining = "-\(self.formatTime(max(0, duration - progress)))"
     }
 
     private func formatTime(_ seconds: TimeInterval) -> String {

--- a/Sources/Kaset/Views/PlayerBar.swift
+++ b/Sources/Kaset/Views/PlayerBar.swift
@@ -933,7 +933,7 @@ struct PlayerBar: View { // swiftlint:disable:this type_body_length
             self.resolvedArtist = artist
             self.isResolvingArtist = false
 
-            guard let artist else { return }
+            guard let artist, !self.isCurrentArtistTarget else { return }
             self.openArtist(artist, playsHaptic: false)
         }
     }

--- a/Sources/Kaset/Views/PlayerBar.swift
+++ b/Sources/Kaset/Views/PlayerBar.swift
@@ -293,15 +293,14 @@ struct PlayerBar: View { // swiftlint:disable:this type_body_length
     private var canOpenCurrentArtist: Bool {
         self.playerService.currentTrack != nil
             && self.navigationAction.openArtist != nil
-            && !self.artistName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            && (self.currentArtistTarget != nil || self.playerService.ytMusicClient != nil)
+            && (self.currentArtistTarget != nil || (self.currentArtistSearchName != nil && self.playerService.ytMusicClient != nil))
             && !self.isCurrentArtistTarget
     }
 
     private var canOpenCurrentAlbum: Bool {
         self.playerService.currentTrack != nil
             && self.navigationAction.openAlbum != nil
-            && (self.currentAlbumTarget != nil || self.playerService.ytMusicClient != nil)
+            && (self.currentAlbumTarget != nil || (self.currentArtistSearchName != nil && self.playerService.ytMusicClient != nil))
             && !self.isCurrentAlbumTarget
             && !self.isResolvingCurrentRouteAlbum
     }
@@ -349,6 +348,11 @@ struct PlayerBar: View { // swiftlint:disable:this type_body_length
 
     private var primaryNavigableArtist: Artist? {
         self.playerService.currentTrack?.artists.first(where: { $0.hasNavigableId })
+    }
+
+    private var currentArtistSearchName: String? {
+        guard let track = self.playerService.currentTrack else { return nil }
+        return self.primaryArtistName(in: track)
     }
 
     private var artistName: String {
@@ -887,13 +891,18 @@ struct PlayerBar: View { // swiftlint:disable:this type_body_length
 
         let identity = self.currentTitleIdentity
 
-        if self.primaryNavigableArtist == nil {
-            let artist = await self.resolveArtist(named: self.artistName, client: client)
+        if self.navigationAction.openArtist != nil,
+           self.primaryNavigableArtist == nil,
+           let artistName = self.currentArtistSearchName
+        {
+            let artist = await self.resolveArtist(named: artistName, client: client)
             guard !Task.isCancelled, self.currentTitleIdentity == identity else { return }
             self.resolvedArtist = artist
         }
 
-        if self.currentAlbumPlaylist == nil,
+        if self.navigationAction.openAlbum != nil,
+           self.currentAlbumPlaylist == nil,
+           self.currentArtistSearchName != nil,
            let track = self.playerService.currentTrack
         {
             let album = await self.resolveAlbum(for: track, client: client)
@@ -912,7 +921,7 @@ struct PlayerBar: View { // swiftlint:disable:this type_body_length
             return
         }
 
-        let query = self.artistName
+        guard let query = self.currentArtistSearchName else { return }
         guard let client = self.playerService.ytMusicClient else { return }
         let identity = self.currentTitleIdentity
 
@@ -972,11 +981,13 @@ struct PlayerBar: View { // swiftlint:disable:this type_body_length
     }
 
     private func resolveArtist(named name: String, client: any YTMusicClientProtocol) async -> Artist? {
+        guard let query = self.trimmedNonEmpty(name) else { return nil }
+
         do {
-            let response = try await client.searchArtists(query: name)
+            let response = try await client.searchArtists(query: query)
             return response.artists.first { artist in
-                artist.hasNavigableId && self.matchesSearchResultTitle(artist.name, query: name)
-            } ?? response.artists.first(where: \.hasNavigableId)
+                artist.hasNavigableId && self.matchesSearchResultTitle(artist.name, query: query)
+            }
         } catch {
             DiagnosticsLogger.ui.error("Failed to resolve player bar artist: \(error.localizedDescription)")
             return nil
@@ -991,9 +1002,14 @@ struct PlayerBar: View { // swiftlint:disable:this type_body_length
         }
 
         do {
-            let response = try await client.searchSongsWithPagination(query: "\(track.title) \(self.artistName)")
+            guard let query = self.searchQuery(parts: [track.title, self.primaryArtistName(in: track)]) else { return nil }
+
+            let response = try await client.searchSongsWithPagination(query: query)
             let matchedSong = response.songs.first { $0.videoId == track.videoId }
-                ?? response.songs.first { self.matchesSearchResultTitle($0.title, query: track.title) }
+                ?? response.songs.first { song in
+                    self.matchesSearchResultTitle(song.title, query: track.title)
+                        && self.matchesTrackArtist(song, fallbackTrack: track)
+                }
 
             guard let album = matchedSong?.album, album.hasNavigableId else { return nil }
             return self.playlist(from: album, track: matchedSong ?? track)
@@ -1008,11 +1024,17 @@ struct PlayerBar: View { // swiftlint:disable:this type_body_length
         fallbackTrack track: Song,
         client: any YTMusicClientProtocol
     ) async -> Playlist? {
+        guard let query = self.searchQuery(parts: [title, self.primaryArtistName(in: track)]),
+              let artistName = self.primaryArtistName(in: track)
+        else { return nil }
+
         do {
-            let response = try await client.searchAlbums(query: title)
+            let response = try await client.searchAlbums(query: query)
             guard let album = response.albums.first(where: { album in
-                album.hasNavigableId && self.matchesSearchResultTitle(album.title, query: title)
-            }) ?? response.albums.first(where: \.hasNavigableId) else {
+                album.hasNavigableId
+                    && self.matchesSearchResultTitle(album.title, query: title)
+                    && self.matchesAlbumArtist(album, artistName: artistName)
+            }) else {
                 return nil
             }
 
@@ -1021,6 +1043,33 @@ struct PlayerBar: View { // swiftlint:disable:this type_body_length
             DiagnosticsLogger.ui.error("Failed to resolve player bar album: \(error.localizedDescription)")
             return nil
         }
+    }
+
+    private func primaryArtistName(in track: Song) -> String? {
+        track.artists.lazy.compactMap { self.trimmedNonEmpty($0.name) }.first
+    }
+
+    private func searchQuery(parts: [String?]) -> String? {
+        let query = parts.compactMap { part in
+            part.flatMap(self.trimmedNonEmpty)
+        }.joined(separator: " ")
+
+        return self.trimmedNonEmpty(query)
+    }
+
+    private func trimmedNonEmpty(_ value: String) -> String? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func matchesTrackArtist(_ song: Song, fallbackTrack track: Song) -> Bool {
+        guard let artistName = self.primaryArtistName(in: track) else { return false }
+        return song.artists.contains { self.matchesSearchResultTitle($0.name, query: artistName) }
+    }
+
+    private func matchesAlbumArtist(_ album: Album, artistName: String) -> Bool {
+        guard let artists = album.artists else { return false }
+        return artists.contains { self.matchesSearchResultTitle($0.name, query: artistName) }
     }
 
     private func matchesSearchResultTitle(_ title: String, query: String) -> Bool {
@@ -1080,7 +1129,7 @@ struct PlayerBar: View { // swiftlint:disable:this type_body_length
     private func performSeek() {
         guard self.isSeeking, self.playerService.duration > 0 else { return }
         let seekTime = self.seekValue * self.playerService.duration
-        let holdToken = self.seekHold.begin(target: seekTime)
+        let holdID = self.seekHold.begin(target: seekTime)
         self.updateFormattedTimes(progress: seekTime, duration: self.playerService.duration)
         self.isSeeking = false
 
@@ -1089,7 +1138,7 @@ struct PlayerBar: View { // swiftlint:disable:this type_body_length
         }
         Task { @MainActor in
             try? await Task.sleep(for: PlayerBarSeekHold.timeout)
-            if self.seekHold.clearIfCurrent(holdToken) {
+            if self.seekHold.clearIfCurrent(holdID) {
                 self.syncSeekValueFromDisplayedProgress()
                 self.updateFormattedTimes(
                     progress: self.displayedPlaybackProgress,

--- a/Sources/Kaset/Views/PlayerBar.swift
+++ b/Sources/Kaset/Views/PlayerBar.swift
@@ -416,6 +416,7 @@ struct PlayerBar: View { // swiftlint:disable:this type_body_length
                         : self.formattedRemaining,
                     isLive: self.playerService.isCurrentItemLive,
                     canSeek: self.canSeek,
+                    isLoading: self.isProgressLoading,
                     onScrub: { fraction in
                         self.isSeeking = true
                         self.seekValue = fraction
@@ -600,6 +601,15 @@ struct PlayerBar: View { // swiftlint:disable:this type_body_length
         self.playerService.currentTrack != nil
             && self.playerService.duration > 0
             && !self.playerService.isCurrentItemLive
+    }
+
+    private var isProgressLoading: Bool {
+        switch self.playerService.state {
+        case .loading, .buffering:
+            self.playerService.currentTrack != nil
+        case .idle, .playing, .paused, .ended, .error:
+            false
+        }
     }
 
     private var canShowCurrentTrackVideo: Bool {

--- a/Sources/Kaset/Views/PlayerBar.swift
+++ b/Sources/Kaset/Views/PlayerBar.swift
@@ -1,9 +1,11 @@
 import SwiftUI
 
+// swiftlint:disable file_length
+
 // MARK: - PlayerBar
 
 /// Player bar shown at the bottom of the content area, styled like Apple Music with Liquid Glass.
-struct PlayerBar: View {
+struct PlayerBar: View { // swiftlint:disable:this type_body_length
     private static let brandAccent = PackageResourceLookup.brandAccent
     private static let fullSongInfoWidth: CGFloat = 234
     private static let compactSongInfoWidth: CGFloat = 116
@@ -13,6 +15,9 @@ struct PlayerBar: View {
     @Environment(SongLikeStatusManager.self) private var likeStatusManager
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.playerBarNavigationAction) private var navigationAction
+    @Environment(\.playerBarCurrentAlbumID) private var currentRouteAlbumID
+    @Environment(\.playerBarCurrentArtistID) private var currentRouteArtistID
 
     /// Namespace for glass effect morphing and unioning.
     @Namespace private var playerNamespace
@@ -25,6 +30,10 @@ struct PlayerBar: View {
     @State private var volumeValue: Double = 1.0
     @State private var isAdjustingVolume = false
     @State private var showsVolumeOverlay = false
+    @State private var resolvedArtist: Artist?
+    @State private var resolvedAlbum: Playlist?
+    @State private var isResolvingArtist = false
+    @State private var isResolvingAlbum = false
 
     /// Cached formatted progress string to avoid repeated formatting.
     @State private var formattedProgress: String = "0:00"
@@ -66,6 +75,9 @@ struct PlayerBar: View {
             self.keyboardShortcuts
         }
         .zIndex(1)
+        .task(id: self.currentTitleIdentity) {
+            await self.prepareCurrentNavigationTargets()
+        }
         .onChange(of: self.playerService.progress) { _, newValue in
             if !self.isSeeking, self.playerService.duration > 0 {
                 self.seekValue = newValue / self.playerService.duration
@@ -175,17 +187,68 @@ struct PlayerBar: View {
     @ViewBuilder
     private var thumbnailView: some View {
         if let track = self.playerService.currentTrack {
-            SongThumbnailView(song: track, size: 32, cornerRadius: 6)
-                .accessibilityIdentifier(AccessibilityID.PlayerBar.thumbnail)
-        } else {
-            RoundedRectangle(cornerRadius: 6, style: .continuous)
-                .fill(.quaternary)
-                .overlay {
-                    CassetteIcon(size: 18)
-                        .foregroundStyle(.secondary)
+            if self.canOpenCurrentAlbum {
+                Button {
+                    self.openCurrentAlbum()
+                } label: {
+                    self.trackArtwork(for: track)
                 }
-                .frame(width: 32, height: 32)
+                .buttonStyle(.plain)
                 .accessibilityIdentifier(AccessibilityID.PlayerBar.thumbnail)
+                .accessibilityLabel(Text("Go to Album"))
+            } else {
+                self.trackArtwork(for: track)
+                    .accessibilityIdentifier(AccessibilityID.PlayerBar.thumbnail)
+            }
+        } else {
+            PlayerBarArtworkView(
+                width: 32,
+                height: 32,
+                cornerRadius: 6,
+                showsHoverOverlay: false
+            ) {
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .fill(.quaternary)
+                    .overlay {
+                        CassetteIcon(size: 18)
+                            .foregroundStyle(.secondary)
+                    }
+            }
+            .accessibilityIdentifier(AccessibilityID.PlayerBar.thumbnail)
+        }
+    }
+
+    private func trackArtwork(for track: Song) -> some View {
+        PlayerBarArtworkView(
+            width: 32,
+            height: 32,
+            cornerRadius: 6,
+            glowSources: self.artworkGlowSources(for: track),
+            glowIdentity: self.artworkGlowIdentity(for: track),
+            glowTargetSize: CGSize(width: 320, height: 320),
+            showsHoverOverlay: self.canOpenCurrentAlbum || self.showsCurrentAlbumHoverOnly,
+            isLoading: self.isResolvingAlbum
+        ) {
+            SongThumbnailView(song: track, size: 32, cornerRadius: 6)
+        }
+    }
+
+    private func artworkGlowSources(for track: Song) -> [URL] {
+        self.uniqueURLs([
+            track.fallbackThumbnailURL,
+            track.thumbnailURL?.highQualityThumbnailURL,
+        ])
+    }
+
+    private func artworkGlowIdentity(for track: Song) -> String {
+        track.videoId
+    }
+
+    private func uniqueURLs(_ urls: [URL?]) -> [URL] {
+        var seen = Set<URL>()
+        return urls.compactMap { url in
+            guard let url, seen.insert(url).inserted else { return nil }
+            return url
         }
     }
 
@@ -198,16 +261,86 @@ struct PlayerBar: View {
                 height: 13,
                 reduceMotion: self.reduceMotion
             )
+            .id(self.currentTitleIdentity)
             .accessibilityIdentifier(AccessibilityID.PlayerBar.trackTitle)
 
-            Text(self.artistName)
-                .font(.system(size: 12))
-                .lineLimit(1)
-                .frame(height: 12, alignment: .leading)
-                .foregroundStyle(.secondary)
-                .accessibilityIdentifier(AccessibilityID.PlayerBar.trackArtist)
+            PlayerBarMetadataButton(
+                text: self.artistName,
+                isEnabled: self.canOpenCurrentArtist,
+                isLoading: self.isResolvingArtist,
+                accessibilityIdentifier: AccessibilityID.PlayerBar.trackArtist,
+                action: self.openCurrentArtist
+            )
         }
         .frame(height: 29, alignment: .leading)
+    }
+
+    private var currentTitleIdentity: String {
+        [
+            self.playerService.currentTrack?.videoId ?? "none",
+            self.playerService.currentTrack?.title ?? "none",
+        ].joined(separator: "|")
+    }
+
+    private var canOpenCurrentArtist: Bool {
+        self.playerService.currentTrack != nil
+            && self.navigationAction.openArtist != nil
+            && !self.artistName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && (self.currentArtistTarget != nil || self.playerService.ytMusicClient != nil)
+            && !self.isCurrentArtistTarget
+    }
+
+    private var canOpenCurrentAlbum: Bool {
+        self.playerService.currentTrack != nil
+            && self.navigationAction.openAlbum != nil
+            && (self.currentAlbumTarget != nil || self.playerService.ytMusicClient != nil)
+            && !self.isCurrentAlbumTarget
+            && !self.isResolvingCurrentRouteAlbum
+    }
+
+    private var currentArtistTarget: Artist? {
+        self.primaryNavigableArtist ?? self.resolvedArtist
+    }
+
+    private var currentAlbumTarget: Playlist? {
+        self.currentAlbumPlaylist ?? self.resolvedAlbum
+    }
+
+    private var isCurrentAlbumTarget: Bool {
+        guard let currentRouteAlbumID,
+              let album = self.currentAlbumTarget
+        else { return false }
+
+        return album.id == currentRouteAlbumID
+    }
+
+    private var showsCurrentAlbumHoverOnly: Bool {
+        self.isCurrentAlbumTarget || self.isResolvingCurrentRouteAlbum
+    }
+
+    private var isResolvingCurrentRouteAlbum: Bool {
+        self.currentRouteAlbumID != nil && self.currentAlbumTarget == nil
+    }
+
+    private var isCurrentArtistTarget: Bool {
+        guard let currentRouteArtistID,
+              let artist = self.currentArtistTarget
+        else { return false }
+
+        return artist.id == currentRouteArtistID || artist.publicChannelId == currentRouteArtistID
+    }
+
+    private var currentAlbumPlaylist: Playlist? {
+        guard let track = self.playerService.currentTrack,
+              let album = track.album,
+              album.hasNavigableId
+        else { return nil }
+
+        return self.playlist(from: album, track: track)
+    }
+
+    private var primaryNavigableArtist: Artist? {
+        self.playerService.currentTrack?.artists.first(where: { $0.hasNavigableId })
     }
 
     private var artistName: String {
@@ -215,6 +348,17 @@ struct PlayerBar: View {
             return String(localized: "Kaset")
         }
         return track.artistsDisplay.isEmpty ? String(localized: "Unknown Artist") : track.artistsDisplay
+    }
+
+    private func playlist(from album: Album, track: Song) -> Playlist {
+        Playlist(
+            id: album.id,
+            title: album.title,
+            description: nil,
+            thumbnailURL: album.thumbnailURL ?? track.thumbnailURL,
+            trackCount: album.trackCount,
+            author: Artist.inline(name: album.artistsDisplay, namespace: "album-artist")
+        )
     }
 
     private var songActionButtons: some View {
@@ -405,7 +549,7 @@ struct PlayerBar: View {
 
                 PlayerBarVerticalSlider(
                     value: self.$volumeValue,
-                    accent: self.volumeSliderTint,
+                    accent: Self.brandAccent,
                     accessibilityIdentifier: AccessibilityID.PlayerBar.volumeSlider,
                     accessibilityLabel: String(localized: "Volume"),
                     onEditingChanged: { editing in
@@ -446,10 +590,6 @@ struct PlayerBar: View {
 
     private var volumeOverlayTint: Color {
         self.colorScheme == .dark ? .white.opacity(0.10) : .black.opacity(0.06)
-    }
-
-    private var volumeSliderTint: Color {
-        self.colorScheme == .dark ? .white.opacity(0.85) : .black.opacity(0.72)
     }
 
     private var volumeOverlayShadow: Color {
@@ -650,22 +790,18 @@ struct PlayerBar: View {
             Divider()
         }
 
-        if let artist {
-            NavigationLink(value: artist) {
+        if let artist, self.navigationAction.openArtist != nil {
+            Button {
+                self.openArtist(artist)
+            } label: {
                 Label("Go to Artist", systemImage: "person")
             }
         }
 
-        if let album, album.hasNavigableId {
-            let playlist = Playlist(
-                id: album.id,
-                title: album.title,
-                description: nil,
-                thumbnailURL: album.thumbnailURL ?? track.thumbnailURL,
-                trackCount: album.trackCount,
-                author: Artist.inline(name: album.artistsDisplay, namespace: "album-artist")
-            )
-            NavigationLink(value: playlist) {
+        if let album, album.hasNavigableId, self.navigationAction.openAlbum != nil {
+            Button {
+                self.openAlbum(self.playlist(from: album, track: track))
+            } label: {
                 Label("Go to Album", systemImage: "square.stack")
             }
         }
@@ -707,6 +843,159 @@ struct PlayerBar: View {
     private func likeCurrentTrack() {
         HapticService.toggle()
         self.playerService.likeCurrentTrack()
+    }
+
+    private func prepareCurrentNavigationTargets() async {
+        self.resolvedArtist = nil
+        self.resolvedAlbum = nil
+        self.isResolvingArtist = false
+        self.isResolvingAlbum = false
+
+        guard self.playerService.currentTrack != nil,
+              let client = self.playerService.ytMusicClient
+        else { return }
+
+        let identity = self.currentTitleIdentity
+
+        if self.primaryNavigableArtist == nil {
+            let artist = await self.resolveArtist(named: self.artistName, client: client)
+            guard !Task.isCancelled, self.currentTitleIdentity == identity else { return }
+            self.resolvedArtist = artist
+        }
+
+        if self.currentAlbumPlaylist == nil,
+           let track = self.playerService.currentTrack
+        {
+            let album = await self.resolveAlbum(for: track, client: client)
+            guard !Task.isCancelled, self.currentTitleIdentity == identity else { return }
+            self.resolvedAlbum = album
+        }
+    }
+
+    private func openCurrentArtist() {
+        guard self.canOpenCurrentArtist else { return }
+        guard !self.isResolvingArtist else { return }
+        HapticService.toggle()
+
+        if let artist = self.currentArtistTarget {
+            self.openArtist(artist, playsHaptic: false)
+            return
+        }
+
+        let query = self.artistName
+        guard let client = self.playerService.ytMusicClient else { return }
+        let identity = self.currentTitleIdentity
+
+        self.isResolvingArtist = true
+
+        Task {
+            let artist = await self.resolveArtist(named: query, client: client)
+            guard !Task.isCancelled, self.currentTitleIdentity == identity else { return }
+            self.resolvedArtist = artist
+            self.isResolvingArtist = false
+
+            guard let artist else { return }
+            self.openArtist(artist, playsHaptic: false)
+        }
+    }
+
+    private func openCurrentAlbum() {
+        guard self.canOpenCurrentAlbum else { return }
+        guard !self.isResolvingAlbum else { return }
+        HapticService.toggle()
+
+        if let album = self.currentAlbumTarget {
+            self.openAlbum(album, playsHaptic: false)
+            return
+        }
+
+        guard let track = self.playerService.currentTrack,
+              let client = self.playerService.ytMusicClient
+        else { return }
+
+        let identity = self.currentTitleIdentity
+        self.isResolvingAlbum = true
+
+        Task {
+            let album = await self.resolveAlbum(for: track, client: client)
+            guard !Task.isCancelled, self.currentTitleIdentity == identity else { return }
+            self.resolvedAlbum = album
+            self.isResolvingAlbum = false
+
+            guard let album else { return }
+            self.openAlbum(album, playsHaptic: false)
+        }
+    }
+
+    private func openArtist(_ artist: Artist, playsHaptic: Bool = true) {
+        if playsHaptic {
+            HapticService.toggle()
+        }
+        self.navigationAction.openArtist?(artist)
+    }
+
+    private func openAlbum(_ album: Playlist, playsHaptic: Bool = true) {
+        if playsHaptic {
+            HapticService.toggle()
+        }
+        self.navigationAction.openAlbum?(album)
+    }
+
+    private func resolveArtist(named name: String, client: any YTMusicClientProtocol) async -> Artist? {
+        do {
+            let response = try await client.searchArtists(query: name)
+            return response.artists.first { artist in
+                artist.hasNavigableId && self.matchesSearchResultTitle(artist.name, query: name)
+            } ?? response.artists.first(where: \.hasNavigableId)
+        } catch {
+            DiagnosticsLogger.ui.error("Failed to resolve player bar artist: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    private func resolveAlbum(for track: Song, client: any YTMusicClientProtocol) async -> Playlist? {
+        if let album = track.album,
+           let playlist = await self.resolveAlbum(named: album.title, fallbackTrack: track, client: client)
+        {
+            return playlist
+        }
+
+        do {
+            let response = try await client.searchSongsWithPagination(query: "\(track.title) \(self.artistName)")
+            let matchedSong = response.songs.first { $0.videoId == track.videoId }
+                ?? response.songs.first { self.matchesSearchResultTitle($0.title, query: track.title) }
+
+            guard let album = matchedSong?.album, album.hasNavigableId else { return nil }
+            return self.playlist(from: album, track: matchedSong ?? track)
+        } catch {
+            DiagnosticsLogger.ui.error("Failed to resolve player bar album from song search: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    private func resolveAlbum(
+        named title: String,
+        fallbackTrack track: Song,
+        client: any YTMusicClientProtocol
+    ) async -> Playlist? {
+        do {
+            let response = try await client.searchAlbums(query: title)
+            guard let album = response.albums.first(where: { album in
+                album.hasNavigableId && self.matchesSearchResultTitle(album.title, query: title)
+            }) ?? response.albums.first(where: \.hasNavigableId) else {
+                return nil
+            }
+
+            return self.playlist(from: album, track: track)
+        } catch {
+            DiagnosticsLogger.ui.error("Failed to resolve player bar album: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    private func matchesSearchResultTitle(_ title: String, query: String) -> Bool {
+        let normalizedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines).localizedCaseInsensitiveCompare(query)
+        return normalizedTitle == .orderedSame
     }
 
     private func dislikeCurrentTrack() {

--- a/Sources/Kaset/Views/PlayerBarArtworkGlow.swift
+++ b/Sources/Kaset/Views/PlayerBarArtworkGlow.swift
@@ -1,0 +1,130 @@
+import AppKit
+import SwiftUI
+
+// MARK: - PlayerBarArtworkGlow
+
+struct PlayerBarArtworkGlow: View {
+    let sources: [URL]
+    let identity: String?
+    let targetSize: CGSize?
+    let width: CGFloat
+    let height: CGFloat
+    let cornerRadius: CGFloat
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    @Environment(\.colorScheme) private var colorScheme
+
+    @State private var image: NSImage?
+    @State private var isVisible = false
+
+    var body: some View {
+        Group {
+            if self.reduceTransparency {
+                Color.clear
+            } else if let image {
+                Image(nsImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(width: self.width, height: self.height)
+                    .clipShape(.rect(cornerRadius: self.cornerRadius, style: .continuous))
+                    .compositingGroup()
+                    .saturation(self.glowSaturation)
+                    .brightness(self.glowBrightness)
+                    .scaleEffect(self.glowScale)
+                    .blur(radius: self.glowRadius)
+                    .blendMode(self.glowBlendMode)
+                    .opacity(self.isVisible ? self.glowOpacity : 0)
+            } else {
+                Color.clear
+            }
+        }
+        .frame(width: self.width, height: self.height)
+        .allowsHitTesting(false)
+        .accessibilityHidden(true)
+        .task(id: self.loadKey) {
+            await self.loadImage()
+        }
+    }
+
+    private var loadKey: String {
+        self.identity ?? "none"
+    }
+
+    private var glowOpacity: Double {
+        self.colorScheme == .dark ? 0.40 : 0.50
+    }
+
+    private var glowRadius: CGFloat {
+        min(max(self.width, self.height) * 0.18, 7)
+    }
+
+    private var glowScale: CGFloat {
+        self.width > self.height ? 1.16 : 1.22
+    }
+
+    private var glowSaturation: Double {
+        self.colorScheme == .dark ? 1.85 : 2.05
+    }
+
+    private var glowBrightness: Double {
+        self.colorScheme == .dark ? 0 : 0.04
+    }
+
+    private var glowBlendMode: BlendMode {
+        self.colorScheme == .dark ? .plusLighter : .multiply
+    }
+
+    @MainActor
+    private func loadImage() async {
+        let sources = self.sources
+
+        await self.hideCurrentImage()
+
+        guard !sources.isEmpty else {
+            self.image = nil
+            return
+        }
+
+        let loadedImage = await Self.loadFirstAvailableImage(from: sources, targetSize: self.targetSize)
+        guard !Task.isCancelled else { return }
+
+        self.image = loadedImage
+        guard loadedImage != nil else { return }
+
+        if self.reduceMotion {
+            self.isVisible = true
+        } else {
+            withAnimation(.easeInOut(duration: 0.22)) {
+                self.isVisible = true
+            }
+        }
+    }
+
+    @MainActor
+    private func hideCurrentImage() async {
+        guard self.image != nil else { return }
+
+        if self.reduceMotion {
+            self.isVisible = false
+            return
+        }
+
+        withAnimation(.easeInOut(duration: 0.16)) {
+            self.isVisible = false
+        }
+
+        try? await Task.sleep(nanoseconds: 160_000_000)
+    }
+
+    private static func loadFirstAvailableImage(from sources: [URL], targetSize: CGSize?) async -> NSImage? {
+        for source in sources {
+            if Task.isCancelled { return nil }
+            if let image = await ImageCache.shared.image(for: source, targetSize: targetSize) {
+                return image
+            }
+        }
+
+        return nil
+    }
+}

--- a/Sources/Kaset/Views/PlayerBarArtworkView.swift
+++ b/Sources/Kaset/Views/PlayerBarArtworkView.swift
@@ -1,0 +1,72 @@
+import SwiftUI
+
+// MARK: - PlayerBarArtworkView
+
+struct PlayerBarArtworkView<Content: View>: View {
+    let width: CGFloat
+    let height: CGFloat
+    let cornerRadius: CGFloat
+    var glowSources: [URL] = []
+    var glowIdentity: String?
+    var glowTargetSize: CGSize?
+    var showsHoverOverlay = true
+    var isLoading = false
+    @ViewBuilder var content: () -> Content
+
+    @Environment(\.colorScheme) private var colorScheme
+    @State private var isHovering = false
+
+    var body: some View {
+        ZStack {
+            PlayerBarArtworkGlow(
+                sources: self.glowSources,
+                identity: self.glowIdentity,
+                targetSize: self.glowTargetSize,
+                width: self.width,
+                height: self.height,
+                cornerRadius: self.cornerRadius
+            )
+
+            ZStack {
+                self.content()
+                    .frame(width: self.width, height: self.height)
+                    .blur(radius: self.showsActiveOverlay ? 3 : 0)
+
+                if self.showsActiveOverlay {
+                    RoundedRectangle(cornerRadius: self.cornerRadius, style: .continuous)
+                        .fill(self.overlayFill)
+
+                    if self.isLoading {
+                        ProgressView()
+                            .controlSize(.small)
+                            .scaleEffect(0.55)
+                    } else {
+                        Image(systemName: "music.pages.fill")
+                            .font(.system(size: self.iconSize, weight: .semibold))
+                            .foregroundStyle(.primary)
+                    }
+                }
+            }
+            .frame(width: self.width, height: self.height)
+            .clipShape(.rect(cornerRadius: self.cornerRadius, style: .continuous))
+        }
+        .frame(width: self.width, height: self.height)
+        .contentShape(.rect(cornerRadius: self.cornerRadius, style: .continuous))
+        .animation(.easeInOut(duration: 0.16), value: self.showsActiveOverlay)
+        .onHover { hovering in
+            self.isHovering = hovering
+        }
+    }
+
+    private var showsActiveOverlay: Bool {
+        self.showsHoverOverlay && (self.isHovering || self.isLoading)
+    }
+
+    private var overlayFill: Color {
+        self.colorScheme == .dark ? .white.opacity(0.14) : .white.opacity(0.42)
+    }
+
+    private var iconSize: CGFloat {
+        min(self.width, self.height) >= 32 ? 14 : 13
+    }
+}

--- a/Sources/Kaset/Views/PlayerBarMarqueeText.swift
+++ b/Sources/Kaset/Views/PlayerBarMarqueeText.swift
@@ -18,6 +18,7 @@ struct PlayerBarMarqueeText: View {
     private let copyGap: CGFloat = 24
     private let initialDelay: TimeInterval = 1.4
     private let scrollSpeed: CGFloat = 18
+    private let descenderAllowance: CGFloat = 3
 
     private var needsMarquee: Bool {
         !self.reduceMotion && self.effectiveTextWidth > self.containerWidth + 1
@@ -34,7 +35,7 @@ struct PlayerBarMarqueeText: View {
             }
             .fixedSize(horizontal: true, vertical: false)
             .offset(x: self.needsMarquee ? self.offset : 0)
-            .frame(width: proxy.size.width, height: self.height, alignment: .leading)
+            .frame(width: proxy.size.width, height: self.renderHeight, alignment: .leading)
             .clipped()
             .mask(self.maskView(phase: self.fadeMaskPhase))
             .overlay(alignment: .leading) {
@@ -59,6 +60,13 @@ struct PlayerBarMarqueeText: View {
         .task(id: self.marqueeTaskID) {
             await self.runMarqueeLoop()
         }
+        .onChange(of: self.text) { _, _ in
+            self.resetMarqueePositionImmediately()
+        }
+    }
+
+    private var renderHeight: CGFloat {
+        self.height + self.descenderAllowance
     }
 
     private var textView: some View {
@@ -159,10 +167,7 @@ struct PlayerBarMarqueeText: View {
 
     @MainActor
     private func resetMarqueePosition() {
-        self.resetOffsetWithoutAnimation()
-        withAnimation(.easeInOut(duration: 0.12)) {
-            self.fadeMaskPhase = .inactive
-        }
+        self.resetMarqueePositionImmediately()
     }
 
     @MainActor
@@ -171,6 +176,16 @@ struct PlayerBarMarqueeText: View {
         transaction.animation = nil
         withTransaction(transaction) {
             self.offset = 0
+        }
+    }
+
+    @MainActor
+    private func resetMarqueePositionImmediately() {
+        var transaction = Transaction()
+        transaction.animation = nil
+        withTransaction(transaction) {
+            self.offset = 0
+            self.fadeMaskPhase = .inactive
         }
     }
 }

--- a/Sources/Kaset/Views/PlayerBarMetadataLink.swift
+++ b/Sources/Kaset/Views/PlayerBarMetadataLink.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+
+// MARK: - PlayerBarMetadataButton
+
+struct PlayerBarMetadataButton: View {
+    let text: String
+    let isEnabled: Bool
+    var isLoading = false
+    var accessibilityIdentifier: String?
+    let action: () -> Void
+
+    var body: some View {
+        if self.isEnabled {
+            PlayerBarMetadataLinkLabel(text: self.text, isLoading: self.isLoading)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(.rect)
+                .onTapGesture(perform: self.action)
+                .accessibilityAddTraits(.isButton)
+                .accessibilityAction {
+                    self.action()
+                }
+                .playerBarMetadataAccessibilityIdentifier(self.accessibilityIdentifier)
+        } else {
+            PlayerBarMetadataLinkLabel(text: self.text, isLoading: false)
+                .playerBarMetadataAccessibilityIdentifier(self.accessibilityIdentifier)
+        }
+    }
+}
+
+// MARK: - PlayerBarMetadataLinkLabel
+
+private struct PlayerBarMetadataLinkLabel: View {
+    let text: String
+    var isLoading = false
+
+    @State private var isHovering = false
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Text(self.text)
+                .font(.system(size: 12))
+                .lineLimit(1)
+
+            if self.isLoading {
+                ProgressView()
+                    .controlSize(.small)
+                    .scaleEffect(0.42)
+                    .frame(width: 8, height: 8)
+            }
+        }
+        .frame(height: 12, alignment: .leading)
+        .padding(.vertical, 6)
+        .padding(.trailing, 14)
+        .contentShape(.rect)
+        .padding(.vertical, -6)
+        .padding(.trailing, -14)
+        .foregroundStyle(self.isHovering ? .primary : .secondary)
+        .animation(.easeInOut(duration: 0.15), value: self.isHovering)
+        .animation(.easeInOut(duration: 0.12), value: self.isLoading)
+        .onHover { hovering in
+            self.isHovering = hovering
+        }
+    }
+}
+
+// MARK: - Accessibility Helpers
+
+private extension View {
+    @ViewBuilder
+    func playerBarMetadataAccessibilityIdentifier(_ identifier: String?) -> some View {
+        if let identifier {
+            self.accessibilityIdentifier(identifier)
+        } else {
+            self
+        }
+    }
+}

--- a/Sources/Kaset/Views/PlayerBarNavigationAction.swift
+++ b/Sources/Kaset/Views/PlayerBarNavigationAction.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+// MARK: - PlayerBarNavigationAction
+
+struct PlayerBarNavigationAction: @unchecked Sendable {
+    var openArtist: ((Artist) -> Void)?
+    var openAlbum: ((Playlist) -> Void)?
+
+    static let disabled = PlayerBarNavigationAction()
+}
+
+extension EnvironmentValues {
+    @Entry var playerBarNavigationAction: PlayerBarNavigationAction = .disabled
+    @Entry var playerBarCurrentAlbumID: String?
+    @Entry var playerBarCurrentArtistID: String?
+}
+
+// MARK: - PlayerBarMusicNavigationModifier
+
+private struct PlayerBarMusicNavigationModifier: ViewModifier {
+    @Binding var navigationPath: NavigationPath
+
+    func body(content: Content) -> some View {
+        content
+            .environment(\.playerBarNavigationAction, PlayerBarNavigationAction(
+                openArtist: { artist in
+                    self.navigationPath.append(artist)
+                },
+                openAlbum: { album in
+                    self.navigationPath.append(album)
+                }
+            ))
+    }
+}
+
+extension View {
+    func playerBarMusicNavigation(path: Binding<NavigationPath>) -> some View {
+        self.modifier(PlayerBarMusicNavigationModifier(navigationPath: path))
+    }
+}

--- a/Sources/Kaset/Views/PlayerBarProgressLane.swift
+++ b/Sources/Kaset/Views/PlayerBarProgressLane.swift
@@ -13,6 +13,8 @@ struct PlayerBarProgressLane: View {
     let onCommit: () -> Void
 
     @Environment(\.colorScheme) private var colorScheme
+    @State private var isDragging = false
+    @State private var isHovering = false
 
     private var clampedFraction: CGFloat {
         CGFloat(min(max(0, self.fraction), 1))
@@ -57,19 +59,22 @@ struct PlayerBarProgressLane: View {
         GeometryReader { proxy in
             let width = proxy.size.width
             let fillWidth = width * self.clampedFraction
-            let thumbDiameter: CGFloat = 12
+            let thumbDiameter = PlayerBarSliderVisuals.thumbDiameter(
+                isHovering: self.isHovering,
+                isDragging: self.isDragging
+            )
 
             ZStack(alignment: .topLeading) {
                 Capsule()
                     .fill(self.trackColor)
-                    .frame(height: 4)
+                    .frame(height: PlayerBarSliderVisuals.trackThickness)
 
                 UnevenRoundedRectangle(
                     topLeadingRadius: 999,
                     bottomLeadingRadius: 999
                 )
                 .fill(self.accent)
-                .frame(width: fillWidth, height: 4)
+                .frame(width: fillWidth, height: PlayerBarSliderVisuals.trackThickness)
                 .opacity(self.isLive ? 0 : 1)
 
                 Circle()
@@ -77,24 +82,35 @@ struct PlayerBarProgressLane: View {
                     .frame(width: thumbDiameter, height: thumbDiameter)
                     .offset(
                         x: min(max(0, fillWidth - thumbDiameter / 2), max(0, width - thumbDiameter)),
-                        y: -4
+                        y: PlayerBarSliderVisuals.trackThickness / 2 - thumbDiameter / 2
                     )
                     .opacity(self.canSeek ? 1 : 0)
             }
             .frame(maxHeight: .infinity, alignment: .top)
+            .animation(PlayerBarSliderVisuals.trackAnimation, value: self.isHovering)
+            .animation(PlayerBarSliderVisuals.thumbAnimation, value: self.isDragging)
+            .animation(PlayerBarSliderVisuals.thumbAnimation, value: self.isHovering)
+            .padding(PlayerBarSliderVisuals.hitOutset)
             .contentShape(Rectangle())
             .gesture(
                 DragGesture(minimumDistance: 0)
                     .onChanged { value in
                         guard self.canSeek, width > 0 else { return }
-                        let fraction = Double(min(max(0, value.location.x / width), 1))
+                        self.isDragging = true
+                        let x = value.location.x - PlayerBarSliderVisuals.hitOutset
+                        let fraction = Double(min(max(0, x / width), 1))
                         self.onScrub(fraction)
                     }
                     .onEnded { _ in
                         guard self.canSeek else { return }
+                        self.isDragging = false
                         self.onCommit()
                     }
             )
+            .padding(-PlayerBarSliderVisuals.hitOutset)
+            .onHover { hovering in
+                self.isHovering = hovering
+            }
         }
         .frame(height: 12)
     }
@@ -105,6 +121,9 @@ struct PlayerBarProgressLane: View {
     }
 
     private var trackColor: Color {
-        self.colorScheme == .dark ? .white.opacity(0.18) : .black.opacity(0.18)
+        PlayerBarSliderVisuals.trackColor(
+            colorScheme: self.colorScheme,
+            isActive: self.isHovering || self.isDragging
+        )
     }
 }

--- a/Sources/Kaset/Views/PlayerBarProgressLane.swift
+++ b/Sources/Kaset/Views/PlayerBarProgressLane.swift
@@ -9,9 +9,11 @@ struct PlayerBarProgressLane: View {
     let remainingText: String
     let isLive: Bool
     let canSeek: Bool
+    let isLoading: Bool
     let onScrub: (Double) -> Void
     let onCommit: () -> Void
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.colorScheme) private var colorScheme
     @State private var isDragging = false
     @State private var isHovering = false
@@ -63,6 +65,8 @@ struct PlayerBarProgressLane: View {
                 isHovering: self.isHovering,
                 isDragging: self.isDragging
             )
+            let fillColor = self.isLoading ? self.loadingFillColor : self.accent
+            let thumbColor = self.isLoading ? self.loadingThumbColor : self.accent
 
             ZStack(alignment: .topLeading) {
                 Capsule()
@@ -73,12 +77,21 @@ struct PlayerBarProgressLane: View {
                     topLeadingRadius: 999,
                     bottomLeadingRadius: 999
                 )
-                .fill(self.accent)
+                .fill(fillColor)
                 .frame(width: fillWidth, height: PlayerBarSliderVisuals.trackThickness)
                 .opacity(self.isLive ? 0 : 1)
 
+                if self.isLoading {
+                    PlayerBarSliderLoadingShimmer(
+                        colorScheme: self.colorScheme,
+                        reduceMotion: self.reduceMotion
+                    )
+                    .frame(height: PlayerBarSliderVisuals.trackThickness)
+                    .transition(.opacity)
+                }
+
                 Circle()
-                    .fill(self.accent)
+                    .fill(thumbColor)
                     .frame(width: thumbDiameter, height: thumbDiameter)
                     .offset(
                         x: min(max(0, fillWidth - thumbDiameter / 2), max(0, width - thumbDiameter)),
@@ -90,6 +103,7 @@ struct PlayerBarProgressLane: View {
             .animation(PlayerBarSliderVisuals.trackAnimation, value: self.isHovering)
             .animation(PlayerBarSliderVisuals.thumbAnimation, value: self.isDragging)
             .animation(PlayerBarSliderVisuals.thumbAnimation, value: self.isHovering)
+            .animation(.easeInOut(duration: 0.18), value: self.isLoading)
             .padding(PlayerBarSliderVisuals.hitOutset)
             .contentShape(Rectangle())
             .gesture(
@@ -123,7 +137,15 @@ struct PlayerBarProgressLane: View {
     private var trackColor: Color {
         PlayerBarSliderVisuals.trackColor(
             colorScheme: self.colorScheme,
-            isActive: self.isHovering || self.isDragging
+            isActive: !self.isLoading && (self.isHovering || self.isDragging)
         )
+    }
+
+    private var loadingFillColor: Color {
+        PlayerBarSliderVisuals.loadingFillColor(colorScheme: self.colorScheme)
+    }
+
+    private var loadingThumbColor: Color {
+        PlayerBarSliderVisuals.loadingThumbColor(colorScheme: self.colorScheme)
     }
 }

--- a/Sources/Kaset/Views/PlayerBarSeekHold.swift
+++ b/Sources/Kaset/Views/PlayerBarSeekHold.swift
@@ -3,9 +3,11 @@ import Foundation
 // MARK: - PlayerBarSeekHold
 
 struct PlayerBarSeekHold {
-    static let timeout: Duration = .milliseconds(2200)
+    private static let timeoutMilliseconds = 2200
 
-    private static let timeoutSeconds: TimeInterval = 2.2
+    static let timeout: Duration = .milliseconds(Self.timeoutMilliseconds)
+
+    private static let timeoutSeconds = TimeInterval(Self.timeoutMilliseconds) / 1000
     private static let minimumConfirmationAgeSeconds: TimeInterval = 0.35
     private static let confirmationTolerance: TimeInterval = 1.25
 
@@ -21,18 +23,19 @@ struct PlayerBarSeekHold {
         self.target
     }
 
-    mutating func begin(target: TimeInterval) -> UUID {
+    @discardableResult
+    mutating func begin(target: TimeInterval, issuedAt: Date = Date()) -> UUID {
         let newID = UUID()
         self.target = max(0, target)
-        self.issuedAt = Date()
+        self.issuedAt = issuedAt
         self.id = newID
         return newID
     }
 
-    mutating func reconcile(observedProgress: TimeInterval) {
+    mutating func reconcile(observedProgress: TimeInterval, now: Date = Date()) {
         guard let target, let issuedAt else { return }
 
-        let age = Date().timeIntervalSince(issuedAt)
+        let age = now.timeIntervalSince(issuedAt)
         if age >= Self.timeoutSeconds {
             self.clear()
             return

--- a/Sources/Kaset/Views/PlayerBarSeekHold.swift
+++ b/Sources/Kaset/Views/PlayerBarSeekHold.swift
@@ -11,7 +11,7 @@ struct PlayerBarSeekHold {
 
     private var target: TimeInterval?
     private var issuedAt: Date?
-    private var token = UUID()
+    private var id = UUID()
 
     var isActive: Bool {
         self.target != nil
@@ -22,11 +22,11 @@ struct PlayerBarSeekHold {
     }
 
     mutating func begin(target: TimeInterval) -> UUID {
-        let newToken = UUID()
+        let newID = UUID()
         self.target = max(0, target)
         self.issuedAt = Date()
-        self.token = newToken
-        return newToken
+        self.id = newID
+        return newID
     }
 
     mutating func reconcile(observedProgress: TimeInterval) {
@@ -51,8 +51,8 @@ struct PlayerBarSeekHold {
     }
 
     @discardableResult
-    mutating func clearIfCurrent(_ token: UUID) -> Bool {
-        guard self.target != nil, self.token == token else { return false }
+    mutating func clearIfCurrent(_ id: UUID) -> Bool {
+        guard self.target != nil, self.id == id else { return false }
         self.clear()
         return true
     }

--- a/Sources/Kaset/Views/PlayerBarSeekHold.swift
+++ b/Sources/Kaset/Views/PlayerBarSeekHold.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+// MARK: - PlayerBarSeekHold
+
+struct PlayerBarSeekHold {
+    static let timeout: Duration = .milliseconds(2200)
+
+    private static let timeoutSeconds: TimeInterval = 2.2
+    private static let minimumConfirmationAgeSeconds: TimeInterval = 0.35
+    private static let confirmationTolerance: TimeInterval = 1.25
+
+    private var target: TimeInterval?
+    private var issuedAt: Date?
+    private var token = UUID()
+
+    var isActive: Bool {
+        self.target != nil
+    }
+
+    var targetProgress: TimeInterval? {
+        self.target
+    }
+
+    mutating func begin(target: TimeInterval) -> UUID {
+        let newToken = UUID()
+        self.target = max(0, target)
+        self.issuedAt = Date()
+        self.token = newToken
+        return newToken
+    }
+
+    mutating func reconcile(observedProgress: TimeInterval) {
+        guard let target, let issuedAt else { return }
+
+        let age = Date().timeIntervalSince(issuedAt)
+        if age >= Self.timeoutSeconds {
+            self.clear()
+            return
+        }
+
+        if age >= Self.minimumConfirmationAgeSeconds,
+           abs(observedProgress - target) <= Self.confirmationTolerance
+        {
+            self.clear()
+        }
+    }
+
+    mutating func clear() {
+        self.target = nil
+        self.issuedAt = nil
+    }
+
+    @discardableResult
+    mutating func clearIfCurrent(_ token: UUID) -> Bool {
+        guard self.target != nil, self.token == token else { return false }
+        self.clear()
+        return true
+    }
+
+    func displayProgress(observedProgress: TimeInterval) -> TimeInterval {
+        self.target ?? observedProgress
+    }
+}

--- a/Sources/Kaset/Views/PlayerBarSliderLoadingShimmer.swift
+++ b/Sources/Kaset/Views/PlayerBarSliderLoadingShimmer.swift
@@ -1,0 +1,53 @@
+import SwiftUI
+
+// MARK: - PlayerBarSliderLoadingShimmer
+
+struct PlayerBarSliderLoadingShimmer: View {
+    let colorScheme: ColorScheme
+    let reduceMotion: Bool
+
+    @State private var isAnimating = false
+
+    var body: some View {
+        GeometryReader { proxy in
+            let width = proxy.size.width
+            let bandWidth = max(42, width * 0.34)
+
+            Capsule()
+                .fill(Color.clear)
+                .overlay(alignment: .leading) {
+                    LinearGradient(
+                        colors: [
+                            Color.clear,
+                            self.shimmerColor.opacity(self.reduceMotion ? 0.28 : 0.08),
+                            self.shimmerColor.opacity(self.reduceMotion ? 0.42 : 0.40),
+                            self.shimmerColor.opacity(self.reduceMotion ? 0.28 : 0.08),
+                            Color.clear,
+                        ],
+                        startPoint: .leading,
+                        endPoint: .trailing
+                    )
+                    .frame(width: bandWidth)
+                    .offset(x: self.reduceMotion ? (width - bandWidth) / 2 : self.shimmerOffset(width: width, bandWidth: bandWidth))
+                }
+                .clipShape(.capsule)
+                .onAppear {
+                    guard !self.reduceMotion else { return }
+                    self.isAnimating = false
+                    withAnimation(.linear(duration: 1.05).repeatForever(autoreverses: false)) {
+                        self.isAnimating = true
+                    }
+                }
+        }
+        .allowsHitTesting(false)
+        .accessibilityHidden(true)
+    }
+
+    private var shimmerColor: Color {
+        self.colorScheme == .dark ? .white : .black
+    }
+
+    private func shimmerOffset(width: CGFloat, bandWidth: CGFloat) -> CGFloat {
+        self.isAnimating ? width + bandWidth * 0.25 : -bandWidth * 1.25
+    }
+}

--- a/Sources/Kaset/Views/PlayerBarSliderVisuals.swift
+++ b/Sources/Kaset/Views/PlayerBarSliderVisuals.swift
@@ -17,6 +17,14 @@ enum PlayerBarSliderVisuals {
         return colorScheme == .dark ? .white.opacity(opacity) : .black.opacity(opacity)
     }
 
+    static func loadingFillColor(colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark ? .white.opacity(0.42) : .black.opacity(0.30)
+    }
+
+    static func loadingThumbColor(colorScheme: ColorScheme) -> Color {
+        Color(.sRGB, white: colorScheme == .dark ? 0.70 : 0.55, opacity: 1)
+    }
+
     static func thumbDiameter(isHovering: Bool, isDragging: Bool) -> CGFloat {
         if isDragging {
             return self.thumbActiveDiameter

--- a/Sources/Kaset/Views/PlayerBarSliderVisuals.swift
+++ b/Sources/Kaset/Views/PlayerBarSliderVisuals.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+// MARK: - PlayerBarSliderVisuals
+
+enum PlayerBarSliderVisuals {
+    static let trackThickness: CGFloat = 4
+    static let hitOutset: CGFloat = 8
+    static let thumbDefaultDiameter: CGFloat = 10
+    static let thumbHoverDiameter: CGFloat = 12
+    static let thumbActiveDiameter: CGFloat = 14
+
+    static let thumbAnimation = Animation.spring(response: 0.24, dampingFraction: 0.72)
+    static let trackAnimation = Animation.easeInOut(duration: 0.15)
+
+    static func trackColor(colorScheme: ColorScheme, isActive: Bool) -> Color {
+        let opacity = isActive ? 0.28 : 0.18
+        return colorScheme == .dark ? .white.opacity(opacity) : .black.opacity(opacity)
+    }
+
+    static func thumbDiameter(isHovering: Bool, isDragging: Bool) -> CGFloat {
+        if isDragging {
+            return self.thumbActiveDiameter
+        }
+        if isHovering {
+            return self.thumbHoverDiameter
+        }
+        return self.thumbDefaultDiameter
+    }
+}

--- a/Sources/Kaset/Views/PlayerBarVerticalSlider.swift
+++ b/Sources/Kaset/Views/PlayerBarVerticalSlider.swift
@@ -13,6 +13,7 @@ struct PlayerBarVerticalSlider: View {
 
     @Environment(\.colorScheme) private var colorScheme
     @State private var isDragging = false
+    @State private var isHovering = false
 
     private var clampedValue: CGFloat {
         CGFloat(min(max(0, self.value), 1))
@@ -22,19 +23,22 @@ struct PlayerBarVerticalSlider: View {
         GeometryReader { proxy in
             let height = proxy.size.height
             let fillHeight = height * self.clampedValue
-            let thumbDiameter: CGFloat = 12
+            let thumbDiameter = PlayerBarSliderVisuals.thumbDiameter(
+                isHovering: self.isHovering,
+                isDragging: self.isDragging
+            )
 
             ZStack(alignment: .bottom) {
                 Capsule()
                     .fill(self.trackColor)
-                    .frame(width: 4)
+                    .frame(width: PlayerBarSliderVisuals.trackThickness)
 
                 UnevenRoundedRectangle(
                     bottomLeadingRadius: 999,
                     bottomTrailingRadius: 999
                 )
                 .fill(self.accent)
-                .frame(width: 4, height: fillHeight)
+                .frame(width: PlayerBarSliderVisuals.trackThickness, height: fillHeight)
 
                 Circle()
                     .fill(self.accent)
@@ -42,17 +46,28 @@ struct PlayerBarVerticalSlider: View {
                     .offset(y: -min(max(0, fillHeight - thumbDiameter / 2), max(0, height - thumbDiameter)))
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .animation(PlayerBarSliderVisuals.trackAnimation, value: self.isHovering)
+            .animation(PlayerBarSliderVisuals.thumbAnimation, value: self.isDragging)
+            .animation(PlayerBarSliderVisuals.thumbAnimation, value: self.isHovering)
+            .padding(PlayerBarSliderVisuals.hitOutset)
             .contentShape(Rectangle())
             .gesture(
                 DragGesture(minimumDistance: 0)
                     .onChanged { drag in
                         self.beginEditingIfNeeded()
-                        self.updateValue(from: drag.location.y, height: height)
+                        self.updateValue(
+                            from: drag.location.y - PlayerBarSliderVisuals.hitOutset,
+                            height: height
+                        )
                     }
                     .onEnded { _ in
                         self.endEditingIfNeeded()
                     }
             )
+            .padding(-PlayerBarSliderVisuals.hitOutset)
+            .onHover { hovering in
+                self.isHovering = hovering
+            }
         }
         .frame(width: 28, height: 122)
         .playerBarVerticalSliderAccessibilityIdentifier(self.accessibilityIdentifier)
@@ -104,7 +119,10 @@ struct PlayerBarVerticalSlider: View {
     }
 
     private var trackColor: Color {
-        self.colorScheme == .dark ? .white.opacity(0.18) : .black.opacity(0.18)
+        PlayerBarSliderVisuals.trackColor(
+            colorScheme: self.colorScheme,
+            isActive: self.isHovering || self.isDragging
+        )
     }
 }
 

--- a/Sources/Kaset/Views/PlaylistDetailView.swift
+++ b/Sources/Kaset/Views/PlaylistDetailView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 @available(macOS 26.0, *)
 struct PlaylistDetailView: View {
     let playlist: Playlist
+    let playerBarNavigationAction: PlayerBarNavigationAction
     @State var viewModel: PlaylistDetailViewModel
     @Environment(PlayerService.self) var playerService
     @Environment(FavoritesManager.self) private var favoritesManager
@@ -33,8 +34,13 @@ struct PlaylistDetailView: View {
 
     private let logger = DiagnosticsLogger.ai
 
-    init(playlist: Playlist, viewModel: PlaylistDetailViewModel) {
+    init(
+        playlist: Playlist,
+        viewModel: PlaylistDetailViewModel,
+        playerBarNavigationAction: PlayerBarNavigationAction = .disabled
+    ) {
         self.playlist = playlist
+        self.playerBarNavigationAction = playerBarNavigationAction
         _viewModel = State(initialValue: viewModel)
     }
 
@@ -69,6 +75,8 @@ struct PlaylistDetailView: View {
             if case .error = self.viewModel.loadingState {
             } else {
                 PlayerBar()
+                    .environment(\.playerBarNavigationAction, self.playerBarNavigationAction)
+                    .environment(\.playerBarCurrentAlbumID, self.playlist.isAlbum ? self.playlist.id : nil)
             }
         }
         .task {

--- a/Sources/Kaset/Views/PodcastsView.swift
+++ b/Sources/Kaset/Views/PodcastsView.swift
@@ -38,10 +38,15 @@ struct PodcastsView: View {
             .navigationDestination(for: PodcastShow.self) { show in
                 PodcastShowView(show: show, client: self.viewModel.client)
             }
-            .navigationDestinations(client: self.viewModel.client)
+            .navigationDestinations(
+                client: self.viewModel.client,
+                playerBarNavigationAction: self.playerBarNavigationAction
+            )
+            .playerBarMusicNavigation(path: self.$navigationPath)
         }
         .safeAreaInset(edge: .bottom, spacing: 0) {
             PlayerBar()
+                .playerBarMusicNavigation(path: self.$navigationPath)
         }
         .onAppear {
             if self.viewModel.loadingState == .idle {
@@ -53,6 +58,13 @@ struct PodcastsView: View {
         .refreshable {
             await self.viewModel.refresh()
         }
+    }
+
+    private var playerBarNavigationAction: PlayerBarNavigationAction {
+        PlayerBarNavigationAction(
+            openArtist: { self.navigationPath.append($0) },
+            openAlbum: { self.navigationPath.append($0) }
+        )
     }
 
     // MARK: - Views

--- a/Sources/Kaset/Views/SearchView.swift
+++ b/Sources/Kaset/Views/SearchView.swift
@@ -39,10 +39,16 @@ struct SearchView: View {
                 self.contentView
             }
             .localizedNavigationTitle("Search")
-            .navigationDestinations(client: self.viewModel.client)
+            .navigationDestinations(
+                client: self.viewModel.client,
+                playerBarNavigationAction: self.playerBarNavigationAction
+            )
+            .playerBarMusicNavigation(path: self.$navigationPath)
         }
+        .playerBarMusicNavigation(path: self.$navigationPath)
         .safeAreaInset(edge: .bottom, spacing: 0) {
             PlayerBar()
+                .playerBarMusicNavigation(path: self.$navigationPath)
         }
         .onAppear {
             self.isSearchFieldFocused = true
@@ -53,6 +59,13 @@ struct SearchView: View {
                 self.focusTrigger = false
             }
         }
+    }
+
+    private var playerBarNavigationAction: PlayerBarNavigationAction {
+        PlayerBarNavigationAction(
+            openArtist: { self.navigationPath.append($0) },
+            openAlbum: { self.navigationPath.append($0) }
+        )
     }
 
     // MARK: - Search Bar

--- a/Sources/Kaset/Views/SharedViews/NavigationDestinationsModifier.swift
+++ b/Sources/Kaset/Views/SharedViews/NavigationDestinationsModifier.swift
@@ -6,9 +6,11 @@ import SwiftUI
 /// Note: Lyrics sidebar is handled globally in MainWindow, outside the NavigationSplitView.
 struct NavigationDestinationsModifier: ViewModifier {
     let client: any YTMusicClientProtocol
+    let playerBarNavigationAction: PlayerBarNavigationAction
     @Environment(LibraryViewModel.self) private var libraryViewModel: LibraryViewModel?
     @Environment(\.usesLegacyMacOS15UI) private var usesLegacyMacOS15UI
 
+    // swiftlint:disable:next function_body_length
     func body(content: Content) -> some View {
         content
             .navigationDestination(for: Playlist.self) { playlist in
@@ -35,7 +37,8 @@ struct NavigationDestinationsModifier: ViewModifier {
                                 viewModel: PlaylistDetailViewModel(
                                     playlist: playlist,
                                     client: self.client
-                                )
+                                ),
+                                playerBarNavigationAction: self.playerBarNavigationAction
                             )
                         } else {
                             SimplePlaylistDetailView(
@@ -43,7 +46,8 @@ struct NavigationDestinationsModifier: ViewModifier {
                                 viewModel: PlaylistDetailViewModel(
                                     playlist: playlist,
                                     client: self.client
-                                )
+                                ),
+                                playerBarNavigationAction: self.playerBarNavigationAction
                             )
                         }
                     }
@@ -54,7 +58,8 @@ struct NavigationDestinationsModifier: ViewModifier {
                             viewModel: PlaylistDetailViewModel(
                                 playlist: playlist,
                                 client: self.client
-                            )
+                            ),
+                            playerBarNavigationAction: self.playerBarNavigationAction
                         )
                     } else {
                         SimplePlaylistDetailView(
@@ -62,7 +67,8 @@ struct NavigationDestinationsModifier: ViewModifier {
                             viewModel: PlaylistDetailViewModel(
                                 playlist: playlist,
                                 client: self.client
-                            )
+                            ),
+                            playerBarNavigationAction: self.playerBarNavigationAction
                         )
                     }
                 }
@@ -82,7 +88,8 @@ struct NavigationDestinationsModifier: ViewModifier {
                         artist: artist,
                         client: self.client,
                         libraryViewModel: self.libraryViewModel
-                    )
+                    ),
+                    playerBarNavigationAction: self.playerBarNavigationAction
                 )
             }
             .navigationDestination(for: TopSongsDestination.self) { destination in
@@ -119,7 +126,13 @@ struct NavigationDestinationsModifier: ViewModifier {
 
 extension View {
     /// Adds common navigation destinations for Playlist, Artist, MoodCategory, and TopSongsDestination.
-    func navigationDestinations(client: any YTMusicClientProtocol) -> some View {
-        modifier(NavigationDestinationsModifier(client: client))
+    func navigationDestinations(
+        client: any YTMusicClientProtocol,
+        playerBarNavigationAction: PlayerBarNavigationAction = .disabled
+    ) -> some View {
+        modifier(NavigationDestinationsModifier(
+            client: client,
+            playerBarNavigationAction: playerBarNavigationAction
+        ))
     }
 }

--- a/Sources/Kaset/Views/YouTube/YouTubeContentView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeContentView.swift
@@ -33,6 +33,7 @@ struct YouTubeContentView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .environment(self.store)
         // Reconcile on (re)mount: switching to the Music source unmounts this
         // view, so the observers below can't see a floating video that finishes
         // or is closed while away. On switching back to YouTube with Home already

--- a/Sources/Kaset/Views/YouTube/YouTubePlayerBar.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubePlayerBar.swift
@@ -236,6 +236,7 @@ struct YouTubePlayerBar: View {
                 remainingText: "-\(Self.formatTime(max(0, self.youtubePlayer.duration - (self.isSeeking ? self.seekValue * self.youtubePlayer.duration : self.youtubePlayer.progress))))",
                 isLive: false,
                 canSeek: self.canSeek,
+                isLoading: self.isProgressLoading,
                 onScrub: { fraction in
                     self.isSeeking = true
                     self.seekValue = fraction
@@ -527,6 +528,10 @@ struct YouTubePlayerBar: View {
     /// Seeking is unavailable during ads or before a duration is known.
     private var canSeek: Bool {
         self.youtubePlayer.duration > 0 && !self.youtubePlayer.isShowingAd
+    }
+
+    private var isProgressLoading: Bool {
+        self.youtubePlayer.isPlaybackLoading
     }
 
     private var canNavigateToCurrentChannel: Bool {

--- a/Sources/Kaset/Views/YouTube/YouTubePlayerBar.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubePlayerBar.swift
@@ -28,6 +28,7 @@ struct YouTubePlayerBar: View {
 
     @State private var seekValue: Double = 0
     @State private var isSeeking = false
+    @State private var seekHold = PlayerBarSeekHold()
     @State private var volumeValue: Double = 1.0
     @State private var isAdjustingVolume = false
     @State private var showsVolumeOverlay = false
@@ -63,9 +64,19 @@ struct YouTubePlayerBar: View {
             self.playerAreaFade
         }
         .onChange(of: self.youtubePlayer.progress) { _, newValue in
-            if !self.isSeeking, self.youtubePlayer.duration > 0 {
-                self.seekValue = newValue / self.youtubePlayer.duration
+            self.seekHold.reconcile(observedProgress: newValue)
+            if !self.isSeeking, !self.seekHold.isActive, self.youtubePlayer.duration > 0 {
+                self.seekValue = self.displayedPlaybackProgress / self.youtubePlayer.duration
             }
+        }
+        .onChange(of: self.youtubePlayer.duration) { _, newValue in
+            self.seekHold.reconcile(observedProgress: self.youtubePlayer.progress)
+            if !self.isSeeking, !self.seekHold.isActive, newValue > 0 {
+                self.seekValue = self.displayedPlaybackProgress / newValue
+            }
+        }
+        .onChange(of: self.currentSeekIdentity) { _, _ in
+            self.clearSeekHold()
         }
         .onChange(of: self.youtubePlayer.volume) { _, newValue in
             if !self.isAdjustingVolume {
@@ -232,8 +243,8 @@ struct YouTubePlayerBar: View {
             PlayerBarProgressLane(
                 fraction: self.displayFraction,
                 accent: Self.brandAccent,
-                elapsedText: Self.formatTime(self.isSeeking ? self.seekValue * self.youtubePlayer.duration : self.youtubePlayer.progress),
-                remainingText: "-\(Self.formatTime(max(0, self.youtubePlayer.duration - (self.isSeeking ? self.seekValue * self.youtubePlayer.duration : self.youtubePlayer.progress))))",
+                elapsedText: Self.formatTime(self.progressTextValue),
+                remainingText: "-\(Self.formatTime(max(0, self.youtubePlayer.duration - self.progressTextValue)))",
                 isLive: false,
                 canSeek: self.canSeek,
                 isLoading: self.isProgressLoading,
@@ -522,7 +533,19 @@ struct YouTubePlayerBar: View {
             return min(max(0, self.seekValue), 1)
         }
         guard self.youtubePlayer.duration > 0 else { return 0 }
-        return min(max(0, self.youtubePlayer.progress / self.youtubePlayer.duration), 1)
+        return min(max(0, self.displayedPlaybackProgress / self.youtubePlayer.duration), 1)
+    }
+
+    private var progressTextValue: TimeInterval {
+        self.isSeeking ? self.seekValue * self.youtubePlayer.duration : self.displayedPlaybackProgress
+    }
+
+    private var displayedPlaybackProgress: TimeInterval {
+        self.seekHold.displayProgress(observedProgress: self.youtubePlayer.progress)
+    }
+
+    private var currentSeekIdentity: String {
+        self.youtubePlayer.currentVideo?.videoId ?? "none"
     }
 
     /// Seeking is unavailable during ads or before a duration is known.
@@ -552,8 +575,31 @@ struct YouTubePlayerBar: View {
 
     private func performSeek() {
         guard self.isSeeking else { return }
-        self.youtubePlayer.seek(to: self.seekValue * self.youtubePlayer.duration)
+        let seekTime = self.seekValue * self.youtubePlayer.duration
+        let holdToken = self.seekHold.begin(target: seekTime)
         self.isSeeking = false
+        self.youtubePlayer.seek(to: seekTime)
+
+        Task { @MainActor in
+            try? await Task.sleep(for: PlayerBarSeekHold.timeout)
+            if self.seekHold.clearIfCurrent(holdToken) {
+                self.syncSeekValueFromDisplayedProgress()
+            }
+        }
+    }
+
+    private func clearSeekHold() {
+        self.seekHold.clear()
+        self.isSeeking = false
+        self.syncSeekValueFromDisplayedProgress()
+    }
+
+    private func syncSeekValueFromDisplayedProgress() {
+        if self.youtubePlayer.duration > 0 {
+            self.seekValue = self.displayedPlaybackProgress / self.youtubePlayer.duration
+        } else {
+            self.seekValue = 0
+        }
     }
 
     private var volumeIcon: String {

--- a/Sources/Kaset/Views/YouTube/YouTubePlayerBar.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubePlayerBar.swift
@@ -19,6 +19,7 @@ struct YouTubePlayerBar: View {
     private static let compactVideoDetailsWidth: CGFloat = 141
 
     @Environment(YouTubePlayerService.self) private var youtubePlayer
+    @Environment(YouTubeViewModelStore.self) private var youtubeStore: YouTubeViewModelStore?
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.colorScheme) private var colorScheme
 
@@ -99,24 +100,34 @@ struct YouTubePlayerBar: View {
 
     private func videoDetailsSection(usesCompactDetails: Bool) -> some View {
         HStack(spacing: 8) {
-            CachedAsyncImage(
-                url: self.youtubePlayer.currentVideo?.thumbnailURL,
-                targetSize: CGSize(width: 128, height: 72)
-            ) { image in
-                image
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-            } placeholder: {
-                RoundedRectangle(cornerRadius: 6, style: .continuous)
-                    .fill(.quaternary)
-                    .overlay {
-                        Image(systemName: "play.rectangle")
-                            .font(.system(size: 16))
-                            .foregroundStyle(.secondary)
-                    }
+            PlayerBarArtworkView(
+                width: 57,
+                height: 32,
+                cornerRadius: 6,
+                glowSources: self.currentVideoGlowSources,
+                glowIdentity: self.currentVideoGlowIdentity,
+                glowTargetSize: CGSize(width: 128, height: 72)
+            ) {
+                CachedAsyncImage(
+                    url: self.youtubePlayer.currentVideo?.thumbnailURL,
+                    targetSize: CGSize(width: 128, height: 72)
+                ) { image in
+                    image
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                } placeholder: {
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .fill(.quaternary)
+                        .overlay {
+                            Image(systemName: "play.rectangle")
+                                .font(.system(size: 16))
+                                .foregroundStyle(.secondary)
+                        }
+                }
+                .frame(width: 57, height: 32)
+                .clipShape(.rect(cornerRadius: 6, style: .continuous))
             }
-            .frame(width: 57, height: 32)
-            .clipShape(.rect(cornerRadius: 6, style: .continuous))
+            .accessibilityHidden(self.youtubePlayer.currentVideo == nil)
 
             if !usesCompactDetails {
                 VStack(alignment: .leading, spacing: 4) {
@@ -127,12 +138,13 @@ struct YouTubePlayerBar: View {
                         height: 13,
                         reduceMotion: self.reduceMotion
                     )
+                    .id(self.currentTitleIdentity)
 
-                    Text(self.youtubePlayer.currentVideo?.channelName ?? String(localized: "YouTube"))
-                        .font(.system(size: 12))
-                        .lineLimit(1)
-                        .frame(height: 12, alignment: .leading)
-                        .foregroundStyle(.secondary)
+                    PlayerBarMetadataButton(
+                        text: self.youtubePlayer.currentVideo?.channelName ?? String(localized: "YouTube"),
+                        isEnabled: self.canNavigateToCurrentChannel,
+                        action: self.openCurrentChannel
+                    )
                 }
                 .frame(width: 129, height: 29, alignment: .leading)
             }
@@ -181,6 +193,38 @@ struct YouTubePlayerBar: View {
         }
         .padding(.leading, 14)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+    }
+
+    private var currentVideoGlowSources: [URL] {
+        guard let video = self.youtubePlayer.currentVideo else { return [] }
+        return self.uniqueURLs([
+            self.fallbackThumbnailURL(for: video.videoId),
+            video.thumbnailURL,
+        ])
+    }
+
+    private var currentVideoGlowIdentity: String? {
+        guard let video = self.youtubePlayer.currentVideo else { return nil }
+        return video.videoId
+    }
+
+    private func fallbackThumbnailURL(for videoId: String) -> URL? {
+        URL(string: "https://i.ytimg.com/vi/\(videoId)/mqdefault.jpg")
+    }
+
+    private func uniqueURLs(_ urls: [URL?]) -> [URL] {
+        var seen = Set<URL>()
+        return urls.compactMap { url in
+            guard let url, seen.insert(url).inserted else { return nil }
+            return url
+        }
+    }
+
+    private var currentTitleIdentity: String {
+        [
+            self.youtubePlayer.currentVideo?.id ?? "none",
+            self.youtubePlayer.currentVideo?.title ?? "none",
+        ].joined(separator: "|")
     }
 
     private var youtubeProgressSection: some View {
@@ -424,7 +468,7 @@ struct YouTubePlayerBar: View {
 
                 PlayerBarVerticalSlider(
                     value: self.$volumeValue,
-                    accent: self.volumeSliderTint,
+                    accent: Self.brandAccent,
                     accessibilityIdentifier: nil,
                     accessibilityLabel: String(localized: "Volume"),
                     onEditingChanged: { editing in
@@ -463,10 +507,6 @@ struct YouTubePlayerBar: View {
         self.colorScheme == .dark ? .white.opacity(0.10) : .black.opacity(0.06)
     }
 
-    private var volumeSliderTint: Color {
-        self.colorScheme == .dark ? .white.opacity(0.85) : .black.opacity(0.72)
-    }
-
     private var volumeOverlayShadow: Color {
         self.colorScheme == .dark ? .black.opacity(0.36) : .black.opacity(0.18)
     }
@@ -487,6 +527,22 @@ struct YouTubePlayerBar: View {
     /// Seeking is unavailable during ads or before a duration is known.
     private var canSeek: Bool {
         self.youtubePlayer.duration > 0 && !self.youtubePlayer.isShowingAd
+    }
+
+    private var canNavigateToCurrentChannel: Bool {
+        self.youtubeStore != nil && self.currentChannelId != nil
+    }
+
+    private var currentChannelId: String? {
+        guard let channelId = self.youtubePlayer.currentVideo?.channelId, !channelId.isEmpty else {
+            return nil
+        }
+        return channelId
+    }
+
+    private func openCurrentChannel() {
+        guard let channelId = self.currentChannelId else { return }
+        self.youtubeStore?.navigationPath.append(YouTubeRoute.channel(channelId: channelId))
     }
 
     private func performSeek() {

--- a/Sources/Kaset/Views/YouTube/YouTubePlayerBar.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubePlayerBar.swift
@@ -117,7 +117,8 @@ struct YouTubePlayerBar: View {
                 cornerRadius: 6,
                 glowSources: self.currentVideoGlowSources,
                 glowIdentity: self.currentVideoGlowIdentity,
-                glowTargetSize: CGSize(width: 128, height: 72)
+                glowTargetSize: CGSize(width: 128, height: 72),
+                showsHoverOverlay: false
             ) {
                 CachedAsyncImage(
                     url: self.youtubePlayer.currentVideo?.thumbnailURL,
@@ -576,13 +577,13 @@ struct YouTubePlayerBar: View {
     private func performSeek() {
         guard self.isSeeking else { return }
         let seekTime = self.seekValue * self.youtubePlayer.duration
-        let holdToken = self.seekHold.begin(target: seekTime)
+        let holdID = self.seekHold.begin(target: seekTime)
         self.isSeeking = false
         self.youtubePlayer.seek(to: seekTime)
 
         Task { @MainActor in
             try? await Task.sleep(for: PlayerBarSeekHold.timeout)
-            if self.seekHold.clearIfCurrent(holdToken) {
+            if self.seekHold.clearIfCurrent(holdID) {
                 self.syncSeekValueFromDisplayedProgress()
             }
         }

--- a/Tests/KasetTests/PlayerBarSeekHoldTests.swift
+++ b/Tests/KasetTests/PlayerBarSeekHoldTests.swift
@@ -48,7 +48,7 @@ struct PlayerBarSeekHoldTests {
 
         hold.reconcile(
             observedProgress: 30.5,
-            now: issuedAt.addingTimeInterval(0.35)
+            now: issuedAt.addingTimeInterval(0.36)
         )
 
         #expect(!hold.isActive)
@@ -79,7 +79,7 @@ struct PlayerBarSeekHoldTests {
 
         hold.reconcile(
             observedProgress: 5,
-            now: issuedAt.addingTimeInterval(2.2)
+            now: issuedAt.addingTimeInterval(2.21)
         )
 
         #expect(!hold.isActive)

--- a/Tests/KasetTests/PlayerBarSeekHoldTests.swift
+++ b/Tests/KasetTests/PlayerBarSeekHoldTests.swift
@@ -1,0 +1,104 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+// MARK: - PlayerBarSeekHoldTests
+
+@Suite(.tags(.model))
+struct PlayerBarSeekHoldTests {
+    @Test("begin holds the requested target for display")
+    func beginHoldsTargetForDisplay() {
+        var hold = PlayerBarSeekHold()
+        hold.begin(target: 42)
+
+        #expect(hold.isActive)
+        #expect(hold.targetProgress == 42)
+        #expect(hold.displayProgress(observedProgress: 10) == 42)
+    }
+
+    @Test("begin clamps negative target to zero")
+    func beginClampsNegativeTarget() {
+        var hold = PlayerBarSeekHold()
+        hold.begin(target: -3)
+
+        #expect(hold.targetProgress == 0)
+        #expect(hold.displayProgress(observedProgress: 12) == 0)
+    }
+
+    @Test("reconcile waits for the minimum confirmation age")
+    func reconcileWaitsForMinimumConfirmationAge() {
+        let issuedAt = Date(timeIntervalSinceReferenceDate: 100)
+        var hold = PlayerBarSeekHold()
+        hold.begin(target: 30, issuedAt: issuedAt)
+
+        hold.reconcile(
+            observedProgress: 30,
+            now: issuedAt.addingTimeInterval(0.34)
+        )
+
+        #expect(hold.isActive)
+        #expect(hold.targetProgress == 30)
+    }
+
+    @Test("reconcile clears after a matching progress confirmation")
+    func reconcileClearsAfterMatchingConfirmation() {
+        let issuedAt = Date(timeIntervalSinceReferenceDate: 100)
+        var hold = PlayerBarSeekHold()
+        hold.begin(target: 30, issuedAt: issuedAt)
+
+        hold.reconcile(
+            observedProgress: 30.5,
+            now: issuedAt.addingTimeInterval(0.35)
+        )
+
+        #expect(!hold.isActive)
+        #expect(hold.targetProgress == nil)
+        #expect(hold.displayProgress(observedProgress: 31) == 31)
+    }
+
+    @Test("reconcile keeps holding progress outside confirmation tolerance")
+    func reconcileKeepsProgressOutsideTolerance() {
+        let issuedAt = Date(timeIntervalSinceReferenceDate: 100)
+        var hold = PlayerBarSeekHold()
+        hold.begin(target: 30, issuedAt: issuedAt)
+
+        hold.reconcile(
+            observedProgress: 32,
+            now: issuedAt.addingTimeInterval(0.5)
+        )
+
+        #expect(hold.isActive)
+        #expect(hold.displayProgress(observedProgress: 32) == 30)
+    }
+
+    @Test("reconcile clears when timeout elapses")
+    func reconcileClearsWhenTimeoutElapses() {
+        let issuedAt = Date(timeIntervalSinceReferenceDate: 100)
+        var hold = PlayerBarSeekHold()
+        hold.begin(target: 30, issuedAt: issuedAt)
+
+        hold.reconcile(
+            observedProgress: 5,
+            now: issuedAt.addingTimeInterval(2.2)
+        )
+
+        #expect(!hold.isActive)
+        #expect(hold.targetProgress == nil)
+    }
+
+    @Test("clearIfCurrent only clears the active hold ID")
+    func clearIfCurrentRequiresMatchingID() {
+        var hold = PlayerBarSeekHold()
+        let activeID = hold.begin(target: 30)
+
+        let staleClearResult = hold.clearIfCurrent(UUID())
+
+        #expect(!staleClearResult)
+        #expect(hold.isActive)
+
+        let activeClearResult = hold.clearIfCurrent(activeID)
+
+        #expect(activeClearResult)
+        #expect(!hold.isActive)
+    }
+}


### PR DESCRIPTION
https://github.com/user-attachments/assets/39487a3f-218b-4249-b9d8-b3b2def605ef

## Description

This PR refines the redesigned player bar with a focused pass on navigation UX, artwork interaction, and slider polish for both the music player and YouTube/video player surfaces.

The main UX addition is that player metadata now behaves more like users expect from a music app: artist/channel text has a larger invisible hit area and can navigate to the related artist/channel context, while artwork can navigate to the album/video-related context where available. The interaction keeps the visual layout unchanged, adds immediate loading feedback, and preserves the player bar's hover state while navigation is in progress.

## AI Prompt (Optional)

<details>
<summary>🤖 AI Prompt Used</summary>

```
A detailed AI-assisted implementation and review process was used. No single prompt generated these changes.
```

**AI Tool:** OpenAI Codex

</details>

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [x] 🎨 UI/UX improvement
- [x] ♻️ Refactoring (no functional changes)
- [ ] 🧪 Test update
- [ ] 🔧 Build/CI configuration

## Related Issues

N/A

## Changes Made

- Added player bar navigation support for artist/channel and album/artwork destinations through `PlayerBarNavigationAction` and `playerBarMusicNavigation(path:)`.
- Added `PlayerBarMetadataButton` to make artist/channel metadata clickable with a larger invisible hit area, hover feedback, accessibility button traits, and loading feedback.
- Added `PlayerBarArtworkView` and `PlayerBarArtworkGlow` to centralize artwork rendering, hover overlays, loading state, shadows/glow, and shared artwork interaction behavior.
- Added `PlayerBarSliderVisuals` to share slider colors, thumb sizing, hover/drag animation values, and hit-area metrics between horizontal and vertical player sliders.
- Updated `PlayerBar` and `YouTubePlayerBar` to use the shared artwork, metadata, navigation, and slider components.
- Updated music navigation containers so player bar actions can push artist and album destinations from the current view context.
- Refined marquee title behavior and slider interaction polish while preserving the existing player/video controls.

## Testing

- [x] Unit tests pass (`xcodebuild test -only-testing:KasetTests`)
- [x] Manual testing performed
- [x] UI tested on macOS 26+

Tested with:

- `swiftformat --lint .`
- `swiftlint lint --strict --reporter github-actions-logging`
- `swift test -q --skip KasetUITests --disable-xctest` — 1541 tests passed
- `KASET_SIGNING=adhoc Scripts/build-app.sh debug`
- `Scripts/verify-release-app.sh .build/app/Kaset.app`
- Targeted UI tests for `PlayerBarUITests` and `VideoUITests`

Notes:

- `VideoUITests` passed 11/11 locally.
- The main targeted `PlayerBarUITests` run passed 17/18 with one local XCUITest flake waiting for `sidebar.home` to become hittable; the isolated rerun of `PlayerBarUITests/testPlayerBarVisibleWithCurrentTrack` passed.
- Artist/channel and artwork navigation UX was also manually verified because asserting real detail navigation through UI mocks would be fragile around mock detail-loading timing.

## Checklist

<!-- Mark completed items with an 'x' -->

- [x] My code follows the project's style guidelines
- [x] I have run `swiftlint --strict && swiftformat .`
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally
- [x] I have updated documentation if needed
- [x] I have checked for any performance implications
- [x] My changes generate no new warnings

## Screenshots

N/A

## Additional Notes

This follow-up intentionally keeps the scope limited to player bar UI/UX, shared player components, and navigation propagation needed for artist/artwork interactions.
