### PR TITLE
feat(ui): make the artists name in the album view clickable

### DIFF
--- a/Sources/Kaset/Views/PlaylistDetailView.swift
+++ b/Sources/Kaset/Views/PlaylistDetailView.swift
@@ -199,9 +199,16 @@ struct PlaylistDetailView: View {
         if !artists.isEmpty {
             HStack(spacing: 0) {
                 ForEach(Array(artists.enumerated()), id: \.offset) { index, artist in
-                    Text(artist.name)
-                        .font(.system(size: 16, weight: .semibold))
-                        .foregroundStyle(.secondary)
+                    if artist.hasNavigableId {
+                        NavigationLink(value: artist) {
+                            HeaderArtistLinkLabel(name: artist.name)
+                        }
+                        .buttonStyle(.plain)
+                    } else {
+                        Text(artist.name)
+                            .font(.system(size: 16, weight: .semibold))
+                            .foregroundStyle(.secondary)
+                    }
 
                     if index < artists.count - 1 {
                         Text(", ")
@@ -760,6 +767,24 @@ private struct HoverUnderlineNavigationLink<Value: Hashable>: View {
         .onHover { hovering in
             self.isHovering = hovering
         }
+    }
+}
+
+// MARK: - HeaderArtistLinkLabel
+
+private struct HeaderArtistLinkLabel: View {
+    let name: String
+
+    @State private var isHovering = false
+
+    var body: some View {
+        Text(self.name)
+            .font(.system(size: 16, weight: .semibold))
+            .foregroundStyle(self.isHovering ? .primary : .secondary)
+            .animation(.easeInOut(duration: 0.15), value: self.isHovering)
+            .onHover { hovering in
+                self.isHovering = hovering
+            }
     }
 }
 


### PR DESCRIPTION
## Description

I've updated the artist name in the album/playlist view to be a link to the artist's page, the hover effect on the artist name is the one that was already implemented in the player bar, to keep it consistent

## AI Prompt (Optional)

<details>
<summary>🤖 AI Prompt Used</summary>

```
make the artist name in the album page redirect to the artist page on click

...

add an hover color, similar to the hover color it has in the player bar
```

**AI Tool:** Claude code

</details>

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [x] 🎨 UI/UX improvement
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🧪 Test update
- [ ] 🔧 Build/CI configuration

## Related Issues

None

## Changes Made

- Update the artist name in the album/playlist view to be a link to the artist's page

## Testing

<!-- Describe how you tested these changes -->

- [x] Unit tests pass (`xcodebuild test -only-testing:KasetTests`)
- [x] Manual testing performed
- [x] UI tested on macOS 26+

## Checklist

<!-- Mark completed items with an 'x' -->

- [x] My code follows the project's style guidelines
- [x] I have run `swiftlint --strict && swiftformat .`
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally
- [x] I have updated documentation if needed
- [x] I have checked for any performance implications
- [x] My changes generate no new warnings

## Screenshots

-

## Additional Notes

-
