### PR TITLE
perf: optimize parsers and load coalescing

### DIFF
--- a/Sources/Kaset/Services/API/MockUITestYouTubeClient.swift
+++ b/Sources/Kaset/Services/API/MockUITestYouTubeClient.swift
@@ -83,6 +83,10 @@ final class MockUITestYouTubeClient: YouTubeClientProtocol {
         nil
     }
 
+    func getSearchContinuation(continuation _: String) async throws -> YouTubeSearchResponse? {
+        nil
+    }
+
     func getWatchNext(videoId _: String) async throws -> WatchNextData {
         WatchNextData(
             videoTitle: "Mock Video One",

--- a/Sources/Kaset/Services/API/Parsers/ArtistParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/ArtistParser.swift
@@ -413,8 +413,7 @@ enum ArtistParser { // swiftlint:disable:this type_body_length
                     .joined()
             }
 
-        let thumbnails = ParsingHelpers.extractThumbnails(from: data)
-        let thumbnailURL = thumbnails.last.flatMap { URL(string: $0) }
+        let thumbnailURL = ParsingHelpers.extractThumbnailURL(from: data)
 
         let isLive = (data["badges"] as? [[String: Any]])?
             .contains { $0["liveBadgeRenderer"] != nil } ?? false
@@ -435,8 +434,7 @@ enum ArtistParser { // swiftlint:disable:this type_body_length
     ) -> PodcastShow? {
         let title = ParsingHelpers.extractTitle(from: data) ?? "Unknown Show"
         let author = ParsingHelpers.extractSubtitle(from: data)
-        let thumbnails = ParsingHelpers.extractThumbnails(from: data)
-        let thumbnailURL = thumbnails.last.flatMap { URL(string: $0) }
+        let thumbnailURL = ParsingHelpers.extractThumbnailURL(from: data)
 
         return PodcastShow(
             id: browseId,
@@ -455,8 +453,7 @@ enum ArtistParser { // swiftlint:disable:this type_body_length
         guard let name = ParsingHelpers.extractTitle(from: data) else {
             return nil
         }
-        let thumbnails = ParsingHelpers.extractThumbnails(from: data)
-        let thumbnailURL = thumbnails.last.flatMap { URL(string: $0) }
+        let thumbnailURL = ParsingHelpers.extractThumbnailURL(from: data)
         return Artist(id: browseId, name: name, thumbnailURL: thumbnailURL)
     }
 
@@ -467,8 +464,7 @@ enum ArtistParser { // swiftlint:disable:this type_body_length
         guard let title = ParsingHelpers.extractTitle(from: data) else {
             return nil
         }
-        let thumbnails = ParsingHelpers.extractThumbnails(from: data)
-        let thumbnailURL = thumbnails.last.flatMap { URL(string: $0) }
+        let thumbnailURL = ParsingHelpers.extractThumbnailURL(from: data)
         let author = ParsingHelpers.extractSubtitle(from: data)
 
         return Playlist(
@@ -490,8 +486,7 @@ enum ArtistParser { // swiftlint:disable:this type_body_length
             return nil
         }
 
-        let thumbnails = ParsingHelpers.extractThumbnails(from: data)
-        let thumbnailURL = thumbnails.last.flatMap { URL(string: $0) }
+        let thumbnailURL = ParsingHelpers.extractThumbnailURL(from: data)
         let title = ParsingHelpers.extractTitle(from: data) ?? "Unknown Album"
 
         var year: String?
@@ -548,8 +543,7 @@ enum ArtistParser { // swiftlint:disable:this type_body_length
                 result.description = runs.compactMap { $0["text"] as? String }.joined()
             }
 
-            let thumbnails = ParsingHelpers.extractThumbnails(from: immersiveHeader)
-            result.thumbnailURL = thumbnails.last.flatMap { URL(string: $0) }
+            result.thumbnailURL = ParsingHelpers.extractThumbnailURL(from: immersiveHeader)
 
             // Parse subscription button for channel ID and subscription status
             self.parseSubscriptionButton(from: immersiveHeader, into: &result)
@@ -571,8 +565,7 @@ enum ArtistParser { // swiftlint:disable:this type_body_length
                 result.name = text
             }
 
-            let thumbnails = ParsingHelpers.extractThumbnails(from: visualHeader)
-            result.thumbnailURL = thumbnails.last.flatMap { URL(string: $0) }
+            result.thumbnailURL = ParsingHelpers.extractThumbnailURL(from: visualHeader)
 
             // Parse subscription button for channel ID and subscription status
             self.parseSubscriptionButton(from: visualHeader, into: &result)
@@ -738,6 +731,7 @@ enum ArtistParser { // swiftlint:disable:this type_body_length
 
     private static func parseTracksFromItems(_ items: [[String: Any]], fallbackThumbnailURL: URL? = nil) -> [Song] {
         var tracks: [Song] = []
+        tracks.reserveCapacity(items.count)
 
         for itemData in items {
             guard let responsiveRenderer = itemData["musicResponsiveListItemRenderer"] as? [String: Any] else {
@@ -750,8 +744,7 @@ enum ArtistParser { // swiftlint:disable:this type_body_length
 
             let title = ParsingHelpers.extractTitleFromFlexColumns(responsiveRenderer) ?? "Unknown"
             let artists = ParsingHelpers.extractArtistsFromFlexColumns(responsiveRenderer)
-            let thumbnails = ParsingHelpers.extractThumbnails(from: responsiveRenderer)
-            let thumbnailURL = thumbnails.last.flatMap { URL(string: $0) } ?? fallbackThumbnailURL
+            let thumbnailURL = ParsingHelpers.extractThumbnailURL(from: responsiveRenderer) ?? fallbackThumbnailURL
             let duration = ParsingHelpers.extractDurationFromFlexColumns(responsiveRenderer)
             let album = ParsingHelpers.extractAlbumFromFlexColumns(responsiveRenderer)
             let isPlayable = ParsingHelpers.isPlayableMusicItem(from: responsiveRenderer)
@@ -788,8 +781,7 @@ enum ArtistParser { // swiftlint:disable:this type_body_length
             return nil
         }
 
-        let thumbnails = ParsingHelpers.extractThumbnails(from: data)
-        let thumbnailURL = thumbnails.last.flatMap { URL(string: $0) }
+        let thumbnailURL = ParsingHelpers.extractThumbnailURL(from: data)
         let title = ParsingHelpers.extractTitle(from: data) ?? "Unknown"
         let pageType = ParsingHelpers.extractPageType(from: browseEndpoint)
         let subtitleText = self.parseCarouselSubtitle(from: data)

--- a/Sources/Kaset/Services/API/Parsers/HomeResponseParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/HomeResponseParser.swift
@@ -26,6 +26,7 @@ enum HomeResponseParser {
             return HomeResponse(sections: [])
         }
 
+        sections.reserveCapacity(sectionContents.count)
         for sectionData in sectionContents {
             if let section = parseHomeSection(sectionData) {
                 sections.append(section)
@@ -152,6 +153,7 @@ enum HomeResponseParser {
         }
 
         var items: [HomeSectionItem] = []
+        items.reserveCapacity(contents.count)
         for itemData in contents {
             if let item = parseHomeSectionItem(itemData) {
                 items.append(item)
@@ -180,6 +182,7 @@ enum HomeResponseParser {
         }
 
         var items: [HomeSectionItem] = []
+        items.reserveCapacity(contents.count)
         for itemData in contents {
             if let item = parseHomeSectionItem(itemData) {
                 items.append(item)
@@ -215,6 +218,7 @@ enum HomeResponseParser {
         }
 
         var items: [HomeSectionItem] = []
+        items.reserveCapacity(contents.count)
         for itemData in contents {
             if let item = parseHomeSectionItem(itemData) {
                 items.append(item)
@@ -243,6 +247,7 @@ enum HomeResponseParser {
         }
 
         var items: [HomeSectionItem] = []
+        items.reserveCapacity(contents.count)
         for itemData in contents {
             if let item = parseHomeSectionItem(itemData) {
                 items.append(item)
@@ -278,6 +283,7 @@ enum HomeResponseParser {
         }
 
         var sectionItems: [HomeSectionItem] = []
+        sectionItems.reserveCapacity(items.count)
         for itemData in items {
             if let item = parseHomeSectionItem(itemData) {
                 sectionItems.append(item)
@@ -372,8 +378,7 @@ enum HomeResponseParser {
     }
 
     private static func parseTwoRowItem(_ data: [String: Any]) -> HomeSectionItem? {
-        let thumbnails = ParsingHelpers.extractThumbnails(from: data)
-        let thumbnailURL = thumbnails.last.flatMap { URL(string: $0) }
+        let thumbnailURL = ParsingHelpers.extractThumbnailURL(from: data)
 
         guard let title = ParsingHelpers.extractTitle(from: data) else {
             return nil
@@ -433,8 +438,7 @@ enum HomeResponseParser {
 
         let title = ParsingHelpers.extractTitleFromFlexColumns(data) ?? "Unknown"
         let artists = ParsingHelpers.extractArtistsFromFlexColumns(data)
-        let thumbnails = ParsingHelpers.extractThumbnails(from: data)
-        let thumbnailURL = thumbnails.last.flatMap { URL(string: $0) }
+        let thumbnailURL = ParsingHelpers.extractThumbnailURL(from: data)
         let duration = ParsingHelpers.extractDurationFromFlexColumns(data)
         let album = ParsingHelpers.extractAlbumFromFlexColumns(data)
 
@@ -458,8 +462,7 @@ enum HomeResponseParser {
         pageType: String?
     ) -> HomeSectionItem? {
         let title = ParsingHelpers.extractTitleFromFlexColumns(data) ?? "Unknown"
-        let thumbnails = ParsingHelpers.extractThumbnails(from: data)
-        let thumbnailURL = thumbnails.last.flatMap { URL(string: $0) }
+        let thumbnailURL = ParsingHelpers.extractThumbnailURL(from: data)
 
         guard let itemType = self.determineBrowseItemType(browseId: browseId, pageType: pageType) else {
             return nil

--- a/Sources/Kaset/Services/API/Parsers/LibraryContentParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/LibraryContentParser.swift
@@ -212,14 +212,13 @@ enum LibraryContentParser {
             return nil
         }
 
-        let thumbnails = ParsingHelpers.extractThumbnails(from: data)
         return LibraryItemCandidate(
             sourceName: "parseLibraryItem",
             browseId: browseId,
             browseEndpoint: browseEndpoint,
             title: ParsingHelpers.extractTitle(from: data) ?? "Unknown",
             subtitle: ParsingHelpers.extractSubtitle(from: data),
-            thumbnailURL: thumbnails.last.flatMap { URL(string: $0) },
+            thumbnailURL: ParsingHelpers.extractThumbnailURL(from: data),
             allowsRadioPlaylist: true,
             renderer: data
         )
@@ -234,14 +233,13 @@ enum LibraryContentParser {
             return nil
         }
 
-        let thumbnails = ParsingHelpers.extractThumbnails(from: data)
         return LibraryItemCandidate(
             sourceName: "parseLibraryItemFromResponsive",
             browseId: browseId,
             browseEndpoint: browseEndpoint,
             title: ParsingHelpers.extractTitleFromFlexColumns(data) ?? "Unknown",
             subtitle: ParsingHelpers.extractSubtitleFromFlexColumns(data),
-            thumbnailURL: thumbnails.last.flatMap { URL(string: $0) },
+            thumbnailURL: ParsingHelpers.extractThumbnailURL(from: data),
             allowsRadioPlaylist: false,
             renderer: data
         )

--- a/Sources/Kaset/Services/API/Parsers/ParsingHelpers.swift
+++ b/Sources/Kaset/Services/API/Parsers/ParsingHelpers.swift
@@ -20,14 +20,37 @@ enum ParsingHelpers {
     ///   - components: Additional identifying components (first item ID, index, etc.)
     /// - Returns: A stable hex string ID derived from the content hash
     static func stableId(title: String, components: String...) -> String {
-        var combined = title
+        var reservedCapacity = title.utf8.count
         for component in components {
-            combined += "|" + component
+            reservedCapacity += 1 + component.utf8.count
         }
+
+        var combined = ""
+        combined.reserveCapacity(reservedCapacity)
+        combined += title
+        for component in components {
+            combined.append("|")
+            combined += component
+        }
+
         let data = Data(combined.utf8)
         let hash = SHA256.hash(data: data)
         // Use first 16 bytes (32 hex chars) for a compact but collision-resistant ID
-        return hash.prefix(16).compactMap { String(format: "%02x", $0) }.joined()
+        return Self.hexString(from: hash.prefix(16))
+    }
+
+    private static let lowercaseHexDigits = Array("0123456789abcdef".utf8)
+
+    private static func hexString(from bytes: some Sequence<UInt8>) -> String {
+        var output: [UInt8] = []
+        output.reserveCapacity(32)
+
+        for byte in bytes {
+            output.append(Self.lowercaseHexDigits[Int(byte >> 4)])
+            output.append(Self.lowercaseHexDigits[Int(byte & 0x0F)])
+        }
+
+        return String(bytes: output, encoding: .utf8) ?? ""
     }
 
     /// Keywords used to identify chart sections for special rendering.
@@ -63,7 +86,7 @@ enum ParsingHelpers {
                let thumbData = musicThumbnailRenderer["thumbnail"] as? [String: Any],
                let thumbnails = thumbData["thumbnails"] as? [[String: Any]]
             {
-                return thumbnails.compactMap { $0["url"] as? String }.map(self.normalizeURL)
+                return self.normalizedThumbnailURLs(from: thumbnails)
             }
 
             // Try croppedSquareThumbnailRenderer (used in library playlists)
@@ -71,12 +94,12 @@ enum ParsingHelpers {
                let thumbnails = croppedRenderer["thumbnail"] as? [String: Any],
                let thumbList = thumbnails["thumbnails"] as? [[String: Any]]
             {
-                return thumbList.compactMap { $0["url"] as? String }.map(self.normalizeURL)
+                return Self.normalizedThumbnailURLs(from: thumbList)
             }
 
             // Direct thumbnails array
             if let thumbnails = thumbnail["thumbnails"] as? [[String: Any]] {
-                return thumbnails.compactMap { $0["url"] as? String }.map(self.normalizeURL)
+                return Self.normalizedThumbnailURLs(from: thumbnails)
             }
         }
 
@@ -86,14 +109,14 @@ enum ParsingHelpers {
                let thumbData = musicThumbnailRenderer["thumbnail"] as? [String: Any],
                let thumbnails = thumbData["thumbnails"] as? [[String: Any]]
             {
-                return thumbnails.compactMap { $0["url"] as? String }.map(self.normalizeURL)
+                return Self.normalizedThumbnailURLs(from: thumbnails)
             }
 
             if let croppedRenderer = thumbnailRenderer["croppedSquareThumbnailRenderer"] as? [String: Any],
                let thumbnails = croppedRenderer["thumbnail"] as? [String: Any],
                let thumbList = thumbnails["thumbnails"] as? [[String: Any]]
             {
-                return thumbList.compactMap { $0["url"] as? String }.map(self.normalizeURL)
+                return Self.normalizedThumbnailURLs(from: thumbList)
             }
         }
 
@@ -103,16 +126,107 @@ enum ParsingHelpers {
                let thumbData = musicThumbnailRenderer["thumbnail"] as? [String: Any],
                let thumbnails = thumbData["thumbnails"] as? [[String: Any]]
             {
-                return thumbnails.compactMap { $0["url"] as? String }.map(self.normalizeURL)
+                return Self.normalizedThumbnailURLs(from: thumbnails)
             }
         }
 
         // Try direct thumbnails array at top level
         if let thumbnails = data["thumbnails"] as? [[String: Any]] {
-            return thumbnails.compactMap { $0["url"] as? String }.map(self.normalizeURL)
+            return Self.normalizedThumbnailURLs(from: thumbnails)
         }
 
         return []
+    }
+
+    private static func normalizedThumbnailURLs(from thumbnails: [[String: Any]]) -> [String] {
+        var urls: [String] = []
+        urls.reserveCapacity(thumbnails.count)
+
+        for thumbnail in thumbnails {
+            if let url = thumbnail["url"] as? String {
+                urls.append(Self.normalizeURL(url))
+            }
+        }
+
+        return urls
+    }
+
+    /// Extracts the largest/last thumbnail URL from YouTube Music thumbnail structures.
+    static func extractThumbnailURL(from data: [String: Any]) -> URL? {
+        guard let urlString = extractLastThumbnailURLString(from: data) else {
+            return nil
+        }
+        return URL(string: urlString)
+    }
+
+    private static func extractLastThumbnailURLString(from data: [String: Any]) -> String? {
+        if let thumbnail = data["thumbnail"] as? [String: Any] {
+            if let musicThumbnailRenderer = thumbnail["musicThumbnailRenderer"] as? [String: Any],
+               let thumbData = musicThumbnailRenderer["thumbnail"] as? [String: Any],
+               let thumbnails = thumbData["thumbnails"] as? [[String: Any]],
+               let url = lastNormalizedThumbnailURL(from: thumbnails)
+            {
+                return url
+            }
+
+            if let croppedRenderer = thumbnail["croppedSquareThumbnailRenderer"] as? [String: Any],
+               let thumbnails = croppedRenderer["thumbnail"] as? [String: Any],
+               let thumbList = thumbnails["thumbnails"] as? [[String: Any]],
+               let url = Self.lastNormalizedThumbnailURL(from: thumbList)
+            {
+                return url
+            }
+
+            if let thumbnails = thumbnail["thumbnails"] as? [[String: Any]],
+               let url = Self.lastNormalizedThumbnailURL(from: thumbnails)
+            {
+                return url
+            }
+        }
+
+        if let thumbnailRenderer = data["thumbnailRenderer"] as? [String: Any] {
+            if let musicThumbnailRenderer = thumbnailRenderer["musicThumbnailRenderer"] as? [String: Any],
+               let thumbData = musicThumbnailRenderer["thumbnail"] as? [String: Any],
+               let thumbnails = thumbData["thumbnails"] as? [[String: Any]],
+               let url = Self.lastNormalizedThumbnailURL(from: thumbnails)
+            {
+                return url
+            }
+
+            if let croppedRenderer = thumbnailRenderer["croppedSquareThumbnailRenderer"] as? [String: Any],
+               let thumbnails = croppedRenderer["thumbnail"] as? [String: Any],
+               let thumbList = thumbnails["thumbnails"] as? [[String: Any]],
+               let url = Self.lastNormalizedThumbnailURL(from: thumbList)
+            {
+                return url
+            }
+        }
+
+        if let foregroundThumbnail = data["foregroundThumbnail"] as? [String: Any],
+           let musicThumbnailRenderer = foregroundThumbnail["musicThumbnailRenderer"] as? [String: Any],
+           let thumbData = musicThumbnailRenderer["thumbnail"] as? [String: Any],
+           let thumbnails = thumbData["thumbnails"] as? [[String: Any]],
+           let url = Self.lastNormalizedThumbnailURL(from: thumbnails)
+        {
+            return url
+        }
+
+        if let thumbnails = data["thumbnails"] as? [[String: Any]],
+           let url = Self.lastNormalizedThumbnailURL(from: thumbnails)
+        {
+            return url
+        }
+
+        return nil
+    }
+
+    private static func lastNormalizedThumbnailURL(from thumbnails: [[String: Any]]) -> String? {
+        for thumbnail in thumbnails.reversed() {
+            if let url = thumbnail["url"] as? String {
+                return self.normalizeURL(url)
+            }
+        }
+        return nil
     }
 
     /// Extracts artists from subtitle data.
@@ -445,13 +559,18 @@ enum ParsingHelpers {
 
     /// Parses a duration string (e.g., "3:45") into seconds.
     static func parseDuration(_ text: String) -> TimeInterval? {
-        let components = text.split(separator: ":").compactMap { Int($0) }
-        if components.count == 2 {
-            return TimeInterval(components[0] * 60 + components[1])
-        } else if components.count == 3 {
-            return TimeInterval(components[0] * 3600 + components[1] * 60 + components[2])
+        let components = text.split(separator: ":")
+        guard components.count == 2 || components.count == 3 else {
+            return nil
         }
-        return nil
+
+        var totalSeconds = 0
+        for component in components {
+            guard let value = Int(component) else { return nil }
+            totalSeconds = totalSeconds * 60 + value
+        }
+
+        return TimeInterval(totalSeconds)
     }
 
     /// Extracts subtitle from flex columns.
@@ -459,15 +578,24 @@ enum ParsingHelpers {
     static func extractSubtitleFromFlexColumns(_ data: [String: Any]) -> String? {
         if let flexColumns = data["flexColumns"] as? [[String: Any]],
            flexColumns.count > 1,
-           let secondColumn = flexColumns[safe: 1],
-           let renderer = secondColumn["musicResponsiveListItemFlexColumnRenderer"] as? [String: Any],
+           let renderer = flexColumns[1]["musicResponsiveListItemFlexColumnRenderer"] as? [String: Any],
            let text = renderer["text"] as? [String: Any],
            let runs = text["runs"] as? [[String: Any]]
         {
-            let subtitle = runs.compactMap { $0["text"] as? String }.joined()
+            let subtitle = Self.joinedText(from: runs)
             return subtitle.isEmpty ? nil : subtitle
         }
         return nil
+    }
+
+    private static func joinedText(from runs: [[String: Any]]) -> String {
+        var text = ""
+        for run in runs {
+            if let runText = run["text"] as? String {
+                text += runText
+            }
+        }
+        return text
     }
 
     /// Extracts song count from flex columns subtitle (e.g., "Playlist • 145 songs" → 145).
@@ -495,17 +623,40 @@ enum ParsingHelpers {
 
     /// Extracts song count from subtitle text (e.g., "Playlist • YouTube Music • 145 songs" → 145).
     static func extractSongCount(from text: String) -> Int? {
-        // Match patterns like "145 songs", "1 song", or "2,429 tracks"
-        guard let regex = try? NSRegularExpression(
-            pattern: #"([\d,]+)\s+(?:songs?|tracks?)"#,
-            options: .caseInsensitive
-        ),
-            let match = regex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)),
-            let countRange = Range(match.range(at: 1), in: text)
-        else {
-            return nil
+        let components = text.split(whereSeparator: \.isWhitespace)
+        guard components.count >= 2 else { return nil }
+
+        for index in components.indices.dropFirst() {
+            let unit = components[index]
+                .trimmingCharacters(in: .punctuationCharacters)
+                .lowercased()
+            guard unit == "song" || unit == "songs" || unit == "track" || unit == "tracks" else {
+                continue
+            }
+
+            let countText = components[components.index(before: index)]
+            var normalizedCount = ""
+            normalizedCount.reserveCapacity(countText.count)
+
+            var hasInvalidCharacter = false
+            for character in countText {
+                if character.isNumber {
+                    normalizedCount.append(character)
+                } else if character != "," {
+                    hasInvalidCharacter = true
+                    break
+                }
+            }
+
+            if !hasInvalidCharacter,
+               !normalizedCount.isEmpty,
+               let count = Int(normalizedCount)
+            {
+                return count
+            }
         }
-        return Int(text[countRange].replacingOccurrences(of: ",", with: ""))
+
+        return nil
     }
 
     /// Extracts title from flex columns.
@@ -533,20 +684,35 @@ enum ParsingHelpers {
     }
 
     private static func isMetadataText(_ text: String) -> Bool {
-        if self.contentTypeKeywords.contains(text)
-            || self.parseDuration(text) != nil
-            || self.isNaturalLanguageDuration(text)
-            || self.extractSongCount(from: text) != nil
-            || self.isStandaloneYear(text)
-        {
+        if self.contentTypeKeywords.contains(text) {
             return true
         }
 
         let lowercased = text.lowercased()
-        return lowercased.contains(" views")
+
+        if lowercased.contains(" views")
             || lowercased.contains(" plays")
             || lowercased.contains(" subscribers")
             || lowercased.contains("episodes")
+        {
+            return true
+        }
+
+        if text.contains(":"), self.parseDuration(text) != nil {
+            return true
+        }
+
+        if self.containsDurationUnit(in: lowercased), self.isNaturalLanguageDuration(text) {
+            return true
+        }
+
+        if lowercased.contains("song") || lowercased.contains("track") {
+            if self.extractSongCount(from: text) != nil {
+                return true
+            }
+        }
+
+        return self.isStandaloneYear(text)
     }
 
     private static func isStandaloneYear(_ text: String) -> Bool {
@@ -563,9 +729,8 @@ enum ParsingHelpers {
 
     private static func isNaturalLanguageDuration(_ text: String) -> Bool {
         let lowercased = text.lowercased()
-        let durationUnits = ["second", "seconds", "minute", "minutes", "hour", "hours"]
 
-        guard durationUnits.contains(where: { lowercased.contains($0) }) else {
+        guard Self.containsDurationUnit(in: lowercased) else {
             return false
         }
 
@@ -573,8 +738,15 @@ enum ParsingHelpers {
             character.isNumber
                 || character.isWhitespace
                 || character == ","
-                || durationUnits.joined().contains(character)
+                || Self.durationUnitCharacters.contains(character)
         }
+    }
+
+    private static let durationUnits = ["second", "seconds", "minute", "minutes", "hour", "hours"]
+    private static let durationUnitCharacters = Set("secondsecondsminuteminuteshourhours")
+
+    private static func containsDurationUnit(in lowercasedText: String) -> Bool {
+        self.durationUnits.contains { lowercasedText.contains($0) }
     }
 
     /// Extracts artists from flex columns.
@@ -583,13 +755,15 @@ enum ParsingHelpers {
 
         guard let flexColumns = data["flexColumns"] as? [[String: Any]],
               flexColumns.count > 1,
-              let secondColumn = flexColumns[safe: 1],
-              let renderer = secondColumn["musicResponsiveListItemFlexColumnRenderer"] as? [String: Any],
+              let renderer = flexColumns[1]["musicResponsiveListItemFlexColumnRenderer"] as? [String: Any],
               let text = renderer["text"] as? [String: Any],
               let runs = text["runs"] as? [[String: Any]]
         else {
             return []
         }
+
+        artists.reserveCapacity(runs.count)
+        var fallbackArtistName: String?
 
         for run in runs {
             guard let artistName = (run["text"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -610,6 +784,11 @@ enum ParsingHelpers {
                     name: artistName,
                     profileKind: Artist.profileKind(forPageType: Self.extractPageType(from: browseEndpoint))
                 ))
+            } else if fallbackArtistName == nil,
+                      run["navigationEndpoint"] == nil,
+                      !Self.isMetadataText(artistName)
+            {
+                fallbackArtistName = artistName
             }
         }
 
@@ -620,15 +799,7 @@ enum ParsingHelpers {
         // Uploaded songs often expose artist metadata as plain text, without a
         // browse endpoint. Preserve that text so playlist rows do not show an
         // empty artist line.
-        guard let artistName = runs.compactMap({ run -> String? in
-            guard run["navigationEndpoint"] == nil,
-                  let artistName = (run["text"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
-                  !artistName.isEmpty,
-                  !Self.isArtistSeparator(artistName),
-                  !Self.isMetadataText(artistName)
-            else { return nil }
-            return artistName
-        }).first else {
+        guard let artistName = fallbackArtistName else {
             return []
         }
 
@@ -648,8 +819,7 @@ enum ParsingHelpers {
         // Album is typically in the second or third column
         // Look through columns 1, 2, and 3 (indices 1, 2, 3) for album data
         for columnIndex in 1 ..< min(4, flexColumns.count) {
-            guard let column = flexColumns[safe: columnIndex],
-                  let renderer = column["musicResponsiveListItemFlexColumnRenderer"] as? [String: Any],
+            guard let renderer = flexColumns[columnIndex]["musicResponsiveListItemFlexColumnRenderer"] as? [String: Any],
                   let text = renderer["text"] as? [String: Any],
                   let runs = text["runs"] as? [[String: Any]]
             else {

--- a/Sources/Kaset/Services/API/Parsers/PlaylistParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/PlaylistParser.swift
@@ -624,8 +624,7 @@ enum PlaylistParser {
             header.description = runs.compactMap { $0["text"] as? String }.joined()
         }
 
-        let thumbnails = ParsingHelpers.extractThumbnails(from: renderer)
-        header.thumbnailURL = thumbnails.last.flatMap { URL(string: $0) }
+        header.thumbnailURL = ParsingHelpers.extractThumbnailURL(from: renderer)
 
         if let subtitleData = renderer["subtitle"] as? [String: Any],
            let runs = subtitleData["runs"] as? [[String: Any]]
@@ -652,8 +651,7 @@ enum PlaylistParser {
         }
 
         if header.thumbnailURL == nil {
-            let thumbnails = ParsingHelpers.extractThumbnails(from: renderer)
-            header.thumbnailURL = thumbnails.last.flatMap { URL(string: $0) }
+            header.thumbnailURL = ParsingHelpers.extractThumbnailURL(from: renderer)
         }
 
         if header.description == nil,
@@ -683,8 +681,7 @@ enum PlaylistParser {
         }
 
         if header.thumbnailURL == nil {
-            let thumbnails = ParsingHelpers.extractThumbnails(from: renderer)
-            header.thumbnailURL = thumbnails.last.flatMap { URL(string: $0) }
+            header.thumbnailURL = ParsingHelpers.extractThumbnailURL(from: renderer)
         }
     }
 
@@ -701,8 +698,7 @@ enum PlaylistParser {
         }
 
         if header.thumbnailURL == nil {
-            let thumbnails = ParsingHelpers.extractThumbnails(from: detailHeader)
-            header.thumbnailURL = thumbnails.last.flatMap { URL(string: $0) }
+            header.thumbnailURL = ParsingHelpers.extractThumbnailURL(from: detailHeader)
         }
 
         if let subtitleData = detailHeader["subtitle"] as? [String: Any],
@@ -782,8 +778,7 @@ enum PlaylistParser {
         }
 
         if header.thumbnailURL == nil {
-            let thumbnails = ParsingHelpers.extractThumbnails(from: renderer)
-            header.thumbnailURL = thumbnails.last.flatMap { URL(string: $0) }
+            header.thumbnailURL = ParsingHelpers.extractThumbnailURL(from: renderer)
         }
 
         if header.description == nil,
@@ -918,14 +913,20 @@ enum PlaylistParser {
             return true
         }
 
-        guard let regex = try? NSRegularExpression(
-            pattern: #"^\d+\+?\s+(?:hours?|minutes?|seconds?)$"#,
-            options: .caseInsensitive
-        ) else {
-            return false
-        }
+        let components = text.lowercased().split(whereSeparator: \.isWhitespace)
+        guard components.count == 2 else { return false }
 
-        return regex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)) != nil
+        let amount = components[0]
+        let unit = components[1]
+        let unitMatches = unit == "hour" || unit == "hours"
+            || unit == "minute" || unit == "minutes"
+            || unit == "second" || unit == "seconds"
+        guard unitMatches else { return false }
+
+        if amount.hasSuffix("+") {
+            return amount.dropLast().allSatisfy(\.isNumber)
+        }
+        return amount.allSatisfy(\.isNumber)
     }
 
     // MARK: - Track Parsing
@@ -988,12 +989,18 @@ enum PlaylistParser {
     }
 
     private static func parseTracksFromSections(_ sections: [[String: Any]], fallbackThumbnailURL: URL?) -> [Song] {
-        let playlistShelfTracks = sections.flatMap { sectionData -> [Song] in
+        var playlistShelfTracks: [Song] = []
+        for sectionData in sections {
             guard let playlistShelfRenderer = sectionData["musicPlaylistShelfRenderer"] as? [String: Any],
                   let playlistContents = playlistShelfRenderer["contents"] as? [[String: Any]]
-            else { return [] }
+            else { continue }
 
-            return playlistContents.compactMap { self.parseTrackItem($0, fallbackThumbnailURL: fallbackThumbnailURL) }
+            playlistShelfTracks.reserveCapacity(playlistShelfTracks.count + playlistContents.count)
+            for itemData in playlistContents {
+                if let track = self.parseTrackItem(itemData, fallbackThumbnailURL: fallbackThumbnailURL) {
+                    playlistShelfTracks.append(track)
+                }
+            }
         }
 
         // When the browse response has a musicPlaylistShelfRenderer, that shelf is
@@ -1012,6 +1019,7 @@ enum PlaylistParser {
                   let shelfContents = shelfRenderer["contents"] as? [[String: Any]]
             else { continue }
 
+            tracks.reserveCapacity(tracks.count + shelfContents.count)
             for itemData in shelfContents {
                 if let track = parseTrackItem(itemData, fallbackThumbnailURL: fallbackThumbnailURL) {
                     tracks.append(track)
@@ -1057,8 +1065,7 @@ enum PlaylistParser {
 
         let title = ParsingHelpers.extractTitleFromFlexColumns(responsiveRenderer) ?? "Unknown"
         let artists = ParsingHelpers.extractArtistsFromFlexColumns(responsiveRenderer)
-        let thumbnails = ParsingHelpers.extractThumbnails(from: responsiveRenderer)
-        let thumbnailURL = thumbnails.last.flatMap { URL(string: $0) } ?? fallbackThumbnailURL
+        let thumbnailURL = ParsingHelpers.extractThumbnailURL(from: responsiveRenderer) ?? fallbackThumbnailURL
         let duration = ParsingHelpers.extractDurationFromFlexColumns(responsiveRenderer)
         let album = ParsingHelpers.extractAlbumFromFlexColumns(responsiveRenderer)
         let isPlayable = ParsingHelpers.isPlayableMusicItem(from: responsiveRenderer)
@@ -1116,8 +1123,7 @@ enum PlaylistParser {
             return nil
         }
 
-        let thumbnails = ParsingHelpers.extractThumbnails(from: data)
-        let thumbnailURL = thumbnails.last.flatMap { URL(string: $0) }
+        let thumbnailURL = ParsingHelpers.extractThumbnailURL(from: data)
         let title = ParsingHelpers.extractTitle(from: data) ?? "Unknown Playlist"
 
         return Playlist(
@@ -1140,8 +1146,7 @@ enum PlaylistParser {
             return nil
         }
 
-        let thumbnails = ParsingHelpers.extractThumbnails(from: data)
-        let thumbnailURL = thumbnails.last.flatMap { URL(string: $0) }
+        let thumbnailURL = ParsingHelpers.extractThumbnailURL(from: data)
         let title = ParsingHelpers.extractTitleFromFlexColumns(data) ?? "Unknown Playlist"
 
         return Playlist(
@@ -1301,7 +1306,7 @@ enum PlaylistParser {
 
         let subtitle = Self.extractText(from: data["subtitle"] as? [String: Any])
             ?? Self.extractText(from: data["secondaryText"] as? [String: Any])
-        let thumbnailURL = ParsingHelpers.extractThumbnails(from: data).last.flatMap { URL(string: $0) }
+        let thumbnailURL = ParsingHelpers.extractThumbnailURL(from: data)
 
         return AddToPlaylistOption(
             playlistId: playlistId,

--- a/Sources/Kaset/Services/API/Parsers/PodcastParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/PodcastParser.swift
@@ -176,8 +176,7 @@ enum PodcastParser {
 
     /// Parses a two-row item (typically a podcast show thumbnail card).
     private static func parseTwoRowItem(_ data: [String: Any]) -> PodcastSectionItem? {
-        let thumbnails = ParsingHelpers.extractThumbnails(from: data)
-        let thumbnailURL = thumbnails.last.flatMap { URL(string: $0) }
+        let thumbnailURL = ParsingHelpers.extractThumbnailURL(from: data)
 
         guard let title = ParsingHelpers.extractTitle(from: data) else {
             return nil
@@ -241,8 +240,7 @@ enum PodcastParser {
         let title = Self.extractMultiRowTitle(from: data) ?? "Unknown Episode"
 
         // Extract thumbnail
-        let thumbnails = ParsingHelpers.extractThumbnails(from: data)
-        let thumbnailURL = thumbnails.last.flatMap { URL(string: $0) }
+        let thumbnailURL = ParsingHelpers.extractThumbnailURL(from: data)
 
         // Extract subtitle (show name)
         let showTitle = Self.extractMultiRowSubtitle(from: data)
@@ -325,8 +323,7 @@ enum PodcastParser {
                browseId.hasPrefix("MPSPP")
             {
                 let title = ParsingHelpers.extractTitleFromFlexColumns(data) ?? "Unknown Show"
-                let thumbnails = ParsingHelpers.extractThumbnails(from: data)
-                let thumbnailURL = thumbnails.last.flatMap { URL(string: $0) }
+                let thumbnailURL = ParsingHelpers.extractThumbnailURL(from: data)
                 let author = ParsingHelpers.extractSubtitleFromFlexColumns(data)
 
                 let show = PodcastShow(
@@ -343,8 +340,7 @@ enum PodcastParser {
         }
 
         let title = ParsingHelpers.extractTitleFromFlexColumns(data) ?? "Unknown Episode"
-        let thumbnails = ParsingHelpers.extractThumbnails(from: data)
-        let thumbnailURL = thumbnails.last.flatMap { URL(string: $0) }
+        let thumbnailURL = ParsingHelpers.extractThumbnailURL(from: data)
         let showTitle = ParsingHelpers.extractSubtitleFromFlexColumns(data)
 
         let episode = PodcastEpisode(
@@ -387,8 +383,7 @@ enum PodcastParser {
             author = ParsingHelpers.extractSubtitle(from: musicDetailHeaderRenderer)
             description = Self.extractDescription(from: musicDetailHeaderRenderer)
 
-            let thumbnails = ParsingHelpers.extractThumbnails(from: musicDetailHeaderRenderer)
-            thumbnailURL = thumbnails.last.flatMap { URL(string: $0) }
+            thumbnailURL = ParsingHelpers.extractThumbnailURL(from: musicDetailHeaderRenderer)
         }
 
         // Parse from twoColumnBrowseResultsRenderer (current format)
@@ -409,9 +404,8 @@ enum PodcastParser {
                         author = ParsingHelpers.extractSubtitle(from: headerRenderer) ?? author
                         description = Self.extractDescription(from: headerRenderer) ?? description
 
-                        let thumbnails = ParsingHelpers.extractThumbnails(from: headerRenderer)
-                        if let thumb = thumbnails.last {
-                            thumbnailURL = URL(string: thumb)
+                        if let headerThumbnailURL = ParsingHelpers.extractThumbnailURL(from: headerRenderer) {
+                            thumbnailURL = headerThumbnailURL
                         }
 
                         // Extract subscription status from buttons

--- a/Sources/Kaset/Services/API/Parsers/ResponseTreeSearch.swift
+++ b/Sources/Kaset/Services/API/Parsers/ResponseTreeSearch.swift
@@ -27,11 +27,17 @@ enum ResponseTreeSearch {
     static func containsKey(_ key: String, in value: Any) -> Bool {
         if let dictionary = value as? [String: Any] {
             if dictionary[key] != nil { return true }
-            return dictionary.values.contains { self.containsKey(key, in: $0) }
+            for child in dictionary.values where self.containsKey(key, in: child) {
+                return true
+            }
+            return false
         }
 
         if let array = value as? [Any] {
-            return array.contains { self.containsKey(key, in: $0) }
+            for child in array where self.containsKey(key, in: child) {
+                return true
+            }
+            return false
         }
 
         return false
@@ -43,11 +49,17 @@ enum ResponseTreeSearch {
         }
 
         if let dictionary = value as? [String: Any] {
-            return dictionary.values.contains { self.containsText(text, in: $0) }
+            for child in dictionary.values where self.containsText(text, in: child) {
+                return true
+            }
+            return false
         }
 
         if let array = value as? [Any] {
-            return array.contains { self.containsText(text, in: $0) }
+            for child in array where self.containsText(text, in: child) {
+                return true
+            }
+            return false
         }
 
         return false

--- a/Sources/Kaset/Services/API/Parsers/SearchResponseParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/SearchResponseParser.swift
@@ -37,6 +37,7 @@ enum SearchResponseParser {
             if let shelfRenderer = sectionData["musicShelfRenderer"] as? [String: Any],
                let shelfContents = shelfRenderer["contents"] as? [[String: Any]]
             {
+                songs.reserveCapacity(songs.count + shelfContents.count)
                 for itemData in shelfContents {
                     if let item = parseSearchResultItem(itemData) {
                         Self.appendItem(item, songs: &songs, albums: &albums, artists: &artists, playlists: &playlists)
@@ -90,6 +91,7 @@ enum SearchResponseParser {
             if let shelfRenderer = sectionData["musicShelfRenderer"] as? [String: Any],
                let shelfContents = shelfRenderer["contents"] as? [[String: Any]]
             {
+                songs.reserveCapacity(songs.count + shelfContents.count)
                 for itemData in shelfContents {
                     if let item = parseSearchResultItem(itemData),
                        case let .song(song) = item
@@ -121,8 +123,7 @@ enum SearchResponseParser {
         }
 
         // Extract thumbnail
-        let thumbnails = ParsingHelpers.extractThumbnails(from: data)
-        let thumbnailURL = thumbnails.last.flatMap { URL(string: $0) }
+        let thumbnailURL = ParsingHelpers.extractThumbnailURL(from: data)
 
         // Extract subtitle
         var subtitle: String?
@@ -159,8 +160,7 @@ enum SearchResponseParser {
            let browseEndpoint = navigationEndpoint["browseEndpoint"] as? [String: Any],
            let browseId = browseEndpoint["browseId"] as? String
         {
-            let thumbnails = ParsingHelpers.extractThumbnails(from: responsiveRenderer)
-            let thumbnailURL = thumbnails.last.flatMap { URL(string: $0) }
+            let thumbnailURL = ParsingHelpers.extractThumbnailURL(from: responsiveRenderer)
             let title = ParsingHelpers.extractTitleFromFlexColumns(responsiveRenderer) ?? "Unknown"
             let subtitle = ParsingHelpers.extractSubtitleFromFlexColumns(responsiveRenderer)
 
@@ -227,8 +227,7 @@ enum SearchResponseParser {
         _ data: [String: Any],
         videoId: String
     ) -> SearchResultItem? {
-        let thumbnails = ParsingHelpers.extractThumbnails(from: data)
-        let thumbnailURL = thumbnails.last.flatMap { URL(string: $0) }
+        let thumbnailURL = ParsingHelpers.extractThumbnailURL(from: data)
         let title = ParsingHelpers.extractTitleFromFlexColumns(data) ?? "Unknown"
         let artists = ParsingHelpers.extractArtistsFromFlexColumns(data)
         let album = ParsingHelpers.extractAlbumFromFlexColumns(data)
@@ -300,6 +299,7 @@ enum SearchResponseParser {
             if let shelfRenderer = sectionData["musicShelfRenderer"] as? [String: Any],
                let shelfContents = shelfRenderer["contents"] as? [[String: Any]]
             {
+                albums.reserveCapacity(albums.count + shelfContents.count)
                 for itemData in shelfContents {
                     if let item = parseSearchResultItem(itemData),
                        case let .album(album) = item
@@ -328,6 +328,7 @@ enum SearchResponseParser {
             if let shelfRenderer = sectionData["musicShelfRenderer"] as? [String: Any],
                let shelfContents = shelfRenderer["contents"] as? [[String: Any]]
             {
+                artists.reserveCapacity(artists.count + shelfContents.count)
                 for itemData in shelfContents {
                     if let item = parseSearchResultItem(itemData),
                        case let .artist(artist) = item
@@ -356,6 +357,7 @@ enum SearchResponseParser {
             if let shelfRenderer = sectionData["musicShelfRenderer"] as? [String: Any],
                let shelfContents = shelfRenderer["contents"] as? [[String: Any]]
             {
+                playlists.reserveCapacity(playlists.count + shelfContents.count)
                 for itemData in shelfContents {
                     if let item = parseSearchResultItem(itemData),
                        case let .playlist(playlist) = item
@@ -384,6 +386,7 @@ enum SearchResponseParser {
             if let shelfRenderer = sectionData["musicShelfRenderer"] as? [String: Any],
                let shelfContents = shelfRenderer["contents"] as? [[String: Any]]
             {
+                podcasts.reserveCapacity(podcasts.count + shelfContents.count)
                 for itemData in shelfContents {
                     if let show = Self.parsePodcastShowFromSearchResult(itemData) {
                         podcasts.append(show)
@@ -411,8 +414,7 @@ enum SearchResponseParser {
             return nil
         }
 
-        let thumbnails = ParsingHelpers.extractThumbnails(from: responsiveRenderer)
-        let thumbnailURL = thumbnails.last.flatMap { URL(string: $0) }
+        let thumbnailURL = ParsingHelpers.extractThumbnailURL(from: responsiveRenderer)
         let title = ParsingHelpers.extractTitleFromFlexColumns(responsiveRenderer) ?? "Unknown Podcast"
         let author = ParsingHelpers.extractSubtitleFromFlexColumns(responsiveRenderer)
 
@@ -440,6 +442,7 @@ enum SearchResponseParser {
             if let shelfRenderer = sectionData["musicShelfRenderer"] as? [String: Any],
                let shelfContents = shelfRenderer["contents"] as? [[String: Any]]
             {
+                songs.reserveCapacity(songs.count + shelfContents.count)
                 for itemData in shelfContents {
                     if let item = parseSearchResultItem(itemData),
                        case let .song(song) = item
@@ -470,6 +473,7 @@ enum SearchResponseParser {
         {
             // Parse items
             if let contents = musicShelfContinuation["contents"] as? [[String: Any]] {
+                songs.reserveCapacity(contents.count)
                 for itemData in contents {
                     // Try to parse as podcast show first (for podcast search continuation)
                     if let show = Self.parsePodcastShowFromSearchResult(itemData) {

--- a/Sources/Kaset/Services/API/YouTubeClient.swift
+++ b/Sources/Kaset/Services/API/YouTubeClient.swift
@@ -228,10 +228,16 @@ final class YouTubeClient: YouTubeClientProtocol {
             return nil
         }
 
-        let data = try await self.request("search", body: ["continuation": continuation])
-        let response = YouTubeSearchParser.parseContinuation(data)
-        self.searchContinuation = response.continuation
+        let response = try await self.getSearchContinuation(continuation: continuation)
+        if self.searchContinuation == continuation {
+            self.searchContinuation = response?.continuation
+        }
         return response
+    }
+
+    func getSearchContinuation(continuation: String) async throws -> YouTubeSearchResponse? {
+        let data = try await self.request("search", body: ["continuation": continuation])
+        return YouTubeSearchParser.parseContinuation(data)
     }
 
     // MARK: - Watch

--- a/Sources/Kaset/Services/Player/PlayerService+PlaybackControls.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+PlaybackControls.swift
@@ -219,12 +219,10 @@ extension PlayerService {
             return
         }
 
-        let previousValue = self.currentTrackHasVideo
-        self.currentTrackHasVideo = hasVideo
+        guard self.currentTrackHasVideo != hasVideo else { return }
 
-        if previousValue != hasVideo {
-            self.logger.debug("Video availability updated: \(hasVideo)")
-        }
+        self.currentTrackHasVideo = hasVideo
+        self.logger.debug("Video availability updated: \(hasVideo)")
     }
 
     /// Called when video window opens to start grace period

--- a/Sources/Kaset/Services/Player/PlayerService+PlaybackRestoration.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+PlaybackRestoration.swift
@@ -174,8 +174,12 @@ private extension PlayerService {
         duration: Double,
         previousProgress: TimeInterval
     ) {
-        self.progress = progress
-        self.duration = duration
+        if self.progress != progress {
+            self.progress = progress
+        }
+        if self.duration != duration {
+            self.duration = duration
+        }
 
         if isPlaying {
             self.confirmPlaybackStarted()
@@ -208,7 +212,10 @@ private extension PlayerService {
             return
         }
 
-        self.progress = progress > 0 ? progress : previousProgress
+        let resolvedProgress = progress > 0 ? progress : previousProgress
+        if self.progress != resolvedProgress {
+            self.progress = resolvedProgress
+        }
         self.reconcileRestoredPlaybackWithoutPendingSeek(
             isPlaying: isPlaying,
             resolvedDuration: resolvedDuration
@@ -217,7 +224,9 @@ private extension PlayerService {
 
     func resolveRestoredDuration(from duration: Double) -> TimeInterval {
         let resolvedDuration = duration > 0 ? duration : self.duration
-        self.duration = resolvedDuration
+        if self.duration != resolvedDuration {
+            self.duration = resolvedDuration
+        }
         return resolvedDuration
     }
 
@@ -228,7 +237,9 @@ private extension PlayerService {
         resolvedDuration: TimeInterval
     ) {
         let clampedTargetProgress = self.clampedRestoredProgress(targetProgress, duration: resolvedDuration)
-        self.progress = clampedTargetProgress
+        if self.progress != clampedTargetProgress {
+            self.progress = clampedTargetProgress
+        }
 
         guard resolvedDuration > 0 || clampedTargetProgress == 0 else {
             self.state = self.shouldAutoResumeAfterRestoredLoad ? .loading : .paused

--- a/Sources/Kaset/Services/YouTubeProtocols.swift
+++ b/Sources/Kaset/Services/YouTubeProtocols.swift
@@ -46,6 +46,9 @@ protocol YouTubeClientProtocol: Sendable {
     /// Fetches the next page of the current search, or `nil` when exhausted.
     func getSearchContinuation() async throws -> YouTubeSearchResponse?
 
+    /// Fetches the next page for an explicit search continuation token.
+    func getSearchContinuation(continuation: String) async throws -> YouTubeSearchResponse?
+
     // MARK: Watch
 
     /// Fetches watch-page companion data (metadata + related videos).

--- a/Sources/Kaset/Utilities/ImageCache.swift
+++ b/Sources/Kaset/Utilities/ImageCache.swift
@@ -129,6 +129,11 @@ actor ImageCache {
         return (200 ..< 300).contains(httpResponse.statusCode)
     }
 
+    private static func uniqued(_ urls: [URL]) -> [URL] {
+        var seen = Set<URL>()
+        return urls.filter { seen.insert($0).inserted }
+    }
+
     /// Prefetches images with controlled concurrency to avoid network congestion.
     /// Supports cooperative cancellation from SwiftUI's structured concurrency.
     /// - Parameters:
@@ -136,6 +141,9 @@ actor ImageCache {
     ///   - targetSize: Optional target size for downsampling.
     ///   - maxConcurrent: Maximum number of concurrent fetches (default: 4).
     func prefetch(urls: [URL], targetSize: CGSize? = nil, maxConcurrent: Int = maxConcurrentPrefetch) async {
+        let urls = Self.uniqued(urls)
+        let maxConcurrent = max(1, maxConcurrent)
+
         // Use structured concurrency directly - cancellation propagates automatically
         // when SwiftUI's .task is cancelled (view disappears or id changes)
         await withTaskGroup(of: Void.self) { group in

--- a/Sources/Kaset/ViewModels/PlaylistDetailViewModel.swift
+++ b/Sources/Kaset/ViewModels/PlaylistDetailViewModel.swift
@@ -13,6 +13,18 @@ final class PlaylistDetailViewModel {
         let task: Task<Void, Never>
     }
 
+    private struct RemainingTracksTask {
+        let generation: Int
+        let task: Task<Void, Never>
+    }
+
+    private struct ContinuationDrainBatch {
+        let generation: Int
+        let continuation: String
+        let currentDetail: PlaylistDetail
+        let isLikedMusicPlaylist: Bool
+    }
+
     /// Current loading state.
     private(set) var loadingState: LoadingState = .idle
 
@@ -31,6 +43,16 @@ final class PlaylistDetailViewModel {
     @ObservationIgnored
     private var liveSyncTasks: [String: LiveSyncTask] = [:]
 
+    @ObservationIgnored
+    private var remainingTracksTask: RemainingTracksTask?
+
+    @ObservationIgnored
+    private var loadGeneration = 0
+
+    private var removedLikedMusicVideoIDs: Set<String> = []
+    private var countedRemovedLikedMusicVideoIDs: Set<String> = []
+    private var insertedLikedMusicVideoIDs: Set<String> = []
+
     private var isLikedMusicPlaylist: Bool {
         LikedMusicPlaylist.matches(id: self.playlist.id)
     }
@@ -38,6 +60,13 @@ final class PlaylistDetailViewModel {
     init(playlist: Playlist, client: any YTMusicClientProtocol) {
         self.playlist = playlist
         self.client = client
+    }
+
+    deinit {
+        self.remainingTracksTask?.task.cancel()
+        for liveSyncTask in self.liveSyncTasks.values {
+            liveSyncTask.task.cancel()
+        }
     }
 
     /// Strips song count patterns from author text (e.g., " • 145 songs" or " • 2,429 tracks").
@@ -67,7 +96,18 @@ final class PlaylistDetailViewModel {
 
     /// Loads the playlist details including tracks.
     func load() async {
-        guard self.loadingState != .loading else { return }
+        await self.load(restartingInFlightLoad: false)
+    }
+
+    private func load(restartingInFlightLoad: Bool) async {
+        guard restartingInFlightLoad || (self.loadingState != .loading && self.loadingState != .loadingMore && self.remainingTracksTask == nil) else { return }
+
+        self.cancelRemainingTracksTask()
+        self.loadGeneration += 1
+        let generation = self.loadGeneration
+        self.removedLikedMusicVideoIDs = []
+        self.countedRemovedLikedMusicVideoIDs = []
+        self.insertedLikedMusicVideoIDs = []
 
         self.loadingState = .loading
         self.continuationToken = nil
@@ -83,6 +123,8 @@ final class PlaylistDetailViewModel {
             self.logger.debug("Playlist ID: \(playlistId), isRadioPlaylist: \(isRadioPlaylist)")
 
             let response = try await client.getPlaylist(id: self.playlist.id)
+            guard self.isCurrentLoadGeneration(generation) else { return }
+
             var detail = response.detail
             self.hasMore = response.hasMore
             var nextContinuationToken = response.continuationToken
@@ -93,6 +135,8 @@ final class PlaylistDetailViewModel {
                 self.logger.info("Radio playlist detected, fetching all tracks via queue API")
                 do {
                     let allTracks = try await client.getPlaylistAllTracks(playlistId: self.playlist.id)
+                    guard self.isCurrentLoadGeneration(generation) else { return }
+
                     if allTracks.count > detail.tracks.count {
                         self.logger.info("Queue API returned \(allTracks.count) tracks (vs \(detail.tracks.count) from browse)")
                         // Update the detail with all tracks from queue API
@@ -165,12 +209,16 @@ final class PlaylistDetailViewModel {
             let loadedTrackCount = detail.tracks.count
             let totalTrackCount = detail.trackCount ?? loadedTrackCount
             self.logger.info("Playlist loaded: \(loadedTrackCount) loaded tracks, total: \(totalTrackCount), hasMore: \(self.hasMore)")
-            await self.loadRemainingTracksIfNeeded()
+            self.startRemainingTracksTaskIfNeeded(generation: generation)
         } catch is CancellationError {
+            guard self.isCurrentLoadGeneration(generation) else { return }
+
             // Task was cancelled (e.g., user navigated away) — reset to idle so it can retry
             self.logger.debug("Playlist detail load cancelled")
             self.loadingState = .idle
         } catch {
+            guard self.isCurrentLoadGeneration(generation) else { return }
+
             self.logger.error("Failed to load playlist: \(error.localizedDescription)")
             self.loadingState = .error(LoadingError(from: error))
         }
@@ -178,22 +226,190 @@ final class PlaylistDetailViewModel {
 
     /// Loads more tracks via continuation.
     func loadMore() async {
-        _ = await self.loadMoreBatch()
+        guard self.remainingTracksTask == nil,
+              self.loadingState == .loaded,
+              self.hasMore,
+              self.continuationToken != nil,
+              self.playlistDetail != nil
+        else { return }
+
+        let generation = self.loadGeneration
+        await withTaskCancellationHandler {
+            _ = await self.loadMoreBatch(generation: generation)
+        } onCancel: {
+            Task { @MainActor in
+                if self.isCurrentLoadGeneration(generation), self.loadingState == .loadingMore {
+                    self.loadGeneration += 1
+                    self.loadingState = .loaded
+                }
+            }
+        }
     }
 
-    private func loadRemainingTracksIfNeeded() async {
+    private func startRemainingTracksTaskIfNeeded(generation: Int) {
         guard let currentDetail = self.playlistDetail,
               self.hasMore,
               self.shouldLoadFullPlaylist(currentDetail)
         else { return }
 
+        let client = self.client
+        let task = Task { [weak self, client] in
+            while !Task.isCancelled {
+                guard let batch = self?.nextRemainingTracksBatch(generation: generation) else { break }
+
+                do {
+                    let loadContinuation = client.getPlaylistContinuation(token:)
+                    let response = try await loadContinuation(batch.continuation)
+                    guard self?.applyRemainingTracksResponse(response, batch: batch) == true else { break }
+                } catch is CancellationError {
+                    self?.restoreLoadedStateIfCurrent(generation: generation)
+                    break
+                } catch {
+                    self?.handleRemainingTracksError(error, generation: generation)
+                    break
+                }
+            }
+
+            self?.finishRemainingTracksTask(generation: generation)
+        }
+        self.remainingTracksTask = RemainingTracksTask(generation: generation, task: task)
+    }
+
+    private func nextRemainingTracksBatch(generation: Int) -> ContinuationDrainBatch? {
+        guard let currentDetail = self.playlistDetail,
+              self.hasMore,
+              self.shouldLoadFullPlaylist(currentDetail),
+              let continuationToken,
+              generation == self.loadGeneration,
+              !Task.isCancelled
+        else { return nil }
+
+        if self.loadingState == .loaded {
+            self.loadingState = .loadingMore
+        }
+
         let initialTrackCount = currentDetail.tracks.count
         let totalTrackCount = currentDetail.trackCount ?? self.playlist.trackCount ?? initialTrackCount
         self.logger.info("Loading full playlist: \(initialTrackCount) loaded tracks, total: \(totalTrackCount)")
 
-        while self.hasMore {
-            let didLoadTracks = await self.loadMoreBatch()
-            guard didLoadTracks else { break }
+        return ContinuationDrainBatch(
+            generation: generation,
+            continuation: continuationToken,
+            currentDetail: currentDetail,
+            isLikedMusicPlaylist: self.isLikedMusicPlaylist
+        )
+    }
+
+    private func applyRemainingTracksResponse(_ response: PlaylistContinuationResponse, batch: ContinuationDrainBatch) -> Bool {
+        guard batch.generation == self.loadGeneration,
+              !Task.isCancelled,
+              let latestDetail = self.playlistDetail
+        else { return false }
+
+        let originalExistingVideoIds = Set(batch.currentDetail.tracks.map(\.videoId))
+        let latestExistingVideoIds = originalExistingVideoIds.union(latestDetail.tracks.map(\.videoId))
+        let skippedRemovedVideoIDs = batch.isLikedMusicPlaylist
+            ? response.tracks.compactMap { song -> String? in
+                guard self.removedLikedMusicVideoIDs.contains(song.videoId),
+                      self.countedRemovedLikedMusicVideoIDs.insert(song.videoId).inserted
+                else { return nil }
+                return song.videoId
+            }
+            : []
+        let candidateTracks = batch.isLikedMusicPlaylist
+            ? response.tracks.filter { !self.removedLikedMusicVideoIDs.contains($0.videoId) }
+            : response.tracks
+        let skippedLiveRemovedTracks = candidateTracks.count != response.tracks.count
+        let responseContainsLiveInsertedTrack = batch.isLikedMusicPlaylist && response.tracks.contains { self.insertedLikedMusicVideoIDs.contains($0.videoId) }
+        let newTracks = candidateTracks.filter { !latestExistingVideoIds.contains($0.videoId) }
+
+        if newTracks.isEmpty {
+            let duplicatesWereAlreadyPresent = candidateTracks.allSatisfy { originalExistingVideoIds.contains($0.videoId) }
+            if duplicatesWereAlreadyPresent, !skippedLiveRemovedTracks, !responseContainsLiveInsertedTrack {
+                self.hasMore = false
+                self.continuationToken = nil
+                self.loadingState = .loaded
+                self.logger.info("No new unique tracks in continuation, stopping pagination")
+                return false
+            }
+
+            self.applySkippedLikedMusicRemovalCount(skippedRemovedVideoIDs.count, to: latestDetail)
+            self.continuationToken = response.continuationToken
+            self.hasMore = response.hasMore
+            self.loadingState = .loaded
+            self.logger.info("Continuation tracks already live-synced; advancing cursor, hasMore: \(self.hasMore)")
+            return self.hasMore
+        }
+
+        let normalizedNewTracks: [Song] = if batch.isLikedMusicPlaylist {
+            self.markSongsAsLiked(newTracks)
+        } else {
+            newTracks
+        }
+
+        let allTracks = latestDetail.tracks + normalizedNewTracks
+        let adjustedTrackCount = self.adjustedTrackCount(latestDetail.trackCount, skippedRemovalCount: skippedRemovedVideoIDs.count)
+        let preservedTrackCount = max(allTracks.count, adjustedTrackCount ?? 0)
+        let updatedPlaylist = Playlist(
+            id: latestDetail.id,
+            title: latestDetail.title,
+            description: latestDetail.description,
+            thumbnailURL: latestDetail.thumbnailURL,
+            trackCount: preservedTrackCount,
+            author: latestDetail.author,
+            canDelete: latestDetail.canDelete
+        )
+        self.playlistDetail = PlaylistDetail(
+            playlist: updatedPlaylist,
+            tracks: allTracks,
+            duration: latestDetail.duration
+        )
+
+        if batch.isLikedMusicPlaylist {
+            for song in normalizedNewTracks {
+                SongLikeStatusManager.shared.setStatus(.like, for: song.videoId)
+            }
+        }
+
+        self.continuationToken = response.continuationToken
+        self.hasMore = response.hasMore
+        self.loadingState = .loaded
+        self.logger.info("Loaded \(normalizedNewTracks.count) new tracks (from \(response.tracks.count)), loaded total: \(allTracks.count), reported total: \(preservedTrackCount), hasMore: \(self.hasMore)")
+        return self.hasMore
+    }
+
+    private func adjustedTrackCount(_ trackCount: Int?, skippedRemovalCount: Int) -> Int? {
+        guard skippedRemovalCount > 0, let trackCount else { return trackCount }
+        return max(0, trackCount - skippedRemovalCount)
+    }
+
+    private func applySkippedLikedMusicRemovalCount(_ skippedRemovalCount: Int, to detail: PlaylistDetail) {
+        guard let adjustedTrackCount = self.adjustedTrackCount(detail.trackCount, skippedRemovalCount: skippedRemovalCount),
+              adjustedTrackCount != detail.trackCount
+        else { return }
+
+        self.playlistDetail = self.updatedPlaylistDetail(
+            from: detail,
+            tracks: detail.tracks,
+            trackCount: max(detail.tracks.count, adjustedTrackCount)
+        )
+    }
+
+    private func restoreLoadedStateIfCurrent(generation: Int) {
+        guard generation == self.loadGeneration else { return }
+        self.logger.debug("Playlist continuation cancelled")
+        self.loadingState = .loaded
+    }
+
+    private func handleRemainingTracksError(_ error: any Error, generation: Int) {
+        guard generation == self.loadGeneration else { return }
+        self.logger.error("Failed to load more playlist tracks: \(error.localizedDescription)")
+        self.loadingState = .loaded
+    }
+
+    private func finishRemainingTracksTask(generation: Int) {
+        if self.remainingTracksTask?.generation == generation {
+            self.remainingTracksTask = nil
         }
     }
 
@@ -209,11 +425,12 @@ final class PlaylistDetailViewModel {
         return detail.tracks.count >= Self.fullPlaylistLoadTrackThreshold
     }
 
-    private func loadMoreBatch() async -> Bool {
+    private func loadMoreBatch(generation: Int? = nil) async -> Bool {
         guard self.loadingState == .loaded,
               self.hasMore,
               let continuationToken,
-              let currentDetail = self.playlistDetail
+              let currentDetail = self.playlistDetail,
+              self.isCurrentLoadGeneration(generation)
         else { return false }
 
         self.loadingState = .loadingMore
@@ -224,6 +441,11 @@ final class PlaylistDetailViewModel {
 
             // Build a set of existing video IDs for deduplication
             let existingVideoIds = Set(currentDetail.tracks.map(\.videoId))
+            guard self.isCurrentLoadGeneration(generation) else { return false }
+            guard !Task.isCancelled else {
+                self.loadingState = .loaded
+                return false
+            }
 
             // Filter out duplicates from the new tracks
             let newTracks = response.tracks.filter { !existingVideoIds.contains($0.videoId) }
@@ -275,10 +497,12 @@ final class PlaylistDetailViewModel {
             self.logger.info("Loaded \(normalizedNewTracks.count) new tracks (from \(response.tracks.count)), loaded total: \(allTracks.count), reported total: \(preservedTrackCount), hasMore: \(self.hasMore)")
             return true
         } catch is CancellationError {
+            guard self.isCurrentLoadGeneration(generation) else { return false }
             self.logger.debug("Playlist continuation cancelled")
             self.loadingState = .loaded
             return false
         } catch {
+            guard self.isCurrentLoadGeneration(generation) else { return false }
             self.logger.error("Failed to load more playlist tracks: \(error.localizedDescription)")
             // Keep loaded state so user can retry
             self.loadingState = .loaded
@@ -294,6 +518,8 @@ final class PlaylistDetailViewModel {
         switch event.status {
         // - Liked songs are inserted at the top.
         case .like:
+            self.removedLikedMusicVideoIDs.remove(event.videoId)
+            self.countedRemovedLikedMusicVideoIDs.remove(event.videoId)
             if let song = event.song, !Self.requiresMetadataFetchForLiveSync(song) {
                 self.cancelLiveSyncTask(for: event.videoId)
                 self.insertLiveSyncedLikedSong(song)
@@ -303,6 +529,13 @@ final class PlaylistDetailViewModel {
             }
         // - Unliked/disliked songs are removed immediately.
         case .indifferent, .dislike:
+            let wasLoaded = self.containsTrack(videoId: event.videoId)
+            self.removedLikedMusicVideoIDs.insert(event.videoId)
+            if wasLoaded {
+                self.countedRemovedLikedMusicVideoIDs.insert(event.videoId)
+            }
+            self.insertedLikedMusicVideoIDs.remove(event.videoId)
+            SongLikeStatusManager.shared.setStatus(event.status, for: event.videoId)
             self.cancelLiveSyncTask(for: event.videoId)
             self.removeLiveSyncedLikedSong(videoId: event.videoId)
         }
@@ -311,10 +544,21 @@ final class PlaylistDetailViewModel {
     /// Refreshes the playlist.
     func refresh() async {
         self.cancelAllLiveSyncTasks()
+        self.cancelRemainingTracksTask()
         self.playlistDetail = nil
         self.hasMore = false
         self.continuationToken = nil
-        await self.load()
+        await self.load(restartingInFlightLoad: true)
+    }
+
+    private func cancelRemainingTracksTask() {
+        self.remainingTracksTask?.task.cancel()
+        self.remainingTracksTask = nil
+    }
+
+    private func isCurrentLoadGeneration(_ generation: Int?) -> Bool {
+        guard let generation else { return true }
+        return generation == self.loadGeneration
     }
 
     private func normalizeLikedMusicDetail(_ detail: PlaylistDetail) -> PlaylistDetail {
@@ -373,6 +617,7 @@ final class PlaylistDetailViewModel {
 
         var likedSong = song
         likedSong.likeStatus = .like
+        self.insertedLikedMusicVideoIDs.insert(song.videoId)
 
         let updatedTracks = [likedSong] + currentDetail.tracks
         let currentTotal = currentDetail.trackCount ?? currentDetail.tracks.count

--- a/Sources/Kaset/ViewModels/PlaylistDetailViewModel.swift
+++ b/Sources/Kaset/ViewModels/PlaylistDetailViewModel.swift
@@ -438,64 +438,13 @@ final class PlaylistDetailViewModel {
 
         do {
             let response = try await client.getPlaylistContinuation(token: continuationToken)
-
-            // Build a set of existing video IDs for deduplication
-            let existingVideoIds = Set(currentDetail.tracks.map(\.videoId))
-            guard self.isCurrentLoadGeneration(generation) else { return false }
-            guard !Task.isCancelled else {
-                self.loadingState = .loaded
-                return false
-            }
-
-            // Filter out duplicates from the new tracks
-            let newTracks = response.tracks.filter { !existingVideoIds.contains($0.videoId) }
-
-            // If no new unique tracks were added, stop pagination
-            // This handles radio playlists that return overlapping data
-            if newTracks.isEmpty {
-                self.hasMore = false
-                self.continuationToken = nil
-                self.loadingState = .loaded
-                self.logger.info("No new unique tracks in continuation, stopping pagination")
-                return false
-            }
-
-            let normalizedNewTracks: [Song] = if self.isLikedMusicPlaylist {
-                self.markSongsAsLiked(newTracks)
-            } else {
-                newTracks
-            }
-
-            // Append only new tracks to existing playlist
-            let allTracks = currentDetail.tracks + normalizedNewTracks
-            let preservedTrackCount = max(allTracks.count, currentDetail.trackCount ?? 0)
-            let updatedPlaylist = Playlist(
-                id: currentDetail.id,
-                title: currentDetail.title,
-                description: currentDetail.description,
-                thumbnailURL: currentDetail.thumbnailURL,
-                trackCount: preservedTrackCount,
-                author: currentDetail.author,
-                canDelete: currentDetail.canDelete
+            let batch = ContinuationDrainBatch(
+                generation: generation ?? self.loadGeneration,
+                continuation: continuationToken,
+                currentDetail: currentDetail,
+                isLikedMusicPlaylist: self.isLikedMusicPlaylist
             )
-            self.playlistDetail = PlaylistDetail(
-                playlist: updatedPlaylist,
-                tracks: allTracks,
-                duration: currentDetail.duration
-            )
-
-            if self.isLikedMusicPlaylist {
-                for song in normalizedNewTracks {
-                    SongLikeStatusManager.shared.setStatus(.like, for: song.videoId)
-                }
-            }
-
-            self.continuationToken = response.continuationToken
-            self.hasMore = response.hasMore
-
-            self.loadingState = .loaded
-            self.logger.info("Loaded \(normalizedNewTracks.count) new tracks (from \(response.tracks.count)), loaded total: \(allTracks.count), reported total: \(preservedTrackCount), hasMore: \(self.hasMore)")
-            return true
+            return self.applyRemainingTracksResponse(response, batch: batch)
         } catch is CancellationError {
             guard self.isCurrentLoadGeneration(generation) else { return false }
             self.logger.debug("Playlist continuation cancelled")

--- a/Sources/Kaset/ViewModels/SearchViewModel.swift
+++ b/Sources/Kaset/ViewModels/SearchViewModel.swift
@@ -14,6 +14,7 @@ final class SearchViewModel {
         didSet {
             self.searchTask?.cancel()
             self.suggestionsTask?.cancel()
+            self.allSearchEnrichmentID = nil
             if self.query != self.suppressedSuggestionsQuery {
                 self.suppressedSuggestionsQuery = nil
             }
@@ -47,7 +48,10 @@ final class SearchViewModel {
 
     /// Whether filters should be shown for the current search.
     var shouldShowFilters: Bool {
-        guard !self.query.isEmpty, self.lastSearchedQuery == self.query else {
+        guard !self.query.isEmpty,
+              self.lastSearchedQuery == self.query,
+              self.allSearchEnrichmentID == nil
+        else {
             return false
         }
 
@@ -160,6 +164,12 @@ final class SearchViewModel {
         let error: (any Error)?
     }
 
+    /// Non-nil while an All-filter search has published its mixed first paint
+    /// but is still awaiting dedicated category requests. Filter chips stay
+    /// hidden during this window because those category calls can still update
+    /// the shared client continuation token.
+    private var allSearchEnrichmentID: UUID?
+
     init(client: any YTMusicClientProtocol) {
         self.client = client
     }
@@ -225,6 +235,7 @@ final class SearchViewModel {
     func search() {
         self.searchTask?.cancel()
         self.suggestionsTask?.cancel()
+        self.allSearchEnrichmentID = nil
         self.suggestions = []
         self.suppressedSuggestionsQuery = self.query
         self.client.clearSearchContinuation()
@@ -249,6 +260,7 @@ final class SearchViewModel {
     func searchImmediately() {
         self.searchTask?.cancel()
         self.suggestionsTask?.cancel()
+        self.allSearchEnrichmentID = nil
         self.suggestions = []
         self.suppressedSuggestionsQuery = self.query
         self.client.clearSearchContinuation()
@@ -267,6 +279,7 @@ final class SearchViewModel {
     /// Performs a search with the current filter (no debounce, called when filter changes).
     private func searchWithFilter() {
         self.searchTask?.cancel()
+        self.allSearchEnrichmentID = nil
         self.client.clearSearchContinuation()
 
         guard !self.query.isEmpty else {
@@ -288,6 +301,15 @@ final class SearchViewModel {
         self.loadingState = .loading
         let currentQuery = self.query
         let currentFilter = self.selectedFilter
+        let allSearchEnrichmentID = currentFilter == .all ? UUID() : nil
+        if let allSearchEnrichmentID {
+            self.allSearchEnrichmentID = allSearchEnrichmentID
+        }
+        defer {
+            if let allSearchEnrichmentID, self.allSearchEnrichmentID == allSearchEnrichmentID {
+                self.allSearchEnrichmentID = nil
+            }
+        }
         self.logger.info("Searching for: \(currentQuery) with filter: \(currentFilter.rawValue)")
 
         do {
@@ -502,6 +524,7 @@ final class SearchViewModel {
         self.lastSearchedQuery = nil
         self.lastSearchedFilter = nil
         self.suppressedSuggestionsQuery = nil
+        self.allSearchEnrichmentID = nil
         self.loadingState = .idle
         self.client.clearSearchContinuation()
     }

--- a/Sources/Kaset/ViewModels/SearchViewModel.swift
+++ b/Sources/Kaset/ViewModels/SearchViewModel.swift
@@ -297,7 +297,7 @@ final class SearchViewModel {
                 = switch currentFilter
             {
             case .all:
-                try await self.searchAll(query: currentQuery)
+                try await self.searchAll(query: currentQuery, filter: currentFilter)
             case .songs:
                 try await self.client.searchSongsWithPagination(query: currentQuery)
             case .albums:
@@ -314,28 +314,36 @@ final class SearchViewModel {
 
             // Check cancellation and query change before updating results
             // This handles the race condition where query changed during the request
-            guard !Task.isCancelled, self.query == currentQuery else {
-                self.logger.debug("Search results discarded: query changed or task cancelled")
+            guard self.isCurrentSearch(query: currentQuery, filter: currentFilter) else {
+                self.logger.debug("Search results discarded: query/filter changed or task cancelled")
                 return
             }
 
-            self.results = searchResults
-            self.lastSearchedQuery = currentQuery
-            self.lastSearchedFilter = currentFilter
-            self.loadingState = .loaded
+            self.publishSearchResults(searchResults, query: currentQuery, filter: currentFilter)
             self.logger.info("Search complete: \(searchResults.allItems.count) results, hasMore: \(searchResults.hasMore)")
         } catch {
             // CancellationError is thrown when task is cancelled during URLSession request
-            if !Task.isCancelled, self.query == currentQuery {
+            if self.isCurrentSearch(query: currentQuery, filter: currentFilter) {
                 self.logger.error("Search failed: \(error.localizedDescription)")
                 self.loadingState = .error(LoadingError(from: error))
             }
         }
     }
 
+    private func isCurrentSearch(query: String, filter: SearchFilter) -> Bool {
+        !Task.isCancelled && self.query == query && self.selectedFilter == filter
+    }
+
+    private func publishSearchResults(_ results: SearchResponse, query: String, filter: SearchFilter) {
+        self.results = results
+        self.lastSearchedQuery = query
+        self.lastSearchedFilter = filter
+        self.loadingState = .loaded
+    }
+
     /// Performs the broadest search for the All filter by combining the mixed search response
     /// with the dedicated result-type searches.
-    private func searchAll(query: String) async throws -> SearchResponse {
+    private func searchAll(query: String, filter: SearchFilter) async throws -> SearchResponse {
         async let mixedResults = self.attemptSearch(label: "mixed search") {
             try await self.client.search(query: query)
         }
@@ -358,8 +366,16 @@ final class SearchViewModel {
             try await self.client.searchPodcasts(query: query)
         }
 
+        let mixedAttempt = await mixedResults
+        if let mixedResponse = mixedAttempt.response,
+           !mixedResponse.isEmpty,
+           self.isCurrentSearch(query: query, filter: filter)
+        {
+            self.publishSearchResults(mixedResponse, query: query, filter: filter)
+        }
+
         let attempts = await [
-            mixedResults,
+            mixedAttempt,
             songResults,
             albumResults,
             artistResults,

--- a/Sources/Kaset/ViewModels/YouTube/YouTubeExploreViewModel.swift
+++ b/Sources/Kaset/ViewModels/YouTube/YouTubeExploreViewModel.swift
@@ -16,6 +16,7 @@ final class YouTubeExploreViewModel {
     var selectedDestination: YouTubeDestination = .gaming {
         didSet {
             guard oldValue != self.selectedDestination else { return }
+            self.cancelLoad()
             self.videos = []
             self.loadingState = .idle
         }
@@ -31,20 +32,44 @@ final class YouTubeExploreViewModel {
     /// Invalidates stale in-flight loads when a newer one starts.
     private var loadGeneration = 0
 
+    /// The single in-flight load, shared by concurrent `load()` callers so
+    /// SwiftUI `.task` restarts coalesce onto one run instead of duplicating the
+    /// destination feed request.
+    private var loadTask: Task<Void, Never>?
+
     func load() async {
+        if case .loaded = self.loadingState {
+            return
+        }
+        if let existing = self.loadTask {
+            await existing.value
+            return
+        }
         self.loadGeneration += 1
-        let generation = self.loadGeneration
+        let runID = self.loadGeneration
+        let task = Task { await self.performLoad(runID: runID) }
+        self.loadTask = task
+        await task.value
+    }
+
+    private func performLoad(runID: Int) async {
+        defer {
+            if self.loadGeneration == runID {
+                self.loadTask = nil
+            }
+        }
+        guard runID == self.loadGeneration, !Task.isCancelled else { return }
         self.loadingState = .loading
         let destination = self.selectedDestination
         do {
-            let feed = try await client.getDestinationFeed(destination)
+            let feed = try await self.client.getDestinationFeed(destination)
             // Ignore stale results (superseded load or switched category).
-            guard generation == self.loadGeneration,
+            guard runID == self.loadGeneration,
                   destination == self.selectedDestination else { return }
             self.videos = feed.videos
             self.loadingState = .loaded
         } catch {
-            guard generation == self.loadGeneration,
+            guard runID == self.loadGeneration,
                   destination == self.selectedDestination else { return }
             // A cancelled load (view went away mid-flight) is not an
             // error; reset so the next task run reloads.
@@ -58,8 +83,15 @@ final class YouTubeExploreViewModel {
     }
 
     func refresh() async {
+        self.cancelLoad()
         self.loadingState = .idle
         self.videos = []
         await self.load()
+    }
+
+    func cancelLoad() {
+        self.loadTask?.cancel()
+        self.loadTask = nil
+        self.loadGeneration += 1
     }
 }

--- a/Sources/Kaset/ViewModels/YouTube/YouTubeHistoryViewModel.swift
+++ b/Sources/Kaset/ViewModels/YouTube/YouTubeHistoryViewModel.swift
@@ -22,6 +22,11 @@ final class YouTubeHistoryViewModel {
     /// (SwiftUI restarts .task during launch/layout churn; latest wins).
     private var loadGeneration = 0
 
+    /// The single in-flight load, shared by concurrent `load()` callers so
+    /// SwiftUI `.task` restarts coalesce onto one run instead of duplicating the
+    /// history request.
+    private var loadTask: Task<Void, Never>?
+
     let client: any YouTubeClientProtocol
     private let logger = DiagnosticsLogger.api
 
@@ -30,17 +35,36 @@ final class YouTubeHistoryViewModel {
     }
 
     func load() async {
+        if case .loaded = self.loadingState {
+            return
+        }
+        if let existing = self.loadTask {
+            await existing.value
+            return
+        }
         self.loadGeneration += 1
-        let generation = self.loadGeneration
+        let runID = self.loadGeneration
+        let task = Task { await self.performLoad(runID: runID) }
+        self.loadTask = task
+        await task.value
+    }
+
+    private func performLoad(runID: Int) async {
+        defer {
+            if self.loadGeneration == runID {
+                self.loadTask = nil
+            }
+        }
+        guard runID == self.loadGeneration, !Task.isCancelled else { return }
         self.loadingState = .loading
         do {
-            let feed = try await client.getHistory()
-            guard generation == self.loadGeneration else { return }
+            let feed = try await self.client.getHistory()
+            guard runID == self.loadGeneration else { return }
             self.videos = feed.videos
             self.continuation = feed.continuation
             self.loadingState = .loaded
         } catch {
-            guard generation == self.loadGeneration else { return }
+            guard runID == self.loadGeneration else { return }
             // A cancelled load (view went away mid-flight) is not an
             // error; reset so the next task run reloads.
             if error is CancellationError {
@@ -53,10 +77,17 @@ final class YouTubeHistoryViewModel {
     }
 
     func refresh() async {
+        self.cancelLoad()
         self.loadingState = .idle
         self.videos = []
         self.continuation = nil
         await self.load()
+    }
+
+    func cancelLoad() {
+        self.loadTask?.cancel()
+        self.loadTask = nil
+        self.loadGeneration += 1
     }
 
     func loadMore() async {

--- a/Sources/Kaset/ViewModels/YouTube/YouTubePlaylistsViewModel.swift
+++ b/Sources/Kaset/ViewModels/YouTube/YouTubePlaylistsViewModel.swift
@@ -15,6 +15,11 @@ final class YouTubePlaylistsViewModel {
     /// (SwiftUI restarts .task during launch/layout churn; latest wins).
     private var loadGeneration = 0
 
+    /// The single in-flight load, shared by concurrent `load()` callers so
+    /// SwiftUI `.task` restarts coalesce onto one run instead of duplicating the
+    /// playlists request.
+    private var loadTask: Task<Void, Never>?
+
     let client: any YouTubeClientProtocol
     private let logger = DiagnosticsLogger.api
 
@@ -23,16 +28,35 @@ final class YouTubePlaylistsViewModel {
     }
 
     func load() async {
+        if case .loaded = self.loadingState {
+            return
+        }
+        if let existing = self.loadTask {
+            await existing.value
+            return
+        }
         self.loadGeneration += 1
-        let generation = self.loadGeneration
+        let runID = self.loadGeneration
+        let task = Task { await self.performLoad(runID: runID) }
+        self.loadTask = task
+        await task.value
+    }
+
+    private func performLoad(runID: Int) async {
+        defer {
+            if self.loadGeneration == runID {
+                self.loadTask = nil
+            }
+        }
+        guard runID == self.loadGeneration, !Task.isCancelled else { return }
         self.loadingState = .loading
         do {
             let playlists = try await self.client.getUserPlaylists()
-            guard generation == self.loadGeneration else { return }
+            guard runID == self.loadGeneration else { return }
             self.playlists = playlists
             self.loadingState = .loaded
         } catch {
-            guard generation == self.loadGeneration else { return }
+            guard runID == self.loadGeneration else { return }
             // A cancelled load (view went away mid-flight) is not an
             // error; reset so the next task run reloads.
             if error is CancellationError {
@@ -45,8 +69,15 @@ final class YouTubePlaylistsViewModel {
     }
 
     func refresh() async {
+        self.cancelLoad()
         self.loadingState = .idle
         self.playlists = []
         await self.load()
+    }
+
+    func cancelLoad() {
+        self.loadTask?.cancel()
+        self.loadTask = nil
+        self.loadGeneration += 1
     }
 }

--- a/Sources/Kaset/ViewModels/YouTube/YouTubeSearchViewModel.swift
+++ b/Sources/Kaset/ViewModels/YouTube/YouTubeSearchViewModel.swift
@@ -1,6 +1,8 @@
 import Foundation
 import Observation
 
+// MARK: - YouTubeSearchViewModel
+
 /// View model for YouTube search.
 @MainActor
 @Observable
@@ -11,15 +13,7 @@ final class YouTubeSearchViewModel {
     /// Current search query.
     var query: String = "" {
         didSet {
-            self.searchTask?.cancel()
-            if self.query.isEmpty {
-                self.results = .empty
-                self.loadingState = .idle
-                self.lastSearchedQuery = nil
-            } else if self.query != self.lastSearchedQuery {
-                self.results = .empty
-                self.loadingState = .idle
-            }
+            self.handleQueryChange(from: oldValue)
         }
     }
 
@@ -29,17 +23,19 @@ final class YouTubeSearchViewModel {
     /// Filter for result kinds.
     var selectedFilter: YouTubeSearchFilter = .all {
         didSet {
-            guard oldValue != self.selectedFilter, !self.query.isEmpty else { return }
-            self.searchTask = Task {
-                await self.search()
-            }
+            guard oldValue != self.selectedFilter else { return }
+            self.handleFilterChange()
         }
     }
 
-    /// The query that produced the current results.
-    private var lastSearchedQuery: String?
-
     @ObservationIgnored private var searchTask: Task<Void, Never>?
+    @ObservationIgnored private var paginationTask: Task<Void, Never>?
+
+    private var searchGeneration = 0
+    private var activeSearchRequest: SearchRequest?
+    private var activePaginationRequest: PaginationRequest?
+    private var publishedSearchContext: SearchContext?
+    private var publishedSearchGeneration: Int?
 
     let client: any YouTubeClientProtocol
     private let logger = DiagnosticsLogger.api
@@ -50,33 +46,167 @@ final class YouTubeSearchViewModel {
 
     /// Performs a search for the current query and filter.
     func search() async {
-        let query = self.query.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !query.isEmpty else { return }
+        guard let context = self.currentSearchContext else {
+            self.resetForEmptyQuery()
+            return
+        }
 
+        let start = self.startSearch(for: context, resetResults: false)
+        if start.didCreate {
+            await self.awaitStartedSearch(start)
+        } else {
+            await start.task.value
+        }
+    }
+
+    func cancelSearch() {
+        self.invalidateInFlightSearch()
+        self.resetForEmptyQuery()
+    }
+
+    /// Loads the next page of results.
+    func loadMore() async {
+        guard self.loadingState == .loaded,
+              let continuation = self.results.continuation,
+              let context = self.publishedSearchContext,
+              let generation = self.publishedSearchGeneration,
+              self.isCurrentPublishedSearch(context: context, generation: generation)
+        else { return }
+
+        let request = PaginationRequest(context: context, generation: generation, continuation: continuation)
+        let start = self.startPagination(request)
+        if start.didCreate {
+            await self.awaitStartedPagination(start)
+        } else {
+            await start.task.value
+        }
+    }
+
+    private var currentSearchContext: SearchContext? {
+        let query = Self.normalizedQuery(self.query)
+        guard !query.isEmpty else { return nil }
+        return SearchContext(query: query, filter: self.selectedFilter)
+    }
+
+    private static func normalizedQuery(_ query: String) -> String {
+        query.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func handleQueryChange(from oldValue: String) {
+        let oldQuery = Self.normalizedQuery(oldValue)
+        let newQuery = Self.normalizedQuery(self.query)
+        guard oldQuery != newQuery else { return }
+
+        self.invalidateInFlightSearch()
+
+        if newQuery.isEmpty {
+            self.resetForEmptyQuery()
+        } else if self.publishedSearchContext?.query != newQuery {
+            self.results = .empty
+            self.loadingState = .idle
+            self.publishedSearchContext = nil
+            self.publishedSearchGeneration = nil
+        }
+    }
+
+    private func handleFilterChange() {
+        guard let context = self.currentSearchContext else {
+            self.invalidateInFlightSearch()
+            self.resetForEmptyQuery()
+            return
+        }
+
+        _ = self.startSearch(for: context, resetResults: true)
+    }
+
+    private func startSearch(for context: SearchContext, resetResults: Bool) -> StartedSearch {
+        if let searchTask, let activeSearchRequest, activeSearchRequest.context == context {
+            return StartedSearch(task: searchTask, request: activeSearchRequest, didCreate: false)
+        }
+
+        self.invalidateInFlightSearch()
+        if resetResults {
+            self.results = .empty
+            self.publishedSearchContext = nil
+            self.publishedSearchGeneration = nil
+        }
         self.loadingState = .loading
+
+        let request = SearchRequest(context: context, generation: self.searchGeneration)
+        self.activeSearchRequest = request
+        let task = Task {
+            await self.performSearch(request)
+        }
+        self.searchTask = task
+        return StartedSearch(task: task, request: request, didCreate: true)
+    }
+
+    private func awaitStartedSearch(_ start: StartedSearch) async {
+        await start.task.value
+    }
+
+    private func performSearch(_ request: SearchRequest) async {
+        defer {
+            if self.activeSearchRequest == request {
+                self.activeSearchRequest = nil
+                self.searchTask = nil
+            }
+        }
+
         do {
-            let results = try await client.search(query: query, filter: self.selectedFilter)
+            let results = try await client.search(query: request.context.query, filter: request.context.filter)
+            guard self.isCurrentSearch(request) else { return }
             guard !Task.isCancelled else { return }
+
             self.results = results
-            self.lastSearchedQuery = self.query
+            self.publishedSearchContext = request.context
+            self.publishedSearchGeneration = request.generation
             self.loadingState = .loaded
         } catch {
-            // A cancelled load (view went away mid-flight) is not an
-            // error; the next .task run reloads.
+            // A cancelled load (view went away mid-flight or a newer search
+            // superseded it) is not an error; the next search owns publishing.
             if error is CancellationError { return }
+            guard self.isCurrentSearch(request) else { return }
             guard !Task.isCancelled else { return }
             self.logger.error("YouTube search failed: \(error.localizedDescription)")
             self.loadingState = .error(LoadingError(from: error))
         }
     }
 
-    /// Loads the next page of results.
-    func loadMore() async {
-        guard self.loadingState == .loaded, self.results.continuation != nil else { return }
+    private func startPagination(_ request: PaginationRequest) -> StartedPagination {
+        if let paginationTask, self.activePaginationRequest == request {
+            return StartedPagination(task: paginationTask, request: request, didCreate: false)
+        }
 
         self.loadingState = .loadingMore
+        let task = Task {
+            await self.performLoadMore(request)
+        }
+        self.activePaginationRequest = request
+        self.paginationTask = task
+        return StartedPagination(task: task, request: request, didCreate: true)
+    }
+
+    private func awaitStartedPagination(_ start: StartedPagination) async {
+        await start.task.value
+    }
+
+    private func performLoadMore(_ request: PaginationRequest) async {
+        defer {
+            if self.activePaginationRequest == request || self.activePaginationRequest == nil {
+                self.activePaginationRequest = nil
+                self.paginationTask = nil
+            }
+        }
+
         do {
-            if let more = try await client.getSearchContinuation() {
+            if let more = try await client.getSearchContinuation(continuation: request.continuation) {
+                guard self.isCurrentPagination(request) else { return }
+                guard !Task.isCancelled else {
+                    self.loadingState = .loaded
+                    return
+                }
+
                 let existingVideos = Set(self.results.videos.map(\.videoId))
                 self.results.videos.append(
                     contentsOf: more.videos.filter { !existingVideos.contains($0.videoId) }
@@ -91,10 +221,13 @@ final class YouTubeSearchViewModel {
                 )
                 self.results.continuation = more.continuation
             } else {
+                guard self.isCurrentPagination(request) else { return }
                 self.results.continuation = nil
             }
+            guard self.isCurrentPagination(request) else { return }
             self.loadingState = .loaded
         } catch {
+            guard self.isCurrentPagination(request) else { return }
             // A cancelled page load is not an error; allow retrying.
             if error is CancellationError {
                 self.loadingState = .loaded
@@ -105,4 +238,81 @@ final class YouTubeSearchViewModel {
             self.results.continuation = nil
         }
     }
+
+    private func invalidateInFlightSearch() {
+        self.searchGeneration += 1
+        self.searchTask?.cancel()
+        self.searchTask = nil
+        self.activeSearchRequest = nil
+        _ = self.cancelInFlightPagination()
+    }
+
+    private func cancelInFlightPagination() -> Task<Void, Never>? {
+        let task = self.paginationTask
+        task?.cancel()
+        self.activePaginationRequest = nil
+        return task
+    }
+
+    private func resetForEmptyQuery() {
+        self.results = .empty
+        self.loadingState = .idle
+        self.publishedSearchContext = nil
+        self.publishedSearchGeneration = nil
+    }
+
+    private func isCurrentSearch(_ request: SearchRequest) -> Bool {
+        self.activeSearchRequest == request &&
+            self.searchGeneration == request.generation &&
+            self.currentSearchContext == request.context
+    }
+
+    private func isCurrentPublishedSearch(context: SearchContext, generation: Int) -> Bool {
+        self.searchGeneration == generation &&
+            self.publishedSearchGeneration == generation &&
+            self.publishedSearchContext == context &&
+            self.currentSearchContext == context
+    }
+
+    private func isCurrentPagination(_ request: PaginationRequest) -> Bool {
+        self.isCurrentPublishedSearch(context: request.context, generation: request.generation)
+    }
+}
+
+// MARK: - SearchContext
+
+private struct SearchContext: Equatable {
+    let query: String
+    let filter: YouTubeSearchFilter
+}
+
+// MARK: - SearchRequest
+
+private struct SearchRequest: Equatable {
+    let context: SearchContext
+    let generation: Int
+}
+
+// MARK: - PaginationRequest
+
+private struct PaginationRequest: Equatable {
+    let context: SearchContext
+    let generation: Int
+    let continuation: String
+}
+
+// MARK: - StartedSearch
+
+private struct StartedSearch {
+    let task: Task<Void, Never>
+    let request: SearchRequest
+    let didCreate: Bool
+}
+
+// MARK: - StartedPagination
+
+private struct StartedPagination {
+    let task: Task<Void, Never>
+    let request: PaginationRequest
+    let didCreate: Bool
 }

--- a/Sources/Kaset/ViewModels/YouTube/YouTubeShortsViewModel.swift
+++ b/Sources/Kaset/ViewModels/YouTube/YouTubeShortsViewModel.swift
@@ -18,6 +18,11 @@ final class YouTubeShortsViewModel {
     /// (SwiftUI restarts .task during launch/layout churn; latest wins).
     private var loadGeneration = 0
 
+    /// The single in-flight load, shared by concurrent `load()` callers so
+    /// SwiftUI `.task` restarts coalesce onto one run instead of duplicating the
+    /// Shorts request.
+    private var loadTask: Task<Void, Never>?
+
     let client: any YouTubeClientProtocol
     private let logger = DiagnosticsLogger.api
 
@@ -26,16 +31,35 @@ final class YouTubeShortsViewModel {
     }
 
     func load() async {
+        if case .loaded = self.loadingState {
+            return
+        }
+        if let existing = self.loadTask {
+            await existing.value
+            return
+        }
         self.loadGeneration += 1
-        let generation = self.loadGeneration
+        let runID = self.loadGeneration
+        let task = Task { await self.performLoad(runID: runID) }
+        self.loadTask = task
+        await task.value
+    }
+
+    private func performLoad(runID: Int) async {
+        defer {
+            if self.loadGeneration == runID {
+                self.loadTask = nil
+            }
+        }
+        guard runID == self.loadGeneration, !Task.isCancelled else { return }
         self.loadingState = .loading
         do {
             let shorts = try await self.client.getShorts()
-            guard generation == self.loadGeneration else { return }
+            guard runID == self.loadGeneration else { return }
             self.shorts = shorts
             self.loadingState = .loaded
         } catch {
-            guard generation == self.loadGeneration else { return }
+            guard runID == self.loadGeneration else { return }
             // A cancelled load (view went away mid-flight) is not an
             // error; reset so the next task run reloads.
             if error is CancellationError {
@@ -48,8 +72,15 @@ final class YouTubeShortsViewModel {
     }
 
     func refresh() async {
+        self.cancelLoad()
         self.loadingState = .idle
         self.shorts = []
         await self.load()
+    }
+
+    func cancelLoad() {
+        self.loadTask?.cancel()
+        self.loadTask = nil
+        self.loadGeneration += 1
     }
 }

--- a/Sources/Kaset/ViewModels/YouTube/YouTubeSubscriptionsViewModel.swift
+++ b/Sources/Kaset/ViewModels/YouTube/YouTubeSubscriptionsViewModel.swift
@@ -26,6 +26,11 @@ final class YouTubeSubscriptionsViewModel {
     /// (SwiftUI restarts .task during launch/layout churn; latest wins).
     private var loadGeneration = 0
 
+    /// The single in-flight load, shared by concurrent `load()` callers so
+    /// SwiftUI `.task` restarts coalesce onto one run instead of duplicating the
+    /// subscriptions feed and guide requests.
+    private var loadTask: Task<Void, Never>?
+
     let client: any YouTubeClientProtocol
     private let logger = DiagnosticsLogger.api
 
@@ -34,22 +39,44 @@ final class YouTubeSubscriptionsViewModel {
     }
 
     func load() async {
+        if case .loaded = self.loadingState {
+            return
+        }
+        if let existing = self.loadTask {
+            await existing.value
+            return
+        }
         self.loadGeneration += 1
-        let generation = self.loadGeneration
+        let runID = self.loadGeneration
+        let task = Task { await self.performLoad(runID: runID) }
+        self.loadTask = task
+        await task.value
+    }
+
+    private func performLoad(runID: Int) async {
+        defer {
+            if self.loadGeneration == runID {
+                self.loadTask = nil
+            }
+        }
+        guard runID == self.loadGeneration, !Task.isCancelled else { return }
         self.loadingState = .loading
         do {
             async let feedTask = self.client.getSubscriptionsFeed()
             async let channelsTask = self.client.getSubscribedChannels()
 
             let feed = try await feedTask
-            guard generation == self.loadGeneration else { return }
+            guard runID == self.loadGeneration else { return }
             self.videos = feed.videos
             self.continuation = feed.continuation
+
             // Channel rail is best-effort; the feed alone is still useful.
-            self.channels = await (try? channelsTask) ?? []
+            let channels = await (try? channelsTask) ?? []
+            guard runID == self.loadGeneration else { return }
+            self.channels = channels
             self.loadingState = .loaded
         } catch {
-            guard generation == self.loadGeneration else { return }
+            guard runID == self.loadGeneration else { return }
             // A cancelled load (view went away mid-flight) is not an
             // error; reset so the next task run reloads.
             if error is CancellationError {
@@ -62,11 +89,18 @@ final class YouTubeSubscriptionsViewModel {
     }
 
     func refresh() async {
+        self.cancelLoad()
         self.loadingState = .idle
         self.videos = []
         self.channels = []
         self.continuation = nil
         await self.load()
+    }
+
+    func cancelLoad() {
+        self.loadTask?.cancel()
+        self.loadTask = nil
+        self.loadGeneration += 1
     }
 
     func loadMore() async {

--- a/Sources/Kaset/Views/CachedAsyncImage.swift
+++ b/Sources/Kaset/Views/CachedAsyncImage.swift
@@ -1,5 +1,12 @@
 import SwiftUI
 
+// MARK: - CachedAsyncImageRequest
+
+private struct CachedAsyncImageRequest: Equatable {
+    let url: URL?
+    let targetSize: CGSize
+}
+
 // MARK: - CachedAsyncImage
 
 /// A cached version of AsyncImage that uses ImageCache.
@@ -14,12 +21,18 @@ struct CachedAsyncImage<Content: View, Placeholder: View>: View {
     @ViewBuilder let content: (Image) -> Content
     @ViewBuilder let placeholder: () -> Placeholder
 
+    @Environment(\.accessibilityReduceMotion) private var accessibilityReduceMotion
+
     @State private var image: NSImage?
     @State private var isLoaded = false
 
+    private var request: CachedAsyncImageRequest {
+        CachedAsyncImageRequest(url: self.url, targetSize: self.targetSize)
+    }
+
     /// Whether to animate the image appearance.
     private var shouldAnimate: Bool {
-        !NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+        !self.accessibilityReduceMotion
     }
 
     var body: some View {
@@ -32,15 +45,17 @@ struct CachedAsyncImage<Content: View, Placeholder: View>: View {
                 self.placeholder()
             }
         }
-        .onChange(of: self.url) { _, _ in
-            // Reset state when URL changes for proper UX
+        .onChange(of: self.request) { _, _ in
+            // Reset state when the underlying request changes for proper UX.
+            // Include targetSize so a reused view does not keep a stale decode.
             self.image = nil
             self.isLoaded = false
         }
-        .task(id: self.url) {
-            guard let url else { return }
-            let loadedImage = await ImageCache.shared.image(for: url, targetSize: self.targetSize)
-            guard !Task.isCancelled else { return }
+        .task(id: self.request) {
+            let request = self.request
+            guard let url = request.url else { return }
+            let loadedImage = await ImageCache.shared.image(for: url, targetSize: request.targetSize)
+            guard !Task.isCancelled, self.request == request else { return }
 
             guard let loadedImage else {
                 self.image = nil
@@ -70,10 +85,12 @@ extension CachedAsyncImage where Placeholder == SizedProgressView {
     /// Convenience initializer with default ProgressView placeholder.
     init(
         url: URL?,
+        targetSize: CGSize = .init(width: 320, height: 320),
         onFailure: (@MainActor () -> Void)? = nil,
         @ViewBuilder content: @escaping (Image) -> Content
     ) {
         self.url = url
+        self.targetSize = targetSize
         self.onFailure = onFailure
         self.content = content
         self.placeholder = { SizedProgressView() }

--- a/Sources/Kaset/Views/MiniPlayerWebView.swift
+++ b/Sources/Kaset/Views/MiniPlayerWebView.swift
@@ -593,10 +593,15 @@ final class SingletonPlayerWebView {
                     self.playerService.updateLikeStatus(likeStatus)
                 }
 
-                // Repeat-one must keep enforcing queue/current song even if WebView doesn't flag `trackChanged`
-                // for a transient autoplay swap. In other modes, keep the existing trackChanged gate.
-                let shouldReconcileMetadata = (trackChanged || self.playerService.repeatMode == .one)
-                    && (observedVideoId != nil || !title.isEmpty)
+                let hasObservedMetadata = observedVideoId != nil || !title.isEmpty
+                // Repeat-one still needs drift recovery, but the normal same-song polling path
+                // should not rewrite `currentTrack` on every observer tick.
+                let repeatOneNeedsReconcile = self.playerService.repeatMode == .one
+                    && hasObservedMetadata
+                    && (trackChanged
+                        || (observedVideoId != nil && observedVideoId != self.playerService.currentTrack?.videoId)
+                        || (observedVideoId == nil && !title.isEmpty && title != self.playerService.currentTrack?.title))
+                let shouldReconcileMetadata = hasObservedMetadata && (trackChanged || repeatOneNeedsReconcile)
 
                 if shouldReconcileMetadata {
                     self.playerService.updateTrackMetadata(

--- a/Sources/Kaset/Views/SharedViews/FavoritesSection.swift
+++ b/Sources/Kaset/Views/SharedViews/FavoritesSection.swift
@@ -236,6 +236,7 @@ private struct FavoriteItemCard: View {
 
     private static let cardWidth: CGFloat = 160
     private static let cardHeight: CGFloat = 160
+    private static let thumbnailTargetSize = CGSize(width: cardWidth, height: cardHeight)
 
     @State private var isHovering = false
 
@@ -259,7 +260,7 @@ private struct FavoriteItemCard: View {
     private var thumbnail: some View {
         ZStack {
             if let url = item.thumbnailURL?.highQualityThumbnailURL {
-                CachedAsyncImage(url: url) { image in
+                CachedAsyncImage(url: url, targetSize: Self.thumbnailTargetSize) { image in
                     image
                         .resizable()
                         .aspectRatio(contentMode: .fill)

--- a/Sources/Kaset/Views/SharedViews/HomeSectionItemCard.swift
+++ b/Sources/Kaset/Views/SharedViews/HomeSectionItemCard.swift
@@ -101,11 +101,18 @@ struct HomeSectionItemCard: View {
     // MARK: - Shared Components
 
     private var thumbnail: some View {
-        ZStack {
+        let thumbnailURLs = self.thumbnailURLs
+        let thumbnailURL = thumbnailURLs.first { !self.failedThumbnailURLs.contains($0) }
+
+        return ZStack {
             self.thumbnailBackground
 
-            if let url = self.thumbnailURL {
-                CachedAsyncImage(url: url, targetSize: self.thumbnailSize, onFailure: self.thumbnailFailureHandler) { image in
+            if let thumbnailURL {
+                CachedAsyncImage(
+                    url: thumbnailURL,
+                    targetSize: self.thumbnailSize,
+                    onFailure: self.thumbnailFailureHandler(for: thumbnailURL, in: thumbnailURLs)
+                ) { image in
                     image
                         .resizable()
                         .aspectRatio(contentMode: self.thumbnailContentMode)
@@ -147,10 +154,6 @@ struct HomeSectionItemCard: View {
         }
     }
 
-    private var thumbnailURL: URL? {
-        self.thumbnailURLs.first { !self.failedThumbnailURLs.contains($0) }
-    }
-
     private var thumbnailURLs: [URL] {
         if self.isVideoSong {
             return Self.uniqueURLs([
@@ -163,10 +166,8 @@ struct HomeSectionItemCard: View {
         return Self.uniqueURLs([self.item.thumbnailURL?.highQualityThumbnailURL])
     }
 
-    private var thumbnailFailureHandler: (@MainActor () -> Void)? {
-        guard let thumbnailURL,
-              self.hasFallback(after: thumbnailURL)
-        else {
+    private func thumbnailFailureHandler(for thumbnailURL: URL, in thumbnailURLs: [URL]) -> (@MainActor () -> Void)? {
+        guard self.hasFallback(after: thumbnailURL, in: thumbnailURLs) else {
             return nil
         }
 
@@ -189,9 +190,9 @@ struct HomeSectionItemCard: View {
         self.isVideoSong ? .fit : .fill
     }
 
-    private func hasFallback(after url: URL) -> Bool {
-        guard let index = self.thumbnailURLs.firstIndex(of: url) else { return false }
-        let fallbackURLs = self.thumbnailURLs.dropFirst(index + 1)
+    private func hasFallback(after url: URL, in thumbnailURLs: [URL]) -> Bool {
+        guard let index = thumbnailURLs.firstIndex(of: url) else { return false }
+        let fallbackURLs = thumbnailURLs.dropFirst(index + 1)
         return fallbackURLs.contains { !self.failedThumbnailURLs.contains($0) }
     }
 

--- a/Sources/Kaset/Views/SharedViews/SongThumbnailView.swift
+++ b/Sources/Kaset/Views/SharedViews/SongThumbnailView.swift
@@ -74,8 +74,13 @@ struct SongThumbnailView: View {
         }
     }
 
+    private var targetSize: CGSize {
+        let dimension = max(self.size, 1)
+        return CGSize(width: dimension, height: dimension)
+    }
+
     var body: some View {
-        CachedAsyncImage(url: self.activeURL, onFailure: self.failureHandler) { image in
+        CachedAsyncImage(url: self.activeURL, targetSize: self.targetSize, onFailure: self.failureHandler) { image in
             image
                 .resizable()
                 .aspectRatio(contentMode: .fill)

--- a/Sources/Kaset/Views/SingletonPlayerWebView+ObserverScript.swift
+++ b/Sources/Kaset/Views/SingletonPlayerWebView+ObserverScript.swift
@@ -29,6 +29,7 @@ extension SingletonPlayerWebView {
             let isPollingActive = false;
             let pollIntervalId = null;
             let lastUpdateTime = 0;
+            let trailingUpdateTimeoutId = null;
             const UPDATE_THROTTLE_MS = 500; // Throttle updates to max 2/sec
             const POLL_INTERVAL_MS = 1000; // Poll at 1Hz during playback (reduced from 250ms)
 
@@ -86,8 +87,8 @@ extension SingletonPlayerWebView {
                         sendTrackEnded();
                         stopPolling();
                     });
-                    video.addEventListener('waiting', () => sendUpdate()); // Buffer state
-                    video.addEventListener('seeked', () => sendUpdate()); // Seek completed
+                    video.addEventListener('waiting', () => sendUpdate(true)); // Buffer state
+                    video.addEventListener('seeked', () => sendUpdate(true)); // Seek completed
 
                     // AirPlay state tracking
                     video.addEventListener('webkitcurrentplaybacktargetiswirelesschanged', () => {
@@ -241,7 +242,7 @@ extension SingletonPlayerWebView {
                 // Don't apply volume here - let volume enforcement handle it
                 // Applying volume on every startPolling causes volume jumps
 
-                sendUpdate(); // Immediate update
+                sendUpdate(true); // Immediate update
                 // Poll at 1Hz during playback for progress updates (reduced CPU usage)
                 pollIntervalId = setInterval(sendUpdate, POLL_INTERVAL_MS);
             }
@@ -252,7 +253,7 @@ extension SingletonPlayerWebView {
                     clearInterval(pollIntervalId);
                     pollIntervalId = null;
                 }
-                sendUpdate(); // Final state update
+                sendUpdate(true); // Final state update
             }
 
             function setupObserver(playerBar) {
@@ -270,7 +271,7 @@ extension SingletonPlayerWebView {
                     childList: true, subtree: true,
                     attributeFilter: ['title', 'aria-label', 'like-status', 'value', 'aria-valuemax']
                 });
-                sendUpdate();
+                sendUpdate(true);
             }
 
             function sendTrackEnded() {
@@ -281,11 +282,25 @@ extension SingletonPlayerWebView {
                 });
             }
 
-            function sendUpdate() {
-                // Throttle updates
+            function sendUpdate(force = false) {
+                // Throttle non-forced updates across polling and mutation paths.
+                // If an update is skipped, keep one trailing send so paused/setup
+                // mutations that are not followed by a polling tick still reach Swift.
                 const now = Date.now();
-                if (now - lastUpdateTime < UPDATE_THROTTLE_MS && isPollingActive) {
-                    return;
+                if (!force) {
+                    const elapsed = now - lastUpdateTime;
+                    if (elapsed < UPDATE_THROTTLE_MS) {
+                        if (!trailingUpdateTimeoutId) {
+                            trailingUpdateTimeoutId = setTimeout(() => {
+                                trailingUpdateTimeoutId = null;
+                                sendUpdate(true);
+                            }, UPDATE_THROTTLE_MS - elapsed);
+                        }
+                        return;
+                    }
+                } else if (trailingUpdateTimeoutId) {
+                    clearTimeout(trailingUpdateTimeoutId);
+                    trailingUpdateTimeoutId = null;
                 }
                 lastUpdateTime = now;
 

--- a/Sources/Kaset/Views/YouTube/VideoCard.swift
+++ b/Sources/Kaset/Views/YouTube/VideoCard.swift
@@ -67,16 +67,12 @@ struct VideoCard: View {
 /// 16:9 video thumbnail with a duration (or LIVE) badge.
 struct VideoThumbnailView: View {
     let video: YouTubeVideo
+    var targetSize = CGSize(width: 320, height: 180)
 
     var body: some View {
         CachedAsyncImage(
             url: self.video.thumbnailURL,
-            // Cards render at ≤320 pt wide (~640 px @2x). ImageCache doubles
-            // targetSize for Retina, so 320×180 → a 640 px decode that matches
-            // the displayed size. The previous 640×360 decoded at 1280 px — ~4×
-            // the pixels — wasting CPU on first paint and thrashing the 50 MB
-            // memory cache (fewer images fit → re-decode on scroll).
-            targetSize: CGSize(width: 320, height: 180)
+            targetSize: self.targetSize
         ) { image in
             image
                 .resizable()

--- a/Sources/Kaset/Views/YouTube/YouTubeListRows.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeListRows.swift
@@ -8,7 +8,7 @@ struct VideoRowView: View {
 
     var body: some View {
         HStack(alignment: .top, spacing: 12) {
-            VideoThumbnailView(video: self.video)
+            VideoThumbnailView(video: self.video, targetSize: CGSize(width: 160, height: 90))
                 .frame(width: 160)
 
             VStack(alignment: .leading, spacing: 3) {
@@ -107,7 +107,7 @@ struct YouTubePlaylistRowView: View {
         HStack(alignment: .top, spacing: 12) {
             CachedAsyncImage(
                 url: self.playlist.thumbnailURL,
-                targetSize: CGSize(width: 320, height: 180)
+                targetSize: CGSize(width: 160, height: 90)
             ) { image in
                 image
                     .resizable()
@@ -172,7 +172,7 @@ struct YouTubePlaylistCard: View {
         VStack(alignment: .leading, spacing: 8) {
             CachedAsyncImage(
                 url: self.playlist.thumbnailURL,
-                targetSize: CGSize(width: 640, height: 360)
+                targetSize: CGSize(width: 320, height: 180)
             ) { image in
                 image
                     .resizable()

--- a/Sources/Kaset/Views/YouTube/YouTubeViewModelStore.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeViewModelStore.swift
@@ -36,11 +36,18 @@ final class YouTubeViewModelStore {
 
     /// Resets account-scoped state after an account switch.
     func resetForAccountChange() {
-        // Cancel the outgoing Home model's in-flight load before discarding it:
-        // its unstructured load task survives view teardown and would otherwise
-        // keep using the shared client after the cache scope moved to the new
-        // account (stale continuation / cache contamination).
+        // Cancel outgoing in-flight work before discarding the models: their
+        // unstructured single-flight tasks intentionally survive SwiftUI task
+        // cancellation, so account changes must explicitly stop them before the
+        // shared client/cache scope moves to the new account.
         self.home.cancelLoad()
+        self.search.cancelSearch()
+        self.explore.cancelLoad()
+        self.shorts.cancelLoad()
+        self.subscriptions.cancelLoad()
+        self.history.cancelLoad()
+        self.playlists.cancelLoad()
+
         self.home = YouTubeHomeViewModel(client: self.client)
         self.search = YouTubeSearchViewModel(client: self.client)
         self.explore = YouTubeExploreViewModel(client: self.client)

--- a/Tests/KasetTests/AccountServiceTests.swift
+++ b/Tests/KasetTests/AccountServiceTests.swift
@@ -423,6 +423,8 @@ struct AccountServiceTests {
             signinURL: URL(string: "https://www.youtube.com/signin?pageid=222222222222222222222&authuser=0&next=%2F")
         )
         await Self.populateAccounts(services, accounts: [primary, brandA, brandB], selectedIndex: 0)
+        await Self.waitForSwitchSessionIdentityCompletions(mockWebKit, count: 1)
+        mockWebKit.reset()
 
         // Gate the FIRST switch (to A) so it is still verifying when B starts.
         let releaseA = AsyncReleaseGate()
@@ -903,6 +905,18 @@ struct AccountServiceTests {
         SongLikeStatusManager.shared.clearCache()
         SongLikeStatusManager.shared.setActiveAccountID(nil)
         return TestServices(account: service, client: mockClient, auth: authService)
+    }
+
+    @MainActor
+    private static func waitForSwitchSessionIdentityCompletions(
+        _ mockWebKit: MockWebKitManager,
+        count: Int
+    ) async {
+        for _ in 0 ..< 1000 {
+            if mockWebKit.switchSessionIdentityCompletedBrandIds.count >= count { return }
+            await Task.yield()
+        }
+        Issue.record("Timed out waiting for switch session identity completions")
     }
 
     /// Populates the AccountService with accounts by going through fetchAccounts().

--- a/Tests/KasetTests/AutoplayRecoveryTests.swift
+++ b/Tests/KasetTests/AutoplayRecoveryTests.swift
@@ -116,6 +116,14 @@ struct AutoplayRecoveryJSTests {
     func observerScriptRetriesRecoveryWhenMediaAlreadyReady() {
         #expect(SingletonPlayerWebView.observerScript.contains("video.readyState >= 3"))
     }
+
+    @Test("Observer script schedules trailing throttled updates")
+    func observerScriptSchedulesTrailingThrottledUpdates() {
+        let script = SingletonPlayerWebView.observerScript
+
+        #expect(script.contains("trailingUpdateTimeoutId"))
+        #expect(script.contains("sendUpdate(true);"))
+    }
 }
 
 // MARK: - AutoplayIntentScriptTests

--- a/Tests/KasetTests/Helpers/AsyncGate.swift
+++ b/Tests/KasetTests/Helpers/AsyncGate.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// A one-shot async gate for tests: `wait()` suspends until `open()` is called.
+actor AsyncGate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        if self.isOpen { return }
+        await withCheckedContinuation { continuation in
+            self.waiters.append(continuation)
+        }
+    }
+
+    func open() {
+        self.isOpen = true
+        let pending = self.waiters
+        self.waiters.removeAll()
+        for continuation in pending {
+            continuation.resume()
+        }
+    }
+}

--- a/Tests/KasetTests/Helpers/MockYTMusicClient.swift
+++ b/Tests/KasetTests/Helpers/MockYTMusicClient.swift
@@ -5,6 +5,18 @@ import Foundation
 /// A mock implementation of YTMusicClientProtocol for testing.
 @MainActor
 final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this type_body_length
+    enum SearchEndpoint: Hashable {
+        case mixed
+        case songs
+        case songsWithPagination
+        case albums
+        case artists
+        case playlists
+        case featuredPlaylists
+        case communityPlaylists
+        case podcasts
+    }
+
     private static func playlistContinuationToken(playlistId: String, index: Int) -> String {
         "mock-playlist-continuation|\(playlistId)|\(index)"
     }
@@ -161,6 +173,16 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     private(set) var getChartsCallCount = 0
     private(set) var searchCalled = false
     private(set) var searchQueries: [String] = []
+    private(set) var completedSearchEndpoints: [SearchEndpoint] = []
+
+    var beforeSearchReturn: (@Sendable (String, SearchEndpoint) async -> Void)?
+
+    private func waitBeforeSearchReturn(query: String, endpoint: SearchEndpoint) async {
+        if let beforeSearchReturn {
+            await beforeSearchReturn(query, endpoint)
+        }
+    }
+
     private(set) var getSearchSuggestionsCalled = false
     private(set) var getSearchSuggestionsQueries: [String] = []
     private(set) var getLibraryContentCalled = false
@@ -393,6 +415,8 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.searchCalled = true
         self.searchQueries.append(query)
         self._searchContinuationIndex = 0
+        await self.waitBeforeSearchReturn(query: query, endpoint: .mixed)
+        defer { self.completedSearchEndpoints.append(.mixed) }
         if let error = shouldThrowError { throw error }
         return self.mixedSearchResponse ?? self.searchResponse
     }
@@ -400,6 +424,8 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     func searchSongs(query: String) async throws -> [Song] {
         self.searchCalled = true
         self.searchQueries.append(query)
+        await self.waitBeforeSearchReturn(query: query, endpoint: .songs)
+        defer { self.completedSearchEndpoints.append(.songs) }
         if let error = shouldThrowError { throw error }
         return (self.songsSearchResponse ?? self.searchResponse).songs
     }
@@ -408,6 +434,8 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.searchCalled = true
         self.searchQueries.append(query)
         self._searchContinuationIndex = 0
+        await self.waitBeforeSearchReturn(query: query, endpoint: .songsWithPagination)
+        defer { self.completedSearchEndpoints.append(.songsWithPagination) }
         if let error = shouldThrowError { throw error }
         let hasMore = !self.searchContinuationResponses.isEmpty
         let response = self.songsSearchResponse ?? self.searchResponse
@@ -424,6 +452,8 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.searchCalled = true
         self.searchQueries.append(query)
         self._searchContinuationIndex = 0
+        await self.waitBeforeSearchReturn(query: query, endpoint: .albums)
+        defer { self.completedSearchEndpoints.append(.albums) }
         if let error = shouldThrowError { throw error }
         let hasMore = !self.searchContinuationResponses.isEmpty
         let response = self.albumsSearchResponse ?? self.searchResponse
@@ -440,6 +470,8 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.searchCalled = true
         self.searchQueries.append(query)
         self._searchContinuationIndex = 0
+        await self.waitBeforeSearchReturn(query: query, endpoint: .artists)
+        defer { self.completedSearchEndpoints.append(.artists) }
         if let error = shouldThrowError { throw error }
         let hasMore = !self.searchContinuationResponses.isEmpty
         let response = self.artistsSearchResponse ?? self.searchResponse
@@ -456,6 +488,8 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.searchCalled = true
         self.searchQueries.append(query)
         self._searchContinuationIndex = 0
+        await self.waitBeforeSearchReturn(query: query, endpoint: .playlists)
+        defer { self.completedSearchEndpoints.append(.playlists) }
         if let error = shouldThrowError { throw error }
         let hasMore = !self.searchContinuationResponses.isEmpty
         let response = self.playlistsSearchResponse ?? self.searchResponse
@@ -472,6 +506,8 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.searchCalled = true
         self.searchQueries.append(query)
         self._searchContinuationIndex = 0
+        await self.waitBeforeSearchReturn(query: query, endpoint: .featuredPlaylists)
+        defer { self.completedSearchEndpoints.append(.featuredPlaylists) }
         if let error = shouldThrowError { throw error }
         let hasMore = !self.searchContinuationResponses.isEmpty
         let response = self.featuredPlaylistsSearchResponse ?? self.searchResponse
@@ -488,6 +524,8 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.searchCalled = true
         self.searchQueries.append(query)
         self._searchContinuationIndex = 0
+        await self.waitBeforeSearchReturn(query: query, endpoint: .communityPlaylists)
+        defer { self.completedSearchEndpoints.append(.communityPlaylists) }
         if let error = shouldThrowError { throw error }
         let hasMore = !self.searchContinuationResponses.isEmpty
         let response = self.communityPlaylistsSearchResponse ?? self.searchResponse
@@ -504,6 +542,8 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.searchCalled = true
         self.searchQueries.append(query)
         self._searchContinuationIndex = 0
+        await self.waitBeforeSearchReturn(query: query, endpoint: .podcasts)
+        defer { self.completedSearchEndpoints.append(.podcasts) }
         if let error = shouldThrowError { throw error }
         let hasMore = !self.searchContinuationResponses.isEmpty
         let response = self.podcastsSearchResponse ?? self.searchResponse
@@ -958,6 +998,8 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self._likedSongsContinuationIndex = 0
         self.searchCalled = false
         self.searchQueries = []
+        self.completedSearchEndpoints = []
+        self.beforeSearchReturn = nil
         self.getSearchSuggestionsCalled = false
         self.getSearchSuggestionsQueries = []
         self.getLibraryContentCalled = false

--- a/Tests/KasetTests/Helpers/MockYouTubeClient.swift
+++ b/Tests/KasetTests/Helpers/MockYouTubeClient.swift
@@ -15,6 +15,7 @@ final class MockYouTubeClient: YouTubeClientProtocol {
     var homeTopicFeeds: [String: YouTubeFeed] = [:]
     var homeTopicError: (continuation: String, error: Error)?
     var searchResponse = YouTubeSearchResponse.empty
+    var searchResponsesByRequest: [String: YouTubeSearchResponse] = [:]
     var searchContinuation: YouTubeSearchResponse?
     var watchNextData = WatchNextData.empty
     var channelDetail: YouTubeChannelDetail?
@@ -29,6 +30,10 @@ final class MockYouTubeClient: YouTubeClientProtocol {
     private(set) var searchCallCount = 0
     private(set) var lastSearchQuery: String?
     private(set) var lastSearchFilter: YouTubeSearchFilter?
+
+    nonisolated static func searchKey(query: String, filter: YouTubeSearchFilter) -> String {
+        "\(filter.rawValue)|\(query)"
+    }
 
     var hasMoreHomeFeed: Bool {
         // When a multi-page queue is configured it drives "has more"; otherwise
@@ -115,19 +120,41 @@ final class MockYouTubeClient: YouTubeClientProtocol {
         return self.homeTopicFeeds[continuation] ?? .empty
     }
 
+    /// Awaited inside `search` before it returns, so a test can hold one
+    /// search request open while a newer query/filter search completes first.
+    var beforeSearchReturn: (@Sendable (String, YouTubeSearchFilter) async -> Void)?
+
     func search(query: String, filter: YouTubeSearchFilter) async throws -> YouTubeSearchResponse {
         if let error { throw error }
         self.searchCallCount += 1
         self.lastSearchQuery = query
         self.lastSearchFilter = filter
-        return self.searchResponse
+        if let beforeSearchReturn {
+            await beforeSearchReturn(query, filter)
+        }
+        let key = Self.searchKey(query: query, filter: filter)
+        return self.searchResponsesByRequest[key] ?? self.searchResponse
     }
 
+    /// Awaited inside `getSearchContinuation` before it returns, so a test can
+    /// hold a pagination request open while a newer search replaces results.
+    var beforeSearchContinuationReturn: (@Sendable () async -> Void)?
+
     func getSearchContinuation() async throws -> YouTubeSearchResponse? {
+        guard let currentContinuation = self.searchContinuation?.continuation else { return nil }
+        return try await self.getSearchContinuation(continuation: currentContinuation)
+    }
+
+    func getSearchContinuation(continuation _: String) async throws -> YouTubeSearchResponse? {
         if let error { throw error }
-        let continuation = self.searchContinuation
-        self.searchContinuation = nil
-        return continuation
+        let response = self.searchContinuation
+        if let beforeSearchContinuationReturn {
+            await beforeSearchContinuationReturn()
+        }
+        if self.searchContinuation?.continuation == response?.continuation {
+            self.searchContinuation = nil
+        }
+        return response
     }
 
     func getWatchNext(videoId _: String) async throws -> WatchNextData {

--- a/Tests/KasetTests/PlaylistDetailViewModelTests.swift
+++ b/Tests/KasetTests/PlaylistDetailViewModelTests.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import Foundation
 import Testing
 @testable import Kaset
@@ -5,6 +6,7 @@ import Testing
 /// Tests for PlaylistDetailViewModel using mock client.
 @Suite(.serialized, .tags(.viewModel), .timeLimit(.minutes(1)))
 @MainActor
+// swiftlint:disable:next type_body_length
 struct PlaylistDetailViewModelTests {
     var mockClient: MockYTMusicClient
     var viewModel: PlaylistDetailViewModel
@@ -37,6 +39,22 @@ struct PlaylistDetailViewModelTests {
         )
         self.mockClient.playlistDetails[playlist.id] = detail
         return PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
+    }
+
+    private func waitUntil(
+        _ condition: @autoclosure () -> Bool,
+        description: String,
+        timeout: Duration = .seconds(3)
+    ) async {
+        let clock = ContinuousClock()
+        let deadline = clock.now + timeout
+
+        while clock.now < deadline {
+            if condition() { return }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+
+        Issue.record("Timed out waiting for \(description)")
     }
 
     // MARK: - Initial State Tests
@@ -132,6 +150,10 @@ struct PlaylistDetailViewModelTests {
         ]
 
         await likedMusicViewModel.load()
+        await self.waitUntil(
+            self.mockClient.getPlaylistContinuationCallCount == 2 && likedMusicViewModel.playlistDetail?.tracks.count == 5,
+            description: "Liked Music background continuation drain"
+        )
 
         #expect(self.mockClient.getPlaylistContinuationCallCount == 2)
         #expect(likedMusicViewModel.playlistDetail?.tracks.map(\.videoId) == [
@@ -141,6 +163,31 @@ struct PlaylistDetailViewModelTests {
             "liked-4",
             "liked-5",
         ])
+        #expect(likedMusicViewModel.playlistDetail?.tracks.allSatisfy { $0.likeStatus == .like } == true)
+        #expect(likedMusicViewModel.hasMore == false)
+    }
+
+    @Test("Liked Music load returns before delayed continuation drain")
+    func likedMusicLoadReturnsBeforeDelayedContinuationDrain() async {
+        let initialTracks = [
+            TestFixtures.makeSong(id: "liked-1", title: "Liked 1"),
+            TestFixtures.makeSong(id: "liked-2", title: "Liked 2"),
+        ]
+        let likedMusicViewModel = self.makeLikedMusicViewModel(with: initialTracks)
+        self.mockClient.playlistContinuationTracks[LikedMusicPlaylist.id] = [
+            [TestFixtures.makeSong(id: "liked-3", title: "Liked 3")],
+        ]
+        self.mockClient.playlistContinuationDelay = .milliseconds(200)
+
+        await likedMusicViewModel.load()
+
+        #expect(likedMusicViewModel.playlistDetail?.tracks.map(\.videoId) == ["liked-1", "liked-2"])
+        #expect(self.mockClient.getPlaylistContinuationReturnCount == 0)
+
+        await self.waitUntil(
+            likedMusicViewModel.playlistDetail?.tracks.map(\.videoId) == ["liked-1", "liked-2", "liked-3"],
+            description: "Liked Music delayed continuation drain"
+        )
         #expect(likedMusicViewModel.playlistDetail?.tracks.allSatisfy { $0.likeStatus == .like } == true)
         #expect(likedMusicViewModel.hasMore == false)
     }
@@ -168,11 +215,256 @@ struct PlaylistDetailViewModelTests {
         ]
 
         await self.viewModel.load()
+        await self.waitUntil(
+            self.mockClient.getPlaylistContinuationCallCount == 2 && self.viewModel.playlistDetail?.tracks.count == 125,
+            description: "large playlist background continuation drain"
+        )
 
         #expect(self.mockClient.getPlaylistContinuationCallCount == 2)
         #expect(self.viewModel.playlistDetail?.tracks.count == 125)
         #expect(self.viewModel.playlistDetail?.trackCount == 125)
         #expect(self.viewModel.hasMore == false)
+    }
+
+    @Test("Large playlist load returns before delayed full continuation drain")
+    func largePlaylistLoadReturnsBeforeDelayedFullContinuationDrain() async {
+        let playlist = Playlist(
+            id: "VL-test-playlist",
+            title: "Large Playlist",
+            description: nil,
+            thumbnailURL: URL(string: "https://example.com/playlist.jpg"),
+            trackCount: 125,
+            author: Artist.inline(name: "Test User", namespace: "playlist-author")
+        )
+        let initialTracks = TestFixtures.makeSongs(count: 100)
+        let detail = PlaylistDetail(playlist: playlist, tracks: initialTracks, duration: nil)
+        self.mockClient.playlistDetails[playlist.id] = detail
+        self.mockClient.playlistContinuationTracks[playlist.id] = [
+            (100 ..< 125).map { index in
+                TestFixtures.makeSong(id: "video-\(index)", title: "Song \(index)")
+            },
+        ]
+        self.mockClient.playlistContinuationDelay = .milliseconds(200)
+
+        await self.viewModel.load()
+
+        #expect(self.viewModel.playlistDetail?.tracks.count == 100)
+        #expect(self.mockClient.getPlaylistContinuationReturnCount == 0)
+
+        await self.waitUntil(
+            self.viewModel.playlistDetail?.tracks.count == 125,
+            description: "large playlist delayed continuation drain"
+        )
+        #expect(self.viewModel.hasMore == false)
+    }
+
+    @Test("Load more during background full drain does not cancel drain")
+    func loadMoreDuringBackgroundFullDrainDoesNotCancelDrain() async {
+        let playlist = Playlist(
+            id: "VL-test-playlist",
+            title: "Large Playlist",
+            description: nil,
+            thumbnailURL: URL(string: "https://example.com/playlist.jpg"),
+            trackCount: 125,
+            author: Artist.inline(name: "Test User", namespace: "playlist-author")
+        )
+        let initialTracks = TestFixtures.makeSongs(count: 100)
+        let detail = PlaylistDetail(playlist: playlist, tracks: initialTracks, duration: nil)
+        self.mockClient.playlistDetails[playlist.id] = detail
+        self.mockClient.playlistContinuationTracks[playlist.id] = [
+            (100 ..< 125).map { index in
+                TestFixtures.makeSong(id: "video-\(index)", title: "Song \(index)")
+            },
+        ]
+        self.mockClient.playlistContinuationDelay = .milliseconds(200)
+
+        await self.viewModel.load()
+        await self.waitUntil(
+            self.mockClient.getPlaylistContinuationCallCount == 1,
+            description: "large playlist background drain to start"
+        )
+
+        await self.viewModel.loadMore()
+
+        await self.waitUntil(
+            self.viewModel.playlistDetail?.tracks.count == 125,
+            description: "large playlist background drain after manual load more"
+        )
+        #expect(self.mockClient.getPlaylistContinuationCallCount == 1)
+        #expect(self.viewModel.hasMore == false)
+    }
+
+    @Test("Repeated load during background continuation drain does not restart playlist")
+    func repeatedLoadDuringBackgroundContinuationDrainDoesNotRestartPlaylist() async {
+        let playlist = Playlist(
+            id: "VL-test-playlist",
+            title: "Large Playlist",
+            description: nil,
+            thumbnailURL: URL(string: "https://example.com/playlist.jpg"),
+            trackCount: 125,
+            author: Artist.inline(name: "Test User", namespace: "playlist-author")
+        )
+        let initialTracks = TestFixtures.makeSongs(count: 100)
+        let detail = PlaylistDetail(playlist: playlist, tracks: initialTracks, duration: nil)
+        self.mockClient.playlistDetails[playlist.id] = detail
+        self.mockClient.playlistContinuationTracks[playlist.id] = [
+            (100 ..< 125).map { index in
+                TestFixtures.makeSong(id: "video-\(index)", title: "Song \(index)")
+            },
+        ]
+        self.mockClient.playlistContinuationDelay = .milliseconds(200)
+
+        await self.viewModel.load()
+        await self.waitUntil(
+            self.viewModel.loadingState == .loadingMore,
+            description: "background continuation drain to enter loadingMore"
+        )
+
+        await self.viewModel.load()
+
+        #expect(self.mockClient.getPlaylistIds == [playlist.id])
+        await self.waitUntil(
+            self.viewModel.playlistDetail?.tracks.count == 125,
+            description: "background drain after repeated load"
+        )
+    }
+
+    @Test("Live-synced loaded removal is not double-counted by continuation overlap")
+    func liveSyncedLoadedRemovalIsNotDoubleCountedByContinuationOverlap() async {
+        let initialTracks = [TestFixtures.makeSong(id: "liked-1", title: "Liked 1")]
+        let likedMusicViewModel = self.makeLikedMusicViewModel(with: initialTracks, trackCount: 2)
+        self.mockClient.playlistContinuationTracks[LikedMusicPlaylist.id] = [
+            [
+                TestFixtures.makeSong(id: "liked-1", title: "Liked 1"),
+                TestFixtures.makeSong(id: "liked-2", title: "Liked 2"),
+            ],
+        ]
+        self.mockClient.playlistContinuationDelay = .milliseconds(200)
+
+        await likedMusicViewModel.load()
+        await self.waitUntil(
+            self.mockClient.getPlaylistContinuationCallCount == 1,
+            description: "overlapping delayed continuation to start"
+        )
+
+        likedMusicViewModel.handleLikeStatusChange(
+            LikeStatusEvent(videoId: "liked-1", status: .indifferent, song: nil)
+        )
+
+        await self.waitUntil(
+            likedMusicViewModel.playlistDetail?.tracks.map(\.videoId) == ["liked-2"],
+            description: "continuation drain to skip loaded unlike overlap"
+        )
+
+        #expect(likedMusicViewModel.playlistDetail?.trackCount == 1)
+        #expect(SongLikeStatusManager.shared.status(for: "liked-1") != .like)
+    }
+
+    @Test("Live-synced removal skips not-yet-loaded continuation track")
+    func liveSyncedRemovalSkipsNotYetLoadedContinuationTrack() async {
+        let initialTracks = [TestFixtures.makeSong(id: "liked-1", title: "Liked 1")]
+        let likedMusicViewModel = self.makeLikedMusicViewModel(with: initialTracks, trackCount: 3)
+        self.mockClient.playlistContinuationTracks[LikedMusicPlaylist.id] = [
+            [TestFixtures.makeSong(id: "future-unliked", title: "Future Unliked")],
+            [TestFixtures.makeSong(id: "liked-3", title: "Liked 3")],
+        ]
+        self.mockClient.playlistContinuationDelay = .milliseconds(200)
+
+        await likedMusicViewModel.load()
+        await self.waitUntil(
+            self.mockClient.getPlaylistContinuationCallCount == 1,
+            description: "first delayed continuation to start"
+        )
+
+        likedMusicViewModel.handleLikeStatusChange(
+            LikeStatusEvent(videoId: "future-unliked", status: .indifferent, song: nil)
+        )
+
+        await self.waitUntil(
+            self.mockClient.getPlaylistContinuationCallCount == 2 && likedMusicViewModel.playlistDetail?.tracks.map(\.videoId).contains("liked-3") == true,
+            description: "continuation drain to skip not-yet-loaded unlike"
+        )
+
+        let videoIds = likedMusicViewModel.playlistDetail?.tracks.map(\.videoId) ?? []
+        #expect(videoIds == ["liked-1", "liked-3"])
+        #expect(videoIds.contains("future-unliked") == false)
+        #expect(likedMusicViewModel.playlistDetail?.trackCount == 2)
+        #expect(SongLikeStatusManager.shared.status(for: "future-unliked") != .like)
+    }
+
+    @Test("Live-synced duplicate page advances continuation drain")
+    func liveSyncedDuplicatePageAdvancesContinuationDrain() async {
+        let initialTracks = [TestFixtures.makeSong(id: "liked-1", title: "Liked 1")]
+        let likedMusicViewModel = self.makeLikedMusicViewModel(with: initialTracks)
+        self.mockClient.playlistContinuationTracks[LikedMusicPlaylist.id] = [
+            [TestFixtures.makeSong(id: "live-inserted", title: "Live Inserted")],
+            [TestFixtures.makeSong(id: "liked-3", title: "Liked 3")],
+        ]
+        self.mockClient.playlistContinuationDelay = .milliseconds(200)
+
+        await likedMusicViewModel.load()
+        await self.waitUntil(
+            self.mockClient.getPlaylistContinuationCallCount == 1,
+            description: "first delayed continuation to start"
+        )
+
+        likedMusicViewModel.handleLikeStatusChange(
+            LikeStatusEvent(
+                videoId: "live-inserted",
+                status: .like,
+                song: TestFixtures.makeSong(id: "live-inserted", title: "Live Inserted")
+            )
+        )
+
+        await self.waitUntil(
+            self.mockClient.getPlaylistContinuationCallCount == 2 && likedMusicViewModel.playlistDetail?.tracks.map(\.videoId).contains("liked-3") == true,
+            description: "continuation drain to advance past live-synced duplicate"
+        )
+
+        #expect(likedMusicViewModel.playlistDetail?.tracks.map(\.videoId) == ["live-inserted", "liked-1", "liked-3"])
+        #expect(likedMusicViewModel.hasMore == false)
+    }
+
+    @Test("Stale background continuation drain cannot mutate after refresh")
+    func staleBackgroundContinuationDrainCannotMutateAfterRefresh() async {
+        let playlist = TestFixtures.makePlaylist(id: "VL-test-playlist", title: "Refresh Playlist")
+        let initialTracks = TestFixtures.makeSongs(count: 100)
+        let initialDetail = PlaylistDetail(playlist: playlist, tracks: initialTracks, duration: nil)
+        self.mockClient.playlistDetails[playlist.id] = initialDetail
+        self.mockClient.playlistContinuationTracks[playlist.id] = [
+            [TestFixtures.makeSong(id: "stale-continuation", title: "Stale")],
+        ]
+        self.mockClient.playlistContinuationDelay = .milliseconds(200)
+
+        await self.viewModel.load()
+        await self.waitUntil(
+            self.mockClient.getPlaylistContinuationCallCount == 1,
+            description: "stale background drain to start"
+        )
+
+        let refreshedPlaylist = Playlist(
+            id: playlist.id,
+            title: playlist.title,
+            description: playlist.description,
+            thumbnailURL: playlist.thumbnailURL,
+            trackCount: 3,
+            author: playlist.author
+        )
+        self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(
+            playlist: refreshedPlaylist,
+            tracks: TestFixtures.makeSongs(count: 3),
+            duration: nil
+        )
+
+        await self.viewModel.refresh()
+        await self.waitUntil(
+            self.mockClient.getPlaylistContinuationReturnCount == 1,
+            description: "stale background drain to return"
+        )
+
+        let videoIds = self.viewModel.playlistDetail?.tracks.map(\.videoId) ?? []
+        #expect(videoIds == ["video-0", "video-1", "video-2"])
+        #expect(videoIds.contains("stale-continuation") == false)
     }
 
     @Test("Small playlist load keeps continuation lazy")
@@ -191,6 +483,36 @@ struct PlaylistDetailViewModelTests {
         #expect(self.mockClient.getPlaylistContinuationCalled == false)
         #expect(self.viewModel.playlistDetail?.tracks.count == 10)
         #expect(self.viewModel.hasMore == true)
+    }
+
+    @Test("Album load keeps continuation lazy")
+    func albumLoadKeepsContinuationLazy() async {
+        let album = Playlist(
+            id: "MPRE-test-album",
+            title: "Test Album",
+            description: nil,
+            thumbnailURL: URL(string: "https://example.com/album.jpg"),
+            trackCount: 125,
+            author: Artist.inline(name: "Test Artist", namespace: "playlist-author")
+        )
+        let albumViewModel = PlaylistDetailViewModel(playlist: album, client: self.mockClient)
+        let detail = PlaylistDetail(
+            playlist: album,
+            tracks: TestFixtures.makeSongs(count: 100),
+            duration: nil
+        )
+        self.mockClient.playlistDetails[album.id] = detail
+        self.mockClient.playlistContinuationTracks[album.id] = [
+            (100 ..< 125).map { index in
+                TestFixtures.makeSong(id: "video-\(index)", title: "Song \(index)")
+            },
+        ]
+
+        await albumViewModel.load()
+
+        #expect(self.mockClient.getPlaylistContinuationCalled == false)
+        #expect(albumViewModel.playlistDetail?.tracks.count == 100)
+        #expect(albumViewModel.hasMore == true)
     }
 
     // MARK: - Load More Tests
@@ -245,8 +567,67 @@ struct PlaylistDetailViewModelTests {
         #expect(!videoIDs.contains("other-continuation"))
     }
 
-    @Test("Load more preserves reported total track count")
-    func loadMorePreservesReportedTotalTrackCount() async {
+    @Test("Cancelled load more restores loaded state")
+    func cancelledLoadMoreRestoresLoadedState() async {
+        let playlistDetail = TestFixtures.makePlaylistDetail(
+            playlist: TestFixtures.makePlaylist(id: "VL-test-playlist"),
+            trackCount: 5
+        )
+        self.mockClient.playlistDetails["VL-test-playlist"] = playlistDetail
+        self.mockClient.playlistContinuationTracks["VL-test-playlist"] = [
+            [TestFixtures.makeSong(id: "cont-1")],
+        ]
+        self.mockClient.playlistContinuationDelay = .milliseconds(200)
+
+        await self.viewModel.load()
+        let loadMoreTask = Task { await self.viewModel.loadMore() }
+        await self.waitUntil(
+            self.viewModel.loadingState == .loadingMore,
+            description: "load more to enter loadingMore"
+        )
+
+        loadMoreTask.cancel()
+        await loadMoreTask.value
+
+        #expect(self.viewModel.loadingState == .loaded)
+        #expect(self.viewModel.playlistDetail?.tracks.count == 5)
+    }
+
+    @Test("Stale manual load more cannot mutate after refresh")
+    func staleManualLoadMoreCannotMutateAfterRefresh() async {
+        let playlistDetail = TestFixtures.makePlaylistDetail(
+            playlist: TestFixtures.makePlaylist(id: "VL-test-playlist"),
+            trackCount: 5
+        )
+        self.mockClient.playlistDetails["VL-test-playlist"] = playlistDetail
+        self.mockClient.playlistContinuationTracks["VL-test-playlist"] = [
+            [TestFixtures.makeSong(id: "stale-manual")],
+        ]
+        self.mockClient.playlistContinuationDelay = .milliseconds(200)
+
+        await self.viewModel.load()
+        let loadMoreTask = Task { await self.viewModel.loadMore() }
+        await self.waitUntil(
+            self.viewModel.loadingState == .loadingMore,
+            description: "manual loadMore to enter loadingMore"
+        )
+
+        let refreshedDetail = TestFixtures.makePlaylistDetail(
+            playlist: TestFixtures.makePlaylist(id: "VL-test-playlist"),
+            trackCount: 3
+        )
+        self.mockClient.playlistDetails["VL-test-playlist"] = refreshedDetail
+        await self.viewModel.refresh()
+        await loadMoreTask.value
+        try? await Task.sleep(for: .milliseconds(220))
+
+        let videoIds = self.viewModel.playlistDetail?.tracks.map(\.videoId) ?? []
+        #expect(videoIds == ["video-0", "video-1", "video-2"])
+        #expect(videoIds.contains("stale-manual") == false)
+    }
+
+    @Test("Continuation drain preserves reported total track count")
+    func continuationDrainPreservesReportedTotalTrackCount() async {
         let playlist = Playlist(
             id: "VL-test-playlist",
             title: "Large Playlist",
@@ -268,7 +649,10 @@ struct PlaylistDetailViewModelTests {
         self.mockClient.playlistContinuationTracks["VL-test-playlist"] = [continuationTracks]
 
         await self.viewModel.load()
-        await self.viewModel.loadMore()
+        await self.waitUntil(
+            self.viewModel.playlistDetail?.tracks.count == 150,
+            description: "reported total count continuation drain"
+        )
 
         #expect(self.viewModel.playlistDetail?.tracks.count == 150)
         #expect(self.viewModel.playlistDetail?.trackCount == 2429)

--- a/Tests/KasetTests/PlaylistDetailViewModelTests.swift
+++ b/Tests/KasetTests/PlaylistDetailViewModelTests.swift
@@ -392,6 +392,45 @@ struct PlaylistDetailViewModelTests {
         #expect(SongLikeStatusManager.shared.status(for: "future-unliked") != .like)
     }
 
+    @Test("Manual load more preserves live removal after background drain failure")
+    func manualLoadMorePreservesLiveRemovalAfterBackgroundDrainFailure() async {
+        let initialTracks = [TestFixtures.makeSong(id: "liked-1", title: "Liked 1")]
+        let likedMusicViewModel = self.makeLikedMusicViewModel(with: initialTracks, trackCount: 3)
+        self.mockClient.playlistContinuationTracks[LikedMusicPlaylist.id] = [
+            [TestFixtures.makeSong(id: "future-unliked", title: "Future Unliked")],
+            [TestFixtures.makeSong(id: "liked-3", title: "Liked 3")],
+        ]
+        self.mockClient.playlistContinuationDelay = .milliseconds(200)
+
+        await likedMusicViewModel.load()
+        await self.waitUntil(
+            self.mockClient.getPlaylistContinuationCallCount == 1,
+            description: "failed background continuation to start"
+        )
+        self.mockClient.shouldThrowError = YTMusicError.networkError(underlying: URLError(.timedOut))
+        await self.waitUntil(
+            self.mockClient.getPlaylistContinuationReturnCount == 1 && likedMusicViewModel.loadingState == .loaded,
+            description: "failed background continuation to return"
+        )
+        self.mockClient.shouldThrowError = nil
+        self.mockClient.playlistContinuationDelay = nil
+
+        #expect(likedMusicViewModel.hasMore == true)
+        likedMusicViewModel.handleLikeStatusChange(
+            LikeStatusEvent(videoId: "future-unliked", status: .indifferent, song: nil)
+        )
+
+        await likedMusicViewModel.loadMore()
+        await likedMusicViewModel.loadMore()
+
+        let videoIds = likedMusicViewModel.playlistDetail?.tracks.map(\.videoId) ?? []
+        #expect(videoIds == ["liked-1", "liked-3"])
+        #expect(videoIds.contains("future-unliked") == false)
+        #expect(likedMusicViewModel.playlistDetail?.trackCount == 2)
+        #expect(SongLikeStatusManager.shared.status(for: "future-unliked") != .like)
+        #expect(likedMusicViewModel.hasMore == false)
+    }
+
     @Test("Live-synced duplicate page advances continuation drain")
     func liveSyncedDuplicatePageAdvancesContinuationDrain() async {
         let initialTracks = [TestFixtures.makeSong(id: "liked-1", title: "Liked 1")]

--- a/Tests/KasetTests/PodcastParserTests.swift
+++ b/Tests/KasetTests/PodcastParserTests.swift
@@ -79,6 +79,30 @@ struct PodcastParserTests {
         #expect(detail.episodes.count == 3)
     }
 
+    @Test("Parse show detail keeps detail header thumbnail when responsive header omits artwork")
+    func parseShowDetailKeepsDetailHeaderThumbnailFallback() {
+        var data = self.makeShowDetailData(title: "Tech Podcast", author: "Tech Company")
+
+        var header = data["header"] as? [String: Any] ?? [:]
+        var detailHeader = header["musicDetailHeaderRenderer"] as? [String: Any] ?? [:]
+        detailHeader["thumbnail"] = [
+            "musicThumbnailRenderer": [
+                "thumbnail": [
+                    "thumbnails": [["url": "https://example.com/detail-header.jpg"]],
+                ],
+            ],
+        ]
+        header["musicDetailHeaderRenderer"] = detailHeader
+        data["header"] = header
+
+        let responsiveHeaderData = self.makeShowDetailDataTwoColumn(title: "Tech Podcast")
+        data["contents"] = responsiveHeaderData["contents"]
+
+        let detail = PodcastParser.parseShowDetail(data, showId: "MPSPP123")
+
+        #expect(detail.show.thumbnailURL?.absoluteString == "https://example.com/detail-header.jpg")
+    }
+
     @Test("Parse show detail with subscription status")
     func parseShowDetailWithSubscriptionStatus() {
         let data = self.makeShowDetailDataTwoColumn(title: "Subscribed Show", isSubscribed: true)

--- a/Tests/KasetTests/SearchViewModelTests.swift
+++ b/Tests/KasetTests/SearchViewModelTests.swift
@@ -2,6 +2,8 @@ import Foundation
 import Testing
 @testable import Kaset
 
+// MARK: - SearchViewModelTests
+
 /// Tests for SearchViewModel using mock client.
 @Suite(.serialized, .tags(.viewModel), .timeLimit(.minutes(1)))
 @MainActor
@@ -29,6 +31,27 @@ struct SearchViewModelTests {
         }
 
         Issue.record("Timed out waiting for suggestion fetch for query: \(query)")
+    }
+
+    private func waitUntil(
+        _ condition: @autoclosure () -> Bool,
+        description: String,
+        timeout: Duration = .seconds(3)
+    ) async {
+        let clock = ContinuousClock()
+        let deadline = clock.now + timeout
+
+        while clock.now < deadline {
+            if condition() { return }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+
+        Issue.record("Timed out waiting for \(description)")
+    }
+
+    private var isErrorLoadingState: Bool {
+        if case .error = self.viewModel.loadingState { return true }
+        return false
     }
 
     @Test("Initial state is idle with empty query")
@@ -162,7 +185,10 @@ struct SearchViewModelTests {
         self.viewModel.selectedFilter = .artists
 
         self.viewModel.searchImmediately()
-        try? await Task.sleep(for: .milliseconds(25))
+        await self.waitUntil(
+            self.viewModel.loadingState == .loaded,
+            description: "filtered search to load"
+        )
 
         #expect(self.viewModel.loadingState == .loaded)
         #expect(self.viewModel.filteredItems.isEmpty)
@@ -215,7 +241,10 @@ struct SearchViewModelTests {
         self.viewModel.query = "lofi"
         self.viewModel.selectedFilter = .all
         self.viewModel.searchImmediately()
-        try? await Task.sleep(for: .milliseconds(50))
+        await self.waitUntil(
+            self.viewModel.filteredItems.count == 6,
+            description: "all-filter aggregate results"
+        )
 
         #expect(self.viewModel.loadingState == .loaded)
         #expect(self.viewModel.filteredItems.count == 6)
@@ -227,6 +256,115 @@ struct SearchViewModelTests {
         #expect(self.mockClient.searchQueries.count == 7)
     }
 
+    @Test("All filter publishes mixed results before category searches complete")
+    func allFilterPublishesMixedResultsBeforeCategorySearchesComplete() async {
+        let categoryGate = AsyncGate()
+        let mixedSong = TestFixtures.makeSong(id: "mixed-song", title: "Mixed Song")
+        let categorySong = TestFixtures.makeSong(id: "category-song", title: "Category Song")
+        self.mockClient.mixedSearchResponse = SearchResponse(
+            songs: [mixedSong],
+            albums: [],
+            artists: [],
+            playlists: []
+        )
+        self.mockClient.songsSearchResponse = SearchResponse(
+            songs: [categorySong],
+            albums: [],
+            artists: [],
+            playlists: []
+        )
+        self.mockClient.albumsSearchResponse = SearchResponse(
+            songs: [],
+            albums: [TestFixtures.makeAlbum(id: "MPRE-category", title: "Category Album")],
+            artists: [],
+            playlists: []
+        )
+        self.mockClient.beforeSearchReturn = { _, endpoint in
+            if endpoint != .mixed {
+                await categoryGate.wait()
+            }
+        }
+
+        self.viewModel.query = "lofi"
+        self.viewModel.selectedFilter = .all
+        self.viewModel.searchImmediately()
+
+        await self.waitUntil(
+            self.viewModel.results.songs.map(\.id) == ["mixed-song"] && self.viewModel.loadingState == .loaded,
+            description: "mixed results first paint"
+        )
+        #expect(self.viewModel.results.albums.isEmpty)
+        #expect(self.mockClient.completedSearchEndpoints == [.mixed])
+
+        await categoryGate.open()
+        await self.waitUntil(
+            self.viewModel.results.songs.map(\.id).contains("category-song") && self.viewModel.results.albums.count == 1,
+            description: "category-enriched all-filter results"
+        )
+
+        #expect(self.viewModel.results.songs.map(\.id) == ["mixed-song", "category-song"])
+        #expect(self.viewModel.results.albums.map(\.id) == ["MPRE-category"])
+        #expect(self.mockClient.searchQueries.count == 7)
+    }
+
+    @Test("All filter discards delayed category results after query changes")
+    func allFilterDiscardsDelayedCategoryResultsAfterQueryChanges() async {
+        let oldCategoryGate = AsyncGate()
+        self.mockClient.beforeSearchReturn = { query, endpoint in
+            if query == "old", endpoint != .mixed {
+                await oldCategoryGate.wait()
+            }
+        }
+        self.mockClient.mixedSearchResponse = SearchResponse(
+            songs: [TestFixtures.makeSong(id: "old-mixed", title: "Old Mixed")],
+            albums: [],
+            artists: [],
+            playlists: []
+        )
+        self.mockClient.songsSearchResponse = SearchResponse(
+            songs: [TestFixtures.makeSong(id: "old-category", title: "Old Category")],
+            albums: [],
+            artists: [],
+            playlists: []
+        )
+
+        self.viewModel.query = "old"
+        self.viewModel.selectedFilter = .all
+        self.viewModel.searchImmediately()
+        await self.waitUntil(
+            self.viewModel.results.songs.map(\.id) == ["old-mixed"],
+            description: "old mixed first paint"
+        )
+
+        self.mockClient.mixedSearchResponse = SearchResponse(
+            songs: [TestFixtures.makeSong(id: "new-mixed", title: "New Mixed")],
+            albums: [],
+            artists: [],
+            playlists: []
+        )
+        self.mockClient.songsSearchResponse = SearchResponse(
+            songs: [TestFixtures.makeSong(id: "new-category", title: "New Category")],
+            albums: [],
+            artists: [],
+            playlists: []
+        )
+        self.viewModel.query = "new"
+        self.viewModel.searchImmediately()
+        await self.waitUntil(
+            self.viewModel.results.songs.map(\.id).contains("new-category"),
+            description: "new all-filter final results"
+        )
+
+        await oldCategoryGate.open()
+        for _ in 0 ..< 10 {
+            await Task.yield()
+        }
+
+        #expect(self.viewModel.results.songs.map(\.id) == ["new-mixed", "new-category"])
+        #expect(self.viewModel.results.songs.map(\.id).contains("old-category") == false)
+        #expect(self.viewModel.loadingState == .loaded)
+    }
+
     @Test("All filter reports error when every aggregate request fails")
     func allFilterReportsErrorWhenEveryAggregateRequestFails() async {
         self.mockClient.shouldThrowError = YTMusicError.networkError(underlying: URLError(.notConnectedToInternet))
@@ -234,7 +372,10 @@ struct SearchViewModelTests {
         self.viewModel.query = "lofi"
         self.viewModel.selectedFilter = .all
         self.viewModel.searchImmediately()
-        try? await Task.sleep(for: .milliseconds(50))
+        await self.waitUntil(
+            self.isErrorLoadingState,
+            description: "all-filter error"
+        )
 
         guard case let .error(error) = self.viewModel.loadingState else {
             Issue.record("Expected all-filter total failure to surface an error")
@@ -245,5 +386,28 @@ struct SearchViewModelTests {
         #expect(error.isRetryable)
         #expect(self.viewModel.results.isEmpty)
         #expect(self.mockClient.searchQueries.count == 7)
+    }
+}
+
+// MARK: - AsyncGate
+
+private actor AsyncGate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        if self.isOpen { return }
+        await withCheckedContinuation { continuation in
+            self.waiters.append(continuation)
+        }
+    }
+
+    func open() {
+        self.isOpen = true
+        let waiters = self.waiters
+        self.waiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
     }
 }

--- a/Tests/KasetTests/SearchViewModelTests.swift
+++ b/Tests/KasetTests/SearchViewModelTests.swift
@@ -294,6 +294,7 @@ struct SearchViewModelTests {
             description: "mixed results first paint"
         )
         #expect(self.viewModel.results.albums.isEmpty)
+        #expect(self.viewModel.shouldShowFilters == false)
         #expect(self.mockClient.completedSearchEndpoints == [.mixed])
 
         await categoryGate.open()
@@ -304,6 +305,7 @@ struct SearchViewModelTests {
 
         #expect(self.viewModel.results.songs.map(\.id) == ["mixed-song", "category-song"])
         #expect(self.viewModel.results.albums.map(\.id) == ["MPRE-category"])
+        #expect(self.viewModel.shouldShowFilters == true)
         #expect(self.mockClient.searchQueries.count == 7)
     }
 
@@ -386,28 +388,5 @@ struct SearchViewModelTests {
         #expect(error.isRetryable)
         #expect(self.viewModel.results.isEmpty)
         #expect(self.mockClient.searchQueries.count == 7)
-    }
-}
-
-// MARK: - AsyncGate
-
-private actor AsyncGate {
-    private var isOpen = false
-    private var waiters: [CheckedContinuation<Void, Never>] = []
-
-    func wait() async {
-        if self.isOpen { return }
-        await withCheckedContinuation { continuation in
-            self.waiters.append(continuation)
-        }
-    }
-
-    func open() {
-        self.isOpen = true
-        let waiters = self.waiters
-        self.waiters.removeAll()
-        for waiter in waiters {
-            waiter.resume()
-        }
     }
 }

--- a/Tests/KasetTests/YouTubeHomeViewModelTests.swift
+++ b/Tests/KasetTests/YouTubeHomeViewModelTests.swift
@@ -638,27 +638,3 @@ struct YouTubeHomeViewModelTests {
         #expect(self.mockClient.homeFeedCallCount == 1) // coalesced to one fetch
     }
 }
-
-// MARK: - AsyncGate
-
-/// A one-shot async gate: `wait()` suspends until `open()` is called.
-private actor AsyncGate {
-    private var isOpen = false
-    private var waiters: [CheckedContinuation<Void, Never>] = []
-
-    func wait() async {
-        if self.isOpen { return }
-        await withCheckedContinuation { continuation in
-            self.waiters.append(continuation)
-        }
-    }
-
-    func open() {
-        self.isOpen = true
-        let pending = self.waiters
-        self.waiters.removeAll()
-        for continuation in pending {
-            continuation.resume()
-        }
-    }
-}

--- a/Tests/KasetTests/YouTubeSearchViewModelTests.swift
+++ b/Tests/KasetTests/YouTubeSearchViewModelTests.swift
@@ -298,27 +298,3 @@ struct YouTubeSearchViewModelTests {
         Issue.record("Timed out waiting for condition")
     }
 }
-
-// MARK: - AsyncGate
-
-/// A one-shot async gate: `wait()` suspends until `open()` is called.
-private actor AsyncGate {
-    private var isOpen = false
-    private var waiters: [CheckedContinuation<Void, Never>] = []
-
-    func wait() async {
-        if self.isOpen { return }
-        await withCheckedContinuation { continuation in
-            self.waiters.append(continuation)
-        }
-    }
-
-    func open() {
-        self.isOpen = true
-        let pending = self.waiters
-        self.waiters.removeAll()
-        for continuation in pending {
-            continuation.resume()
-        }
-    }
-}

--- a/Tests/KasetTests/YouTubeSearchViewModelTests.swift
+++ b/Tests/KasetTests/YouTubeSearchViewModelTests.swift
@@ -2,6 +2,8 @@ import Foundation
 import Testing
 @testable import Kaset
 
+// MARK: - YouTubeSearchViewModelTests
+
 @Suite("YouTubeSearchViewModel", .serialized, .tags(.viewModel), .timeLimit(.minutes(1)))
 @MainActor
 struct YouTubeSearchViewModelTests {
@@ -98,5 +100,225 @@ struct YouTubeSearchViewModelTests {
 
         #expect(self.sut.results.videos.map(\.videoId) == ["video-0", "video-1", "video-extra"])
         #expect(self.sut.results.continuation == nil)
+    }
+
+    @Test("Concurrent submits coalesce to one in-flight search")
+    func concurrentSubmitsCoalesce() async {
+        let gate = AsyncGate()
+        self.mockClient.searchResponse = YouTubeSearchResponse(
+            videos: [MockYouTubeClient.makeVideo(videoId: "coalesced")],
+            channels: [],
+            playlists: [],
+            continuation: nil
+        )
+        self.mockClient.beforeSearchReturn = { _, _ in await gate.wait() }
+        self.sut.query = "swift"
+
+        let first = Task { await self.sut.search() }
+        await self.waitUntil(self.mockClient.searchCallCount == 1)
+
+        let second = Task { await self.sut.search() }
+        for _ in 0 ..< 10 {
+            await Task.yield()
+        }
+
+        #expect(self.mockClient.searchCallCount == 1)
+
+        await gate.open()
+        await first.value
+        await second.value
+        #expect(self.sut.results.videos.map(\.videoId) == ["coalesced"])
+    }
+
+    @Test("Cancelling one coalesced search waiter does not cancel shared request")
+    func cancellingOneCoalescedSearchWaiterDoesNotCancelSharedRequest() async {
+        let gate = AsyncGate()
+        self.mockClient.searchResponse = YouTubeSearchResponse(
+            videos: [MockYouTubeClient.makeVideo(videoId: "survived")],
+            channels: [],
+            playlists: [],
+            continuation: "next-token"
+        )
+        self.mockClient.beforeSearchReturn = { _, _ in await gate.wait() }
+        self.sut.query = "swift"
+
+        let first = Task { await self.sut.search() }
+        await self.waitUntil(self.mockClient.searchCallCount == 1)
+        let second = Task { await self.sut.search() }
+        await Task.yield()
+
+        first.cancel()
+        await Task.yield()
+        #expect(self.mockClient.searchCallCount == 1)
+
+        await gate.open()
+        await first.value
+        await second.value
+
+        #expect(self.sut.results.videos.map(\.videoId) == ["survived"])
+        #expect(self.sut.results.continuation == "next-token")
+        #expect(self.sut.loadingState == .loaded)
+    }
+
+    @Test("Late results from an older query cannot overwrite the newer query")
+    func lateOlderQueryCannotOverwriteNewerQuery() async {
+        let oldQueryGate = AsyncGate()
+        self.mockClient.searchResponsesByRequest = [
+            MockYouTubeClient.searchKey(query: "swift", filter: .all): YouTubeSearchResponse(
+                videos: [MockYouTubeClient.makeVideo(videoId: "old-query")],
+                channels: [],
+                playlists: [],
+                continuation: "old-token"
+            ),
+            MockYouTubeClient.searchKey(query: "swiftui", filter: .all): YouTubeSearchResponse(
+                videos: [MockYouTubeClient.makeVideo(videoId: "new-query")],
+                channels: [],
+                playlists: [],
+                continuation: "new-token"
+            ),
+        ]
+        self.mockClient.beforeSearchReturn = { query, _ in
+            if query == "swift" {
+                await oldQueryGate.wait()
+            }
+        }
+
+        self.sut.query = "swift"
+        let oldSearch = Task { await self.sut.search() }
+        await self.waitUntil(self.mockClient.lastSearchQuery == "swift")
+
+        self.sut.query = "swiftui"
+        await self.sut.search()
+
+        #expect(self.sut.results.videos.map(\.videoId) == ["new-query"])
+        #expect(self.sut.results.continuation == "new-token")
+
+        await oldQueryGate.open()
+        await oldSearch.value
+
+        #expect(self.sut.results.videos.map(\.videoId) == ["new-query"])
+        #expect(self.sut.results.continuation == "new-token")
+        #expect(self.sut.loadingState == .loaded)
+    }
+
+    @Test("Stale pagination cannot append into newer search results")
+    func stalePaginationCannotCorruptNewerSearchContinuation() async {
+        let paginationGate = AsyncGate()
+        self.mockClient.searchResponsesByRequest = [
+            MockYouTubeClient.searchKey(query: "swift", filter: .all): YouTubeSearchResponse(
+                videos: [MockYouTubeClient.makeVideo(videoId: "old-query")],
+                channels: [],
+                playlists: [],
+                continuation: "old-token"
+            ),
+            MockYouTubeClient.searchKey(query: "swiftui", filter: .all): YouTubeSearchResponse(
+                videos: [MockYouTubeClient.makeVideo(videoId: "new-query")],
+                channels: [],
+                playlists: [],
+                continuation: "new-token"
+            ),
+        ]
+
+        self.sut.query = "swift"
+        await self.sut.search()
+        self.mockClient.searchContinuation = YouTubeSearchResponse(
+            videos: [MockYouTubeClient.makeVideo(videoId: "old-page")],
+            channels: [],
+            playlists: [],
+            continuation: "old-next-token"
+        )
+        self.mockClient.beforeSearchContinuationReturn = { await paginationGate.wait() }
+
+        let oldPage = Task { await self.sut.loadMore() }
+        await self.waitUntil(self.sut.loadingState == .loadingMore)
+
+        self.sut.query = "swiftui"
+        let newSearch = Task { await self.sut.search() }
+        for _ in 0 ..< 10 {
+            await Task.yield()
+        }
+
+        await paginationGate.open()
+        await oldPage.value
+        await newSearch.value
+
+        #expect(self.sut.results.videos.map(\.videoId) == ["new-query"])
+        #expect(self.sut.results.continuation == "new-token")
+        #expect(self.sut.loadingState == .loaded)
+    }
+
+    @Test("Late results from an older filter cannot corrupt newer filter continuation")
+    func lateOlderFilterCannotOverwriteNewerFilterOrContinuation() async {
+        let oldFilterGate = AsyncGate()
+        self.mockClient.searchResponsesByRequest = [
+            MockYouTubeClient.searchKey(query: "swift", filter: .videos): YouTubeSearchResponse(
+                videos: [MockYouTubeClient.makeVideo(videoId: "old-videos")],
+                channels: [],
+                playlists: [],
+                continuation: "videos-token"
+            ),
+            MockYouTubeClient.searchKey(query: "swift", filter: .channels): YouTubeSearchResponse(
+                videos: [],
+                channels: [YouTubeChannel(channelId: "new-channel", name: "New Channel")],
+                playlists: [],
+                continuation: "channels-token"
+            ),
+        ]
+        self.mockClient.beforeSearchReturn = { _, filter in
+            if filter == .videos {
+                await oldFilterGate.wait()
+            }
+        }
+
+        self.sut.selectedFilter = .videos
+        self.sut.query = "swift"
+        let oldSearch = Task { await self.sut.search() }
+        await self.waitUntil(self.mockClient.lastSearchFilter == .videos)
+
+        self.sut.selectedFilter = .channels
+        await self.waitUntil(self.sut.results.channels.map(\.channelId) == ["new-channel"])
+
+        #expect(self.sut.results.channels.map(\.channelId) == ["new-channel"])
+        #expect(self.sut.results.continuation == "channels-token")
+
+        await oldFilterGate.open()
+        await oldSearch.value
+
+        #expect(self.sut.results.channels.map(\.channelId) == ["new-channel"])
+        #expect(self.sut.results.videos.isEmpty)
+        #expect(self.sut.results.continuation == "channels-token")
+        #expect(self.sut.loadingState == .loaded)
+    }
+
+    private func waitUntil(_ condition: @autoclosure () -> Bool) async {
+        for _ in 0 ..< 1000 {
+            if condition() { return }
+            await Task.yield()
+        }
+        Issue.record("Timed out waiting for condition")
+    }
+}
+
+// MARK: - AsyncGate
+
+/// A one-shot async gate: `wait()` suspends until `open()` is called.
+private actor AsyncGate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        if self.isOpen { return }
+        await withCheckedContinuation { continuation in
+            self.waiters.append(continuation)
+        }
+    }
+
+    func open() {
+        self.isOpen = true
+        let pending = self.waiters
+        self.waiters.removeAll()
+        for continuation in pending {
+            continuation.resume()
+        }
     }
 }

--- a/Tests/KasetTests/YouTubeSingleFlightViewModelTests.swift
+++ b/Tests/KasetTests/YouTubeSingleFlightViewModelTests.swift
@@ -420,27 +420,3 @@ private final class SingleFlightYouTubeClient: YouTubeClientProtocol {
         }
     }
 }
-
-// MARK: - AsyncGate
-
-/// A one-shot async gate: `wait()` suspends until `open()` is called.
-private actor AsyncGate {
-    private var isOpen = false
-    private var waiters: [CheckedContinuation<Void, Never>] = []
-
-    func wait() async {
-        if self.isOpen { return }
-        await withCheckedContinuation { continuation in
-            self.waiters.append(continuation)
-        }
-    }
-
-    func open() {
-        self.isOpen = true
-        let pending = self.waiters
-        self.waiters.removeAll()
-        for continuation in pending {
-            continuation.resume()
-        }
-    }
-}

--- a/Tests/KasetTests/YouTubeSingleFlightViewModelTests.swift
+++ b/Tests/KasetTests/YouTubeSingleFlightViewModelTests.swift
@@ -1,0 +1,446 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+// MARK: - YouTubeSingleFlightViewModelTests
+
+@Suite("YouTube non-Home view model single-flight", .serialized, .tags(.viewModel), .timeLimit(.minutes(1)))
+@MainActor
+struct YouTubeSingleFlightViewModelTests {
+    @Test("History concurrent loads coalesce and loaded load is a no-op")
+    func historyLoadCoalescesAndNoOpsWhenLoaded() async {
+        let client = SingleFlightYouTubeClient()
+        client.historyFeed = YouTubeFeed(videos: MockYouTubeClient.makeVideos(count: 2), continuation: nil)
+        let gate = AsyncGate()
+        client.gate = gate
+        let sut = YouTubeHistoryViewModel(client: client)
+
+        let first = Task { await sut.load() }
+        await self.waitUntil(client.historyCallCount == 1, "history request started")
+        let second = Task { await sut.load() }
+        await Task.yield()
+        first.cancel()
+        await Task.yield()
+
+        #expect(client.historyCallCount == 1)
+        await gate.open()
+        await first.value
+        await second.value
+
+        #expect(sut.loadingState == .loaded)
+        #expect(sut.videos.count == 2)
+        await sut.load()
+        #expect(client.historyCallCount == 1)
+
+        client.gate = nil
+        await sut.refresh()
+        #expect(client.historyCallCount == 2)
+    }
+
+    @Test("Subscriptions concurrent loads coalesce feed and channel rail requests")
+    func subscriptionsLoadCoalescesFeedAndChannels() async {
+        let client = SingleFlightYouTubeClient()
+        client.subscriptionsFeed = YouTubeFeed(videos: MockYouTubeClient.makeVideos(count: 3), continuation: nil)
+        client.subscribedChannels = [YouTubeChannel(channelId: "UC1", name: "One")]
+        let gate = AsyncGate()
+        client.gate = gate
+        let sut = YouTubeSubscriptionsViewModel(client: client)
+
+        let first = Task { await sut.load() }
+        await self.waitUntil(
+            client.subscriptionsFeedCallCount == 1 && client.subscribedChannelsCallCount == 1,
+            "subscriptions requests started"
+        )
+        let second = Task { await sut.load() }
+        await Task.yield()
+        first.cancel()
+        await Task.yield()
+
+        #expect(client.subscriptionsFeedCallCount == 1)
+        #expect(client.subscribedChannelsCallCount == 1)
+        await gate.open()
+        await first.value
+        await second.value
+
+        #expect(sut.loadingState == .loaded)
+        #expect(sut.videos.count == 3)
+        #expect(sut.channels.count == 1)
+        await sut.load()
+        #expect(client.subscriptionsFeedCallCount == 1)
+        #expect(client.subscribedChannelsCallCount == 1)
+
+        client.gate = nil
+        await sut.refresh()
+        #expect(client.subscriptionsFeedCallCount == 2)
+        #expect(client.subscribedChannelsCallCount == 2)
+    }
+
+    @Test("Shorts concurrent loads coalesce and refresh forces a reload")
+    func shortsLoadCoalescesAndRefreshes() async {
+        let client = SingleFlightYouTubeClient()
+        client.shorts = MockYouTubeClient.makeVideos(count: 2)
+        let gate = AsyncGate()
+        client.gate = gate
+        let sut = YouTubeShortsViewModel(client: client)
+
+        let first = Task { await sut.load() }
+        await self.waitUntil(client.shortsCallCount == 1, "Shorts request started")
+        let second = Task { await sut.load() }
+        await Task.yield()
+        first.cancel()
+        await Task.yield()
+
+        #expect(client.shortsCallCount == 1)
+        await gate.open()
+        await first.value
+        await second.value
+
+        #expect(sut.loadingState == .loaded)
+        #expect(sut.shorts.count == 2)
+        await sut.load()
+        #expect(client.shortsCallCount == 1)
+
+        client.gate = nil
+        await sut.refresh()
+        #expect(client.shortsCallCount == 2)
+    }
+
+    @Test("Explore concurrent loads coalesce and loaded load is a no-op")
+    func exploreLoadCoalescesAndNoOpsWhenLoaded() async {
+        let client = SingleFlightYouTubeClient()
+        client.destinationFeed = YouTubeFeed(videos: MockYouTubeClient.makeVideos(count: 2), continuation: nil)
+        let gate = AsyncGate()
+        client.gate = gate
+        let sut = YouTubeExploreViewModel(client: client)
+        sut.selectedDestination = .news
+
+        let first = Task { await sut.load() }
+        await self.waitUntil(client.destinationFeedCallCount == 1, "destination request started")
+        let second = Task { await sut.load() }
+        await Task.yield()
+        first.cancel()
+        await Task.yield()
+
+        #expect(client.destinationFeedCallCount == 1)
+        await gate.open()
+        await first.value
+        await second.value
+
+        #expect(sut.loadingState == .loaded)
+        #expect(sut.videos.count == 2)
+        #expect(client.requestedDestinations == [.news])
+        await sut.load()
+        #expect(client.destinationFeedCallCount == 1)
+
+        client.gate = nil
+        await sut.refresh()
+        #expect(client.destinationFeedCallCount == 2)
+        #expect(client.requestedDestinations == [.news, .news])
+    }
+
+    @Test("Explore destination change cancels stale work and fetches the new selection")
+    func exploreDestinationChangeStartsFreshLoad() async {
+        let client = SingleFlightYouTubeClient()
+        client.destinationFeed = YouTubeFeed(videos: [MockYouTubeClient.makeVideo(videoId: "selected")], continuation: nil)
+        let gate = AsyncGate()
+        client.gate = gate
+        let sut = YouTubeExploreViewModel(client: client)
+        sut.selectedDestination = .news
+
+        let stale = Task { await sut.load() }
+        await self.waitUntil(client.destinationFeedCallCount == 1, "stale destination request started")
+
+        sut.selectedDestination = .sports
+        client.gate = nil
+        await sut.load()
+        #expect(client.destinationFeedCallCount == 2)
+        #expect(client.requestedDestinations == [.news, .sports])
+        #expect(sut.loadingState == .loaded)
+        #expect(sut.videos.map(\.videoId) == ["selected"])
+
+        await gate.open()
+        await stale.value
+        #expect(sut.loadingState == .loaded)
+        #expect(sut.videos.map(\.videoId) == ["selected"])
+    }
+
+    @Test("Store account reset cancels and replaces account-scoped view models")
+    func storeResetCancelsAndReplacesAccountScopedViewModels() async {
+        let client = SingleFlightYouTubeClient()
+        client.historyFeed = YouTubeFeed(videos: [MockYouTubeClient.makeVideo(videoId: "new-account")], continuation: nil)
+        let gate = AsyncGate()
+        client.gate = gate
+        let store = YouTubeViewModelStore(client: client)
+        let oldHistory = store.history
+
+        let staleLoad = Task { await oldHistory.load() }
+        await self.waitUntil(client.historyCallCount == 1, "old history request started")
+
+        store.resetForAccountChange()
+        let newHistory = store.history
+
+        #expect(ObjectIdentifier(oldHistory) != ObjectIdentifier(newHistory))
+
+        client.gate = nil
+        await newHistory.load()
+        #expect(client.historyCallCount == 2)
+        #expect(newHistory.loadingState == .loaded)
+        #expect(newHistory.videos.map(\.videoId) == ["new-account"])
+
+        await gate.open()
+        await staleLoad.value
+        #expect(newHistory.videos.map(\.videoId) == ["new-account"])
+    }
+
+    @Test("Playlists concurrent loads coalesce and refresh forces a reload")
+    func playlistsLoadCoalescesAndRefreshes() async {
+        let client = SingleFlightYouTubeClient()
+        client.userPlaylists = [YouTubePlaylist(playlistId: "PL1", title: "One")]
+        let gate = AsyncGate()
+        client.gate = gate
+        let sut = YouTubePlaylistsViewModel(client: client)
+
+        let first = Task { await sut.load() }
+        await self.waitUntil(client.userPlaylistsCallCount == 1, "playlists request started")
+        let second = Task { await sut.load() }
+        await Task.yield()
+        first.cancel()
+        await Task.yield()
+
+        #expect(client.userPlaylistsCallCount == 1)
+        await gate.open()
+        await first.value
+        await second.value
+
+        #expect(sut.loadingState == .loaded)
+        #expect(sut.playlists.map(\.playlistId) == ["PL1"])
+        await sut.load()
+        #expect(client.userPlaylistsCallCount == 1)
+
+        client.gate = nil
+        await sut.refresh()
+        #expect(client.userPlaylistsCallCount == 2)
+    }
+
+    private func waitUntil(_ condition: @autoclosure () -> Bool, _ description: String) async {
+        for _ in 0 ..< 1000 {
+            if condition() { return }
+            await Task.yield()
+        }
+        Issue.record("Timed out waiting for \(description)")
+    }
+}
+
+// MARK: - SingleFlightYouTubeClient
+
+@MainActor
+private final class SingleFlightYouTubeClient: YouTubeClientProtocol {
+    var gate: AsyncGate?
+
+    var homeFeed = YouTubeFeed.empty
+    var homeBundle = YouTubeHomeBundle(feed: .empty, chips: [], shelves: [])
+    var homeFeedContinuation: YouTubeFeed?
+    var homeChips: [YouTubeHomeChip] = []
+    var homeShelves: [YouTubeHomeSection] = []
+    var homeTopicFeed = YouTubeFeed.empty
+    var hasMoreHomeFeed = false
+
+    var searchResponse = YouTubeSearchResponse.empty
+    var searchContinuation: YouTubeSearchResponse?
+    var watchNextData = WatchNextData.empty
+    var commentsPage = YouTubeCommentsPage.empty
+    var channelDetail: YouTubeChannelDetail?
+    var playlistDetail: YouTubePlaylistDetail?
+    var destinationFeed = YouTubeFeed.empty
+    var shorts: [YouTubeVideo] = []
+    var feedContinuation = YouTubeFeed.empty
+    var subscriptionsFeed = YouTubeFeed.empty
+    var subscribedChannels: [YouTubeChannel] = []
+    var historyFeed = YouTubeFeed.empty
+    var userPlaylists: [YouTubePlaylist] = []
+
+    private(set) var historyCallCount = 0
+    private(set) var subscriptionsFeedCallCount = 0
+    private(set) var subscribedChannelsCallCount = 0
+    private(set) var shortsCallCount = 0
+    private(set) var destinationFeedCallCount = 0
+    private(set) var requestedDestinations: [YouTubeDestination] = []
+    private(set) var channelCallCount = 0
+    private(set) var playlistCallCount = 0
+    private(set) var userPlaylistsCallCount = 0
+
+    func getHomeFeed() async throws -> YouTubeFeed {
+        try await self.waitIfNeeded()
+        return self.homeFeed
+    }
+
+    func getHomeBundle() async throws -> YouTubeHomeBundle {
+        try await self.waitIfNeeded()
+        return self.homeBundle
+    }
+
+    func getHomeFeedContinuation() async throws -> YouTubeFeed? {
+        try await self.waitIfNeeded()
+        let continuation = self.homeFeedContinuation
+        self.homeFeedContinuation = nil
+        return continuation
+    }
+
+    func getHomeChips() async throws -> [YouTubeHomeChip] {
+        try await self.waitIfNeeded()
+        return self.homeChips
+    }
+
+    func getHomeShelves() async throws -> [YouTubeHomeSection] {
+        try await self.waitIfNeeded()
+        return self.homeShelves
+    }
+
+    func getHomeTopicFeed(continuation _: String) async throws -> YouTubeFeed {
+        try await self.waitIfNeeded()
+        return self.homeTopicFeed
+    }
+
+    func search(query _: String, filter _: YouTubeSearchFilter) async throws -> YouTubeSearchResponse {
+        try await self.waitIfNeeded()
+        return self.searchResponse
+    }
+
+    func getSearchContinuation() async throws -> YouTubeSearchResponse? {
+        guard let currentContinuation = self.searchContinuation?.continuation else { return nil }
+        return try await self.getSearchContinuation(continuation: currentContinuation)
+    }
+
+    func getSearchContinuation(continuation _: String) async throws -> YouTubeSearchResponse? {
+        try await self.waitIfNeeded()
+        let continuation = self.searchContinuation
+        self.searchContinuation = nil
+        return continuation
+    }
+
+    func getWatchNext(videoId _: String) async throws -> WatchNextData {
+        try await self.waitIfNeeded()
+        return self.watchNextData
+    }
+
+    func getComments(continuation _: String) async throws -> YouTubeCommentsPage {
+        try await self.waitIfNeeded()
+        return self.commentsPage
+    }
+
+    func postComment(text _: String, createCommentParams _: String) async throws {
+        try await self.waitIfNeeded()
+    }
+
+    func performCommentAction(_: String) async throws {
+        try await self.waitIfNeeded()
+    }
+
+    func getChannel(channelId: String) async throws -> YouTubeChannelDetail {
+        self.channelCallCount += 1
+        try await self.waitIfNeeded()
+        if let channelDetail { return channelDetail }
+        return YouTubeChannelDetail(channel: YouTubeChannel(channelId: channelId, name: "Mock Channel"), videos: [])
+    }
+
+    func getPlaylist(playlistId: String) async throws -> YouTubePlaylistDetail {
+        self.playlistCallCount += 1
+        try await self.waitIfNeeded()
+        if let playlistDetail { return playlistDetail }
+        return YouTubePlaylistDetail(playlist: YouTubePlaylist(playlistId: playlistId, title: "Mock Playlist"), videos: [])
+    }
+
+    func getDestinationFeed(_ destination: YouTubeDestination) async throws -> YouTubeFeed {
+        self.destinationFeedCallCount += 1
+        self.requestedDestinations.append(destination)
+        try await self.waitIfNeeded()
+        return self.destinationFeed
+    }
+
+    func getShorts() async throws -> [YouTubeVideo] {
+        self.shortsCallCount += 1
+        try await self.waitIfNeeded()
+        return self.shorts
+    }
+
+    func getFeedContinuation(continuation _: String) async throws -> YouTubeFeed {
+        try await self.waitIfNeeded()
+        return self.feedContinuation
+    }
+
+    func getSubscriptionsFeed() async throws -> YouTubeFeed {
+        self.subscriptionsFeedCallCount += 1
+        try await self.waitIfNeeded()
+        return self.subscriptionsFeed
+    }
+
+    func getSubscribedChannels() async throws -> [YouTubeChannel] {
+        self.subscribedChannelsCallCount += 1
+        try await self.waitIfNeeded()
+        return self.subscribedChannels
+    }
+
+    func getHistory(forceRefresh _: Bool) async throws -> YouTubeFeed {
+        self.historyCallCount += 1
+        try await self.waitIfNeeded()
+        return self.historyFeed
+    }
+
+    func getUserPlaylists() async throws -> [YouTubePlaylist] {
+        self.userPlaylistsCallCount += 1
+        try await self.waitIfNeeded()
+        return self.userPlaylists
+    }
+
+    func rateVideo(videoId _: String, rating _: YouTubeRating) async throws {
+        try await self.waitIfNeeded()
+    }
+
+    func setSubscribed(_: Bool, channelId _: String) async throws {
+        try await self.waitIfNeeded()
+    }
+
+    func addToWatchLater(videoId _: String) async throws {
+        try await self.waitIfNeeded()
+    }
+
+    func removeFromWatchLater(videoId _: String) async throws {
+        try await self.waitIfNeeded()
+    }
+
+    private func waitIfNeeded() async throws {
+        if Task.isCancelled {
+            throw CancellationError()
+        }
+        if let gate {
+            await gate.wait()
+        }
+        if Task.isCancelled {
+            throw CancellationError()
+        }
+    }
+}
+
+// MARK: - AsyncGate
+
+/// A one-shot async gate: `wait()` suspends until `open()` is called.
+private actor AsyncGate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        if self.isOpen { return }
+        await withCheckedContinuation { continuation in
+            self.waiters.append(continuation)
+        }
+    }
+
+    func open() {
+        self.isOpen = true
+        let pending = self.waiters
+        self.waiters.removeAll()
+        for continuation in pending {
+            continuation.resume()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- optimize parser traversal and thumbnail/playback helper paths for lower API response parse overhead
- stage Music search `All` results so mixed results paint before slower category enrichment finishes
- coalesce concurrent YouTube root/search loads into a single shared in-flight request
- let large playlists and Liked Music become usable after the initial page while continuation pages drain in the background

## Performance
Measured current branch (`857a4e3b`) against merge-base (`2a0769e`) with `ParserPerformanceTests` in isolated worktrees:

| Parser scenario | Base mean | Current mean | Gain |
| --- | ---: | ---: | ---: |
| Artist detail | 9.64 ms | 5.63 ms | 41.6% faster |
| Home | 20.56 ms | 8.38 ms | 59.3% faster |
| Home section | 4.70 ms | 0.61 ms | 86.9% faster |
| Library playlists | 4.32 ms | 4.31 ms | flat |
| Playlist detail | 15.61 ms | 9.54 ms | 38.9% faster |
| Search mixed | 4.60 ms | 2.40 ms | 47.8% faster |
| Search songs-only | 12.69 ms | 6.10 ms | 52.0% faster |

Overall parser suite summed mean: **72.13 ms → 36.97 ms** (**48.7% faster**). Summed median: **60.00 ms → 31.53 ms** (**47.4% faster**).

## Validation
- `swift test --skip KasetUITests --filter PlayerServiceLibraryTests` passes: 23 tests
- `swift test --skip KasetUITests` builds and runs the non-UI suite, but the aggregate run reports one flaky issue in `PlayerServiceLibraryTests.likeCurrentTrack reverts on API failure`; the focused suite passes on rerun
- Parser perf comparison run via `xcrun xctest -XCTest ParserPerformanceTests` on baseline/current worktrees
