### PR TITLE
fix: resolve API key behind YouTube's EU consent wall

### DIFF
--- a/Sources/Kaset/Services/API/APISessionConfiguration.swift
+++ b/Sources/Kaset/Services/API/APISessionConfiguration.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Builds the shared `URLSessionConfiguration` used by the YouTube Music and YouTube API clients.
+///
+/// Both clients present a browser-like User-Agent and tuned connection/cache settings. The
+/// configuration deliberately does **not** set an `Accept-Encoding` header: URLSession negotiates
+/// compression and transparently decompresses the response only when it owns the header. Setting
+/// `Accept-Encoding` manually disables that automatic decompression, so responses that YouTube
+/// serves compressed (e.g. Brotli behind the EU consent redirect) arrive as raw bytes that fail
+/// JSON/HTML parsing. See `APISessionConfigurationTests`.
+enum APISessionConfiguration {
+    /// User-Agent shared by the API clients so requests look like the YouTube Music web client.
+    static let userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15"
+
+    /// Creates the browser-like configuration used for API requests.
+    static func make() -> URLSessionConfiguration {
+        let configuration = URLSessionConfiguration.default
+        // Only set headers that do not interfere with URLSession's automatic response handling.
+        // Do NOT set Accept-Encoding here — that disables transparent decompression.
+        configuration.httpAdditionalHeaders = [
+            "User-Agent": Self.userAgent,
+        ]
+        // Increase connection pool for parallel requests (HTTP/2 multiplexing is automatic).
+        configuration.httpMaximumConnectionsPerHost = 6
+        // Use shared URL cache for transport-level caching.
+        configuration.urlCache = URLCache.shared
+        configuration.requestCachePolicy = .useProtocolCachePolicy
+        // Reduce timeouts for faster failure detection.
+        configuration.timeoutIntervalForRequest = 15
+        configuration.timeoutIntervalForResource = 30
+        return configuration
+    }
+}

--- a/Sources/Kaset/Services/API/YTMusicClient.swift
+++ b/Sources/Kaset/Services/API/YTMusicClient.swift
@@ -68,24 +68,10 @@ final class YTMusicClient: YTMusicClientProtocol {
         self.authService = authService
         self.webKitManager = webKitManager
 
-        let resolvedSession: URLSession
-        if let session {
-            resolvedSession = session
+        let resolvedSession: URLSession = if let session {
+            session
         } else {
-            let configuration = URLSessionConfiguration.default
-            configuration.httpAdditionalHeaders = [
-                "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
-                "Accept-Encoding": "gzip, deflate, br",
-            ]
-            // Increase connection pool for parallel requests (HTTP/2 multiplexing is automatic)
-            configuration.httpMaximumConnectionsPerHost = 6
-            // Use shared URL cache for transport-level caching
-            configuration.urlCache = URLCache.shared
-            configuration.requestCachePolicy = .useProtocolCachePolicy
-            // Reduce timeout for faster failure detection
-            configuration.timeoutIntervalForRequest = 15
-            configuration.timeoutIntervalForResource = 30
-            resolvedSession = URLSession(configuration: configuration)
+            URLSession(configuration: APISessionConfiguration.make())
         }
 
         self.session = resolvedSession
@@ -1826,6 +1812,13 @@ final class YTMusicAPIKeyResolver {
                 "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
                 forHTTPHeaderField: "User-Agent"
             )
+            // The Innertube API key is public and needs no authentication. Do NOT send the user's
+            // cookie jar for this fetch: a stale/partial consent cookie lands the request on the EU
+            // consent interstitial (consent.youtube.com), whose HTML has no key, breaking every API
+            // call with "Data Error". A cookieless request with a pre-accepted SOCS consent cookie
+            // bypasses the consent wall and returns the real web client page.
+            request.httpShouldHandleCookies = false
+            request.setValue("SOCS=CAI", forHTTPHeaderField: "Cookie")
             let (data, response) = try await self.session.data(for: request)
             if let httpResponse = response as? HTTPURLResponse,
                !(200 ... 399).contains(httpResponse.statusCode)

--- a/Sources/Kaset/Services/API/YTMusicClient.swift
+++ b/Sources/Kaset/Services/API/YTMusicClient.swift
@@ -1808,10 +1808,7 @@ final class YTMusicAPIKeyResolver {
 
         do {
             var request = URLRequest(url: self.webClientURL)
-            request.setValue(
-                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
-                forHTTPHeaderField: "User-Agent"
-            )
+            request.setValue(APISessionConfiguration.userAgent, forHTTPHeaderField: "User-Agent")
             // The Innertube API key is public and needs no authentication. Do NOT send the user's
             // cookie jar for this fetch: a stale/partial consent cookie lands the request on the EU
             // consent interstitial (consent.youtube.com), whose HTML has no key, breaking every API

--- a/Sources/Kaset/Services/API/YouTubeClient.swift
+++ b/Sources/Kaset/Services/API/YouTubeClient.swift
@@ -63,17 +63,7 @@ final class YouTubeClient: YouTubeClientProtocol {
         if let session {
             self.session = session
         } else {
-            let configuration = URLSessionConfiguration.default
-            configuration.httpAdditionalHeaders = [
-                "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
-                "Accept-Encoding": "gzip, deflate, br",
-            ]
-            configuration.httpMaximumConnectionsPerHost = 6
-            configuration.urlCache = URLCache.shared
-            configuration.requestCachePolicy = .useProtocolCachePolicy
-            configuration.timeoutIntervalForRequest = 15
-            configuration.timeoutIntervalForResource = 30
-            self.session = URLSession(configuration: configuration)
+            self.session = URLSession(configuration: APISessionConfiguration.make())
         }
     }
 

--- a/Tests/KasetTests/APISessionConfigurationTests.swift
+++ b/Tests/KasetTests/APISessionConfigurationTests.swift
@@ -1,0 +1,37 @@
+// APISessionConfigurationTests.swift
+// KasetTests
+//
+// Tests for the shared API URLSession configuration using Swift Testing framework.
+
+import Foundation
+import Testing
+@testable import Kaset
+
+// MARK: - APISessionConfigurationTests
+
+struct APISessionConfigurationTests {
+    /// Regression guard for the "Data Error" outage: the API session must NOT set an
+    /// `Accept-Encoding` header. Setting it manually disables URLSession's transparent
+    /// decompression, so responses YouTube serves compressed (Brotli behind the EU consent
+    /// redirect, gzip, etc.) arrive as raw bytes. The INNERTUBE key regex / JSON parsing then
+    /// fail and every request throws a parse error.
+    @Test func doesNotSetManualAcceptEncoding() {
+        let headers = APISessionConfiguration.make().httpAdditionalHeaders ?? [:]
+
+        #expect(headers["Accept-Encoding"] == nil)
+    }
+
+    @Test func keepsBrowserUserAgent() {
+        let headers = APISessionConfiguration.make().httpAdditionalHeaders ?? [:]
+
+        #expect(headers["User-Agent"] as? String == APISessionConfiguration.userAgent)
+    }
+
+    @Test func retainsTunedConnectionSettings() {
+        let configuration = APISessionConfiguration.make()
+
+        #expect(configuration.httpMaximumConnectionsPerHost == 6)
+        #expect(configuration.timeoutIntervalForRequest == 15)
+        #expect(configuration.timeoutIntervalForResource == 30)
+    }
+}

--- a/Tests/KasetTests/YTMusicClientTests.swift
+++ b/Tests/KasetTests/YTMusicClientTests.swift
@@ -312,6 +312,47 @@ struct YTMusicAPIKeyResolverTests {
         #expect(requestCount == 1)
     }
 
+    @Test("API key fetch is cookieless and sends consent cookie")
+    @MainActor
+    func apiKeyFetchIsCookielessAndSendsConsentCookie() async throws {
+        let session = MockURLProtocol.makeMockSession()
+        let html = #"ytcfg.set({"INNERTUBE_API_KEY":"mock-html-api-key"});"#
+        nonisolated(unsafe) var observedShouldHandleCookies: Bool?
+        nonisolated(unsafe) var observedCookieHeader: String?
+        nonisolated(unsafe) var observedUserAgent: String?
+
+        MockURLProtocol.requestHandler = { request in
+            observedShouldHandleCookies = request.httpShouldHandleCookies
+            observedCookieHeader = request.value(forHTTPHeaderField: "Cookie")
+            observedUserAgent = request.value(forHTTPHeaderField: "User-Agent")
+
+            guard let url = request.url,
+                  let response = HTTPURLResponse(
+                      url: url,
+                      statusCode: 200,
+                      httpVersion: nil,
+                      headerFields: ["Content-Type": "text/html"]
+                  )
+            else {
+                throw URLError(.badURL)
+            }
+
+            return (response, Data(html.utf8))
+        }
+        defer {
+            MockURLProtocol.reset()
+        }
+
+        let resolver = YTMusicAPIKeyResolver(session: session, environment: { _ in nil })
+
+        let apiKey = try await resolver.resolve()
+
+        #expect(apiKey == "mock-html-api-key")
+        #expect(observedShouldHandleCookies == false)
+        #expect(observedCookieHeader == "SOCS=CAI")
+        #expect(observedUserAgent == APISessionConfiguration.userAgent)
+    }
+
     @Test("HTTP failures map to YTMusic API errors")
     @MainActor
     func httpFailureMapsToAPIError() async throws {


### PR DESCRIPTION
## Description

Fixes a "Data Error – Unable to load content" that blocks every YouTube Music screen (Home, Library, Liked Music, account/profile) when the client is routed through YouTube's EU consent page.

`YTMusicAPIKeyResolver.resolve()` scrapes the public `INNERTUBE_API_KEY` from `music.youtube.com`. It fetched that page through the authenticated `URLSession`, which sends the signed-in user's cookies. When the user's consent cookie (`SOCS`) is missing or pending, YouTube redirects the request to the consent interstitial at `consent.youtube.com` (captured in the failing state: HTTP 200, final URL `consent.youtube.com/m?…gl=PL`, and the HTML does not contain `INNERTUBE_API_KEY`). The resolver then throws `YTMusicError.parseError` ("Could not resolve YouTube Music API configuration"), and because every API request depends on the key, every screen shows "Data Error".

The key is public and needs no authentication, so this PR fetches it with a cookieless request (`httpShouldHandleCookies = false`) plus a pre-accepted `SOCS=CAI` consent cookie, which bypasses the consent wall and returns the real web-client page.

I also removed the manually set `Accept-Encoding: gzip, deflate, br` header from both API sessions. Per Apple's documented behavior, `URLSession` transparently decompresses a response only when it sets `Accept-Encoding` itself; setting it manually disables that, so a compressed response (e.g. the Brotli page served behind the consent redirect) arrives as raw bytes that fail to parse. (Mechanism confirmed via a curl A/B, not an in-app toggle.) The shared session config now lives in a new `APISessionConfiguration` type that omits the header, so `URLSession` negotiates and decompresses automatically.

**AI Tool:**  Claude

</details>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)


## Changes Made

- **New `APISessionConfiguration`** — shared `URLSession` configuration for the API clients (browser User-Agent, connection pool, cache, timeouts) that deliberately does **not** set `Accept-Encoding`, so `URLSession` handles decompression transparently.
- **`YTMusicClient` / `YouTubeClient`** build their default session via `APISessionConfiguration.make()`, removing the duplicated inline config and the decompression-breaking header.
- **`YTMusicAPIKeyResolver.resolve()`** fetches the public key cookieless (`httpShouldHandleCookies = false`) with a `SOCS=CAI` consent cookie, so a stale/pending consent state can no longer park the request on `consent.youtube.com`.
- **`APISessionConfigurationTests`** — regression test asserting the session never sets `Accept-Encoding` (and that the User-Agent and tuned settings are retained).

## Testing

- [x] Unit tests pass — `swift test --skip KasetUITests` → 1613 tests, 0 failures
- [x] Manual testing performed — reproduced the failure and confirmed the fix once, from a single connection routed through Poland (an affected consent region); not tested across other regions or accounts

Coverage note: the regression test covers the `Accept-Encoding` removal (config-level). The consent-bypass path (`httpShouldHandleCookies` / `SOCS`) is verified manually only and has no automated test.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `swiftlint --strict && swiftformat .`
- [x] I have added tests (regression test for the `Accept-Encoding` removal — see coverage note)
- [x] New and existing unit tests pass locally
- [x] I have checked for any performance implications — removing the manual header doesn't change what the client advertises; `URLSession` still requests compression and now decompresses it
- [x] My changes generate no new warnings

## Additional Notes

- The manual `Accept-Encoding` header dates to a3bb306d (shipped in v0.12.0); it's latent because it only breaks when a response is actually served compressed.
- Scope: affects users in an EU-consent region whose YouTube consent cookie is missing or pending; for them the key resolve fails intermittently. Users with an accepted consent cookie, and users outside consent regions, are unaffected.
- `SOCS=CAI` is the minimal "consent accepted" value (same approach used by yt-dlp / ytmusicapi). Happy to adjust if you'd prefer a different consent-handling approach.
