### PR TITLE
fix(ui): keep sidebar icons branded after navigation

### DIFF
--- a/Sources/Kaset/Views/SharedViews/KasetSidebarRow.swift
+++ b/Sources/Kaset/Views/SharedViews/KasetSidebarRow.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+
+// MARK: - KasetSidebarRow
+
+/// A stable Apple-Music-style sidebar row.
+///
+/// SwiftUI's source-list `NavigationLink` chrome changes when the sidebar list
+/// becomes the active control: selected rows switch to the system accent fill
+/// and symbols become selected-text colored. Kaset drives detail content from
+/// explicit selection state, so use a plain button row with our own selected
+/// background and brand-accent symbol instead of relying on `NavigationLink`'s
+/// active/inactive source-list styling.
+struct KasetSidebarRow: View {
+    let title: String
+    let systemImage: String
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: self.action) {
+            Label {
+                Text(self.title)
+                    .lineLimit(1)
+                    .foregroundStyle(.primary)
+            } icon: {
+                Image(systemName: self.systemImage)
+                    .foregroundStyle(PackageResourceLookup.brandAccent)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .background(self.selectionBackground)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .listRowInsets(EdgeInsets(top: 1, leading: 10, bottom: 1, trailing: 10))
+        .accessibilityAddTraits(self.isSelected ? .isSelected : [])
+    }
+
+    @ViewBuilder
+    private var selectionBackground: some View {
+        if self.isSelected {
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Color.secondary.opacity(0.22))
+        }
+    }
+}
+
+#Preview {
+    List {
+        KasetSidebarRow(
+            title: "Home",
+            systemImage: "house",
+            isSelected: true,
+            action: {}
+        )
+        KasetSidebarRow(
+            title: "Search",
+            systemImage: "magnifyingglass",
+            isSelected: false,
+            action: {}
+        )
+    }
+    .listStyle(.sidebar)
+    .frame(width: 220)
+}

--- a/Sources/Kaset/Views/Sidebar.swift
+++ b/Sources/Kaset/Views/Sidebar.swift
@@ -13,66 +13,46 @@ struct Sidebar: View {
     @Environment(PodcastsAvailabilityService.self) private var podcastsAvailability
 
     var body: some View {
-        List(selection: self.sidebarSelection) {
+        List {
             // Main navigation
             Section {
-                NavigationLink(value: SidebarSelection.navigation(.search)) {
-                    Label(NavigationItem.search.displayName, systemImage: NavigationItem.search.icon)
-                }
-                .accessibilityIdentifier(AccessibilityID.Sidebar.searchItem)
+                self.navigationRow(.search)
+                    .accessibilityIdentifier(AccessibilityID.Sidebar.searchItem)
 
-                NavigationLink(value: SidebarSelection.navigation(.home)) {
-                    Label(NavigationItem.home.displayName, systemImage: NavigationItem.home.icon)
-                }
-                .accessibilityIdentifier(AccessibilityID.Sidebar.homeItem)
+                self.navigationRow(.home)
+                    .accessibilityIdentifier(AccessibilityID.Sidebar.homeItem)
             }
 
             // Discover section
             Section(String(localized: "Discover")) {
-                NavigationLink(value: SidebarSelection.navigation(.explore)) {
-                    Label(NavigationItem.explore.displayName, systemImage: NavigationItem.explore.icon)
-                }
-                .accessibilityIdentifier(AccessibilityID.Sidebar.exploreItem)
+                self.navigationRow(.explore)
+                    .accessibilityIdentifier(AccessibilityID.Sidebar.exploreItem)
 
-                NavigationLink(value: SidebarSelection.navigation(.charts)) {
-                    Label(NavigationItem.charts.displayName, systemImage: NavigationItem.charts.icon)
-                }
-                .accessibilityIdentifier(AccessibilityID.Sidebar.chartsItem)
+                self.navigationRow(.charts)
+                    .accessibilityIdentifier(AccessibilityID.Sidebar.chartsItem)
 
-                NavigationLink(value: SidebarSelection.navigation(.moodsAndGenres)) {
-                    Label(NavigationItem.moodsAndGenres.displayName, systemImage: NavigationItem.moodsAndGenres.icon)
-                }
-                .accessibilityIdentifier(AccessibilityID.Sidebar.moodsAndGenresItem)
+                self.navigationRow(.moodsAndGenres)
+                    .accessibilityIdentifier(AccessibilityID.Sidebar.moodsAndGenresItem)
 
-                NavigationLink(value: SidebarSelection.navigation(.newReleases)) {
-                    Label(NavigationItem.newReleases.displayName, systemImage: NavigationItem.newReleases.icon)
-                }
-                .accessibilityIdentifier(AccessibilityID.Sidebar.newReleasesItem)
+                self.navigationRow(.newReleases)
+                    .accessibilityIdentifier(AccessibilityID.Sidebar.newReleasesItem)
 
                 if self.podcastsAvailability.availability != .unavailable {
-                    NavigationLink(value: SidebarSelection.navigation(.podcasts)) {
-                        Label(NavigationItem.podcasts.displayName, systemImage: NavigationItem.podcasts.icon)
-                    }
-                    .accessibilityIdentifier(AccessibilityID.Sidebar.podcastsItem)
+                    self.navigationRow(.podcasts)
+                        .accessibilityIdentifier(AccessibilityID.Sidebar.podcastsItem)
                 }
             }
 
             // Collection section
             Section(String(localized: "Collection")) {
-                NavigationLink(value: SidebarSelection.navigation(.library)) {
-                    Label(NavigationItem.library.displayName, systemImage: NavigationItem.library.icon)
-                }
-                .accessibilityIdentifier(AccessibilityID.Sidebar.libraryItem)
+                self.navigationRow(.library)
+                    .accessibilityIdentifier(AccessibilityID.Sidebar.libraryItem)
 
-                NavigationLink(value: SidebarSelection.navigation(.likedMusic)) {
-                    Label(NavigationItem.likedMusic.displayName, systemImage: NavigationItem.likedMusic.icon)
-                }
-                .accessibilityIdentifier(AccessibilityID.Sidebar.likedMusicItem)
+                self.navigationRow(.likedMusic)
+                    .accessibilityIdentifier(AccessibilityID.Sidebar.likedMusicItem)
 
-                NavigationLink(value: SidebarSelection.navigation(.history)) {
-                    Label(NavigationItem.history.displayName, systemImage: NavigationItem.history.icon)
-                }
-                .accessibilityIdentifier(AccessibilityID.Sidebar.historyItem)
+                self.navigationRow(.history)
+                    .accessibilityIdentifier(AccessibilityID.Sidebar.historyItem)
             }
 
             if self.sidebarPinnedItemsManager.isVisible {
@@ -108,38 +88,39 @@ struct Sidebar: View {
         return nil
     }
 
-    private var sidebarSelection: Binding<SidebarSelection?> {
-        Binding {
-            self.currentSidebarSelection
-        } set: { newValue in
-            guard self.currentSidebarSelection != newValue else { return }
-
-            switch newValue {
-            case let .navigation(item):
-                self.selection = item
-                self.pinnedSelection = nil
-            case let .pinned(item):
-                self.selection = nil
-                self.pinnedSelection = item
-            case nil:
-                self.selection = nil
-                self.pinnedSelection = nil
-            }
-
-            HapticService.navigation()
+    private func navigationRow(_ item: NavigationItem) -> some View {
+        KasetSidebarRow(
+            title: item.displayName,
+            systemImage: item.icon,
+            isSelected: self.currentSidebarSelection == .navigation(item)
+        ) {
+            self.selectNavigationItem(item)
         }
     }
 
+    private func selectNavigationItem(_ item: NavigationItem) {
+        let newSelection = SidebarSelection.navigation(item)
+        guard self.currentSidebarSelection != newSelection else { return }
+        self.selection = item
+        self.pinnedSelection = nil
+        HapticService.navigation()
+    }
+
+    private func selectPinnedItem(_ item: SidebarPinnedItem) {
+        let newSelection = SidebarSelection.pinned(item)
+        guard self.currentSidebarSelection != newSelection else { return }
+        self.selection = nil
+        self.pinnedSelection = item
+        HapticService.navigation()
+    }
+
     private func sidebarPinnedRow(_ item: SidebarPinnedItem) -> some View {
-        NavigationLink(value: SidebarSelection.pinned(item)) {
-            Label {
-                Text(item.title)
-                    .lineLimit(1)
-            } icon: {
-                Image(systemName: item.systemImage)
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .contentShape(Rectangle())
+        KasetSidebarRow(
+            title: item.title,
+            systemImage: item.systemImage,
+            isSelected: self.currentSidebarSelection == .pinned(item)
+        ) {
+            self.selectPinnedItem(item)
         }
         .contextMenu {
             Button {

--- a/Sources/Kaset/Views/YouTube/YouTubeSidebar.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeSidebar.swift
@@ -11,7 +11,7 @@ struct YouTubeSidebar: View {
     @Binding var selection: YouTubeNavigationItem?
 
     var body: some View {
-        List(selection: self.listSelection) {
+        List {
             // Main navigation
             Section {
                 self.row(for: .search)
@@ -42,22 +42,21 @@ struct YouTubeSidebar: View {
         .navigationSplitViewColumnWidth(min: 200, ideal: 220, max: 300)
     }
 
-    /// Selection binding that adds haptic feedback on change.
-    private var listSelection: Binding<YouTubeNavigationItem?> {
-        Binding {
-            self.selection
-        } set: { newValue in
-            guard self.selection != newValue else { return }
-            self.selection = newValue
-            HapticService.navigation()
-        }
-    }
-
     private func row(for item: YouTubeNavigationItem) -> some View {
-        NavigationLink(value: item) {
-            Label(item.displayName, systemImage: item.icon)
+        KasetSidebarRow(
+            title: item.displayName,
+            systemImage: item.icon,
+            isSelected: self.selection == item
+        ) {
+            self.select(item)
         }
         .accessibilityIdentifier(AccessibilityID.YouTubeSidebar.item(for: item))
+    }
+
+    private func select(_ item: YouTubeNavigationItem) {
+        guard self.selection != item else { return }
+        self.selection = item
+        HapticService.navigation()
     }
 }
 

--- a/Tests/KasetTests/KasetSidebarRowTests.swift
+++ b/Tests/KasetTests/KasetSidebarRowTests.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+import Testing
+@testable import Kaset
+
+@MainActor
+@Suite(.tags(.model))
+struct KasetSidebarRowTests {
+    @Test("KasetSidebarRow constructs selected and unselected rows")
+    func constructsSelectedAndUnselectedRows() {
+        let selected = KasetSidebarRow(
+            title: "Home",
+            systemImage: "house",
+            isSelected: true,
+            action: {}
+        )
+        let unselected = KasetSidebarRow(
+            title: "Search",
+            systemImage: "magnifyingglass",
+            isSelected: false,
+            action: {}
+        )
+
+        #expect(String(describing: selected).isEmpty == false)
+        #expect(String(describing: unselected).isEmpty == false)
+    }
+}


### PR DESCRIPTION
## Summary
- Replace native source-list `NavigationLink` sidebar rows with an explicit `KasetSidebarRow` that keeps brand-accent symbols stable.
- Apply the custom row to both Music and YouTube sidebars, including pinned sidebar items.
- Add a smoke test for the new sidebar row view.

## Root Cause
SwiftUI's source-list `NavigationLink` chrome changes when the sidebar list becomes the active control after drill-in navigation, returning from a video, or window restoration. In that state, macOS can switch the selected row to active accent-fill styling and recolor symbols white/monochrome. The previous attempted fix forced the list into an inactive control state, but that dimmed/faded the sidebar chrome. This revision removes that inactive-state override and instead renders sidebar rows with explicit brand-accent icons plus a neutral selected background.

## Validation
- Local SwiftUI/AppKit render harness comparing native `NavigationLink` sidebar rows with explicit custom rows
- `swiftformat .`
- `swift build`
- `swift test --filter KasetSidebarRowTests`
- `swift test --skip KasetUITests`
- `swiftlint --strict`
- `.agents/skills/autoreview/scripts/autoreview --mode local`

No UI tests were run.
