### PR TITLE
Fix startup Keychain deadlock and empty account session expiration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,8 @@ Default local workflow is CLI-first: use the commands above for day-to-day verif
 
 See `docs/common-bug-patterns.md` for the timestamped-trace template, the sandbox tmp path, and the single-flight load pattern that resolves the `.task`-restart cancellation deadlock.
 
+> 🔐 **Keychain vs. File-based Cookie Storage**: Sandboxed macOS apps without a valid Developer ID or provisioning profile (such as local debug or ad-hoc builds) will hang inside `SecItemCopyMatching` when querying the Keychain. To bypass this, in `#if DEBUG` builds the app stores cookies in the sandboxed Application Support folder under `Kaset/cookies.dat` and completely bypasses Keychain API calls.
+
 ## Continuous Review
 
 For non-trivial code changes, run `$autoreview` (`.agents/skills/autoreview/SKILL.md`) before final/commit/ship and keep going until there are no accepted/actionable findings, unless the change is trivial/docs-only, equivalent manual review already happened, or the human opts out.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ Default local workflow is CLI-first: use the commands above for day-to-day verif
 
 See `docs/common-bug-patterns.md` for the timestamped-trace template, the sandbox tmp path, and the single-flight load pattern that resolves the `.task`-restart cancellation deadlock.
 
-> 🔐 **Keychain vs. File-based Cookie Storage**: Sandboxed macOS apps without a valid Developer ID or provisioning profile (such as local debug or ad-hoc builds) will hang inside `SecItemCopyMatching` when querying the Keychain. To bypass this, in `#if DEBUG` builds the app stores cookies in the sandboxed Application Support folder under `Kaset/cookies.dat` and completely bypasses Keychain API calls.
+> 🔐 **Keychain vs. File-based Cookie Storage**: Sandboxed macOS apps without a valid Developer ID or provisioning profile (such as local debug or ad-hoc builds) will hang inside `SecItemCopyMatching` when querying the Keychain. To bypass this, `#if DEBUG` builds store cookies in the sandboxed Application Support folder under `Kaset/cookies.dat` and completely bypass Keychain API calls by default. To test the production Keychain path locally, launch with `KASET_DEBUG_COOKIE_STORAGE=keychain`.
 
 ## Continuous Review
 

--- a/Sources/Kaset/Services/Auth/AccountService.swift
+++ b/Sources/Kaset/Services/Auth/AccountService.swift
@@ -249,7 +249,6 @@ final class AccountService {
         }
     }
 
-
     // swiftlint:disable cyclomatic_complexity
     /// Schedules a best-effort WebView session pin for the restored account, off
     /// the `fetchAccounts` path so it never blocks launch or holds `isLoading`.

--- a/Sources/Kaset/Services/Auth/AccountService.swift
+++ b/Sources/Kaset/Services/Auth/AccountService.swift
@@ -200,6 +200,13 @@ final class AccountService {
                 self.logger.info("AccountService: Ignoring stale account fetch after auth/account state changed")
                 return
             }
+
+            if response.accounts.isEmpty {
+                self.logger.warning("AccountService: 0 accounts returned, marking session as expired")
+                self.authService.sessionExpired()
+                return
+            }
+
             self.accounts = response.accounts
 
             // Restore previously selected account if stored
@@ -241,6 +248,7 @@ final class AccountService {
             self.errorSequence += 1
         }
     }
+
 
     // swiftlint:disable cyclomatic_complexity
     /// Schedules a best-effort WebView session pin for the restored account, off

--- a/Sources/Kaset/Services/WebKit/WebKitManager+Cookies.swift
+++ b/Sources/Kaset/Services/WebKit/WebKitManager+Cookies.swift
@@ -51,8 +51,12 @@ final class CookieArchiveWriteCoordinator: @unchecked Sendable {
 
 // MARK: - KeychainCookieStorage
 
-/// Securely stores auth cookies in the macOS Keychain.
-/// Provides encryption at rest and app-specific access control.
+/// Stores auth cookie backups in the configured backing store.
+///
+/// Release builds use the macOS Keychain for encryption at rest and app-specific
+/// access control. DEBUG builds default to a sandboxed file to avoid local
+/// ad-hoc signing hangs inside Security.framework; set
+/// `KASET_DEBUG_COOKIE_STORAGE=keychain` to exercise the Keychain path locally.
 enum KeychainCookieStorage {
     private static let logger = DiagnosticsLogger.webKit
     private static let writeCoordinator = CookieArchiveWriteCoordinator()
@@ -62,6 +66,14 @@ enum KeychainCookieStorage {
 
     /// Keychain account identifier.
     private static let account = "youtube-music-cookies"
+
+    #if DEBUG
+        private static let debugCookieStorageEnvironmentKey = "KASET_DEBUG_COOKIE_STORAGE"
+
+        private static var usesDebugFileStorage: Bool {
+            ProcessInfo.processInfo.environment[debugCookieStorageEnvironmentKey]?.lowercased() != "keychain"
+        }
+    #endif
 
     /// Cookie names required for YouTube Music authentication.
     static let authCookieNames = Set([
@@ -77,7 +89,7 @@ enum KeychainCookieStorage {
         return true
     }
 
-    /// Creates the serialized archive we persist to Keychain (and in DEBUG to `cookies.dat`).
+    /// Creates the serialized archive persisted by the active cookie backup store.
     /// Returns nil if there are no valid auth cookies to store.
     static func makeArchiveData(from cookies: [HTTPCookie]) -> (data: Data, cookieCount: Int)? {
         let now = Date()
@@ -109,14 +121,14 @@ enum KeychainCookieStorage {
                   requiringSecureCoding: true
               )
         else {
-            Self.logger.error("Failed to serialize cookies for Keychain")
+            Self.logger.error("Failed to serialize cookies for backup storage")
             return nil
         }
 
         return (data: data, cookieCount: cookieData.count)
     }
 
-    /// Saves YouTube auth cookies to the Keychain.
+    /// Saves YouTube auth cookies to the active cookie backup store.
     static func saveCookies(_ cookies: [HTTPCookie]) {
         guard let archive = makeArchiveData(from: cookies) else { return }
 
@@ -135,30 +147,13 @@ enum KeychainCookieStorage {
             .appendingPathComponent("cookies.dat")
     }
 
-    /// Saves an already-serialized cookie archive to the Keychain.
+    /// Saves an already-serialized cookie archive to the active cookie backup store.
     @discardableResult
     static func saveArchiveData(_ data: Data, cookieCount: Int) -> Bool {
         #if DEBUG
-        // Bypass Keychain completely to avoid hangs in local adhoc-signed/unsigned builds
-        if let fileURL = self.debugCookieFileURL {
-            do {
-                try FileManager.default.createDirectory(
-                    at: fileURL.deletingLastPathComponent(),
-                    withIntermediateDirectories: true
-                )
-                try data.write(to: fileURL, options: .atomic)
-                try FileManager.default.setAttributes(
-                    [.posixPermissions: 0o600],
-                    ofItemAtPath: fileURL.path
-                )
-                self.writeCoordinator.finishSave(data, success: true)
-                Self.logger.info("Saved \(cookieCount) auth cookies to debug file: \(fileURL.path)")
-                return true
-            } catch {
-                Self.logger.error("Failed to save debug cookies file: \(error.localizedDescription)")
-                return false
+            if self.usesDebugFileStorage {
+                return self.saveArchiveDataToDebugFile(data, cookieCount: cookieCount)
             }
-        }
         #endif
 
         guard self.writeCoordinator.beginSaveIfNeeded(data) else {
@@ -200,14 +195,43 @@ enum KeychainCookieStorage {
         }
     }
 
-    /// Returns `true` if a Keychain item exists for our cookie storage.
+    #if DEBUG
+        private static func saveArchiveDataToDebugFile(_ data: Data, cookieCount: Int) -> Bool {
+            guard let fileURL = debugCookieFileURL else {
+                self.logger.error("Debug cookie file storage is unavailable")
+                self.writeCoordinator.seedPersistedArchive(nil)
+                return false
+            }
+
+            do {
+                try FileManager.default.createDirectory(
+                    at: fileURL.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+                try data.write(to: fileURL, options: .atomic)
+                try FileManager.default.setAttributes(
+                    [.posixPermissions: 0o600],
+                    ofItemAtPath: fileURL.path
+                )
+                self.writeCoordinator.finishSave(data, success: true)
+                Self.logger.info("Saved \(cookieCount) auth cookies to debug file storage")
+                return true
+            } catch {
+                Self.logger.error("Failed to save debug cookies file: \(error.localizedDescription)")
+                return false
+            }
+        }
+    #endif
+
+    /// Returns `true` if a cookie backup exists in the active backing store.
     static func hasCookieItem() -> Bool {
         #if DEBUG
-        if let fileURL = self.debugCookieFileURL {
-            return FileManager.default.fileExists(atPath: fileURL.path)
-        }
-        return false
-        #else
+            if self.usesDebugFileStorage {
+                guard let fileURL = self.debugCookieFileURL else { return false }
+                return FileManager.default.fileExists(atPath: fileURL.path)
+            }
+        #endif
+
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: Self.service,
@@ -218,26 +242,16 @@ enum KeychainCookieStorage {
 
         let status = SecItemCopyMatching(query as CFDictionary, nil)
         return status == errSecSuccess
-        #endif
     }
 
-    /// Loads the raw serialized cookie archive data from Keychain.
+    /// Loads the raw serialized cookie archive data from the active backing store.
     static func loadArchiveData() -> Data? {
         #if DEBUG
-        if let fileURL = self.debugCookieFileURL {
-            if FileManager.default.fileExists(atPath: fileURL.path) {
-                if let data = try? Data(contentsOf: fileURL) {
-                    self.writeCoordinator.seedPersistedArchive(data)
-                    Self.logger.info("Loaded cookies from debug file: \(fileURL.path)")
-                    return data
-                }
+            if self.usesDebugFileStorage {
+                return self.loadArchiveDataFromDebugFile()
             }
-            Self.logger.info("No debug cookies file found, returning nil directly")
-            self.writeCoordinator.seedPersistedArchive(nil)
-            return nil
-        }
-        return nil
-        #else
+        #endif
+
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: Self.service,
@@ -267,8 +281,33 @@ enum KeychainCookieStorage {
 
         Self.writeCoordinator.seedPersistedArchive(data)
         return data
-        #endif
     }
+
+    #if DEBUG
+        private static func loadArchiveDataFromDebugFile() -> Data? {
+            guard let fileURL = self.debugCookieFileURL else {
+                self.logger.error("Debug cookie file storage is unavailable")
+                self.writeCoordinator.seedPersistedArchive(nil)
+                return nil
+            }
+
+            guard FileManager.default.fileExists(atPath: fileURL.path) else {
+                Self.logger.info("No debug cookies file found")
+                self.writeCoordinator.seedPersistedArchive(nil)
+                return nil
+            }
+
+            guard let data = try? Data(contentsOf: fileURL) else {
+                Self.logger.error("Failed to load debug cookies file")
+                self.writeCoordinator.seedPersistedArchive(nil)
+                return nil
+            }
+
+            self.writeCoordinator.seedPersistedArchive(data)
+            Self.logger.info("Loaded cookies from debug file storage")
+            return data
+        }
+    #endif
 
     /// Decodes cookies from a serialized archive created by `makeArchiveData(from:)`.
     static func decodeCookies(from archiveData: Data) -> [HTTPCookie] {
@@ -297,12 +336,12 @@ enum KeychainCookieStorage {
         }
 
         if !cookies.isEmpty {
-            Self.logger.info("Loaded \(cookies.count) auth cookies from Keychain")
+            Self.logger.info("Loaded \(cookies.count) auth cookies from cookie backup storage")
         }
         return cookies
     }
 
-    /// Retrieves YouTube auth cookies from the Keychain.
+    /// Retrieves YouTube auth cookies from the active cookie backup store.
     /// Returns the cookies if found, nil otherwise.
     static func loadCookies() -> [HTTPCookie]? {
         guard let archiveData = loadArchiveData() else { return nil }
@@ -310,15 +349,18 @@ enum KeychainCookieStorage {
         return cookies.isEmpty ? nil : cookies
     }
 
-    /// Deletes cookies from the Keychain.
+    /// Deletes cookies from the active cookie backup store.
     static func deleteCookies() {
         #if DEBUG
-        if let fileURL = self.debugCookieFileURL {
-            try? FileManager.default.removeItem(at: fileURL)
-            self.writeCoordinator.seedPersistedArchive(nil)
-            Self.logger.info("Deleted cookies from debug file")
-            return
-        }
+            if self.usesDebugFileStorage {
+                self.deleteDebugCookieFile()
+                return
+            }
+
+            // When explicitly testing the Keychain path in DEBUG, also clear
+            // the default debug file so switching backends cannot resurrect a
+            // session the developer just signed out from.
+            self.deleteDebugCookieFile()
         #endif
 
         let query: [String: Any] = [
@@ -336,6 +378,27 @@ enum KeychainCookieStorage {
             Self.logger.error("Failed to delete cookies from Keychain: \(status)")
         }
     }
+
+    #if DEBUG
+        private static func deleteDebugCookieFile() {
+            guard let fileURL = self.debugCookieFileURL else {
+                self.logger.error("Debug cookie file storage is unavailable")
+                self.writeCoordinator.seedPersistedArchive(nil)
+                return
+            }
+
+            do {
+                if FileManager.default.fileExists(atPath: fileURL.path) {
+                    try FileManager.default.removeItem(at: fileURL)
+                    Self.logger.info("Deleted cookies from debug file storage")
+                }
+            } catch {
+                Self.logger.warning("Failed to delete debug cookies file: \(error.localizedDescription)")
+            }
+
+            self.writeCoordinator.seedPersistedArchive(nil)
+        }
+    #endif
 }
 
 // MARK: - LegacyCookieMigration

--- a/Sources/Kaset/Services/WebKit/WebKitManager+Cookies.swift
+++ b/Sources/Kaset/Services/WebKit/WebKitManager+Cookies.swift
@@ -123,9 +123,44 @@ enum KeychainCookieStorage {
         _ = Self.saveArchiveData(archive.data, cookieCount: archive.cookieCount)
     }
 
+    private static var debugCookieFileURL: URL? {
+        guard let appSupport = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first else {
+            return nil
+        }
+        return appSupport
+            .appendingPathComponent("Kaset", isDirectory: true)
+            .appendingPathComponent("cookies.dat")
+    }
+
     /// Saves an already-serialized cookie archive to the Keychain.
     @discardableResult
     static func saveArchiveData(_ data: Data, cookieCount: Int) -> Bool {
+        #if DEBUG
+        // Bypass Keychain completely to avoid hangs in local adhoc-signed/unsigned builds
+        if let fileURL = self.debugCookieFileURL {
+            do {
+                try FileManager.default.createDirectory(
+                    at: fileURL.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+                try data.write(to: fileURL, options: .atomic)
+                try FileManager.default.setAttributes(
+                    [.posixPermissions: 0o600],
+                    ofItemAtPath: fileURL.path
+                )
+                self.writeCoordinator.finishSave(data, success: true)
+                Self.logger.info("Saved \(cookieCount) auth cookies to debug file: \(fileURL.path)")
+                return true
+            } catch {
+                Self.logger.error("Failed to save debug cookies file: \(error.localizedDescription)")
+                return false
+            }
+        }
+        #endif
+
         guard self.writeCoordinator.beginSaveIfNeeded(data) else {
             self.logger.debug("Skipping Keychain cookie save because archive is already saved or a write is in progress")
             return false
@@ -167,6 +202,12 @@ enum KeychainCookieStorage {
 
     /// Returns `true` if a Keychain item exists for our cookie storage.
     static func hasCookieItem() -> Bool {
+        #if DEBUG
+        if let fileURL = self.debugCookieFileURL {
+            return FileManager.default.fileExists(atPath: fileURL.path)
+        }
+        return false
+        #else
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: Self.service,
@@ -177,10 +218,26 @@ enum KeychainCookieStorage {
 
         let status = SecItemCopyMatching(query as CFDictionary, nil)
         return status == errSecSuccess
+        #endif
     }
 
     /// Loads the raw serialized cookie archive data from Keychain.
     static func loadArchiveData() -> Data? {
+        #if DEBUG
+        if let fileURL = self.debugCookieFileURL {
+            if FileManager.default.fileExists(atPath: fileURL.path) {
+                if let data = try? Data(contentsOf: fileURL) {
+                    self.writeCoordinator.seedPersistedArchive(data)
+                    Self.logger.info("Loaded cookies from debug file: \(fileURL.path)")
+                    return data
+                }
+            }
+            Self.logger.info("No debug cookies file found, returning nil directly")
+            self.writeCoordinator.seedPersistedArchive(nil)
+            return nil
+        }
+        return nil
+        #else
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: Self.service,
@@ -210,6 +267,7 @@ enum KeychainCookieStorage {
 
         Self.writeCoordinator.seedPersistedArchive(data)
         return data
+        #endif
     }
 
     /// Decodes cookies from a serialized archive created by `makeArchiveData(from:)`.
@@ -254,6 +312,15 @@ enum KeychainCookieStorage {
 
     /// Deletes cookies from the Keychain.
     static func deleteCookies() {
+        #if DEBUG
+        if let fileURL = self.debugCookieFileURL {
+            try? FileManager.default.removeItem(at: fileURL)
+            self.writeCoordinator.seedPersistedArchive(nil)
+            Self.logger.info("Deleted cookies from debug file")
+            return
+        }
+        #endif
+
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: Self.service,

--- a/Sources/Kaset/Views/LoginWebView.swift
+++ b/Sources/Kaset/Views/LoginWebView.swift
@@ -17,7 +17,9 @@ struct LoginWebView: NSViewRepresentable {
         let webView = WKWebView(frame: .zero, configuration: configuration)
         webView.navigationDelegate = context.coordinator
         webView.customUserAgent = WebKitManager.userAgent
-        webView.isInspectable = true
+        #if DEBUG
+            webView.isInspectable = true
+        #endif
 
         // Load YouTube Music login page
         if let url = URL(string: "https://accounts.google.com/ServiceLogin?service=youtube&uilel=3&passive=true&continue=https%3A%2F%2Fwww.youtube.com%2Fsignin%3Faction_handle_signin%3Dtrue%26app%3Ddesktop%26hl%3Den%26next%3Dhttps%253A%252F%252Fmusic.youtube.com%252F") {

--- a/Sources/Kaset/Views/LoginWebView.swift
+++ b/Sources/Kaset/Views/LoginWebView.swift
@@ -17,6 +17,7 @@ struct LoginWebView: NSViewRepresentable {
         let webView = WKWebView(frame: .zero, configuration: configuration)
         webView.navigationDelegate = context.coordinator
         webView.customUserAgent = WebKitManager.userAgent
+        webView.isInspectable = true
 
         // Load YouTube Music login page
         if let url = URL(string: "https://accounts.google.com/ServiceLogin?service=youtube&uilel=3&passive=true&continue=https%3A%2F%2Fwww.youtube.com%2Fsignin%3Faction_handle_signin%3Dtrue%26app%3Ddesktop%26hl%3Den%26next%3Dhttps%253A%252F%252Fmusic.youtube.com%252F") {

--- a/Tests/KasetTests/AccountServiceSessionExpirationTests.swift
+++ b/Tests/KasetTests/AccountServiceSessionExpirationTests.swift
@@ -1,0 +1,41 @@
+import Testing
+@testable import Kaset
+
+// MARK: - AccountServiceSessionExpirationTests
+
+@Suite(.serialized)
+@MainActor
+struct AccountServiceSessionExpirationTests {
+    @Test func fetchAccountsWithEmptyAccountsExpiresSession() async {
+        let services = Self.createService()
+
+        services.client.accountsListResponse = AccountsListResponse(googleEmail: "test@gmail.com", accounts: [])
+        services.auth.completeLogin(sapisid: "test-sapisid")
+
+        await services.account.fetchAccounts()
+
+        #expect(services.auth.state == .loggedOut)
+        #expect(services.auth.needsReauth == true)
+        #expect(services.account.accounts.isEmpty)
+        #expect(services.account.currentAccount == nil)
+        #expect(services.account.lastError == nil)
+        #expect(services.account.isLoading == false)
+    }
+
+    private static func createService() -> SessionExpirationTestServices {
+        let authService = AuthService()
+        let mockClient = MockYTMusicClient()
+        let accountService = AccountService(ytMusicClient: mockClient, authService: authService)
+        SongLikeStatusManager.shared.clearCache()
+        SongLikeStatusManager.shared.setActiveAccountID(nil)
+        return SessionExpirationTestServices(account: accountService, client: mockClient, auth: authService)
+    }
+}
+
+// MARK: - SessionExpirationTestServices
+
+private struct SessionExpirationTestServices {
+    let account: AccountService
+    let client: MockYTMusicClient
+    let auth: AuthService
+}


### PR DESCRIPTION
This PR resolves issues with the login flow, startup deadlock, and blank profile loading state on macOS 14+ (Tahoe/Sequoia).

### Core Changes

1. **Bypass Keychain Deadlock in `#if DEBUG`**
   - **Problem**: When running local debug/ad-hoc builds or under quarantine, the Keychain API call `SecItemCopyMatching` deadlocks indefinitely inside the macOS Security daemon (`securityd`). Because the app startup synchronously awaited this task, the entire application hung during initialization.
   - **Solution**: In `#if DEBUG` builds, `KeychainCookieStorage` is modified to read and write cookies directly from/to a local file (`Kaset/cookies.dat` inside the sandboxed Application Support folder), bypassing Keychain calls completely.

2. **Session Expiration Trigger on Empty Accounts list**
   - **Problem**: If the Keychain failed to restore cookies, or if cookies expired on the YouTube side, the account switcher API call returned `0 accounts`. The app did not trigger a logout/re-auth, leaving the profile icon stuck in the skeleton loading state (blank grey circle) forever with no login button visible to recover.
   - **Solution**: Updated `AccountService` to detect when `response.accounts` is empty. In this case, it calls `self.authService.sessionExpired()`, which transitions the app state to logged out and displays the onboarding/login view cleanly.

3. **Inspectable Login Web View**
   - Enabled `webView.isInspectable = true` on `LoginWebView` to allow inspection of the login sheet using Safari's Develop menu.

Closes #338
