### PR TITLE
Add Like/Unlike entry to Dock menu

### DIFF
--- a/Sources/Kaset/AppDelegate.swift
+++ b/Sources/Kaset/AppDelegate.swift
@@ -133,6 +133,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationDockMenu(_: NSApplication) -> NSMenu? {
         let menu = NSMenu()
+        // Menu-wide: with auto-enable off, every item must set `isEnabled` itself —
+        // AppKit no longer enables an item just because its target responds to the
+        // action. Required so the Like item can grey out with no track; the transport
+        // items below rely on NSMenuItem's default (enabled). Any future item added
+        // here must set its own isEnabled.
+        menu.autoenablesItems = false
 
         let playPauseItem = NSMenuItem(
             title: "Play/Pause",
@@ -157,6 +163,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         )
         previousItem.target = self
         menu.addItem(previousItem)
+
+        menu.addItem(.separator())
+
+        // Like/Unlike the current track. Title mirrors the player-bar thumbs-up
+        // toggle; disabled when nothing is playing. A disliked track also reads
+        // "Like" — clicking replaces the dislike with a like, matching the player
+        // bar (the dock has no dislike affordance).
+        let isLiked = self.playerService?.currentTrackLikeStatus == .like
+        let likeItem = NSMenuItem(
+            title: isLiked ? String(localized: "Unlike") : String(localized: "Like"),
+            action: #selector(self.dockMenuToggleLike),
+            keyEquivalent: ""
+        )
+        likeItem.target = self
+        likeItem.isEnabled = self.playerService?.currentTrack != nil
+        menu.addItem(likeItem)
 
         return menu
     }
@@ -192,6 +214,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         Task {
             await playerService.previous()
         }
+    }
+
+    @objc private func dockMenuToggleLike() {
+        // Like requires the API-backed SongLikeStatusManager, so there is no
+        // WebView-only fallback like the transport actions have.
+        self.playerService?.likeCurrentTrack()
     }
 
     /// Keep app running when the window is closed (for background audio).

--- a/Tests/KasetTests/AppDelegateDockMenuTests.swift
+++ b/Tests/KasetTests/AppDelegateDockMenuTests.swift
@@ -1,0 +1,124 @@
+import AppKit
+import Testing
+@testable import Kaset
+
+@Suite("Dock menu Like item", .serialized)
+@MainActor
+struct AppDelegateDockMenuTests {
+    init() {
+        // Neutralize the shared like-status singleton so the optimistic-update
+        // Task spawned by likeCurrentTrack() can't leak across tests.
+        SongLikeStatusManager.shared.clearCache()
+        SongLikeStatusManager.shared.setActiveAccountID(nil)
+    }
+
+    private func likeItem(_ delegate: AppDelegate) -> NSMenuItem? {
+        let menu = delegate.applicationDockMenu(NSApplication.shared)
+        // Locate structurally by action selector so the lookup is locale-independent
+        // (the title is localized); title equality is asserted separately.
+        return menu?.items.first { $0.action == NSSelectorFromString("dockMenuToggleLike") }
+    }
+
+    @Test("Disabled and reads 'Like' for a live player with no current track")
+    func disabledWithNoTrack() {
+        let delegate = AppDelegate()
+        // playerService is a weak var; the strong local keeps the live player
+        // alive so we exercise the no-track path, not the nil-player path.
+        let player = PlayerService()
+        delegate.playerService = player
+        #expect(player.currentTrack == nil)
+
+        let item = self.likeItem(delegate)
+
+        #expect(item?.title == "Like")
+        #expect(item?.isEnabled == false)
+    }
+
+    @Test("Reads 'Like' and is enabled for an unliked current track")
+    func likeForUnlikedTrack() {
+        let delegate = AppDelegate()
+        let player = PlayerService()
+        player.currentTrack = TestFixtures.makeSong(id: "v1")
+        player.currentTrackLikeStatus = .indifferent
+        delegate.playerService = player
+
+        let item = self.likeItem(delegate)
+
+        #expect(item?.title == "Like")
+        #expect(item?.isEnabled == true)
+    }
+
+    @Test("Reads 'Unlike' for an already-liked current track")
+    func unlikeForLikedTrack() {
+        let delegate = AppDelegate()
+        let player = PlayerService()
+        player.currentTrack = TestFixtures.makeSong(id: "v1")
+        player.currentTrackLikeStatus = .like
+        delegate.playerService = player
+
+        let item = self.likeItem(delegate)
+
+        #expect(item?.title == "Unlike")
+        #expect(item?.isEnabled == true)
+    }
+
+    @Test("Triggering the item toggles the like state via likeCurrentTrack()")
+    func triggeringItemTogglesLike() {
+        let delegate = AppDelegate()
+        let player = PlayerService()
+        player.currentTrack = TestFixtures.makeSong(id: "v1")
+        player.currentTrackLikeStatus = .indifferent
+        delegate.playerService = player
+
+        let item = self.likeItem(delegate)
+        #expect(item?.target === delegate)
+
+        guard let action = item?.action else {
+            Issue.record("Like item has no action wired")
+            return
+        }
+        _ = delegate.perform(action)
+
+        // likeCurrentTrack() applies a synchronous optimistic update before its
+        // async API call, so the toggle is observable immediately. This proves
+        // the item is wired to like (not dislike) and the handler is not a no-op.
+        #expect(player.currentTrackLikeStatus == .like)
+    }
+
+    @Test("Triggering the item un-likes an already-liked track")
+    func triggeringItemUnlikesLikedTrack() {
+        let delegate = AppDelegate()
+        let player = PlayerService()
+        player.currentTrack = TestFixtures.makeSong(id: "v1")
+        player.currentTrackLikeStatus = .like
+        delegate.playerService = player
+
+        let item = self.likeItem(delegate)
+        guard let action = item?.action else {
+            Issue.record("Like item has no action wired")
+            return
+        }
+        _ = delegate.perform(action)
+
+        // The optimistic toggle takes a liked track back to indifferent — the
+        // un-like direction that makes the "Unlike" title truthful.
+        #expect(player.currentTrackLikeStatus == .indifferent)
+    }
+
+    @Test("Transport items stay enabled even with no current track")
+    func transportItemsEnabledWithNoTrack() {
+        let delegate = AppDelegate()
+        let player = PlayerService()
+        delegate.playerService = player
+        #expect(player.currentTrack == nil)
+
+        // autoenablesItems = false means each item manages its own isEnabled. The
+        // transport items rely on NSMenuItem's default (enabled); guard that the
+        // Like item's menu-wide switch never silently greys them out.
+        let menu = delegate.applicationDockMenu(NSApplication.shared)
+        for title in ["Play/Pause", "Next Track", "Previous Track"] {
+            let item = menu?.items.first { $0.title == title }
+            #expect(item?.isEnabled == true, "\(title) should remain enabled under autoenablesItems = false")
+        }
+    }
+}


### PR DESCRIPTION
## Description

Adds a dynamic **Like/Unlike** item to the macOS Dock icon menu. It toggles the
current track's like state, its title reflects that state ("Like" when not liked,
"Unlike" when liked), and it is disabled when nothing is playing. It mirrors the
player-bar thumbs-up control — same `PlayerService.likeCurrentTrack()` toggle, same
"no current track" disable condition.

The Dock menu already had Play/Pause / Next Track / Previous Track; this adds the Like
item below a separator.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🎨 UI/UX improvement

## Related Issues

Related Issues — Relates to #65 (Context menu for player bar) — same goal of acting on the current track from a menu; this addresses the "quick like the current song" part from the Dock surface. It does not fully close #65 (which asks for a right-click menu on the player bar with broader actions).

## Changes Made

- Add a Like/Unlike `NSMenuItem` to `applicationDockMenu(_:)` in `AppDelegate.swift`:
  localized title driven by `currentTrackLikeStatus`, enabled only when a track is playing, wired to a new `dockMenuToggleLike` handler that calls
  `PlayerService.likeCurrentTrack()` (the same toggle the player-bar thumbs-up uses).
- Set `menu.autoenablesItems = false` so the item can grey out with no current track, documented as a menu-wide contract (the existing transport items keep AppKit's default-enabled state).
- Add `AppDelegateDockMenuTests` (6 tests): title + enablement for the no-track / unliked / liked states, the like-trigger and un-like-trigger directions, and a regression guard that the transport items stay enabled under `autoenablesItems = false`. The test helper locates the item by action selector so it is locale-robust.

## Testing

- [x] Unit tests pass (`swift test --skip KasetUITests` — 1554 tests, 132 suites; 6 cover the Dock item)
- [x] Manual testing performed
- [x] UI tested on macOS 26+

Verified from the real Dock menu (right-click the Dock icon): the Like item enables when
a track is playing, its title toggles Like↔Unlike with the like state (matching the
player-bar thumbs-up), and it greys out when nothing is playing.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `swiftlint --strict && swiftformat .` (0 violations, 0 formatting changes)
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally
- [x] I have updated documentation if needed (N/A — no keyboard shortcut; no existing Dock-menu doc)
- [x] I have checked for any performance implications (trivial menu construction)
- [x] My changes generate no new warnings

## Screenshots

<img width="1662" height="1080" alt="2026-06-30 23-09-14" src="https://github.com/user-attachments/assets/65c3bd10-a37c-49c5-8bdb-7526e6d07e60" />


## Additional Notes

- The "Like"/"Unlike" titles reuse existing `Localizable.xcstrings` keys (already translated in all bundled languages) — no new strings or Crowdin work required.
- `likeCurrentTrack()` is a toggle (like ↔ indifferent). A disliked track shows "Like"; clicking replaces the dislike with a like, matching the player bar (the Dock has no dislike affordance).
- Haptic feedback is intentionally not fired from the Dock menu (unlike the player-bar button).