### PR TITLE
perf: optimize parser and queue hot paths

### DIFF
--- a/Scripts/benchmark-xctest.sh
+++ b/Scripts/benchmark-xctest.sh
@@ -30,7 +30,30 @@ run_tests() {
 }
 
 copy_sparkle_into_xctest_bundle() {
-  local products_dir="$PWD/.build/out/Products/Release"
+  local products_dir=""
+  local show_bin
+  show_bin=$(swift build -c release --show-bin-path 2>/dev/null || true)
+
+  for candidate in \
+    "$PWD/.build/out/Products/Release" \
+    "$PWD/.build/out/arm64-apple-macosx/release" \
+    "$PWD/.build/out/x86_64-apple-macosx/release" \
+    "$show_bin" \
+    "$PWD/.build/release" \
+    "$PWD/.build/arm64-apple-macosx/release" \
+    "$PWD/.build/x86_64-apple-macosx/release"
+  do
+    if [[ -n "$candidate" && -d "$candidate/KasetTests.xctest" && -d "$candidate/Sparkle.framework" ]]; then
+      products_dir="$candidate"
+      break
+    fi
+  done
+
+  if [[ -z "$products_dir" || ! -d "$products_dir" ]]; then
+    echo "Could not locate SwiftPM release XCTest/Sparkle products for Sparkle fallback" >&2
+    return 0
+  fi
+
   local xctest_bundle="$products_dir/KasetTests.xctest"
   local sparkle_framework="$products_dir/Sparkle.framework"
 

--- a/Scripts/benchmark-xctest.sh
+++ b/Scripts/benchmark-xctest.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FILTER="${1:-ParserPerformanceTests}"
+LABEL="${2:-$(date -u +%Y%m%dT%H%M%SZ)-$(git rev-parse --short HEAD)}"
+BENCH_ROOT="${BENCH_ROOT:-}"
+if [[ -z "$BENCH_ROOT" ]]; then
+  BENCH_ROOT="/tmp/kaset-perf2-bench"
+fi
+OUT="$BENCH_ROOT/$LABEL"
+mkdir -p "$OUT"
+
+{
+  echo "filter=$FILTER"
+  echo "label=$LABEL"
+  date -u
+  git rev-parse HEAD
+  sw_vers
+  swift --version
+  xcodebuild -version 2>/dev/null || true
+} | tee "$OUT/env.txt"
+
+run_tests() {
+  local mode="$1"
+  if [[ "$mode" == "skip-build" ]]; then
+    swift test -c release --skip-build --filter "$FILTER" --skip KasetUITests
+  else
+    swift test -c release --filter "$FILTER" --skip KasetUITests
+  fi
+}
+
+copy_sparkle_into_xctest_bundle() {
+  local products_dir="$PWD/.build/out/Products/Release"
+  local xctest_bundle="$products_dir/KasetTests.xctest"
+  local sparkle_framework="$products_dir/Sparkle.framework"
+
+  if [[ -d "$xctest_bundle" && -d "$sparkle_framework" ]]; then
+    mkdir -p "$xctest_bundle/Contents/Frameworks"
+    rm -rf "$xctest_bundle/Contents/Frameworks/Sparkle.framework"
+    cp -R "$sparkle_framework" "$xctest_bundle/Contents/Frameworks/"
+  fi
+}
+
+set +e
+run_tests build-and-run 2>&1 | tee "$OUT/test.log"
+status=${PIPESTATUS[0]}
+set -e
+
+if [[ "$status" -ne 0 ]] && grep -q 'Sparkle.framework' "$OUT/test.log"; then
+  copy_sparkle_into_xctest_bundle
+  set +e
+  run_tests skip-build 2>&1 | tee "$OUT/test-rerun.log"
+  status=${PIPESTATUS[0]}
+  set -e
+  cat "$OUT/test-rerun.log" >> "$OUT/test.log"
+fi
+
+perl -ne 'if (/Test Case '\''-\[.* ([^\] ]+)\]'\'' measured \[[^\]]+\] average: ([0-9.]+)/) { print "$1\t$2\n" }' \
+  "$OUT/test.log" | tee "$OUT/performance.tsv"
+
+printf 'benchmark_dir=%s\n' "$OUT" | tee "$OUT/location.txt"
+exit "$status"

--- a/Sources/Kaset/Services/API/Parsers/ArtistParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/ArtistParser.swift
@@ -401,16 +401,12 @@ enum ArtistParser { // swiftlint:disable:this type_body_length
 
         let subtitle = (data["subtitle"] as? [String: Any])
             .flatMap { subtitleData in
-                (subtitleData["runs"] as? [[String: Any]])?
-                    .compactMap { $0["text"] as? String }
-                    .joined()
+                (subtitleData["runs"] as? [[String: Any]]).map(ParsingHelpers.joinedRunText(_:))
             }
 
         let description = (data["description"] as? [String: Any])
             .flatMap { descData in
-                (descData["runs"] as? [[String: Any]])?
-                    .compactMap { $0["text"] as? String }
-                    .joined()
+                (descData["runs"] as? [[String: Any]]).map(ParsingHelpers.joinedRunText(_:))
             }
 
         let thumbnailURL = ParsingHelpers.extractThumbnailURL(from: data)
@@ -540,7 +536,7 @@ enum ArtistParser { // swiftlint:disable:this type_body_length
             if let descData = immersiveHeader["description"] as? [String: Any],
                let runs = descData["runs"] as? [[String: Any]]
             {
-                result.description = runs.compactMap { $0["text"] as? String }.joined()
+                result.description = ParsingHelpers.joinedRunText(runs)
             }
 
             result.thumbnailURL = ParsingHelpers.extractThumbnailURL(from: immersiveHeader)
@@ -598,24 +594,24 @@ enum ArtistParser { // swiftlint:disable:this type_body_length
             if let shortSubscriberCountText = subscribeButtonRenderer["shortSubscriberCountText"] as? [String: Any],
                let runs = shortSubscriberCountText["runs"] as? [[String: Any]]
             {
-                result.subscriberCount = runs.compactMap { $0["text"] as? String }.joined()
+                result.subscriberCount = ParsingHelpers.joinedRunText(runs)
             } else if let subscriberCountText = subscribeButtonRenderer["subscriberCountText"] as? [String: Any],
                       let runs = subscriberCountText["runs"] as? [[String: Any]]
             {
-                result.subscriberCount = runs.compactMap { $0["text"] as? String }.joined()
+                result.subscriberCount = ParsingHelpers.joinedRunText(runs)
             }
 
             if let subscribedButtonText = subscribeButtonRenderer["subscribedButtonText"] as? [String: Any],
                let runs = subscribedButtonText["runs"] as? [[String: Any]]
             {
-                result.subscribedButtonText = runs.compactMap { $0["text"] as? String }.joined()
+                result.subscribedButtonText = ParsingHelpers.joinedRunText(runs)
                     .trimmingCharacters(in: .whitespacesAndNewlines)
             }
 
             if let unsubscribedButtonText = subscribeButtonRenderer["unsubscribedButtonText"] as? [String: Any],
                let runs = unsubscribedButtonText["runs"] as? [[String: Any]]
             {
-                result.unsubscribedButtonText = runs.compactMap { $0["text"] as? String }.joined()
+                result.unsubscribedButtonText = ParsingHelpers.joinedRunText(runs)
                     .trimmingCharacters(in: .whitespacesAndNewlines)
             }
         }
@@ -675,7 +671,7 @@ enum ArtistParser { // swiftlint:disable:this type_body_length
 
     private static func parseMonthlyAudience(from data: [String: Any]) -> String? {
         guard let runs = data["runs"] as? [[String: Any]] else { return nil }
-        let text = runs.compactMap { $0["text"] as? String }.joined().trimmingCharacters(in: .whitespacesAndNewlines)
+        let text = ParsingHelpers.joinedRunText(runs).trimmingCharacters(in: .whitespacesAndNewlines)
         guard !text.isEmpty else { return nil }
 
         return text
@@ -902,7 +898,7 @@ enum ArtistParser { // swiftlint:disable:this type_body_length
             return nil
         }
 
-        let text = runs.compactMap { $0["text"] as? String }.joined().trimmingCharacters(in: .whitespacesAndNewlines)
+        let text = ParsingHelpers.joinedRunText(runs).trimmingCharacters(in: .whitespacesAndNewlines)
         return text.isEmpty ? nil : text
     }
 

--- a/Sources/Kaset/Services/API/Parsers/LyricsParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/LyricsParser.swift
@@ -118,7 +118,7 @@ enum LyricsParser {
         if let description = shelf["description"] as? [String: Any],
            let runs = description["runs"] as? [[String: Any]]
         {
-            lyricsText = runs.compactMap { $0["text"] as? String }.joined()
+            lyricsText = ParsingHelpers.joinedRunText(runs)
         }
 
         // Extract the footer (source attribution)
@@ -126,7 +126,7 @@ enum LyricsParser {
         if let footer = shelf["footer"] as? [String: Any],
            let runs = footer["runs"] as? [[String: Any]]
         {
-            source = runs.compactMap { $0["text"] as? String }.joined()
+            source = ParsingHelpers.joinedRunText(runs)
         }
 
         if lyricsText.isEmpty {

--- a/Sources/Kaset/Services/API/Parsers/ParsingHelpers.swift
+++ b/Sources/Kaset/Services/API/Parsers/ParsingHelpers.swift
@@ -277,8 +277,7 @@ enum ParsingHelpers {
         if let subtitleData = data["subtitle"] as? [String: Any],
            let runs = subtitleData["runs"] as? [[String: Any]]
         {
-            let texts = runs.compactMap { $0["text"] as? String }
-            let subtitle = texts.joined()
+            let subtitle = Self.joinedRunText(runs)
             return subtitle.isEmpty ? nil : subtitle
         }
         return nil
@@ -589,14 +588,22 @@ enum ParsingHelpers {
            let text = renderer["text"] as? [String: Any],
            let runs = text["runs"] as? [[String: Any]]
         {
-            let subtitle = Self.joinedText(from: runs)
+            let subtitle = Self.joinedRunText(runs)
             return subtitle.isEmpty ? nil : subtitle
         }
         return nil
     }
 
-    private static func joinedText(from runs: [[String: Any]]) -> String {
+    static func joinedRunText(_ runs: [[String: Any]]) -> String {
+        var capacity = 0
+        for run in runs {
+            if let runText = run["text"] as? String {
+                capacity += runText.count
+            }
+        }
+
         var text = ""
+        text.reserveCapacity(capacity)
         for run in runs {
             if let runText = run["text"] as? String {
                 text += runText

--- a/Sources/Kaset/Services/API/Parsers/ParsingHelpers.swift
+++ b/Sources/Kaset/Services/API/Parsers/ParsingHelpers.swift
@@ -41,6 +41,16 @@ enum ParsingHelpers {
 
     private static let lowercaseHexDigits = Array("0123456789abcdef".utf8)
 
+    private static let accessibilityMinuteDurationRegex = try? NSRegularExpression(
+        pattern: #"(\d+)\s*minutes?"#,
+        options: .caseInsensitive
+    )
+
+    private static let accessibilitySecondDurationRegex = try? NSRegularExpression(
+        pattern: #"(\d+)\s*seconds?"#,
+        options: .caseInsensitive
+    )
+
     private static func hexString(from bytes: some Sequence<UInt8>) -> String {
         var output: [UInt8] = []
         output.reserveCapacity(32)
@@ -529,22 +539,19 @@ enum ParsingHelpers {
     /// Extracts duration from accessibility label text.
     /// Handles formats like "4 minutes, 55 seconds" or "4:55"
     private static func extractDurationFromAccessibilityLabel(_ label: String) -> TimeInterval? {
-        // Try "X minutes, Y seconds" format
-        let minutePattern = #"(\d+)\s*minutes?"#
-        let secondPattern = #"(\d+)\s*seconds?"#
-
         var minutes = 0
         var seconds = 0
+        let fullRange = NSRange(label.startIndex..., in: label)
 
-        if let minuteRegex = try? NSRegularExpression(pattern: minutePattern, options: .caseInsensitive),
-           let minuteMatch = minuteRegex.firstMatch(in: label, range: NSRange(label.startIndex..., in: label)),
+        if let minuteRegex = Self.accessibilityMinuteDurationRegex,
+           let minuteMatch = minuteRegex.firstMatch(in: label, range: fullRange),
            let minuteRange = Range(minuteMatch.range(at: 1), in: label)
         {
             minutes = Int(label[minuteRange]) ?? 0
         }
 
-        if let secondRegex = try? NSRegularExpression(pattern: secondPattern, options: .caseInsensitive),
-           let secondMatch = secondRegex.firstMatch(in: label, range: NSRange(label.startIndex..., in: label)),
+        if let secondRegex = Self.accessibilitySecondDurationRegex,
+           let secondMatch = secondRegex.firstMatch(in: label, range: fullRange),
            let secondRange = Range(secondMatch.range(at: 1), in: label)
         {
             seconds = Int(label[secondRange]) ?? 0

--- a/Sources/Kaset/Services/API/Parsers/PlaylistEditability.swift
+++ b/Sources/Kaset/Services/API/Parsers/PlaylistEditability.swift
@@ -2,11 +2,18 @@ import Foundation
 
 /// Interprets ownership/delete affordances from YouTube Music playlist renderers.
 enum PlaylistEditability {
+    private static let deleteAffordanceKeys: Set<String> = [
+        "deletePlaylistEndpoint",
+        "musicEditablePlaylistDetailHeaderRenderer",
+    ]
+
     /// Returns true only when the response payload exposes commands that are available
     /// for playlists the signed-in user can delete. Unknown ownership is treated as false.
     static func canDeletePlaylist(from value: Any) -> Bool {
-        ResponseTreeSearch.containsKey("deletePlaylistEndpoint", in: value)
-            || ResponseTreeSearch.containsKey("musicEditablePlaylistDetailHeaderRenderer", in: value)
-            || ResponseTreeSearch.containsText("playlist/delete", in: value)
+        ResponseTreeSearch.containsAny(
+            keys: self.deleteAffordanceKeys,
+            text: "playlist/delete",
+            in: value
+        )
     }
 }

--- a/Sources/Kaset/Services/API/Parsers/PlaylistParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/PlaylistParser.swift
@@ -621,7 +621,7 @@ enum PlaylistParser {
         if let descData = renderer["description"] as? [String: Any],
            let runs = descData["runs"] as? [[String: Any]]
         {
-            header.description = runs.compactMap { $0["text"] as? String }.joined()
+            header.description = ParsingHelpers.joinedRunText(runs)
         }
 
         header.thumbnailURL = ParsingHelpers.extractThumbnailURL(from: renderer)
@@ -658,7 +658,7 @@ enum PlaylistParser {
            let descData = renderer["description"] as? [String: Any],
            let runs = descData["runs"] as? [[String: Any]]
         {
-            header.description = runs.compactMap { $0["text"] as? String }.joined()
+            header.description = ParsingHelpers.joinedRunText(runs)
         }
 
         if let subtitleData = renderer["subtitle"] as? [String: Any],
@@ -787,7 +787,7 @@ enum PlaylistParser {
            let bodyText = descriptionShelfRenderer["description"] as? [String: Any],
            let runs = bodyText["runs"] as? [[String: Any]]
         {
-            header.description = runs.compactMap { $0["text"] as? String }.joined()
+            header.description = ParsingHelpers.joinedRunText(runs)
         }
 
         if let facepileArtist = ParsingHelpers.extractFacepileArtist(from: renderer) {
@@ -1390,7 +1390,7 @@ enum PlaylistParser {
             return content
         }
         if let runs = data["runs"] as? [[String: Any]] {
-            let text = runs.compactMap { $0["text"] as? String }.joined()
+            let text = ParsingHelpers.joinedRunText(runs)
             return text.isEmpty ? nil : text
         }
         return nil

--- a/Sources/Kaset/Services/API/Parsers/PodcastParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/PodcastParser.swift
@@ -295,7 +295,7 @@ enum PodcastParser {
         if let descriptionData = data["description"] as? [String: Any],
            let runs = descriptionData["runs"] as? [[String: Any]]
         {
-            description = runs.compactMap { $0["text"] as? String }.joined()
+            description = ParsingHelpers.joinedRunText(runs)
         }
 
         let episode = PodcastEpisode(
@@ -599,7 +599,7 @@ enum PodcastParser {
         if let description = data["description"] as? [String: Any],
            let runs = description["runs"] as? [[String: Any]]
         {
-            return runs.compactMap { $0["text"] as? String }.joined()
+            return ParsingHelpers.joinedRunText(runs)
         }
         return nil
     }

--- a/Sources/Kaset/Services/API/Parsers/ResponseTreeSearch.swift
+++ b/Sources/Kaset/Services/API/Parsers/ResponseTreeSearch.swift
@@ -43,6 +43,32 @@ enum ResponseTreeSearch {
         return false
     }
 
+    static func containsAny(keys: Set<String>, text: String? = nil, in value: Any) -> Bool {
+        if let dictionary = value as? [String: Any] {
+            for key in keys where dictionary[key] != nil {
+                return true
+            }
+
+            for child in dictionary.values where self.containsAny(keys: keys, text: text, in: child) {
+                return true
+            }
+            return false
+        }
+
+        if let array = value as? [Any] {
+            for child in array where self.containsAny(keys: keys, text: text, in: child) {
+                return true
+            }
+            return false
+        }
+
+        if let text, let string = value as? String {
+            return string.localizedCaseInsensitiveContains(text)
+        }
+
+        return false
+    }
+
     static func containsText(_ text: String, in value: Any) -> Bool {
         if let string = value as? String {
             return string.localizedCaseInsensitiveContains(text)

--- a/Sources/Kaset/Services/API/Parsers/SearchResponseParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/SearchResponseParser.swift
@@ -130,7 +130,7 @@ enum SearchResponseParser {
         if let subtitleData = data["subtitle"] as? [String: Any],
            let subtitleRuns = subtitleData["runs"] as? [[String: Any]]
         {
-            subtitle = subtitleRuns.compactMap { $0["text"] as? String }.joined()
+            subtitle = ParsingHelpers.joinedRunText(subtitleRuns)
         }
 
         let pageType = ParsingHelpers.extractPageType(from: browseEndpoint)

--- a/Sources/Kaset/Services/API/Parsers/SearchSuggestionsParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/SearchSuggestionsParser.swift
@@ -58,7 +58,7 @@ enum SearchSuggestionsParser {
         }
 
         // Combine all text runs into the full suggestion
-        let queryText = runs.compactMap { $0["text"] as? String }.joined()
+        let queryText = ParsingHelpers.joinedRunText(runs)
 
         guard !queryText.isEmpty else {
             return nil

--- a/Sources/Kaset/Services/API/Parsers/YouTube/YouTubeItemParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/YouTube/YouTubeItemParser.swift
@@ -262,7 +262,7 @@ enum YouTubeItemParser {
         }
 
         if let runs = dict["runs"] as? [[String: Any]] {
-            let joined = runs.compactMap { $0["text"] as? String }.joined()
+            let joined = ParsingHelpers.joinedRunText(runs)
             return joined.isEmpty ? nil : joined
         }
 

--- a/Sources/Kaset/Services/Player/PlayerService+Queue.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+Queue.swift
@@ -310,30 +310,35 @@ extension PlayerService {
     /// - Parameter entryIDs: Set of queue entry IDs to remove.
     func removeFromQueue(entryIDs: Set<UUID>) {
         guard !entryIDs.isEmpty else { return }
-        let indicesToRemove = self.queueEntries.enumerated()
-            .filter { entryIDs.contains($0.element.id) }
-            .map(\.offset)
-            .sorted(by: >)
 
-        guard !indicesToRemove.isEmpty else { return }
+        let priorEntries = self.queueEntries
+        var remainingEntries: [QueueEntry] = []
+        remainingEntries.reserveCapacity(priorEntries.count)
+        var removedIndices: [Int] = []
+
+        for (index, entry) in priorEntries.enumerated() {
+            if entryIDs.contains(entry.id) {
+                removedIndices.append(index)
+            } else {
+                remainingEntries.append(entry)
+            }
+        }
+
+        guard !removedIndices.isEmpty else { return }
 
         self.clearForwardSkipNavigationStack()
         self.recordQueueStateForUndo()
-        let previousCount = self.queue.count
+        let previousCount = priorEntries.count
         let currentEntryID = self.currentQueueEntryID
         let originalCurrentIndex = self.currentIndex
-        var remainingEntries = self.queueEntries
-        for index in indicesToRemove {
-            remainingEntries.remove(at: index)
-        }
         self.setQueue(entries: remainingEntries)
         self.realignCurrentIndexAfterQueueMutation(
             currentEntryID: currentEntryID,
             originalCurrentIndex: originalCurrentIndex,
-            removedIndices: indicesToRemove
+            removedIndices: removedIndices
         )
 
-        self.logger.info("Removed \(previousCount - self.queue.count) songs from queue")
+        self.logger.info("Removed \(previousCount - remainingEntries.count) songs from queue")
         self.saveQueueForPersistence()
     }
 
@@ -387,8 +392,9 @@ extension PlayerService {
         originalCurrentIndex: Int,
         removedIndices: [Int]
     ) {
+        let currentEntries = self.queueEntries
         if let currentEntryID,
-           let newIndex = self.queueEntryIDs.firstIndex(of: currentEntryID)
+           let newIndex = currentEntries.firstIndex(where: { $0.id == currentEntryID })
         {
             self.currentIndex = newIndex
             return
@@ -396,7 +402,7 @@ extension PlayerService {
 
         let removedBeforeCurrent = removedIndices.count(where: { $0 < originalCurrentIndex })
         let adjustedIndex = max(0, originalCurrentIndex - removedBeforeCurrent)
-        self.currentIndex = min(adjustedIndex, max(0, self.queue.count - 1))
+        self.currentIndex = min(adjustedIndex, max(0, currentEntries.count - 1))
     }
 
     private func realignCurrentIndexAfterDuplicateRemoval(
@@ -418,7 +424,7 @@ extension PlayerService {
             return
         }
 
-        self.currentIndex = min(self.currentIndex, max(0, self.queue.count - 1))
+        self.currentIndex = min(self.currentIndex, max(0, self.queueEntries.count - 1))
     }
 
     /// Removes songs from the queue by video ID.
@@ -483,8 +489,9 @@ extension PlayerService {
         self.clearForwardSkipNavigationStack()
         self.recordQueueStateForUndo()
         let currentEntryID = self.currentQueueEntryID
+        let currentEntries = self.queueEntries
         var entriesByVideoId: [String: [QueueEntry]] = [:]
-        for entry in self.queueEntries {
+        for entry in currentEntries {
             entriesByVideoId[entry.song.videoId, default: []].append(entry)
         }
 
@@ -499,7 +506,7 @@ extension PlayerService {
 
         // Update currentIndex to match current track's new position
         if let currentEntryID,
-           let newIndex = self.queueEntryIDs.firstIndex(of: currentEntryID)
+           let newIndex = reorderedEntries.firstIndex(where: { $0.id == currentEntryID })
         {
             self.currentIndex = newIndex
         }
@@ -629,7 +636,8 @@ extension PlayerService {
 
     /// Saves the current queue to UserDefaults for restoration on next launch.
     func saveQueueForPersistence() {
-        guard !self.queue.isEmpty else {
+        let queue = self.queue
+        guard !queue.isEmpty else {
             self.removeSavedPlaybackSession()
             self.logger.info("Cleared saved playback session (queue is empty)")
             return
@@ -637,17 +645,17 @@ extension PlayerService {
 
         do {
             let encoder = JSONEncoder()
-            let safeIndex = min(max(self.currentIndex, 0), self.queue.count - 1)
-            let currentVideoId = self.currentTrack?.videoId ?? self.queue[safe: safeIndex]?.videoId
-            let resolvedDuration = max(self.duration, self.currentTrack?.duration ?? self.queue[safe: safeIndex]?.duration ?? 0)
+            let safeIndex = min(max(self.currentIndex, 0), queue.count - 1)
+            let currentVideoId = self.currentTrack?.videoId ?? queue[safe: safeIndex]?.videoId
+            let resolvedDuration = max(self.duration, self.currentTrack?.duration ?? queue[safe: safeIndex]?.duration ?? 0)
             let clampedProgress = resolvedDuration > 0
                 ? min(max(self.progress, 0), resolvedDuration)
                 : max(self.progress, 0)
 
-            let queueData = try encoder.encode(self.queue)
+            let queueData = try encoder.encode(queue)
             let sessionData = try encoder.encode(
                 PersistedPlaybackSession(
-                    queue: self.queue,
+                    queue: queue,
                     currentIndex: safeIndex,
                     currentVideoId: currentVideoId,
                     progress: clampedProgress,
@@ -658,7 +666,7 @@ extension PlayerService {
             UserDefaults.standard.set(queueData, forKey: Self.savedQueueKey)
             UserDefaults.standard.set(safeIndex, forKey: Self.savedQueueIndexKey)
             UserDefaults.standard.set(sessionData, forKey: Self.savedPlaybackSessionKey)
-            self.logger.info("Saved playback session with \(self.queue.count) songs at index \(safeIndex)")
+            self.logger.info("Saved playback session with \(queue.count) songs at index \(safeIndex)")
         } catch {
             self.logger.error("Failed to save playback session: \(error.localizedDescription)")
         }

--- a/Sources/Kaset/Services/Player/PlayerService.swift
+++ b/Sources/Kaset/Services/Player/PlayerService.swift
@@ -402,7 +402,7 @@ final class PlayerService: NSObject, PlayerServiceProtocol {
     }
 
     func synchronizeCurrentQueueEntryID() {
-        self.currentQueueEntryID = self.queueEntries[safe: self.currentIndex]?.id
+        self.currentQueueEntryID = self.queueStorage[safe: self.currentIndex]?.id
     }
 
     /// Records the current index before `next()` moves to `newIndex` (no-op if unchanged).

--- a/Sources/Kaset/Services/SongLikeStatusManager.swift
+++ b/Sources/Kaset/Services/SongLikeStatusManager.swift
@@ -220,6 +220,26 @@ final class SongLikeStatusManager {
         self.setStatus(status, for: videoId, accountID: self.activeAccountID)
     }
 
+    /// Updates the cache with the same known status for multiple songs.
+    ///
+    /// This is used by bulk API response normalization paths (for example Liked
+    /// Music loads) so a large response mutates the per-account cache once
+    /// instead of repeatedly copying it for each track.
+    /// - Parameters:
+    ///   - status: The like status to cache.
+    ///   - videoIds: The video IDs to update.
+    ///   - accountID: Optional account scope override.
+    func setStatus(_ status: LikeStatus, for videoIds: some Sequence<String>, accountID: String? = nil) {
+        let resolvedAccountID = accountID.map(Self.resolvedAccountID) ?? self.activeAccountID
+        var cache = self.statusCacheByAccount[resolvedAccountID] ?? [:]
+
+        for videoId in videoIds {
+            cache[videoId] = status
+        }
+
+        self.statusCacheByAccount[resolvedAccountID] = cache
+    }
+
     /// Clears all cached statuses.
     func clearCache() {
         self.statusCacheByAccount.removeAll()
@@ -235,9 +255,7 @@ final class SongLikeStatusManager {
     }
 
     private func setStatus(_ status: LikeStatus, for videoId: String, accountID: String) {
-        var cache = self.statusCacheByAccount[accountID] ?? [:]
-        cache[videoId] = status
-        self.statusCacheByAccount[accountID] = cache
+        self.statusCacheByAccount[accountID, default: [:]][videoId] = status
     }
 
     private func restoreStatus(_ status: LikeStatus?, for videoId: String, accountID: String) {
@@ -249,13 +267,11 @@ final class SongLikeStatusManager {
     }
 
     private func removeStatus(for videoId: String, accountID: String) {
-        guard var cache = self.statusCacheByAccount[accountID] else { return }
+        guard self.statusCacheByAccount[accountID] != nil else { return }
 
-        cache.removeValue(forKey: videoId)
-        if cache.isEmpty {
+        self.statusCacheByAccount[accountID]?.removeValue(forKey: videoId)
+        if self.statusCacheByAccount[accountID]?.isEmpty == true {
             self.statusCacheByAccount.removeValue(forKey: accountID)
-        } else {
-            self.statusCacheByAccount[accountID] = cache
         }
     }
 

--- a/Sources/Kaset/ViewModels/PlaylistDetailViewModel.swift
+++ b/Sources/Kaset/ViewModels/PlaylistDetailViewModel.swift
@@ -323,10 +323,13 @@ final class PlaylistDetailViewModel {
             : response.tracks
         let skippedLiveRemovedTracks = candidateTracks.count != response.tracks.count
         let responseContainsLiveInsertedTrack = batch.isLikedMusicPlaylist && response.tracks.contains { self.insertedLikedMusicVideoIDs.contains($0.videoId) }
-        let newTracks = candidateTracks.filter { !self.loadedTrackVideoIds.contains($0.videoId) }
+        let originalExistingVideoIds = Set(batch.currentDetail.tracks.map(\.videoId))
+        let newTracks = candidateTracks.filter {
+            !self.loadedTrackVideoIds.contains($0.videoId)
+                && !originalExistingVideoIds.contains($0.videoId)
+        }
 
         if newTracks.isEmpty {
-            let originalExistingVideoIds = Set(batch.currentDetail.tracks.map(\.videoId))
             let duplicatesWereAlreadyPresent = candidateTracks.allSatisfy { originalExistingVideoIds.contains($0.videoId) }
             if duplicatesWereAlreadyPresent, !skippedLiveRemovedTracks, !responseContainsLiveInsertedTrack {
                 self.hasMore = false

--- a/Sources/Kaset/ViewModels/PlaylistDetailViewModel.swift
+++ b/Sources/Kaset/ViewModels/PlaylistDetailViewModel.swift
@@ -49,6 +49,9 @@ final class PlaylistDetailViewModel {
     @ObservationIgnored
     private var loadGeneration = 0
 
+    @ObservationIgnored
+    private var loadedTrackVideoIds: Set<String> = []
+
     private var removedLikedMusicVideoIDs: Set<String> = []
     private var countedRemovedLikedMusicVideoIDs: Set<String> = []
     private var insertedLikedMusicVideoIDs: Set<String> = []
@@ -209,6 +212,7 @@ final class PlaylistDetailViewModel {
             let loadedTrackCount = detail.tracks.count
             let totalTrackCount = detail.trackCount ?? loadedTrackCount
             self.logger.info("Playlist loaded: \(loadedTrackCount) loaded tracks, total: \(totalTrackCount), hasMore: \(self.hasMore)")
+            self.replaceLoadedTrackVideoIds(with: detail.tracks)
             self.startRemainingTracksTaskIfNeeded(generation: generation)
         } catch is CancellationError {
             guard self.isCurrentLoadGeneration(generation) else { return }
@@ -306,8 +310,6 @@ final class PlaylistDetailViewModel {
               let latestDetail = self.playlistDetail
         else { return false }
 
-        let originalExistingVideoIds = Set(batch.currentDetail.tracks.map(\.videoId))
-        let latestExistingVideoIds = originalExistingVideoIds.union(latestDetail.tracks.map(\.videoId))
         let skippedRemovedVideoIDs = batch.isLikedMusicPlaylist
             ? response.tracks.compactMap { song -> String? in
                 guard self.removedLikedMusicVideoIDs.contains(song.videoId),
@@ -321,9 +323,10 @@ final class PlaylistDetailViewModel {
             : response.tracks
         let skippedLiveRemovedTracks = candidateTracks.count != response.tracks.count
         let responseContainsLiveInsertedTrack = batch.isLikedMusicPlaylist && response.tracks.contains { self.insertedLikedMusicVideoIDs.contains($0.videoId) }
-        let newTracks = candidateTracks.filter { !latestExistingVideoIds.contains($0.videoId) }
+        let newTracks = candidateTracks.filter { !self.loadedTrackVideoIds.contains($0.videoId) }
 
         if newTracks.isEmpty {
+            let originalExistingVideoIds = Set(batch.currentDetail.tracks.map(\.videoId))
             let duplicatesWereAlreadyPresent = candidateTracks.allSatisfy { originalExistingVideoIds.contains($0.videoId) }
             if duplicatesWereAlreadyPresent, !skippedLiveRemovedTracks, !responseContainsLiveInsertedTrack {
                 self.hasMore = false
@@ -347,7 +350,9 @@ final class PlaylistDetailViewModel {
             newTracks
         }
 
-        let allTracks = latestDetail.tracks + normalizedNewTracks
+        var allTracks = latestDetail.tracks
+        allTracks.reserveCapacity(latestDetail.tracks.count + normalizedNewTracks.count)
+        allTracks.append(contentsOf: normalizedNewTracks)
         let adjustedTrackCount = self.adjustedTrackCount(latestDetail.trackCount, skippedRemovalCount: skippedRemovedVideoIDs.count)
         let preservedTrackCount = max(allTracks.count, adjustedTrackCount ?? 0)
         let updatedPlaylist = Playlist(
@@ -364,11 +369,10 @@ final class PlaylistDetailViewModel {
             tracks: allTracks,
             duration: latestDetail.duration
         )
+        self.insertLoadedTrackVideoIds(from: normalizedNewTracks)
 
         if batch.isLikedMusicPlaylist {
-            for song in normalizedNewTracks {
-                SongLikeStatusManager.shared.setStatus(.like, for: song.videoId)
-            }
+            SongLikeStatusManager.shared.setStatus(.like, for: normalizedNewTracks.lazy.map(\.videoId))
         }
 
         self.continuationToken = response.continuationToken
@@ -494,7 +498,7 @@ final class PlaylistDetailViewModel {
     func refresh() async {
         self.cancelAllLiveSyncTasks()
         self.cancelRemainingTracksTask()
-        self.playlistDetail = nil
+        self.replacePlaylistDetail(nil)
         self.hasMore = false
         self.continuationToken = nil
         await self.load(restartingInFlightLoad: true)
@@ -512,9 +516,7 @@ final class PlaylistDetailViewModel {
 
     private func normalizeLikedMusicDetail(_ detail: PlaylistDetail) -> PlaylistDetail {
         let likedTracks = self.markSongsAsLiked(detail.tracks, deduplicating: true)
-        for song in likedTracks {
-            SongLikeStatusManager.shared.setStatus(.like, for: song.videoId)
-        }
+        SongLikeStatusManager.shared.setStatus(.like, for: likedTracks.lazy.map(\.videoId))
 
         let resolvedTrackCount = max(detail.trackCount ?? 0, likedTracks.count)
         return self.updatedPlaylistDetail(
@@ -557,12 +559,28 @@ final class PlaylistDetailViewModel {
     }
 
     private func containsTrack(videoId: String) -> Bool {
-        self.playlistDetail?.tracks.contains(where: { $0.videoId == videoId }) == true
+        self.loadedTrackVideoIds.contains(videoId)
+    }
+
+    private func replacePlaylistDetail(_ detail: PlaylistDetail?) {
+        self.playlistDetail = detail
+        self.replaceLoadedTrackVideoIds(with: detail?.tracks ?? [])
+    }
+
+    private func replaceLoadedTrackVideoIds(with tracks: [Song]) {
+        self.loadedTrackVideoIds = Set(tracks.map(\.videoId))
+    }
+
+    private func insertLoadedTrackVideoIds(from tracks: [Song]) {
+        self.loadedTrackVideoIds.reserveCapacity(self.loadedTrackVideoIds.count + tracks.count)
+        for track in tracks {
+            self.loadedTrackVideoIds.insert(track.videoId)
+        }
     }
 
     private func insertLiveSyncedLikedSong(_ song: Song) {
         guard let currentDetail = self.playlistDetail else { return }
-        guard !currentDetail.tracks.contains(where: { $0.videoId == song.videoId }) else { return }
+        guard !self.loadedTrackVideoIds.contains(song.videoId) else { return }
 
         var likedSong = song
         likedSong.likeStatus = .like
@@ -577,6 +595,7 @@ final class PlaylistDetailViewModel {
             tracks: updatedTracks,
             trackCount: updatedTrackCount
         )
+        self.loadedTrackVideoIds.insert(song.videoId)
         SongLikeStatusManager.shared.setStatus(.like, for: song.videoId)
         self.logger.info("Live sync: added song \(song.videoId) to liked music")
     }
@@ -595,6 +614,7 @@ final class PlaylistDetailViewModel {
             tracks: updatedTracks,
             trackCount: updatedTrackCount
         )
+        self.loadedTrackVideoIds.remove(videoId)
         self.logger.info("Live sync: removed song \(videoId) from liked music")
     }
 

--- a/Tests/KasetTests/LRCParserTests.swift
+++ b/Tests/KasetTests/LRCParserTests.swift
@@ -40,4 +40,52 @@ struct LRCParserTests {
         #expect(synced.lines[1].timeInMs == 9500)
         #expect(synced.lines[2].timeInMs == 19500)
     }
+
+    @Test("Parse word-level timing")
+    func parseWordLevelTiming() throws {
+        let lrc = "[00:00.12]<00:00.12>Hello <00:00.45>world"
+
+        let synced = try #require(LRCParser.parse(lrc))
+        let line = try #require(synced.lines.first)
+
+        #expect(line.timeInMs == 120)
+        #expect(line.text == "Hello world")
+        #expect(line.words == [
+            TimedWord(timeInMs: 120, word: "Hello "),
+            TimedWord(timeInMs: 450, word: "world"),
+        ])
+    }
+
+    @Test("Parse three digit milliseconds")
+    func parseThreeDigitMilliseconds() throws {
+        let synced = try #require(LRCParser.parse("[00:01.234]Line"))
+
+        #expect(synced.lines.first?.timeInMs == 0)
+        #expect(synced.lines.dropFirst().first?.timeInMs == 1234)
+    }
+
+    @Test("Offset clamps negative timestamps to zero")
+    func offsetClampsNegativeTimestamp() throws {
+        let synced = try #require(LRCParser.parse("[offset:500]\n[00:00.10]Early"))
+
+        #expect(synced.lines.first?.timeInMs == 0)
+        #expect(synced.lines.first?.text == "Early")
+    }
+
+    @Test("Pure metadata only returns nil")
+    func pureMetadataOnlyReturnsNil() {
+        #expect(LRCParser.parse("[ar:Artist]\n[ti:Title]") == nil)
+    }
+
+    @Test("First line blank insertion threshold")
+    func firstLineBlankInsertionThreshold() throws {
+        let noBlank = try #require(LRCParser.parse("[00:00.30]No blank"))
+        let blank = try #require(LRCParser.parse("[00:00.31]Blank"))
+
+        #expect(noBlank.lines.count == 1)
+        #expect(noBlank.lines.first?.text == "No blank")
+        #expect(blank.lines.count == 2)
+        #expect(blank.lines.first?.text.isEmpty == true)
+        #expect(blank.lines.last?.text == "Blank")
+    }
 }

--- a/Tests/KasetTests/ParsingHelpersTests.swift
+++ b/Tests/KasetTests/ParsingHelpersTests.swift
@@ -385,6 +385,20 @@ struct ParsingHelpersTests {
         #expect(duration == nil)
     }
 
+    @Test(
+        "Extract duration from accessibility overlay labels",
+        arguments: [
+            ("Play Song by Artist, 4 minutes, 55 seconds", 295.0),
+            ("Play Song, 1 minute, 1 second", 61.0),
+            ("Play Song, 45 seconds", 45.0),
+            ("Play Song, 4 minutes", 240.0),
+        ]
+    )
+    func extractDurationFromAccessibilityOverlayLabel(label: String, expectedSeconds: TimeInterval) {
+        let duration = ParsingHelpers.extractDurationFromFlexColumns(self.makeAccessibilityOverlayRow(label: label))
+        #expect(duration == expectedSeconds)
+    }
+
     // MARK: - Flex Column Extraction
 
     @Test("Extract title from flex columns")
@@ -491,5 +505,62 @@ struct ParsingHelpersTests {
 
         let duration = ParsingHelpers.extractDurationFromFlexColumns(data)
         #expect(duration == 295.0) // 4 * 60 + 55
+    }
+
+    @Test("Linked duration-looking flex run is skipped")
+    func extractDurationSkipsLinkedDurationLookingRun() {
+        let data: [String: Any] = [
+            "flexColumns": [[
+                "musicResponsiveListItemFlexColumnRenderer": [
+                    "text": [
+                        "runs": [[
+                            "text": "4:44",
+                            "navigationEndpoint": ["browseEndpoint": ["browseId": "MPRE444"]],
+                        ]],
+                    ],
+                ],
+            ]],
+        ]
+
+        let duration = ParsingHelpers.extractDurationFromFlexColumns(data)
+        #expect(duration == nil)
+    }
+
+    @Test("Unlinked duration after linked numeric title is extracted")
+    func extractDurationUsesUnlinkedDurationAfterLinkedRun() {
+        let data: [String: Any] = [
+            "flexColumns": [[
+                "musicResponsiveListItemFlexColumnRenderer": [
+                    "text": [
+                        "runs": [
+                            [
+                                "text": "4:44",
+                                "navigationEndpoint": ["browseEndpoint": ["browseId": "MPRE444"]],
+                            ],
+                            ["text": "3:21"],
+                        ],
+                    ],
+                ],
+            ]],
+        ]
+
+        let duration = ParsingHelpers.extractDurationFromFlexColumns(data)
+        #expect(duration == 201.0)
+    }
+
+    private func makeAccessibilityOverlayRow(label: String) -> [String: Any] {
+        [
+            "overlay": [
+                "musicItemThumbnailOverlayRenderer": [
+                    "content": [
+                        "musicPlayButtonRenderer": [
+                            "accessibilityPlayData": [
+                                "accessibilityData": ["label": label],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]
     }
 }

--- a/Tests/KasetTests/ParsingHelpersTests.swift
+++ b/Tests/KasetTests/ParsingHelpersTests.swift
@@ -446,6 +446,17 @@ struct ParsingHelpersTests {
         #expect(subtitle == "Artist • Album")
     }
 
+    @Test("Join run text skips missing text without intermediate arrays")
+    func joinedRunTextSkipsMissingText() {
+        let runs: [[String: Any]] = [
+            ["text": "First"],
+            ["navigationEndpoint": ["browseEndpoint": ["browseId": "UC123"]]],
+            ["text": " Second"],
+        ]
+
+        #expect(ParsingHelpers.joinedRunText(runs) == "First Second")
+    }
+
     @Test("Extract artists from flex columns")
     func extractArtistsFromFlexColumns() {
         let data: [String: Any] = [

--- a/Tests/KasetTests/PerformanceTests/DataFlowPerformanceTests.swift
+++ b/Tests/KasetTests/PerformanceTests/DataFlowPerformanceTests.swift
@@ -20,4 +20,58 @@ final class DataFlowPerformanceTests: XCTestCase {
             }
         }
     }
+
+    @MainActor
+    func testQueuePersistenceLargeQueuePerformance() {
+        let player = PlayerService()
+        let songs = (0 ..< 3000).map { index in
+            TestFixtures.makeSong(id: "persist-video-\(index)", title: "Persist Song \(index)")
+        }
+        let options = XCTMeasureOptions()
+        options.iterationCount = 5
+        defer { Self.clearSavedPlaybackSession() }
+
+        self.measure(metrics: [XCTClockMetric()], options: options) {
+            MainActor.assumeIsolated {
+                Self.clearSavedPlaybackSession()
+                player.setQueue(songs)
+                player.currentIndex = songs.count / 2
+                player.saveQueueForPersistence()
+                XCTAssertNotNil(UserDefaults.standard.data(forKey: "kaset.saved.playbackSession"))
+            }
+        }
+    }
+
+    @MainActor
+    func testBulkQueueRemovalPerformance() {
+        let player = PlayerService()
+        let entries = (0 ..< 3000).map { index in
+            QueueEntry(
+                id: UUID(),
+                song: TestFixtures.makeSong(id: "remove-video-\(index)", title: "Remove Song \(index)")
+            )
+        }
+        let entryIDsToRemove = Set(entries.enumerated().compactMap { index, entry in
+            index.isMultiple(of: 2) ? entry.id : nil
+        })
+        let options = XCTMeasureOptions()
+        options.iterationCount = 5
+        defer { Self.clearSavedPlaybackSession() }
+
+        self.measure(metrics: [XCTClockMetric()], options: options) {
+            MainActor.assumeIsolated {
+                Self.clearSavedPlaybackSession()
+                player.setQueue(entries: entries)
+                player.currentIndex = entries.count - 1
+                player.removeFromQueue(entryIDs: entryIDsToRemove)
+                XCTAssertEqual(player.queueEntries.count, entries.count - entryIDsToRemove.count)
+            }
+        }
+    }
+
+    private static func clearSavedPlaybackSession() {
+        UserDefaults.standard.removeObject(forKey: "kaset.saved.queue")
+        UserDefaults.standard.removeObject(forKey: "kaset.saved.queueIndex")
+        UserDefaults.standard.removeObject(forKey: "kaset.saved.playbackSession")
+    }
 }

--- a/Tests/KasetTests/PerformanceTests/DataFlowPerformanceTests.swift
+++ b/Tests/KasetTests/PerformanceTests/DataFlowPerformanceTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import Kaset
+
+/// Performance tests for app data-flow helpers that are hot during large library/playlist loads.
+final class DataFlowPerformanceTests: XCTestCase {
+    @MainActor
+    func testLikeStatusSingleWritePerformance() {
+        let manager = SongLikeStatusManager.shared
+        let videoIds = (0 ..< 10000).map { "liked-video-\($0)" }
+        let options = XCTMeasureOptions()
+        options.iterationCount = 5
+
+        self.measure(metrics: [XCTClockMetric()], options: options) {
+            MainActor.assumeIsolated {
+                manager.clearCache()
+                for videoId in videoIds {
+                    manager.setStatus(.like, for: videoId)
+                }
+                XCTAssertEqual(manager.status(for: videoIds[9999]), .like)
+            }
+        }
+    }
+}

--- a/Tests/KasetTests/PerformanceTests/ParserPerformanceTests.swift
+++ b/Tests/KasetTests/PerformanceTests/ParserPerformanceTests.swift
@@ -88,6 +88,34 @@ final class ParserPerformanceTests: XCTestCase {
         }
     }
 
+    // MARK: - Regex-heavy Parser Performance
+
+    func testAccessibilityDurationFallbackPerformance() {
+        // Given: Rows that only expose duration in accessibility labels.
+        let rows = self.makeAccessibilityDurationRows(count: 1000)
+        _ = ParsingHelpers.extractDurationFromFlexColumns(rows[0])
+
+        // When/Then: Measure duration extraction without network/UI work.
+        measure {
+            var total: TimeInterval = 0
+            for row in rows {
+                total += ParsingHelpers.extractDurationFromFlexColumns(row) ?? 0
+            }
+            XCTAssertGreaterThan(total, 0)
+        }
+    }
+
+    func testLRCParsingPerformance() {
+        // Given: Mixed line-level and word-level synced lyric data.
+        let raw = self.makeLRCData(lineCount: 600)
+        XCTAssertNotNil(LRCParser.parse(raw))
+
+        // When/Then: Measure LRC parsing throughput.
+        measure {
+            XCTAssertNotNil(LRCParser.parse(raw))
+        }
+    }
+
     // MARK: - Helpers: Home Response
 
     private func makeHomeResponseData(sectionCount: Int, itemsPerSection: Int) -> [String: Any] {
@@ -501,5 +529,60 @@ final class ParserPerformanceTests: XCTestCase {
                 ],
             ],
         ]
+    }
+
+    private func makeAccessibilityDurationRows(count: Int) -> [[String: Any]] {
+        (0 ..< count).map { index in
+            [
+                "overlay": [
+                    "musicItemThumbnailOverlayRenderer": [
+                        "content": [
+                            "musicPlayButtonRenderer": [
+                                "accessibilityPlayData": [
+                                    "accessibilityData": [
+                                        "label": "Play Benchmark Song \(index), \((index % 5) + 1) minutes, \((index % 50) + 1) seconds",
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ]
+        }
+    }
+
+    private func makeLRCData(lineCount: Int) -> String {
+        var lines = [
+            "[ar:Benchmark Artist]",
+            "[ti:Benchmark Song]",
+            "[offset:125]",
+        ]
+        lines.reserveCapacity(lineCount + lines.count)
+
+        for index in 0 ..< lineCount {
+            let minute = index / 60
+            let second = index % 60
+            let centisecond = index % 100
+            if index.isMultiple(of: 3) {
+                lines.append(String(
+                    format: "[%02d:%02d.%02d]<%02d:%02d.%02d>word%d <%02d:%02d.%02d>line%d",
+                    minute,
+                    second,
+                    centisecond,
+                    minute,
+                    second,
+                    centisecond,
+                    index,
+                    minute,
+                    min(59, second + 1),
+                    centisecond,
+                    index
+                ))
+            } else {
+                lines.append(String(format: "[%02d:%02d.%02d]Benchmark lyric line %d", minute, second, centisecond, index))
+            }
+        }
+
+        return lines.joined(separator: "\n")
     }
 }

--- a/Tests/KasetTests/PlayerServiceLibraryTests.swift
+++ b/Tests/KasetTests/PlayerServiceLibraryTests.swift
@@ -87,10 +87,9 @@ struct PlayerServiceLibraryTests {
         // Optimistic update should happen immediately
         #expect(self.playerService.currentTrackLikeStatus == .like)
 
-        // Wait for SongLikeStatusManager to call API, fail, rollback, and PlayerService to sync back
-        try? await Task.sleep(for: .milliseconds(300))
-
-        #expect(self.playerService.currentTrackLikeStatus == .indifferent)
+        // Wait for SongLikeStatusManager to call API, fail, rollback, and PlayerService to sync back.
+        let reverted = await self.waitUntilLikeStatus(.indifferent)
+        #expect(reverted)
     }
 
     @Test("likeCurrentTrack ignores stale completion after current track changes")
@@ -196,10 +195,9 @@ struct PlayerServiceLibraryTests {
 
         #expect(self.playerService.currentTrackLikeStatus == .dislike)
 
-        // Wait for SongLikeStatusManager to call API, fail, rollback, and PlayerService to sync back
-        try? await Task.sleep(for: .milliseconds(300))
-
-        #expect(self.playerService.currentTrackLikeStatus == .indifferent)
+        // Wait for SongLikeStatusManager to call API, fail, rollback, and PlayerService to sync back.
+        let reverted = await self.waitUntilLikeStatus(.indifferent)
+        #expect(reverted)
     }
 
     @Test("dislikeCurrentTrack ignores stale completion after current track changes")
@@ -394,5 +392,19 @@ struct PlayerServiceLibraryTests {
         #expect(self.playerService.currentTrackLikeStatus == .indifferent)
         #expect(self.playerService.currentTrackInLibrary == false)
         #expect(self.playerService.currentTrackFeedbackTokens == nil)
+    }
+
+    private func waitUntilLikeStatus(
+        _ expectedStatus: LikeStatus,
+        attempts: Int = 200,
+        pollInterval: Duration = .milliseconds(10)
+    ) async -> Bool {
+        for _ in 0 ..< attempts {
+            if self.playerService.currentTrackLikeStatus == expectedStatus {
+                return true
+            }
+            try? await Task.sleep(for: pollInterval)
+        }
+        return false
     }
 }

--- a/Tests/KasetTests/PlaylistEditabilityTests.swift
+++ b/Tests/KasetTests/PlaylistEditabilityTests.swift
@@ -44,4 +44,17 @@ struct PlaylistEditabilityTests {
 
         #expect(!PlaylistEditability.canDeletePlaylist(from: response))
     }
+
+    @Test("Delete affordance is true for delete command text")
+    func canDeleteForDeleteCommandText() {
+        let response: [String: Any] = [
+            "menu": [
+                "items": [[
+                    "label": "music/playlist/delete",
+                ]],
+            ],
+        ]
+
+        #expect(PlaylistEditability.canDeletePlaylist(from: response))
+    }
 }

--- a/Tests/KasetTests/ResponseTreeSearchTests.swift
+++ b/Tests/KasetTests/ResponseTreeSearchTests.swift
@@ -35,4 +35,18 @@ struct ResponseTreeSearchTests {
         #expect(ResponseTreeSearch.containsText("playlist/delete", in: response))
         #expect(!ResponseTreeSearch.containsKey("createPlaylistEndpoint", in: response))
     }
+
+    @Test("Detects nested key or text in one pass")
+    func detectsNestedKeyOrTextInOnePass() {
+        let response: [String: Any] = [
+            "outer": [[
+                "command": [
+                    "label": "Playlist/Delete",
+                ],
+            ]],
+        ]
+
+        #expect(ResponseTreeSearch.containsAny(keys: ["missingRenderer"], text: "playlist/delete", in: response))
+        #expect(!ResponseTreeSearch.containsAny(keys: ["missingRenderer"], text: "not-present", in: response))
+    }
 }

--- a/Tests/KasetTests/SongLikeStatusManagerTests.swift
+++ b/Tests/KasetTests/SongLikeStatusManagerTests.swift
@@ -182,6 +182,30 @@ struct SongLikeStatusManagerTests {
         #expect(self.manager.status(for: "video-2") == .dislike)
     }
 
+    @Test("bulk setStatus updates cache for active account")
+    func bulkSetStatusUpdatesCacheForActiveAccount() {
+        let videoIds = ["bulk-video-1", "bulk-video-2", "bulk-video-3"]
+
+        self.manager.setStatus(.like, for: videoIds)
+
+        for videoId in videoIds {
+            #expect(self.manager.status(for: videoId) == .like)
+        }
+    }
+
+    @Test("bulk setStatus respects active account scope")
+    func bulkSetStatusRespectsActiveAccountScope() {
+        let videoIds = ["bulk-scoped-video-1", "bulk-scoped-video-2"]
+
+        self.manager.setActiveAccountID("brand-account")
+        self.manager.setStatus(.like, for: videoIds)
+
+        for videoId in videoIds {
+            #expect(self.manager.status(for: videoId) == .like)
+            #expect(self.manager.status(for: videoId, accountID: "primary") == nil)
+        }
+    }
+
     @Test("cache is isolated by active account")
     func cacheIsIsolatedByActiveAccount() {
         self.manager.setActiveAccountID("primary")


### PR DESCRIPTION
## Summary

- Optimizes YouTube Music parser hot paths by reducing repeated tree walks, regex compilation, and intermediate run-text arrays.
- Optimizes liked-music and queue data-flow hot paths by bulk seeding like-status cache entries, preserving continuation duplicate snapshots, and streamlining queue removal/persistence.
- Adds benchmark coverage and a repeatable XCTest benchmark helper for parser/data-flow performance checks.

## Performance impact

- Like-status cache seeding: `0.433s -> 0.003s` (~99.3% faster).
- Playlist detail parser benchmark: `0.007s -> 0.005s` (~28.6% faster) after one-pass editability detection.
- Accessibility duration parsing: `0.071s -> 0.008s` (~88.7% faster).
- Run-text join slice improved several parser benchmarks, including playlist detail `0.007s -> 0.004s` and home parsing `0.007s -> 0.005s`.
- Bulk queue removal benchmark: `0.025s -> 0.018s` (~28.0% faster).

## Validation

- `swift build`
- `swift test --skip KasetUITests --filter SongLikeStatusManagerTests`
- `swift test --skip KasetUITests --filter PlaylistDetailViewModelTests`
- `swift test --skip KasetUITests --filter PlayerServiceQueueTests`
- `swift test --skip KasetUITests --filter PlayerServiceMixTests`
- `swift test --skip KasetUITests --filter DataFlowPerformanceTests`
- Parser-focused test filters covering `ParsingHelpersTests`, `ArtistParserTests`, `PlaylistParserTests`, `SearchResponseParserTests`, `PodcastParserTests`, `YouTubeItemParserTests`, `LyricsParserTests`, `LRCParserTests`, `PlaylistEditabilityTests`, and `ResponseTreeSearchTests`
- `swiftlint --strict`
- `Scripts/benchmark-xctest.sh` focused benchmark runs, with comparisons tracked in `/tmp/perf2-kaset.md`
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `.agents/skills/autoreview/scripts/autoreview --mode commit --commit HEAD`
