### PR TITLE
fix(extensions): host playback webviews for web extensions

### DIFF
--- a/Sources/Kaset/Services/WebKit/WebExtensionHost.swift
+++ b/Sources/Kaset/Services/WebKit/WebExtensionHost.swift
@@ -1,0 +1,287 @@
+import AppKit
+import Foundation
+import os
+import WebKit
+
+// MARK: - WebExtensionHostedWebViewRole
+
+/// Browser-tab identity for Kaset-owned playback WebViews exposed to WebKit Web Extensions.
+///
+/// Kaset does not have browser tabs in its UI, but WebKit's extension runtime still
+/// needs a tab/window model so content scripts and extension APIs can resolve the
+/// `WKWebView` they operate on.
+enum WebExtensionHostedWebViewRole: String {
+    case musicPlayer
+    case youtubeWatch
+
+    var displayTitle: String {
+        switch self {
+        case .musicPlayer:
+            "YouTube Music Playback"
+        case .youtubeWatch:
+            "YouTube Video Playback"
+        }
+    }
+}
+
+#if compiler(>=5.9)
+    @available(macOS 15.4, *)
+    @MainActor
+    final class KasetWebExtensionHost {
+        private let controller: WKWebExtensionController
+        private let logger: Logger
+        private let window = KasetWebExtensionWindow()
+        private var tabsByRole: [WebExtensionHostedWebViewRole: KasetWebExtensionTab] = [:]
+        private var tabsByWebViewID: [ObjectIdentifier: KasetWebExtensionTab] = [:]
+        private weak var activeTab: KasetWebExtensionTab?
+        private var didOpenWindow = false
+
+        init(controller: WKWebExtensionController, logger: Logger = DiagnosticsLogger.extensions) {
+            self.controller = controller
+            self.logger = logger
+        }
+
+        var registeredTabCount: Int {
+            self.tabsByRole.count
+        }
+
+        var openWindows: [any WKWebExtensionWindow] {
+            guard !self.tabsByRole.isEmpty else { return [] }
+            return [self.window]
+        }
+
+        var focusedWindow: (any WKWebExtensionWindow)? {
+            self.tabsByRole.isEmpty ? nil : self.window
+        }
+
+        @discardableResult
+        func register(webView: WKWebView, role: WebExtensionHostedWebViewRole) -> KasetWebExtensionTab? {
+            guard webView.configuration.webExtensionController === self.controller else {
+                self.logger.warning("Skipping WebExtension tab registration for \(role.rawValue): configuration uses a different controller")
+                return nil
+            }
+
+            let webViewID = ObjectIdentifier(webView)
+            if let existing = self.tabsByRole[role] {
+                if existing.webView !== webView {
+                    if let oldWebView = existing.webView {
+                        self.tabsByWebViewID.removeValue(forKey: ObjectIdentifier(oldWebView))
+                    }
+                    existing.webView = webView
+                    existing.pendingNavigationURL = nil
+                    self.tabsByWebViewID[webViewID] = existing
+                    self.controller.didChangeTabProperties([.loading, .title, .URL, .size], for: existing)
+                }
+                self.activate(existing)
+                return existing
+            }
+
+            let tab = KasetWebExtensionTab(role: role, webView: webView)
+            tab.window = self.window
+            self.tabsByRole[role] = tab
+            self.tabsByWebViewID[webViewID] = tab
+            self.window.append(tab)
+
+            self.openWindowIfNeeded()
+            self.controller.didOpenTab(tab)
+            self.activate(tab)
+
+            self.logger.info("Registered WebExtension tab for \(role.rawValue)")
+            return tab
+        }
+
+        func noteNavigationStarted(for webView: WKWebView, pendingURL: URL?) {
+            guard let tab = self.tab(for: webView) else { return }
+            tab.pendingNavigationURL = pendingURL ?? tab.pendingNavigationURL
+            if tab.pendingNavigationURL?.scheme?.hasPrefix("http") == true {
+                self.activate(tab)
+            }
+            self.controller.didChangeTabProperties([.loading, .URL], for: tab)
+        }
+
+        func noteBecameActive(webView: WKWebView) {
+            guard let tab = self.tab(for: webView) else { return }
+            self.activate(tab)
+        }
+
+        func deactivate(role: WebExtensionHostedWebViewRole) {
+            guard let tab = self.tabsByRole[role], self.activeTab === tab else { return }
+
+            let fallbackTab = self.window.firstTab(excluding: tab)
+            self.activeTab = nil
+            self.window.activeTab = nil
+            self.controller.didDeselectTabs([tab])
+
+            if let fallbackTab {
+                self.activate(fallbackTab)
+            } else {
+                self.controller.didFocusWindow(self.window)
+            }
+        }
+
+        func noteNavigationFinished(for webView: WKWebView) {
+            guard let tab = self.tab(for: webView) else { return }
+            tab.pendingNavigationURL = nil
+            self.controller.didChangeTabProperties([.loading, .title, .URL], for: tab)
+        }
+
+        func noteNavigationFailed(for webView: WKWebView) {
+            guard let tab = self.tab(for: webView) else { return }
+            tab.pendingNavigationURL = nil
+            self.controller.didChangeTabProperties([.loading, .URL], for: tab)
+        }
+
+        private func tab(for webView: WKWebView) -> KasetWebExtensionTab? {
+            self.tabsByWebViewID[ObjectIdentifier(webView)]
+        }
+
+        private func openWindowIfNeeded() {
+            guard !self.didOpenWindow else { return }
+            self.didOpenWindow = true
+            self.controller.didOpenWindow(self.window)
+            self.controller.didFocusWindow(self.window)
+        }
+
+        private func activate(_ tab: KasetWebExtensionTab) {
+            guard self.activeTab !== tab else {
+                self.controller.didFocusWindow(self.window)
+                return
+            }
+
+            let previousTab = self.activeTab
+            self.activeTab = tab
+            self.window.activeTab = tab
+            if let previousTab {
+                self.controller.didDeselectTabs([previousTab])
+            }
+            self.controller.didActivateTab(tab, previousActiveTab: previousTab)
+            self.controller.didSelectTabs([tab])
+            self.controller.didFocusWindow(self.window)
+        }
+    }
+
+    // MARK: - KasetWebExtensionTab
+
+    @available(macOS 15.4, *)
+    @MainActor
+    final class KasetWebExtensionTab: NSObject, WKWebExtensionTab {
+        let role: WebExtensionHostedWebViewRole
+        weak var webView: WKWebView?
+        weak var window: KasetWebExtensionWindow?
+        var pendingNavigationURL: URL?
+
+        init(role: WebExtensionHostedWebViewRole, webView: WKWebView) {
+            self.role = role
+            self.webView = webView
+            super.init()
+        }
+
+        func window(for _: WKWebExtensionContext) -> (any WKWebExtensionWindow)? {
+            self.window
+        }
+
+        func indexInWindow(for _: WKWebExtensionContext) -> Int {
+            guard let window = self.window else { return NSNotFound }
+            return window.index(of: self) ?? NSNotFound
+        }
+
+        func webView(for _: WKWebExtensionContext) -> WKWebView? {
+            self.webView
+        }
+
+        func title(for _: WKWebExtensionContext) -> String? {
+            self.webView?.title ?? self.role.displayTitle
+        }
+
+        func url(for _: WKWebExtensionContext) -> URL? {
+            self.webView?.url
+        }
+
+        func pendingURL(for _: WKWebExtensionContext) -> URL? {
+            self.pendingNavigationURL
+        }
+
+        func isSelected(for _: WKWebExtensionContext) -> Bool {
+            self.window?.activeTab === self
+        }
+
+        func isLoadingComplete(for _: WKWebExtensionContext) -> Bool {
+            self.pendingNavigationURL == nil && self.webView?.isLoading == false
+        }
+
+        func size(for _: WKWebExtensionContext) -> CGSize {
+            self.webView?.bounds.size ?? .zero
+        }
+    }
+
+    // MARK: - KasetWebExtensionWindow
+
+    @available(macOS 15.4, *)
+    @MainActor
+    final class KasetWebExtensionWindow: NSObject, WKWebExtensionWindow {
+        private var tabs: [KasetWebExtensionTab] = []
+        weak var activeTab: KasetWebExtensionTab?
+
+        func append(_ tab: KasetWebExtensionTab) {
+            guard !self.tabs.contains(where: { $0 === tab }) else { return }
+            self.tabs.append(tab)
+            if self.activeTab == nil {
+                self.activeTab = tab
+            }
+        }
+
+        func index(of tab: KasetWebExtensionTab) -> Int? {
+            self.tabs.firstIndex { $0 === tab }
+        }
+
+        func firstTab(excluding excludedTab: KasetWebExtensionTab) -> KasetWebExtensionTab? {
+            self.tabs.first { $0 !== excludedTab }
+        }
+
+        func tabs(for _: WKWebExtensionContext) -> [any WKWebExtensionTab] {
+            self.tabs
+        }
+
+        func activeTab(for _: WKWebExtensionContext) -> (any WKWebExtensionTab)? {
+            self.activeTab
+        }
+
+        func windowType(for _: WKWebExtensionContext) -> WKWebExtension.WindowType {
+            .normal
+        }
+
+        func windowState(for _: WKWebExtensionContext) -> WKWebExtension.WindowState {
+            guard let nsWindow = self.representativeNSWindow else { return .normal }
+            if nsWindow.styleMask.contains(.fullScreen) { return .fullscreen }
+            if nsWindow.isMiniaturized { return .minimized }
+            if nsWindow.isZoomed { return .maximized }
+            return .normal
+        }
+
+        func isPrivate(for _: WKWebExtensionContext) -> Bool {
+            false
+        }
+
+        func screenFrame(for _: WKWebExtensionContext) -> CGRect {
+            self.representativeNSWindow?.screen?.frame ?? NSScreen.main?.frame ?? .null
+        }
+
+        func frame(for _: WKWebExtensionContext) -> CGRect {
+            self.representativeNSWindow?.frame ?? .null
+        }
+
+        func focus(for _: WKWebExtensionContext, completionHandler: @escaping (Error?) -> Void) {
+            self.representativeNSWindow?.makeKeyAndOrderFront(nil)
+            completionHandler(nil)
+        }
+
+        private var representativeNSWindow: NSWindow? {
+            for tab in self.tabs {
+                if let window = tab.webView?.window {
+                    return window
+                }
+            }
+            return nil
+        }
+    }
+#endif

--- a/Sources/Kaset/Services/WebKit/WebKitManager.swift
+++ b/Sources/Kaset/Services/WebKit/WebKitManager.swift
@@ -54,6 +54,15 @@ final class WebKitManager: NSObject, WebKitManagerProtocol {
 
     private var extensionContexts: [String: WKWebExtensionContext] = [:]
 
+    #if compiler(>=5.9)
+        @ObservationIgnored
+        @available(macOS 15.4, *)
+        private lazy var webExtensionHost = KasetWebExtensionHost(
+            controller: self.webExtensionController,
+            logger: DiagnosticsLogger.extensions
+        )
+    #endif
+
     private init(dataStore: WKWebsiteDataStore, restoresCookies: Bool, loadsExtensions: Bool) {
         self.dataStore = dataStore
 
@@ -196,6 +205,10 @@ final class WebKitManager: NSObject, WebKitManagerProtocol {
         do {
             let webExtension = try await WKWebExtension(resourceBaseURL: url)
             let context = WKWebExtensionContext(for: webExtension)
+            // WebKit generates a new context identifier by default, which would
+            // move extension storage and webkit-extension:// origins every launch.
+            // Use Kaset's persisted managed-extension ID as the stable host identity.
+            context.uniqueIdentifier = id
 
             self.extensionContexts[id] = context
 
@@ -207,12 +220,40 @@ final class WebKitManager: NSObject, WebKitManagerProtocol {
                 context.setPermissionStatus(.grantedExplicitly, for: matchPattern)
             }
 
+            if #available(macOS 15.4, *) {
+                for matchPattern in Self.contentScriptMatchPatterns(from: webExtension.manifest) {
+                    context.setPermissionStatus(.grantedExplicitly, for: matchPattern)
+                }
+            }
+
             try self.webExtensionController.load(context)
-            try? await context.loadBackgroundContent()
+            if webExtension.hasBackgroundContent {
+                try? await context.loadBackgroundContent()
+            }
             self.logger.info("Loaded extension \(webExtension.displayName ?? url.lastPathComponent) (\(webExtension.version ?? "?")). Options: \(context.optionsPageURL?.absoluteString ?? "none")")
         } catch {
             self.logger.error("Failed to load extension at \(url.path): \(error.localizedDescription)")
         }
+    }
+
+    @available(macOS 15.4, *)
+    static func contentScriptMatchPatterns(from manifest: [AnyHashable: Any]) -> [WKWebExtension.MatchPattern] {
+        guard let contentScripts = manifest["content_scripts"] as? [[String: Any]] else {
+            return []
+        }
+
+        var patterns: [WKWebExtension.MatchPattern] = []
+        var seen = Set<String>()
+
+        for contentScript in contentScripts {
+            guard let matches = contentScript["matches"] as? [String] else { continue }
+            for match in matches where seen.insert(match).inserted {
+                guard let pattern = try? WKWebExtension.MatchPattern(string: match) else { continue }
+                patterns.append(pattern)
+            }
+        }
+
+        return patterns
     }
 
     /// Creates a WebView configuration using the shared persistent data store.
@@ -233,6 +274,67 @@ final class WebKitManager: NSObject, WebKitManagerProtocol {
         configuration.allowsAirPlayForMediaPlayback = true
 
         return configuration
+    }
+
+    /// Registers a Kaset-owned playback WebView as a browser tab for Web Extensions.
+    ///
+    /// WebKit can attach a `WKWebExtensionController` to a `WKWebViewConfiguration`,
+    /// but content injection and tab-scoped APIs also require the app to expose a
+    /// lightweight `WKWebExtensionTab`/`WKWebExtensionWindow` model.
+    func registerExtensionHostWebView(_ webView: WKWebView, role: WebExtensionHostedWebViewRole) {
+        #if compiler(>=5.9)
+            if #available(macOS 15.4, *) {
+                self.webExtensionHost.register(webView: webView, role: role)
+            }
+        #endif
+    }
+
+    func extensionHostWebViewWillNavigate(_ webView: WKWebView, to url: URL?) {
+        #if compiler(>=5.9)
+            if #available(macOS 15.4, *) {
+                self.webExtensionHost.noteNavigationStarted(for: webView, pendingURL: url)
+            }
+        #endif
+    }
+
+    func extensionHostWebViewDidStartNavigation(_ webView: WKWebView) {
+        #if compiler(>=5.9)
+            if #available(macOS 15.4, *) {
+                self.webExtensionHost.noteNavigationStarted(for: webView, pendingURL: nil)
+            }
+        #endif
+    }
+
+    func extensionHostWebViewDidBecomeActive(_ webView: WKWebView) {
+        #if compiler(>=5.9)
+            if #available(macOS 15.4, *) {
+                self.webExtensionHost.noteBecameActive(webView: webView)
+            }
+        #endif
+    }
+
+    func extensionHostWebViewDidDeactivate(role: WebExtensionHostedWebViewRole) {
+        #if compiler(>=5.9)
+            if #available(macOS 15.4, *) {
+                self.webExtensionHost.deactivate(role: role)
+            }
+        #endif
+    }
+
+    func extensionHostWebViewDidFinishNavigation(_ webView: WKWebView) {
+        #if compiler(>=5.9)
+            if #available(macOS 15.4, *) {
+                self.webExtensionHost.noteNavigationFinished(for: webView)
+            }
+        #endif
+    }
+
+    func extensionHostWebViewDidFailNavigation(_ webView: WKWebView) {
+        #if compiler(>=5.9)
+            if #available(macOS 15.4, *) {
+                self.webExtensionHost.noteNavigationFailed(for: webView)
+            }
+        #endif
     }
 
     /// Creates the minimal WebView configuration used for hidden account-switch
@@ -539,6 +641,16 @@ extension WebKitManager: WKHTTPCookieStoreObserver {
         func webExtensionController(_: WKWebExtensionController, shouldShowPromptFor matchPatterns: Set<WKWebExtension.MatchPattern>, in _: WKWebExtensionContext) async -> Bool {
             self.logger.info("Showing match-pattern prompt for: \(matchPatterns.map(\.string).joined(separator: ", "))")
             return true
+        }
+
+        @available(macOS 15.4, *)
+        func webExtensionController(_: WKWebExtensionController, openWindowsFor _: WKWebExtensionContext) -> [any WKWebExtensionWindow] {
+            self.webExtensionHost.openWindows
+        }
+
+        @available(macOS 15.4, *)
+        func webExtensionController(_: WKWebExtensionController, focusedWindowFor _: WKWebExtensionContext) -> (any WKWebExtensionWindow)? {
+            self.webExtensionHost.focusedWindow
         }
     }
 #endif

--- a/Sources/Kaset/Views/LoginWebView.swift
+++ b/Sources/Kaset/Views/LoginWebView.swift
@@ -13,7 +13,7 @@ struct LoginWebView: NSViewRepresentable {
     }
 
     func makeNSView(context: Context) -> WKWebView {
-        let configuration = self.webKitManager.createWebViewConfiguration()
+        let configuration = self.webKitManager.createSessionSwitchWebViewConfiguration()
         let webView = WKWebView(frame: .zero, configuration: configuration)
         webView.navigationDelegate = context.coordinator
         webView.customUserAgent = WebKitManager.userAgent

--- a/Sources/Kaset/Views/MiniPlayerWebView.swift
+++ b/Sources/Kaset/Views/MiniPlayerWebView.swift
@@ -223,6 +223,7 @@ final class SingletonPlayerWebView {
     static let shared = SingletonPlayerWebView()
 
     private(set) var webView: WKWebView?
+    weak var webKitManager: WebKitManager?
     var currentVideoId: String?
     var coordinator: Coordinator?
     let logger = DiagnosticsLogger.player
@@ -293,6 +294,8 @@ final class SingletonPlayerWebView {
         let newWebView = WKWebView(frame: .zero, configuration: configuration)
         newWebView.navigationDelegate = self.coordinator
         newWebView.customUserAgent = WebKitManager.userAgent
+        self.webKitManager = webKitManager
+        webKitManager.registerExtensionHostWebView(newWebView, role: .musicPlayer)
 
         #if DEBUG
             newWebView.isInspectable = true
@@ -304,7 +307,9 @@ final class SingletonPlayerWebView {
 
     /// Ensures the WebView is in the given container's view hierarchy.
     func ensureInHierarchy(container: NSView) {
-        guard let webView, webView.superview !== container else { return }
+        guard let webView else { return }
+        self.webKitManager?.extensionHostWebViewDidBecomeActive(webView)
+        guard webView.superview !== container else { return }
         webView.removeFromSuperview()
         container.addSubview(webView)
 
@@ -828,7 +833,29 @@ final class SingletonPlayerWebView {
             return nil
         }
 
+        func webView(
+            _ webView: WKWebView,
+            decidePolicyFor navigationAction: WKNavigationAction,
+            decisionHandler: @escaping @MainActor (WKNavigationActionPolicy) -> Void
+        ) {
+            guard navigationAction.targetFrame?.isMainFrame == true else {
+                decisionHandler(.allow)
+                return
+            }
+
+            SingletonPlayerWebView.shared.webKitManager?.extensionHostWebViewWillNavigate(
+                webView,
+                to: navigationAction.request.url
+            )
+            decisionHandler(.allow)
+        }
+
+        func webView(_ webView: WKWebView, didStartProvisionalNavigation _: WKNavigation!) {
+            SingletonPlayerWebView.shared.webKitManager?.extensionHostWebViewDidStartNavigation(webView)
+        }
+
         func webView(_ webView: WKWebView, didFinish _: WKNavigation!) {
+            SingletonPlayerWebView.shared.webKitManager?.extensionHostWebViewDidFinishNavigation(webView)
             DiagnosticsLogger.player.info(
                 "Singleton WebView finished loading: \(webView.url?.absoluteString ?? "nil")"
             )
@@ -888,6 +915,14 @@ final class SingletonPlayerWebView {
                     SingletonPlayerWebView.shared.injectVideoModeCSS()
                 }
             }
+        }
+
+        func webView(_ webView: WKWebView, didFail _: WKNavigation!, withError _: Error) {
+            SingletonPlayerWebView.shared.webKitManager?.extensionHostWebViewDidFailNavigation(webView)
+        }
+
+        func webView(_ webView: WKWebView, didFailProvisionalNavigation _: WKNavigation!, withError _: Error) {
+            SingletonPlayerWebView.shared.webKitManager?.extensionHostWebViewDidFailNavigation(webView)
         }
 
         func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {

--- a/Sources/Kaset/Views/YouTube/YouTubeWatchWebView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeWatchWebView.swift
@@ -19,6 +19,7 @@ final class YouTubeWatchWebView {
     static let shared = YouTubeWatchWebView()
 
     private(set) var webView: WKWebView?
+    weak var webKitManager: WebKitManager?
     var currentVideoId: String?
     var coordinator: Coordinator?
     let logger = DiagnosticsLogger.player
@@ -60,6 +61,8 @@ final class YouTubeWatchWebView {
         let newWebView = WKWebView(frame: .zero, configuration: configuration)
         newWebView.navigationDelegate = self.coordinator
         newWebView.customUserAgent = WebKitManager.userAgent
+        self.webKitManager = webKitManager
+        webKitManager.registerExtensionHostWebView(newWebView, role: .youtubeWatch)
 
         // Kill the white flash between page navigations.
         newWebView.underPageBackgroundColor = .black
@@ -74,7 +77,9 @@ final class YouTubeWatchWebView {
 
     /// Ensures the WebView fills the given container (reparenting if needed).
     func ensureInHierarchy(container: NSView) {
-        guard let webView, webView.superview !== container else { return }
+        guard let webView else { return }
+        self.webKitManager?.extensionHostWebViewDidBecomeActive(webView)
+        guard webView.superview !== container else { return }
         webView.removeFromSuperview()
         container.addSubview(webView)
         webView.translatesAutoresizingMaskIntoConstraints = true
@@ -157,6 +162,7 @@ final class YouTubeWatchWebView {
         webView.evaluateJavaScript("document.querySelector('video')?.pause()") { _, _ in }
         webView.loadHTMLString("", baseURL: nil)
         webView.removeFromSuperview()
+        self.webKitManager?.extensionHostWebViewDidDeactivate(role: .youtubeWatch)
     }
 
     // MARK: - User Scripts
@@ -251,7 +257,29 @@ final class YouTubeWatchWebView {
             }
         }
 
+        func webView(
+            _ webView: WKWebView,
+            decidePolicyFor navigationAction: WKNavigationAction,
+            decisionHandler: @escaping @MainActor (WKNavigationActionPolicy) -> Void
+        ) {
+            guard navigationAction.targetFrame?.isMainFrame == true else {
+                decisionHandler(.allow)
+                return
+            }
+
+            YouTubeWatchWebView.shared.webKitManager?.extensionHostWebViewWillNavigate(
+                webView,
+                to: navigationAction.request.url
+            )
+            decisionHandler(.allow)
+        }
+
+        func webView(_ webView: WKWebView, didStartProvisionalNavigation _: WKNavigation!) {
+            YouTubeWatchWebView.shared.webKitManager?.extensionHostWebViewDidStartNavigation(webView)
+        }
+
         func webView(_ webView: WKWebView, didFinish _: WKNavigation!) {
+            YouTubeWatchWebView.shared.webKitManager?.extensionHostWebViewDidFinishNavigation(webView)
             DiagnosticsLogger.player.info(
                 "YouTube watch WebView finished loading: \(webView.url?.absoluteString ?? "nil")"
             )
@@ -275,6 +303,14 @@ final class YouTubeWatchWebView {
                 """,
                 completionHandler: nil
             )
+        }
+
+        func webView(_ webView: WKWebView, didFail _: WKNavigation!, withError _: Error) {
+            YouTubeWatchWebView.shared.webKitManager?.extensionHostWebViewDidFailNavigation(webView)
+        }
+
+        func webView(_ webView: WKWebView, didFailProvisionalNavigation _: WKNavigation!, withError _: Error) {
+            YouTubeWatchWebView.shared.webKitManager?.extensionHostWebViewDidFailNavigation(webView)
         }
 
         func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {

--- a/Tests/KasetTests/WebKitManagerTests.swift
+++ b/Tests/KasetTests/WebKitManagerTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Testing
+import WebKit
 @testable import Kaset
 
 /// Tests for WebKitManager.
@@ -27,6 +28,103 @@ struct WebKitManagerTests {
     func createWebViewConfiguration() {
         let configuration = self.webKitManager.createWebViewConfiguration()
         #expect(configuration.websiteDataStore === self.webKitManager.dataStore)
+    }
+
+    @Test("Extension host registers playback WebViews as extension-visible tabs")
+    @MainActor
+    func extensionHostRegistersPlaybackWebViews() {
+        #if compiler(>=5.9)
+            if #available(macOS 15.4, *) {
+                let controller = WKWebExtensionController()
+                let host = KasetWebExtensionHost(controller: controller)
+                let configuration = WKWebViewConfiguration()
+                configuration.websiteDataStore = .nonPersistent()
+                configuration.webExtensionController = controller
+
+                let webView = WKWebView(frame: CGRect(x: 0, y: 0, width: 320, height: 180), configuration: configuration)
+                let tab = host.register(webView: webView, role: .musicPlayer)
+
+                #expect(tab != nil)
+                #expect(host.registeredTabCount == 1)
+                #expect(host.openWindows.count == 1)
+                #expect(host.focusedWindow != nil)
+
+                // Re-registering the same WebView should activate the existing tab, not create another one.
+                _ = host.register(webView: webView, role: .musicPlayer)
+                #expect(host.registeredTabCount == 1)
+
+                // Rebuilding the playback WebView for the same role should replace the tab's target,
+                // not leave a stale ghost tab behind.
+                let replacementWebView = WKWebView(frame: CGRect(x: 0, y: 0, width: 320, height: 180), configuration: configuration)
+                _ = host.register(webView: replacementWebView, role: .musicPlayer)
+                #expect(host.registeredTabCount == 1)
+            }
+        #endif
+    }
+
+    @Test("Extension window does not invent an active tab after deactivation")
+    @MainActor
+    func extensionWindowDoesNotInventActiveTab() async throws {
+        #if compiler(>=5.9)
+            if #available(macOS 15.4, *) {
+                let tempDirectory = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("KasetWebExtensionWindowTests-\(UUID().uuidString)", isDirectory: true)
+                try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+                defer { try? FileManager.default.removeItem(at: tempDirectory) }
+
+                let manifest: [String: Any] = [
+                    "manifest_version": 3,
+                    "name": "Window Active Tab Test",
+                    "description": "Test extension",
+                    "version": "1.0",
+                ]
+                let manifestData = try JSONSerialization.data(withJSONObject: manifest, options: [.sortedKeys])
+                try manifestData.write(to: tempDirectory.appendingPathComponent("manifest.json"))
+
+                let webExtension = try await WKWebExtension(resourceBaseURL: tempDirectory)
+                let context = WKWebExtensionContext(for: webExtension)
+
+                let window = KasetWebExtensionWindow()
+                let configuration = WKWebViewConfiguration()
+                configuration.websiteDataStore = .nonPersistent()
+                let webView = WKWebView(frame: CGRect(x: 0, y: 0, width: 320, height: 180), configuration: configuration)
+                let tab = KasetWebExtensionTab(role: .youtubeWatch, webView: webView)
+                window.append(tab)
+
+                #expect(window.activeTab(for: context) != nil)
+
+                window.activeTab = nil
+
+                #expect(window.activeTab(for: context) == nil)
+            }
+        #endif
+    }
+
+    @Test("Content script match patterns are extracted for permission grants")
+    @MainActor
+    func contentScriptMatchPatternsAreExtracted() {
+        #if compiler(>=5.9)
+            if #available(macOS 15.4, *) {
+                let manifest: [AnyHashable: Any] = [
+                    "content_scripts": [
+                        [
+                            "matches": [
+                                "https://*.youtube.com/*",
+                                "https://www.youtube-nocookie.com/embed/*",
+                                "https://*.youtube.com/*",
+                            ],
+                        ],
+                    ],
+                ]
+
+                let patterns = WebKitManager.contentScriptMatchPatterns(from: manifest).map(\.string).sorted()
+
+                #expect(patterns == [
+                    "https://*.youtube.com/*",
+                    "https://www.youtube-nocookie.com/embed/*",
+                ])
+            }
+        #endif
     }
 
     @Test("Session switch WebView configuration excludes extensions")

--- a/docs/adr/0014-extensions.md
+++ b/docs/adr/0014-extensions.md
@@ -34,7 +34,8 @@ ExtensionsManager (singleton, @MainActor @Observable)
   └── toggleExtension(id:)
 
 WebKitManager
-  └── loadExtensions()  iterates ExtensionsManager.resolvedURLs(), loads via WKWebExtensionController
+  ├── loadExtensions()  iterates ExtensionsManager.resolvedURLs(), loads via WKWebExtensionController
+  └── KasetWebExtensionHost exposes playback WebViews as WKWebExtension tabs/windows
 
 ExtensionsSettingsView
   └── renders manager.extensions, calls add/remove/toggle
@@ -52,12 +53,22 @@ ExtensionsSettingsView
 | `popupPath` | String? | Relative path to an extension-provided popup page, when present |
 | `localBookmark` | Data? | Optional security-scoped bookmark for the copied local folder |
 
+### Playback WebView hosting
+
+WebKit extension injection is not driven by `WKWebViewConfiguration.webExtensionController` alone. WebKit also asks the containing app for browser-like tabs and windows, and `WKWebExtensionTab.webView(for:)` is the seam that lets extension content injection and tab-scoped APIs resolve the target `WKWebView`. Kaset does not expose browser tabs in its product UI, so `KasetWebExtensionHost` provides a small internal tab/window model for the two long-lived playback surfaces:
+
+- `SingletonPlayerWebView` (`music.youtube.com`) registers as the music playback tab.
+- `YouTubeWatchWebView` (`www.youtube.com/watch`) registers as the YouTube video playback tab.
+
+The host is intentionally an adapter around existing singleton playback WebViews rather than a new owner of playback lifecycle. Playback services still own loading, teardown, and navigation; the host only supplies WebKit extension tab/window identity and forwards navigation property changes.
+
 ## Consequences
 
 - **Positive**: Users have full control — they can install any WebKit-compatible extension, custom content scripts, privacy tools, and similar tooling.
 - **Positive**: No extension is loaded by default — the app has zero implicit behavioural dependencies on a third-party codebase at runtime.
 - **Positive**: Copying extensions into app storage avoids depending on the original import location remaining available.
 - **Positive**: Extension options and popup pages can be surfaced through the native settings flow when available.
+- **Positive**: Playback WebViews are exposed through a focused WebKit tab/window adapter, concentrating extension-hosting behaviour in one module instead of spreading `WKWebExtensionTab` protocol details across player views.
 - **Negative**: Imported extensions are snapshots; if the original source folder changes, users must re-import it to pick up updates.
 - **Negative**: Changes require a restart (no public unload API on `WKWebExtensionController`). The UI communicates this clearly.
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -29,6 +29,7 @@ Click the **trash** icon next to any extension, then restart Kaset.
 - **Imported files:** Kaset copies each added extension into `~/Library/Application Support/Kaset/ManagedExtensions/` and loads that local snapshot.
 - **Security:** Kaset may store a local security-scoped bookmark for the copied extension folder when WebKit needs sandbox-friendly access.
 - **Loading:** At launch, `WebKitManager` loads all enabled extensions in order via `WKWebExtensionController`, granting them all requested permissions.
+- **Playback hosting:** Kaset registers its long-lived YouTube Music and YouTube watch WebViews as lightweight WebKit extension tabs/windows so content scripts and tab-scoped extension APIs can resolve the playback page WebView.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- Add a lightweight WebKit WebExtension host that exposes the YouTube Music and YouTube watch playback WebViews as extension-visible tabs/windows.
- Register the music and video playback WebViews with that host and forward main-frame navigation state to WebKit.
- Grant required permissions plus manifest-declared content-script match patterns, so Safari/MV2-style extensions such as SponsorBlock can access their declared YouTube content-script hosts without unsafe optional-permission escalation.
- Document the playback WebView hosting model and add focused WebKitManager tests.

## Root cause
Kaset attached a `WKWebExtensionController` to playback WebViews, but WebKit also needs a browser-like tab/window model to resolve tab-scoped APIs and content injection targets. SponsorBlock also declares YouTube access through static `content_scripts.matches`, so dynamic script paths lacked host access unless those declared matches were reflected into the extension context.

## Validation
- `swift build`
- `swift test --filter WebKitManagerTests --skip KasetUITests`
- `swift test --filter ExtensionsManagerTests --skip KasetUITests`
- `swiftlint --strict`
- `.agents/skills/autoreview/scripts/autoreview` → clean, no accepted/actionable findings

UI tests were not run.
