### PR TITLE
feat(youtube): add chapter navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ Thumbs.db
 *.key
 
 TEMP_*
+.tmp/
 build/
 .codex/environments/environment.toml
 Build

--- a/Sources/APIExplorer/main.swift
+++ b/Sources/APIExplorer/main.swift
@@ -523,6 +523,250 @@ func rendererHistogram(_ data: [String: Any], limit: Int = 25) -> String {
     return output
 }
 
+// MARK: - ChapterProbeItem
+
+private struct ChapterProbeItem: Hashable {
+    let videoId: String?
+    let title: String
+    let startMillis: Int?
+    let endMillis: Int?
+    let timeText: String?
+    let hasThumbnail: Bool
+}
+
+private func textValue(from value: Any?) -> String? {
+    if let string = value as? String {
+        return string.isEmpty ? nil : string
+    }
+
+    guard let dictionary = value as? [String: Any] else {
+        return nil
+    }
+
+    if let simpleText = dictionary["simpleText"] as? String, !simpleText.isEmpty {
+        return simpleText
+    }
+
+    if let content = dictionary["content"] as? String, !content.isEmpty {
+        return content
+    }
+
+    if let runs = dictionary["runs"] as? [[String: Any]] {
+        let text = runs.compactMap { $0["text"] as? String }.joined()
+        return text.isEmpty ? nil : text
+    }
+
+    return nil
+}
+
+private func intValue(from value: Any?) -> Int? {
+    switch value {
+    case let int as Int:
+        int
+    case let double as Double:
+        Int(double)
+    case let number as NSNumber:
+        Int(number.int64Value)
+    case let string as String:
+        Int(string)
+    default:
+        nil
+    }
+}
+
+private func formatMillis(_ millis: Int?) -> String {
+    guard let millis else { return "?:??" }
+
+    let totalSeconds = max(0, millis / 1000)
+    let hours = totalSeconds / 3600
+    let minutes = (totalSeconds % 3600) / 60
+    let seconds = totalSeconds % 60
+
+    if hours > 0 {
+        return String(format: "%d:%02d:%02d", hours, minutes, seconds)
+    }
+    return String(format: "%d:%02d", minutes, seconds)
+}
+
+private func findRepeatChapterCommand(in value: Any?) -> [String: Any]? {
+    if let dictionary = value as? [String: Any] {
+        if let command = dictionary["repeatChapterCommand"] as? [String: Any] {
+            return command
+        }
+
+        for nestedValue in dictionary.values {
+            if let command = findRepeatChapterCommand(in: nestedValue) {
+                return command
+            }
+        }
+    } else if let array = value as? [Any] {
+        for item in array {
+            if let command = findRepeatChapterCommand(in: item) {
+                return command
+            }
+        }
+    }
+
+    return nil
+}
+
+private func watchEndpoint(from renderer: [String: Any]) -> [String: Any]? {
+    guard let onTap = renderer["onTap"] as? [String: Any],
+          let watchEndpoint = onTap["watchEndpoint"] as? [String: Any]
+    else {
+        return nil
+    }
+
+    return watchEndpoint
+}
+
+private func chapterProbeItem(fromChapterRenderer renderer: [String: Any]) -> ChapterProbeItem? {
+    guard let title = textValue(from: renderer["title"]) else {
+        return nil
+    }
+
+    return ChapterProbeItem(
+        videoId: nil,
+        title: title,
+        startMillis: intValue(from: renderer["timeRangeStartMillis"]),
+        endMillis: nil,
+        timeText: nil,
+        hasThumbnail: renderer["thumbnail"] != nil
+    )
+}
+
+private func chapterProbeItem(fromMacroMarkerRenderer renderer: [String: Any]) -> ChapterProbeItem? {
+    guard let title = textValue(from: renderer["title"]) else {
+        return nil
+    }
+
+    let repeatCommand = findRepeatChapterCommand(in: renderer["repeatButton"])
+    let endpoint = watchEndpoint(from: renderer)
+    let startMillis = intValue(from: repeatCommand?["startTimeMs"])
+        ?? intValue(from: endpoint?["startTimeSeconds"]).map { $0 * 1000 }
+
+    return ChapterProbeItem(
+        videoId: endpoint?["videoId"] as? String,
+        title: title,
+        startMillis: startMillis,
+        endMillis: intValue(from: repeatCommand?["endTimeMs"]),
+        timeText: textValue(from: renderer["timeDescription"]),
+        hasThumbnail: renderer["thumbnail"] != nil
+    )
+}
+
+private func collectChapterProbeItems(
+    in value: Any,
+    chapterRenderers: inout [ChapterProbeItem],
+    macroMarkerItems: inout [ChapterProbeItem]
+) {
+    if let dictionary = value as? [String: Any] {
+        if let renderer = dictionary["chapterRenderer"] as? [String: Any],
+           let item = chapterProbeItem(fromChapterRenderer: renderer)
+        {
+            chapterRenderers.append(item)
+        }
+
+        if let renderer = dictionary["macroMarkersListItemRenderer"] as? [String: Any],
+           let item = chapterProbeItem(fromMacroMarkerRenderer: renderer)
+        {
+            macroMarkerItems.append(item)
+        }
+
+        for nestedValue in dictionary.values {
+            collectChapterProbeItems(
+                in: nestedValue,
+                chapterRenderers: &chapterRenderers,
+                macroMarkerItems: &macroMarkerItems
+            )
+        }
+    } else if let array = value as? [Any] {
+        for item in array {
+            collectChapterProbeItems(
+                in: item,
+                chapterRenderers: &chapterRenderers,
+                macroMarkerItems: &macroMarkerItems
+            )
+        }
+    }
+}
+
+private func deduplicatedChapterItems(_ items: [ChapterProbeItem]) -> [ChapterProbeItem] {
+    var seen: Set<String> = []
+    var result: [ChapterProbeItem] = []
+
+    for item in items {
+        let key = "\(item.videoId ?? "")|\(item.startMillis ?? -1)|\(item.title)"
+        guard seen.insert(key).inserted else { continue }
+        result.append(item)
+    }
+
+    return result.sorted { lhs, rhs in
+        switch (lhs.startMillis, rhs.startMillis) {
+        case let (left?, right?):
+            if left != right {
+                return left < right
+            }
+            return lhs.title < rhs.title
+        case (.some, nil):
+            return true
+        case (nil, .some):
+            return false
+        case (nil, nil):
+            return lhs.title < rhs.title
+        }
+    }
+}
+
+private func chapterProbeSummary(_ data: [String: Any], limit: Int = 8) -> String {
+    var chapterRenderers: [ChapterProbeItem] = []
+    var macroMarkerItems: [ChapterProbeItem] = []
+    collectChapterProbeItems(
+        in: data,
+        chapterRenderers: &chapterRenderers,
+        macroMarkerItems: &macroMarkerItems
+    )
+
+    let uniqueChapterRenderers = deduplicatedChapterItems(chapterRenderers)
+    let uniqueMacroMarkerItems = deduplicatedChapterItems(macroMarkerItems)
+    guard !uniqueChapterRenderers.isEmpty || !uniqueMacroMarkerItems.isEmpty else {
+        return ""
+    }
+
+    var output = "\n🎬 Chapter markers:\n"
+    if !uniqueChapterRenderers.isEmpty {
+        output += "  • playerOverlays chapterRenderer: \(uniqueChapterRenderers.count) unique chapter(s)"
+        if chapterRenderers.count != uniqueChapterRenderers.count {
+            output += " (\(chapterRenderers.count) raw)"
+        }
+        output += "\n"
+        output += "    Path: playerOverlays…multiMarkersPlayerBarRenderer.markersMap[].value.chapters[]\n"
+    }
+
+    if !uniqueMacroMarkerItems.isEmpty {
+        output += "  • macroMarkersListItemRenderer: \(uniqueMacroMarkerItems.count) unique chapter(s)"
+        if macroMarkerItems.count != uniqueMacroMarkerItems.count {
+            output += " (\(macroMarkerItems.count) raw; often duplicated in chapters panel + structured description/search preview)"
+        }
+        output += "\n"
+    }
+
+    let preferredItems = uniqueChapterRenderers.isEmpty ? uniqueMacroMarkerItems : uniqueChapterRenderers
+    let multipleVideoIds = Set(preferredItems.compactMap(\.videoId)).count > 1
+    for (index, item) in preferredItems.prefix(limit).enumerated() {
+        let start = item.timeText ?? formatMillis(item.startMillis)
+        let endSuffix = item.endMillis.map { "–\(formatMillis($0))" } ?? ""
+        let thumbnailSuffix = item.hasThumbnail ? " · thumbnail" : ""
+        let videoSuffix = multipleVideoIds ? " · videoId \(item.videoId ?? "unknown")" : ""
+        output += "    \(index + 1). \(start)\(endSuffix) — \(item.title)\(thumbnailSuffix)\(videoSuffix)\n"
+    }
+    if preferredItems.count > limit {
+        output += "    … and \(preferredItems.count - limit) more\n"
+    }
+
+    return output
+}
+
 func analyzeResponse(_ data: [String: Any], verbose: Bool = false) -> String {
     var output = ""
 
@@ -606,6 +850,8 @@ func analyzeResponse(_ data: [String: Any], verbose: Bool = false) -> String {
     if let playlistSummary = playlistBrowseSummary(data) {
         output += playlistSummary
     }
+
+    output += chapterProbeSummary(data)
 
     output += rendererHistogram(data)
 
@@ -1285,8 +1531,11 @@ func probeSigninSwitchReal(nextURLString: String) async {
         return
     }
     // Normalize protocol-relative URLs.
-    if signin.hasPrefix("//") { signin = "https:" + signin }
-    else if signin.hasPrefix("/") { signin = "https://www.youtube.com" + signin }
+    if signin.hasPrefix("//") {
+        signin = "https:" + signin
+    } else if signin.hasPrefix("/") {
+        signin = "https://www.youtube.com" + signin
+    }
 
     // Rewrite only the `next` param.
     guard var comps = URLComponents(string: signin) else {

--- a/Sources/Kaset/Models/YouTube/YouTubeFeed.swift
+++ b/Sources/Kaset/Models/YouTube/YouTubeFeed.swift
@@ -72,6 +72,26 @@ struct YouTubeHomeBundle {
     let shelves: [YouTubeHomeSection]
 }
 
+// MARK: - YouTubeChapter
+
+/// A navigation chapter exposed by YouTube's watch-next `next` response.
+struct YouTubeChapter: Identifiable, Hashable {
+    /// The video this chapter belongs to, when the renderer includes it.
+    let videoId: String?
+    let title: String
+    /// Chapter start time in seconds.
+    let startTime: TimeInterval
+    /// Chapter end time in seconds, when YouTube exposes chapter bounds.
+    let endTime: TimeInterval?
+    /// Display-ready time text from YouTube, e.g. "3:17".
+    let timeText: String?
+    let thumbnailURL: URL?
+
+    var id: String {
+        "\(self.videoId ?? "")-\(Int((self.startTime * 1000).rounded()))-\(self.title)"
+    }
+}
+
 // MARK: - YouTubeSearchResponse
 
 /// Results of a YouTube search, split by result kind.
@@ -146,11 +166,33 @@ struct WatchNextData {
     let publishedText: String?
     let channel: YouTubeChannel?
     let related: [YouTubeVideo]
+    /// Navigation chapters for the current video, when YouTube exposes them.
+    let chapters: [YouTubeChapter]
     /// Whether the signed-in user is subscribed to the video's channel
     /// (nil when the page did not expose a subscribe button).
     var isSubscribed: Bool?
     /// Continuation token for the video's comments section.
     var commentsContinuation: String?
+
+    init(
+        videoTitle: String?,
+        viewCountText: String?,
+        publishedText: String?,
+        channel: YouTubeChannel?,
+        related: [YouTubeVideo],
+        chapters: [YouTubeChapter] = [],
+        isSubscribed: Bool? = nil,
+        commentsContinuation: String? = nil
+    ) {
+        self.videoTitle = videoTitle
+        self.viewCountText = viewCountText
+        self.publishedText = publishedText
+        self.channel = channel
+        self.related = related
+        self.chapters = chapters
+        self.isSubscribed = isSubscribed
+        self.commentsContinuation = commentsContinuation
+    }
 
     static let empty = WatchNextData(
         videoTitle: nil,

--- a/Sources/Kaset/Services/API/Parsers/YouTube/WatchNextParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/YouTube/WatchNextParser.swift
@@ -254,15 +254,18 @@ enum WatchNextParser {
 
     private static func milliseconds(fromTimeText text: String) -> Int? {
         let parts = text.split(separator: ":")
-        guard parts.count == 2 || parts.count == 3 else { return nil }
+        guard parts.count == 2 || parts.count == 3 else {
+            return nil
+        }
         let values = parts.compactMap { Int($0) }
-        guard values.count == parts.count else { return nil }
+        guard values.count == parts.count else {
+            return nil
+        }
 
-        let seconds: Int
-        if values.count == 3 {
-            seconds = values[0] * 3600 + values[1] * 60 + values[2]
+        let seconds: Int = if values.count == 3 {
+            values[0] * 3600 + values[1] * 60 + values[2]
         } else {
-            seconds = values[0] * 60 + values[1]
+            values[0] * 60 + values[1]
         }
         return seconds * 1000
     }

--- a/Sources/Kaset/Services/API/Parsers/YouTube/WatchNextParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/YouTube/WatchNextParser.swift
@@ -52,15 +52,39 @@ enum WatchNextParser {
             )
         }
 
+        let chapters = Self.chapters(of: data)
+
         return WatchNextData(
             videoTitle: videoTitle,
             viewCountText: viewCountText,
             publishedText: publishedText,
             channel: channel,
             related: YouTubeFeedParser.deduplicate(related),
+            chapters: chapters,
             isSubscribed: isSubscribed,
             commentsContinuation: Self.commentsContinuation(of: data)
         )
+    }
+
+    /// Navigation chapters exposed by YouTube's watch-next response.
+    ///
+    /// Prefer the player bar's `chapterRenderer` markers because they are the
+    /// canonical watch-page timeline source. Fall back to
+    /// `macroMarkersListItemRenderer`, which can appear in the chapters panel,
+    /// structured description, and search previews, and therefore needs
+    /// de-duplication.
+    static func chapters(of data: [String: Any]) -> [YouTubeChapter] {
+        let videoId = self.currentVideoId(of: data)
+        var chapterRenderers: [YouTubeChapter] = []
+        self.collectChapterRenderers(in: data, videoId: videoId, chapters: &chapterRenderers)
+        let canonical = self.deduplicateChapters(chapterRenderers)
+        if !canonical.isEmpty {
+            return canonical
+        }
+
+        var macroMarkers: [YouTubeChapter] = []
+        self.collectMacroMarkerRenderers(in: data, fallbackVideoId: videoId, chapters: &macroMarkers)
+        return self.deduplicateChapters(macroMarkers)
     }
 
     /// The continuation token for the watch page's comments section
@@ -111,6 +135,179 @@ enum WatchNextParser {
             }
         }
         return nil
+    }
+
+    private static func currentVideoId(of data: [String: Any]) -> String? {
+        if let endpoint = data["currentVideoEndpoint"] as? [String: Any],
+           let watchEndpoint = endpoint["watchEndpoint"] as? [String: Any],
+           let videoId = watchEndpoint["videoId"] as? String,
+           !videoId.isEmpty
+        {
+            return videoId
+        }
+
+        return nil
+    }
+
+    private static func collectChapterRenderers(
+        in value: Any,
+        videoId: String?,
+        chapters: inout [YouTubeChapter]
+    ) {
+        if let dict = value as? [String: Any] {
+            if let renderer = dict["chapterRenderer"] as? [String: Any],
+               let chapter = self.chapter(fromChapterRenderer: renderer, videoId: videoId)
+            {
+                chapters.append(chapter)
+            }
+
+            for nested in dict.values {
+                self.collectChapterRenderers(in: nested, videoId: videoId, chapters: &chapters)
+            }
+        } else if let array = value as? [Any] {
+            for element in array {
+                self.collectChapterRenderers(in: element, videoId: videoId, chapters: &chapters)
+            }
+        }
+    }
+
+    private static func collectMacroMarkerRenderers(
+        in value: Any,
+        fallbackVideoId: String?,
+        chapters: inout [YouTubeChapter]
+    ) {
+        if let dict = value as? [String: Any] {
+            if let renderer = dict["macroMarkersListItemRenderer"] as? [String: Any],
+               let chapter = self.chapter(fromMacroMarkerRenderer: renderer, fallbackVideoId: fallbackVideoId)
+            {
+                chapters.append(chapter)
+            }
+
+            for nested in dict.values {
+                self.collectMacroMarkerRenderers(
+                    in: nested,
+                    fallbackVideoId: fallbackVideoId,
+                    chapters: &chapters
+                )
+            }
+        } else if let array = value as? [Any] {
+            for element in array {
+                self.collectMacroMarkerRenderers(
+                    in: element,
+                    fallbackVideoId: fallbackVideoId,
+                    chapters: &chapters
+                )
+            }
+        }
+    }
+
+    private static func chapter(
+        fromChapterRenderer renderer: [String: Any],
+        videoId: String?
+    ) -> YouTubeChapter? {
+        guard let title = YouTubeItemParser.text(from: renderer["title"]),
+              let startMillis = self.intValue(from: renderer["timeRangeStartMillis"])
+        else {
+            return nil
+        }
+
+        return YouTubeChapter(
+            videoId: videoId,
+            title: title,
+            startTime: TimeInterval(startMillis) / 1000,
+            endTime: nil,
+            timeText: nil,
+            thumbnailURL: YouTubeItemParser.thumbnailURL(fromThumbnail: renderer["thumbnail"])
+        )
+    }
+
+    private static func chapter(
+        fromMacroMarkerRenderer renderer: [String: Any],
+        fallbackVideoId: String?
+    ) -> YouTubeChapter? {
+        guard let title = YouTubeItemParser.text(from: renderer["title"]) else {
+            return nil
+        }
+
+        let repeatCommand = self.findRepeatChapterCommand(in: renderer["repeatButton"])
+        let watchEndpoint = self.watchEndpoint(from: renderer)
+        let endpointVideoId = watchEndpoint?["videoId"] as? String
+        if let fallbackVideoId, let endpointVideoId, endpointVideoId != fallbackVideoId {
+            return nil
+        }
+        let startMillis = self.intValue(from: repeatCommand?["startTimeMs"])
+            ?? self.intValue(from: watchEndpoint?["startTimeSeconds"]).map { $0 * 1000 }
+
+        guard let startMillis else { return nil }
+
+        return YouTubeChapter(
+            videoId: endpointVideoId ?? fallbackVideoId,
+            title: title,
+            startTime: TimeInterval(startMillis) / 1000,
+            endTime: self.intValue(from: repeatCommand?["endTimeMs"]).map { TimeInterval($0) / 1000 },
+            timeText: YouTubeItemParser.text(from: renderer["timeDescription"]),
+            thumbnailURL: YouTubeItemParser.thumbnailURL(fromThumbnail: renderer["thumbnail"])
+        )
+    }
+
+    private static func watchEndpoint(from renderer: [String: Any]) -> [String: Any]? {
+        guard let onTap = renderer["onTap"] as? [String: Any] else { return nil }
+        return onTap["watchEndpoint"] as? [String: Any]
+    }
+
+    private static func findRepeatChapterCommand(in value: Any?) -> [String: Any]? {
+        if let dict = value as? [String: Any] {
+            if let command = dict["repeatChapterCommand"] as? [String: Any] {
+                return command
+            }
+
+            for nested in dict.values {
+                if let command = self.findRepeatChapterCommand(in: nested) {
+                    return command
+                }
+            }
+        } else if let array = value as? [Any] {
+            for element in array {
+                if let command = self.findRepeatChapterCommand(in: element) {
+                    return command
+                }
+            }
+        }
+
+        return nil
+    }
+
+    private static func intValue(from value: Any?) -> Int? {
+        switch value {
+        case let int as Int:
+            int
+        case let double as Double:
+            Int(double)
+        case let number as NSNumber:
+            Int(number.int64Value)
+        case let string as String:
+            Int(string)
+        default:
+            nil
+        }
+    }
+
+    private static func deduplicateChapters(_ chapters: [YouTubeChapter]) -> [YouTubeChapter] {
+        var seen: Set<String> = []
+        var result: [YouTubeChapter] = []
+
+        for chapter in chapters {
+            let key = "\(chapter.videoId ?? "")|\(Int((chapter.startTime * 1000).rounded()))|\(chapter.title)"
+            guard seen.insert(key).inserted else { continue }
+            result.append(chapter)
+        }
+
+        return result.sorted { lhs, rhs in
+            if lhs.startTime != rhs.startTime {
+                return lhs.startTime < rhs.startTime
+            }
+            return lhs.title < rhs.title
+        }
     }
 
     // MARK: - Private

--- a/Sources/Kaset/Services/API/Parsers/YouTube/WatchNextParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/YouTube/WatchNextParser.swift
@@ -235,8 +235,10 @@ enum WatchNextParser {
         if let fallbackVideoId, let endpointVideoId, endpointVideoId != fallbackVideoId {
             return nil
         }
+        let timeText = YouTubeItemParser.text(from: renderer["timeDescription"])
         let startMillis = self.intValue(from: repeatCommand?["startTimeMs"])
             ?? self.intValue(from: watchEndpoint?["startTimeSeconds"]).map { $0 * 1000 }
+            ?? timeText.flatMap(self.milliseconds(fromTimeText:))
 
         guard let startMillis else { return nil }
 
@@ -245,9 +247,24 @@ enum WatchNextParser {
             title: title,
             startTime: TimeInterval(startMillis) / 1000,
             endTime: self.intValue(from: repeatCommand?["endTimeMs"]).map { TimeInterval($0) / 1000 },
-            timeText: YouTubeItemParser.text(from: renderer["timeDescription"]),
+            timeText: timeText,
             thumbnailURL: YouTubeItemParser.thumbnailURL(fromThumbnail: renderer["thumbnail"])
         )
+    }
+
+    private static func milliseconds(fromTimeText text: String) -> Int? {
+        let parts = text.split(separator: ":")
+        guard parts.count == 2 || parts.count == 3 else { return nil }
+        let values = parts.compactMap { Int($0) }
+        guard values.count == parts.count else { return nil }
+
+        let seconds: Int
+        if values.count == 3 {
+            seconds = values[0] * 3600 + values[1] * 60 + values[2]
+        } else {
+            seconds = values[0] * 60 + values[1]
+        }
+        return seconds * 1000
     }
 
     private static func watchEndpoint(from renderer: [String: Any]) -> [String: Any]? {

--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -251,7 +251,7 @@ final class YouTubePlayerService {
     // MARK: - Commands
 
     /// Starts playback of a video, docked inline.
-    func play(video: YouTubeVideo, usesCookieFreeDataStore: Bool = false) {
+    func play(video: YouTubeVideo, usesCookieFreeDataStore: Bool = false, startAt: Double? = nil) {
         self.logger.info("YouTubePlayer: play video")
         self.usesCookieFreePlaybackDataStore = usesCookieFreeDataStore
         self.playbackWillStart?()
@@ -275,7 +275,11 @@ final class YouTubePlayerService {
             playerService: self,
             usesCookieFreeDataStore: self.usesCookieFreePlaybackDataStore
         )
-        self.playbackController.loadVideo(videoId: video.videoId)
+        if let startAt, startAt > 0 {
+            self.playbackController.reloadVideo(videoId: video.videoId, resumeAt: startAt)
+        } else {
+            self.playbackController.loadVideo(videoId: video.videoId)
+        }
     }
 
     /// Re-points the current video under the WebView session's current

--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -275,7 +275,7 @@ final class YouTubePlayerService {
             playerService: self,
             usesCookieFreeDataStore: self.usesCookieFreePlaybackDataStore
         )
-        if let startAt, startAt > 0 {
+        if let startAt, startAt >= 0 {
             self.playbackController.reloadVideo(videoId: video.videoId, resumeAt: startAt)
         } else {
             self.playbackController.loadVideo(videoId: video.videoId)

--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -166,6 +166,10 @@ final class YouTubePlayerService {
     /// Up-next candidates for skip-forward (related videos from the watch page).
     private(set) var upNext: [YouTubeVideo] = []
 
+    /// Navigation chapters for the current video, loaded from the watch page's
+    /// companion `next` response.
+    private(set) var chapters: [YouTubeChapter] = []
+
     /// Videos played earlier this session, for skip-backward.
     private var history: [YouTubeVideo] = []
 
@@ -332,7 +336,9 @@ final class YouTubePlayerService {
     /// Toggles play/pause.
     func playPause() {
         if !self.isPlaying {
-            if self.reloadPendingPausedIdentitySwitchForUserResume() { return }
+            if self.reloadPendingPausedIdentitySwitchForUserResume() {
+                return
+            }
             self.playbackWillStart?()
         } else {
             self.deferInFlightIdentityReloadIfNeeded()
@@ -343,7 +349,9 @@ final class YouTubePlayerService {
 
     /// Resumes playback.
     func resume() {
-        if self.reloadPendingPausedIdentitySwitchForUserResume() { return }
+        if self.reloadPendingPausedIdentitySwitchForUserResume() {
+            return
+        }
         self.playbackWillStart?()
         self.playbackController.play()
     }
@@ -460,6 +468,15 @@ final class YouTubePlayerService {
         self.upNext = videos.filter { $0.videoId != currentId && !$0.isShort }
     }
 
+    /// Supplies chapter navigation markers for the current video.
+    func setChapters(_ chapters: [YouTubeChapter]) {
+        guard let currentId = self.currentVideo?.videoId else {
+            self.chapters = []
+            return
+        }
+        self.chapters = chapters.filter { $0.videoId == nil || $0.videoId == currentId }
+    }
+
     /// Skips to the next video (first up-next candidate; fetched lazily
     /// when none are known, e.g. when playing in the floating window).
     func skipForward() async {
@@ -533,6 +550,7 @@ final class YouTubePlayerService {
         self.duration = 0
         self.currentRating = .none
         self.isInWatchLater = false
+        self.chapters = []
         self.captionTracks = []
         self.activeCaptionLanguageCode = nil
         self.qualityLevels = []

--- a/Sources/Kaset/Views/PlayerBarProgressLane.swift
+++ b/Sources/Kaset/Views/PlayerBarProgressLane.swift
@@ -19,7 +19,6 @@ struct PlayerBarProgressLane: View {
     @Environment(\.colorScheme) private var colorScheme
     @State private var isDragging = false
     @State private var isHovering = false
-    @State private var hoverFraction: Double?
     @State private var dragFraction: Double?
     @State private var previewChapterMarker: PlayerBarProgressMarker?
 
@@ -177,12 +176,10 @@ struct PlayerBarProgressLane: View {
                 case let .active(location):
                     let x = location.x - PlayerBarSliderVisuals.hitOutset
                     let fraction = Double(min(max(0, x / width), 1))
-                    self.hoverFraction = fraction
                     if self.dragFraction == nil {
                         self.updatePreviewMarker(self.nearestMarker(to: fraction, width: width))
                     }
                 case .ended:
-                    self.hoverFraction = nil
                     if self.dragFraction == nil {
                         self.updatePreviewMarker(nil)
                     }
@@ -192,7 +189,6 @@ struct PlayerBarProgressLane: View {
             .onHover { hovering in
                 self.isHovering = hovering
                 if !hovering {
-                    self.hoverFraction = nil
                     if self.dragFraction == nil {
                         self.updatePreviewMarker(nil)
                     }

--- a/Sources/Kaset/Views/PlayerBarProgressLane.swift
+++ b/Sources/Kaset/Views/PlayerBarProgressLane.swift
@@ -7,19 +7,50 @@ struct PlayerBarProgressLane: View {
     let accent: Color
     let elapsedText: String
     let remainingText: String
+    let markers: [PlayerBarProgressMarker]
     let isLive: Bool
     let canSeek: Bool
     let isLoading: Bool
     let onScrub: (Double) -> Void
     let onCommit: () -> Void
+    let onMarkerPreviewChange: (PlayerBarProgressMarker?) -> Void
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.colorScheme) private var colorScheme
     @State private var isDragging = false
     @State private var isHovering = false
+    @State private var hoverFraction: Double?
+    @State private var dragFraction: Double?
+    @State private var previewChapterMarker: PlayerBarProgressMarker?
 
     private var clampedFraction: CGFloat {
         CGFloat(min(max(0, self.fraction), 1))
+    }
+
+    init(
+        fraction: Double,
+        accent: Color,
+        elapsedText: String,
+        remainingText: String,
+        markers: [PlayerBarProgressMarker] = [],
+        isLive: Bool,
+        canSeek: Bool,
+        isLoading: Bool,
+        onScrub: @escaping (Double) -> Void,
+        onCommit: @escaping () -> Void,
+        onMarkerPreviewChange: @escaping (PlayerBarProgressMarker?) -> Void = { _ in }
+    ) {
+        self.fraction = fraction
+        self.accent = accent
+        self.elapsedText = elapsedText
+        self.remainingText = remainingText
+        self.markers = markers
+        self.isLive = isLive
+        self.canSeek = canSeek
+        self.isLoading = isLoading
+        self.onScrub = onScrub
+        self.onCommit = onCommit
+        self.onMarkerPreviewChange = onMarkerPreviewChange
     }
 
     var body: some View {
@@ -67,6 +98,7 @@ struct PlayerBarProgressLane: View {
             )
             let fillColor = self.isLoading ? self.loadingFillColor : self.accent
             let thumbColor = self.isLoading ? self.loadingThumbColor : self.accent
+            let previewMarker = self.previewChapterMarker
 
             ZStack(alignment: .topLeading) {
                 Capsule()
@@ -88,6 +120,16 @@ struct PlayerBarProgressLane: View {
                     )
                     .frame(height: PlayerBarSliderVisuals.trackThickness)
                     .transition(.opacity)
+                }
+
+                ForEach(self.markers) { marker in
+                    self.markerView(marker, isHighlighted: marker.id == previewMarker?.id)
+                        .offset(
+                            x: self.markerX(marker, trackWidth: width),
+                            y: -3
+                        )
+                        .opacity(self.isLive || self.isLoading ? 0 : 1)
+                        .accessibilityHidden(true)
                 }
 
                 Circle()
@@ -113,20 +155,91 @@ struct PlayerBarProgressLane: View {
                         self.isDragging = true
                         let x = value.location.x - PlayerBarSliderVisuals.hitOutset
                         let fraction = Double(min(max(0, x / width), 1))
+                        self.dragFraction = fraction
+                        self.updatePreviewMarker(self.nearestMarker(to: fraction, width: width))
                         self.onScrub(fraction)
                     }
-                    .onEnded { _ in
-                        guard self.canSeek else { return }
+                    .onEnded { value in
+                        guard self.canSeek, width > 0 else { return }
+                        let x = value.location.x - PlayerBarSliderVisuals.hitOutset
+                        let fraction = Double(min(max(0, x / width), 1))
+                        let targetFraction = self.snappedFraction(fraction, width: width)
+                        self.onScrub(targetFraction)
+                        self.dragFraction = nil
+                        self.updatePreviewMarker(nil)
                         self.isDragging = false
                         self.onCommit()
                     }
             )
+            .onContinuousHover { phase in
+                guard width > 0 else { return }
+                switch phase {
+                case let .active(location):
+                    let x = location.x - PlayerBarSliderVisuals.hitOutset
+                    let fraction = Double(min(max(0, x / width), 1))
+                    self.hoverFraction = fraction
+                    if self.dragFraction == nil {
+                        self.updatePreviewMarker(self.nearestMarker(to: fraction, width: width))
+                    }
+                case .ended:
+                    self.hoverFraction = nil
+                    if self.dragFraction == nil {
+                        self.updatePreviewMarker(nil)
+                    }
+                }
+            }
             .padding(-PlayerBarSliderVisuals.hitOutset)
             .onHover { hovering in
                 self.isHovering = hovering
+                if !hovering {
+                    self.hoverFraction = nil
+                    if self.dragFraction == nil {
+                        self.updatePreviewMarker(nil)
+                    }
+                }
             }
         }
         .frame(height: 12)
+    }
+
+    private func updatePreviewMarker(_ marker: PlayerBarProgressMarker?) {
+        guard self.previewChapterMarker != marker else { return }
+        self.previewChapterMarker = marker
+        self.onMarkerPreviewChange(marker)
+    }
+
+    private func markerX(_ marker: PlayerBarProgressMarker, trackWidth: CGFloat) -> CGFloat {
+        // Marker and thumb offsets are inside the visual-track ZStack. Gesture
+        // locations subtract `hitOutset` because the gesture is attached after
+        // padding expands the hit target; visual offsets do not include it.
+        min(max(0, trackWidth * CGFloat(marker.fraction) - 2), max(0, trackWidth - 4))
+    }
+
+    private func markerView(_: PlayerBarProgressMarker, isHighlighted: Bool) -> some View {
+        ZStack {
+            Capsule()
+                .fill(self.markerHaloColor)
+                .frame(width: isHighlighted ? 6 : 5, height: PlayerBarSliderVisuals.trackThickness + 8)
+
+            Capsule()
+                .fill(isHighlighted ? self.accent : self.markerColor)
+                .frame(width: isHighlighted ? 3 : 2, height: PlayerBarSliderVisuals.trackThickness + 5)
+        }
+        .animation(PlayerBarSliderVisuals.thumbAnimation, value: isHighlighted)
+    }
+
+    private func snappedFraction(_ fraction: Double, width: CGFloat) -> Double {
+        self.nearestMarker(to: fraction, width: width)?.fraction ?? fraction
+    }
+
+    private func nearestMarker(to fraction: Double, width: CGFloat) -> PlayerBarProgressMarker? {
+        guard !self.markers.isEmpty, width > 0 else { return nil }
+        let threshold = max(0.006, min(0.025, 14 / Double(width)))
+        return self.markers
+            .map { marker in (marker: marker, distance: abs(marker.fraction - fraction)) }
+            .filter { $0.distance <= threshold }
+            .min { lhs, rhs in lhs.distance < rhs.distance }?
+            .marker
     }
 
     private func nudge(by delta: Double) {
@@ -147,5 +260,29 @@ struct PlayerBarProgressLane: View {
 
     private var loadingThumbColor: Color {
         PlayerBarSliderVisuals.loadingThumbColor(colorScheme: self.colorScheme)
+    }
+
+    private var markerColor: Color {
+        self.colorScheme == .dark ? .white.opacity(0.88) : .black.opacity(0.48)
+    }
+
+    private var markerHaloColor: Color {
+        self.colorScheme == .dark ? .black.opacity(0.55) : .white.opacity(0.9)
+    }
+}
+
+// MARK: - PlayerBarProgressMarker
+
+struct PlayerBarProgressMarker: Identifiable, Hashable {
+    let id: String
+    let fraction: Double
+    let title: String?
+    let subtitle: String?
+
+    init(id: String, fraction: Double, title: String? = nil, subtitle: String? = nil) {
+        self.id = id
+        self.fraction = min(max(0, fraction), 1)
+        self.title = title
+        self.subtitle = subtitle
     }
 }

--- a/Sources/Kaset/Views/PlayerBarProgressLane.swift
+++ b/Sources/Kaset/Views/PlayerBarProgressLane.swift
@@ -160,14 +160,16 @@ struct PlayerBarProgressLane: View {
                         self.onScrub(fraction)
                     }
                     .onEnded { value in
+                        defer {
+                            self.dragFraction = nil
+                            self.updatePreviewMarker(nil)
+                            self.isDragging = false
+                        }
                         guard self.canSeek, width > 0 else { return }
                         let x = value.location.x - PlayerBarSliderVisuals.hitOutset
                         let fraction = Double(min(max(0, x / width), 1))
                         let targetFraction = self.snappedFraction(fraction, width: width)
                         self.onScrub(targetFraction)
-                        self.dragFraction = nil
-                        self.updatePreviewMarker(nil)
-                        self.isDragging = false
                         self.onCommit()
                     }
             )

--- a/Sources/Kaset/Views/PlayerBarProgressLane.swift
+++ b/Sources/Kaset/Views/PlayerBarProgressLane.swift
@@ -122,9 +122,10 @@ struct PlayerBarProgressLane: View {
                 }
 
                 ForEach(self.markers) { marker in
-                    self.markerView(marker, isHighlighted: marker.id == previewMarker?.id)
+                    let isHighlighted = marker.id == previewMarker?.id
+                    self.markerView(marker, isHighlighted: isHighlighted)
                         .offset(
-                            x: self.markerX(marker, trackWidth: width),
+                            x: self.markerX(marker, trackWidth: width, isHighlighted: isHighlighted),
                             y: -3
                         )
                         .opacity(self.isLive || self.isLoading ? 0 : 1)
@@ -204,24 +205,47 @@ struct PlayerBarProgressLane: View {
         self.onMarkerPreviewChange(marker)
     }
 
-    private func markerX(_ marker: PlayerBarProgressMarker, trackWidth: CGFloat) -> CGFloat {
+    private func markerX(_ marker: PlayerBarProgressMarker, trackWidth: CGFloat, isHighlighted: Bool) -> CGFloat {
         // Marker and thumb offsets are inside the visual-track ZStack. Gesture
         // locations subtract `hitOutset` because the gesture is attached after
         // padding expands the hit target; visual offsets do not include it.
-        min(max(0, trackWidth * CGFloat(marker.fraction) - 2), max(0, trackWidth - 4))
+        let markerWidth = self.markerWidth(isHighlighted: isHighlighted)
+        return min(
+            max(0, trackWidth * CGFloat(marker.fraction) - markerWidth / 2),
+            max(0, trackWidth - markerWidth)
+        )
     }
 
     private func markerView(_: PlayerBarProgressMarker, isHighlighted: Bool) -> some View {
-        ZStack {
-            Capsule()
-                .fill(self.markerHaloColor)
-                .frame(width: isHighlighted ? 6 : 5, height: PlayerBarSliderVisuals.trackThickness + 8)
+        Capsule()
+            .fill(self.markerFallbackFill(isHighlighted: isHighlighted))
+            .frame(
+                width: self.markerWidth(isHighlighted: isHighlighted),
+                height: self.markerHeight(isHighlighted: isHighlighted)
+            )
+            .compatGlass(
+                interactive: isHighlighted,
+                tint: self.markerGlassTint(isHighlighted: isHighlighted),
+                in: .capsule
+            )
+            .overlay {
+                Capsule()
+                    .strokeBorder(self.markerRimColor(isHighlighted: isHighlighted), lineWidth: 0.6)
+            }
+            .shadow(
+                color: self.markerShadowColor(isHighlighted: isHighlighted),
+                radius: isHighlighted ? 5 : 1.5,
+                y: isHighlighted ? 2 : 0.5
+            )
+            .animation(PlayerBarSliderVisuals.thumbAnimation, value: isHighlighted)
+    }
 
-            Capsule()
-                .fill(isHighlighted ? self.accent : self.markerColor)
-                .frame(width: isHighlighted ? 3 : 2, height: PlayerBarSliderVisuals.trackThickness + 5)
-        }
-        .animation(PlayerBarSliderVisuals.thumbAnimation, value: isHighlighted)
+    private func markerWidth(isHighlighted: Bool) -> CGFloat {
+        isHighlighted ? 8 : 4
+    }
+
+    private func markerHeight(isHighlighted: Bool) -> CGFloat {
+        PlayerBarSliderVisuals.trackThickness + (isHighlighted ? 10 : 7)
     }
 
     private func snappedFraction(_ fraction: Double, width: CGFloat) -> Double {
@@ -258,12 +282,32 @@ struct PlayerBarProgressLane: View {
         PlayerBarSliderVisuals.loadingThumbColor(colorScheme: self.colorScheme)
     }
 
-    private var markerColor: Color {
-        self.colorScheme == .dark ? .white.opacity(0.88) : .black.opacity(0.48)
+    private func markerGlassTint(isHighlighted: Bool) -> Color {
+        if isHighlighted {
+            return self.accent.opacity(self.colorScheme == .dark ? 0.48 : 0.34)
+        }
+        return self.colorScheme == .dark ? .white.opacity(0.10) : .black.opacity(0.06)
     }
 
-    private var markerHaloColor: Color {
-        self.colorScheme == .dark ? .black.opacity(0.55) : .white.opacity(0.9)
+    private func markerFallbackFill(isHighlighted: Bool) -> Color {
+        if isHighlighted {
+            return self.accent.opacity(self.colorScheme == .dark ? 0.50 : 0.34)
+        }
+        return self.colorScheme == .dark ? .white.opacity(0.20) : .black.opacity(0.14)
+    }
+
+    private func markerRimColor(isHighlighted: Bool) -> Color {
+        if isHighlighted {
+            return self.colorScheme == .dark ? .white.opacity(0.42) : .white.opacity(0.72)
+        }
+        return self.colorScheme == .dark ? .white.opacity(0.26) : .white.opacity(0.58)
+    }
+
+    private func markerShadowColor(isHighlighted: Bool) -> Color {
+        if isHighlighted {
+            return self.accent.opacity(self.colorScheme == .dark ? 0.36 : 0.22)
+        }
+        return .black.opacity(self.colorScheme == .dark ? 0.18 : 0.08)
     }
 }
 

--- a/Sources/Kaset/Views/YouTube/YouTubePlayerBar.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubePlayerBar.swift
@@ -10,7 +10,8 @@ import SwiftUI
 /// - No shuffle/repeat — left/right transport controls seek 30 seconds
 ///   back/forward within the current video.
 /// - Center shows the video thumbnail, title, and channel · views.
-/// - No lyrics/queue buttons.
+/// - No lyrics/queue buttons; chapter breaks appear in the progress bar when
+///   the watch page response exposes chapters.
 /// - The minimize button drives the video pop-out (picture in picture);
 ///   the TV button toggles fullscreen on the popped-out window.
 struct YouTubePlayerBar: View {
@@ -33,6 +34,7 @@ struct YouTubePlayerBar: View {
     @State private var volumeValue: Double = 1.0
     @State private var isAdjustingVolume = false
     @State private var showsVolumeOverlay = false
+    @State private var chapterPreviewMarker: PlayerBarProgressMarker?
 
     var body: some View {
         CompatGlassContainer(spacing: 0) {
@@ -78,6 +80,7 @@ struct YouTubePlayerBar: View {
         }
         .onChange(of: self.currentSeekIdentity) { _, _ in
             self.clearSeekHold()
+            self.chapterPreviewMarker = nil
         }
         .onChange(of: self.youtubePlayer.volume) { _, newValue in
             if !self.isAdjustingVolume {
@@ -145,7 +148,7 @@ struct YouTubePlayerBar: View {
             if !usesCompactDetails {
                 VStack(alignment: .leading, spacing: 4) {
                     PlayerBarMarqueeText(
-                        text: self.youtubePlayer.currentVideo?.title ?? String(localized: "Not Playing"),
+                        text: self.videoDetailsTitle,
                         font: .system(size: 13),
                         color: .primary,
                         height: 13,
@@ -153,11 +156,16 @@ struct YouTubePlayerBar: View {
                     )
                     .id(self.currentTitleIdentity)
 
-                    PlayerBarMetadataButton(
-                        text: self.youtubePlayer.currentVideo?.channelName ?? String(localized: "YouTube"),
-                        isEnabled: self.canNavigateToCurrentChannel,
-                        action: self.openCurrentChannel
-                    )
+                    if self.isShowingChapterPreview {
+                        Spacer()
+                            .frame(height: 11)
+                    } else {
+                        PlayerBarMetadataButton(
+                            text: self.youtubePlayer.currentVideo?.channelName ?? String(localized: "YouTube"),
+                            isEnabled: self.canNavigateToCurrentChannel,
+                            action: self.openCurrentChannel
+                        )
+                    }
                 }
                 .frame(width: 129, height: 29, alignment: .leading)
             }
@@ -243,7 +251,22 @@ struct YouTubePlayerBar: View {
         [
             self.youtubePlayer.currentVideo?.id ?? "none",
             self.youtubePlayer.currentVideo?.title ?? "none",
+            self.chapterPreviewMarker?.id ?? "none",
         ].joined(separator: "|")
+    }
+
+    private var videoDetailsTitle: String {
+        guard let chapterPreviewMarker, let title = chapterPreviewMarker.title else {
+            return self.youtubePlayer.currentVideo?.title ?? String(localized: "Not Playing")
+        }
+        if let subtitle = chapterPreviewMarker.subtitle {
+            return "\(subtitle) · \(title)"
+        }
+        return title
+    }
+
+    private var isShowingChapterPreview: Bool {
+        self.chapterPreviewMarker?.title != nil
     }
 
     private var youtubeProgressSection: some View {
@@ -253,6 +276,7 @@ struct YouTubePlayerBar: View {
                 accent: Self.brandAccent,
                 elapsedText: Self.formatTime(self.progressTextValue),
                 remainingText: "-\(Self.formatTime(max(0, self.youtubePlayer.duration - self.progressTextValue)))",
+                markers: self.chapterProgressMarkers,
                 isLive: false,
                 canSeek: self.canSeek,
                 isLoading: self.isProgressLoading,
@@ -262,6 +286,9 @@ struct YouTubePlayerBar: View {
                 },
                 onCommit: {
                     self.performSeek()
+                },
+                onMarkerPreviewChange: { marker in
+                    self.chapterPreviewMarker = marker
                 }
             )
             .padding(.top, 18)
@@ -556,6 +583,19 @@ struct YouTubePlayerBar: View {
 
     private var currentSeekIdentity: String {
         self.youtubePlayer.currentVideo?.videoId ?? "none"
+    }
+
+    private var chapterProgressMarkers: [PlayerBarProgressMarker] {
+        guard self.youtubePlayer.duration > 0 else { return [] }
+        return self.youtubePlayer.chapters.compactMap { chapter in
+            guard chapter.startTime > 0, chapter.startTime < self.youtubePlayer.duration else { return nil }
+            return PlayerBarProgressMarker(
+                id: chapter.id,
+                fraction: chapter.startTime / self.youtubePlayer.duration,
+                title: chapter.title,
+                subtitle: chapter.timeText ?? Self.formatTime(chapter.startTime)
+            )
+        }
     }
 
     /// Seeking is unavailable during ads or before a duration is known.

--- a/Sources/Kaset/Views/YouTube/YouTubeWatchView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeWatchView.swift
@@ -226,13 +226,17 @@ struct YouTubeWatchView: View {
 
     /// Starts playback of this view's video, or adopts the surface if this
     /// video is already playing (e.g. docking back from the floating window).
-    private func startOrAdoptPlayback() {
+    private func startOrAdoptPlayback(startAt: Double? = nil) {
         if self.youtubePlayer.currentVideo?.videoId == self.video.videoId {
             if self.youtubePlayer.surfaceLocation == .floating {
                 self.youtubePlayer.dockInline()
             }
         } else {
-            self.youtubePlayer.play(video: self.video, usesCookieFreeDataStore: self.authService.shouldUseCookieFreePlaybackDataStore)
+            self.youtubePlayer.play(
+                video: self.video,
+                usesCookieFreeDataStore: self.authService.shouldUseCookieFreePlaybackDataStore,
+                startAt: startAt
+            )
         }
         self.youtubePlayer.setUpNext(self.viewModel.data.related)
         self.youtubePlayer.setChapters(self.viewModel.data.chapters)
@@ -361,7 +365,8 @@ struct YouTubeWatchView: View {
 
     private func seekToChapter(_ chapter: YouTubeChapter) {
         if self.youtubePlayer.currentVideo?.videoId != self.video.videoId {
-            self.startOrAdoptPlayback()
+            self.startOrAdoptPlayback(startAt: chapter.startTime)
+            return
         }
         self.youtubePlayer.seek(to: chapter.startTime)
     }

--- a/Sources/Kaset/Views/YouTube/YouTubeWatchView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeWatchView.swift
@@ -355,6 +355,7 @@ struct YouTubeWatchView: View {
                         .accessibilityLabel(
                             String(localized: "Jump to chapter: \(chapter.title)")
                         )
+                        .disabled(!self.canSeekToChapter(chapter))
                     }
                 }
                 .padding(.vertical, 2)
@@ -364,11 +365,24 @@ struct YouTubeWatchView: View {
     }
 
     private func seekToChapter(_ chapter: YouTubeChapter) {
+        guard self.canSeekToChapter(chapter) else { return }
         if self.youtubePlayer.currentVideo?.videoId != self.video.videoId {
             self.startOrAdoptPlayback(startAt: chapter.startTime)
             return
         }
         self.youtubePlayer.seek(to: chapter.startTime)
+    }
+
+    private func canSeekToChapter(_ chapter: YouTubeChapter) -> Bool {
+        if let chapterVideoId = chapter.videoId, chapterVideoId != self.video.videoId {
+            return false
+        }
+        guard self.youtubePlayer.currentVideo?.videoId == self.video.videoId else {
+            return true
+        }
+        return self.youtubePlayer.duration > 0
+            && !self.youtubePlayer.isPlaybackLoading
+            && !self.youtubePlayer.isShowingAd
     }
 
     private func isActiveChapter(_ chapter: YouTubeChapter) -> Bool {

--- a/Sources/Kaset/Views/YouTube/YouTubeWatchView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeWatchView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 /// this view owns it. Navigating away while playing hands the surface off
 /// to the floating window (`YouTubeVideoWindowController`).
 struct YouTubeWatchView: View {
-    private static let brandAccent = PackageResourceLookup.brandAccent
+    fileprivate static let brandAccent = PackageResourceLookup.brandAccent
 
     let video: YouTubeVideo
 
@@ -58,11 +58,17 @@ struct YouTubeWatchView: View {
             VStack(alignment: .leading, spacing: 16) {
                 self.videoSurface
 
-                // Below the video: title/metadata + comments down the left,
-                // the related rail down the right.
+                // Below the video: title/metadata + chapters/comments down the
+                // left, the related rail down the right.
                 HStack(alignment: .top, spacing: 24) {
                     VStack(alignment: .leading, spacing: 16) {
                         self.metadataSection
+
+                        if !self.viewModel.data.chapters.isEmpty {
+                            Divider()
+
+                            self.chaptersSection
+                        }
 
                         Divider()
 
@@ -103,6 +109,7 @@ struct YouTubeWatchView: View {
                 // buttons can skip between videos.
                 if self.youtubePlayer.currentVideo?.videoId == self.video.videoId {
                     self.youtubePlayer.setUpNext(self.viewModel.data.related)
+                    self.youtubePlayer.setChapters(self.viewModel.data.chapters)
                 }
             }
             .onDisappear {
@@ -227,6 +234,8 @@ struct YouTubeWatchView: View {
         } else {
             self.youtubePlayer.play(video: self.video, usesCookieFreeDataStore: self.authService.shouldUseCookieFreePlaybackDataStore)
         }
+        self.youtubePlayer.setUpNext(self.viewModel.data.related)
+        self.youtubePlayer.setChapters(self.viewModel.data.chapters)
         self.youtubePlayer.activeInlineVideoId = self.video.videoId
     }
 
@@ -315,6 +324,61 @@ struct YouTubeWatchView: View {
         }
         .buttonStyle(.plain)
         .accessibilityIdentifier(AccessibilityID.YouTubeContent.subscribeButton)
+    }
+
+    // MARK: - Chapters
+
+    private var chaptersSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Chapters", comment: "Video chapters section header")
+                .font(.title3.bold())
+
+            CarouselShelf(
+                accessibilityLabel: String(localized: "Video chapters"),
+                pageFraction: 0.82,
+                showsControls: true,
+                controlVerticalAlignment: .center,
+                contentInset: 0
+            ) {
+                LazyHStack(alignment: .top, spacing: 10) {
+                    ForEach(self.viewModel.data.chapters) { chapter in
+                        Button {
+                            self.seekToChapter(chapter)
+                        } label: {
+                            ChapterCard(chapter: chapter, isActive: self.isActiveChapter(chapter))
+                        }
+                        .buttonStyle(.interactiveRow)
+                        .accessibilityLabel(
+                            String(localized: "Jump to chapter: \(chapter.title)")
+                        )
+                    }
+                }
+                .padding(.vertical, 2)
+            }
+        }
+        .accessibilityIdentifier(AccessibilityID.YouTubeContent.chaptersSection)
+    }
+
+    private func seekToChapter(_ chapter: YouTubeChapter) {
+        if self.youtubePlayer.currentVideo?.videoId != self.video.videoId {
+            self.startOrAdoptPlayback()
+        }
+        self.youtubePlayer.seek(to: chapter.startTime)
+    }
+
+    private func isActiveChapter(_ chapter: YouTubeChapter) -> Bool {
+        guard self.youtubePlayer.currentVideo?.videoId == self.video.videoId else { return false }
+        let currentTime = self.youtubePlayer.progress
+        guard currentTime >= chapter.startTime else { return false }
+        if let endTime = chapter.endTime {
+            return currentTime < endTime
+        }
+        guard let index = self.viewModel.data.chapters.firstIndex(where: { $0.id == chapter.id }) else {
+            return false
+        }
+        let nextIndex = self.viewModel.data.chapters.index(after: index)
+        guard nextIndex < self.viewModel.data.chapters.endIndex else { return true }
+        return currentTime < self.viewModel.data.chapters[nextIndex].startTime
     }
 
     // MARK: - Related Column
@@ -662,6 +726,68 @@ private struct CommentRow: View {
     }
 }
 
+// MARK: - ChapterCard
+
+private struct ChapterCard: View {
+    let chapter: YouTubeChapter
+    let isActive: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            self.thumbnail
+                .frame(width: 160, height: 90)
+                .clipShape(.rect(cornerRadius: 8))
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(self.chapter.title)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.leading)
+
+                Text(self.chapter.timeText ?? Self.formatTime(self.chapter.startTime))
+                    .font(.caption)
+                    .foregroundStyle(self.isActive ? YouTubeWatchView.brandAccent : .secondary)
+            }
+        }
+        .padding(8)
+        .frame(width: 176, alignment: .leading)
+        .background(self.isActive ? YouTubeWatchView.brandAccent.opacity(0.14) : Color.secondary.opacity(0.08), in: .rect(cornerRadius: 12))
+        .contentShape(.rect(cornerRadius: 10))
+    }
+
+    private var thumbnail: some View {
+        CachedAsyncImage(
+            url: self.chapter.thumbnailURL,
+            targetSize: CGSize(width: 192, height: 108)
+        ) { image in
+            image
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+        } placeholder: {
+            Rectangle()
+                .fill(.quaternary)
+                .overlay {
+                    Image(systemName: "text.append")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                }
+        }
+    }
+
+    private static func formatTime(_ seconds: TimeInterval) -> String {
+        let totalSeconds = max(0, Int(seconds.rounded(.down)))
+        let hours = totalSeconds / 3600
+        let minutes = (totalSeconds % 3600) / 60
+        let seconds = totalSeconds % 60
+
+        if hours > 0 {
+            return String(format: "%d:%02d:%02d", hours, minutes, seconds)
+        }
+        return String(format: "%d:%02d", minutes, seconds)
+    }
+}
+
 // MARK: - RelatedVideoRow
 
 /// Compact related-rail row sized for the right column.
@@ -706,6 +832,7 @@ private struct RelatedVideoRow: View {
 
 extension AccessibilityID.YouTubeContent {
     static let watchSurface = "youtubeContent.watchSurface"
+    static let chaptersSection = "youtubeContent.chaptersSection"
     static let commentsSection = "youtubeContent.commentsSection"
     static let commentField = "youtubeContent.commentField"
     static let commentPostButton = "youtubeContent.commentPostButton"

--- a/Sources/Kaset/Views/YouTube/YouTubeWatchWebView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeWatchWebView.swift
@@ -233,7 +233,7 @@ final class YouTubeWatchWebView {
     nonisolated static func pageBootstrapScript(targetVolume: Double, pendingSeek: Double? = nil) -> String {
         let clamped = targetVolume.isFinite ? min(max(targetVolume, 0), 1) : 1.0
         var script = "window.__kasetTargetVolume = \(clamped);"
-        if let pendingSeek, pendingSeek.isFinite, pendingSeek > 0 {
+        if let pendingSeek, pendingSeek.isFinite, pendingSeek >= 0 {
             script += " window.__kasetPendingSeek = \(pendingSeek);"
         }
         return script

--- a/Tests/KasetTests/PlayerServiceLibraryTests.swift
+++ b/Tests/KasetTests/PlayerServiceLibraryTests.swift
@@ -82,7 +82,7 @@ struct PlayerServiceLibraryTests {
 
     @Test("likeCurrentTrack reverts on API failure")
     func likeCurrentTrackRevertsOnFailure() async {
-        self.playerService.currentTrack = TestFixtures.makeSong(id: "test-video")
+        self.playerService.currentTrack = TestFixtures.makeSong(id: "test-video-\(UUID().uuidString)")
         self.playerService.currentTrackLikeStatus = .indifferent
         self.mockClient.shouldThrowError = YTMusicError.networkError(underlying: URLError(.notConnectedToInternet))
 
@@ -207,7 +207,7 @@ struct PlayerServiceLibraryTests {
 
     @Test("dislikeCurrentTrack reverts on API failure")
     func dislikeCurrentTrackRevertsOnFailure() async {
-        self.playerService.currentTrack = TestFixtures.makeSong(id: "test-video")
+        self.playerService.currentTrack = TestFixtures.makeSong(id: "test-video-\(UUID().uuidString)")
         self.playerService.currentTrackLikeStatus = .indifferent
         self.mockClient.shouldThrowError = YTMusicError.networkError(underlying: URLError(.notConnectedToInternet))
 

--- a/Tests/KasetTests/YouTubePlayerServiceTests.swift
+++ b/Tests/KasetTests/YouTubePlayerServiceTests.swift
@@ -797,6 +797,34 @@ struct YouTubePlayerServiceTests {
         #expect(self.sut.upNext.map(\.videoId) == ["keeper"])
     }
 
+    @Test("Chapter markers filter to the current video")
+    func chapterMarkersFilter() {
+        self.sut.setChapters([
+            YouTubeChapter(videoId: nil, title: "No current", startTime: 1, endTime: nil, timeText: nil, thumbnailURL: nil),
+        ])
+        #expect(self.sut.chapters.isEmpty)
+
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "current"))
+
+        self.sut.setChapters([
+            YouTubeChapter(videoId: "current", title: "Matching", startTime: 10, endTime: nil, timeText: "0:10", thumbnailURL: nil),
+            YouTubeChapter(videoId: "other", title: "Other", startTime: 20, endTime: nil, timeText: "0:20", thumbnailURL: nil),
+            YouTubeChapter(videoId: nil, title: "Implicit", startTime: 30, endTime: nil, timeText: "0:30", thumbnailURL: nil),
+        ])
+
+        #expect(self.sut.chapters.map(\.title) == ["Matching", "Implicit"])
+    }
+
+    @Test("Play can start at a deferred seek position")
+    func playWithStartPositionDefersSeekUntilLoad() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "chaptered"), startAt: 42)
+
+        #expect(self.controller.loadedVideoIds.isEmpty)
+        #expect(self.controller.reloadedVideoIds == ["chaptered"])
+        #expect(self.controller.reloadResumeSeconds == [42])
+        #expect(self.controller.seeks.isEmpty)
+    }
+
     @Test("Skipping while floating keeps the surface in the window")
     func skipWhileFloatingStaysFloating() async {
         self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "first"))

--- a/Tests/KasetTests/YouTubePlayerServiceTests.swift
+++ b/Tests/KasetTests/YouTubePlayerServiceTests.swift
@@ -825,6 +825,16 @@ struct YouTubePlayerServiceTests {
         #expect(self.controller.seeks.isEmpty)
     }
 
+    @Test("Play can start at an explicit zero seek position")
+    func playWithZeroStartPositionDefersSeekUntilLoad() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "chaptered"), startAt: 0)
+
+        #expect(self.controller.loadedVideoIds.isEmpty)
+        #expect(self.controller.reloadedVideoIds == ["chaptered"])
+        #expect(self.controller.reloadResumeSeconds == [0])
+        #expect(self.controller.seeks.isEmpty)
+    }
+
     @Test("Skipping while floating keeps the surface in the window")
     func skipWhileFloatingStaysFloating() async {
         self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "first"))

--- a/Tests/KasetTests/YouTubeResponseParserTests.swift
+++ b/Tests/KasetTests/YouTubeResponseParserTests.swift
@@ -266,6 +266,196 @@ struct WatchNextParserTests {
         #expect(firstRelated.channelName == "Plingoro")
         #expect(firstRelated.lengthText == "17:10")
     }
+
+    @Test("Parses canonical player-overlay chapter renderers")
+    func parsesPlayerOverlayChapters() throws {
+        let watchNext = WatchNextParser.parse(Self.chapterRendererResponse())
+
+        #expect(watchNext.chapters.count == 2)
+
+        let first = try #require(watchNext.chapters.first)
+        #expect(first.videoId == "video-1")
+        #expect(first.title == "Introduction")
+        #expect(first.startTime == 0)
+        #expect(first.endTime == nil)
+        #expect(first.timeText == nil)
+        #expect(first.thumbnailURL?.absoluteString == "https://example.com/intro-336.jpg")
+
+        let second = watchNext.chapters[1]
+        #expect(second.title == "Single-threaded code")
+        #expect(second.startTime == 197)
+    }
+
+    @Test("Falls back to deduplicated macro marker chapter cards")
+    func parsesMacroMarkerFallbackChapters() throws {
+        let chapters = WatchNextParser.chapters(of: Self.macroMarkerOnlyResponse())
+
+        #expect(chapters.count == 2)
+
+        let first = try #require(chapters.first)
+        #expect(first.videoId == "video-1")
+        #expect(first.title == "Introduction")
+        #expect(first.startTime == 0)
+        #expect(first.endTime == 197)
+        #expect(first.timeText == "0:00")
+        #expect(first.thumbnailURL?.absoluteString == "https://example.com/intro-336.jpg")
+
+        let second = chapters[1]
+        #expect(second.title == "Single-threaded code")
+        #expect(second.startTime == 197)
+        #expect(second.endTime == 360)
+    }
+
+    @Test("Ignores heatmap replay markers when chapters are absent")
+    func ignoresHeatmapMarkers() {
+        let chapters = WatchNextParser.chapters(of: Self.heatmapOnlyResponse())
+
+        #expect(chapters.isEmpty)
+    }
+
+    private static func chapterRendererResponse() -> [String: Any] {
+        [
+            "currentVideoEndpoint": [
+                "watchEndpoint": ["videoId": "video-1"],
+            ],
+            "playerOverlays": [
+                "playerOverlayRenderer": [
+                    "decoratedPlayerBarRenderer": [
+                        "decoratedPlayerBarRenderer": [
+                            "playerBar": [
+                                "multiMarkersPlayerBarRenderer": [
+                                    "markersMap": [
+                                        [
+                                            "key": "DESCRIPTION_CHAPTERS",
+                                            "value": [
+                                                "chapters": [
+                                                    ["chapterRenderer": self.chapterRenderer(title: "Introduction", startMs: 0, imageName: "intro")],
+                                                    ["chapterRenderer": self.chapterRenderer(title: "Single-threaded code", startMs: 197_000, imageName: "single")],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            // This duplicate fallback shape should be ignored when canonical
+            // chapterRenderer data exists.
+            "engagementPanels": [
+                [
+                    "engagementPanelSectionListRenderer": [
+                        "content": [
+                            "macroMarkersListRenderer": [
+                                "contents": [
+                                    ["macroMarkersListItemRenderer": self.macroMarkerRenderer(title: "Introduction", startMs: 0, endMs: 197_000, imageName: "intro")],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]
+    }
+
+    private static func macroMarkerOnlyResponse() -> [String: Any] {
+        [
+            "currentVideoEndpoint": [
+                "watchEndpoint": ["videoId": "video-1"],
+            ],
+            "engagementPanels": [
+                [
+                    "engagementPanelSectionListRenderer": [
+                        "content": [
+                            "macroMarkersListRenderer": [
+                                "contents": [
+                                    ["macroMarkersListItemRenderer": self.macroMarkerRenderer(title: "Introduction", startMs: 0, endMs: 197_000, imageName: "intro")],
+                                    ["macroMarkersListItemRenderer": self.macroMarkerRenderer(title: "Introduction", startMs: 0, endMs: 197_000, imageName: "intro")],
+                                    ["macroMarkersListItemRenderer": self.macroMarkerRenderer(title: "Other video chapter", startMs: 45000, endMs: 90000, imageName: "other", videoId: "other-video")],
+                                    ["macroMarkersListItemRenderer": self.macroMarkerRenderer(title: "Single-threaded code", startMs: 197_000, endMs: 360_000, imageName: "single")],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]
+    }
+
+    private static func heatmapOnlyResponse() -> [String: Any] {
+        [
+            "frameworkUpdates": [
+                "entityBatchUpdate": [
+                    "mutations": [
+                        [
+                            "payload": [
+                                "macroMarkersListEntity": [
+                                    "markersList": [
+                                        "markerType": "MARKER_TYPE_HEATMAP",
+                                        "markers": [
+                                            ["startMillis": "0", "durationMillis": "1000", "intensityScoreNormalized": 1],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]
+    }
+
+    private static func chapterRenderer(title: String, startMs: Int, imageName: String) -> [String: Any] {
+        [
+            "timeRangeStartMillis": startMs,
+            "title": ["simpleText": title],
+            "thumbnail": self.thumbnail(imageName: imageName),
+        ]
+    }
+
+    private static func macroMarkerRenderer(
+        title: String,
+        startMs: Int,
+        endMs: Int,
+        imageName: String,
+        videoId: String = "video-1"
+    ) -> [String: Any] {
+        [
+            "title": ["runs": [["text": title]]],
+            "timeDescription": ["simpleText": self.timeText(seconds: startMs / 1000)],
+            "thumbnail": self.thumbnail(imageName: imageName),
+            "onTap": [
+                "watchEndpoint": [
+                    "videoId": videoId,
+                    "startTimeSeconds": startMs / 1000,
+                ],
+            ],
+            "repeatButton": [
+                "toggleButtonRenderer": [
+                    "defaultServiceEndpoint": [
+                        "repeatChapterCommand": [
+                            "startTimeMs": "\(startMs)",
+                            "endTimeMs": "\(endMs)",
+                        ],
+                    ],
+                ],
+            ],
+        ]
+    }
+
+    private static func thumbnail(imageName: String) -> [String: Any] {
+        [
+            "thumbnails": [
+                ["url": "https://example.com/\(imageName)-168.jpg", "width": 168, "height": 94],
+                ["url": "https://example.com/\(imageName)-336.jpg", "width": 336, "height": 188],
+            ],
+        ]
+    }
+
+    private static func timeText(seconds: Int) -> String {
+        String(format: "%d:%02d", seconds / 60, seconds % 60)
+    }
 }
 
 // MARK: - ChannelPageParserTests

--- a/Tests/KasetTests/YouTubeResponseParserTests.swift
+++ b/Tests/KasetTests/YouTubeResponseParserTests.swift
@@ -349,7 +349,7 @@ struct WatchNextParserTests {
                         "content": [
                             "macroMarkersListRenderer": [
                                 "contents": [
-                                    ["macroMarkersListItemRenderer": self.macroMarkerRenderer(title: "Introduction", startMs: 0, endMs: 197_000, imageName: "intro")],
+                                    ["macroMarkersListItemRenderer": self.macroMarkerRenderer(title: "Introduction", startMs: 0, endMs: 197_000, imageName: "intro", includesExplicitStart: false)],
                                 ],
                             ],
                         ],
@@ -419,19 +419,26 @@ struct WatchNextParserTests {
         startMs: Int,
         endMs: Int,
         imageName: String,
-        videoId: String = "video-1"
+        videoId: String = "video-1",
+        includesExplicitStart: Bool = true
     ) -> [String: Any] {
-        [
+        var renderer: [String: Any] = [
             "title": ["runs": [["text": title]]],
             "timeDescription": ["simpleText": self.timeText(seconds: startMs / 1000)],
             "thumbnail": self.thumbnail(imageName: imageName),
-            "onTap": [
-                "watchEndpoint": [
-                    "videoId": videoId,
-                    "startTimeSeconds": startMs / 1000,
-                ],
+        ]
+
+        renderer["onTap"] = [
+            "watchEndpoint": includesExplicitStart ? [
+                "videoId": videoId,
+                "startTimeSeconds": startMs / 1000,
+            ] : [
+                "videoId": videoId,
             ],
-            "repeatButton": [
+        ]
+
+        if includesExplicitStart {
+            renderer["repeatButton"] = [
                 "toggleButtonRenderer": [
                     "defaultServiceEndpoint": [
                         "repeatChapterCommand": [
@@ -440,8 +447,10 @@ struct WatchNextParserTests {
                         ],
                     ],
                 ],
-            ],
-        ]
+            ]
+        }
+
+        return renderer
     }
 
     private static func thumbnail(imageName: String) -> [String: Any] {

--- a/Tests/KasetTests/YouTubeWatchScriptTests.swift
+++ b/Tests/KasetTests/YouTubeWatchScriptTests.swift
@@ -51,15 +51,17 @@ struct YouTubeWatchScriptTests {
             .contains("__kasetTargetVolume = 0.0"))
     }
 
-    @Test("Bootstrap carries a pending resume-seek only when present and positive")
+    @Test("Bootstrap carries a pending resume-seek when present")
     func bootstrapCarriesPendingSeek() {
         #expect(YouTubeWatchWebView.pageBootstrapScript(targetVolume: 1, pendingSeek: 42.5)
             .contains("__kasetPendingSeek = 42.5"))
+        #expect(YouTubeWatchWebView.pageBootstrapScript(targetVolume: 1, pendingSeek: 0)
+            .contains("__kasetPendingSeek = 0.0"))
         // No seek pending → no marker injected.
         #expect(!YouTubeWatchWebView.pageBootstrapScript(targetVolume: 1, pendingSeek: nil)
             .contains("__kasetPendingSeek"))
-        // Zero/negative is not a resume position.
-        #expect(!YouTubeWatchWebView.pageBootstrapScript(targetVolume: 1, pendingSeek: 0)
+        // Negative is not a valid seek position.
+        #expect(!YouTubeWatchWebView.pageBootstrapScript(targetVolume: 1, pendingSeek: -1)
             .contains("__kasetPendingSeek"))
     }
 

--- a/docs/api-discovery.md
+++ b/docs/api-discovery.md
@@ -76,7 +76,7 @@ Forced signed-out API Explorer probes confirmed these public surfaces:
 | Music bulk queue metadata | `music/get_queue` | HTTP 200; `playlistPanelVideoRenderer` metadata returned |
 | Public Music browse | `FEmusic_home`, `FEmusic_explore`, `FEmusic_charts`, `FEmusic_moods_and_genres`, `FEmusic_new_releases`, `FEmusic_podcasts` | HTTP 200 public content |
 | Lyrics browse | `MPLYt...` from `next` | HTTP 200 when lyrics are public |
-| YouTube search/watch-next | `--youtube search`, `--youtube next` | HTTP 200 public results / related videos |
+| YouTube search/watch-next | `--youtube search`, `--youtube next` | HTTP 200 public results / related videos; chapter markers are present in `next` for videos that expose chapters |
 
 Personal surfaces and mutations remain sign-in-only. Gate or hide UI for:
 
@@ -1205,6 +1205,50 @@ swift run api-explorer --youtube browse FEhistory
 swift run api-explorer --youtube action search '{"query":"swift concurrency"}'
 swift run api-explorer --youtube action next '{"videoId":"VIDEO_ID"}'
 ```
+
+#### YouTube chapter markers (verified 2026-07-07)
+
+Regular YouTube chapter data is exposed by the WEB `next` watch-page response,
+not by the `player` endpoint. `api-explorer` now summarizes both known chapter
+shapes when they appear:
+
+```bash
+swift run api-explorer --youtube --guest action next '{"videoId":"u2rYp8AMuSg"}'
+```
+
+Observed chapter paths:
+
+```text
+playerOverlays.playerOverlayRenderer.decoratedPlayerBarRenderer
+  .decoratedPlayerBarRenderer.playerBar.multiMarkersPlayerBarRenderer
+  .markersMap[].value.chapters[].chapterRenderer
+
+engagementPanels[].engagementPanelSectionListRenderer.content
+  .macroMarkersListRenderer.contents[].macroMarkersListItemRenderer
+
+engagementPanels[].engagementPanelSectionListRenderer.content
+  .structuredDescriptionContentRenderer.items[]
+  .horizontalCardListRenderer.cards[].macroMarkersListItemRenderer
+```
+
+Field notes:
+
+- `chapterRenderer` is the best watch-page source for navigation markers.
+  It includes `timeRangeStartMillis`, `title.simpleText`, and chapter
+  thumbnails.
+- `macroMarkersListItemRenderer` appears in the chapters panel and may be
+  duplicated in the structured description or search result metadata. It adds
+  `onTap.watchEndpoint.startTimeSeconds`, `timeDescription`, and repeat-chapter
+  commands whose `startTimeMs` / `endTimeMs` can provide chapter bounds.
+- Videos without chapters may still expose heatmap markers through
+  `macroMarkersListEntity.markersList`; do not treat heatmap markers as
+  chapters.
+- Auth was not required for the verified chapter response: both `--guest` and
+  signed-in `--youtube action next` returned the same chapter marker counts for
+  the test video.
+- `--youtube action player '{"videoId":"..."}'` returned metadata/captions and
+  streaming/player state, but no `chapterRenderer` or
+  `macroMarkersListItemRenderer` chapter data in the verified probes.
 
 Prefer the destination feeds documented in [youtube.md](youtube.md) for Explore; YouTube's old `FEtrending` feed is no longer a reliable target.
 

--- a/docs/youtube.md
+++ b/docs/youtube.md
@@ -98,9 +98,11 @@ The bottom Liquid Glass bar adapts to the active source. In YouTube mode
 - Actions: like/dislike, Watch Later, AirPlay (video picker), closed
   captions menu (player tracks + Off), quality menu, full view, and picture in
   picture (pop out / pop in; hidden in fullscreen). When chapters are available,
-  their break points are drawn directly into the progress bar; hovering or
-  dragging near a break temporarily shows the chapter name/time in the player
-  metadata title area, and release-near-chapter scrubs snap to that chapter.
+  their break points are drawn directly into the progress bar as Liquid
+  Glass-style seams with a material fallback; hovering or dragging near a break
+  highlights it as a small glass bead, temporarily shows the chapter name/time
+  in the player metadata title area, and release-near-chapter scrubs snap to
+  that chapter.
 - No shuffle/repeat/lyrics/queue — those are music concepts. Chapters use a
   horizontal scroller with chevron paging controls on the watch page.
 

--- a/docs/youtube.md
+++ b/docs/youtube.md
@@ -64,6 +64,7 @@ controls music while browsing YouTube), shared view components, and
 | User playlists | `browse` `FEplaylist_aggregation` |
 | Search | `search` (+`params` filters: videos `EgIQAQ==`, channels `EgIQAg==`, playlists `EgIQAw==`) |
 | Watch metadata + related | `next` |
+| Watch chapters | `next` (`playerOverlays…multiMarkersPlayerBarRenderer.markersMap[].value.chapters[]`) |
 | Like / unlike | `like/like`, `like/dislike`, `like/removelike` |
 | Subscribe | `subscription/subscribe` / `subscription/unsubscribe` |
 | Watch Later edit | `browse/edit_playlist` (playlistId `WL`) |
@@ -95,9 +96,13 @@ The bottom Liquid Glass bar adapts to the active source. In YouTube mode
 - Player bar transport buttons seek 30 seconds back/forward within the
   current video.
 - Actions: like/dislike, Watch Later, AirPlay (video picker), closed
-  captions menu (player tracks + Off), quality menu, full view, and
-  picture in picture (pop out / pop in; hidden in fullscreen).
-- No shuffle/repeat/lyrics/queue — those are music concepts.
+  captions menu (player tracks + Off), quality menu, full view, and picture in
+  picture (pop out / pop in; hidden in fullscreen). When chapters are available,
+  their break points are drawn directly into the progress bar; hovering or
+  dragging near a break temporarily shows the chapter name/time in the player
+  metadata title area, and release-near-chapter scrubs snap to that chapter.
+- No shuffle/repeat/lyrics/queue — those are music concepts. Chapters use a
+  horizontal scroller with chevron paging controls on the watch page.
 
 Every navigable YouTube view carries its own bar inset (pushed views
 don't inherit `safeAreaInset` — same rule as the music side).
@@ -178,8 +183,10 @@ from the regular grids, and routed to this surface.
 ### Watch Page
 
 Below the video, the layout is two-column: title/metadata/channel and
-the comments section down the left, the related rail down the right.
-Comments come from the watch page's `comment-item-section` continuation
+chapters/comments down the left, the related rail down the right.
+Chapters come from the watch page's `next` response (see Endpoints above), show
+as a horizontal scroller with chevron paging controls, and seek the active video
+natively. Comments come from the watch page's `comment-item-section` continuation
 (entity-payload mutations joined to comment view models, with a legacy
 `commentRenderer` fallback): paged reading, posting via
 `comment/create_comment`, like/dislike toggles via
@@ -217,3 +224,12 @@ the native scrubber is disabled; YouTube Premium accounts see no ads.
 - Reply posting and comment sorting controls are intentionally minimal; the
   current watch page supports loading top-level comments, posting a top-level
   comment, and optimistic like/dislike toggles.
+
+Chapter markers are available from the same `next` watch-page response for
+videos that expose chapters. The stable watch-page path observed on
+2026-07-07 is `playerOverlays…multiMarkersPlayerBarRenderer.markersMap[].value.chapters[]`
+with `chapterRenderer.timeRangeStartMillis`, `title.simpleText`, and
+thumbnails. The response can also contain `macroMarkersListItemRenderer` entries
+in the chapters panel or structured description; those are useful fallbacks but
+can be duplicated. Heatmap `macroMarkersListEntity.markersList` data is separate
+and should not be treated as chapters.


### PR DESCRIPTION
## Summary

- Adds YouTube chapter extraction from watch-next responses, preferring canonical player overlay chapter renderers with a deduped macro-marker fallback.
- Adds chapter models and parser coverage, including heatmap exclusion and filtering fallback markers to the current video.
- Shows chapters as a horizontal watch-page carousel with chevron paging controls.
- Integrates chapter break markers into the YouTube player bar scrubber, with hover/drag preview in the metadata title area and snap-to-chapter release behavior.
- Documents the discovered API shapes and ignores local API probe dumps via `.tmp/`.

## Validation

- `swift build`
- `swiftlint --strict`
- `swiftformat` on touched files / `swiftformat .` with unrelated formatting reverted
- `.agents/skills/autoreview/scripts/autoreview --mode local`
- `swift run api-explorer --youtube --guest action next '{"videoId":"u2rYp8AMuSg"}'`

## Notes

- `swift test --skip KasetUITests --filter WatchNextParserTests` builds the test bundle but is blocked locally by the existing `Sparkle.framework` runtime/rpath load issue.
- UI tests were not run.
