### PR TITLE
feat(liked-music): add live track search and restore detail-page scroll-edge effect

### DIFF
--- a/Sources/Kaset/Utilities/AccessibilityIdentifiers.swift
+++ b/Sources/Kaset/Utilities/AccessibilityIdentifiers.swift
@@ -192,6 +192,9 @@ enum AccessibilityID {
         static let scrollView = "likedMusicView.scrollView"
         static let loadingIndicator = "likedMusicView.loading"
         static let emptyState = "likedMusicView.emptyState"
+        static let searchField = "likedMusicView.searchField"
+        static let clearSearchButton = "likedMusicView.clearSearchButton"
+        static let searchEmptyState = "likedMusicView.searchEmptyState"
 
         static func songRow(index: Int) -> String {
             "likedMusicView.song.\(index)"

--- a/Sources/Kaset/ViewModels/PlaylistDetailViewModel.swift
+++ b/Sources/Kaset/ViewModels/PlaylistDetailViewModel.swift
@@ -32,6 +32,9 @@ final class PlaylistDetailViewModel {
     /// The loaded playlist detail.
     private(set) var playlistDetail: PlaylistDetail?
 
+    /// Current live search query for Liked Music tracks.
+    var likedMusicSearchQuery = ""
+
     /// Whether more tracks are available to load.
     private(set) var hasMore: Bool = false
 
@@ -71,6 +74,43 @@ final class PlaylistDetailViewModel {
         for liveSyncTask in self.liveSyncTasks.values {
             liveSyncTask.task.cancel()
         }
+    }
+
+    var hasActiveLikedMusicSearch: Bool {
+        self.isLikedMusicPlaylist && !self.normalizedLikedMusicSearchQuery.isEmpty
+    }
+
+    var normalizedLikedMusicSearchQuery: String {
+        self.likedMusicSearchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    func clearLikedMusicSearch() {
+        self.likedMusicSearchQuery = ""
+    }
+
+    func visibleTracks(for detail: PlaylistDetail) -> [Song] {
+        guard self.hasActiveLikedMusicSearch else {
+            return detail.tracks
+        }
+
+        let query = self.normalizedLikedMusicSearchQuery
+        return detail.tracks.filter { self.song($0, matches: query) }
+    }
+
+    private func song(_ song: Song, matches query: String) -> Bool {
+        let searchableText = [
+            song.title,
+            song.artistsDisplay,
+            song.album?.title,
+            song.videoId,
+        ]
+        .compactMap(\.self)
+        .joined(separator: " ")
+
+        return searchableText.range(
+            of: query,
+            options: [.caseInsensitive, .diacriticInsensitive]
+        ) != nil
     }
 
     /// Strips song count patterns from author text (e.g., " • 145 songs" or " • 2,429 tracks").

--- a/Sources/Kaset/Views/ArtistDetailView.swift
+++ b/Sources/Kaset/Views/ArtistDetailView.swift
@@ -43,7 +43,6 @@ struct ArtistDetailView: View { // swiftlint:disable:this type_body_length
         }
         .accentBackground(from: self.viewModel.artistDetail?.thumbnailURL?.highQualityThumbnailURL)
         .navigationTitle(self.artist.name)
-        .toolbarBackgroundVisibility(.hidden, for: .automatic)
         .safeAreaInset(edge: .bottom, spacing: 0) {
             if case .error = self.viewModel.loadingState {} else {
                 PlayerBar()
@@ -132,7 +131,6 @@ struct ArtistDetailView: View { // swiftlint:disable:this type_body_length
         // padding above, while horizontal shelves pass `contentInset` so their
         // tracks reach the under-sidebar band and slide under the floating glass
         // on macOS 26. The accent backdrop (ignores safe area) refracts through.
-        .topFade(style: .contentMask)
     }
 
     private func headerView(_ detail: ArtistDetail) -> some View {

--- a/Sources/Kaset/Views/ArtistDiscographyView.swift
+++ b/Sources/Kaset/Views/ArtistDiscographyView.swift
@@ -22,8 +22,6 @@ struct ArtistDiscographyView: View {
             }
         }
         .navigationTitle(self.viewModel.destination.sectionTitle)
-        .toolbarBackgroundVisibility(.hidden, for: .automatic)
-        .topFade()
         .safeAreaInset(edge: .bottom, spacing: 0) {
             if case .error = self.viewModel.loadingState {} else {
                 PlayerBar()

--- a/Sources/Kaset/Views/ArtistEpisodesListView.swift
+++ b/Sources/Kaset/Views/ArtistEpisodesListView.swift
@@ -30,8 +30,6 @@ struct ArtistEpisodesListView: View {
             }
         }
         .navigationTitle(self.viewModel.destination.sectionTitle)
-        .toolbarBackgroundVisibility(.hidden, for: .automatic)
-        .topFade()
         .safeAreaInset(edge: .bottom, spacing: 0) {
             if case .error = self.viewModel.loadingState {} else {
                 PlayerBar()

--- a/Sources/Kaset/Views/LegacyFallbackViews.swift
+++ b/Sources/Kaset/Views/LegacyFallbackViews.swift
@@ -16,6 +16,7 @@ struct SimplePlaylistDetailView: View {
     @State var viewModel: PlaylistDetailViewModel
     @Environment(PlayerService.self) private var playerService
     @Environment(SongLikeStatusManager.self) private var likeStatusManager
+    @FocusState private var isLikedMusicSearchFocused: Bool
 
     init(
         playlist: Playlist,
@@ -77,7 +78,19 @@ struct SimplePlaylistDetailView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
                 self.headerView(detail)
-                self.trackList(detail.tracks)
+                let visibleTracks = self.viewModel.visibleTracks(for: detail)
+                if LikedMusicPlaylist.matches(id: self.playlist.id) {
+                    LikedMusicSearchField(
+                        text: self.$viewModel.likedMusicSearchQuery,
+                        isFocused: self.$isLikedMusicSearchFocused,
+                        isActive: self.viewModel.hasActiveLikedMusicSearch,
+                        style: .fallback
+                    ) {
+                        self.viewModel.clearLikedMusicSearch()
+                        self.isLikedMusicSearchFocused = true
+                    }
+                }
+                self.trackList(visibleTracks, allTracks: detail.tracks)
             }
             .padding(.horizontal, 20)
             .padding(.top, 20)
@@ -133,52 +146,62 @@ struct SimplePlaylistDetailView: View {
         }
     }
 
-    private func trackList(_ tracks: [Song]) -> some View {
+    private func trackList(_ tracks: [Song], allTracks: [Song]? = nil) -> some View {
         VStack(spacing: 0) {
-            ForEach(Array(tracks.enumerated()), id: \.offset) { index, track in
-                Button {
-                    Task { await self.playFromIndex(index, tracks: tracks) }
-                } label: {
-                    HStack(spacing: 12) {
-                        Text("\(index + 1)")
-                            .font(.callout.monospacedDigit())
-                            .foregroundStyle(.secondary)
-                            .frame(width: 28, alignment: .trailing)
-                        AsyncImage(url: track.thumbnailURL) { image in
-                            image.resizable().aspectRatio(contentMode: .fill)
-                        } placeholder: {
-                            Color.secondary.opacity(0.15)
-                        }
-                        .frame(width: 36, height: 36)
-                        .clipShape(RoundedRectangle(cornerRadius: 4))
+            if tracks.isEmpty, self.viewModel.hasActiveLikedMusicSearch {
+                LikedMusicSearchEmptyState(hasMore: self.viewModel.hasMore, iconSize: 32)
+            } else {
+                ForEach(Array(tracks.enumerated()), id: \.offset) { index, track in
+                    Button {
+                        Task { await self.playFromIndex(index, tracks: tracks) }
+                    } label: {
+                        HStack(spacing: 12) {
+                            Text("\(index + 1)")
+                                .font(.callout.monospacedDigit())
+                                .foregroundStyle(.secondary)
+                                .frame(width: 28, alignment: .trailing)
+                            AsyncImage(url: track.thumbnailURL) { image in
+                                image.resizable().aspectRatio(contentMode: .fill)
+                            } placeholder: {
+                                Color.secondary.opacity(0.15)
+                            }
+                            .frame(width: 36, height: 36)
+                            .clipShape(RoundedRectangle(cornerRadius: 4))
 
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text(track.title).lineLimit(1)
-                            Text(track.artistsDisplay)
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                                .lineLimit(1)
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(track.title).lineLimit(1)
+                                Text(track.artistsDisplay)
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(1)
+                            }
+                            Spacer()
+                            if let dur = track.duration {
+                                Text(self.formatDuration(dur))
+                                    .font(.caption.monospacedDigit())
+                                    .foregroundStyle(.secondary)
+                            }
                         }
-                        Spacer()
-                        if let dur = track.duration {
-                            Text(self.formatDuration(dur))
-                                .font(.caption.monospacedDigit())
-                                .foregroundStyle(.secondary)
+                        .padding(.vertical, 6)
+                        .padding(.horizontal, 8)
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(!track.isPlayable)
+                    .opacity(track.isPlayable ? 1 : 0.5)
+                    .onAppear {
+                        let paginationTracks = allTracks ?? tracks
+                        if index >= tracks.count - 3, self.viewModel.hasMore {
+                            Task { await self.viewModel.loadMore() }
+                        } else if let originalIndex = paginationTracks.firstIndex(where: { $0.videoId == track.videoId }),
+                                  originalIndex >= paginationTracks.count - 3,
+                                  self.viewModel.hasMore
+                        {
+                            Task { await self.viewModel.loadMore() }
                         }
                     }
-                    .padding(.vertical, 6)
-                    .padding(.horizontal, 8)
-                    .contentShape(Rectangle())
+                    Divider().opacity(0.2)
                 }
-                .buttonStyle(.plain)
-                .disabled(!track.isPlayable)
-                .opacity(track.isPlayable ? 1 : 0.5)
-                .onAppear {
-                    if index >= tracks.count - 3, self.viewModel.hasMore {
-                        Task { await self.viewModel.loadMore() }
-                    }
-                }
-                Divider().opacity(0.2)
             }
 
             if self.viewModel.loadingState == .loadingMore {

--- a/Sources/Kaset/Views/LikedMusicSearchViews.swift
+++ b/Sources/Kaset/Views/LikedMusicSearchViews.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+
+// MARK: - LikedMusicSearchFieldStyle
+
+enum LikedMusicSearchFieldStyle {
+    case liquidGlass
+    case fallback
+}
+
+// MARK: - LikedMusicSearchField
+
+struct LikedMusicSearchField: View {
+    let text: Binding<String>
+    let isFocused: FocusState<Bool>.Binding
+    let isActive: Bool
+    let style: LikedMusicSearchFieldStyle
+    let onClear: () -> Void
+
+    var body: some View {
+        switch self.style {
+        case .liquidGlass:
+            self.content
+                .padding(10)
+                .compatGlass(in: .capsule)
+        case .fallback:
+            self.content
+                .padding(10)
+                .background(Color.secondary.opacity(0.12), in: Capsule())
+        }
+    }
+
+    private var content: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+
+            TextField(String(localized: "Search liked songs..."), text: self.text)
+                .textFieldStyle(.plain)
+                .focused(self.isFocused)
+                .accessibilityIdentifier(AccessibilityID.LikedMusic.searchField)
+
+            if self.isActive {
+                Button {
+                    self.onClear()
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(String(localized: "Clear liked music search"))
+                .accessibilityIdentifier(AccessibilityID.LikedMusic.clearSearchButton)
+            }
+        }
+    }
+}
+
+// MARK: - LikedMusicSearchEmptyState
+
+struct LikedMusicSearchEmptyState: View {
+    let hasMore: Bool
+    var iconSize: CGFloat = 36
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: self.iconSize))
+                .foregroundStyle(.tertiary)
+
+            Text(self.hasMore ? String(localized: "Still searching liked songs...") : String(localized: "No liked songs found"))
+                .font(.headline)
+                .foregroundStyle(.secondary)
+
+            Text(
+                self.hasMore
+                    ? String(localized: "More liked songs are loading and results will appear here as they match.")
+                    : String(localized: "Try a different song, artist, or album name.")
+            )
+            .font(.subheadline)
+            .foregroundStyle(.tertiary)
+            .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 32)
+        .accessibilityIdentifier(AccessibilityID.LikedMusic.searchEmptyState)
+    }
+}

--- a/Sources/Kaset/Views/PlaylistDetailRows.swift
+++ b/Sources/Kaset/Views/PlaylistDetailRows.swift
@@ -1,0 +1,119 @@
+import SwiftUI
+
+// MARK: - PlaylistTrackRow
+
+@available(macOS 26.0, *)
+struct PlaylistTrackRow<Menu: View>: View {
+    let track: Song
+    let index: Int
+    let isAlbum: Bool
+    let subtitle: String?
+    let allowsLikeActions: Bool
+    let onPlay: () -> Void
+    @ViewBuilder let menu: () -> Menu
+
+    @State private var isHovered: Bool = false
+    @Environment(PlayerService.self) private var playerService
+
+    var body: some View {
+        let isCurrent = self.playerService.currentTrack?.videoId == self.track.videoId
+
+        Button(action: self.onPlay) {
+            HStack(spacing: 12) {
+                Group {
+                    if isCurrent {
+                        NowPlayingIndicator(isPlaying: self.playerService.isPlaying, size: 14)
+                    } else {
+                        Text("\(self.index + 1)")
+                            .font(.system(size: 14))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .frame(width: 28, alignment: .trailing)
+
+                if !self.isAlbum {
+                    CachedAsyncImage(url: self.track.thumbnailURL) { image in
+                        image.resizable().aspectRatio(contentMode: .fill)
+                    } placeholder: {
+                        Rectangle().fill(.quaternary)
+                    }
+                    .frame(width: 40, height: 40)
+                    .clipShape(.rect(cornerRadius: 4))
+                }
+
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack(spacing: 6) {
+                        Text(self.track.title)
+                            .font(.system(size: 14))
+                            .foregroundStyle(isCurrent ? .red : .primary)
+                            .lineLimit(1)
+                        if self.track.isExplicit == true {
+                            ExplicitBadge()
+                        }
+                    }
+                    if let subtitle {
+                        Text(subtitle)
+                            .font(.system(size: 12))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                LikeButton(song: self.track, isRowHovered: self.isHovered, allowsActions: self.allowsLikeActions)
+
+                Text(self.track.durationDisplay)
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 45, alignment: .trailing)
+            }
+            .padding(.vertical, 8)
+            .padding(.horizontal, 4)
+            .contentShape(Rectangle())
+            .opacity(self.track.isPlayable ? 1 : 0.5)
+        }
+        .buttonStyle(.interactiveRow(cornerRadius: 6))
+        .disabled(!self.track.isPlayable)
+        .onHover { hovering in self.isHovered = hovering }
+        .contextMenu { self.menu() }
+    }
+}
+
+// MARK: - HoverUnderlineNavigationLink
+
+struct HoverUnderlineNavigationLink<Value: Hashable>: View {
+    let value: Value
+    let title: String
+
+    @State private var isHovering = false
+
+    var body: some View {
+        NavigationLink(value: self.value) {
+            Text(self.title)
+                .font(.subheadline)
+                .underline(self.isHovering)
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in
+            self.isHovering = hovering
+        }
+    }
+}
+
+// MARK: - HeaderArtistLinkLabel
+
+struct HeaderArtistLinkLabel: View {
+    let name: String
+
+    @State private var isHovering = false
+
+    var body: some View {
+        Text(self.name)
+            .font(.system(size: 16, weight: .semibold))
+            .foregroundStyle(self.isHovering ? .primary : .secondary)
+            .animation(.easeInOut(duration: 0.15), value: self.isHovering)
+            .onHover { hovering in
+                self.isHovering = hovering
+            }
+    }
+}

--- a/Sources/Kaset/Views/PlaylistDetailView.swift
+++ b/Sources/Kaset/Views/PlaylistDetailView.swift
@@ -28,6 +28,8 @@ struct PlaylistDetailView: View {
     @State private var isRefining: Bool = false
     /// Error message from refine operation.
     @State private var refineError: String?
+    /// Whether the liked music search field is focused.
+    @FocusState private var isLikedMusicSearchFocused: Bool
     /// Computed property to check if playlist is in library.
     var isInLibrary: Bool {
         self.libraryViewModel?.isInLibrary(playlistId: self.playlist.id) ?? false
@@ -75,7 +77,6 @@ struct PlaylistDetailView: View {
             from: self.viewModel.playlistDetail?.thumbnailURL?.highQualityThumbnailURL
         )
         .navigationTitle(self.playlist.title)
-        .toolbarBackgroundVisibility(.hidden, for: .automatic)
         .safeAreaInset(edge: .bottom, spacing: 0) {
             if case .error = self.viewModel.loadingState {
             } else {
@@ -118,35 +119,91 @@ struct PlaylistDetailView: View {
 
     // MARK: - Views
 
+    /// Scroll anchor for the top of the Liked Music list, used to return focus to
+    /// the pinned search field when active-search results shrink.
+    private static let likedMusicScrollTopID = "likedMusicScrollTop"
+
     private func contentView(_ detail: PlaylistDetail) -> some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 24) {
-                // Header
-                self.headerView(detail)
+        let isLikedMusicPlaylist = LikedMusicPlaylist.matches(id: self.playlist.id)
+        let fallbackAlbum = Album(
+            id: detail.id,
+            title: detail.title,
+            artists: detail.author.map { [$0] },
+            thumbnailURL: detail.thumbnailURL,
+            year: nil,
+            trackCount: detail.trackCount ?? detail.tracks.count
+        )
+        let visibleTracks = self.viewModel.visibleTracks(for: detail)
 
-                Divider()
+        return ScrollViewReader { proxy in
+            ScrollView {
+                if isLikedMusicPlaylist {
+                    LazyVStack(alignment: .leading, spacing: 16, pinnedViews: [.sectionHeaders]) {
+                        self.headerView(detail)
+                            .id(Self.likedMusicScrollTopID)
 
-                // Tracks
-                let fallbackAlbum = Album(
-                    id: detail.id,
-                    title: detail.title,
-                    artists: detail.author.map { [$0] },
-                    thumbnailURL: detail.thumbnailURL,
-                    year: nil,
-                    trackCount: detail.trackCount ?? detail.tracks.count
-                )
-                self.tracksView(
-                    detail.tracks, isAlbum: detail.isAlbum, author: detail.author?.name,
-                    fallbackAlbum: fallbackAlbum
-                )
+                        Section {
+                            self.tracksView(
+                                visibleTracks,
+                                allTracks: detail.tracks,
+                                isAlbum: detail.isAlbum,
+                                author: detail.author?.name,
+                                fallbackAlbum: fallbackAlbum
+                            )
+                        } header: {
+                            self.likedMusicSearchField
+                        }
+                    }
+                    .padding(.vertical, 16)
+                } else {
+                    VStack(alignment: .leading, spacing: 24) {
+                        self.headerView(detail)
+
+                        Divider()
+
+                        self.tracksView(
+                            visibleTracks,
+                            allTracks: detail.tracks,
+                            isAlbum: detail.isAlbum,
+                            author: detail.author?.name,
+                            fallbackAlbum: fallbackAlbum
+                        )
+                    }
+                    .padding(.vertical, 24)
+                }
             }
-            .padding(.vertical, 24)
+            // Inset the resting content while the scroll view stays edge-to-edge so
+            // content extends under the floating glass sidebar; the accent backdrop
+            // (which ignores the safe area) refracts through it.
+            .contentMargins(.horizontal, DetailContentLayout.horizontalInset, for: .scrollContent)
+            // When an active search shrinks the visible results, the scroll offset
+            // can end up past the (now shorter) content, which strands and unpins
+            // the sticky search field and drops its focus. Returning to the top
+            // keeps the field pinned, focused, and the results in view.
+            .onChange(of: visibleTracks.count) { oldCount, newCount in
+                guard isLikedMusicPlaylist,
+                      self.viewModel.hasActiveLikedMusicSearch,
+                      newCount < oldCount
+                else { return }
+                withAnimation(.easeInOut(duration: 0.25)) {
+                    proxy.scrollTo(Self.likedMusicScrollTopID, anchor: .top)
+                }
+            }
         }
-        // Inset the resting content while the scroll view stays edge-to-edge so
-        // content extends under the floating glass sidebar; the accent backdrop
-        // (which ignores the safe area) refracts through it.
-        .contentMargins(.horizontal, DetailContentLayout.horizontalInset, for: .scrollContent)
-        .topFade(style: .contentMask)
+    }
+
+    private var likedMusicSearchField: some View {
+        LikedMusicSearchField(
+            text: self.$viewModel.likedMusicSearchQuery,
+            isFocused: self.$isLikedMusicSearchFocused,
+            isActive: self.viewModel.hasActiveLikedMusicSearch,
+            style: .liquidGlass
+        ) {
+            self.viewModel.clearLikedMusicSearch()
+            self.isLikedMusicSearchFocused = true
+        }
+        .padding(.bottom, 8)
+        .background(.clear)
     }
 
     private func headerView(_ detail: PlaylistDetail) -> some View {
@@ -240,26 +297,40 @@ struct PlaylistDetailView: View {
     }
 
     private func tracksView(
-        _ tracks: [Song], isAlbum: Bool, author: String?, fallbackAlbum: Album? = nil
+        _ tracks: [Song],
+        allTracks: [Song]? = nil,
+        isAlbum: Bool,
+        author: String?,
+        fallbackAlbum: Album? = nil
     ) -> some View {
         LazyVStack(spacing: 0) {
-            ForEach(Array(tracks.enumerated()), id: \.offset) { index, track in
-                self.trackRow(
-                    track, index: index, tracks: tracks, isAlbum: isAlbum, author: author,
-                    fallbackAlbum: fallbackAlbum
-                )
-                .onAppear {
-                    // Load more when reaching the last few items
-                    if index >= tracks.count - 3, self.viewModel.hasMore {
-                        Task { await self.viewModel.loadMore() }
+            if tracks.isEmpty, self.viewModel.hasActiveLikedMusicSearch {
+                LikedMusicSearchEmptyState(hasMore: self.viewModel.hasMore)
+            } else {
+                ForEach(Array(tracks.enumerated()), id: \.offset) { index, track in
+                    self.trackRow(
+                        track, index: index, tracks: tracks, isAlbum: isAlbum, author: author,
+                        fallbackAlbum: fallbackAlbum
+                    )
+                    .onAppear {
+                        // Load more when reaching the last few items.
+                        let paginationTracks = allTracks ?? tracks
+                        if index >= tracks.count - 3, self.viewModel.hasMore {
+                            Task { await self.viewModel.loadMore() }
+                        } else if let originalIndex = paginationTracks.firstIndex(where: { $0.videoId == track.videoId }),
+                                  originalIndex >= paginationTracks.count - 3,
+                                  self.viewModel.hasMore
+                        {
+                            Task { await self.viewModel.loadMore() }
+                        }
                     }
-                }
 
-                if index < tracks.count - 1 {
-                    Divider()
-                        // For albums: 28 (index) + 12 (spacing)
-                        // For playlists: 28 (index) + 12 (spacing) + 40 (thumbnail) + 16 (spacing)
-                        .padding(.leading, isAlbum ? 40 : 96)
+                    if index < tracks.count - 1 {
+                        Divider()
+                            // For albums: 28 (index) + 12 (spacing)
+                            // For playlists: 28 (index) + 12 (spacing) + 40 (thumbnail) + 16 (spacing)
+                            .padding(.leading, isAlbum ? 40 : 96)
+                    }
                 }
             }
 
@@ -269,9 +340,14 @@ struct PlaylistDetailView: View {
                     Spacer()
                     ProgressView()
                         .controlSize(.small)
-                        .padding()
+                    if self.viewModel.hasActiveLikedMusicSearch {
+                        Text(String(localized: "Searching more liked songs..."))
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
                     Spacer()
                 }
+                .padding()
             }
         }
     }
@@ -710,124 +786,6 @@ struct PlaylistDetailView: View {
 
         self.partialChanges = nil
         self.isRefining = false
-    }
-}
-
-// MARK: - PlaylistTrackRow
-
-@available(macOS 26.0, *)
-private struct PlaylistTrackRow<Menu: View>: View {
-    let track: Song
-    let index: Int
-    let isAlbum: Bool
-    let subtitle: String?
-    let allowsLikeActions: Bool
-    let onPlay: () -> Void
-    @ViewBuilder let menu: () -> Menu
-
-    @State private var isHovered: Bool = false
-    @Environment(PlayerService.self) private var playerService
-
-    var body: some View {
-        let isCurrent = self.playerService.currentTrack?.videoId == self.track.videoId
-
-        Button(action: self.onPlay) {
-            HStack(spacing: 12) {
-                Group {
-                    if isCurrent {
-                        NowPlayingIndicator(isPlaying: self.playerService.isPlaying, size: 14)
-                    } else {
-                        Text("\(self.index + 1)")
-                            .font(.system(size: 14))
-                            .foregroundStyle(.secondary)
-                    }
-                }
-                .frame(width: 28, alignment: .trailing)
-
-                if !self.isAlbum {
-                    CachedAsyncImage(url: self.track.thumbnailURL) { image in
-                        image.resizable().aspectRatio(contentMode: .fill)
-                    } placeholder: {
-                        Rectangle().fill(.quaternary)
-                    }
-                    .frame(width: 40, height: 40)
-                    .clipShape(.rect(cornerRadius: 4))
-                }
-
-                VStack(alignment: .leading, spacing: 2) {
-                    HStack(spacing: 6) {
-                        Text(self.track.title)
-                            .font(.system(size: 14))
-                            .foregroundStyle(isCurrent ? .red : .primary)
-                            .lineLimit(1)
-                        if self.track.isExplicit == true {
-                            ExplicitBadge()
-                        }
-                    }
-                    if let subtitle = self.subtitle {
-                        Text(subtitle)
-                            .font(.system(size: 12))
-                            .foregroundStyle(.secondary)
-                            .lineLimit(1)
-                    }
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-                LikeButton(song: self.track, isRowHovered: self.isHovered, allowsActions: self.allowsLikeActions)
-
-                Text(self.track.durationDisplay)
-                    .font(.system(size: 12))
-                    .foregroundStyle(.secondary)
-                    .frame(width: 45, alignment: .trailing)
-            }
-            .padding(.vertical, 8)
-            .padding(.horizontal, 4)
-            .contentShape(Rectangle())
-            .opacity(self.track.isPlayable ? 1 : 0.5)
-        }
-        .buttonStyle(.interactiveRow(cornerRadius: 6))
-        .disabled(!self.track.isPlayable)
-        .onHover { hovering in self.isHovered = hovering }
-        .contextMenu { self.menu() }
-    }
-}
-
-// MARK: - HoverUnderlineNavigationLink
-
-private struct HoverUnderlineNavigationLink<Value: Hashable>: View {
-    let value: Value
-    let title: String
-
-    @State private var isHovering = false
-
-    var body: some View {
-        NavigationLink(value: self.value) {
-            Text(self.title)
-                .font(.subheadline)
-                .underline(self.isHovering)
-        }
-        .buttonStyle(.plain)
-        .onHover { hovering in
-            self.isHovering = hovering
-        }
-    }
-}
-
-// MARK: - HeaderArtistLinkLabel
-
-private struct HeaderArtistLinkLabel: View {
-    let name: String
-
-    @State private var isHovering = false
-
-    var body: some View {
-        Text(self.name)
-            .font(.system(size: 16, weight: .semibold))
-            .foregroundStyle(self.isHovering ? .primary : .secondary)
-            .animation(.easeInOut(duration: 0.15), value: self.isHovering)
-            .onHover { hovering in
-                self.isHovering = hovering
-            }
     }
 }
 

--- a/Sources/Kaset/Views/TopSongsView.swift
+++ b/Sources/Kaset/Views/TopSongsView.swift
@@ -37,8 +37,6 @@ struct TopSongsView: View {
             }
         }
         .navigationTitle(self.viewModel.title)
-        .toolbarBackgroundVisibility(.hidden, for: .automatic)
-        .topFade()
         .safeAreaInset(edge: .bottom, spacing: 0) {
             if case .error = self.viewModel.loadingState {} else {
                 PlayerBar()

--- a/Tests/KasetTests/PlaylistDetailViewModelTests.swift
+++ b/Tests/KasetTests/PlaylistDetailViewModelTests.swift
@@ -192,6 +192,125 @@ struct PlaylistDetailViewModelTests {
         #expect(likedMusicViewModel.hasMore == false)
     }
 
+    @Test("Liked Music search filters loaded tracks by title artist album and video ID")
+    func likedMusicSearchFiltersLoadedTracks() async {
+        let albumMatchedSong = Song(
+            id: "album-match",
+            title: "Quiet Track",
+            artists: [Artist(id: "artist-quiet", name: "Quiet Artist")],
+            album: TestFixtures.makeAlbum(id: "album-synth", title: "Neon Nights"),
+            videoId: "album-match"
+        )
+        let tracks = [
+            TestFixtures.makeSong(id: "title-match", title: "Blue Horizon", artistName: "Ocean Band"),
+            TestFixtures.makeSong(id: "artist-match", title: "Morning", artistName: "Blue Choir"),
+            albumMatchedSong,
+            TestFixtures.makeSong(id: "video-special-123", title: "Hidden", artistName: "Other Artist"),
+            TestFixtures.makeSong(id: "no-match", title: "Sunrise", artistName: "Warm Band"),
+        ]
+        let likedMusicViewModel = self.makeLikedMusicViewModel(with: tracks, trackCount: tracks.count)
+
+        await likedMusicViewModel.load()
+        guard let detail = likedMusicViewModel.playlistDetail else {
+            Issue.record("Expected Liked Music detail")
+            return
+        }
+
+        likedMusicViewModel.likedMusicSearchQuery = " blue "
+        #expect(likedMusicViewModel.visibleTracks(for: detail).map(\.videoId) == ["title-match", "artist-match"])
+
+        likedMusicViewModel.likedMusicSearchQuery = "neon"
+        #expect(likedMusicViewModel.visibleTracks(for: detail).map(\.videoId) == ["album-match"])
+
+        likedMusicViewModel.likedMusicSearchQuery = "SPECIAL-123"
+        #expect(likedMusicViewModel.visibleTracks(for: detail).map(\.videoId) == ["video-special-123"])
+    }
+
+    @Test("Liked Music blank search keeps all loaded tracks visible")
+    func likedMusicBlankSearchKeepsAllTracksVisible() async {
+        let tracks = [
+            TestFixtures.makeSong(id: "liked-1", title: "Liked 1"),
+            TestFixtures.makeSong(id: "liked-2", title: "Liked 2"),
+        ]
+        let likedMusicViewModel = self.makeLikedMusicViewModel(with: tracks, trackCount: 2)
+
+        await likedMusicViewModel.load()
+        likedMusicViewModel.likedMusicSearchQuery = "   "
+
+        guard let detail = likedMusicViewModel.playlistDetail else {
+            Issue.record("Expected Liked Music detail")
+            return
+        }
+        #expect(likedMusicViewModel.hasActiveLikedMusicSearch == false)
+        #expect(likedMusicViewModel.visibleTracks(for: detail).map(\.videoId) == ["liked-1", "liked-2"])
+    }
+
+    @Test("Liked Music search results update as continuation batches load")
+    func likedMusicSearchResultsUpdateAsContinuationBatchesLoad() async {
+        let initialTracks = [
+            TestFixtures.makeSong(id: "liked-1", title: "Calm Intro"),
+            TestFixtures.makeSong(id: "liked-2", title: "Soft Verse"),
+        ]
+        let likedMusicViewModel = self.makeLikedMusicViewModel(with: initialTracks, trackCount: 4)
+        self.mockClient.playlistContinuationDelay = .milliseconds(80)
+        self.mockClient.playlistContinuationTracks[LikedMusicPlaylist.id] = [
+            [
+                TestFixtures.makeSong(id: "liked-3", title: "Live Search Match"),
+                TestFixtures.makeSong(id: "liked-4", title: "Finale"),
+            ],
+        ]
+
+        likedMusicViewModel.likedMusicSearchQuery = "search match"
+        await likedMusicViewModel.load()
+
+        guard let partialDetail = likedMusicViewModel.playlistDetail else {
+            Issue.record("Expected initial Liked Music detail before continuation finishes")
+            return
+        }
+        #expect(likedMusicViewModel.visibleTracks(for: partialDetail).isEmpty)
+
+        await self.waitUntil(
+            likedMusicViewModel.playlistDetail?.tracks.count == 4,
+            description: "Liked Music search continuation result"
+        )
+
+        guard let finalDetail = likedMusicViewModel.playlistDetail else {
+            Issue.record("Expected final Liked Music detail")
+            return
+        }
+        #expect(likedMusicViewModel.visibleTracks(for: finalDetail).map(\.videoId) == ["liked-3"])
+        #expect(likedMusicViewModel.hasMore == false)
+    }
+
+    @Test("Non Liked Music playlist ignores liked music search query")
+    func nonLikedMusicPlaylistIgnoresLikedMusicSearchQuery() async {
+        let playlistDetail = TestFixtures.makePlaylistDetail(
+            playlist: TestFixtures.makePlaylist(id: "VL-test-playlist"),
+            trackCount: 2
+        )
+        self.mockClient.playlistDetails["VL-test-playlist"] = playlistDetail
+
+        await self.viewModel.load()
+        self.viewModel.likedMusicSearchQuery = "no-result"
+
+        guard let detail = self.viewModel.playlistDetail else {
+            Issue.record("Expected playlist detail")
+            return
+        }
+        #expect(self.viewModel.hasActiveLikedMusicSearch == false)
+        #expect(self.viewModel.visibleTracks(for: detail).count == 2)
+    }
+
+    @Test("Clear Liked Music search resets query")
+    func clearLikedMusicSearchResetsQuery() {
+        let likedMusicViewModel = self.makeLikedMusicViewModel(with: [], trackCount: 0)
+        likedMusicViewModel.likedMusicSearchQuery = "blue"
+
+        likedMusicViewModel.clearLikedMusicSearch()
+
+        #expect(likedMusicViewModel.likedMusicSearchQuery.isEmpty)
+    }
+
     @Test("Large playlist load fetches every continuation")
     func largePlaylistLoadFetchesEveryContinuation() async {
         let playlist = Playlist(


### PR DESCRIPTION
https://github.com/user-attachments/assets/f365f50a-e386-4d99-a378-ef1b5feef9a1

## Description

Adds live, in-place search to **Liked Music** and restores the native macOS 26 toolbar scroll-edge effect on track/detail pages that had it disabled.

The Liked Music page already eagerly paginates the full liked library, so search filters the loaded tracks client-side and matches keep appearing "live" as continuation batches arrive with no extra API calls and no new endpoint. The search field is pinned to the top of the list while scrolling. Separately, the detail/track pages (Liked Music, albums, releases, playlists, artist, top songs, discography, episodes) previously hid the toolbar background and painted a manual top fade, which suppressed the system scroll-edge effect; this restores the default effect while keeping the album-art accent background intact.

## AI Prompt (Optional)

<details>
<summary>🤖 AI Prompt Used</summary>

Developed with the assistance of Claude.

**AI Tool:** Claude

</details>

## Type of Change

- [x] ✨ New feature (live search in Liked Music)
- [x] 🎨 UI/UX improvement (restored native toolbar scroll-edge effect on detail pages)

## Related Issues

N/A

## Changes Made

- **Liked Music live search:** added `likedMusicSearchQuery` and `visibleTracks(for:)` filtering to `PlaylistDetailViewModel`, matching title, artists, album, and video ID (case- and diacritic-insensitive). Results update live as the liked library keeps paginating — filtering runs over already-loaded tracks, with no new API or endpoint.
- **Search UI:** new `LikedMusicSearchField` (liquid-glass + macOS 15 fallback styles) and `LikedMusicSearchEmptyState`, pinned as a sticky section header on the Liked Music list, with a live result count and clear button. Wired into both `PlaylistDetailView` (macOS 26) and `SimplePlaylistDetailView` (macOS 15).
- **Sticky-search fix:** when an active search shrinks the visible results, the list now scrolls back to the top via `ScrollViewReader`, so the pinned field stays visible and keeps focus (previously it unpinned mid-scroll and lost focus while the viewport stayed put).
- **Restored scroll-edge effect:** removed `.toolbarBackgroundVisibility(.hidden)` and the manual `.topFade(...)` from `PlaylistDetailView`, `ArtistDetailView`, `ArtistDiscographyView`, `ArtistEpisodesListView`, and `TopSongsView`, so the native macOS 26 toolbar scroll-edge effect returns. The `accentBackground` album-art gradient is untouched.
- **Refactor:** extracted shared track-row / navigation-link views into `PlaylistDetailRows.swift`.
- **Accessibility:** added search field / clear button / empty-state identifiers.
- **Tests:** added `PlaylistDetailViewModelTests` coverage for search filtering, blank-query passthrough, live continuation updates, the non–Liked-Music guard, and clearing.

## Testing

- [x] Unit tests pass (`swift test --skip KasetUITests` — 1690 tests across 141 suites)
- [x] Manual testing performed (Liked Music search + scroll-to-top; restored scroll-edge effect on detail pages)
- [x] UI tested on macOS 26+ (`KasetUITests/LikedMusicViewUITests`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `swiftlint --strict && swiftformat .` (0 violations; 0 files require formatting)
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally
- [ ] I have updated documentation if needed (N/A — no doc-facing behavior changed)
- [x] I have checked for any performance implications (client-side filter over already-loaded tracks; no extra requests)
- [x] My changes generate no new warnings

## Additional Notes

Search intentionally reuses the existing Liked Music playlist pagination rather than a server-side "search liked songs" endpoint YouTube Music exposes no such scoped endpoint, so filtering the fully-paginated liked set client-side is consistent with the current Liked Music loading path.
