### PR TITLE
feat: add seek AppleScript command and now-playing notification broad…

### DIFF
--- a/Sources/Kaset/Resources/Kaset.sdef
+++ b/Sources/Kaset/Resources/Kaset.sdef
@@ -52,6 +52,11 @@
             <direct-parameter type="integer" description="Volume level (0-100)."/>
         </command>
 
+        <command name="seek" code="Kastseek" description="Seek to a position (in seconds) in the current track.">
+            <cocoa class="KasetSeekCommand"/>
+            <direct-parameter type="real" description="Position in seconds."/>
+        </command>
+
         <command name="toggle shuffle" code="Kastshuf" description="Toggle shuffle on or off (binary; does not enable Smart Shuffle).">
             <cocoa class="KasetToggleShuffleCommand"/>
         </command>

--- a/Sources/Kaset/Services/Player/NowPlayingBroadcaster.swift
+++ b/Sources/Kaset/Services/Player/NowPlayingBroadcaster.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Observation
+
+/// Broadcasts a distributed notification when playback state changes so external
+/// now-playing surfaces (e.g. the boring.notch "Kaset" media source) can refresh
+/// without polling.
+///
+/// The notification is a bare, change-only trigger: it carries no `userInfo` (the
+/// App Sandbox strips `userInfo` from a sandboxed sender's distributed
+/// notifications), and the name is prefixed with the app's bundle id so the sandbox
+/// permits posting it. It fires only on a *change* after `configure()` — there is no
+/// initial snapshot and a missed notification is not resent — so listeners read the
+/// full state via the `get player info` AppleScript command, and must poll it for the
+/// initial state and for high-frequency values (position, volume) that are
+/// deliberately not triggers.
+@MainActor
+final class NowPlayingBroadcaster {
+    static let shared = NowPlayingBroadcaster()
+
+    /// Distributed-notification name. **Published cross-process contract** — external
+    /// listeners (e.g. boring.notch) match this exact string, so it must not change
+    /// casually. Bundle-id-prefixed so the App Sandbox permits posting it.
+    static let notificationName = "com.sertacozercan.Kaset.playerInfo"
+
+    /// Weak: `PlayerService.shared` owns its own lifetime; the broadcaster must not retain it.
+    private weak var playerService: PlayerService?
+    private let logger = DiagnosticsLogger.player
+    private var isConfigured = false
+
+    private init() {}
+
+    /// Begins observing the player and broadcasting on change. Idempotent.
+    func configure(playerService: PlayerService) {
+        guard !self.isConfigured else {
+            self.logger.debug("NowPlayingBroadcaster already configured, skipping")
+            return
+        }
+        self.isConfigured = true
+        self.playerService = playerService
+        self.observe()
+        self.logger.info("NowPlayingBroadcaster configured")
+    }
+
+    private func observe() {
+        withObservationTracking {
+            // Track only the discrete fields a now-playing surface reacts to.
+            // Deliberately excludes `progress` and `volume`: both change rapidly
+            // (continuous playback / volume drags) and would flood the cross-process
+            // notification. Consumers read position and volume via `get player info`.
+            _ = self.playerService?.currentTrack?.videoId
+            _ = self.playerService?.state
+            _ = self.playerService?.currentTrackLikeStatus
+            _ = self.playerService?.shuffleEnabled
+            _ = self.playerService?.repeatMode
+        } onChange: {
+            Task { @MainActor [weak self] in
+                self?.post()
+                self?.observe()
+            }
+        }
+    }
+
+    private func post() {
+        DistributedNotificationCenter.default().postNotificationName(
+            NSNotification.Name(Self.notificationName),
+            object: nil,
+            userInfo: nil,
+            deliverImmediately: true
+        )
+    }
+}

--- a/Sources/Kaset/Services/Scripting/ScriptCommands.swift
+++ b/Sources/Kaset/Services/Scripting/ScriptCommands.swift
@@ -184,6 +184,33 @@ final class SetVolumeCommand: NSScriptCommand {
     }
 }
 
+// MARK: - SeekCommand
+
+/// Seek command: jump to a position (in seconds) in the current track.
+@objc(KasetSeekCommand)
+final class SeekCommand: NSScriptCommand {
+    override func performDefaultImplementation() -> Any? {
+        guard let seconds = (directParameter as? NSNumber)?.doubleValue else {
+            logger.error("Seek command failed: invalid position parameter")
+            scriptErrorNumber = errAECoercionFail
+            scriptErrorString = "Position must be a number of seconds."
+            return nil
+        }
+
+        guard let playerService = MainActor.assumeIsolated({ getPlayerService() }) else {
+            logger.error("Seek command failed: PlayerService.shared is nil")
+            scriptErrorNumber = errPlayerNotAvailable
+            scriptErrorString = playerNotAvailableMessage
+            return nil
+        }
+        logger.info("Executing seek command to position: \(seconds)")
+        Task { @MainActor in
+            await playerService.seek(to: max(0, seconds))
+        }
+        return nil
+    }
+}
+
 // MARK: - ToggleShuffleCommand
 
 /// ToggleShuffle command: toggle shuffle mode.

--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -343,6 +343,7 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
         }
         .task {
             NowPlayingManager.shared.configure(playerService: self.playerService)
+            NowPlayingBroadcaster.shared.configure(playerService: self.playerService)
         }
         .task(id: self.accountService.currentAccount?.id) {
             // Keep PodcastsViewModel in sync with the active account so

--- a/Tests/KasetTests/NowPlayingBroadcasterTests.swift
+++ b/Tests/KasetTests/NowPlayingBroadcasterTests.swift
@@ -1,0 +1,14 @@
+import Testing
+@testable import Kaset
+
+@MainActor
+struct NowPlayingBroadcasterTests {
+    /// `notificationName` is a published cross-process contract: external now-playing
+    /// surfaces (e.g. the boring.notch "Kaset" media source) listen for this exact
+    /// string. Pin it so an accidental rename fails CI here instead of silently
+    /// breaking those integrations.
+    @Test("Broadcaster notification name matches the published contract")
+    func notificationNameIsStableContract() {
+        #expect(NowPlayingBroadcaster.notificationName == "com.sertacozercan.Kaset.playerInfo")
+    }
+}

--- a/Tests/KasetTests/ScriptCommandsTests.swift
+++ b/Tests/KasetTests/ScriptCommandsTests.swift
@@ -64,6 +64,10 @@ struct ScriptCommandsTests {
             #expect(json["repeating"] != nil)
             #expect(json["muted"] != nil)
             #expect(json["likeStatus"] != nil)
+            // Cross-process contract keys consumed by external now-playing surfaces
+            // (e.g. boring.notch): pin them so a rename can't silently break consumers.
+            #expect(json["position"] != nil)
+            #expect(json["duration"] != nil)
         } else {
             Issue.record("Failed to parse JSON response")
         }
@@ -100,6 +104,7 @@ struct ScriptCommandsTests {
             #expect(trackInfo["album"] as? String == "Test Album")
             #expect(trackInfo["videoId"] as? String == "test-video-id")
             #expect(trackInfo["duration"] as? TimeInterval == 180)
+            #expect(trackInfo["artworkURL"] as? String == "https://example.com/thumb.jpg")
         } else {
             Issue.record("Failed to parse track info from JSON response")
         }
@@ -229,6 +234,35 @@ struct ScriptCommandsTests {
 
         #expect(command.scriptErrorNumber == errAECoercionFail)
         #expect(command.scriptErrorString?.contains("Volume must be an integer") == true)
+
+        // Cleanup
+        PlayerService.shared = nil
+    }
+
+    // MARK: - SeekCommand Tests
+
+    @Test("Seek sets error when PlayerService is nil")
+    func seekSetsErrorWhenNil() {
+        PlayerService.shared = nil
+
+        let command = SeekCommand()
+        command.directParameter = 30 as NSNumber
+        _ = command.performDefaultImplementation()
+
+        #expect(command.scriptErrorNumber == -1728)
+    }
+
+    @Test("Seek sets error for invalid parameter type")
+    func seekSetsErrorForInvalidParameter() {
+        let playerService = PlayerService()
+        PlayerService.shared = playerService
+
+        let command = SeekCommand()
+        command.directParameter = "not a number" as NSString
+        _ = command.performDefaultImplementation()
+
+        #expect(command.scriptErrorNumber == errAECoercionFail)
+        #expect(command.scriptErrorString?.contains("Position must be a number") == true)
 
         // Cleanup
         PlayerService.shared = nil

--- a/docs/applescript.md
+++ b/docs/applescript.md
@@ -13,6 +13,7 @@ Kaset supports AppleScript for automation with tools like Raycast, Alfred, and S
 | `next track` | Skip to next track |
 | `previous track` | Go to previous track |
 | `set volume N` | Set volume (0-100) |
+| `seek N` | Seek to position N seconds in the current track |
 | `toggle mute` | Mute/unmute |
 | `toggle shuffle` | Toggle shuffle on/off (binary; does not reach Smart Shuffle) |
 | `cycle repeat` | Cycle repeat (Off → All → One) |
@@ -131,6 +132,9 @@ osascript -e 'tell application "Kaset" to next track'
 # Set volume (0-100)
 osascript -e 'tell application "Kaset" to set volume 75'
 
+# Seek to a position (seconds into the current track)
+osascript -e 'tell application "Kaset" to seek 30'
+
 # Toggle modes
 osascript -e 'tell application "Kaset" to toggle shuffle'
 osascript -e 'tell application "Kaset" to cycle repeat'
@@ -147,6 +151,25 @@ osascript -e 'tell application "Kaset" to get play queue'
 # Play track at index 2 (1-based index)
 osascript -e 'tell application "Kaset" to play track at index 2'
 ```
+
+## Now Playing Notifications
+
+Kaset posts a distributed notification named `com.sertacozercan.Kaset.playerInfo`
+whenever discrete playback state changes (current track, play/pause, like status,
+shuffle, or repeat). External now-playing surfaces — menu-bar widgets, or notch apps
+such as boring.notch — can observe it to refresh reactively instead of polling on a
+timer.
+
+The notification is a **bare, change-only trigger**:
+
+- It carries no payload (the App Sandbox strips `userInfo` from a sandboxed sender),
+  so observers read the current state with `get player info`.
+- It fires only on a *change*; there is no initial snapshot and a missed notification
+  is not resent. Observers should call `get player info` once on startup for the
+  initial state and keep a low-frequency poll as a fallback.
+- High-frequency values — **playback position and volume** — are intentionally not
+  triggers (they would flood the notification during playback and volume drags). Read
+  `position` and `volume` from `get player info`, polling if you need them live.
 
 ## Error Handling
 


### PR DESCRIPTION
## Description

Adds the AppleScript + notification plumbing that lets external "now playing"
surfaces — menu-bar widgets, Stream Deck, and notch apps such as boring.notch —
mirror and control Kaset playback reactively, without polling the app.

Two additions:

1. **`seek` AppleScript command** — jump to an absolute position (in seconds) in the current track, e.g. `tell application "Kaset" to seek 90`. This completes the transport surface (alongside the existing play / pause / next / previous /
   `set volume` commands) so an external scrubber can drive playback position.
2. **`NowPlayingBroadcaster`** — posts a lightweight distributed notification (`com.sertacozercan.Kaset.playerInfo`) whenever discrete playback state changes (current track, play/pause, like status, shuffle, repeat). Listeners refresh by calling the existing `get player info` command instead of polling on a timer. High-frequency `progress` and `volume` are intentionally excluded so the notification doesn't fire continuously during playback or volume drags.

Both are read/control affordances over already-exposed state; no playback or auth
behavior changes.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Related Issues

Enables external now-playing integrations such as TheBoredTeam/boring.notch#1167
("Kaset as a music source"). No Kaset-side issue.

## Changes Made

- Add `SeekCommand` (`KasetSeekCommand`) `NSScriptCommand` → `PlayerService.seek(to:)`; coercion-fails with a clear error on a non-numeric argument.
- Declare the `seek` command (code `Kastseek`, `real` direct-parameter) in `Kaset.sdef`.
- Add `NowPlayingBroadcaster` (in `Services/Player/`, beside `NowPlayingManager`):
  observes `PlayerService` via `withObservationTracking` and posts a bundle-id-prefixed distributed notification on discrete state changes. Wired up once in `MainWindow`'s
  `.task`.
- Document `seek` (+ shell example) and the notification contract ("Now Playing Notifications") in `docs/applescript.md`.
- Tests: `SeekCommand` (nil-player + invalid-arg); pin the cross-process `get player info` contract keys consumed by external surfaces (`position`, `duration`,
  `artworkURL`); pin the broadcaster's `notificationName` string.

## Testing

- [x] Unit tests pass (`swift test --skip KasetUITests` — 1551 tests, 132 suites)
- [x] Manual testing performed
- [x] UI tested on macOS 26+ (no UI surface in this change)

Manual verification against a live build:
- `get player info` returns the full state contract; `seek 30` / `seek 90` jump the position exactly; `like track` toggles `liked`↔`none`; `toggle shuffle`,
  `cycle repeat`, `playpause`, `next track` all work.
- End-to-end with an external consumer (boring.notch): the notch reflects and toggles like status and updates faster than its fallback poll, confirming the distributed notification is delivered across the process boundary.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `swiftlint --strict && swiftformat .` (0 violations, 0 formatting changes)
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally
- [x] I have updated documentation if needed (`docs/applescript.md`)
- [x] I have checked for any performance implications (notification excludes high-frequency `progress`/`volume`)
- [x] My changes generate no new warnings

## Additional Notes

- The like/favourite toggle that motivated this work uses Kaset's **existing**
  `like track` command — no change is required here for liking. This PR adds the reactive refresh signal (so an external heart updates promptly instead of on a poll) and the `seek` transport command.
- The distributed notification carries no `userInfo` (the App Sandbox strips it from a sandboxed sender) and uses a bundle-id-prefixed name so the sandbox permits posting; listeners read full state via `get player info`. It is a bare, change-only trigger, so consumers poll `get player info` for the initial state and for position/volume.

<img width="1662" height="1080" alt="2026-06-30 22-15-19" src="https://github.com/user-attachments/assets/19b75599-06fd-4c5a-bc71-72d5d7833e99" />
