### PR TITLE
perf: improve energy efficiency across app

### DIFF
--- a/Sources/APIExplorer/main.swift
+++ b/Sources/APIExplorer/main.swift
@@ -1285,8 +1285,11 @@ func probeSigninSwitchReal(nextURLString: String) async {
         return
     }
     // Normalize protocol-relative URLs.
-    if signin.hasPrefix("//") { signin = "https:" + signin }
-    else if signin.hasPrefix("/") { signin = "https://www.youtube.com" + signin }
+    if signin.hasPrefix("//") {
+        signin = "https:" + signin
+    } else if signin.hasPrefix("/") {
+        signin = "https://www.youtube.com" + signin
+    }
 
     // Rewrite only the `next` param.
     guard var comps = URLComponents(string: signin) else {

--- a/Sources/Kaset/Models/SyncedLyrics.swift
+++ b/Sources/Kaset/Models/SyncedLyrics.swift
@@ -42,15 +42,56 @@ struct SyncedLyrics: Equatable {
 
     func lineStatuses(at timeMs: Int) -> [LineStatus] {
         self.lines.map { line in
-            if line.timeInMs > timeMs { return .upcoming }
+            if line.timeInMs > timeMs {
+                return .upcoming
+            }
             // If the time passed the start time + duration, it's previous
-            if timeMs - line.timeInMs >= line.duration, line.duration > 0 { return .previous }
+            if timeMs - line.timeInMs >= line.duration, line.duration > 0 {
+                return .previous
+            }
             return .current
         }
     }
 
     func currentLineIndex(at timeMs: Int) -> Int? {
         self.lineStatuses(at: timeMs).lastIndex(of: .current)
+    }
+
+    /// Returns the display-update bucket for a playback timestamp.
+    ///
+    /// The synced lyrics UI only changes when the current line changes (or no line is active), so
+    /// WebView bridge traffic can be coalesced to this value instead of publishing raw 10 Hz time.
+    func displayBucket(at timeMs: Int) -> Int {
+        let ranges = self.bridgeLineRanges
+        guard !ranges.isEmpty else { return -1 }
+
+        for (index, range) in ranges.enumerated() {
+            let startMs = range["startMs"] ?? 0
+            let endMs = range["endMs"] ?? Int.max
+            if timeMs >= startMs, timeMs < endMs {
+                return index
+            }
+            if timeMs < startMs {
+                return -(index + 1)
+            }
+        }
+
+        return -(ranges.count + 1)
+    }
+
+    /// Compact line timing ranges passed to the playback WebView for line-boundary bridge updates.
+    var bridgeLineRanges: [[String: Int]] {
+        self.lines.indices.map { index in
+            let line = self.lines[index]
+            let nextStartMs = self.lines.indices.contains(index + 1) ? self.lines[index + 1].timeInMs : Int.max
+            let naturalEndMs = if line.duration > 0 {
+                line.timeInMs + line.duration
+            } else {
+                Int.max
+            }
+            let endMs = min(naturalEndMs, nextStartMs)
+            return ["startMs": line.timeInMs, "endMs": endMs]
+        }
     }
 }
 

--- a/Sources/Kaset/Models/WhatsNew.swift
+++ b/Sources/Kaset/Models/WhatsNew.swift
@@ -63,9 +63,15 @@ extension WhatsNew {
         // MARK: Comparable
 
         static func < (lhs: Version, rhs: Version) -> Bool {
-            if lhs.major != rhs.major { return lhs.major < rhs.major }
-            if lhs.minor != rhs.minor { return lhs.minor < rhs.minor }
-            if lhs.patch != rhs.patch { return lhs.patch < rhs.patch }
+            if lhs.major != rhs.major {
+                return lhs.major < rhs.major
+            }
+            if lhs.minor != rhs.minor {
+                return lhs.minor < rhs.minor
+            }
+            if lhs.patch != rhs.patch {
+                return lhs.patch < rhs.patch
+            }
             return self.compareSuffix(lhs.suffix, rhs.suffix)
         }
 
@@ -77,8 +83,12 @@ extension WhatsNew {
 
         private static func compareSuffix(_ lhs: String, _ rhs: String) -> Bool {
             guard lhs != rhs else { return false }
-            if lhs.isEmpty { return false }
-            if rhs.isEmpty { return true }
+            if lhs.isEmpty {
+                return false
+            }
+            if rhs.isEmpty {
+                return true
+            }
             return lhs.compare(rhs, options: [.numeric]) == .orderedAscending
         }
     }

--- a/Sources/Kaset/Services/AI/CommandExecutor.swift
+++ b/Sources/Kaset/Services/AI/CommandExecutor.swift
@@ -365,7 +365,9 @@ struct CommandExecutor {
                     }
 
                     let songs = section.items.compactMap { item -> Song? in
-                        if case let .song(song) = item { return song }
+                        if case let .song(song) = item {
+                            return song
+                        }
                         return nil
                     }
                     if !songs.isEmpty {
@@ -394,7 +396,9 @@ struct CommandExecutor {
 
             for section in response.sections {
                 let songs = section.items.compactMap { item -> Song? in
-                    if case let .song(song) = item { return song }
+                    if case let .song(song) = item {
+                        return song
+                    }
                     return nil
                 }
                 if songs.count >= 5 {

--- a/Sources/Kaset/Services/AI/ContentSourceResolver.swift
+++ b/Sources/Kaset/Services/AI/ContentSourceResolver.swift
@@ -35,13 +35,27 @@ enum ContentSourceResolver {
         let wantsHits = queryLower.contains("hit") || queryLower.contains("best") ||
             queryLower.contains("greatest") || queryLower.contains("top")
 
-        if !intent.mood.isEmpty { parts.append(intent.mood) }
-        if !intent.genre.isEmpty { parts.append(intent.genre) }
-        if wantsHits { parts.append("hits") }
-        if !intent.artist.isEmpty { parts.append("by \(intent.artist)") }
-        if !intent.era.isEmpty { parts.append("from the \(intent.era)") }
-        if !intent.version.isEmpty { parts.append("(\(intent.version))") }
-        if !intent.activity.isEmpty { parts.append("for \(intent.activity)") }
+        if !intent.mood.isEmpty {
+            parts.append(intent.mood)
+        }
+        if !intent.genre.isEmpty {
+            parts.append(intent.genre)
+        }
+        if wantsHits {
+            parts.append("hits")
+        }
+        if !intent.artist.isEmpty {
+            parts.append("by \(intent.artist)")
+        }
+        if !intent.era.isEmpty {
+            parts.append("from the \(intent.era)")
+        }
+        if !intent.version.isEmpty {
+            parts.append("(\(intent.version))")
+        }
+        if !intent.activity.isEmpty {
+            parts.append("for \(intent.activity)")
+        }
 
         if parts.isEmpty {
             return intent.query
@@ -113,8 +127,12 @@ enum ContentSourceResolver {
             hasHits = true
         }
 
-        if !intent.genre.isEmpty { parts.append(intent.genre) }
-        if !intent.mood.isEmpty { parts.append(intent.mood) }
+        if !intent.genre.isEmpty {
+            parts.append(intent.genre)
+        }
+        if !intent.mood.isEmpty {
+            parts.append(intent.mood)
+        }
 
         return (parts, hasHits)
     }
@@ -134,8 +152,12 @@ enum ContentSourceResolver {
 
     private static func buildGenericQuery(from intent: MusicIntent) -> [String] {
         var parts: [String] = []
-        if !intent.genre.isEmpty { parts.append(intent.genre) }
-        if !intent.mood.isEmpty { parts.append(intent.mood) }
+        if !intent.genre.isEmpty {
+            parts.append(intent.genre)
+        }
+        if !intent.mood.isEmpty {
+            parts.append(intent.mood)
+        }
 
         if intent.genre.isEmpty, !intent.mood.isEmpty, intent.artist.isEmpty, intent.activity.isEmpty {
             parts.append("music")
@@ -178,13 +200,27 @@ enum ContentSourceResolver {
     private static func normalizeEra(_ era: String) -> String {
         let lowered = era.lowercased()
 
-        if lowered.contains("1960") { return "60s" }
-        if lowered.contains("1970") { return "70s" }
-        if lowered.contains("1980") { return "80s" }
-        if lowered.contains("1990") { return "90s" }
-        if lowered.contains("2000") { return "2000s" }
-        if lowered.contains("2010") { return "2010s" }
-        if lowered.contains("2020") { return "2020s" }
+        if lowered.contains("1960") {
+            return "60s"
+        }
+        if lowered.contains("1970") {
+            return "70s"
+        }
+        if lowered.contains("1980") {
+            return "80s"
+        }
+        if lowered.contains("1990") {
+            return "90s"
+        }
+        if lowered.contains("2000") {
+            return "2000s"
+        }
+        if lowered.contains("2010") {
+            return "2010s"
+        }
+        if lowered.contains("2020") {
+            return "2020s"
+        }
 
         return era
     }

--- a/Sources/Kaset/Services/API/Parsers/ArtistParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/ArtistParser.swift
@@ -77,7 +77,9 @@ enum ArtistParser { // swiftlint:disable:this type_body_length
                             shelfTitle: shelfTitle,
                             buckets: &buckets
                         )
-                        if shelfKind == nil { shelfKind = kind }
+                        if shelfKind == nil {
+                            shelfKind = kind
+                        }
 
                         switch kind {
                         case .albums:

--- a/Sources/Kaset/Services/API/Parsers/PlaylistParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/PlaylistParser.swift
@@ -1106,7 +1106,9 @@ enum PlaylistParser {
                         tracks.append(contentsOf: self.findTracksRecursively(in: item, depth: depth + 1, fallbackThumbnailURL: fallbackThumbnailURL))
                     }
                 }
-                if !tracks.isEmpty { break }
+                if !tracks.isEmpty {
+                    break
+                }
             }
         }
 
@@ -1374,9 +1376,15 @@ enum PlaylistParser {
             Self.extractText(from: data["subtitle"] as? [String: Any]),
         ].compactMap(\.self).joined(separator: " ").uppercased()
 
-        if possibleText.contains("PRIVATE") { return .private }
-        if possibleText.contains("UNLISTED") { return .unlisted }
-        if possibleText.contains("PUBLIC") { return .public }
+        if possibleText.contains("PRIVATE") {
+            return .private
+        }
+        if possibleText.contains("UNLISTED") {
+            return .unlisted
+        }
+        if possibleText.contains("PUBLIC") {
+            return .public
+        }
         return nil
     }
 

--- a/Sources/Kaset/Services/API/Parsers/ResponseTreeSearch.swift
+++ b/Sources/Kaset/Services/API/Parsers/ResponseTreeSearch.swift
@@ -26,7 +26,9 @@ enum ResponseTreeSearch {
 
     static func containsKey(_ key: String, in value: Any) -> Bool {
         if let dictionary = value as? [String: Any] {
-            if dictionary[key] != nil { return true }
+            if dictionary[key] != nil {
+                return true
+            }
             for child in dictionary.values where self.containsKey(key, in: child) {
                 return true
             }

--- a/Sources/Kaset/Services/API/Parsers/SongMetadataParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/SongMetadataParser.swift
@@ -181,10 +181,14 @@ enum SongMetadataParser {
 
         switch iconType {
         case "LIBRARY_ADD", "BOOKMARK_BORDER":
-            if let token { result.feedbackTokens = FeedbackTokens(add: token, remove: nil) }
+            if let token {
+                result.feedbackTokens = FeedbackTokens(add: token, remove: nil)
+            }
         case "LIBRARY_REMOVE", "BOOKMARK":
             result.isInLibrary = true
-            if let token { result.feedbackTokens = FeedbackTokens(add: nil, remove: token) }
+            if let token {
+                result.feedbackTokens = FeedbackTokens(add: nil, remove: token)
+            }
         default:
             break
         }

--- a/Sources/Kaset/Services/API/Parsers/YouTube/YouTubeFeedParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/YouTube/YouTubeFeedParser.swift
@@ -88,7 +88,9 @@ enum YouTubeFeedParser {
         for entry in chips {
             guard let chip = entry["chipCloudChipRenderer"] as? [String: Any] else { continue }
             // The default "All" chip is pre-selected and carries no token.
-            if chip["isSelected"] as? Bool == true { continue }
+            if chip["isSelected"] as? Bool == true {
+                continue
+            }
             guard let title = YouTubeItemParser.text(from: chip["text"]),
                   let continuation = (
                       (chip["navigationEndpoint"] as? [String: Any])?["continuationCommand"]

--- a/Sources/Kaset/Services/API/YTMusicClient.swift
+++ b/Sources/Kaset/Services/API/YTMusicClient.swift
@@ -1032,13 +1032,25 @@ final class YTMusicClient: YTMusicClientProtocol {
         }
 
         let albumSections = detail.orderedSections.compactMap {
-            if case let .albums(albums) = $0.content { albums } else { nil }
+            if case let .albums(albums) = $0.content {
+                albums
+            } else {
+                nil
+            }
         }
         let playlistSections = detail.orderedSections.compactMap {
-            if case let .playlists(playlists) = $0.content { playlists } else { nil }
+            if case let .playlists(playlists) = $0.content {
+                playlists
+            } else {
+                nil
+            }
         }
         let artistSections = detail.orderedSections.compactMap {
-            if case let .artists(artists) = $0.content { artists } else { nil }
+            if case let .artists(artists) = $0.content {
+                artists
+            } else {
+                nil
+            }
         }
         let artistCount = artistSections.reduce(0) { $0 + $1.count }
         let playlistCount = playlistSections.reduce(0) { $0 + $1.count }
@@ -1735,17 +1747,17 @@ final class YTMusicClient: YTMusicClientProtocol {
 
     /// Builds authentication headers for API requests.
     private func buildAuthHeaders() async throws -> [String: String] {
-        // Log available cookies for debugging auth issues
-        let allCookies = await webKitManager.getAllCookies()
-        let youtubeCookies = await webKitManager.getCookies(for: "youtube.com")
-        self.logger.debug("Building auth headers - total cookies: \(allCookies.count), youtube.com cookies: \(youtubeCookies.count)")
+        // Snapshot cookies once per request; deriving the cookie header and SAPISID from
+        // the same snapshot avoids repeated WebKit cookie-store enumerations during API fanout.
+        let authMaterial = await webKitManager.authMaterial(for: "youtube.com")
+        self.logger.debug("Building auth headers - total cookies: \(authMaterial.totalCookieCount), youtube.com cookies: \(authMaterial.domainCookieCount)")
 
-        guard let cookieHeader = await webKitManager.cookieHeader(for: "youtube.com") else {
+        guard let cookieHeader = authMaterial.cookieHeader else {
             self.logger.error("No cookies found for youtube.com domain")
             throw YTMusicError.notAuthenticated
         }
 
-        guard let sapisid = await webKitManager.getSAPISID() else {
+        guard let sapisid = authMaterial.sapisid else {
             self.logger.error("SAPISID cookie not found or expired")
             throw YTMusicError.authExpired
         }

--- a/Sources/Kaset/Services/API/YTMusicClient.swift
+++ b/Sources/Kaset/Services/API/YTMusicClient.swift
@@ -1993,6 +1993,7 @@ final class YTMusicAPIKeyResolver {
     private let environment: @Sendable (String) -> String?
     private let webClientURL: URL
     private var cachedAPIKey: String?
+    private var inFlightResolve: Task<String, any Error>?
 
     init(
         session: URLSession = .shared,
@@ -2017,8 +2018,29 @@ final class YTMusicAPIKeyResolver {
             return trimmed
         }
 
+        if let inFlightResolve {
+            return try await inFlightResolve.value
+        }
+
+        let task = Task { [session, webClientURL] in
+            try await Self.fetchAPIKey(session: session, webClientURL: webClientURL)
+        }
+        self.inFlightResolve = task
+
         do {
-            var request = URLRequest(url: self.webClientURL)
+            let apiKey = try await task.value
+            self.cachedAPIKey = apiKey
+            self.inFlightResolve = nil
+            return apiKey
+        } catch {
+            self.inFlightResolve = nil
+            throw error
+        }
+    }
+
+    private static func fetchAPIKey(session: URLSession, webClientURL: URL) async throws -> String {
+        do {
+            var request = URLRequest(url: webClientURL)
             request.setValue(APISessionConfiguration.userAgent, forHTTPHeaderField: "User-Agent")
             // The Innertube API key is public and needs no authentication. Do NOT send the user's
             // cookie jar for this fetch: a stale/partial consent cookie lands the request on the EU
@@ -2027,7 +2049,7 @@ final class YTMusicAPIKeyResolver {
             // bypasses the consent wall and returns the real web client page.
             request.httpShouldHandleCookies = false
             request.setValue("SOCS=CAI", forHTTPHeaderField: "Cookie")
-            let (data, response) = try await self.session.data(for: request)
+            let (data, response) = try await session.data(for: request)
             if let httpResponse = response as? HTTPURLResponse,
                !(200 ... 399).contains(httpResponse.statusCode)
             {
@@ -2043,7 +2065,6 @@ final class YTMusicAPIKeyResolver {
                 throw YTMusicError.parseError(message: "Could not resolve YouTube Music API configuration")
             }
 
-            self.cachedAPIKey = apiKey
             return apiKey
         } catch let error as YTMusicError {
             throw error

--- a/Sources/Kaset/Services/API/YouTubeClient.swift
+++ b/Sources/Kaset/Services/API/YouTubeClient.swift
@@ -344,7 +344,9 @@ final class YouTubeClient: YouTubeClientProtocol {
                 for short in feed.shorts where seen.insert(short.videoId).inserted {
                     collected.append(short)
                 }
-                if collected.count >= 30 { break }
+                if collected.count >= 30 {
+                    break
+                }
             } catch {
                 self.logger.debug("Shorts fallback destination failed: \(destination.rawValue, privacy: .public) — \(error.localizedDescription, privacy: .public)")
             }
@@ -519,12 +521,17 @@ final class YouTubeClient: YouTubeClientProtocol {
 
     /// Builds authentication headers with the YouTube (not music) origin.
     private func buildAuthHeaders() async throws -> [String: String] {
-        guard let cookieHeader = await webKitManager.cookieHeader(for: "youtube.com") else {
+        // Snapshot cookies once per request; deriving the cookie header and SAPISID from
+        // the same snapshot avoids repeated WebKit cookie-store enumerations during API fanout.
+        let authMaterial = await webKitManager.authMaterial(for: "youtube.com")
+        self.logger.debug("Building YouTube auth headers - total cookies: \(authMaterial.totalCookieCount), youtube.com cookies: \(authMaterial.domainCookieCount)")
+
+        guard let cookieHeader = authMaterial.cookieHeader else {
             self.logger.error("No cookies found for youtube.com domain")
             throw YTMusicError.notAuthenticated
         }
 
-        guard let sapisid = await webKitManager.getSAPISID() else {
+        guard let sapisid = authMaterial.sapisid else {
             self.logger.error("SAPISID cookie not found or expired")
             throw YTMusicError.authExpired
         }

--- a/Sources/Kaset/Services/Audio/EqualizerAudioEngine.swift
+++ b/Sources/Kaset/Services/Audio/EqualizerAudioEngine.swift
@@ -459,7 +459,9 @@ final class EqualizerAudioEngine: EqualizerAudioEngineProtocol {
         /// Whether the failure is recoverable just by playing audio — we
         /// shouldn't show a permission warning in this case.
         var isWaitingForPlayback: Bool {
-            if case .tap(.noAudioSource) = self { return true }
+            if case .tap(.noAudioSource) = self {
+                return true
+            }
             return false
         }
 

--- a/Sources/Kaset/Services/Audio/EqualizerService.swift
+++ b/Sources/Kaset/Services/Audio/EqualizerService.swift
@@ -275,7 +275,9 @@ final class EqualizerService {
             ))
         }
         guard self.settings.isEnabled else { return .off }
-        if self.engine.isRunning { return .active }
+        if self.engine.isRunning {
+            return .active
+        }
         if let failure = self.lastFailure {
             if failure.isPermissionLikely {
                 return .permissionNeeded(message: failure.userFacingMessage)

--- a/Sources/Kaset/Services/Audio/ProcessTapHelper.swift
+++ b/Sources/Kaset/Services/Audio/ProcessTapHelper.swift
@@ -267,7 +267,9 @@ final class ProcessTapHelper {
             ownedChildPIDs: Self.childPIDs(of: ourPID),
             hostProcessNames: Self.hostProcessNames
         )
-        if !ours.isEmpty { return ours }
+        if !ours.isEmpty {
+            return ours
+        }
         if !candidates.isEmpty {
             Self.logger.warning(
                 "found \(candidates.count) WebKit audio process(es) but none were provably owned by Kaset; skipping tap to avoid hijacking unrelated audio"

--- a/Sources/Kaset/Services/Auth/AuthService.swift
+++ b/Sources/Kaset/Services/Auth/AuthService.swift
@@ -14,7 +14,9 @@ final class AuthService: AuthServiceProtocol {
         case loggedIn(sapisid: String)
 
         var isLoggedIn: Bool {
-            if case .loggedIn = self { return true }
+            if case .loggedIn = self {
+                return true
+            }
             return false
         }
 
@@ -42,9 +44,15 @@ final class AuthService: AuthServiceProtocol {
     /// Reauth prompts keep the existing account-cookie playback store so active
     /// playback is not torn down while the user re-authenticates.
     var shouldUseCookieFreePlaybackDataStore: Bool {
-        if self.isGuestModeEnabled { return true }
-        if self.state == .loggedOut, !self.needsReauth { return true }
-        if self.state == .loggingIn, self.stateBeforeLogin == .loggedOut, !self.needsReauth { return true }
+        if self.isGuestModeEnabled {
+            return true
+        }
+        if self.state == .loggedOut, !self.needsReauth {
+            return true
+        }
+        if self.state == .loggingIn, self.stateBeforeLogin == .loggedOut, !self.needsReauth {
+            return true
+        }
         return false
     }
 
@@ -53,9 +61,15 @@ final class AuthService: AuthServiceProtocol {
     /// open; that flow should still preserve guest-owned queues if cancelled.
     var shouldPersistGuestPlaybackState: Bool {
         guard !self.needsReauth else { return false }
-        if self.isGuestModeEnabled { return true }
-        if self.state == .loggedOut { return true }
-        if self.state == .loggingIn, self.stateBeforeLogin == .loggedOut { return true }
+        if self.isGuestModeEnabled {
+            return true
+        }
+        if self.state == .loggedOut {
+            return true
+        }
+        if self.state == .loggingIn, self.stateBeforeLogin == .loggedOut {
+            return true
+        }
         return false
     }
 

--- a/Sources/Kaset/Services/ExtensionsManager.swift
+++ b/Sources/Kaset/Services/ExtensionsManager.swift
@@ -157,7 +157,11 @@ final class ExtensionsManager {
         }
 
         let accessingSource = url.startAccessingSecurityScopedResource()
-        defer { if accessingSource { url.stopAccessingSecurityScopedResource() } }
+        defer {
+            if accessingSource {
+                url.stopAccessingSecurityScopedResource()
+            }
+        }
 
         guard let data = try? Data(contentsOf: manifestURL),
               let manifest = try? JSONSerialization.jsonObject(with: data) as? [String: Any]

--- a/Sources/Kaset/Services/Lyrics/Romanization/RomanizationService.swift
+++ b/Sources/Kaset/Services/Lyrics/Romanization/RomanizationService.swift
@@ -15,8 +15,12 @@ final class RomanizationService {
 
     /// Romanizes a single line of text. Returns nil if the text is already Latin or romanization produced no change.
     func romanize(_ text: String) -> String? {
-        if ScriptDetector.isLatinOnly(text) { return nil }
-        if let cached = self.cache[text] { return cached }
+        if ScriptDetector.isLatinOnly(text) {
+            return nil
+        }
+        if let cached = self.cache[text] {
+            return cached
+        }
 
         let result: String? = switch ScriptDetector.dominantScript(text) {
         case .japanese: JapaneseRomanizer.romanize(text)

--- a/Sources/Kaset/Services/Lyrics/Romanization/ScriptDetector.swift
+++ b/Sources/Kaset/Services/Lyrics/Romanization/ScriptDetector.swift
@@ -80,11 +80,17 @@ enum ScriptDetector {
         for scalar in text.unicodeScalars {
             let v = scalar.value
             // Hangul Jamo U+1100–11FF
-            if v >= 0x1100, v <= 0x11FF { return true }
+            if v >= 0x1100, v <= 0x11FF {
+                return true
+            }
             // Hangul Syllables U+AC00–D7AF
-            if v >= 0xAC00, v <= 0xD7AF { return true }
+            if v >= 0xAC00, v <= 0xD7AF {
+                return true
+            }
             // Hangul Compatibility Jamo U+3130–318F
-            if v >= 0x3130, v <= 0x318F { return true }
+            if v >= 0x3130, v <= 0x318F {
+                return true
+            }
         }
         return false
     }
@@ -126,10 +132,18 @@ enum ScriptDetector {
             // Latin Extended-A (U+0100–017F), Latin Extended-B (U+0180–024F)
             if v > 0x024F {
                 // Also allow common punctuation and symbols
-                if v >= 0x2000, v <= 0x206F { continue } // General Punctuation
-                if v >= 0x20A0, v <= 0x20CF { continue } // Currency Symbols
-                if v >= 0xFE00, v <= 0xFE0F { continue } // Variation Selectors
-                if v >= 0xFFF0, v <= 0xFFFF { continue } // Specials
+                if v >= 0x2000, v <= 0x206F {
+                    continue
+                } // General Punctuation
+                if v >= 0x20A0, v <= 0x20CF {
+                    continue
+                } // Currency Symbols
+                if v >= 0xFE00, v <= 0xFE0F {
+                    continue
+                } // Variation Selectors
+                if v >= 0xFFF0, v <= 0xFFFF {
+                    continue
+                } // Specials
                 return false
             }
         }
@@ -139,13 +153,27 @@ enum ScriptDetector {
     /// Returns the most prevalent non-Latin script in the text.
     static func dominantScript(_ text: String) -> Script {
         // Check in order of specificity
-        if self.hasJapanese(text) { return .japanese }
-        if self.hasKorean(text) { return .korean }
-        if self.hasChinese(text) { return .chinese }
-        if self.hasThai(text) { return .thai }
-        if self.hasBengali(text) { return .bengali }
-        if self.hasHindi(text) { return .hindi }
-        if self.isLatinOnly(text) { return .latin }
+        if self.hasJapanese(text) {
+            return .japanese
+        }
+        if self.hasKorean(text) {
+            return .korean
+        }
+        if self.hasChinese(text) {
+            return .chinese
+        }
+        if self.hasThai(text) {
+            return .thai
+        }
+        if self.hasBengali(text) {
+            return .bengali
+        }
+        if self.hasHindi(text) {
+            return .hindi
+        }
+        if self.isLatinOnly(text) {
+            return .latin
+        }
         return .unknown
     }
 }

--- a/Sources/Kaset/Services/Notification/NotificationService.swift
+++ b/Sources/Kaset/Services/Notification/NotificationService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Observation
 import UserNotifications
 
 /// Posts silent local notifications when the current track changes.
@@ -7,11 +8,20 @@ final class NotificationService {
     private let playerService: PlayerService
     private let settingsManager: SettingsManager
     private let logger = DiagnosticsLogger.notification
-    // swiftformat:disable modifierOrder
-    /// Task for observing player changes, cancelled in deinit.
-    /// nonisolated(unsafe) required for deinit access; Swift 6.2 warning is expected.
-    nonisolated(unsafe) private var observationTask: Task<Void, Never>?
-    // swiftformat:enable modifierOrder
+    private static let loadingResolutionCheckInterval: Duration = .milliseconds(10)
+    private static let loadingResolutionMaxChecks = 50
+    /// Whether player observation is currently registered.
+    private var isObservationActive = false
+    /// Monotonic token used to ignore stale one-shot observation callbacks after stopObserving().
+    private var observationGeneration = 0
+    /// Bounded follow-up task used only while a current track has unresolved metadata.
+    private var loadingResolutionTask: Task<Void, Never>?
+    /// Track ID currently being checked for loading-placeholder resolution.
+    private var pendingLoadingTrackId: String?
+    /// Last player track ID observed by the event-driven watcher.
+    private var previousObservedTrackId: String?
+    /// Last playback-active value observed by the event-driven watcher.
+    private var previousObservedIsPlaying = false
     /// Tracks the last notified track to prevent duplicate notifications.
     /// Internal for testing.
     private(set) var lastNotifiedTrackId: String?
@@ -21,10 +31,6 @@ final class NotificationService {
         self.settingsManager = settingsManager
         self.requestAuthorization()
         self.startObserving()
-    }
-
-    deinit {
-        observationTask?.cancel()
     }
 
     // MARK: - Authorization
@@ -46,34 +52,166 @@ final class NotificationService {
     // MARK: - Observation
 
     private func startObserving() {
-        self.observationTask = Task { @MainActor [weak self] in
-            guard let self else { return }
-            var previousTrack: Song?
-            var previousIsPlaying = self.playerService.isPlaying
+        guard !self.isObservationActive else { return }
 
-            while !Task.isCancelled {
-                let currentTrack = self.playerService.currentTrack
-                let isPlaying = self.playerService.isPlaying
+        self.isObservationActive = true
+        self.observationGeneration += 1
+        let generation = self.observationGeneration
 
-                // Notify once active playback starts for a new, fully resolved track.
-                if let track = currentTrack,
-                   track.id != self.lastNotifiedTrackId,
-                   track.title != "Loading..."
-                {
-                    let trackChanged = track.id != previousTrack?.id
-                    let playbackJustStarted = isPlaying && !previousIsPlaying
+        // Match the former polling loop's first cycle: treat an already-current
+        // track as a change, while preserving the current playback-active edge.
+        self.previousObservedTrackId = nil
+        self.previousObservedIsPlaying = self.playerService.isPlaying
+        let initialTrackToNotify = self.notificationCandidateForCurrentState()
 
-                    if isPlaying, trackChanged || playbackJustStarted {
-                        await self.postTrackNotification(track)
-                        self.lastNotifiedTrackId = track.id
-                    }
-                }
+        self.registerPlayerObservation(generation: generation)
 
-                previousTrack = currentTrack
-                previousIsPlaying = isPlaying
-                try? await Task.sleep(for: .milliseconds(500))
+        guard let initialTrackToNotify else { return }
+        Task { @MainActor [weak self] in
+            guard let self, self.isObserving(generation: generation) else { return }
+            await self.postTrackNotification(initialTrackToNotify)
+        }
+    }
+
+    private func registerPlayerObservation(generation: Int) {
+        guard self.isObserving(generation: generation) else { return }
+
+        let playerService = self.playerService
+        withObservationTracking {
+            _ = playerService.currentTrack
+            _ = playerService.currentTrack?.id
+            _ = playerService.currentTrack?.title
+            _ = playerService.state
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in
+                await self?.handlePlayerObservationChanged(generation: generation)
             }
         }
+    }
+
+    private func handlePlayerObservationChanged(generation: Int) async {
+        guard self.isObserving(generation: generation) else { return }
+
+        let trackToNotify = self.notificationCandidateForCurrentState()
+
+        // Re-register before posting so changes that arrive while UserNotifications
+        // is awaiting do not get dropped.
+        self.registerPlayerObservation(generation: generation)
+
+        guard let trackToNotify, self.isObserving(generation: generation) else { return }
+        await self.postTrackNotification(trackToNotify)
+    }
+
+    private func notificationCandidateForCurrentState() -> Song? {
+        let currentTrack = self.playerService.currentTrack
+        let isPlaying = self.playerService.isPlaying
+
+        defer {
+            if currentTrack == nil {
+                self.previousObservedTrackId = nil
+            } else if currentTrack?.title != "Loading..." {
+                self.previousObservedTrackId = currentTrack?.id
+            }
+            self.previousObservedIsPlaying = isPlaying
+        }
+
+        guard let track = currentTrack else { return nil }
+
+        if track.title == "Loading..." {
+            if isPlaying, track.id != self.lastNotifiedTrackId {
+                self.scheduleLoadingResolutionCheck(for: track.id)
+            }
+            return nil
+        }
+
+        // Notify once active playback starts for a new, fully resolved track.
+        guard track.id != self.lastNotifiedTrackId else { return nil }
+
+        let trackChanged = track.id != self.previousObservedTrackId
+        let playbackJustStarted = isPlaying && !self.previousObservedIsPlaying
+
+        guard isPlaying, trackChanged || playbackJustStarted else { return nil }
+
+        self.clearLoadingResolutionCheck()
+        self.lastNotifiedTrackId = track.id
+        return track
+    }
+
+    private func scheduleLoadingResolutionCheck(for trackId: String) {
+        guard self.pendingLoadingTrackId != trackId else { return }
+
+        self.loadingResolutionTask?.cancel()
+        self.pendingLoadingTrackId = trackId
+        let generation = self.observationGeneration
+
+        self.loadingResolutionTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+
+            for _ in 0 ..< Self.loadingResolutionMaxChecks {
+                guard self.isObserving(generation: generation), !Task.isCancelled else { return }
+
+                await Task.yield()
+                if let trackToNotify = self.loadingResolutionNotificationCandidate(for: trackId) ?? self.notificationCandidateForCurrentState(),
+                   self.isObserving(generation: generation)
+                {
+                    await self.postTrackNotification(trackToNotify)
+                    return
+                }
+
+                guard self.playerService.currentTrack?.id == trackId,
+                      self.playerService.currentTrack?.title == "Loading..."
+                else {
+                    self.clearLoadingResolutionCheck()
+                    return
+                }
+
+                do {
+                    try await Task.sleep(for: Self.loadingResolutionCheckInterval)
+                } catch {
+                    return
+                }
+            }
+
+            self.clearLoadingResolutionCheck()
+        }
+    }
+
+    private func loadingResolutionNotificationCandidate(for trackId: String) -> Song? {
+        guard let track = self.playerService.currentTrack,
+              track.id == trackId,
+              track.title != "Loading...",
+              self.playerService.isPlaying,
+              track.id != self.lastNotifiedTrackId
+        else { return nil }
+
+        self.previousObservedTrackId = track.id
+        self.previousObservedIsPlaying = true
+        self.clearLoadingResolutionCheck()
+        self.lastNotifiedTrackId = track.id
+        return track
+    }
+
+    private func clearLoadingResolutionCheck() {
+        self.pendingLoadingTrackId = nil
+        self.loadingResolutionTask = nil
+    }
+
+    private func isObserving(generation: Int) -> Bool {
+        self.isObservationActive && self.observationGeneration == generation
+    }
+
+    /// Whether the observation registration is active.
+    var isObserving: Bool {
+        self.isObservationActive
+    }
+
+    func stopObserving() {
+        guard self.isObservationActive else { return }
+
+        self.isObservationActive = false
+        self.observationGeneration += 1
+        self.loadingResolutionTask?.cancel()
+        self.clearLoadingResolutionCheck()
     }
 
     // MARK: - Notification
@@ -104,18 +242,5 @@ final class NotificationService {
         } catch {
             self.logger.error("Failed to post notification: \(error.localizedDescription)")
         }
-    }
-
-    /// Whether the observation loop is actively running.
-    var isObserving: Bool {
-        if let task = self.observationTask {
-            return !task.isCancelled
-        }
-        return false
-    }
-
-    func stopObserving() {
-        self.observationTask?.cancel()
-        self.observationTask = nil
     }
 }

--- a/Sources/Kaset/Services/Player/PlayerService+Library.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+Library.swift
@@ -15,9 +15,11 @@ extension PlayerService {
         self.logger.info("Liking current track: \(track.videoId)")
         let activeAccountID = SongLikeStatusManager.shared.activeAccountID
         let client = self.ytMusicClient
+        let previousStatus = self.currentTrackLikeStatus
+        SongLikeStatusManager.shared.setStatus(previousStatus, for: [track.videoId], accountID: activeAccountID)
 
         // Toggle: if already liked, remove the like
-        let newStatus: LikeStatus = self.currentTrackLikeStatus == .like ? .indifferent : .like
+        let newStatus: LikeStatus = previousStatus == .like ? .indifferent : .like
         // Optimistic UI update for PlayerBar
         self.currentTrackLikeStatus = newStatus
 
@@ -37,13 +39,11 @@ extension PlayerService {
                 )
             }
 
-            guard SongLikeStatusManager.shared.activeAccountID == activeAccountID,
-                  self.currentTrack?.videoId == track.videoId
-            else {
-                return
-            }
-
-            self.currentTrackLikeStatus = finalStatus
+            self.reconcileCurrentTrackLikeStatusAfterRating(
+                track: track,
+                requestedAccountID: activeAccountID,
+                finalStatus: finalStatus
+            )
         }
     }
 
@@ -58,9 +58,11 @@ extension PlayerService {
         self.logger.info("Disliking current track: \(track.videoId)")
         let activeAccountID = SongLikeStatusManager.shared.activeAccountID
         let client = self.ytMusicClient
+        let previousStatus = self.currentTrackLikeStatus
+        SongLikeStatusManager.shared.setStatus(previousStatus, for: [track.videoId], accountID: activeAccountID)
 
         // Toggle: if already disliked, remove the dislike
-        let newStatus: LikeStatus = self.currentTrackLikeStatus == .dislike ? .indifferent : .dislike
+        let newStatus: LikeStatus = previousStatus == .dislike ? .indifferent : .dislike
         // Optimistic UI update for PlayerBar
         self.currentTrackLikeStatus = newStatus
 
@@ -80,14 +82,29 @@ extension PlayerService {
                 )
             }
 
-            guard SongLikeStatusManager.shared.activeAccountID == activeAccountID,
-                  self.currentTrack?.videoId == track.videoId
-            else {
-                return
-            }
-
-            self.currentTrackLikeStatus = finalStatus
+            self.reconcileCurrentTrackLikeStatusAfterRating(
+                track: track,
+                requestedAccountID: activeAccountID,
+                finalStatus: finalStatus
+            )
         }
+    }
+
+    private func reconcileCurrentTrackLikeStatusAfterRating(
+        track: Song,
+        requestedAccountID: String,
+        finalStatus: LikeStatus
+    ) {
+        guard self.currentTrack?.videoId == track.videoId else {
+            return
+        }
+
+        guard SongLikeStatusManager.shared.activeAccountID == requestedAccountID else {
+            self.currentTrackLikeStatus = SongLikeStatusManager.shared.status(for: track.videoId) ?? .indifferent
+            return
+        }
+
+        self.currentTrackLikeStatus = finalStatus
     }
 
     /// Toggles the library status of the current track.

--- a/Sources/Kaset/Services/Player/PlayerService+PlaybackControls.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+PlaybackControls.swift
@@ -595,7 +595,8 @@ extension PlayerService {
         self.currentTrack = nil
         self.pendingPlayVideoId = nil
         self.progress = 0
-        self.currentTimeMs = 0
+        self.currentLyricsLineIndex = nil
+        self.currentLyricsDisplayTimeMs = nil
         self.duration = 0
         self.showMiniPlayer = false
         self.isMiniPlayerVisible = false

--- a/Sources/Kaset/Services/Player/PlayerService+Queue.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+Queue.swift
@@ -720,6 +720,24 @@ extension PlayerService {
     private static let savedQueueIndexKey = "kaset.saved.queueIndex"
     private static let savedPlaybackSessionKey = "kaset.saved.playbackSession"
 
+    private var savedQueueKey: String {
+        Self.savedQueueKey + self.queuePersistenceKeySuffix
+    }
+
+    private var savedQueueIndexKey: String {
+        Self.savedQueueIndexKey + self.queuePersistenceKeySuffix
+    }
+
+    private var savedPlaybackSessionKey: String {
+        Self.savedPlaybackSessionKey + self.queuePersistenceKeySuffix
+    }
+
+    #if DEBUG
+        func useQueuePersistenceNamespaceForTesting(_ namespace: String) {
+            self.queuePersistenceKeySuffix = namespace.isEmpty ? "" : ".\(namespace)"
+        }
+    #endif
+
     private func playbackPersistenceSignature(for session: PersistedPlaybackSession) -> Int {
         var hasher = Hasher()
         hasher.combine(session)
@@ -727,9 +745,9 @@ extension PlayerService {
     }
 
     private func hasPersistedPlaybackSessionPayload() -> Bool {
-        UserDefaults.standard.data(forKey: Self.savedQueueKey) != nil &&
-            UserDefaults.standard.object(forKey: Self.savedQueueIndexKey) != nil &&
-            UserDefaults.standard.data(forKey: Self.savedPlaybackSessionKey) != nil
+        UserDefaults.standard.data(forKey: self.savedQueueKey) != nil &&
+            UserDefaults.standard.object(forKey: self.savedQueueIndexKey) != nil &&
+            UserDefaults.standard.data(forKey: self.savedPlaybackSessionKey) != nil
     }
 
     /// Saves the current queue to UserDefaults for restoration on next launch.
@@ -796,9 +814,9 @@ extension PlayerService {
             let queueData = try encoder.encode(persistedQueue)
             let sessionData = try encoder.encode(session)
 
-            UserDefaults.standard.set(queueData, forKey: Self.savedQueueKey)
-            UserDefaults.standard.set(safeIndex, forKey: Self.savedQueueIndexKey)
-            UserDefaults.standard.set(sessionData, forKey: Self.savedPlaybackSessionKey)
+            UserDefaults.standard.set(queueData, forKey: self.savedQueueKey)
+            UserDefaults.standard.set(safeIndex, forKey: self.savedQueueIndexKey)
+            UserDefaults.standard.set(sessionData, forKey: self.savedPlaybackSessionKey)
             self.lastSavedPlaybackSessionSignature = signature
             self.queuePersistenceWriteCountForTesting += 1
             self.restoredPlaybackSessionOwnerScope = ownerScope
@@ -827,7 +845,7 @@ extension PlayerService {
     func updateRestoredPlaybackSessionOwnerScope(_ ownerScope: String?) {
         self.restoredPlaybackSessionOwnerScope = ownerScope
 
-        guard let sessionData = UserDefaults.standard.data(forKey: Self.savedPlaybackSessionKey) else { return }
+        guard let sessionData = UserDefaults.standard.data(forKey: self.savedPlaybackSessionKey) else { return }
 
         do {
             let decoder = JSONDecoder()
@@ -842,7 +860,7 @@ extension PlayerService {
                 ownerScope: ownerScope
             )
             let sessionData = try JSONEncoder().encode(updatedSession)
-            UserDefaults.standard.set(sessionData, forKey: Self.savedPlaybackSessionKey)
+            UserDefaults.standard.set(sessionData, forKey: self.savedPlaybackSessionKey)
             self.lastSavedPlaybackSessionSignature = nil
         } catch {
             self.logger.error("Failed to update playback session owner scope: \(error.localizedDescription)")
@@ -855,7 +873,7 @@ extension PlayerService {
     func restoreQueueFromPersistence() -> Bool {
         let decoder = JSONDecoder()
 
-        if let sessionData = UserDefaults.standard.data(forKey: Self.savedPlaybackSessionKey) {
+        if let sessionData = UserDefaults.standard.data(forKey: self.savedPlaybackSessionKey) {
             do {
                 let savedSession = try decoder.decode(PersistedPlaybackSession.self, from: sessionData)
                 let restoredQueue = savedSession.ownerScope == Self.playbackSessionScopeGuest
@@ -863,7 +881,7 @@ extension PlayerService {
                     : savedSession.queue
                 guard !restoredQueue.isEmpty else {
                     self.logger.info("Saved playback session is empty")
-                    UserDefaults.standard.removeObject(forKey: Self.savedPlaybackSessionKey)
+                    UserDefaults.standard.removeObject(forKey: self.savedPlaybackSessionKey)
                     return self.restoreLegacyQueueFromPersistence(using: decoder)
                 }
 
@@ -888,7 +906,7 @@ extension PlayerService {
                 return true
             } catch {
                 self.logger.error("Failed to restore playback session: \(error.localizedDescription)")
-                UserDefaults.standard.removeObject(forKey: Self.savedPlaybackSessionKey)
+                UserDefaults.standard.removeObject(forKey: self.savedPlaybackSessionKey)
             }
         }
 
@@ -911,8 +929,8 @@ extension PlayerService {
 
     /// Restores the legacy queue/index payload when no playback session is available.
     private func restoreLegacyQueueFromPersistence(using decoder: JSONDecoder) -> Bool {
-        guard let queueData = UserDefaults.standard.data(forKey: Self.savedQueueKey),
-              let savedIndex = UserDefaults.standard.object(forKey: Self.savedQueueIndexKey) as? Int
+        guard let queueData = UserDefaults.standard.data(forKey: self.savedQueueKey),
+              let savedIndex = UserDefaults.standard.object(forKey: self.savedQueueIndexKey) as? Int
         else {
             self.logger.info("No saved queue found")
             return false
@@ -952,9 +970,9 @@ extension PlayerService {
 
     /// Removes all persisted queue/session payloads.
     private func removeSavedPlaybackSession() {
-        UserDefaults.standard.removeObject(forKey: Self.savedQueueKey)
-        UserDefaults.standard.removeObject(forKey: Self.savedQueueIndexKey)
-        UserDefaults.standard.removeObject(forKey: Self.savedPlaybackSessionKey)
+        UserDefaults.standard.removeObject(forKey: self.savedQueueKey)
+        UserDefaults.standard.removeObject(forKey: self.savedQueueIndexKey)
+        UserDefaults.standard.removeObject(forKey: self.savedPlaybackSessionKey)
         self.restoredPlaybackSessionOwnerScope = nil
         self.lastSavedPlaybackSessionSignature = nil
     }

--- a/Sources/Kaset/Services/Player/PlayerService+Queue.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+Queue.swift
@@ -705,7 +705,7 @@ extension PlayerService {
     // MARK: - Queue Persistence
 
     /// Serialized playback session persisted across launches.
-    private struct PersistedPlaybackSession: Codable {
+    private struct PersistedPlaybackSession: Codable, Hashable {
         let queue: [Song]
         let entrySources: [QueueEntry.Source]?
         let currentIndex: Int
@@ -719,6 +719,18 @@ extension PlayerService {
     private static let savedQueueKey = "kaset.saved.queue"
     private static let savedQueueIndexKey = "kaset.saved.queueIndex"
     private static let savedPlaybackSessionKey = "kaset.saved.playbackSession"
+
+    private func playbackPersistenceSignature(for session: PersistedPlaybackSession) -> Int {
+        var hasher = Hasher()
+        hasher.combine(session)
+        return hasher.finalize()
+    }
+
+    private func hasPersistedPlaybackSessionPayload() -> Bool {
+        UserDefaults.standard.data(forKey: Self.savedQueueKey) != nil &&
+            UserDefaults.standard.object(forKey: Self.savedQueueIndexKey) != nil &&
+            UserDefaults.standard.data(forKey: Self.savedPlaybackSessionKey) != nil
+    }
 
     /// Saves the current queue to UserDefaults for restoration on next launch.
     func saveQueueForPersistence() {
@@ -765,22 +777,30 @@ extension PlayerService {
                 ? Self.playbackSessionScopeGuest
                 : Self.playbackSessionScopeAuthenticated
             let persistedQueue = isKnownGuestSession ? Self.queueWithoutAccountMetadata(persistableQueue) : persistableQueue
-            let queueData = try encoder.encode(persistedQueue)
-            let sessionData = try encoder.encode(
-                PersistedPlaybackSession(
-                    queue: persistedQueue,
-                    entrySources: persistedEntries.map(\.source),
-                    currentIndex: safeIndex,
-                    currentVideoId: currentVideoId,
-                    progress: clampedProgress,
-                    duration: resolvedDuration,
-                    ownerScope: ownerScope
-                )
+            let entrySources = persistedEntries.map(\.source)
+            let session = PersistedPlaybackSession(
+                queue: persistedQueue,
+                entrySources: entrySources,
+                currentIndex: safeIndex,
+                currentVideoId: currentVideoId,
+                progress: clampedProgress,
+                duration: resolvedDuration,
+                ownerScope: ownerScope
             )
+            let signature = self.playbackPersistenceSignature(for: session)
+            if self.lastSavedPlaybackSessionSignature == signature, self.hasPersistedPlaybackSessionPayload() {
+                self.logger.debug("Skipped unchanged playback session persistence")
+                return
+            }
+
+            let queueData = try encoder.encode(persistedQueue)
+            let sessionData = try encoder.encode(session)
 
             UserDefaults.standard.set(queueData, forKey: Self.savedQueueKey)
             UserDefaults.standard.set(safeIndex, forKey: Self.savedQueueIndexKey)
             UserDefaults.standard.set(sessionData, forKey: Self.savedPlaybackSessionKey)
+            self.lastSavedPlaybackSessionSignature = signature
+            self.queuePersistenceWriteCountForTesting += 1
             self.restoredPlaybackSessionOwnerScope = ownerScope
             self.logger.info("Saved playback session with \(persistedQueue.count) songs at index \(safeIndex)")
         } catch {
@@ -823,6 +843,7 @@ extension PlayerService {
             )
             let sessionData = try JSONEncoder().encode(updatedSession)
             UserDefaults.standard.set(sessionData, forKey: Self.savedPlaybackSessionKey)
+            self.lastSavedPlaybackSessionSignature = nil
         } catch {
             self.logger.error("Failed to update playback session owner scope: \(error.localizedDescription)")
         }
@@ -935,6 +956,7 @@ extension PlayerService {
         UserDefaults.standard.removeObject(forKey: Self.savedQueueIndexKey)
         UserDefaults.standard.removeObject(forKey: Self.savedPlaybackSessionKey)
         self.restoredPlaybackSessionOwnerScope = nil
+        self.lastSavedPlaybackSessionSignature = nil
     }
 
     /// Resolves the queue index from saved metadata.

--- a/Sources/Kaset/Services/Player/PlayerService+QueueEnrichment.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+QueueEnrichment.swift
@@ -4,31 +4,154 @@ import Foundation
 
 @MainActor
 extension PlayerService {
-    /// Starts the background metadata enrichment service.
-    /// This periodically checks the queue for songs with incomplete metadata and fetches full details.
+    /// Starts queue metadata enrichment if the current queue needs it.
+    ///
+    /// This is intentionally one-shot/event-driven: no app-lifetime polling loop is kept alive.
     func startQueueEnrichmentService() {
-        // Cancel any existing task
-        enrichmentTask?.cancel()
+        self.scheduleQueueEnrichmentIfNeeded()
+    }
 
-        enrichmentTask = Task { [weak self] in
-            guard let self else { return }
+    /// Stops any scheduled/running one-shot enrichment pass.
+    func stopQueueEnrichmentService() {
+        self.queueEnrichmentNeedsReschedule = false
+        self.queueEnrichmentGeneration += 1
+        self.queueEnrichmentRunningGeneration = nil
+        self.isQueueEnrichmentRunning = false
+        self.enrichmentTask?.cancel()
+        self.enrichmentTask = nil
+    }
 
-            while !Task.isCancelled {
-                // Wait 30 seconds between checks
-                try? await Task.sleep(for: .seconds(30))
+    /// Reacts to external queue mutations by re-arming bounded retries and scheduling enrichment only when needed.
+    func queueDidChangeForEnrichment() {
+        guard !self.isApplyingQueueEnrichmentResult else { return }
 
-                guard !Task.isCancelled else { break }
+        self.resetQueueEnrichmentAttemptState()
+        self.scheduleQueueEnrichmentIfNeeded()
+    }
 
-                // Perform enrichment
-                await self.enrichQueueMetadata()
+    /// Re-arms bounded retry state after an external queue/client event.
+    func resetQueueEnrichmentAttemptState() {
+        self.queueEnrichmentAttemptsByEntryID.removeAll()
+
+        // If a previous retry backoff is merely sleeping, replace it with the new external event's
+        // normal coalescing delay. Running fetches are left to finish/cancel through their generation guard.
+        guard !self.isQueueEnrichmentRunning, self.enrichmentTask != nil else { return }
+        self.queueEnrichmentGeneration += 1
+        self.enrichmentTask?.cancel()
+        self.enrichmentTask = nil
+    }
+
+    /// Schedules a single delayed enrichment pass when the queue has incomplete metadata.
+    func scheduleQueueEnrichmentIfNeeded(delay requestedDelay: Duration? = nil) {
+        self.pruneQueueEnrichmentAttemptState()
+
+        guard self.ytMusicClient != nil else {
+            self.stopQueueEnrichmentService()
+            return
+        }
+
+        let songsNeedingEnrichment = self.identifySongsNeedingEnrichment()
+        guard !songsNeedingEnrichment.isEmpty else {
+            self.queueEnrichmentAttemptsByEntryID.removeAll()
+            self.stopQueueEnrichmentService()
+            return
+        }
+
+        guard !self.identifyEnrichableSongsNeedingEnrichment().isEmpty else {
+            self.stopQueueEnrichmentService()
+            return
+        }
+
+        if self.isQueueEnrichmentRunning {
+            self.queueEnrichmentNeedsReschedule = true
+            return
+        }
+
+        guard self.enrichmentTask == nil else { return }
+
+        self.queueEnrichmentGeneration += 1
+        let generation = self.queueEnrichmentGeneration
+        let delay = requestedDelay ?? self.queueEnrichmentInitialDelay
+
+        self.enrichmentTask = Task { @MainActor [weak self] in
+            do {
+                try await Task.sleep(for: delay)
+            } catch {
+                await self?.finishScheduledQueueEnrichment(generation: generation)
+                return
             }
+
+            guard !Task.isCancelled else {
+                await self?.finishScheduledQueueEnrichment(generation: generation)
+                return
+            }
+
+            await self?.runScheduledQueueEnrichment(generation: generation)
         }
     }
 
-    /// Stops the background enrichment service.
-    func stopQueueEnrichmentService() {
-        enrichmentTask?.cancel()
-        enrichmentTask = nil
+    /// Runs the scheduled enrichment pass and clears/reschedules state as appropriate.
+    func runScheduledQueueEnrichment(generation: Int) async {
+        guard generation == self.queueEnrichmentGeneration else { return }
+        let songsToEnrich = self.identifyEnrichableSongsNeedingEnrichment()
+        guard self.ytMusicClient != nil, !songsToEnrich.isEmpty else {
+            await self.finishScheduledQueueEnrichment(generation: generation)
+            return
+        }
+
+        self.isQueueEnrichmentRunning = true
+        self.queueEnrichmentRunningGeneration = generation
+        self.queueEnrichmentNeedsReschedule = false
+        await self.enrichQueueMetadata(songsToEnrich: songsToEnrich)
+        if self.queueEnrichmentRunningGeneration == generation {
+            self.queueEnrichmentRunningGeneration = nil
+            self.isQueueEnrichmentRunning = false
+        }
+
+        guard generation == self.queueEnrichmentGeneration, !Task.isCancelled else { return }
+
+        let shouldRescheduleForMutation = self.queueEnrichmentNeedsReschedule
+        let shouldRetryIncompleteEntries = !self.identifyEnrichableSongsNeedingEnrichment().isEmpty
+        await self.finishScheduledQueueEnrichment(generation: generation)
+
+        if shouldRescheduleForMutation {
+            self.scheduleQueueEnrichmentIfNeeded()
+        } else if shouldRetryIncompleteEntries {
+            self.scheduleQueueEnrichmentIfNeeded(delay: self.queueEnrichmentRetryDelay)
+        }
+    }
+
+    /// Clears a scheduled task if it still owns the current enrichment generation.
+    func finishScheduledQueueEnrichment(generation: Int) async {
+        guard generation == self.queueEnrichmentGeneration else { return }
+
+        self.enrichmentTask = nil
+    }
+
+    /// Identifies incomplete queue entries that have not exhausted their bounded retry budget.
+    func identifyEnrichableSongsNeedingEnrichment() -> [(index: Int, videoId: String)] {
+        self.identifySongsNeedingEnrichment().filter { item in
+            guard let entryID = self.queueEntries[safe: item.index]?.id else { return false }
+
+            return self.queueEnrichmentAttemptsByEntryID[entryID, default: 0] < Self.maxQueueEnrichmentAttempts
+        }
+    }
+
+    /// Drops retry state for entries that are no longer in the queue.
+    func pruneQueueEnrichmentAttemptState() {
+        let activeEntryIDs = Set(self.queueEntryIDs)
+        self.queueEnrichmentAttemptsByEntryID = self.queueEnrichmentAttemptsByEntryID.filter { entryID, _ in
+            activeEntryIDs.contains(entryID)
+        }
+    }
+
+    /// Returns whether a song has placeholder or missing metadata that the API can improve.
+    func songNeedsQueueMetadataEnrichment(_ song: Song) -> Bool {
+        song.artists.isEmpty ||
+            song.artists.allSatisfy { $0.name.isEmpty || $0.name == "Unknown Artist" } ||
+            song.title.isEmpty ||
+            song.title == "Loading..." ||
+            song.thumbnailURL == nil
     }
 
     /// Identifies songs in the queue that need metadata enrichment.
@@ -36,20 +159,12 @@ extension PlayerService {
     func identifySongsNeedingEnrichment() -> [(index: Int, videoId: String)] {
         var songsNeedingEnrichment: [(index: Int, videoId: String)] = []
 
-        for (index, song) in queue.enumerated() {
-            // Check if song needs enrichment:
-            // 1. No artists or all artists are empty/unknown
-            // 2. Title is placeholder ("Loading..." or empty)
-            // 3. No thumbnail
-            let needsEnrichment = song.artists.isEmpty ||
-                song.artists.allSatisfy { $0.name.isEmpty || $0.name == "Unknown Artist" } ||
-                song.title.isEmpty ||
-                song.title == "Loading..." ||
-                song.thumbnailURL == nil
-
-            if needsEnrichment {
-                songsNeedingEnrichment.append((index: index, videoId: song.videoId))
-            }
+        // Check if song needs enrichment:
+        // 1. No artists or all artists are empty/unknown
+        // 2. Title is placeholder ("Loading..." or empty)
+        // 3. No thumbnail
+        for (index, song) in queue.enumerated() where self.songNeedsQueueMetadataEnrichment(song) {
+            songsNeedingEnrichment.append((index: index, videoId: song.videoId))
         }
 
         return songsNeedingEnrichment
@@ -57,23 +172,32 @@ extension PlayerService {
 
     /// Enriches queue metadata by fetching full song details for incomplete entries.
     /// This updates the queue in-place and persists the enriched data.
-    func enrichQueueMetadata() async {
+    func enrichQueueMetadata(songsToEnrich requestedSongsToEnrich: [(index: Int, videoId: String)]? = nil) async {
         guard let client = self.ytMusicClient else { return }
 
-        let songsToEnrich = self.identifySongsNeedingEnrichment()
+        let songsToEnrich = requestedSongsToEnrich ?? self.identifySongsNeedingEnrichment()
 
         guard !songsToEnrich.isEmpty else { return }
 
         self.logger.info("Enriching metadata for \(songsToEnrich.count) songs in queue")
 
-        // Process in small batches to avoid overwhelming the API
-        // Process one song at a time to be gentle on the API
+        var didUpdateQueue = false
+
+        // Process one song at a time to be gentle on the API.
         for (index, videoId) in songsToEnrich {
+            guard !Task.isCancelled else { break }
+
             // Check if still needed (song might have been removed)
             guard index < queue.count, queue[index].videoId == videoId else { continue }
+            let entryID = self.queueEntries[safe: index]?.id
+            if let entryID {
+                self.queueEnrichmentAttemptsByEntryID[entryID, default: 0] += 1
+            }
 
             do {
                 let enrichedSong = try await client.getSong(videoId: videoId)
+
+                guard !Task.isCancelled else { break }
 
                 // Update the queue in-place
                 if index < queue.count, queue[index].videoId == videoId {
@@ -84,7 +208,13 @@ extension PlayerService {
                         song: enrichedSong,
                         source: updatedEntries[index].source
                     )
+                    self.isApplyingQueueEnrichmentResult = true
                     self.setQueue(entries: updatedEntries)
+                    self.isApplyingQueueEnrichmentResult = false
+                    didUpdateQueue = true
+                    if let entryID, !self.songNeedsQueueMetadataEnrichment(enrichedSong) {
+                        self.queueEnrichmentAttemptsByEntryID.removeValue(forKey: entryID)
+                    }
                     self.logger.debug("Enriched song \(index): '\(enrichedSong.title)' - artists: \(enrichedSong.artistsDisplay)")
                 }
 
@@ -98,7 +228,11 @@ extension PlayerService {
         }
 
         // Save the enriched queue to persistence
-        self.saveQueueForPersistence()
-        self.logger.info("Queue metadata enrichment complete, saved to persistence")
+        if didUpdateQueue {
+            self.saveQueueForPersistence()
+            self.logger.info("Queue metadata enrichment complete, saved to persistence")
+        } else {
+            self.logger.info("Queue metadata enrichment complete, no queue updates to persist")
+        }
     }
 }

--- a/Sources/Kaset/Services/Player/PlayerService+QueueEnrichment.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+QueueEnrichment.swift
@@ -32,13 +32,11 @@ extension PlayerService {
     /// Re-arms bounded retry state after an external queue/client event.
     func resetQueueEnrichmentAttemptState() {
         self.queueEnrichmentAttemptsByEntryID.removeAll()
-
-        // If a previous retry backoff is merely sleeping, replace it with the new external event's
-        // normal coalescing delay. Running fetches are left to finish/cancel through their generation guard.
-        guard !self.isQueueEnrichmentRunning, self.enrichmentTask != nil else { return }
-        self.queueEnrichmentGeneration += 1
-        self.enrichmentTask?.cancel()
-        self.enrichmentTask = nil
+        // Queue replacements and client/account switches invalidate both sleeping
+        // retries and active fetches. The cancelled pass checks cancellation before
+        // applying its response, while the generation bump prevents it from clearing
+        // a replacement task scheduled by the external event.
+        self.stopQueueEnrichmentService()
     }
 
     /// Schedules a single delayed enrichment pass when the queue has incomplete metadata.

--- a/Sources/Kaset/Services/Player/PlayerService+SmartShuffle.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+SmartShuffle.swift
@@ -143,7 +143,9 @@ extension PlayerService {
             let entries = self.queueEntries
             let upcomingStart = min(self.currentIndex + 1, entries.count)
             let suggestionsAhead = entries[upcomingStart...].count(where: { $0.source == .suggested })
-            if suggestionsAhead >= target { break }
+            if suggestionsAhead >= target {
+                break
+            }
             guard let slot = Self.nextSuggestionSlot(
                 in: entries,
                 afterIndex: self.currentIndex,
@@ -164,7 +166,9 @@ extension PlayerService {
                 // aborting the whole fill on the nearest gap.
                 transientlyFailedSeeds.insert(seedEntry.song.videoId)
                 radioErrorBudget -= 1
-                if radioErrorBudget <= 0 { break }
+                if radioErrorBudget <= 0 {
+                    break
+                }
                 continue
             }
 

--- a/Sources/Kaset/Services/Player/PlayerService.swift
+++ b/Sources/Kaset/Services/Player/PlayerService.swift
@@ -309,6 +309,9 @@ final class PlayerService: NSObject, PlayerServiceProtocol {
 
     @ObservationIgnored var queuePersistenceWriteCountForTesting = 0
 
+    /// Optional suffix for test-only queue persistence isolation. Production uses the empty suffix.
+    @ObservationIgnored var queuePersistenceKeySuffix = ""
+
     /// Task handle for the one-shot queue metadata enrichment pass, if one is scheduled or running.
     @ObservationIgnored var enrichmentTask: Task<Void, Never>?
 

--- a/Sources/Kaset/Services/Player/PlayerService.swift
+++ b/Sources/Kaset/Services/Player/PlayerService.swift
@@ -300,8 +300,35 @@ final class PlayerService: NSObject, PlayerServiceProtocol {
     /// UserDefaults key for persisting repeat mode.
     static let repeatModeKey = "playerRepeatMode"
 
-    /// Task handle for the background queue metadata enrichment service.
-    var enrichmentTask: Task<Void, Never>?
+    /// Task handle for the one-shot queue metadata enrichment pass, if one is scheduled or running.
+    @ObservationIgnored var enrichmentTask: Task<Void, Never>?
+
+    /// Delay used to coalesce queue mutations before the one-shot metadata enrichment pass runs.
+    @ObservationIgnored var queueEnrichmentInitialDelay: Duration = .seconds(2)
+
+    /// Delay used before retrying entries that remain incomplete after a scheduled enrichment pass.
+    @ObservationIgnored var queueEnrichmentRetryDelay: Duration = .seconds(30)
+
+    /// Maximum scheduled enrichment attempts per stable queue entry before waiting for another queue event.
+    static let maxQueueEnrichmentAttempts = 3
+
+    /// Scheduled enrichment attempts by stable queue entry identity.
+    @ObservationIgnored var queueEnrichmentAttemptsByEntryID: [UUID: Int] = [:]
+
+    /// Monotonic token used to prevent stale scheduled enrichment tasks from clearing a newer task.
+    @ObservationIgnored var queueEnrichmentGeneration = 0
+
+    /// True while the one-shot enrichment pass is actively fetching metadata.
+    @ObservationIgnored var isQueueEnrichmentRunning = false
+
+    /// Generation of the currently running enrichment pass, if any.
+    @ObservationIgnored var queueEnrichmentRunningGeneration: Int?
+
+    /// Set when an external queue mutation happens while enrichment is running.
+    @ObservationIgnored var queueEnrichmentNeedsReschedule = false
+
+    /// Suppresses scheduler churn for queue writes that are produced by the enrichment pass itself.
+    @ObservationIgnored var isApplyingQueueEnrichmentResult = false
 
     // MARK: - Initialization
 
@@ -368,7 +395,8 @@ final class PlayerService: NSObject, PlayerServiceProtocol {
         // Load mock state for UI tests
         self.loadMockStateIfNeeded()
 
-        // Start queue metadata enrichment service
+        // Queue metadata enrichment is event/one-shot driven; this only schedules if restored
+        // state already needs enrichment and a client is available.
         self.startQueueEnrichmentService()
     }
 
@@ -481,6 +509,7 @@ final class PlayerService: NSObject, PlayerServiceProtocol {
     func setQueue(entries: [QueueEntry]) {
         self.queueStorage = entries
         self.synchronizeCurrentQueueEntryID()
+        self.queueDidChangeForEnrichment()
     }
 
     func synchronizeCurrentQueueEntryID() {
@@ -548,6 +577,8 @@ final class PlayerService: NSObject, PlayerServiceProtocol {
     /// Sets the YTMusicClient for API calls (dependency injection).
     func setYTMusicClient(_ client: any YTMusicClientProtocol) {
         self.ytMusicClient = client
+        self.resetQueueEnrichmentAttemptState()
+        self.scheduleQueueEnrichmentIfNeeded()
     }
 
     /// Sets the AuthService used to guard account-scoped mutations.

--- a/Sources/Kaset/Services/Player/PlayerService.swift
+++ b/Sources/Kaset/Services/Player/PlayerService.swift
@@ -304,6 +304,11 @@ final class PlayerService: NSObject, PlayerServiceProtocol {
     /// UserDefaults key for persisting repeat mode.
     static let repeatModeKey = "playerRepeatMode"
 
+    /// Last playback-session signature written in this process, used to skip redundant UserDefaults writes.
+    @ObservationIgnored var lastSavedPlaybackSessionSignature: Int?
+
+    @ObservationIgnored var queuePersistenceWriteCountForTesting = 0
+
     /// Task handle for the one-shot queue metadata enrichment pass, if one is scheduled or running.
     @ObservationIgnored var enrichmentTask: Task<Void, Never>?
 

--- a/Sources/Kaset/Services/Player/PlayerService.swift
+++ b/Sources/Kaset/Services/Player/PlayerService.swift
@@ -81,8 +81,12 @@ final class PlayerService: NSObject, PlayerServiceProtocol {
     /// Current playback position in seconds.
     var progress: TimeInterval = 0
 
-    /// High-resolution playback time in milliseconds, updated at ~10Hz when synced lyrics are active.
-    var currentTimeMs: Int = 0
+    /// Current synced-lyrics line index, updated only when the displayed lyric line changes.
+    var currentLyricsLineIndex: Int?
+
+    /// Representative playback timestamp for synced lyrics display state.
+    /// Updated with the line index, not at raw playback cadence.
+    var currentLyricsDisplayTimeMs: Int?
 
     /// Total duration of current track in seconds.
     var duration: TimeInterval = 0

--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -617,19 +617,6 @@ final class YouTubePlayerService {
         }
     }
 
-    /// Fetches the storyboard spec for the ambient backdrop, keyed to its video
-    /// so a previous video's spec never leaks forward. Kept separate from
-    /// `refreshPlaybackOptions` so this cosmetic-only data never delays caption
-    /// or quality loading. Retries briefly since the player response, like the
-    /// captions module, isn't ready the instant playback starts.
-    func refreshStoryboardSpec() async {
-        guard let videoId = self.currentVideo?.videoId,
-              self.beginStoryboardSpecRefreshIfNeeded(videoId: videoId)
-        else { return }
-
-        await self.fetchStoryboardSpec(for: videoId)
-    }
-
     /// Starts the cosmetic storyboard refresh from a synchronous playback-state
     /// update only when a task is actually needed. This avoids allocating a new
     /// `Task` every 1 Hz progress tick once a fetch is in-flight or already

--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -1,4 +1,5 @@
 // swiftlint:disable file_length
+import AppKit
 import Foundation
 import Observation
 
@@ -332,7 +333,9 @@ final class YouTubePlayerService {
     /// Toggles play/pause.
     func playPause() {
         if !self.isPlaying {
-            if self.reloadPendingPausedIdentitySwitchForUserResume() { return }
+            if self.reloadPendingPausedIdentitySwitchForUserResume() {
+                return
+            }
             self.playbackWillStart?()
         } else {
             self.deferInFlightIdentityReloadIfNeeded()
@@ -343,7 +346,9 @@ final class YouTubePlayerService {
 
     /// Resumes playback.
     func resume() {
-        if self.reloadPendingPausedIdentitySwitchForUserResume() { return }
+        if self.reloadPendingPausedIdentitySwitchForUserResume() {
+            return
+        }
         self.playbackWillStart?()
         self.playbackController.play()
     }
@@ -600,27 +605,54 @@ final class YouTubePlayerService {
     /// or quality loading. Retries briefly since the player response, like the
     /// captions module, isn't ready the instant playback starts.
     func refreshStoryboardSpec() async {
-        let videoId = self.currentVideo?.videoId
+        guard let videoId = self.currentVideo?.videoId,
+              self.beginStoryboardSpecRefreshIfNeeded(videoId: videoId)
+        else { return }
+
+        await self.fetchStoryboardSpec(for: videoId)
+    }
+
+    /// Starts the cosmetic storyboard refresh from a synchronous playback-state
+    /// update only when a task is actually needed. This avoids allocating a new
+    /// `Task` every 1 Hz progress tick once a fetch is in-flight or already
+    /// resolved for the current video.
+    @discardableResult
+    func startStoryboardSpecRefreshIfNeeded() -> Bool {
+        guard let videoId = self.currentVideo?.videoId,
+              self.beginStoryboardSpecRefreshIfNeeded(videoId: videoId)
+        else { return false }
+
+        Task {
+            await self.fetchStoryboardSpec(for: videoId)
+        }
+        return true
+    }
+
+    private func beginStoryboardSpecRefreshIfNeeded(videoId: String) -> Bool {
         // Already resolved this exact video (got a spec, or confirmed it has
         // none after a full retry) — nothing to do. The trigger only calls this
         // for real content, never during a preroll ad, so a resolved `nil` here
         // is a genuine "no storyboard" and is safe to cache as a negative result
         // instead of re-fetching on every 1 Hz playback update.
         if self.storyboardFetchVideoId == videoId {
-            return
+            return false
         }
         if self.storyboardFetchInFlightVideoId == videoId {
-            return
+            return false
         }
         self.storyboardFetchInFlightVideoId = videoId
+        // Drop any spec from a previous video before awaiting the refetch.
+        self.storyboardSpec = nil
+        self.storyboardFetchVideoId = nil
+        return true
+    }
+
+    private func fetchStoryboardSpec(for videoId: String) async {
         defer {
             if self.storyboardFetchInFlightVideoId == videoId {
                 self.storyboardFetchInFlightVideoId = nil
             }
         }
-        // Drop any spec from a previous video before awaiting the refetch.
-        self.storyboardSpec = nil
-        self.storyboardFetchVideoId = nil
 
         for attempt in 0 ..< 3 {
             let spec = await self.playbackController.storyboardSpec(expectedVideoId: videoId)
@@ -810,20 +842,24 @@ final class YouTubePlayerService {
             }
         }
 
-        // Storyboard color drives the ambient backdrop, so only fetch it when
-        // the feature is on and real content (not a preroll ad) is playing.
+        // Storyboard color drives the `.live` ambient backdrop, so only fetch it
+        // when that style is actually active and real content (not a preroll ad)
+        // is playing.
         // Not gated on the one-shot playback-options branch above, so it also
         // fires when the user enables ambient mid-playback or when content
-        // starts after an ad. `refreshStoryboardSpec` is self-guarding, so
-        // calling it on each qualifying update is cheap.
+        // starts after an ad. `startStoryboardSpecRefreshIfNeeded` is
+        // synchronously guarded, so the 1 Hz playback tick does not allocate a
+        // new Task once a fetch is in-flight or already resolved.
         if update.isPlaying,
            !update.isAd,
            self.currentVideo != nil,
-           SettingsManager.shared.ambientBackdropEnabled
+           AmbientVideoBackdrop.effectiveStyle(
+               requestedStyle: SettingsManager.shared.resolvedAmbientStyle,
+               reduceMotion: NSWorkspace.shared.accessibilityDisplayShouldReduceMotion,
+               lowPowerModeEnabled: ProcessInfo.processInfo.isLowPowerModeEnabled
+           ) == .live
         {
-            Task {
-                await self.refreshStoryboardSpec()
-            }
+            self.startStoryboardSpecRefreshIfNeeded()
         }
 
         // Track SPA drift: if the page moved to a different video, follow it

--- a/Sources/Kaset/Services/Scrobbling/LastFMService.swift
+++ b/Sources/Kaset/Services/Scrobbling/LastFMService.swift
@@ -287,7 +287,9 @@ final class LastFMService: ScrobbleServiceProtocol {
                     return
                 }
             } catch {
-                if Task.isCancelled { return }
+                if Task.isCancelled {
+                    return
+                }
                 self.logger.debug("Auth polling attempt \(attempts) failed: \(error.localizedDescription)")
                 // Continue polling on transient errors
             }

--- a/Sources/Kaset/Services/Scrobbling/ScrobbleServiceProtocol.swift
+++ b/Sources/Kaset/Services/Scrobbling/ScrobbleServiceProtocol.swift
@@ -108,13 +108,17 @@ enum ScrobbleAuthState: Equatable {
 
     /// Whether the service is currently connected.
     var isConnected: Bool {
-        if case .connected = self { return true }
+        if case .connected = self {
+            return true
+        }
         return false
     }
 
     /// The connected username, if any.
     var username: String? {
-        if case let .connected(username) = self { return username }
+        if case let .connected(username) = self {
+            return username
+        }
         return nil
     }
 }

--- a/Sources/Kaset/Services/Scrobbling/ScrobblingCoordinator.swift
+++ b/Sources/Kaset/Services/Scrobbling/ScrobblingCoordinator.swift
@@ -2,8 +2,8 @@ import Foundation
 import Observation
 
 /// Bridges PlayerService to scrobbling backends.
-/// Polls PlayerService at 500ms intervals (matching NotificationService pattern),
-/// tracks accumulated play time, and triggers scrobbles when thresholds are met.
+/// Observes PlayerService playback mutations, tracks accumulated play time,
+/// and triggers scrobbles when thresholds are met.
 @MainActor
 @Observable
 final class ScrobblingCoordinator {
@@ -51,11 +51,11 @@ final class ScrobblingCoordinator {
     private var hasSentNowPlaying = false
 
     // swiftformat:disable modifierOrder
-    /// Polling task, cancelled in deinit.
-    private var pollingTask: Task<Void, Never>?
-
     /// Queue flush task, cancelled in deinit.
     private var flushTask: Task<Void, Never>?
+
+    /// Monotonic token that prevents stale flush tasks from clearing newer scheduled work.
+    private var flushTaskGeneration = 0
 
     /// Now-playing tasks, cancelled in stopMonitoring/deinit.
     private var nowPlayingTasks: [Task<Void, Never>] = []
@@ -63,6 +63,9 @@ final class ScrobblingCoordinator {
 
     /// Whether the coordinator is actively monitoring.
     private(set) var isMonitoring = false
+
+    /// Monotonic token used to ignore one-shot Observation callbacks armed before a stop/start cycle.
+    private var monitoringGeneration = 0
 
     // MARK: - Init
 
@@ -112,16 +115,20 @@ final class ScrobblingCoordinator {
     func startMonitoring() {
         guard !self.isMonitoring else { return }
         self.isMonitoring = true
+        self.monitoringGeneration += 1
+        let generation = self.monitoringGeneration
         self.logger.info("Scrobbling coordinator started monitoring")
 
-        self.startPolling()
-        self.startQueueFlush()
+        self.observePlayerStateChanges(generation: generation)
+        self.observeMonitoringEligibilityChanges(generation: generation)
+        self.pollPlayerState()
+        self.scheduleQueueFlushIfNeeded()
     }
 
     /// Stops monitoring and cancels all tasks.
     func stopMonitoring() {
-        self.pollingTask?.cancel()
-        self.pollingTask = nil
+        self.monitoringGeneration += 1
+        self.flushTaskGeneration += 1
         self.flushTask?.cancel()
         self.flushTask = nil
         self.nowPlayingTasks.forEach { $0.cancel() }
@@ -137,21 +144,56 @@ final class ScrobblingCoordinator {
         }
     }
 
-    // MARK: - Polling
+    // MARK: - Observation
 
-    private func startPolling() {
-        self.pollingTask?.cancel()
-        self.pollingTask = Task { @MainActor [weak self] in
-            guard let self else { return }
+    /// Re-arms Observation tracking for playback fields that affect scrobbling.
+    ///
+    /// Progress updates already arrive from the playback WebView while media is playing, so observing those
+    /// mutations avoids an independent app-lifetime 500 ms timer when the app is idle or scrobbling is disabled.
+    private func observePlayerStateChanges(generation: Int) {
+        guard self.isMonitoring(generation: generation) else { return }
 
-            while !Task.isCancelled {
+        withObservationTracking {
+            _ = self.playerService.currentTrack?.videoId
+            _ = self.playerService.currentTrack?.title
+            _ = self.playerService.currentTrack?.artistsDisplay
+            _ = self.playerService.isPlaying
+            _ = self.playerService.progress
+            _ = self.playerService.duration
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self, self.isMonitoring(generation: generation) else { return }
                 self.pollPlayerState()
-                try? await Task.sleep(for: .milliseconds(500))
+                self.observePlayerStateChanges(generation: generation)
             }
         }
     }
 
-    /// Core polling logic — called every 500ms.
+    /// Re-arms Observation tracking for service auth/enablement. When no service is eligible, playback
+    /// observation remains cheap and `pollPlayerState()` returns immediately; queue flushes are unscheduled.
+    private func observeMonitoringEligibilityChanges(generation: Int) {
+        guard self.isMonitoring(generation: generation) else { return }
+
+        withObservationTracking {
+            for service in self.services {
+                _ = self.settingsManager.isServiceEnabled(service.serviceName)
+                _ = service.authState
+            }
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in
+                guard let self, self.isMonitoring(generation: generation) else { return }
+                self.pollPlayerState()
+                self.scheduleQueueFlushIfNeeded()
+                self.observeMonitoringEligibilityChanges(generation: generation)
+            }
+        }
+    }
+
+    private func isMonitoring(generation: Int) -> Bool {
+        self.isMonitoring && self.monitoringGeneration == generation
+    }
+
+    /// Core scrobbling logic — driven by observed playback mutations instead of a periodic timer.
     private func pollPlayerState() {
         // Skip if no service is both enabled and connected
         guard self.hasAnyEnabledConnectedService else { return }
@@ -261,7 +303,7 @@ final class ScrobblingCoordinator {
         let progressDelta = progress - self.lastProgress
 
         // Only count positive, small deltas (< 2s wall clock) to ignore seeks
-        // A normal 500ms poll should show ~0.5s of progress
+        // A normal playback progress update should show ~1s or less of progress.
         if progressDelta > 0, progressDelta < 2.0, wallClockDelta < 2.0 {
             self.accumulatedPlayTime += progressDelta
         }
@@ -294,6 +336,7 @@ final class ScrobblingCoordinator {
 
             let scrobbleTrack = ScrobbleTrack(from: track, timestamp: startTime)
             self.queue.enqueue(scrobbleTrack)
+            self.scheduleQueueFlushIfNeeded()
             self.logger.info("Scrobble threshold met for: \(track.title) (accumulated: \(String(format: "%.1f", self.accumulatedPlayTime))s)")
         }
     }
@@ -329,18 +372,42 @@ final class ScrobblingCoordinator {
 
     // MARK: - Queue Flush
 
-    private func startQueueFlush() {
-        self.flushTask?.cancel()
-        self.flushTask = Task { @MainActor [weak self] in
-            guard let self else { return }
-
-            while !Task.isCancelled {
-                try? await Task.sleep(for: .seconds(30))
-
-                guard !Task.isCancelled else { return }
-                await self.flushQueue()
-            }
+    private func scheduleQueueFlushIfNeeded(after delay: Duration = .seconds(30)) {
+        guard self.isMonitoring,
+              self.hasAnyEnabledConnectedService,
+              !self.queue.isEmpty
+        else {
+            self.flushTaskGeneration += 1
+            self.flushTask?.cancel()
+            self.flushTask = nil
+            return
         }
+
+        guard self.flushTask == nil || self.flushTask?.isCancelled == true else { return }
+
+        self.flushTaskGeneration += 1
+        let generation = self.flushTaskGeneration
+        self.flushTask = Task { @MainActor [weak self] in
+            do {
+                try await Task.sleep(for: delay)
+            } catch {
+                guard let self, self.flushTaskGeneration == generation else { return }
+                self.flushTask = nil
+                return
+            }
+
+            guard let self, self.isMonitoring, self.flushTaskGeneration == generation else { return }
+            await self.flushQueue()
+            guard self.isMonitoring, self.flushTaskGeneration == generation else { return }
+            self.flushTask = nil
+            self.scheduleQueueFlushIfNeeded()
+        }
+    }
+
+    /// Exposed for focused tests; true only when there is pending queue work eligible for a one-shot flush.
+    var isQueueFlushScheduled: Bool {
+        guard let flushTask else { return false }
+        return !flushTask.isCancelled
     }
 
     /// Flushes pending scrobbles from the queue to all enabled services.

--- a/Sources/Kaset/Services/SettingsManager.swift
+++ b/Sources/Kaset/Services/SettingsManager.swift
@@ -6,6 +6,7 @@ import Observation
 @Observable
 final class SettingsManager {
     static let shared = SettingsManager()
+    nonisolated static let defaultAmbientBackdropStyle: AmbientBackdropStyle = .soft
 
     // MARK: - Settings Keys
 
@@ -384,10 +385,23 @@ final class SettingsManager {
         }
     }
 
-    /// The style the YouTube watch page should actually render: the chosen
-    /// style when enabled, `.off` when the feature is disabled.
+    /// The style the YouTube watch page should request: the chosen style when
+    /// enabled, `.off` when the feature is disabled. Runtime energy/accessibility
+    /// downgrades are applied inside `AmbientVideoBackdrop`, which observes those
+    /// external states directly.
     var resolvedAmbientStyle: AmbientBackdropStyle {
-        self.ambientBackdropEnabled ? self.ambientBackdropStyle : .off
+        Self.resolveAmbientStyle(
+            enabled: self.ambientBackdropEnabled,
+            preferredStyle: self.ambientBackdropStyle
+        )
+    }
+
+    nonisolated static func resolveAmbientStyle(
+        enabled: Bool,
+        preferredStyle: AmbientBackdropStyle
+    ) -> AmbientBackdropStyle {
+        guard enabled, preferredStyle != .off else { return .off }
+        return preferredStyle
     }
 
     /// The language used for the app interface and API content.
@@ -475,7 +489,7 @@ final class SettingsManager {
         {
             self.ambientBackdropStyle = style
         } else {
-            self.ambientBackdropStyle = .live
+            self.ambientBackdropStyle = Self.defaultAmbientBackdropStyle
         }
 
         if let rawValue = UserDefaults.standard.string(forKey: Keys.defaultLaunchPage),

--- a/Sources/Kaset/Services/WebKit/WebExtensionHost.swift
+++ b/Sources/Kaset/Services/WebKit/WebExtensionHost.swift
@@ -252,9 +252,15 @@ enum WebExtensionHostedWebViewRole: String {
 
         func windowState(for _: WKWebExtensionContext) -> WKWebExtension.WindowState {
             guard let nsWindow = self.representativeNSWindow else { return .normal }
-            if nsWindow.styleMask.contains(.fullScreen) { return .fullscreen }
-            if nsWindow.isMiniaturized { return .minimized }
-            if nsWindow.isZoomed { return .maximized }
+            if nsWindow.styleMask.contains(.fullScreen) {
+                return .fullscreen
+            }
+            if nsWindow.isMiniaturized {
+                return .minimized
+            }
+            if nsWindow.isZoomed {
+                return .maximized
+            }
             return .normal
         }
 

--- a/Sources/Kaset/Services/WebKit/WebKitManager+AuthMaterial.swift
+++ b/Sources/Kaset/Services/WebKit/WebKitManager+AuthMaterial.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+// MARK: - WebKitManager Auth Material
+
+extension WebKitManager {
+    nonisolated struct AuthMaterial: Equatable {
+        let cookieHeader: String?
+        let sapisid: String?
+        let totalCookieCount: Int
+        let domainCookieCount: Int
+    }
+
+    nonisolated static func cookies(_ cookies: [HTTPCookie], matching domain: String) -> [HTTPCookie] {
+        let normalizedDomain = domain.lowercased()
+        return cookies.filter { cookie in
+            let cookieDomain = cookie.domain.lowercased()
+            // Exact match
+            if cookieDomain == normalizedDomain {
+                return true
+            }
+            // Cookie domain with leading dot matches the domain and all subdomains
+            // e.g., ".youtube.com" matches "music.youtube.com" and "youtube.com"
+            if cookieDomain.hasPrefix(".") {
+                let withoutDot = String(cookieDomain.dropFirst())
+                return normalizedDomain == withoutDot || normalizedDomain.hasSuffix("." + withoutDot)
+            }
+            // Request domain is a subdomain of cookie domain
+            // e.g., cookie for "youtube.com" should match "music.youtube.com"
+            if normalizedDomain.hasSuffix("." + cookieDomain) {
+                return true
+            }
+            return false
+        }
+    }
+
+    nonisolated static func authMaterial(from cookies: [HTTPCookie], domain: String, now: Date = Date()) -> AuthMaterial {
+        let domainCookies = Self.cookies(cookies, matching: domain)
+        let cookieHeader = domainCookies.isEmpty ? nil : HTTPCookie.requestHeaderFields(with: domainCookies)["Cookie"]
+
+        // Preserve the existing secure-first semantics: if the secure auth cookie is present but expired,
+        // auth is expired even if a fallback cookie also exists.
+        let secureCookie = domainCookies.first { $0.name == Self.authCookieName }
+        let fallbackCookie = domainCookies.first { $0.name == Self.fallbackAuthCookieName }
+        let authCookie = secureCookie ?? fallbackCookie
+        let sapisid: String? = if let authCookie {
+            if let expiresDate = authCookie.expiresDate, expiresDate < now {
+                nil
+            } else {
+                authCookie.value
+            }
+        } else {
+            nil
+        }
+
+        return AuthMaterial(
+            cookieHeader: cookieHeader,
+            sapisid: sapisid,
+            totalCookieCount: cookies.count,
+            domainCookieCount: domainCookies.count
+        )
+    }
+
+    /// Returns cookie/auth material for one request by enumerating the WebKit cookie store once.
+    func authMaterial(for domain: String) async -> AuthMaterial {
+        let cookies = await self.getAllCookies()
+        return Self.authMaterial(from: cookies, domain: domain)
+    }
+}

--- a/Sources/Kaset/Services/WebKit/WebKitManager.swift
+++ b/Sources/Kaset/Services/WebKit/WebKitManager.swift
@@ -42,10 +42,10 @@ final class WebKitManager: NSObject, WebKitManagerProtocol {
     let webExtensionController = WKWebExtensionController()
 
     /// Required cookie name for authentication.
-    static let authCookieName = "__Secure-3PAPISID"
+    nonisolated static let authCookieName = "__Secure-3PAPISID"
 
     /// Fallback cookie name (non-secure version).
-    static let fallbackAuthCookieName = "SAPISID"
+    nonisolated static let fallbackAuthCookieName = "SAPISID"
 
     /// Custom user agent to appear as Safari to avoid "browser not supported" errors.
     static let userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15"
@@ -434,26 +434,7 @@ final class WebKitManager: NSObject, WebKitManagerProtocol {
     /// Uses proper domain matching: exact match or cookie domain with leading dot matches subdomains.
     func getCookies(for domain: String) async -> [HTTPCookie] {
         let allCookies = await getAllCookies()
-        let normalizedDomain = domain.lowercased()
-        return allCookies.filter { cookie in
-            let cookieDomain = cookie.domain.lowercased()
-            // Exact match
-            if cookieDomain == normalizedDomain {
-                return true
-            }
-            // Cookie domain with leading dot matches the domain and all subdomains
-            // e.g., ".youtube.com" matches "music.youtube.com" and "youtube.com"
-            if cookieDomain.hasPrefix(".") {
-                let withoutDot = String(cookieDomain.dropFirst())
-                return normalizedDomain == withoutDot || normalizedDomain.hasSuffix("." + withoutDot)
-            }
-            // Request domain is a subdomain of cookie domain
-            // e.g., cookie for "youtube.com" should match "music.youtube.com"
-            if normalizedDomain.hasSuffix("." + cookieDomain) {
-                return true
-            }
-            return false
-        }
+        return Self.cookies(allCookies, matching: domain)
     }
 
     /// Builds a Cookie header string for the given domain.

--- a/Sources/Kaset/Utilities/ColorExtractor.swift
+++ b/Sources/Kaset/Utilities/ColorExtractor.swift
@@ -210,16 +210,23 @@ actor ColorPaletteCache {
     static let shared = ColorPaletteCache()
 
     private let imageCache: ImageCache
+    private let maximumPaletteCount: Int
     private var palettes: [String: ColorExtractor.ColorPalette] = [:]
+    private var mostRecentlyUsedKeys: [String] = []
     private var inFlight: [String: Task<ColorExtractor.ColorPalette?, Never>] = [:]
 
-    init(imageCache: ImageCache = ImageCache.shared) {
+    init(
+        imageCache: ImageCache = ImageCache.shared,
+        maximumPaletteCount: Int = 200
+    ) {
         self.imageCache = imageCache
+        self.maximumPaletteCount = max(1, maximumPaletteCount)
     }
 
     func palette(for url: URL, targetSize: CGSize) async -> ColorExtractor.ColorPalette {
         let key = self.cacheKey(for: url, targetSize: targetSize)
         if let cached = self.palettes[key] {
+            self.markPaletteUsed(for: key)
             return cached
         }
         if let existing = self.inFlight[key] {
@@ -241,9 +248,35 @@ actor ColorPaletteCache {
         guard let palette else {
             return .default
         }
-        self.palettes[key] = palette
+        self.storePalette(palette, for: key)
         return palette
     }
+
+    private func storePalette(_ palette: ColorExtractor.ColorPalette, for key: String) {
+        self.palettes[key] = palette
+        self.markPaletteUsed(for: key)
+        self.evictLeastRecentlyUsedPalettesIfNeeded()
+    }
+
+    private func markPaletteUsed(for key: String) {
+        self.mostRecentlyUsedKeys.removeAll { $0 == key }
+        self.mostRecentlyUsedKeys.append(key)
+    }
+
+    private func evictLeastRecentlyUsedPalettesIfNeeded() {
+        while self.palettes.count > self.maximumPaletteCount,
+              let evictedKey = self.mostRecentlyUsedKeys.first
+        {
+            self.mostRecentlyUsedKeys.removeFirst()
+            self.palettes.removeValue(forKey: evictedKey)
+        }
+    }
+
+    #if DEBUG
+        var cachedPaletteCountForTesting: Int {
+            self.palettes.count
+        }
+    #endif
 
     private func cacheKey(for url: URL, targetSize: CGSize) -> String {
         "\(url.absoluteString)@\(Int(targetSize.width))x\(Int(targetSize.height))"

--- a/Sources/Kaset/Utilities/ColorExtractor.swift
+++ b/Sources/Kaset/Utilities/ColorExtractor.swift
@@ -2,6 +2,8 @@ import AppKit
 import CoreGraphics
 import SwiftUI
 
+// MARK: - ColorExtractor
+
 /// Extracts dominant colors from images for UI accent backgrounds.
 enum ColorExtractor {
     /// Represents a weighted color sample for averaging.
@@ -13,7 +15,7 @@ enum ColorExtractor {
     }
 
     /// Represents extracted color palette from an image.
-    struct ColorPalette: Equatable {
+    struct ColorPalette: Equatable, Sendable {
         /// Dark mode primary color (darker, saturated).
         let primary: Color
         /// Dark mode secondary color (even darker).
@@ -27,6 +29,17 @@ enum ColorExtractor {
             secondary: Color(nsColor: NSColor(white: 0.08, alpha: 1)),
             lightTint: Color(nsColor: NSColor.controlAccentColor).opacity(0.3)
         )
+    }
+
+    /// Returns an image-derived palette for a URL, reusing a shared cache so accent
+    /// backgrounds across detail views do not redownload or re-extract the same
+    /// artwork. `targetSize` is expressed in display points; `ImageCache` applies
+    /// the Retina multiplier while downsampling.
+    static func cachedPalette(
+        for url: URL,
+        targetSize: CGSize = CGSize(width: 64, height: 64)
+    ) async -> ColorPalette {
+        await ColorPaletteCache.shared.palette(for: url, targetSize: targetSize)
     }
 
     /// Extracts a color palette from an NSImage.
@@ -186,5 +199,53 @@ enum ColorExtractor {
             brightness: adjustedBrightness,
             alpha: 1.0
         )
+    }
+}
+
+// MARK: - ColorPaletteCache
+
+/// Shared palette cache backed by `ImageCache`, with an injectable image cache so
+/// tests can verify network coalescing without touching the app-wide singleton.
+actor ColorPaletteCache {
+    static let shared = ColorPaletteCache()
+
+    private let imageCache: ImageCache
+    private var palettes: [String: ColorExtractor.ColorPalette] = [:]
+    private var inFlight: [String: Task<ColorExtractor.ColorPalette?, Never>] = [:]
+
+    init(imageCache: ImageCache = ImageCache.shared) {
+        self.imageCache = imageCache
+    }
+
+    func palette(for url: URL, targetSize: CGSize) async -> ColorExtractor.ColorPalette {
+        let key = self.cacheKey(for: url, targetSize: targetSize)
+        if let cached = self.palettes[key] {
+            return cached
+        }
+        if let existing = self.inFlight[key] {
+            return await existing.value ?? .default
+        }
+
+        let imageCache = self.imageCache
+        let task = Task<ColorExtractor.ColorPalette?, Never>(priority: .utility) {
+            guard let image = await imageCache.image(for: url, targetSize: targetSize) else {
+                return nil
+            }
+            return ColorExtractor.extractPalette(from: image)
+        }
+
+        self.inFlight[key] = task
+        let palette = await task.value
+        self.inFlight[key] = nil
+
+        guard let palette else {
+            return .default
+        }
+        self.palettes[key] = palette
+        return palette
+    }
+
+    private func cacheKey(for url: URL, targetSize: CGSize) -> String {
+        "\(url.absoluteString)@\(Int(targetSize.width))x\(Int(targetSize.height))"
     }
 }

--- a/Sources/Kaset/Utilities/ColorExtractor.swift
+++ b/Sources/Kaset/Utilities/ColorExtractor.swift
@@ -15,7 +15,7 @@ enum ColorExtractor {
     }
 
     /// Represents extracted color palette from an image.
-    struct ColorPalette: Equatable, Sendable {
+    struct ColorPalette: Equatable {
         /// Dark mode primary color (darker, saturated).
         let primary: Color
         /// Dark mode secondary color (even darker).

--- a/Sources/Kaset/Utilities/ImageCache.swift
+++ b/Sources/Kaset/Utilities/ImageCache.swift
@@ -12,7 +12,11 @@ actor ImageCache {
     private static let maxConcurrentPrefetch = 4
 
     /// Maximum disk cache size in bytes (200MB).
-    private static let maxDiskCacheSize: Int64 = 200 * 1024 * 1024
+    private static let defaultMaxDiskCacheSize: Int64 = 200 * 1024 * 1024
+
+    /// Reconcile the approximate disk-size counter periodically to account for
+    /// external changes without scanning the cache directory after every write.
+    private static let defaultDiskEvictionWriteThreshold = 32
 
     private let memoryCache = NSCache<NSString, NSImage>()
     /// Keyed by URL + target size (the memory-cache key), so an in-flight
@@ -21,23 +25,49 @@ actor ImageCache {
     private var inFlight: [NSString: Task<NSImage?, Never>] = [:]
     private let fileManager = FileManager.default
     private let diskCacheURL: URL
+    private let maxDiskCacheSize: Int64
+    private let diskEvictionWriteThreshold: Int
+    private var estimatedDiskCacheSize: Int64?
+    private var writesSinceDiskEvictionCheck = 0
+    private var diskEvictionTask: Task<Void, Never>?
+    #if DEBUG
+        private(set) var diskCacheSizeScanCountForTesting = 0
+    #endif
 
-    private init() {
+    init(
+        diskCacheURL: URL? = nil,
+        maxDiskCacheSize: Int64 = ImageCache.defaultMaxDiskCacheSize,
+        initialEstimatedDiskCacheSize: Int64? = nil,
+        diskEvictionWriteThreshold: Int = ImageCache.defaultDiskEvictionWriteThreshold,
+        startsEvictionTask: Bool = true,
+        monitorsMemoryPressure: Bool = true
+    ) {
         self.memoryCache.countLimit = 200
         self.memoryCache.totalCostLimit = 50 * 1024 * 1024 // 50MB
 
         // Set up disk cache directory
-        let cacheDir = self.fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first!
-        self.diskCacheURL = cacheDir.appendingPathComponent("com.kaset.imagecache", isDirectory: true)
+        if let diskCacheURL {
+            self.diskCacheURL = diskCacheURL
+        } else {
+            let cacheDir = self.fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first!
+            self.diskCacheURL = cacheDir.appendingPathComponent("com.kaset.imagecache", isDirectory: true)
+        }
+        self.maxDiskCacheSize = maxDiskCacheSize
+        self.diskEvictionWriteThreshold = max(1, diskEvictionWriteThreshold)
+        self.estimatedDiskCacheSize = initialEstimatedDiskCacheSize
         try? self.fileManager.createDirectory(at: self.diskCacheURL, withIntermediateDirectories: true)
 
-        // Set up memory pressure monitoring
-        Self.setupMemoryPressureMonitoring(cache: self)
+        // Set up memory pressure monitoring.
+        if monitorsMemoryPressure {
+            Self.setupMemoryPressureMonitoring(cache: self)
+        }
 
-        // Evict disk cache if needed on startup.
+        // Evict disk cache if needed on startup and initialize the size estimate.
         // Perform file system I/O off the main actor.
-        Task(priority: .utility) {
-            await self.evictDiskCacheIfNeeded()
+        if startsEvictionTask {
+            Task(priority: .utility) {
+                await self.scheduleDiskEviction(force: true)
+            }
         }
     }
 
@@ -220,10 +250,20 @@ actor ImageCache {
         self.clearMemoryCache()
         try? self.fileManager.removeItem(at: self.diskCacheURL)
         try? self.fileManager.createDirectory(at: self.diskCacheURL, withIntermediateDirectories: true)
+        self.estimatedDiskCacheSize = 0
     }
 
     /// Returns the total size of the disk cache in bytes.
     func diskCacheSize() -> Int64 {
+        let size = self.scanDiskCacheSize()
+        self.estimatedDiskCacheSize = size
+        return size
+    }
+
+    private func scanDiskCacheSize() -> Int64 {
+        #if DEBUG
+            self.diskCacheSizeScanCountForTesting += 1
+        #endif
         var totalSize: Int64 = 0
         guard let enumerator = fileManager.enumerator(
             at: diskCacheURL,
@@ -270,13 +310,54 @@ actor ImageCache {
 
     private func saveToDisk(url: URL, data: Data) {
         let path = self.diskCachePath(for: url)
-        try? data.write(to: path, options: .atomic)
-
-        // Evict old files if disk cache exceeds limit.
-        // Perform file system I/O off the main actor.
-        Task(priority: .utility) {
-            await self.evictDiskCacheIfNeeded()
+        let previousSize = self.fileSize(at: path)
+        do {
+            try data.write(to: path, options: .atomic)
+        } catch {
+            return
         }
+
+        if let estimatedDiskCacheSize {
+            self.estimatedDiskCacheSize = max(0, estimatedDiskCacheSize - previousSize + Int64(data.count))
+            self.writesSinceDiskEvictionCheck += 1
+            self.scheduleDiskEvictionIfNeededAfterWrite()
+        } else {
+            // First write before the startup/lazy size scan completes. Coalesce a
+            // single forced reconciliation instead of scanning on every save.
+            self.scheduleDiskEviction(force: true)
+        }
+    }
+
+    private func fileSize(at url: URL) -> Int64 {
+        guard let size = try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize else { return 0 }
+        return Int64(size)
+    }
+
+    private func scheduleDiskEvictionIfNeededAfterWrite() {
+        guard let estimatedDiskCacheSize else {
+            self.scheduleDiskEviction(force: true)
+            return
+        }
+
+        let shouldReconcile = self.writesSinceDiskEvictionCheck >= self.diskEvictionWriteThreshold
+        let shouldEvict = estimatedDiskCacheSize > self.maxDiskCacheSize
+        if shouldReconcile || shouldEvict {
+            self.scheduleDiskEviction(force: shouldReconcile)
+        }
+    }
+
+    private func scheduleDiskEviction(force: Bool = false) {
+        if self.diskEvictionTask != nil {
+            return
+        }
+        if !force, let estimatedDiskCacheSize, estimatedDiskCacheSize <= self.maxDiskCacheSize {
+            return
+        }
+
+        let task = Task(priority: .utility) {
+            await self.evictDiskCacheIfNeeded(force: force)
+        }
+        self.diskEvictionTask = task
     }
 
     // MARK: - Disk Cache Eviction
@@ -291,29 +372,79 @@ actor ImageCache {
     /// Evicts oldest files until disk cache is under the size limit.
     /// Uses LRU (Least Recently Used) eviction based on file modification dates.
     /// Marked async to document the I/O-bound nature and satisfy actor isolation.
-    private func evictDiskCacheIfNeeded() async {
-        let currentSize = self.diskCacheSize()
-        guard currentSize > Self.maxDiskCacheSize else { return }
+    private func evictDiskCacheIfNeeded(force: Bool = false) async {
+        defer {
+            self.diskEvictionTask = nil
+            self.writesSinceDiskEvictionCheck = 0
+        }
 
-        // Get all cached files sorted by modification date (oldest first)
+        if !force, let estimatedDiskCacheSize, estimatedDiskCacheSize <= self.maxDiskCacheSize {
+            return
+        }
+
+        // One directory pass gives both exact size and eviction metadata. This
+        // avoids the previous save path's diskCacheSize() pass plus a second
+        // directory listing to choose victims.
+        guard let files = self.cachedFilesForEviction() else { return }
+        let currentSize = files.reduce(Int64(0)) { $0 + Int64($1.fileSize) }
+        self.estimatedDiskCacheSize = currentSize
+        guard currentSize > self.maxDiskCacheSize else { return }
+
+        let sortedFiles = files.sorted { $0.modificationDate < $1.modificationDate }
+        var sizeToFree = currentSize - self.maxDiskCacheSize
+        var freedSize: Int64 = 0
+        for fileInfo in sortedFiles where sizeToFree > 0 {
+            do {
+                try self.fileManager.removeItem(at: fileInfo.url)
+                let fileSize = Int64(fileInfo.fileSize)
+                sizeToFree -= fileSize
+                freedSize += fileSize
+            } catch {
+                continue
+            }
+        }
+        self.estimatedDiskCacheSize = max(0, currentSize - freedSize)
+    }
+
+    private func cachedFilesForEviction() -> [CachedFileInfo]? {
+        #if DEBUG
+            self.diskCacheSizeScanCountForTesting += 1
+        #endif
         guard let files = try? fileManager.contentsOfDirectory(
             at: diskCacheURL,
             includingPropertiesForKeys: [.contentModificationDateKey, .fileSizeKey],
             options: [.skipsHiddenFiles]
-        ) else { return }
+        ) else { return nil }
 
-        let sortedFiles = files.compactMap { url -> CachedFileInfo? in
+        return files.compactMap { url -> CachedFileInfo? in
             guard let values = try? url.resourceValues(forKeys: [.contentModificationDateKey, .fileSizeKey]),
                   let date = values.contentModificationDate,
                   let size = values.fileSize
             else { return nil }
             return CachedFileInfo(url: url, modificationDate: date, fileSize: size)
-        }.sorted { $0.modificationDate < $1.modificationDate } // Sort by date ascending (oldest first)
-
-        var sizeToFree = currentSize - Self.maxDiskCacheSize
-        for fileInfo in sortedFiles where sizeToFree > 0 {
-            try? self.fileManager.removeItem(at: fileInfo.url)
-            sizeToFree -= Int64(fileInfo.fileSize)
         }
     }
+
+    #if DEBUG
+        func saveToDiskForTesting(url: URL, data: Data) {
+            self.saveToDisk(url: url, data: data)
+        }
+
+        func estimatedDiskCacheSizeForTesting() -> Int64? {
+            self.estimatedDiskCacheSize
+        }
+
+        func evictDiskCacheIfNeededForTesting(force: Bool = false) async {
+            await self.evictDiskCacheIfNeeded(force: force)
+        }
+
+        func waitForScheduledDiskEvictionForTesting() async {
+            guard let task = self.diskEvictionTask else { return }
+            await task.value
+        }
+
+        func diskCachePathForTesting(url: URL) -> URL {
+            self.diskCachePath(for: url)
+        }
+    #endif
 }

--- a/Sources/Kaset/Utilities/ImageCache.swift
+++ b/Sources/Kaset/Utilities/ImageCache.swift
@@ -23,7 +23,9 @@ actor ImageCache {
     /// 320×180 fetch is not awaited by a 1280×720 request and handed back the
     /// small downsampled image.
     private var inFlight: [NSString: Task<NSImage?, Never>] = [:]
+    private var rawDataInFlight: [String: Task<Data?, Never>] = [:]
     private let fileManager = FileManager.default
+    private let session: URLSession
     private let diskCacheURL: URL
     private let maxDiskCacheSize: Int64
     private let diskEvictionWriteThreshold: Int
@@ -38,7 +40,8 @@ actor ImageCache {
         initialEstimatedDiskCacheSize: Int64? = nil,
         diskEvictionWriteThreshold: Int = ImageCache.defaultDiskEvictionWriteThreshold,
         startsEvictionTask: Bool = true,
-        monitorsMemoryPressure: Bool = true
+        monitorsMemoryPressure: Bool = true,
+        session: URLSession = .shared
     ) {
         self.memoryCache.countLimit = 200
         self.memoryCache.totalCostLimit = 50 * 1024 * 1024 // 50MB
@@ -53,6 +56,7 @@ actor ImageCache {
         self.maxDiskCacheSize = maxDiskCacheSize
         self.diskEvictionWriteThreshold = max(1, diskEvictionWriteThreshold)
         self.estimatedDiskCacheSize = initialEstimatedDiskCacheSize
+        self.session = session
         try? self.fileManager.createDirectory(at: self.diskCacheURL, withIntermediateDirectories: true)
 
         // Set up memory pressure monitoring.
@@ -125,18 +129,13 @@ actor ImageCache {
                 return diskImage
             }
 
-            // Cold miss: download once, decode, and cache the raw bytes.
-            do {
-                let (data, response) = try await URLSession.shared.data(from: url)
-                guard Self.isSuccessfulResponse(response) else { return nil }
-                guard let image = Self.createImage(from: data, targetSize: targetSize) else { return nil }
-                let cost = targetSize != nil ? Int(image.size.width * image.size.height * 4) : data.count
-                self.memoryCache.setObject(image, forKey: memoryKey, cost: cost)
-                self.saveToDisk(url: url, data: data)
-                return image
-            } catch {
-                return nil
-            }
+            // Cold miss: download raw bytes once per URL, then decode independently per target size.
+            guard let data = await self.rawImageData(for: url),
+                  let image = Self.createImage(from: data, targetSize: targetSize)
+            else { return nil }
+            let cost = targetSize != nil ? Int(image.size.width * image.size.height * 4) : data.count
+            self.memoryCache.setObject(image, forKey: memoryKey, cost: cost)
+            return image
         }
 
         self.inFlight[memoryKey] = task
@@ -155,6 +154,30 @@ actor ImageCache {
     private static func isSuccessfulResponse(_ response: URLResponse) -> Bool {
         guard let httpResponse = response as? HTTPURLResponse else { return true }
         return (200 ..< 300).contains(httpResponse.statusCode)
+    }
+
+    private func rawImageData(for url: URL) async -> Data? {
+        let key = self.cacheKey(for: url)
+        if let existing = self.rawDataInFlight[key] {
+            return await existing.value
+        }
+
+        let task = Task<Data?, Never> { [session] in
+            do {
+                let (data, response) = try await session.data(from: url)
+                guard Self.isSuccessfulResponse(response) else { return nil }
+                return data
+            } catch {
+                return nil
+            }
+        }
+        self.rawDataInFlight[key] = task
+        let data = await task.value
+        self.rawDataInFlight.removeValue(forKey: key)
+        if let data {
+            self.saveToDisk(url: url, data: data)
+        }
+        return data
     }
 
     private static func uniqued(_ urls: [URL]) -> [URL] {
@@ -241,6 +264,7 @@ actor ImageCache {
     func clearMemoryCache() {
         self.memoryCache.removeAllObjects()
         self.inFlight.removeAll()
+        self.rawDataInFlight.removeAll()
     }
 
     /// Clears both memory and disk caches.

--- a/Sources/Kaset/Utilities/ImageCache.swift
+++ b/Sources/Kaset/Utilities/ImageCache.swift
@@ -30,9 +30,7 @@ actor ImageCache {
     private var estimatedDiskCacheSize: Int64?
     private var writesSinceDiskEvictionCheck = 0
     private var diskEvictionTask: Task<Void, Never>?
-    #if DEBUG
-        private(set) var diskCacheSizeScanCountForTesting = 0
-    #endif
+    private(set) var diskCacheSizeScanCountForTesting = 0
 
     init(
         diskCacheURL: URL? = nil,
@@ -261,9 +259,7 @@ actor ImageCache {
     }
 
     private func scanDiskCacheSize() -> Int64 {
-        #if DEBUG
-            self.diskCacheSizeScanCountForTesting += 1
-        #endif
+        self.diskCacheSizeScanCountForTesting += 1
         var totalSize: Int64 = 0
         guard let enumerator = fileManager.enumerator(
             at: diskCacheURL,
@@ -407,9 +403,7 @@ actor ImageCache {
     }
 
     private func cachedFilesForEviction() -> [CachedFileInfo]? {
-        #if DEBUG
-            self.diskCacheSizeScanCountForTesting += 1
-        #endif
+        self.diskCacheSizeScanCountForTesting += 1
         guard let files = try? fileManager.contentsOfDirectory(
             at: diskCacheURL,
             includingPropertiesForKeys: [.contentModificationDateKey, .fileSizeKey],
@@ -425,26 +419,24 @@ actor ImageCache {
         }
     }
 
-    #if DEBUG
-        func saveToDiskForTesting(url: URL, data: Data) {
-            self.saveToDisk(url: url, data: data)
-        }
+    func saveToDiskForTesting(url: URL, data: Data) {
+        self.saveToDisk(url: url, data: data)
+    }
 
-        func estimatedDiskCacheSizeForTesting() -> Int64? {
-            self.estimatedDiskCacheSize
-        }
+    func estimatedDiskCacheSizeForTesting() -> Int64? {
+        self.estimatedDiskCacheSize
+    }
 
-        func evictDiskCacheIfNeededForTesting(force: Bool = false) async {
-            await self.evictDiskCacheIfNeeded(force: force)
-        }
+    func evictDiskCacheIfNeededForTesting(force: Bool = false) async {
+        await self.evictDiskCacheIfNeeded(force: force)
+    }
 
-        func waitForScheduledDiskEvictionForTesting() async {
-            guard let task = self.diskEvictionTask else { return }
-            await task.value
-        }
+    func waitForScheduledDiskEvictionForTesting() async {
+        guard let task = self.diskEvictionTask else { return }
+        await task.value
+    }
 
-        func diskCachePathForTesting(url: URL) -> URL {
-            self.diskCachePath(for: url)
-        }
-    #endif
+    func diskCachePathForTesting(url: URL) -> URL {
+        self.diskCachePath(for: url)
+    }
 }

--- a/Sources/Kaset/ViewModels/ChartsViewModel.swift
+++ b/Sources/Kaset/ViewModels/ChartsViewModel.swift
@@ -18,105 +18,106 @@ final class ChartsViewModel {
     /// The API client (exposed for navigation to detail views).
     let client: any YTMusicClientProtocol
     private let logger = DiagnosticsLogger.api
-    // swiftformat:disable modifierOrder
-    /// Task for background loading, cancelled in deinit.
-    /// nonisolated(unsafe) required for deinit access; Swift 6.2 warning is expected.
-    @ObservationIgnored private var backgroundLoadTask: Task<Void, Never>?
-    // swiftformat:enable modifierOrder
+    /// Whether a user-visible continuation load is currently in flight.
+    private var isLoadingMoreSections = false
 
-    /// Number of background continuations loaded.
-    private var continuationsLoaded = 0
+    /// Waiters that should resume once the current continuation request finishes.
+    @ObservationIgnored private var continuationWaiters: [CheckedContinuation<Void, Never>] = []
 
-    /// Maximum continuations to load in background.
-    private static let maxContinuations = 4
+    /// Monotonic token used to discard stale continuation results after refreshes.
+    private var loadGeneration = 0
 
     init(client: any YTMusicClientProtocol) {
         self.client = client
-    }
-
-    deinit {
-        self.backgroundLoadTask?.cancel()
     }
 
     /// Loads charts content with fast initial load.
     func load() async {
         guard self.loadingState != .loading else { return }
 
+        self.loadGeneration += 1
+        let generation = self.loadGeneration
         self.loadingState = .loading
         self.logger.info("Loading charts content")
 
         do {
             let response = try await self.client.getCharts()
+            guard generation == self.loadGeneration else { return }
             self.sections = response.sections
             self.hasMoreSections = self.hasMoreSectionsForCurrentSource
             self.loadingState = .loaded
-            self.continuationsLoaded = 0
             let sectionCount = self.sections.count
             self.logger.info("Charts content loaded: \(sectionCount) sections")
-
-            // Start background loading of additional sections
-            self.startBackgroundLoading()
         } catch is CancellationError {
+            guard generation == self.loadGeneration else { return }
             // Task was cancelled (e.g., user navigated away) — reset to idle so it can retry
             self.logger.debug("Charts load cancelled")
             self.loadingState = .idle
         } catch {
+            guard generation == self.loadGeneration else { return }
             self.logger.error("Failed to load charts: \(error.localizedDescription)")
             self.loadingState = .error(LoadingError(from: error))
         }
     }
 
-    /// Loads more sections in the background progressively.
-    private func startBackgroundLoading() {
-        self.backgroundLoadTask?.cancel()
-        self.backgroundLoadTask = Task { [weak self] in
-            guard let self else { return }
+    /// Loads one additional continuation page on explicit user demand.
+    func loadMore() async {
+        guard self.hasMoreSections,
+              !self.isLoadingMoreSections,
+              self.loadingState == .loaded
+        else { return }
 
-            // Brief delay to let the UI settle
-            try? await Task.sleep(for: .milliseconds(300))
-
-            guard !Task.isCancelled else { return }
-
-            await self.loadMoreSections()
-        }
-    }
-
-    /// Loads additional sections from continuations progressively.
-    private func loadMoreSections() async {
-        while self.hasMoreSections, self.continuationsLoaded < Self.maxContinuations {
-            guard self.loadingState == .loaded else { break }
-
-            do {
-                if let additionalSections = try await self.getContinuationForCurrentSource() {
-                    self.sections.append(contentsOf: additionalSections)
-                    self.continuationsLoaded += 1
-                    self.hasMoreSections = self.hasMoreSectionsForCurrentSource
-                    let continuationNum = self.continuationsLoaded
-                    self.logger.info("Background loaded \(additionalSections.count) more sections (continuation \(continuationNum))")
-                } else {
-                    self.hasMoreSections = false
-                    break
-                }
-            } catch is CancellationError {
-                self.logger.debug("Background loading cancelled")
-                break
-            } catch {
-                self.logger.warning("Background section load failed: \(error.localizedDescription)")
-                break
+        let generation = self.loadGeneration
+        self.isLoadingMoreSections = true
+        self.loadingState = .loadingMore
+        defer {
+            self.isLoadingMoreSections = false
+            if self.loadingState == .loadingMore {
+                self.loadingState = .loaded
             }
+            self.resumeContinuationWaiters()
         }
 
-        let totalCount = self.sections.count
-        self.logger.info("Background section loading completed, total sections: \(totalCount)")
+        do {
+            if let additionalSections = try await self.getContinuationForCurrentSource() {
+                guard generation == self.loadGeneration else { return }
+                let sectionsToAppend = additionalSections
+                self.sections.append(contentsOf: sectionsToAppend)
+                self.hasMoreSections = self.hasMoreSectionsForCurrentSource
+                self.logger.info("Loaded \(sectionsToAppend.count) more charts sections on demand")
+            } else {
+                guard generation == self.loadGeneration else { return }
+                self.hasMoreSections = false
+            }
+        } catch is CancellationError {
+            self.logger.debug("Charts continuation load cancelled")
+        } catch {
+            self.logger.warning("Charts continuation load failed: \(error.localizedDescription)")
+        }
     }
 
     /// Refreshes charts content.
     func refresh() async {
-        self.backgroundLoadTask?.cancel()
+        await self.waitForInFlightContinuation()
         self.sections = []
         self.hasMoreSections = true
-        self.continuationsLoaded = 0
+        self.isLoadingMoreSections = false
         await self.load()
+    }
+
+    private func waitForInFlightContinuation() async {
+        guard self.isLoadingMoreSections else { return }
+        await withCheckedContinuation { continuation in
+            self.continuationWaiters.append(continuation)
+        }
+    }
+
+    private func resumeContinuationWaiters() {
+        let waiters = self.continuationWaiters
+        self.continuationWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
     }
 
     // MARK: - Private Helpers

--- a/Sources/Kaset/ViewModels/ExploreViewModel.swift
+++ b/Sources/Kaset/ViewModels/ExploreViewModel.swift
@@ -80,7 +80,7 @@ final class ExploreViewModel {
         }
 
         do {
-            if let additionalSections = try await getContinuationForCurrentSource() {
+            if let additionalSections = try await self.getContinuationForCurrentSource() {
                 guard generation == self.loadGeneration else { return }
                 // Filter out Charts section since it's available in the sidebar
                 let sectionsToAppend = additionalSections.filter { !self.isChartsSection($0) }

--- a/Sources/Kaset/ViewModels/ExploreViewModel.swift
+++ b/Sources/Kaset/ViewModels/ExploreViewModel.swift
@@ -18,108 +18,108 @@ final class ExploreViewModel {
     /// The API client (exposed for navigation to detail views).
     let client: any YTMusicClientProtocol
     private let logger = DiagnosticsLogger.api
-    // swiftformat:disable modifierOrder
-    /// Task for background loading, cancelled in deinit.
-    /// nonisolated(unsafe) required for deinit access; Swift 6.2 warning is expected.
-    @ObservationIgnored private var backgroundLoadTask: Task<Void, Never>?
-    // swiftformat:enable modifierOrder
+    /// Whether a user-visible continuation load is currently in flight.
+    private var isLoadingMoreSections = false
 
-    /// Number of background continuations loaded.
-    private var continuationsLoaded = 0
+    /// Waiters that should resume once the current continuation request finishes.
+    @ObservationIgnored private var continuationWaiters: [CheckedContinuation<Void, Never>] = []
 
-    /// Maximum continuations to load in background.
-    private static let maxContinuations = 4
+    /// Monotonic token used to discard stale continuation results after refreshes.
+    private var loadGeneration = 0
 
     init(client: any YTMusicClientProtocol) {
         self.client = client
-    }
-
-    deinit {
-        self.backgroundLoadTask?.cancel()
     }
 
     /// Loads explore content with fast initial load.
     func load() async {
         guard self.loadingState != .loading else { return }
 
+        self.loadGeneration += 1
+        let generation = self.loadGeneration
         self.loadingState = .loading
         self.logger.info("Loading explore content")
 
         do {
             let response = try await self.client.getExplore()
+            guard generation == self.loadGeneration else { return }
             // Filter out Charts section since it's available in the sidebar
             self.sections = response.sections.filter { !self.isChartsSection($0) }
             self.hasMoreSections = self.hasMoreSectionsForCurrentSource
             self.loadingState = .loaded
-            self.continuationsLoaded = 0
             let sectionCount = self.sections.count
             self.logger.info("Explore content loaded: \(sectionCount) sections")
-
-            // Start background loading of additional sections
-            self.startBackgroundLoading()
         } catch is CancellationError {
+            guard generation == self.loadGeneration else { return }
             // Task was cancelled (e.g., user navigated away) — reset to idle so it can retry
             self.logger.debug("Explore load cancelled")
             self.loadingState = .idle
         } catch {
+            guard generation == self.loadGeneration else { return }
             self.logger.error("Failed to load explore: \(error.localizedDescription)")
             self.loadingState = .error(LoadingError(from: error))
         }
     }
 
-    /// Loads more sections in the background progressively.
-    private func startBackgroundLoading() {
-        self.backgroundLoadTask?.cancel()
-        self.backgroundLoadTask = Task { [weak self] in
-            guard let self else { return }
+    /// Loads one additional continuation page on explicit user demand.
+    func loadMore() async {
+        guard self.hasMoreSections,
+              !self.isLoadingMoreSections,
+              self.loadingState == .loaded
+        else { return }
 
-            // Brief delay to let the UI settle
-            try? await Task.sleep(for: .milliseconds(300))
-
-            guard !Task.isCancelled else { return }
-
-            await self.loadMoreSections()
-        }
-    }
-
-    /// Loads additional sections from continuations progressively.
-    private func loadMoreSections() async {
-        while self.hasMoreSections, self.continuationsLoaded < Self.maxContinuations {
-            guard self.loadingState == .loaded else { break }
-
-            do {
-                if let additionalSections = try await self.getContinuationForCurrentSource() {
-                    // Filter out Charts section since it's available in the sidebar
-                    let filteredSections = additionalSections.filter { !self.isChartsSection($0) }
-                    self.sections.append(contentsOf: filteredSections)
-                    self.continuationsLoaded += 1
-                    self.hasMoreSections = self.hasMoreSectionsForCurrentSource
-                    let continuationNum = self.continuationsLoaded
-                    self.logger.info("Background loaded \(filteredSections.count) more sections (continuation \(continuationNum))")
-                } else {
-                    self.hasMoreSections = false
-                    break
-                }
-            } catch is CancellationError {
-                self.logger.debug("Background loading cancelled")
-                break
-            } catch {
-                self.logger.warning("Background section load failed: \(error.localizedDescription)")
-                break
+        let generation = self.loadGeneration
+        self.isLoadingMoreSections = true
+        self.loadingState = .loadingMore
+        defer {
+            self.isLoadingMoreSections = false
+            if self.loadingState == .loadingMore {
+                self.loadingState = .loaded
             }
+            self.resumeContinuationWaiters()
         }
 
-        let totalCount = self.sections.count
-        self.logger.info("Background section loading completed, total sections: \(totalCount)")
+        do {
+            if let additionalSections = try await getContinuationForCurrentSource() {
+                guard generation == self.loadGeneration else { return }
+                // Filter out Charts section since it's available in the sidebar
+                let sectionsToAppend = additionalSections.filter { !self.isChartsSection($0) }
+                self.sections.append(contentsOf: sectionsToAppend)
+                self.hasMoreSections = self.hasMoreSectionsForCurrentSource
+                self.logger.info("Loaded \(sectionsToAppend.count) more explore sections on demand")
+            } else {
+                guard generation == self.loadGeneration else { return }
+                self.hasMoreSections = false
+            }
+        } catch is CancellationError {
+            self.logger.debug("Explore continuation load cancelled")
+        } catch {
+            self.logger.warning("Explore continuation load failed: \(error.localizedDescription)")
+        }
     }
 
     /// Refreshes explore content.
     func refresh() async {
-        self.backgroundLoadTask?.cancel()
+        await self.waitForInFlightContinuation()
         self.sections = []
         self.hasMoreSections = true
-        self.continuationsLoaded = 0
+        self.isLoadingMoreSections = false
         await self.load()
+    }
+
+    private func waitForInFlightContinuation() async {
+        guard self.isLoadingMoreSections else { return }
+        await withCheckedContinuation { continuation in
+            self.continuationWaiters.append(continuation)
+        }
+    }
+
+    private func resumeContinuationWaiters() {
+        let waiters = self.continuationWaiters
+        self.continuationWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
     }
 
     // MARK: - Private Helpers

--- a/Sources/Kaset/ViewModels/HistoryViewModel.swift
+++ b/Sources/Kaset/ViewModels/HistoryViewModel.swift
@@ -34,6 +34,9 @@ final class HistoryViewModel {
     /// Whether a user-visible continuation load is currently in flight.
     private var isLoadingMoreSections = false
 
+    /// Whether a refresh is currently rewinding the history cursor.
+    private(set) var isRefreshingHistory = false
+
     /// Monotonic token used to discard stale continuation results after refreshes/resets.
     private var loadGeneration = 0
 
@@ -104,6 +107,7 @@ final class HistoryViewModel {
         self.continuationsLoaded = 0
         self.pendingContinuationSkips = 0
         self.isLoadingMoreSections = false
+        self.isRefreshingHistory = false
         self.lastSeenPlaybackVideoId = nil
     }
 
@@ -138,6 +142,7 @@ final class HistoryViewModel {
     func loadMore() async {
         guard self.hasMoreSections,
               self.continuationTask == nil,
+              !self.isRefreshingHistory,
               self.loadingState == .loaded
         else { return }
 
@@ -204,6 +209,11 @@ final class HistoryViewModel {
     /// Returns true if data changed, false otherwise.
     @discardableResult
     func refresh() async -> Bool {
+        guard !self.isRefreshingHistory else { return false }
+
+        self.isRefreshingHistory = true
+        defer { self.isRefreshingHistory = false }
+
         await self.cancelInFlightContinuation()
         let generation = self.loadGeneration
 

--- a/Sources/Kaset/ViewModels/HistoryViewModel.swift
+++ b/Sources/Kaset/ViewModels/HistoryViewModel.swift
@@ -21,6 +21,7 @@ final class HistoryViewModel {
     // swiftformat:disable modifierOrder
     /// Explicit user-requested continuation task, cancelled in reset.
     @ObservationIgnored private var continuationTask: Task<Void, Never>?
+    @ObservationIgnored private var continuationTaskID: UUID?
     /// Task for delayed playback-driven refreshes, cancelled in deinit/reset.
     @ObservationIgnored private var playbackRefreshTask: Task<Void, Never>?
     // swiftformat:enable modifierOrder
@@ -98,6 +99,7 @@ final class HistoryViewModel {
     func reset() {
         self.continuationTask?.cancel()
         self.continuationTask = nil
+        self.continuationTaskID = nil
         self.playbackRefreshTask?.cancel()
         self.loadGeneration += 1
         self.loadingState = .idle
@@ -147,15 +149,18 @@ final class HistoryViewModel {
         else { return }
 
         let generation = self.loadGeneration
+        let taskID = UUID()
         let task = Task { @MainActor [weak self] in
             guard let self else { return }
-            await self.performLoadMore(generation: generation)
+            await self.performLoadMore(generation: generation, taskID: taskID)
         }
         self.continuationTask = task
+        self.continuationTaskID = taskID
+        defer { self.clearContinuationTaskIfCurrent(taskID) }
         await task.value
     }
 
-    private func performLoadMore(generation: Int) async {
+    private func performLoadMore(generation: Int, taskID: UUID) async {
         guard generation == self.loadGeneration, !Task.isCancelled else { return }
 
         self.isLoadingMoreSections = true
@@ -163,7 +168,7 @@ final class HistoryViewModel {
         defer {
             if generation == self.loadGeneration {
                 self.isLoadingMoreSections = false
-                self.continuationTask = nil
+                self.clearContinuationTaskIfCurrent(taskID)
                 if self.loadingState == .loadingMore {
                     self.loadingState = .loaded
                 }
@@ -290,13 +295,20 @@ final class HistoryViewModel {
     private func cancelInFlightContinuation() async {
         guard let continuationTask else { return }
         self.loadGeneration += 1
+        self.continuationTask = nil
+        self.continuationTaskID = nil
         continuationTask.cancel()
         await continuationTask.value
-        self.continuationTask = nil
         self.isLoadingMoreSections = false
         if self.loadingState == .loadingMore {
             self.loadingState = .loaded
         }
+    }
+
+    private func clearContinuationTaskIfCurrent(_ taskID: UUID) {
+        guard self.continuationTaskID == taskID else { return }
+        self.continuationTask = nil
+        self.continuationTaskID = nil
     }
 
     /// Compares refreshed first-page sections using stable section and item identifiers.

--- a/Sources/Kaset/ViewModels/HistoryViewModel.swift
+++ b/Sources/Kaset/ViewModels/HistoryViewModel.swift
@@ -19,17 +19,23 @@ final class HistoryViewModel {
     let client: any YTMusicClientProtocol
     private let logger = DiagnosticsLogger.history
     // swiftformat:disable modifierOrder
-    /// Task for background loading, cancelled in deinit.
-    @ObservationIgnored private var backgroundLoadTask: Task<Void, Never>?
+    /// Explicit user-requested continuation task, cancelled in reset.
+    @ObservationIgnored private var continuationTask: Task<Void, Never>?
     /// Task for delayed playback-driven refreshes, cancelled in deinit/reset.
     @ObservationIgnored private var playbackRefreshTask: Task<Void, Never>?
     // swiftformat:enable modifierOrder
 
-    /// Number of background continuations loaded.
+    /// Number of continuation pages currently represented in `sections`.
     private var continuationsLoaded = 0
 
-    /// Maximum continuations to load in background.
-    private static let maxContinuations = 4
+    /// Preserved continuation pages to skip after `getHistory()` rewinds the client cursor.
+    private var pendingContinuationSkips = 0
+
+    /// Whether a user-visible continuation load is currently in flight.
+    private var isLoadingMoreSections = false
+
+    /// Monotonic token used to discard stale continuation results after refreshes/resets.
+    private var loadGeneration = 0
 
     /// Cached first page from the last successful history fetch.
     private var initialSections: [HomeSection] = []
@@ -48,32 +54,38 @@ final class HistoryViewModel {
     }
 
     deinit {
-        self.backgroundLoadTask?.cancel()
+        self.continuationTask?.cancel()
         self.playbackRefreshTask?.cancel()
     }
 
     /// Loads history content with fast initial load.
     func load() async {
-        guard self.loadingState != .loading else { return }
+        guard self.loadingState != .loading,
+              self.loadingState != .loadingMore
+        else { return }
 
+        self.loadGeneration += 1
+        let generation = self.loadGeneration
         self.loadingState = .loading
         self.logger.info("Loading history content")
 
         do {
             let response = try await self.client.getHistory()
+            guard generation == self.loadGeneration else { return }
             self.initialSections = response.sections
             self.sections = response.sections
             self.hasMoreSections = self.client.hasMoreHistorySections
             self.loadingState = .loaded
             self.continuationsLoaded = 0
+            self.pendingContinuationSkips = 0
             let sectionCount = self.sections.count
             self.logger.info("History content loaded: \(sectionCount) sections")
-
-            self.startBackgroundLoading()
         } catch is CancellationError {
+            guard generation == self.loadGeneration else { return }
             self.logger.debug("History load cancelled")
             self.loadingState = .idle
         } catch {
+            guard generation == self.loadGeneration else { return }
             self.logger.error("Failed to load history: \(error.localizedDescription)")
             self.loadingState = .error(LoadingError(from: error))
         }
@@ -81,13 +93,17 @@ final class HistoryViewModel {
 
     /// Resets local history state, used when switching accounts.
     func reset() {
-        self.backgroundLoadTask?.cancel()
+        self.continuationTask?.cancel()
+        self.continuationTask = nil
         self.playbackRefreshTask?.cancel()
+        self.loadGeneration += 1
         self.loadingState = .idle
         self.sections = []
         self.initialSections = []
         self.hasMoreSections = true
         self.continuationsLoaded = 0
+        self.pendingContinuationSkips = 0
+        self.isLoadingMoreSections = false
         self.lastSeenPlaybackVideoId = nil
     }
 
@@ -118,62 +134,69 @@ final class HistoryViewModel {
         }
     }
 
-    /// Loads more sections in the background progressively.
-    private func startBackgroundLoading(skippingPreviouslyLoadedContinuations pagesToSkip: Int = 0) {
-        self.backgroundLoadTask?.cancel()
-        self.backgroundLoadTask = Task { [weak self] in
+    /// Loads one additional history continuation page on explicit user demand.
+    func loadMore() async {
+        guard self.hasMoreSections,
+              self.continuationTask == nil,
+              self.loadingState == .loaded
+        else { return }
+
+        let generation = self.loadGeneration
+        let task = Task { @MainActor [weak self] in
             guard let self else { return }
-
-            try? await Task.sleep(for: .milliseconds(300))
-
-            guard !Task.isCancelled else { return }
-
-            await self.loadMoreSections(skippingPreviouslyLoadedContinuations: pagesToSkip)
+            await self.performLoadMore(generation: generation)
         }
+        self.continuationTask = task
+        await task.value
     }
 
-    /// Loads additional sections from continuations progressively.
-    private func loadMoreSections(skippingPreviouslyLoadedContinuations pagesToSkip: Int = 0) async {
-        var skippedContinuations = 0
+    private func performLoadMore(generation: Int) async {
+        guard generation == self.loadGeneration, !Task.isCancelled else { return }
 
-        while self.hasMoreSections, self.continuationsLoaded < Self.maxContinuations {
-            guard self.loadingState == .loaded else { break }
-
-            do {
-                if let additionalSections = try await self.client.getHistoryContinuation() {
-                    self.hasMoreSections = self.client.hasMoreHistorySections
-
-                    if skippedContinuations < pagesToSkip {
-                        skippedContinuations += 1
-                        let skippedCount = additionalSections.count
-                        let skippedContinuation = skippedContinuations
-                        self.logger.debug(
-                            "Skipped \(skippedCount) already-loaded history sections from continuation \(skippedContinuation)"
-                        )
-                        continue
-                    }
-
-                    self.sections.append(contentsOf: additionalSections)
-                    self.continuationsLoaded += 1
-                    let continuationNum = self.continuationsLoaded
-                    self.logger.info(
-                        "Background loaded \(additionalSections.count) more history sections (continuation \(continuationNum))"
-                    )
-                } else {
-                    self.hasMoreSections = false
-                    break
+        self.isLoadingMoreSections = true
+        self.loadingState = .loadingMore
+        defer {
+            if generation == self.loadGeneration {
+                self.isLoadingMoreSections = false
+                self.continuationTask = nil
+                if self.loadingState == .loadingMore {
+                    self.loadingState = .loaded
                 }
-            } catch is CancellationError {
-                self.logger.debug("Background history loading cancelled")
-                break
-            } catch {
-                self.logger.warning("Background history section load failed: \(error.localizedDescription)")
-                break
             }
         }
 
-        let totalCount = self.sections.count
-        self.logger.info("Background history section loading completed, total sections: \(totalCount)")
+        do {
+            var skipsRemaining = self.pendingContinuationSkips
+            while skipsRemaining > 0 {
+                guard generation == self.loadGeneration, !Task.isCancelled else { return }
+                guard let skippedSections = try await self.client.getHistoryContinuation() else {
+                    guard generation == self.loadGeneration else { return }
+                    self.pendingContinuationSkips = 0
+                    self.hasMoreSections = false
+                    return
+                }
+                guard generation == self.loadGeneration else { return }
+                skipsRemaining -= 1
+                self.pendingContinuationSkips = skipsRemaining
+                self.hasMoreSections = self.client.hasMoreHistorySections
+                self.logger.debug("Skipped \(skippedSections.count) preserved history sections")
+            }
+
+            if let additionalSections = try await self.client.getHistoryContinuation() {
+                guard generation == self.loadGeneration else { return }
+                self.sections.append(contentsOf: additionalSections)
+                self.continuationsLoaded += 1
+                self.hasMoreSections = self.client.hasMoreHistorySections
+                self.logger.info("Loaded \(additionalSections.count) more history sections on demand")
+            } else {
+                guard generation == self.loadGeneration else { return }
+                self.hasMoreSections = false
+            }
+        } catch is CancellationError {
+            self.logger.debug("History continuation load cancelled")
+        } catch {
+            self.logger.warning("History continuation load failed: \(error.localizedDescription)")
+        }
     }
 
     /// Refreshes history content while keeping existing data visible.
@@ -181,10 +204,12 @@ final class HistoryViewModel {
     /// Returns true if data changed, false otherwise.
     @discardableResult
     func refresh() async -> Bool {
-        self.backgroundLoadTask?.cancel()
+        await self.cancelInFlightContinuation()
+        let generation = self.loadGeneration
 
         do {
             let response = try await self.client.getHistory()
+            guard generation == self.loadGeneration else { return false }
             let previousContinuationsLoaded = self.continuationsLoaded
             let shouldPreservePaginatedSections =
                 previousContinuationsLoaded > 0 && self.sections.count > response.sections.count
@@ -202,12 +227,11 @@ final class HistoryViewModel {
                 } else {
                     self.sections = response.sections
                     self.continuationsLoaded = 0
+                    self.pendingContinuationSkips = 0
                     self.logger.debug("History unchanged, skipping update")
                 }
 
-                self.startBackgroundLoading(
-                    skippingPreviouslyLoadedContinuations: shouldPreservePaginatedSections ? previousContinuationsLoaded : 0
-                )
+                self.pendingContinuationSkips = shouldPreservePaginatedSections ? previousContinuationsLoaded : 0
                 return false
             }
 
@@ -216,13 +240,14 @@ final class HistoryViewModel {
             self.hasMoreSections = self.client.hasMoreHistorySections
             self.loadingState = .loaded
             self.continuationsLoaded = 0
+            self.pendingContinuationSkips = 0
             self.logger.info("History refreshed: \(response.sections.count) sections")
-            self.startBackgroundLoading()
             return true
         } catch is CancellationError {
             self.logger.debug("History refresh cancelled")
             return false
         } catch {
+            guard generation == self.loadGeneration else { return false }
             self.logger.warning("History refresh failed: \(error.localizedDescription)")
             return false
         }
@@ -252,15 +277,35 @@ final class HistoryViewModel {
         _ = await self.refresh()
     }
 
+    private func cancelInFlightContinuation() async {
+        guard let continuationTask else { return }
+        self.loadGeneration += 1
+        continuationTask.cancel()
+        await continuationTask.value
+        self.continuationTask = nil
+        self.isLoadingMoreSections = false
+        if self.loadingState == .loadingMore {
+            self.loadingState = .loaded
+        }
+    }
+
     /// Compares refreshed first-page sections using stable section and item identifiers.
     private func sectionsChanged(_ oldSections: [HomeSection], comparedTo newSections: [HomeSection]) -> Bool {
         guard oldSections.count == newSections.count else { return true }
 
         for (oldSection, newSection) in zip(oldSections, newSections) {
-            if oldSection.id != newSection.id { return true }
-            if oldSection.title != newSection.title { return true }
-            if oldSection.isChart != newSection.isChart { return true }
-            if oldSection.items.map(\.id) != newSection.items.map(\.id) { return true }
+            if oldSection.id != newSection.id {
+                return true
+            }
+            if oldSection.title != newSection.title {
+                return true
+            }
+            if oldSection.isChart != newSection.isChart {
+                return true
+            }
+            if oldSection.items.map(\.id) != newSection.items.map(\.id) {
+                return true
+            }
         }
 
         return false

--- a/Sources/Kaset/ViewModels/HistoryViewModel.swift
+++ b/Sources/Kaset/ViewModels/HistoryViewModel.swift
@@ -294,11 +294,14 @@ final class HistoryViewModel {
 
     private func cancelInFlightContinuation() async {
         guard let continuationTask else { return }
+        let taskID = self.continuationTaskID
         self.loadGeneration += 1
-        self.continuationTask = nil
-        self.continuationTaskID = nil
         continuationTask.cancel()
         await continuationTask.value
+        if self.continuationTaskID == taskID {
+            self.continuationTask = nil
+            self.continuationTaskID = nil
+        }
         self.isLoadingMoreSections = false
         if self.loadingState == .loadingMore {
             self.loadingState = .loaded

--- a/Sources/Kaset/ViewModels/HomeViewModel.swift
+++ b/Sources/Kaset/ViewModels/HomeViewModel.swift
@@ -18,108 +18,141 @@ final class HomeViewModel {
     /// The API client (exposed for navigation to detail views).
     let client: any YTMusicClientProtocol
     private let logger = DiagnosticsLogger.api
-    // swiftformat:disable modifierOrder
-    /// Task for background loading, cancelled in deinit.
-    /// nonisolated(unsafe) required for deinit access; Swift 6.2 warning is expected.
-    @ObservationIgnored private var backgroundLoadTask: Task<Void, Never>?
-    // swiftformat:enable modifierOrder
 
-    /// Number of background continuations loaded.
-    private var continuationsLoaded = 0
+    /// Whether a user-visible continuation load is currently in flight.
+    private var isLoadingMoreSections = false
 
-    /// Maximum continuations to load in background.
-    private static let maxContinuations = 4
+    /// Whether the initial Home request is in flight.
+    private var isLoadingHome = false
+
+    /// Waiters that should resume once the current initial Home request finishes.
+    @ObservationIgnored private var loadWaiters: [CheckedContinuation<Void, Never>] = []
+
+    /// Waiters that should resume once the current continuation request finishes.
+    @ObservationIgnored private var continuationWaiters: [CheckedContinuation<Void, Never>] = []
+
+    /// Monotonic token used to discard stale continuation loads after refreshes.
+    private var loadGeneration = 0
 
     init(client: any YTMusicClientProtocol) {
         self.client = client
     }
 
-    deinit {
-        self.backgroundLoadTask?.cancel()
-    }
-
     /// Loads home content with fast initial load.
     func load() async {
-        guard self.loadingState != .loading else { return }
+        guard !self.isLoadingHome else { return }
+        await self.performLoad()
+    }
 
+    private func performLoad() async {
+        self.loadGeneration += 1
+        let generation = self.loadGeneration
+        self.isLoadingHome = true
         self.loadingState = .loading
         self.logger.info("Loading home content")
+        defer {
+            self.isLoadingHome = false
+            self.resumeLoadWaiters()
+        }
 
         do {
             let response = try await client.getHome()
+            guard generation == self.loadGeneration else { return }
             self.sections = response.sections
             self.hasMoreSections = self.client.hasMoreHomeSections
             self.loadingState = .loaded
-            self.continuationsLoaded = 0
             let sectionCount = self.sections.count
             self.logger.info("Home content loaded: \(sectionCount) sections")
             let sectionSummary = self.sections
                 .map { "\($0.title) (\($0.items.count))" }
                 .joined(separator: ", ")
             self.logger.debug("Home sections: [\(sectionSummary)]")
-
-            // Start background loading of additional sections
-            self.startBackgroundLoading()
         } catch is CancellationError {
+            guard generation == self.loadGeneration else { return }
             // Task was cancelled (e.g., user navigated away) — reset to idle so it can retry
             self.logger.debug("Home load cancelled")
             self.loadingState = .idle
         } catch {
+            guard generation == self.loadGeneration else { return }
             self.logger.error("Failed to load home: \(error.localizedDescription)")
             self.loadingState = .error(LoadingError(from: error))
         }
     }
 
-    /// Loads more sections in the background progressively.
-    private func startBackgroundLoading() {
-        self.backgroundLoadTask?.cancel()
-        self.backgroundLoadTask = Task { [weak self] in
-            guard let self else { return }
+    /// Loads one additional home continuation on demand, typically from the bottom-of-scroll sentinel.
+    /// Avoids the previous initial background drain of up to four pages for users who never scroll.
+    func loadMore() async {
+        guard self.hasMoreSections,
+              !self.isLoadingMoreSections,
+              self.loadingState == .loaded
+        else { return }
 
-            // Brief delay to let the UI settle
-            try? await Task.sleep(for: .milliseconds(300))
-
-            guard !Task.isCancelled else { return }
-
-            await self.loadMoreSections()
-        }
-    }
-
-    /// Loads additional sections from continuations progressively.
-    private func loadMoreSections() async {
-        while self.hasMoreSections, self.continuationsLoaded < Self.maxContinuations {
-            guard self.loadingState == .loaded else { break }
-
-            do {
-                if let additionalSections = try await client.getHomeContinuation() {
-                    self.sections.append(contentsOf: additionalSections)
-                    self.continuationsLoaded += 1
-                    self.hasMoreSections = self.client.hasMoreHomeSections
-                    let continuationNum = self.continuationsLoaded
-                    self.logger.info("Background loaded \(additionalSections.count) more sections (continuation \(continuationNum))")
-                } else {
-                    self.hasMoreSections = false
-                    break
-                }
-            } catch is CancellationError {
-                self.logger.debug("Background loading cancelled")
-                break
-            } catch {
-                self.logger.warning("Background section load failed: \(error.localizedDescription)")
-                break
+        let generation = self.loadGeneration
+        self.isLoadingMoreSections = true
+        self.loadingState = .loadingMore
+        defer {
+            self.isLoadingMoreSections = false
+            if self.loadingState == .loadingMore {
+                self.loadingState = .loaded
             }
+            self.resumeContinuationWaiters()
         }
 
-        let totalCount = self.sections.count
-        self.logger.info("Background section loading completed, total sections: \(totalCount)")
+        do {
+            if let additionalSections = try await client.getHomeContinuation() {
+                guard generation == self.loadGeneration else { return }
+                self.sections.append(contentsOf: additionalSections)
+                self.hasMoreSections = self.client.hasMoreHomeSections
+                self.logger.info("Loaded \(additionalSections.count) more home sections on demand")
+            } else {
+                guard generation == self.loadGeneration else { return }
+                self.hasMoreSections = false
+            }
+        } catch is CancellationError {
+            self.logger.debug("Home continuation load cancelled")
+        } catch {
+            self.logger.warning("Home continuation load failed: \(error.localizedDescription)")
+        }
     }
 
     /// Refreshes home content.
     func refresh() async {
-        self.backgroundLoadTask?.cancel()
+        await self.waitForInFlightLoad()
+        await self.waitForInFlightContinuation()
+
         self.sections = []
         self.hasMoreSections = true
-        self.continuationsLoaded = 0
-        await self.load()
+        self.isLoadingMoreSections = false
+        await self.performLoad()
+    }
+
+    private func waitForInFlightLoad() async {
+        guard self.isLoadingHome else { return }
+        await withCheckedContinuation { continuation in
+            self.loadWaiters.append(continuation)
+        }
+    }
+
+    private func waitForInFlightContinuation() async {
+        guard self.isLoadingMoreSections else { return }
+        await withCheckedContinuation { continuation in
+            self.continuationWaiters.append(continuation)
+        }
+    }
+
+    private func resumeLoadWaiters() {
+        let waiters = self.loadWaiters
+        self.loadWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
+
+    private func resumeContinuationWaiters() {
+        let waiters = self.continuationWaiters
+        self.continuationWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
     }
 }

--- a/Sources/Kaset/ViewModels/HomeViewModel.swift
+++ b/Sources/Kaset/ViewModels/HomeViewModel.swift
@@ -25,6 +25,18 @@ final class HomeViewModel {
     /// Whether the initial Home request is in flight.
     private var isLoadingHome = false
 
+    /// Shared refresh operation so concurrent callers join the same wait-and-reload
+    /// sequence even when the API response completes without suspending.
+    @ObservationIgnored private var refreshTask: Task<Void, Never>?
+
+    /// Whether the current refresh cycle has issued its Home request. A refresh
+    /// arriving after this point represents newer state and needs one follow-up.
+    @ObservationIgnored private var refreshRequestIssued = false
+
+    /// Coalesces any number of refreshes that arrive during one issued request
+    /// into a single follow-up cycle using the latest client/account state.
+    @ObservationIgnored private var refreshNeedsFollowUp = false
+
     /// Waiters that should resume once the current initial Home request finishes.
     @ObservationIgnored private var loadWaiters: [CheckedContinuation<Void, Never>] = []
 
@@ -40,7 +52,7 @@ final class HomeViewModel {
 
     /// Loads home content with fast initial load.
     func load() async {
-        guard !self.isLoadingHome else { return }
+        guard !self.isLoadingHome, !self.isLoadingMoreSections else { return }
         await self.performLoad()
     }
 
@@ -117,12 +129,43 @@ final class HomeViewModel {
 
     /// Refreshes home content.
     func refresh() async {
+        if let refreshTask = self.refreshTask {
+            if self.refreshRequestIssued {
+                self.refreshNeedsFollowUp = true
+            }
+            await refreshTask.value
+            return
+        }
+
+        let refreshTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.runRefreshLoop()
+        }
+        self.refreshTask = refreshTask
+        await refreshTask.value
+    }
+
+    private func runRefreshLoop() async {
+        defer {
+            self.refreshTask = nil
+            self.refreshRequestIssued = false
+            self.refreshNeedsFollowUp = false
+        }
+
+        repeat {
+            self.refreshRequestIssued = false
+            self.refreshNeedsFollowUp = false
+            await self.performRefreshCycle()
+        } while self.refreshNeedsFollowUp
+    }
+
+    private func performRefreshCycle() async {
         await self.waitForInFlightLoad()
         await self.waitForInFlightContinuation()
-
         self.sections = []
         self.hasMoreSections = true
         self.isLoadingMoreSections = false
+        self.refreshRequestIssued = true
         await self.performLoad()
     }
 

--- a/Sources/Kaset/ViewModels/MoodsAndGenresViewModel.swift
+++ b/Sources/Kaset/ViewModels/MoodsAndGenresViewModel.swift
@@ -18,30 +18,25 @@ final class MoodsAndGenresViewModel {
     /// The API client (exposed for navigation to detail views).
     let client: any YTMusicClientProtocol
     private let logger = DiagnosticsLogger.api
-    // swiftformat:disable modifierOrder
-    /// Task for background loading, cancelled in deinit.
-    /// nonisolated(unsafe) required for deinit access; Swift 6.2 warning is expected.
-    @ObservationIgnored private var backgroundLoadTask: Task<Void, Never>?
-    // swiftformat:enable modifierOrder
+    /// Whether a user-visible continuation load is currently in flight.
+    private var isLoadingMoreSections = false
 
-    /// Number of background continuations loaded.
-    private var continuationsLoaded = 0
+    /// Waiters that should resume once the current continuation request finishes.
+    @ObservationIgnored private var continuationWaiters: [CheckedContinuation<Void, Never>] = []
 
-    /// Maximum continuations to load in background.
-    private static let maxContinuations = 4
+    /// Monotonic token used to discard stale continuation results after refreshes.
+    private var loadGeneration = 0
 
     init(client: any YTMusicClientProtocol) {
         self.client = client
-    }
-
-    deinit {
-        self.backgroundLoadTask?.cancel()
     }
 
     /// Loads moods and genres content with fast initial load.
     func load() async {
         guard self.loadingState != .loading else { return }
 
+        self.loadGeneration += 1
+        let generation = self.loadGeneration
         self.loadingState = .loading
         self.logger.info("Loading moods and genres content")
 
@@ -50,72 +45,77 @@ final class MoodsAndGenresViewModel {
             self.sections = response.sections
             self.hasMoreSections = self.client.hasMoreMoodsAndGenresSections
             self.loadingState = .loaded
-            self.continuationsLoaded = 0
             let sectionCount = self.sections.count
             self.logger.info("Moods and genres content loaded: \(sectionCount) sections")
-
-            // Start background loading of additional sections
-            self.startBackgroundLoading()
         } catch is CancellationError {
+            guard generation == self.loadGeneration else { return }
             // Task was cancelled (e.g., user navigated away) — reset to idle so it can retry
             self.logger.debug("Moods and genres load cancelled")
             self.loadingState = .idle
         } catch {
+            guard generation == self.loadGeneration else { return }
             self.logger.error("Failed to load moods and genres: \(error.localizedDescription)")
             self.loadingState = .error(LoadingError(from: error))
         }
     }
 
-    /// Loads more sections in the background progressively.
-    private func startBackgroundLoading() {
-        self.backgroundLoadTask?.cancel()
-        self.backgroundLoadTask = Task { [weak self] in
-            guard let self else { return }
+    /// Loads one additional continuation page on explicit user demand.
+    func loadMore() async {
+        guard self.hasMoreSections,
+              !self.isLoadingMoreSections,
+              self.loadingState == .loaded
+        else { return }
 
-            // Brief delay to let the UI settle
-            try? await Task.sleep(for: .milliseconds(300))
-
-            guard !Task.isCancelled else { return }
-
-            await self.loadMoreSections()
-        }
-    }
-
-    /// Loads additional sections from continuations progressively.
-    private func loadMoreSections() async {
-        while self.hasMoreSections, self.continuationsLoaded < Self.maxContinuations {
-            guard self.loadingState == .loaded else { break }
-
-            do {
-                if let additionalSections = try await client.getMoodsAndGenresContinuation() {
-                    self.sections.append(contentsOf: additionalSections)
-                    self.continuationsLoaded += 1
-                    self.hasMoreSections = self.client.hasMoreMoodsAndGenresSections
-                    let continuationNum = self.continuationsLoaded
-                    self.logger.info("Background loaded \(additionalSections.count) more sections (continuation \(continuationNum))")
-                } else {
-                    self.hasMoreSections = false
-                    break
-                }
-            } catch is CancellationError {
-                self.logger.debug("Background loading cancelled")
-                break
-            } catch {
-                self.logger.warning("Background section load failed: \(error.localizedDescription)")
-                break
+        let generation = self.loadGeneration
+        self.isLoadingMoreSections = true
+        self.loadingState = .loadingMore
+        defer {
+            self.isLoadingMoreSections = false
+            if self.loadingState == .loadingMore {
+                self.loadingState = .loaded
             }
+            self.resumeContinuationWaiters()
         }
 
-        let totalCount = self.sections.count
-        self.logger.info("Background section loading completed, total sections: \(totalCount)")
+        do {
+            if let additionalSections = try await client.getMoodsAndGenresContinuation() {
+                guard generation == self.loadGeneration else { return }
+                let sectionsToAppend = additionalSections
+                self.sections.append(contentsOf: sectionsToAppend)
+                self.hasMoreSections = self.client.hasMoreMoodsAndGenresSections
+                self.logger.info("Loaded \(sectionsToAppend.count) more moods and genres sections on demand")
+            } else {
+                guard generation == self.loadGeneration else { return }
+                self.hasMoreSections = false
+            }
+        } catch is CancellationError {
+            self.logger.debug("Moods and genres continuation load cancelled")
+        } catch {
+            self.logger.warning("Moods and genres continuation load failed: \(error.localizedDescription)")
+        }
     }
 
     /// Refreshes moods and genres content.
     func refresh() async {
-        self.backgroundLoadTask?.cancel()
+        await self.waitForInFlightContinuation()
         self.sections = []
         self.hasMoreSections = true
-        self.continuationsLoaded = 0
+        self.isLoadingMoreSections = false
         await self.load()
+    }
+
+    private func waitForInFlightContinuation() async {
+        guard self.isLoadingMoreSections else { return }
+        await withCheckedContinuation { continuation in
+            self.continuationWaiters.append(continuation)
+        }
+    }
+
+    private func resumeContinuationWaiters() {
+        let waiters = self.continuationWaiters
+        self.continuationWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
     }
 }

--- a/Sources/Kaset/ViewModels/NewReleasesViewModel.swift
+++ b/Sources/Kaset/ViewModels/NewReleasesViewModel.swift
@@ -18,30 +18,25 @@ final class NewReleasesViewModel {
     /// The API client (exposed for navigation to detail views).
     let client: any YTMusicClientProtocol
     private let logger = DiagnosticsLogger.api
-    // swiftformat:disable modifierOrder
-    /// Task for background loading, cancelled in deinit.
-    /// nonisolated(unsafe) required for deinit access; Swift 6.2 warning is expected.
-    @ObservationIgnored private var backgroundLoadTask: Task<Void, Never>?
-    // swiftformat:enable modifierOrder
+    /// Whether a user-visible continuation load is currently in flight.
+    private var isLoadingMoreSections = false
 
-    /// Number of background continuations loaded.
-    private var continuationsLoaded = 0
+    /// Waiters that should resume once the current continuation request finishes.
+    @ObservationIgnored private var continuationWaiters: [CheckedContinuation<Void, Never>] = []
 
-    /// Maximum continuations to load in background.
-    private static let maxContinuations = 4
+    /// Monotonic token used to discard stale continuation results after refreshes.
+    private var loadGeneration = 0
 
     init(client: any YTMusicClientProtocol) {
         self.client = client
-    }
-
-    deinit {
-        self.backgroundLoadTask?.cancel()
     }
 
     /// Loads new releases content with fast initial load.
     func load() async {
         guard self.loadingState != .loading else { return }
 
+        self.loadGeneration += 1
+        let generation = self.loadGeneration
         self.loadingState = .loading
         self.logger.info("Loading new releases content")
 
@@ -50,72 +45,77 @@ final class NewReleasesViewModel {
             self.sections = response.sections
             self.hasMoreSections = self.client.hasMoreNewReleasesSections
             self.loadingState = .loaded
-            self.continuationsLoaded = 0
             let sectionCount = self.sections.count
             self.logger.info("New releases content loaded: \(sectionCount) sections")
-
-            // Start background loading of additional sections
-            self.startBackgroundLoading()
         } catch is CancellationError {
+            guard generation == self.loadGeneration else { return }
             // Task was cancelled (e.g., user navigated away) — reset to idle so it can retry
             self.logger.debug("New releases load cancelled")
             self.loadingState = .idle
         } catch {
+            guard generation == self.loadGeneration else { return }
             self.logger.error("Failed to load new releases: \(error.localizedDescription)")
             self.loadingState = .error(LoadingError(from: error))
         }
     }
 
-    /// Loads more sections in the background progressively.
-    private func startBackgroundLoading() {
-        self.backgroundLoadTask?.cancel()
-        self.backgroundLoadTask = Task { [weak self] in
-            guard let self else { return }
+    /// Loads one additional continuation page on explicit user demand.
+    func loadMore() async {
+        guard self.hasMoreSections,
+              !self.isLoadingMoreSections,
+              self.loadingState == .loaded
+        else { return }
 
-            // Brief delay to let the UI settle
-            try? await Task.sleep(for: .milliseconds(300))
-
-            guard !Task.isCancelled else { return }
-
-            await self.loadMoreSections()
-        }
-    }
-
-    /// Loads additional sections from continuations progressively.
-    private func loadMoreSections() async {
-        while self.hasMoreSections, self.continuationsLoaded < Self.maxContinuations {
-            guard self.loadingState == .loaded else { break }
-
-            do {
-                if let additionalSections = try await client.getNewReleasesContinuation() {
-                    self.sections.append(contentsOf: additionalSections)
-                    self.continuationsLoaded += 1
-                    self.hasMoreSections = self.client.hasMoreNewReleasesSections
-                    let continuationNum = self.continuationsLoaded
-                    self.logger.info("Background loaded \(additionalSections.count) more sections (continuation \(continuationNum))")
-                } else {
-                    self.hasMoreSections = false
-                    break
-                }
-            } catch is CancellationError {
-                self.logger.debug("Background loading cancelled")
-                break
-            } catch {
-                self.logger.warning("Background section load failed: \(error.localizedDescription)")
-                break
+        let generation = self.loadGeneration
+        self.isLoadingMoreSections = true
+        self.loadingState = .loadingMore
+        defer {
+            self.isLoadingMoreSections = false
+            if self.loadingState == .loadingMore {
+                self.loadingState = .loaded
             }
+            self.resumeContinuationWaiters()
         }
 
-        let totalCount = self.sections.count
-        self.logger.info("Background section loading completed, total sections: \(totalCount)")
+        do {
+            if let additionalSections = try await client.getNewReleasesContinuation() {
+                guard generation == self.loadGeneration else { return }
+                let sectionsToAppend = additionalSections
+                self.sections.append(contentsOf: sectionsToAppend)
+                self.hasMoreSections = self.client.hasMoreNewReleasesSections
+                self.logger.info("Loaded \(sectionsToAppend.count) more new releases sections on demand")
+            } else {
+                guard generation == self.loadGeneration else { return }
+                self.hasMoreSections = false
+            }
+        } catch is CancellationError {
+            self.logger.debug("New releases continuation load cancelled")
+        } catch {
+            self.logger.warning("New releases continuation load failed: \(error.localizedDescription)")
+        }
     }
 
     /// Refreshes new releases content.
     func refresh() async {
-        self.backgroundLoadTask?.cancel()
+        await self.waitForInFlightContinuation()
         self.sections = []
         self.hasMoreSections = true
-        self.continuationsLoaded = 0
+        self.isLoadingMoreSections = false
         await self.load()
+    }
+
+    private func waitForInFlightContinuation() async {
+        guard self.isLoadingMoreSections else { return }
+        await withCheckedContinuation { continuation in
+            self.continuationWaiters.append(continuation)
+        }
+    }
+
+    private func resumeContinuationWaiters() {
+        let waiters = self.continuationWaiters
+        self.continuationWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
     }
 }

--- a/Sources/Kaset/ViewModels/PlaylistDetailViewModel.swift
+++ b/Sources/Kaset/ViewModels/PlaylistDetailViewModel.swift
@@ -6,15 +6,8 @@ import os
 @MainActor
 @Observable
 final class PlaylistDetailViewModel {
-    private static let fullPlaylistLoadTrackThreshold = 100
-
     private struct LiveSyncTask {
         let id: UUID
-        let task: Task<Void, Never>
-    }
-
-    private struct RemainingTracksTask {
-        let generation: Int
         let task: Task<Void, Never>
     }
 
@@ -45,9 +38,6 @@ final class PlaylistDetailViewModel {
     private var liveSyncTasks: [String: LiveSyncTask] = [:]
 
     @ObservationIgnored
-    private var remainingTracksTask: RemainingTracksTask?
-
-    @ObservationIgnored
     private var loadGeneration = 0
 
     @ObservationIgnored
@@ -67,7 +57,6 @@ final class PlaylistDetailViewModel {
     }
 
     deinit {
-        self.remainingTracksTask?.task.cancel()
         for liveSyncTask in self.liveSyncTasks.values {
             liveSyncTask.task.cancel()
         }
@@ -153,9 +142,8 @@ final class PlaylistDetailViewModel {
     }
 
     private func load(restartingInFlightLoad: Bool) async {
-        guard restartingInFlightLoad || (self.loadingState != .loading && self.loadingState != .loadingMore && self.remainingTracksTask == nil) else { return }
+        guard restartingInFlightLoad || (self.loadingState != .loading && self.loadingState != .loadingMore) else { return }
 
-        self.cancelRemainingTracksTask()
         self.cancelFullLoadTask()
         self.loadGeneration += 1
         let generation = self.loadGeneration
@@ -280,8 +268,7 @@ final class PlaylistDetailViewModel {
 
     /// Loads more tracks via continuation.
     func loadMore() async {
-        guard self.remainingTracksTask == nil,
-              self.loadingState == .loaded,
+        guard self.loadingState == .loaded,
               self.hasMore,
               self.continuationToken != nil,
               self.playlistDetail != nil
@@ -298,63 +285,6 @@ final class PlaylistDetailViewModel {
                 }
             }
         }
-    }
-
-    private func startRemainingTracksTaskIfNeeded(generation: Int) {
-        guard let currentDetail = self.playlistDetail,
-              self.hasMore,
-              self.shouldLoadFullPlaylist(currentDetail)
-        else { return }
-
-        let client = self.client
-        let task = Task { [weak self, client] in
-            while !Task.isCancelled {
-                guard let batch = self?.nextRemainingTracksBatch(generation: generation) else { break }
-
-                do {
-                    let response = try await client.getPlaylistContinuation(
-                        token: batch.continuation,
-                        requiresAuth: batch.requiresAuth
-                    )
-                    guard self?.applyRemainingTracksResponse(response, batch: batch) == true else { break }
-                } catch is CancellationError {
-                    self?.restoreLoadedStateIfCurrent(generation: generation)
-                    break
-                } catch {
-                    self?.handleRemainingTracksError(error, generation: generation)
-                    break
-                }
-            }
-
-            self?.finishRemainingTracksTask(generation: generation)
-        }
-        self.remainingTracksTask = RemainingTracksTask(generation: generation, task: task)
-    }
-
-    private func nextRemainingTracksBatch(generation: Int) -> ContinuationDrainBatch? {
-        guard let currentDetail = self.playlistDetail,
-              self.hasMore,
-              self.shouldLoadFullPlaylist(currentDetail),
-              let continuationToken,
-              generation == self.loadGeneration,
-              !Task.isCancelled
-        else { return nil }
-
-        if self.loadingState == .loaded {
-            self.loadingState = .loadingMore
-        }
-
-        let initialTrackCount = currentDetail.tracks.count
-        let totalTrackCount = currentDetail.trackCount ?? self.playlist.trackCount ?? initialTrackCount
-        self.logger.info("Loading full playlist: \(initialTrackCount) loaded tracks, total: \(totalTrackCount)")
-
-        return ContinuationDrainBatch(
-            generation: generation,
-            continuation: continuationToken,
-            currentDetail: currentDetail,
-            isLikedMusicPlaylist: self.isLikedMusicPlaylist,
-            requiresAuth: currentDetail.requiresPersonalAccountForContinuations
-        )
     }
 
     private func applyRemainingTracksResponse(_ response: PlaylistContinuationResponse, batch: ContinuationDrainBatch) -> Bool {
@@ -455,38 +385,6 @@ final class PlaylistDetailViewModel {
         )
     }
 
-    private func restoreLoadedStateIfCurrent(generation: Int) {
-        guard generation == self.loadGeneration else { return }
-        self.logger.debug("Playlist continuation cancelled")
-        self.loadingState = .loaded
-    }
-
-    private func handleRemainingTracksError(_ error: any Error, generation: Int) {
-        guard generation == self.loadGeneration else { return }
-        self.logger.error("Failed to load more playlist tracks: \(error.localizedDescription)")
-        self.loadingState = .loaded
-    }
-
-    private func finishRemainingTracksTask(generation: Int) {
-        if self.remainingTracksTask?.generation == generation {
-            self.remainingTracksTask = nil
-        }
-    }
-
-    private func shouldLoadFullPlaylist(_ detail: PlaylistDetail) -> Bool {
-        guard !detail.isAlbum else { return false }
-        if self.isLikedMusicPlaylist {
-            return true
-        }
-
-        let reportedTrackCount = max(detail.trackCount ?? 0, self.playlist.trackCount ?? 0)
-        if reportedTrackCount > Self.fullPlaylistLoadTrackThreshold {
-            return true
-        }
-
-        return detail.tracks.count >= Self.fullPlaylistLoadTrackThreshold
-    }
-
     /// Single-flight wrapper around one continuation fetch. Concurrent callers — the initial
     /// full-playlist load, the scroll-triggered `loadMore()`, `loadAllRemaining`, and repeated play
     /// triggers — coalesce onto the in-flight batch and receive its real result, instead of colliding
@@ -576,16 +474,10 @@ final class PlaylistDetailViewModel {
     /// Refreshes the playlist.
     func refresh() async {
         self.cancelAllLiveSyncTasks()
-        self.cancelRemainingTracksTask()
         self.replacePlaylistDetail(nil)
         self.hasMore = false
         self.continuationToken = nil
         await self.load(restartingInFlightLoad: true)
-    }
-
-    private func cancelRemainingTracksTask() {
-        self.remainingTracksTask?.task.cancel()
-        self.remainingTracksTask = nil
     }
 
     private func cancelFullLoadTask() {

--- a/Sources/Kaset/ViewModels/PlaylistDetailViewModel.swift
+++ b/Sources/Kaset/ViewModels/PlaylistDetailViewModel.swift
@@ -126,11 +126,12 @@ final class PlaylistDetailViewModel {
             await fullLoadTask.value
             return
         }
+        let generation = self.loadGeneration
         let task = Task { @MainActor in
             var consecutiveStalls = 0
-            while self.hasMore, consecutiveStalls < 8 {
+            while self.isCurrentLoadGeneration(generation), self.hasMore, consecutiveStalls < 8 {
                 let before = self.playlistDetail?.tracks.count ?? 0
-                _ = await self.loadMoreBatch()
+                _ = await self.loadMoreBatch(generation: generation)
                 if (self.playlistDetail?.tracks.count ?? 0) > before {
                     consecutiveStalls = 0
                 } else {
@@ -141,7 +142,9 @@ final class PlaylistDetailViewModel {
         }
         self.fullLoadTask = task
         await task.value
-        self.fullLoadTask = nil
+        if self.isCurrentLoadGeneration(generation) {
+            self.fullLoadTask = nil
+        }
     }
 
     /// Loads the playlist details including tracks.
@@ -153,6 +156,7 @@ final class PlaylistDetailViewModel {
         guard restartingInFlightLoad || (self.loadingState != .loading && self.loadingState != .loadingMore && self.remainingTracksTask == nil) else { return }
 
         self.cancelRemainingTracksTask()
+        self.cancelFullLoadTask()
         self.loadGeneration += 1
         let generation = self.loadGeneration
         self.removedLikedMusicVideoIDs = []
@@ -260,7 +264,6 @@ final class PlaylistDetailViewModel {
             let totalTrackCount = detail.trackCount ?? loadedTrackCount
             self.logger.info("Playlist loaded: \(loadedTrackCount) loaded tracks, total: \(totalTrackCount), hasMore: \(self.hasMore)")
             self.replaceLoadedTrackVideoIds(with: detail.tracks)
-            self.startRemainingTracksTaskIfNeeded(generation: generation)
         } catch is CancellationError {
             guard self.isCurrentLoadGeneration(generation) else { return }
 
@@ -472,7 +475,9 @@ final class PlaylistDetailViewModel {
 
     private func shouldLoadFullPlaylist(_ detail: PlaylistDetail) -> Bool {
         guard !detail.isAlbum else { return false }
-        if self.isLikedMusicPlaylist { return true }
+        if self.isLikedMusicPlaylist {
+            return true
+        }
 
         let reportedTrackCount = max(detail.trackCount ?? 0, self.playlist.trackCount ?? 0)
         if reportedTrackCount > Self.fullPlaylistLoadTrackThreshold {
@@ -581,6 +586,11 @@ final class PlaylistDetailViewModel {
     private func cancelRemainingTracksTask() {
         self.remainingTracksTask?.task.cancel()
         self.remainingTracksTask = nil
+    }
+
+    private func cancelFullLoadTask() {
+        self.fullLoadTask?.cancel()
+        self.fullLoadTask = nil
     }
 
     private func isCurrentLoadGeneration(_ generation: Int?) -> Bool {

--- a/Sources/Kaset/ViewModels/PodcastsViewModel.swift
+++ b/Sources/Kaset/ViewModels/PodcastsViewModel.swift
@@ -31,6 +31,7 @@ final class PodcastsViewModel {
 
     /// Current explicit continuation request, cancelled on account switch.
     @ObservationIgnored private var continuationTask: Task<Void, Never>?
+    @ObservationIgnored private var continuationTaskID: UUID?
 
     /// Incremented whenever foreground load results should no longer be
     /// allowed to mutate this view model (account switch, refresh, or a
@@ -139,15 +140,18 @@ final class PodcastsViewModel {
 
         let generation = self.loadGeneration
         let accountId = self.accountId
+        let taskID = UUID()
         let task = Task { @MainActor [weak self] in
             guard let self else { return }
-            await self.performLoadMore(generation: generation, accountId: accountId)
+            await self.performLoadMore(generation: generation, accountId: accountId, taskID: taskID)
         }
         self.continuationTask = task
+        self.continuationTaskID = taskID
+        defer { self.clearContinuationTaskIfCurrent(taskID) }
         await task.value
     }
 
-    private func performLoadMore(generation: Int, accountId: String?) async {
+    private func performLoadMore(generation: Int, accountId: String?, taskID: UUID) async {
         guard self.isCurrentLoad(generation: generation, accountId: accountId),
               !Task.isCancelled
         else { return }
@@ -157,7 +161,7 @@ final class PodcastsViewModel {
         defer {
             if self.isCurrentLoad(generation: generation, accountId: accountId) {
                 self.isLoadingMoreSections = false
-                self.continuationTask = nil
+                self.clearContinuationTaskIfCurrent(taskID)
                 if self.loadingState == .loadingMore {
                     self.loadingState = .loaded
                 }
@@ -195,6 +199,7 @@ final class PodcastsViewModel {
     private func resetContentForAccountSwitch() {
         self.continuationTask?.cancel()
         self.continuationTask = nil
+        self.continuationTaskID = nil
         self.client.resetSessionStateForAccountSwitch()
         self.loadGeneration += 1
         self.sections = []
@@ -206,10 +211,17 @@ final class PodcastsViewModel {
     private func cancelInFlightContinuation() async {
         guard let continuationTask else { return }
         self.loadGeneration += 1
+        self.continuationTask = nil
+        self.continuationTaskID = nil
         continuationTask.cancel()
         await continuationTask.value
-        self.continuationTask = nil
         self.isLoadingMoreSections = false
+    }
+
+    private func clearContinuationTaskIfCurrent(_ taskID: UUID) {
+        guard self.continuationTaskID == taskID else { return }
+        self.continuationTask = nil
+        self.continuationTaskID = nil
     }
 
     private func isCurrentLoad(generation: Int, accountId: String?) -> Bool {

--- a/Sources/Kaset/ViewModels/PodcastsViewModel.swift
+++ b/Sources/Kaset/ViewModels/PodcastsViewModel.swift
@@ -26,22 +26,16 @@ final class PodcastsViewModel {
     /// the right key. Updated by `configure` on account switches.
     private(set) var accountId: String?
     private let logger = DiagnosticsLogger.api
-    // swiftformat:disable modifierOrder
-    /// Task for background loading, cancelled in deinit.
-    /// nonisolated(unsafe) required for deinit access; Swift 6.2 warning is expected.
-    @ObservationIgnored private var backgroundLoadTask: Task<Void, Never>?
-    // swiftformat:enable modifierOrder
+    /// Whether a user-visible continuation load is currently in flight.
+    private var isLoadingMoreSections = false
 
-    /// Number of background continuations loaded.
-    private var continuationsLoaded = 0
+    /// Current explicit continuation request, cancelled on account switch.
+    @ObservationIgnored private var continuationTask: Task<Void, Never>?
 
     /// Incremented whenever foreground load results should no longer be
     /// allowed to mutate this view model (account switch, refresh, or a
     /// newer load).
     private var loadGeneration = 0
-
-    /// Maximum continuations to load in background.
-    private static let maxContinuations = 4
 
     init(
         client: any YTMusicClientProtocol,
@@ -70,13 +64,11 @@ final class PodcastsViewModel {
         }
     }
 
-    deinit {
-        self.backgroundLoadTask?.cancel()
-    }
-
     /// Loads podcasts content with fast initial load.
     func load() async {
-        guard self.loadingState != .loading else { return }
+        guard self.loadingState != .loading,
+              self.loadingState != .loadingMore
+        else { return }
 
         self.loadGeneration += 1
         let loadGeneration = self.loadGeneration
@@ -95,7 +87,6 @@ final class PodcastsViewModel {
             self.sections = sections
             self.hasMoreSections = self.client.hasMorePodcastsSections
             self.loadingState = .loaded
-            self.continuationsLoaded = 0
             let sectionCount = self.sections.count
             self.logger.info("Podcasts content loaded: \(sectionCount) sections")
 
@@ -106,10 +97,6 @@ final class PodcastsViewModel {
                 self.availabilityService?.markUnavailable(for: loadAccountId)
             } else {
                 self.availabilityService?.markAvailable(for: loadAccountId)
-                // Only continue progressive loading when there's real
-                // content; an empty payload means there's nothing to
-                // continue and the tab is about to disappear anyway.
-                self.startBackgroundLoading()
             }
         } catch is CancellationError {
             guard self.isCurrentLoad(generation: loadGeneration, accountId: loadAccountId) else { return }
@@ -143,78 +130,86 @@ final class PodcastsViewModel {
         }
     }
 
-    /// Loads more sections in the background progressively.
-    private func startBackgroundLoading() {
-        self.backgroundLoadTask?.cancel()
-        let backgroundGeneration = self.loadGeneration
-        let backgroundAccountId = self.accountId
-        self.backgroundLoadTask = Task { [weak self] in
+    /// Loads one additional podcast continuation page on explicit user demand.
+    func loadMore() async {
+        guard self.hasMoreSections,
+              self.continuationTask == nil,
+              self.loadingState == .loaded
+        else { return }
+
+        let generation = self.loadGeneration
+        let accountId = self.accountId
+        let task = Task { @MainActor [weak self] in
             guard let self else { return }
-
-            // Brief delay to let the UI settle
-            try? await Task.sleep(for: .milliseconds(300))
-
-            guard !Task.isCancelled else { return }
-
-            await self.loadMoreSections(generation: backgroundGeneration, accountId: backgroundAccountId)
+            await self.performLoadMore(generation: generation, accountId: accountId)
         }
+        self.continuationTask = task
+        await task.value
     }
 
-    /// Loads additional sections from continuations progressively.
-    private func loadMoreSections(generation: Int, accountId: String?) async {
-        while self.hasMoreSections, self.continuationsLoaded < Self.maxContinuations {
-            guard self.loadingState == .loaded,
-                  self.isCurrentLoad(generation: generation, accountId: accountId),
-                  !Task.isCancelled
-            else { break }
+    private func performLoadMore(generation: Int, accountId: String?) async {
+        guard self.isCurrentLoad(generation: generation, accountId: accountId),
+              !Task.isCancelled
+        else { return }
 
-            do {
-                let additionalSections = try await client.getPodcastsContinuation()
-                guard self.isCurrentLoad(generation: generation, accountId: accountId),
-                      !Task.isCancelled
-                else { break }
-
-                if let additionalSections {
-                    self.sections.append(contentsOf: additionalSections)
-                    self.continuationsLoaded += 1
-                    self.hasMoreSections = self.client.hasMorePodcastsSections
-                    let continuationNum = self.continuationsLoaded
-                    self.logger.info("Background loaded \(additionalSections.count) more podcast sections (continuation \(continuationNum))")
-                } else {
-                    self.hasMoreSections = false
-                    break
+        self.isLoadingMoreSections = true
+        self.loadingState = .loadingMore
+        defer {
+            if self.isCurrentLoad(generation: generation, accountId: accountId) {
+                self.isLoadingMoreSections = false
+                self.continuationTask = nil
+                if self.loadingState == .loadingMore {
+                    self.loadingState = .loaded
                 }
-            } catch is CancellationError {
-                self.logger.debug("Background loading cancelled")
-                break
-            } catch {
-                self.logger.warning("Background section load failed: \(error.localizedDescription)")
-                break
             }
         }
 
-        let totalCount = self.sections.count
-        self.logger.info("Background section loading completed, total sections: \(totalCount)")
+        do {
+            if let additionalSections = try await self.client.getPodcastsContinuation() {
+                guard self.isCurrentLoad(generation: generation, accountId: accountId) else { return }
+                self.sections.append(contentsOf: additionalSections)
+                self.hasMoreSections = self.client.hasMorePodcastsSections
+                self.logger.info("Loaded \(additionalSections.count) more podcast sections on demand")
+            } else {
+                guard self.isCurrentLoad(generation: generation, accountId: accountId) else { return }
+                self.hasMoreSections = false
+            }
+        } catch is CancellationError {
+            self.logger.debug("Podcast continuation load cancelled")
+        } catch {
+            self.logger.warning("Podcast continuation load failed: \(error.localizedDescription)")
+        }
     }
 
     /// Refreshes podcasts content.
     func refresh() async {
-        self.backgroundLoadTask?.cancel()
+        await self.cancelInFlightContinuation()
         self.loadGeneration += 1
         self.sections = []
         self.hasMoreSections = true
-        self.continuationsLoaded = 0
+        self.isLoadingMoreSections = false
         self.loadingState = .idle
         await self.load()
     }
 
     private func resetContentForAccountSwitch() {
-        self.backgroundLoadTask?.cancel()
+        self.continuationTask?.cancel()
+        self.continuationTask = nil
+        self.client.resetSessionStateForAccountSwitch()
         self.loadGeneration += 1
         self.sections = []
         self.hasMoreSections = true
-        self.continuationsLoaded = 0
+        self.isLoadingMoreSections = false
         self.loadingState = .idle
+    }
+
+    private func cancelInFlightContinuation() async {
+        guard let continuationTask else { return }
+        self.loadGeneration += 1
+        continuationTask.cancel()
+        await continuationTask.value
+        self.continuationTask = nil
+        self.isLoadingMoreSections = false
     }
 
     private func isCurrentLoad(generation: Int, accountId: String?) -> Bool {

--- a/Sources/Kaset/ViewModels/PodcastsViewModel.swift
+++ b/Sources/Kaset/ViewModels/PodcastsViewModel.swift
@@ -210,11 +210,14 @@ final class PodcastsViewModel {
 
     private func cancelInFlightContinuation() async {
         guard let continuationTask else { return }
+        let taskID = self.continuationTaskID
         self.loadGeneration += 1
-        self.continuationTask = nil
-        self.continuationTaskID = nil
         continuationTask.cancel()
         await continuationTask.value
+        if self.continuationTaskID == taskID {
+            self.continuationTask = nil
+            self.continuationTaskID = nil
+        }
         self.isLoadingMoreSections = false
     }
 

--- a/Sources/Kaset/ViewModels/SearchViewModel.swift
+++ b/Sources/Kaset/ViewModels/SearchViewModel.swift
@@ -363,12 +363,37 @@ final class SearchViewModel {
         self.loadingState = .loaded
     }
 
-    /// Performs the broadest search for the All filter by combining the mixed search response
-    /// with the dedicated result-type searches.
+    /// Performs the All-filter search. The mixed search response usually already contains
+    /// representative results for every visible category, so keep the common path to a single
+    /// request. Dedicated category searches are only used as a fallback when mixed search returns
+    /// nothing (or fails with a non-auth transient error), avoiding seven-request fanout per query.
     private func searchAll(query: String, filter: SearchFilter) async throws -> SearchResponse {
-        async let mixedResults = self.attemptSearch(label: "mixed search") {
+        let mixedAttempt = await self.attemptSearch(label: "mixed search") {
             try await self.client.search(query: query)
         }
+
+        if let authError = mixedAttempt.error.flatMap(Self.authenticationError) {
+            throw authError
+        }
+
+        if let mixedResponse = mixedAttempt.response, !mixedResponse.isEmpty {
+            return mixedResponse
+        }
+
+        guard self.isCurrentSearch(query: query, filter: filter) else {
+            throw CancellationError()
+        }
+
+        return try await self.searchAllCategoryFallback(
+            query: query,
+            mixedError: mixedAttempt.error
+        )
+    }
+
+    /// Runs dedicated category searches only when the mixed All response cannot paint useful
+    /// results. This preserves empty-mixed fallback quality without paying the network/WebKit
+    /// authentication cost on every ordinary All search.
+    private func searchAllCategoryFallback(query: String, mixedError: (any Error)?) async throws -> SearchResponse {
         async let songResults = self.attemptSearch(label: "songs search") {
             try await self.client.searchSongsWithPagination(query: query)
         }
@@ -388,16 +413,7 @@ final class SearchViewModel {
             try await self.client.searchPodcasts(query: query)
         }
 
-        let mixedAttempt = await mixedResults
-        if let mixedResponse = mixedAttempt.response,
-           !mixedResponse.isEmpty,
-           self.isCurrentSearch(query: query, filter: filter)
-        {
-            self.publishSearchResults(mixedResponse, query: query, filter: filter)
-        }
-
         let attempts = await [
-            mixedAttempt,
             songResults,
             albumResults,
             artistResults,
@@ -406,13 +422,13 @@ final class SearchViewModel {
             podcastResults,
         ]
 
-        if let authError = attempts.compactMap(\.error).first(where: Self.isAuthenticationError) {
+        if let authError = attempts.compactMap(\.error).compactMap(Self.authenticationError).first {
             throw authError
         }
 
         let responses = attempts.compactMap(\.response)
         guard !responses.isEmpty else {
-            throw attempts.compactMap(\.error).first ?? YTMusicError.unknown(message: "All-filter search failed")
+            throw attempts.compactMap(\.error).first ?? mixedError ?? YTMusicError.unknown(message: "All-filter search failed")
         }
 
         return Self.mergeSearchResponses(responses)
@@ -433,8 +449,12 @@ final class SearchViewModel {
     }
 
     private static func isAuthenticationError(_ error: any Error) -> Bool {
-        guard let ytError = error as? YTMusicError else { return false }
-        return ytError.requiresReauth
+        self.authenticationError(error) != nil
+    }
+
+    private static func authenticationError(_ error: (any Error)?) -> YTMusicError? {
+        guard let ytError = error as? YTMusicError, ytError.requiresReauth else { return nil }
+        return ytError
     }
 
     /// Combines multiple search responses while keeping the first occurrence of each item.

--- a/Sources/Kaset/ViewModels/YouTube/YouTubeHistoryViewModel.swift
+++ b/Sources/Kaset/ViewModels/YouTube/YouTubeHistoryViewModel.swift
@@ -14,6 +14,9 @@ final class YouTubeHistoryViewModel {
     /// Continuation token for the next page.
     private var continuation: String?
 
+    /// Changes whenever pagination advances, even if the page adds no visible videos.
+    private(set) var paginationTrigger = 0
+
     var hasMoreVideos: Bool {
         self.continuation != nil
     }
@@ -62,6 +65,7 @@ final class YouTubeHistoryViewModel {
             guard runID == self.loadGeneration else { return }
             self.videos = feed.videos
             self.continuation = feed.continuation
+            self.paginationTrigger += 1
             self.loadingState = .loaded
         } catch {
             guard runID == self.loadGeneration else { return }
@@ -81,6 +85,7 @@ final class YouTubeHistoryViewModel {
         self.loadingState = .idle
         self.videos = []
         self.continuation = nil
+        self.paginationTrigger += 1
         await self.load()
     }
 
@@ -99,6 +104,7 @@ final class YouTubeHistoryViewModel {
             let existing = Set(self.videos.map(\.videoId))
             self.videos.append(contentsOf: feed.videos.filter { !existing.contains($0.videoId) })
             self.continuation = feed.continuation
+            self.paginationTrigger += 1
             self.loadingState = .loaded
         } catch {
             // A cancelled page load is not an error; allow retrying.

--- a/Sources/Kaset/ViewModels/YouTube/YouTubeHomeViewModel.swift
+++ b/Sources/Kaset/ViewModels/YouTube/YouTubeHomeViewModel.swift
@@ -445,16 +445,17 @@ final class YouTubeHomeViewModel {
         let result = await self.topicSections(for: batch)
         guard generation == self.loadGeneration else { return .stale }
 
-        if preserveOnFailure, result.hadFailure {
-            // A deferred topic fetch may fail transiently. Put the whole batch
-            // back so the footer stays available for retry instead of silently
-            // burning through every pending chip while auto-loading.
-            self.pendingTopicChips.insert(contentsOf: batch, at: 0)
-            self.hasMoreTopicRails = true
-            return .failed
+        if preserveOnFailure, !result.failedChips.isEmpty {
+            // Retry only failed chips, after untouched queued chips. Successful
+            // rails stay published and a permanently bad continuation cannot
+            // keep otherwise valid later topics behind the same batch forever.
+            self.pendingTopicChips.append(contentsOf: result.failedChips)
         }
+        self.hasMoreTopicRails = !self.pendingTopicChips.isEmpty
 
-        guard !result.sections.isEmpty else { return .empty }
+        guard !result.sections.isEmpty else {
+            return preserveOnFailure && !result.failedChips.isEmpty ? .failed : .empty
+        }
 
         self.sections.append(contentsOf: result.sections)
         if !gridReady, self.loadingState == .loading {
@@ -477,18 +478,19 @@ final class YouTubeHomeViewModel {
         }
 
         var sections: [YouTubeHomeSection] = []
-        var hadFailure = false
-        for outcome in slots.compactMap(\.self) {
+        var failedChips: [YouTubeHomeChip] = []
+        for (index, outcome) in slots.enumerated() {
+            guard let outcome else { continue }
             switch outcome {
             case let .section(section):
                 sections.append(section)
             case .empty:
                 break
             case .failed:
-                hadFailure = true
+                failedChips.append(chips[index])
             }
         }
-        return TopicBatchFetchResult(sections: sections, hadFailure: hadFailure)
+        return TopicBatchFetchResult(sections: sections, failedChips: failedChips)
     }
 
     /// Forces a fresh reload (e.g. after account switches).
@@ -806,7 +808,7 @@ final class YouTubeHomeViewModel {
 
     private struct TopicBatchFetchResult {
         let sections: [YouTubeHomeSection]
-        let hadFailure: Bool
+        let failedChips: [YouTubeHomeChip]
     }
 
     private enum TopicBatchLoadOutcome {

--- a/Sources/Kaset/ViewModels/YouTube/YouTubeHomeViewModel.swift
+++ b/Sources/Kaset/ViewModels/YouTube/YouTubeHomeViewModel.swift
@@ -299,7 +299,8 @@ final class YouTubeHomeViewModel {
             await self.loadNextTopicRailBatch(
                 generation: generation,
                 gridReady: gridReady,
-                batchSize: Self.initialTopicRailBatchSize
+                batchSize: Self.initialTopicRailBatchSize,
+                preserveOnFailure: false
             )
             try Task.checkCancellation()
             guard generation == self.loadGeneration else { return true }
@@ -428,40 +429,66 @@ final class YouTubeHomeViewModel {
         }
     }
 
+    @discardableResult
     private func loadNextTopicRailBatch(
         generation: Int,
         gridReady: Bool,
-        batchSize: Int
-    ) async {
-        guard generation == self.loadGeneration, !self.pendingTopicChips.isEmpty else { return }
+        batchSize: Int,
+        preserveOnFailure: Bool
+    ) async -> TopicBatchLoadOutcome {
+        guard generation == self.loadGeneration, !self.pendingTopicChips.isEmpty else { return .stale }
 
         let batch = Array(self.pendingTopicChips.prefix(batchSize))
         self.pendingTopicChips.removeFirst(batch.count)
         self.hasMoreTopicRails = !self.pendingTopicChips.isEmpty
 
-        let sections = await self.topicSections(for: batch)
-        guard generation == self.loadGeneration else { return }
-        guard !sections.isEmpty else { return }
+        let result = await self.topicSections(for: batch)
+        guard generation == self.loadGeneration else { return .stale }
 
-        self.sections.append(contentsOf: sections)
+        if preserveOnFailure, result.hadFailure {
+            // A deferred topic fetch may fail transiently. Put the whole batch
+            // back so the footer stays available for retry instead of silently
+            // burning through every pending chip while auto-loading.
+            self.pendingTopicChips.insert(contentsOf: batch, at: 0)
+            self.hasMoreTopicRails = true
+            return .failed
+        }
+
+        guard !result.sections.isEmpty else { return .empty }
+
+        self.sections.append(contentsOf: result.sections)
         if !gridReady, self.loadingState == .loading {
             self.loadingState = .loaded
         }
+        return .appended
     }
 
-    private func topicSections(for chips: [YouTubeHomeChip]) async -> [YouTubeHomeSection] {
-        var slots = [YouTubeHomeSection?](repeating: nil, count: chips.count)
-        await withTaskGroup(of: (Int, YouTubeHomeSection?).self) { group in
+    private func topicSections(for chips: [YouTubeHomeChip]) async -> TopicBatchFetchResult {
+        var slots = [TopicFetchOutcome?](repeating: nil, count: chips.count)
+        await withTaskGroup(of: (Int, TopicFetchOutcome).self) { group in
             for (index, chip) in chips.enumerated() {
                 group.addTask {
-                    await (index, self.topicSection(for: chip))
+                    await (index, self.topicFetchOutcome(for: chip))
                 }
             }
-            for await (index, section) in group {
-                slots[index] = section
+            for await (index, outcome) in group {
+                slots[index] = outcome
             }
         }
-        return slots.compactMap(\.self)
+
+        var sections: [YouTubeHomeSection] = []
+        var hadFailure = false
+        for outcome in slots.compactMap(\.self) {
+            switch outcome {
+            case let .section(section):
+                sections.append(section)
+            case .empty:
+                break
+            case .failed:
+                hadFailure = true
+            }
+        }
+        return TopicBatchFetchResult(sections: sections, hadFailure: hadFailure)
     }
 
     /// Forces a fresh reload (e.g. after account switches).
@@ -526,11 +553,15 @@ final class YouTubeHomeViewModel {
             }
         }
 
-        await self.loadNextTopicRailBatch(
-            generation: generation,
-            gridReady: !self.videos.isEmpty,
-            batchSize: Self.initialTopicRailBatchSize
-        )
+        var outcome: TopicBatchLoadOutcome = .empty
+        repeat {
+            outcome = await self.loadNextTopicRailBatch(
+                generation: generation,
+                gridReady: !self.videos.isEmpty,
+                batchSize: Self.initialTopicRailBatchSize,
+                preserveOnFailure: true
+            )
+        } while generation == self.loadGeneration && outcome == .empty && self.hasMoreTopicRails
     }
 
     /// Loads the next feed page when the user nears the end of the grid.
@@ -767,23 +798,56 @@ final class YouTubeHomeViewModel {
 
     // MARK: - Topic Rails
 
-    /// Browses a single chip token into a topic section, or `nil` on
-    /// failure / empty result.
-    private func topicSection(for chip: YouTubeHomeChip) async -> YouTubeHomeSection? {
+    private enum TopicFetchOutcome {
+        case section(YouTubeHomeSection)
+        case empty
+        case failed
+    }
+
+    private struct TopicBatchFetchResult {
+        let sections: [YouTubeHomeSection]
+        let hadFailure: Bool
+    }
+
+    private enum TopicBatchLoadOutcome {
+        case appended
+        case empty
+        case failed
+        case stale
+    }
+
+    /// Browses a single chip token into a topic section outcome, preserving the
+    /// distinction between a valid empty response and a transient fetch failure.
+    private func topicFetchOutcome(for chip: YouTubeHomeChip) async -> TopicFetchOutcome {
         do {
             let feed = try await self.client.getHomeTopicFeed(continuation: chip.continuation)
-            guard !feed.videos.isEmpty else { return nil }
-            return YouTubeHomeSection(
-                id: "topic-\(chip.title)",
-                title: chip.title,
-                videos: feed.videos,
-                kind: .topic
+            guard !feed.videos.isEmpty else { return .empty }
+            return .section(
+                YouTubeHomeSection(
+                    id: "topic-\(chip.title)",
+                    title: chip.title,
+                    videos: feed.videos,
+                    kind: .topic
+                )
             )
         } catch {
             if !(error is CancellationError) {
                 self.logger.error("Topic rail '\(chip.title)' unavailable: \(error.localizedDescription)")
             }
-            return nil
+            return .failed
+        }
+    }
+
+    /// Browses a single chip token into a topic section, or `nil` on failure /
+    /// empty result. Initial rail streaming keeps the older omit-on-failure
+    /// behaviour; deferred auto-loading uses `topicFetchOutcome(for:)` so
+    /// failures can remain retryable.
+    private func topicSection(for chip: YouTubeHomeChip) async -> YouTubeHomeSection? {
+        switch await self.topicFetchOutcome(for: chip) {
+        case let .section(section):
+            section
+        case .empty, .failed:
+            nil
         }
     }
 }

--- a/Sources/Kaset/ViewModels/YouTube/YouTubeHomeViewModel.swift
+++ b/Sources/Kaset/ViewModels/YouTube/YouTubeHomeViewModel.swift
@@ -19,19 +19,32 @@ final class YouTubeHomeViewModel {
     /// Whether more feed pages are available.
     private(set) var hasMoreVideos = true
 
+    /// Whether more personalized topic rails are queued behind explicit user demand.
+    private(set) var hasMoreTopicRails = false
+
+    /// Whether an explicit topic-rail batch is currently loading.
+    private(set) var isLoadingTopicRails = false
+
     /// Video IDs already surfaced in titled shelf rails, excluded from the flat
     /// "For you" grid (including continuation pages) so a shelf video is never
     /// rendered twice.
     private var shelfVideoIDs: Set<String> = []
 
+    /// Personalized topic chips not fetched at cold start. Continuation tokens
+    /// are account-scoped and live only in this model; refresh/account switch
+    /// clears them before a new Home bundle repopulates the queue.
+    private var pendingTopicChips: [YouTubeHomeChip] = []
+
     /// Resume-progress band for the Continue Watching rail: started but not
     /// effectively finished. `nil`/0 = not started; ≥96 = finished.
     private static let continueWatchingRange = 1 ... 95
 
-    /// Cap on Continue Watching items and on topic rails shown at first paint.
+    /// Caps on Home rails. Topic rails keep the previous total cap for parity,
+    /// but cold start only browses the first batch; the rest load on demand.
     private static let continueWatchingCap = 20
     private static let guestFallbackRailCap = 20
     private static let topicRailCap = 8
+    private static let initialTopicRailBatchSize = 2
 
     /// Public destination rails used when signed-out Home returns YouTube's empty
     /// recommendation shell. These are browseable without a user account and keep
@@ -162,6 +175,9 @@ final class YouTubeHomeViewModel {
 
             try Task.checkCancellation()
             guard generation == self.loadGeneration else { return }
+            self.pendingTopicChips = []
+            self.hasMoreTopicRails = false
+            self.isLoadingTopicRails = false
 
             // `YouTubeFeedParser.parse` collects shelf videos into `feed.videos`
             // too, and the shelf rail surfaces them again — exclude shelf video
@@ -184,11 +200,12 @@ final class YouTubeHomeViewModel {
                 self.loadingState = .loaded
             }
 
-            // Publish the shelves immediately and start the topic rails now —
-            // do NOT block on the watch-history request (it can be slow/retrying
-            // and would otherwise delay the rails and keep an empty grid stuck on
-            // the skeleton). The Continue Watching rail is inserted at the front
-            // once history resolves.
+            // Publish the shelves immediately and start only the first topic
+            // batch now — do NOT block on the watch-history request (it can be
+            // slow/retrying and would otherwise delay the rails and keep an
+            // empty grid stuck on the skeleton). The Continue Watching rail is
+            // inserted at the front once history resolves; remaining topic chips
+            // stay queued for explicit demand instead of cold-launch fanout.
             if !shelves.isEmpty {
                 self.sections = shelves
                 if !gridReady {
@@ -196,9 +213,11 @@ final class YouTubeHomeViewModel {
                 }
             }
 
-            let chips = Array(bundle.chips.prefix(Self.topicRailCap))
+            let cappedChips = Array(bundle.chips.prefix(Self.topicRailCap))
+            let initialChips = Array(cappedChips.prefix(Self.initialTopicRailBatchSize))
+            self.pendingTopicChips = Array(cappedChips.dropFirst(initialChips.count))
 
-            let mayNeedGuestFallback = gridVideos.isEmpty && shelves.isEmpty && chips.isEmpty
+            let mayNeedGuestFallback = gridVideos.isEmpty && shelves.isEmpty
 
             // Stream the rails in as each resolves; the streamer is the single
             // writer of `sections` and prepends Continue Watching when its
@@ -209,7 +228,7 @@ final class YouTubeHomeViewModel {
             guard generation == self.loadGeneration else { return }
             self.isStreamingInitialRails = true
             await self.streamTopicRails(
-                chips: chips,
+                chips: initialChips,
                 shelves: shelves,
                 continueWatching: { [weak self] in
                     guard let self else { return nil }
@@ -226,23 +245,12 @@ final class YouTubeHomeViewModel {
                 self.isStreamingInitialRails = false
             }
 
-            // Empty grid: flip the initial-load skeleton to `.loaded` so the
-            // "No recommendations" placeholder can show. Only from `.loading` —
-            // if `loadMore()` started a continuation (empty first page with
-            // `hasMoreVideos`), don't clobber its `.loadingMore`.
-            try Task.checkCancellation()
-            guard generation == self.loadGeneration else { return }
-            if mayNeedGuestFallback, self.sections.isEmpty {
-                // Signed-out YouTube Home can legally return an empty recommendation
-                // shell. Only fall back after the Continue Watching attempt: an
-                // authenticated user can have an empty Home response while history
-                // is still the sole useful rail.
-                await self.loadGuestFallbackRails(generation: generation)
+            if try await self.settleInitialEmptyHomeIfNeeded(
+                mayNeedGuestFallback: mayNeedGuestFallback,
+                gridReady: gridReady,
+                generation: generation
+            ) {
                 return
-            }
-
-            if !gridReady, self.loadingState == .loading {
-                self.loadingState = .loaded
             }
 
             // A watch happened while Home was still loading or streaming its
@@ -267,6 +275,50 @@ final class YouTubeHomeViewModel {
             self.logger.error("Failed to load YouTube home feed: \(error.localizedDescription)")
             self.loadingState = .error(LoadingError(from: error))
         }
+    }
+
+    private func settleInitialEmptyHomeIfNeeded(
+        mayNeedGuestFallback: Bool,
+        gridReady: Bool,
+        generation: Int
+    ) async throws -> Bool {
+        // Empty grid: flip the initial-load skeleton to `.loaded` so the
+        // "No recommendations" placeholder can show. Only from `.loading` —
+        // if `loadMore()` started a continuation (empty first page with
+        // `hasMoreVideos`), don't clobber its `.loadingMore`.
+        try Task.checkCancellation()
+        guard generation == self.loadGeneration else { return true }
+
+        self.hasMoreTopicRails = !self.pendingTopicChips.isEmpty
+        while mayNeedGuestFallback, self.sections.isEmpty, !self.pendingTopicChips.isEmpty {
+            // With an empty grid/shelf surface, topic rails are the only possible
+            // personalized content. Walk queued chips in small batches until one
+            // produces content or the capped chip set is exhausted, so the user
+            // never sees a premature empty state just because the first
+            // cold-start topic batch was empty.
+            await self.loadNextTopicRailBatch(
+                generation: generation,
+                gridReady: gridReady,
+                batchSize: Self.initialTopicRailBatchSize
+            )
+            try Task.checkCancellation()
+            guard generation == self.loadGeneration else { return true }
+        }
+
+        self.hasMoreTopicRails = !self.pendingTopicChips.isEmpty
+        if mayNeedGuestFallback, self.sections.isEmpty, self.pendingTopicChips.isEmpty {
+            // Signed-out YouTube Home can legally return an empty recommendation
+            // shell. Only fall back after the Continue Watching and capped
+            // topic-chip attempts: an authenticated user can have an empty Home
+            // response while history/topics are still the sole useful rails.
+            await self.loadGuestFallbackRails(generation: generation)
+            return true
+        }
+
+        if !gridReady, self.loadingState == .loading {
+            self.loadingState = .loaded
+        }
+        return false
     }
 
     private func loadGuestFallbackRails(generation: Int) async {
@@ -338,7 +390,9 @@ final class YouTubeHomeViewModel {
         func publish() {
             guard generation == self.loadGeneration else { return }
             var next: [YouTubeHomeSection] = []
-            if let continueWatchingRail { next.append(continueWatchingRail) }
+            if let continueWatchingRail {
+                next.append(continueWatchingRail)
+            }
             next.append(contentsOf: shelves)
             next.append(contentsOf: topicSlot.compactMap(\.self))
             self.sections = next
@@ -374,6 +428,42 @@ final class YouTubeHomeViewModel {
         }
     }
 
+    private func loadNextTopicRailBatch(
+        generation: Int,
+        gridReady: Bool,
+        batchSize: Int
+    ) async {
+        guard generation == self.loadGeneration, !self.pendingTopicChips.isEmpty else { return }
+
+        let batch = Array(self.pendingTopicChips.prefix(batchSize))
+        self.pendingTopicChips.removeFirst(batch.count)
+        self.hasMoreTopicRails = !self.pendingTopicChips.isEmpty
+
+        let sections = await self.topicSections(for: batch)
+        guard generation == self.loadGeneration else { return }
+        guard !sections.isEmpty else { return }
+
+        self.sections.append(contentsOf: sections)
+        if !gridReady, self.loadingState == .loading {
+            self.loadingState = .loaded
+        }
+    }
+
+    private func topicSections(for chips: [YouTubeHomeChip]) async -> [YouTubeHomeSection] {
+        var slots = [YouTubeHomeSection?](repeating: nil, count: chips.count)
+        await withTaskGroup(of: (Int, YouTubeHomeSection?).self) { group in
+            for (index, chip) in chips.enumerated() {
+                group.addTask {
+                    await (index, self.topicSection(for: chip))
+                }
+            }
+            for await (index, section) in group {
+                slots[index] = section
+            }
+        }
+        return slots.compactMap(\.self)
+    }
+
     /// Forces a fresh reload (e.g. after account switches).
     func refresh() async {
         // Cancel and drop any in-flight load so `load()` starts a fresh one
@@ -400,6 +490,9 @@ final class YouTubeHomeViewModel {
         self.videos = []
         self.sections = []
         self.shelfVideoIDs = []
+        self.pendingTopicChips = []
+        self.hasMoreTopicRails = false
+        self.isLoadingTopicRails = false
         await self.load()
     }
 
@@ -416,6 +509,28 @@ final class YouTubeHomeViewModel {
         self.continueWatchingRefreshTask = nil
         self.pendingGeneration = nil
         self.inFlightRefreshGeneration = nil
+        self.pendingTopicChips = []
+        self.hasMoreTopicRails = false
+        self.isLoadingTopicRails = false
+    }
+
+    /// Loads the next queued personalized topic-rail batch on explicit user demand.
+    func loadMoreTopicRails() async {
+        guard self.hasMoreTopicRails, !self.isLoadingTopicRails, !self.isStreamingInitialRails else { return }
+
+        let generation = self.loadGeneration
+        self.isLoadingTopicRails = true
+        defer {
+            if generation == self.loadGeneration {
+                self.isLoadingTopicRails = false
+            }
+        }
+
+        await self.loadNextTopicRailBatch(
+            generation: generation,
+            gridReady: !self.videos.isEmpty,
+            batchSize: Self.initialTopicRailBatchSize
+        )
     }
 
     /// Loads the next feed page when the user nears the end of the grid.

--- a/Sources/Kaset/ViewModels/YouTube/YouTubeSearchViewModel.swift
+++ b/Sources/Kaset/ViewModels/YouTube/YouTubeSearchViewModel.swift
@@ -165,7 +165,9 @@ final class YouTubeSearchViewModel {
         } catch {
             // A cancelled load (view went away mid-flight or a newer search
             // superseded it) is not an error; the next search owns publishing.
-            if error is CancellationError { return }
+            if error is CancellationError {
+                return
+            }
             guard self.isCurrentSearch(request) else { return }
             guard !Task.isCancelled else { return }
             self.logger.error("YouTube search failed: \(error.localizedDescription)")

--- a/Sources/Kaset/ViewModels/YouTube/YouTubeSubscriptionsViewModel.swift
+++ b/Sources/Kaset/ViewModels/YouTube/YouTubeSubscriptionsViewModel.swift
@@ -18,6 +18,9 @@ final class YouTubeSubscriptionsViewModel {
     /// Continuation token for the next feed page.
     private var continuation: String?
 
+    /// Changes whenever pagination advances, even if the page adds no visible videos.
+    private(set) var paginationTrigger = 0
+
     var hasMoreVideos: Bool {
         self.continuation != nil
     }
@@ -69,6 +72,7 @@ final class YouTubeSubscriptionsViewModel {
             guard runID == self.loadGeneration else { return }
             self.videos = feed.videos
             self.continuation = feed.continuation
+            self.paginationTrigger += 1
 
             // Channel rail is best-effort; the feed alone is still useful.
             let channels = await (try? channelsTask) ?? []
@@ -94,6 +98,7 @@ final class YouTubeSubscriptionsViewModel {
         self.videos = []
         self.channels = []
         self.continuation = nil
+        self.paginationTrigger += 1
         await self.load()
     }
 
@@ -112,6 +117,7 @@ final class YouTubeSubscriptionsViewModel {
             let existing = Set(self.videos.map(\.videoId))
             self.videos.append(contentsOf: feed.videos.filter { !existing.contains($0.videoId) })
             self.continuation = feed.continuation
+            self.paginationTrigger += 1
             self.loadingState = .loaded
         } catch {
             // A cancelled page load is not an error; allow retrying.

--- a/Sources/Kaset/ViewModels/YouTube/YouTubeWatchViewModel.swift
+++ b/Sources/Kaset/ViewModels/YouTube/YouTubeWatchViewModel.swift
@@ -113,7 +113,9 @@ final class YouTubeWatchViewModel {
                 self.createCommentParams = params
             }
         } catch {
-            if error is CancellationError { return }
+            if error is CancellationError {
+                return
+            }
             self.logger.error("Failed to load comments: \(error.localizedDescription)")
             self.commentsContinuation = nil
         }
@@ -177,7 +179,9 @@ final class YouTubeWatchViewModel {
             // Reply pages can echo the parent; drop it.
             self.repliesByComment[comment.id] = page.comments.filter { $0.id != comment.id }
         } catch {
-            if error is CancellationError { return }
+            if error is CancellationError {
+                return
+            }
             self.logger.error("Failed to load replies: \(error.localizedDescription)")
         }
     }

--- a/Sources/Kaset/Views/AccentBackground.swift
+++ b/Sources/Kaset/Views/AccentBackground.swift
@@ -75,20 +75,10 @@ struct AccentBackground: View {
             return
         }
 
-        // Fetch image data
-        do {
-            let (data, _) = try await URLSession.shared.data(from: url)
-            let extracted = await ColorExtractor.extractPalette(from: data)
-            self.palette = extracted
-            self.isLoaded = true
-        } catch is CancellationError {
-            // Task was cancelled (e.g., imageURL changed) - expected behavior, no logging needed
-            return
-        } catch {
-            DiagnosticsLogger.ui.debug("Failed to extract accent colors: \(error.localizedDescription)")
-            self.palette = .default
-            self.isLoaded = true
-        }
+        let extracted = await ColorExtractor.cachedPalette(for: url)
+        guard !Task.isCancelled else { return }
+        self.palette = extracted
+        self.isLoaded = true
     }
 }
 

--- a/Sources/Kaset/Views/AccountRowView.swift
+++ b/Sources/Kaset/Views/AccountRowView.swift
@@ -72,7 +72,7 @@ struct AccountRowView: View {
     private var avatarView: some View {
         Group {
             if let thumbnailURL = account.thumbnailURL {
-                CachedAsyncImage(url: thumbnailURL, targetSize: CGSize(width: 80, height: 80)) { image in
+                CachedAsyncImage(url: thumbnailURL, targetSize: CGSize(width: 40, height: 40)) { image in
                     image
                         .resizable()
                         .aspectRatio(contentMode: .fill)

--- a/Sources/Kaset/Views/ArtistDetailView.swift
+++ b/Sources/Kaset/Views/ArtistDetailView.swift
@@ -138,7 +138,7 @@ struct ArtistDetailView: View { // swiftlint:disable:this type_body_length
     private func headerView(_ detail: ArtistDetail) -> some View {
         HStack(alignment: .top, spacing: 20) {
             // Thumbnail
-            CachedAsyncImage(url: detail.thumbnailURL?.highQualityThumbnailURL) { image in
+            CachedAsyncImage(url: detail.thumbnailURL?.highQualityThumbnailURL, targetSize: CGSize(width: 180, height: 180)) { image in
                 image
                     .resizable()
                     .aspectRatio(contentMode: .fill)
@@ -517,7 +517,7 @@ struct ArtistDetailView: View { // swiftlint:disable:this type_body_length
     private func albumCard(_ album: Album) -> some View {
         VStack(alignment: .leading, spacing: 8) {
             // Thumbnail
-            CachedAsyncImage(url: album.thumbnailURL?.highQualityThumbnailURL) { image in
+            CachedAsyncImage(url: album.thumbnailURL?.highQualityThumbnailURL, targetSize: CGSize(width: 140, height: 140)) { image in
                 image
                     .resizable()
                     .aspectRatio(contentMode: .fill)
@@ -552,7 +552,7 @@ struct ArtistDetailView: View { // swiftlint:disable:this type_body_length
 
     private func playlistCard(_ playlist: Playlist) -> some View {
         VStack(alignment: .leading, spacing: 8) {
-            CachedAsyncImage(url: playlist.thumbnailURL?.highQualityThumbnailURL) { image in
+            CachedAsyncImage(url: playlist.thumbnailURL?.highQualityThumbnailURL, targetSize: CGSize(width: 140, height: 140)) { image in
                 image
                     .resizable()
                     .aspectRatio(contentMode: .fill)
@@ -591,7 +591,7 @@ struct ArtistDetailView: View { // swiftlint:disable:this type_body_length
 
     private func artistCard(_ artist: Artist) -> some View {
         VStack(alignment: .center, spacing: 8) {
-            CachedAsyncImage(url: artist.thumbnailURL?.highQualityThumbnailURL) { image in
+            CachedAsyncImage(url: artist.thumbnailURL?.highQualityThumbnailURL, targetSize: CGSize(width: 140, height: 140)) { image in
                 image
                     .resizable()
                     .aspectRatio(contentMode: .fill)
@@ -671,7 +671,7 @@ struct ArtistDetailView: View { // swiftlint:disable:this type_body_length
     private func episodeCard(_ episode: ArtistEpisode) -> some View {
         VStack(alignment: .leading, spacing: 8) {
             ZStack(alignment: .topLeading) {
-                CachedAsyncImage(url: episode.thumbnailURL?.highQualityThumbnailURL) { image in
+                CachedAsyncImage(url: episode.thumbnailURL?.highQualityThumbnailURL, targetSize: CGSize(width: 220, height: 124)) { image in
                     image
                         .resizable()
                         .aspectRatio(contentMode: .fill)
@@ -748,7 +748,7 @@ struct ArtistDetailView: View { // swiftlint:disable:this type_body_length
         } itemContent: { playlist in
             NavigationLink(value: playlist) {
                 VStack(alignment: .leading, spacing: 8) {
-                    CachedAsyncImage(url: playlist.thumbnailURL?.highQualityThumbnailURL) { image in
+                    CachedAsyncImage(url: playlist.thumbnailURL?.highQualityThumbnailURL, targetSize: CGSize(width: 140, height: 140)) { image in
                         image
                             .resizable()
                             .aspectRatio(contentMode: .fill)
@@ -794,7 +794,7 @@ struct ArtistDetailView: View { // swiftlint:disable:this type_body_length
 
     private func podcastCard(_ show: PodcastShow) -> some View {
         VStack(alignment: .leading, spacing: 8) {
-            CachedAsyncImage(url: show.thumbnailURL?.highQualityThumbnailURL) { image in
+            CachedAsyncImage(url: show.thumbnailURL?.highQualityThumbnailURL, targetSize: CGSize(width: 140, height: 140)) { image in
                 image
                     .resizable()
                     .aspectRatio(contentMode: .fill)
@@ -837,7 +837,7 @@ struct ArtistDetailView: View { // swiftlint:disable:this type_body_length
 
     private func relatedArtistCard(_ artist: Artist) -> some View {
         VStack(alignment: .center, spacing: 8) {
-            CachedAsyncImage(url: artist.thumbnailURL?.highQualityThumbnailURL) { image in
+            CachedAsyncImage(url: artist.thumbnailURL?.highQualityThumbnailURL, targetSize: CGSize(width: 120, height: 120)) { image in
                 image
                     .resizable()
                     .aspectRatio(contentMode: .fill)

--- a/Sources/Kaset/Views/ArtistEpisodesListView.swift
+++ b/Sources/Kaset/Views/ArtistEpisodesListView.swift
@@ -64,7 +64,7 @@ struct ArtistEpisodesListView: View {
             Task { await self.playerService.playEpisode(episode) }
         } label: {
             HStack(alignment: .top, spacing: 12) {
-                CachedAsyncImage(url: episode.thumbnailURL?.highQualityThumbnailURL) { image in
+                CachedAsyncImage(url: episode.thumbnailURL?.highQualityThumbnailURL, targetSize: CGSize(width: 160, height: 90)) { image in
                     image
                         .resizable()
                         .aspectRatio(contentMode: .fill)

--- a/Sources/Kaset/Views/ChartsView.swift
+++ b/Sources/Kaset/Views/ChartsView.swift
@@ -75,7 +75,8 @@ struct ChartsView: View {
                     LoadMoreFooter(
                         isLoading: self.viewModel.loadingState == .loadingMore,
                         title: "Load More",
-                        loadingTitle: "Loading more..."
+                        loadingTitle: "Loading more...",
+                        autoLoad: true
                     ) {
                         await self.viewModel.loadMore()
                     }

--- a/Sources/Kaset/Views/ChartsView.swift
+++ b/Sources/Kaset/Views/ChartsView.swift
@@ -70,6 +70,16 @@ struct ChartsView: View {
                 ForEach(self.viewModel.sections) { section in
                     self.sectionView(section)
                 }
+
+                if self.viewModel.hasMoreSections || self.viewModel.loadingState == .loadingMore {
+                    LoadMoreFooter(
+                        isLoading: self.viewModel.loadingState == .loadingMore,
+                        title: "Load More",
+                        loadingTitle: "Loading more..."
+                    ) {
+                        await self.viewModel.loadMore()
+                    }
+                }
             }
             // Edge-to-edge so shelves slide under the glass sidebar; resting
             // inset is restored per-shelf via contentInset.

--- a/Sources/Kaset/Views/ChartsView.swift
+++ b/Sources/Kaset/Views/ChartsView.swift
@@ -76,7 +76,8 @@ struct ChartsView: View {
                         isLoading: self.viewModel.loadingState == .loadingMore,
                         title: "Load More",
                         loadingTitle: "Loading more...",
-                        autoLoad: true
+                        autoLoad: true,
+                        autoLoadTrigger: self.viewModel.sections.count
                     ) {
                         await self.viewModel.loadMore()
                     }

--- a/Sources/Kaset/Views/EqualizerSettingsView.swift
+++ b/Sources/Kaset/Views/EqualizerSettingsView.swift
@@ -215,7 +215,9 @@ private struct EQStatusRow: View {
     }
 
     private var showsSettingsLink: Bool {
-        if case .permissionNeeded = self.status { return true }
+        if case .permissionNeeded = self.status {
+            return true
+        }
         return false
     }
 }

--- a/Sources/Kaset/Views/ExploreView.swift
+++ b/Sources/Kaset/Views/ExploreView.swift
@@ -76,7 +76,8 @@ struct ExploreView: View {
                         isLoading: self.viewModel.loadingState == .loadingMore,
                         title: "Load More",
                         loadingTitle: "Loading more...",
-                        autoLoad: true
+                        autoLoad: true,
+                        autoLoadTrigger: self.viewModel.sections.count
                     ) {
                         await self.viewModel.loadMore()
                     }

--- a/Sources/Kaset/Views/ExploreView.swift
+++ b/Sources/Kaset/Views/ExploreView.swift
@@ -70,6 +70,16 @@ struct ExploreView: View {
                 ForEach(self.viewModel.sections) { section in
                     self.sectionView(section)
                 }
+
+                if self.viewModel.hasMoreSections || self.viewModel.loadingState == .loadingMore {
+                    LoadMoreFooter(
+                        isLoading: self.viewModel.loadingState == .loadingMore,
+                        title: "Load More",
+                        loadingTitle: "Loading more..."
+                    ) {
+                        await self.viewModel.loadMore()
+                    }
+                }
             }
             // Edge-to-edge so shelves slide under the glass sidebar; resting
             // inset is restored per-shelf via contentInset.

--- a/Sources/Kaset/Views/ExploreView.swift
+++ b/Sources/Kaset/Views/ExploreView.swift
@@ -75,7 +75,8 @@ struct ExploreView: View {
                     LoadMoreFooter(
                         isLoading: self.viewModel.loadingState == .loadingMore,
                         title: "Load More",
-                        loadingTitle: "Loading more..."
+                        loadingTitle: "Loading more...",
+                        autoLoad: true
                     ) {
                         await self.viewModel.loadMore()
                     }

--- a/Sources/Kaset/Views/HistoryView.swift
+++ b/Sources/Kaset/Views/HistoryView.swift
@@ -164,7 +164,7 @@ struct HistoryView: View {
 
                 if self.viewModel.hasMoreSections || self.viewModel.loadingState == .loadingMore {
                     LoadMoreFooter(
-                        isLoading: self.viewModel.loadingState == .loadingMore,
+                        isLoading: self.viewModel.loadingState == .loadingMore || self.viewModel.isRefreshingHistory,
                         title: "Load More History",
                         loadingTitle: "Loading more history...",
                         autoLoad: true

--- a/Sources/Kaset/Views/HistoryView.swift
+++ b/Sources/Kaset/Views/HistoryView.swift
@@ -167,7 +167,8 @@ struct HistoryView: View {
                         isLoading: self.viewModel.loadingState == .loadingMore || self.viewModel.isRefreshingHistory,
                         title: "Load More History",
                         loadingTitle: "Loading more history...",
-                        autoLoad: true
+                        autoLoad: true,
+                        autoLoadTrigger: self.viewModel.sections.count
                     ) {
                         await self.viewModel.loadMore()
                     }

--- a/Sources/Kaset/Views/HistoryView.swift
+++ b/Sources/Kaset/Views/HistoryView.swift
@@ -166,7 +166,8 @@ struct HistoryView: View {
                     LoadMoreFooter(
                         isLoading: self.viewModel.loadingState == .loadingMore,
                         title: "Load More History",
-                        loadingTitle: "Loading more history..."
+                        loadingTitle: "Loading more history...",
+                        autoLoad: true
                     ) {
                         await self.viewModel.loadMore()
                     }

--- a/Sources/Kaset/Views/HistoryView.swift
+++ b/Sources/Kaset/Views/HistoryView.swift
@@ -146,7 +146,9 @@ struct HistoryView: View {
                         .padding(.bottom, 8)
 
                     let songs = section.items.compactMap { item -> Song? in
-                        if case let .song(song) = item { return song }
+                        if case let .song(song) = item {
+                            return song
+                        }
                         return nil
                     }
 
@@ -157,6 +159,16 @@ struct HistoryView: View {
                             Divider()
                                 .padding(.leading, 72)
                         }
+                    }
+                }
+
+                if self.viewModel.hasMoreSections || self.viewModel.loadingState == .loadingMore {
+                    LoadMoreFooter(
+                        isLoading: self.viewModel.loadingState == .loadingMore,
+                        title: "Load More History",
+                        loadingTitle: "Loading more history..."
+                    ) {
+                        await self.viewModel.loadMore()
                     }
                 }
             }

--- a/Sources/Kaset/Views/HomeView.swift
+++ b/Sources/Kaset/Views/HomeView.swift
@@ -113,7 +113,8 @@ struct HomeView: View {
             isLoading: self.viewModel.loadingState == .loadingMore,
             title: "Load More",
             loadingTitle: "Loading more...",
-            autoLoad: true
+            autoLoad: true,
+            autoLoadTrigger: self.viewModel.sections.count
         ) {
             await self.viewModel.loadMore()
         }

--- a/Sources/Kaset/Views/HomeView.swift
+++ b/Sources/Kaset/Views/HomeView.swift
@@ -108,20 +108,14 @@ struct HomeView: View {
         .accessibilityIdentifier(AccessibilityID.Home.scrollView)
     }
 
-    @ViewBuilder
     private var loadMoreControl: some View {
-        if self.viewModel.loadingState == .loadingMore {
-            ProgressView()
-                .controlSize(.small)
-                .frame(maxWidth: .infinity)
-        } else {
-            Button {
-                Task { await self.viewModel.loadMore() }
-            } label: {
-                Label("Load More", systemImage: "arrow.down.circle")
-            }
-            .buttonStyle(.borderless)
-            .frame(maxWidth: .infinity)
+        LoadMoreFooter(
+            isLoading: self.viewModel.loadingState == .loadingMore,
+            title: "Load More",
+            loadingTitle: "Loading more...",
+            autoLoad: true
+        ) {
+            await self.viewModel.loadMore()
         }
     }
 

--- a/Sources/Kaset/Views/HomeView.swift
+++ b/Sources/Kaset/Views/HomeView.swift
@@ -94,6 +94,10 @@ struct HomeView: View {
                             await self.prefetchImagesAsync(for: section)
                         }
                 }
+
+                if self.viewModel.hasMoreSections || self.viewModel.loadingState == .loadingMore {
+                    self.loadMoreControl
+                }
             }
             // The ScrollView fills the detail column edge-to-edge so shelves
             // scroll under the floating glass sidebar; each shelf restores a
@@ -102,6 +106,23 @@ struct HomeView: View {
             .padding(.vertical, 20)
         }
         .accessibilityIdentifier(AccessibilityID.Home.scrollView)
+    }
+
+    @ViewBuilder
+    private var loadMoreControl: some View {
+        if self.viewModel.loadingState == .loadingMore {
+            ProgressView()
+                .controlSize(.small)
+                .frame(maxWidth: .infinity)
+        } else {
+            Button {
+                Task { await self.viewModel.loadMore() }
+            } label: {
+                Label("Load More", systemImage: "arrow.down.circle")
+            }
+            .buttonStyle(.borderless)
+            .frame(maxWidth: .infinity)
+        }
     }
 
     private func sectionView(_ section: HomeSection) -> some View {
@@ -289,13 +310,13 @@ struct HomeView: View {
         // Early exit if task is cancelled
         guard !Task.isCancelled else { return }
 
-        let urls = section.items.prefix(10).compactMap { $0.thumbnailURL?.highQualityThumbnailURL }
+        let urls = section.items.prefix(6).compactMap { $0.thumbnailURL?.highQualityThumbnailURL }
         guard !urls.isEmpty else { return }
 
         await ImageCache.shared.prefetch(
             urls: urls,
             targetSize: Self.thumbnailDisplaySize,
-            maxConcurrent: 4
+            maxConcurrent: 2
         )
     }
 

--- a/Sources/Kaset/Views/LegacyFallbackViews.swift
+++ b/Sources/Kaset/Views/LegacyFallbackViews.swift
@@ -284,7 +284,8 @@ struct SimpleLyricsView: View {
             case let .synced(synced):
                 SyncedLyricsDisplayView(
                     lyrics: synced,
-                    currentTimeMs: self.playerService.currentTimeMs,
+                    currentLineIndex: self.playerService.currentLyricsLineIndex,
+                    displayTimeMs: self.playerService.currentLyricsDisplayTimeMs,
                     onSeek: { timeMs in
                         Task { await self.playerService.seek(to: Double(timeMs) / 1000.0) }
                     }
@@ -373,10 +374,14 @@ struct SimpleLyricsView: View {
     }
 
     private func updateLyricsPolling(for result: LyricResult) {
-        if case .synced = result {
-            SingletonPlayerWebView.shared.startLyricsPoll()
+        if case let .synced(synced) = result {
+            self.playerService.currentLyricsLineIndex = nil
+            self.playerService.currentLyricsDisplayTimeMs = nil
+            SingletonPlayerWebView.shared.startLyricsPoll(lineRanges: synced.bridgeLineRanges)
         } else {
             SingletonPlayerWebView.shared.stopLyricsPoll()
+            self.playerService.currentLyricsLineIndex = nil
+            self.playerService.currentLyricsDisplayTimeMs = nil
         }
     }
 

--- a/Sources/Kaset/Views/LibraryView.swift
+++ b/Sources/Kaset/Views/LibraryView.swift
@@ -233,29 +233,28 @@ struct LibraryView: View {
         return [.uploadedSongs(uploadedSongsPlaylist)]
     }
 
+    @ViewBuilder
     private var libraryGrid: some View {
-        Group {
-            if self.filteredItems.isEmpty {
-                self.emptyStateView
-            } else {
-                LazyVGrid(columns: [
-                    GridItem(.adaptive(minimum: self.libraryItemSize, maximum: 200), spacing: self.libraryItemSpacing),
-                ], spacing: 24) {
-                    ForEach(self.filteredItems) { item in
-                        switch item {
-                        case let .playlist(playlist):
-                            self.playlistCard(playlist)
-                        case let .uploadedSongs(playlist):
-                            self.uploadedSongsCard(playlist)
-                        case let .artist(artist):
-                            self.artistCard(artist)
-                        case let .podcast(show):
-                            self.podcastCard(show)
-                        }
+        if self.filteredItems.isEmpty {
+            self.emptyStateView
+        } else {
+            LazyVGrid(columns: [
+                GridItem(.adaptive(minimum: self.libraryItemSize, maximum: 200), spacing: self.libraryItemSpacing),
+            ], spacing: 24) {
+                ForEach(self.filteredItems) { item in
+                    switch item {
+                    case let .playlist(playlist):
+                        self.playlistCard(playlist)
+                    case let .uploadedSongs(playlist):
+                        self.uploadedSongsCard(playlist)
+                    case let .artist(artist):
+                        self.artistCard(artist)
+                    case let .podcast(show):
+                        self.podcastCard(show)
                     }
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 

--- a/Sources/Kaset/Views/LyricsView.swift
+++ b/Sources/Kaset/Views/LyricsView.swift
@@ -73,10 +73,14 @@ struct LyricsView: View {
     }
 
     private func updateLyricsPolling(for result: LyricResult) {
-        if case .synced = result {
-            SingletonPlayerWebView.shared.startLyricsPoll()
+        if case let .synced(synced) = result {
+            self.playerService.currentLyricsLineIndex = nil
+            self.playerService.currentLyricsDisplayTimeMs = nil
+            SingletonPlayerWebView.shared.startLyricsPoll(lineRanges: synced.bridgeLineRanges)
         } else {
             SingletonPlayerWebView.shared.stopLyricsPoll()
+            self.playerService.currentLyricsLineIndex = nil
+            self.playerService.currentLyricsDisplayTimeMs = nil
         }
     }
 
@@ -176,7 +180,8 @@ struct LyricsView: View {
 
             SyncedLyricsDisplayView(
                 lyrics: synced,
-                currentTimeMs: self.playerService.currentTimeMs,
+                currentLineIndex: self.playerService.currentLyricsLineIndex,
+                displayTimeMs: self.playerService.currentLyricsDisplayTimeMs,
                 onSeek: { timeMs in
                     Task { await self.playerService.seek(to: Double(timeMs) / 1000.0) }
                 }

--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -5,7 +5,7 @@ import SwiftUI
 // MARK: - MainWindow
 
 /// Main application window with sidebar navigation and player bar.
-struct MainWindow: View {
+struct MainWindow: View { // swiftlint:disable:this type_body_length
     private struct PresentedWhatsNew: Identifiable {
         let whatsNew: WhatsNew
         let requestedVersion: WhatsNew.Version

--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -537,21 +537,33 @@ struct MainWindow: View {
         Group {
             switch item {
             case .home:
-                if let vm = homeViewModel { HomeView(viewModel: vm) }
+                if let vm = homeViewModel {
+                    HomeView(viewModel: vm)
+                }
             case .explore:
-                if let vm = exploreViewModel { ExploreView(viewModel: vm) }
+                if let vm = exploreViewModel {
+                    ExploreView(viewModel: vm)
+                }
             case .search:
                 if let vm = searchViewModel {
                     SearchView(viewModel: vm, focusTrigger: self.searchFocusTrigger)
                 }
             case .charts:
-                if let vm = chartsViewModel { ChartsView(viewModel: vm) }
+                if let vm = chartsViewModel {
+                    ChartsView(viewModel: vm)
+                }
             case .moodsAndGenres:
-                if let vm = moodsAndGenresViewModel { MoodsAndGenresView(viewModel: vm) }
+                if let vm = moodsAndGenresViewModel {
+                    MoodsAndGenresView(viewModel: vm)
+                }
             case .newReleases:
-                if let vm = newReleasesViewModel { NewReleasesView(viewModel: vm) }
+                if let vm = newReleasesViewModel {
+                    NewReleasesView(viewModel: vm)
+                }
             case .podcasts:
-                if let vm = podcastsViewModel { PodcastsView(viewModel: vm) }
+                if let vm = podcastsViewModel {
+                    PodcastsView(viewModel: vm)
+                }
             case .likedMusic:
                 if self.requiresSignIn(item) {
                     self.signInRequiredView(for: item)

--- a/Sources/Kaset/Views/MiniPlayerWebView.swift
+++ b/Sources/Kaset/Views/MiniPlayerWebView.swift
@@ -258,9 +258,13 @@ final class SingletonPlayerWebView {
     /// See `beginBackgroundMediaControlReassertion()`.
     var mediaControlReassertTimer: Timer?
 
-    /// Tracks if lyrics high-frequency polling should be active
-    /// Used to restore polling after full-page navigation
+    /// Tracks if lyrics line-boundary polling should be active.
+    /// Used to restore polling after full-page navigation.
     var isLyricsPollActive = false
+
+    /// Last synced-lyrics line ranges supplied by the visible lyrics panel.
+    /// Used by the reload fallback so polling does not restart with an empty range list.
+    private var lastLyricsLineRanges: [[String: Int]] = []
 
     private init() {
         self.mediaControlUsesNextPrev = SettingsManager.shared.mediaControlStyle == .nextPreviousTrack
@@ -341,10 +345,18 @@ final class SingletonPlayerWebView {
         // updateDisplayMode(.video) handles the initial injection perfectly.
     }
 
-    /// Starts high frequency polling for synced lyrics
-    func startLyricsPoll() {
+    /// Starts low-frequency line-boundary polling for synced lyrics.
+    func startLyricsPoll(lineRanges: [[String: Int]]) {
         self.isLyricsPollActive = true
-        self.webView?.evaluateJavaScript("if (window.startLyricsPoll) { window.startLyricsPoll(); }")
+        self.lastLyricsLineRanges = lineRanges
+        let jsonData = (try? JSONSerialization.data(withJSONObject: lineRanges)) ?? Data("[]".utf8)
+        let lineRangesJSON = String(data: jsonData, encoding: .utf8) ?? "[]"
+        self.webView?.evaluateJavaScript("if (window.startLyricsPoll) { window.startLyricsPoll(\(lineRangesJSON)); }")
+    }
+
+    /// Backward-compatible fallback used after page reloads before the lyrics view re-supplies line boundaries.
+    func startLyricsPoll() {
+        self.startLyricsPoll(lineRanges: self.lastLyricsLineRanges)
     }
 
     /// Stops high frequency polling for synced lyrics
@@ -593,8 +605,8 @@ final class SingletonPlayerWebView {
                 }
             case "AIRPLAY_STATUS":
                 self.handleAirPlayStatusUpdate(body: body)
-            case "LYRICS_TIME":
-                self.handleLyricsTimeUpdate(body: body)
+            case "LYRICS_LINE":
+                self.handleLyricsLineUpdate(body: body)
             case "PLAYBACK_AUDIO_QUALITY_STATS":
                 Self.logAudioQualityStats(body: body, observedVideoId: observedVideoId)
             case "STATE_UPDATE":
@@ -621,11 +633,17 @@ final class SingletonPlayerWebView {
             }
         }
 
-        private func handleLyricsTimeUpdate(body: [String: Any]) {
-            guard let time = body["time"] as? Double else { return }
+        private func handleLyricsLineUpdate(body: [String: Any]) {
+            let lineIndex = body["lineIndex"] as? Int ?? -1
+            let normalizedLineIndex = lineIndex >= 0 ? lineIndex : nil
+            let displayTimeMs = body["timeMs"] as? Int
 
             Task { @MainActor in
-                self.playerService.currentTimeMs = Int(time * 1000)
+                guard self.playerService.currentLyricsLineIndex != normalizedLineIndex ||
+                    self.playerService.currentLyricsDisplayTimeMs != displayTimeMs
+                else { return }
+                self.playerService.currentLyricsLineIndex = normalizedLineIndex
+                self.playerService.currentLyricsDisplayTimeMs = displayTimeMs
             }
         }
 

--- a/Sources/Kaset/Views/MoodCategoryDetailView.swift
+++ b/Sources/Kaset/Views/MoodCategoryDetailView.swift
@@ -43,25 +43,24 @@ struct MoodCategoryDetailView: View {
 
     // MARK: - Views
 
+    @ViewBuilder
     private var contentView: some View {
-        Group {
-            if self.viewModel.sections.isEmpty {
-                ContentUnavailableView(
-                    "No Content Available",
-                    systemImage: "music.note",
-                    description: Text("No songs or playlists found in this category.")
-                )
-            } else {
-                ScrollView {
-                    LazyVStack(alignment: .leading, spacing: 32) {
-                        ForEach(self.viewModel.sections) { section in
-                            self.sectionView(section)
-                        }
+        if self.viewModel.sections.isEmpty {
+            ContentUnavailableView(
+                "No Content Available",
+                systemImage: "music.note",
+                description: Text("No songs or playlists found in this category.")
+            )
+        } else {
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 32) {
+                    ForEach(self.viewModel.sections) { section in
+                        self.sectionView(section)
                     }
-                    // Edge-to-edge so shelves slide under the glass sidebar;
-                    // resting inset is restored per-shelf via contentInset.
-                    .padding(.vertical, 20)
                 }
+                // Edge-to-edge so shelves slide under the glass sidebar;
+                // resting inset is restored per-shelf via contentInset.
+                .padding(.vertical, 20)
             }
         }
     }

--- a/Sources/Kaset/Views/MoodsAndGenresView.swift
+++ b/Sources/Kaset/Views/MoodsAndGenresView.swift
@@ -77,7 +77,8 @@ struct MoodsAndGenresView: View {
                     LoadMoreFooter(
                         isLoading: self.viewModel.loadingState == .loadingMore,
                         title: "Load More",
-                        loadingTitle: "Loading more..."
+                        loadingTitle: "Loading more...",
+                        autoLoad: true
                     ) {
                         await self.viewModel.loadMore()
                     }
@@ -94,7 +95,8 @@ struct MoodsAndGenresView: View {
                         LoadMoreFooter(
                             isLoading: self.viewModel.loadingState == .loadingMore,
                             title: "Load More",
-                            loadingTitle: "Loading more..."
+                            loadingTitle: "Loading more...",
+                            autoLoad: true
                         ) {
                             await self.viewModel.loadMore()
                         }

--- a/Sources/Kaset/Views/MoodsAndGenresView.swift
+++ b/Sources/Kaset/Views/MoodsAndGenresView.swift
@@ -64,25 +64,45 @@ struct MoodsAndGenresView: View {
 
     // MARK: - Views
 
+    @ViewBuilder
     private var contentView: some View {
-        Group {
-            if self.viewModel.sections.isEmpty {
+        if self.viewModel.sections.isEmpty {
+            VStack(spacing: 16) {
                 ContentUnavailableView(
                     "No Moods & Genres Available",
                     systemImage: "guitars",
                     description: Text("Content may not be available in your region.")
                 )
-            } else {
-                ScrollView {
-                    LazyVStack(alignment: .leading, spacing: 32) {
-                        ForEach(self.viewModel.sections) { section in
-                            self.sectionView(section)
+                if self.viewModel.hasMoreSections || self.viewModel.loadingState == .loadingMore {
+                    LoadMoreFooter(
+                        isLoading: self.viewModel.loadingState == .loadingMore,
+                        title: "Load More",
+                        loadingTitle: "Loading more..."
+                    ) {
+                        await self.viewModel.loadMore()
+                    }
+                }
+            }
+        } else {
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 32) {
+                    ForEach(self.viewModel.sections) { section in
+                        self.sectionView(section)
+                    }
+
+                    if self.viewModel.hasMoreSections || self.viewModel.loadingState == .loadingMore {
+                        LoadMoreFooter(
+                            isLoading: self.viewModel.loadingState == .loadingMore,
+                            title: "Load More",
+                            loadingTitle: "Loading more..."
+                        ) {
+                            await self.viewModel.loadMore()
                         }
                     }
-                    // Edge-to-edge so shelves slide under the glass sidebar;
-                    // resting inset is restored per-shelf via contentInset.
-                    .padding(.vertical, 20)
                 }
+                // Edge-to-edge so shelves slide under the glass sidebar;
+                // resting inset is restored per-shelf via contentInset.
+                .padding(.vertical, 20)
             }
         }
     }

--- a/Sources/Kaset/Views/MoodsAndGenresView.swift
+++ b/Sources/Kaset/Views/MoodsAndGenresView.swift
@@ -78,7 +78,8 @@ struct MoodsAndGenresView: View {
                         isLoading: self.viewModel.loadingState == .loadingMore,
                         title: "Load More",
                         loadingTitle: "Loading more...",
-                        autoLoad: true
+                        autoLoad: true,
+                        autoLoadTrigger: self.viewModel.sections.count
                     ) {
                         await self.viewModel.loadMore()
                     }
@@ -96,7 +97,8 @@ struct MoodsAndGenresView: View {
                             isLoading: self.viewModel.loadingState == .loadingMore,
                             title: "Load More",
                             loadingTitle: "Loading more...",
-                            autoLoad: true
+                            autoLoad: true,
+                            autoLoadTrigger: self.viewModel.sections.count
                         ) {
                             await self.viewModel.loadMore()
                         }

--- a/Sources/Kaset/Views/NewReleasesView.swift
+++ b/Sources/Kaset/Views/NewReleasesView.swift
@@ -75,7 +75,8 @@ struct NewReleasesView: View {
                     LoadMoreFooter(
                         isLoading: self.viewModel.loadingState == .loadingMore,
                         title: "Load More",
-                        loadingTitle: "Loading more..."
+                        loadingTitle: "Loading more...",
+                        autoLoad: true
                     ) {
                         await self.viewModel.loadMore()
                     }

--- a/Sources/Kaset/Views/NewReleasesView.swift
+++ b/Sources/Kaset/Views/NewReleasesView.swift
@@ -76,7 +76,8 @@ struct NewReleasesView: View {
                         isLoading: self.viewModel.loadingState == .loadingMore,
                         title: "Load More",
                         loadingTitle: "Loading more...",
-                        autoLoad: true
+                        autoLoad: true,
+                        autoLoadTrigger: self.viewModel.sections.count
                     ) {
                         await self.viewModel.loadMore()
                     }

--- a/Sources/Kaset/Views/NewReleasesView.swift
+++ b/Sources/Kaset/Views/NewReleasesView.swift
@@ -70,6 +70,16 @@ struct NewReleasesView: View {
                 ForEach(self.viewModel.sections) { section in
                     self.sectionView(section)
                 }
+
+                if self.viewModel.hasMoreSections || self.viewModel.loadingState == .loadingMore {
+                    LoadMoreFooter(
+                        isLoading: self.viewModel.loadingState == .loadingMore,
+                        title: "Load More",
+                        loadingTitle: "Loading more..."
+                    ) {
+                        await self.viewModel.loadMore()
+                    }
+                }
             }
             // Edge-to-edge so shelves slide under the glass sidebar; resting
             // inset is restored per-shelf via contentInset.

--- a/Sources/Kaset/Views/PlayerBar.swift
+++ b/Sources/Kaset/Views/PlayerBar.swift
@@ -134,40 +134,39 @@ struct PlayerBar: View { // swiftlint:disable:this type_body_length
         .accessibilityHidden(true)
     }
 
+    @ViewBuilder
     private var keyboardShortcuts: some View {
-        Group {
-            Button("") {
-                Task { await self.playerService.playPause() }
-            }
-            .keyboardShortcut(.space, modifiers: [])
-            .opacity(0)
-
-            Button("") {
-                Task { await self.playerService.next() }
-            }
-            .keyboardShortcut(.rightArrow, modifiers: .command)
-            .disabled(self.playerService.currentEpisode != nil)
-            .opacity(0)
-
-            Button("") {
-                Task { await self.playerService.previous() }
-            }
-            .keyboardShortcut(.leftArrow, modifiers: .command)
-            .disabled(self.playerService.currentEpisode != nil)
-            .opacity(0)
-
-            Button("") {
-                Task { await self.playerService.setVolume(min(1.0, self.playerService.volume + 0.1)) }
-            }
-            .keyboardShortcut(.upArrow, modifiers: .command)
-            .opacity(0)
-
-            Button("") {
-                Task { await self.playerService.setVolume(max(0.0, self.playerService.volume - 0.1)) }
-            }
-            .keyboardShortcut(.downArrow, modifiers: .command)
-            .opacity(0)
+        Button("") {
+            Task { await self.playerService.playPause() }
         }
+        .keyboardShortcut(.space, modifiers: [])
+        .opacity(0)
+
+        Button("") {
+            Task { await self.playerService.next() }
+        }
+        .keyboardShortcut(.rightArrow, modifiers: .command)
+        .disabled(self.playerService.currentEpisode != nil)
+        .opacity(0)
+
+        Button("") {
+            Task { await self.playerService.previous() }
+        }
+        .keyboardShortcut(.leftArrow, modifiers: .command)
+        .disabled(self.playerService.currentEpisode != nil)
+        .opacity(0)
+
+        Button("") {
+            Task { await self.playerService.setVolume(min(1.0, self.playerService.volume + 0.1)) }
+        }
+        .keyboardShortcut(.upArrow, modifiers: .command)
+        .opacity(0)
+
+        Button("") {
+            Task { await self.playerService.setVolume(max(0.0, self.playerService.volume - 0.1)) }
+        }
+        .keyboardShortcut(.downArrow, modifiers: .command)
+        .opacity(0)
     }
 
     // MARK: - Song Info
@@ -234,7 +233,7 @@ struct PlayerBar: View { // swiftlint:disable:this type_body_length
             cornerRadius: 6,
             glowSources: self.artworkGlowSources(for: track),
             glowIdentity: self.artworkGlowIdentity(for: track),
-            glowTargetSize: CGSize(width: 320, height: 320),
+            glowTargetSize: CGSize(width: 64, height: 64),
             showsHoverOverlay: self.canOpenCurrentAlbum || self.showsCurrentAlbumHoverOnly,
             isLoading: self.isResolvingAlbum
         ) {

--- a/Sources/Kaset/Views/PlayerBarArtworkGlow.swift
+++ b/Sources/Kaset/Views/PlayerBarArtworkGlow.swift
@@ -119,7 +119,9 @@ struct PlayerBarArtworkGlow: View {
 
     private static func loadFirstAvailableImage(from sources: [URL], targetSize: CGSize?) async -> NSImage? {
         for source in sources {
-            if Task.isCancelled { return nil }
+            if Task.isCancelled {
+                return nil
+            }
             if let image = await ImageCache.shared.image(for: source, targetSize: targetSize) {
                 return image
             }

--- a/Sources/Kaset/Views/PlaylistDetailView.swift
+++ b/Sources/Kaset/Views/PlaylistDetailView.swift
@@ -152,7 +152,7 @@ struct PlaylistDetailView: View {
     private func headerView(_ detail: PlaylistDetail) -> some View {
         HStack(alignment: .top, spacing: 20) {
             // Thumbnail
-            CachedAsyncImage(url: detail.thumbnailURL?.highQualityThumbnailURL) { image in
+            CachedAsyncImage(url: detail.thumbnailURL?.highQualityThumbnailURL, targetSize: CGSize(width: 180, height: 180)) { image in
                 image
                     .resizable()
                     .aspectRatio(contentMode: .fill)
@@ -530,7 +530,9 @@ struct PlaylistDetailView: View {
     {
         tracks.map { song in
             var cleanedArtists = song.artists.compactMap { artist -> Artist? in
-                if artist.name == "Album" { return nil }
+                if artist.name == "Album" {
+                    return nil
+                }
                 var cleanName = artist.name
                 if cleanName.hasPrefix("Album, ") {
                     cleanName = String(cleanName.dropFirst(7))
@@ -745,7 +747,7 @@ private struct PlaylistTrackRow<Menu: View>: View {
                 .frame(width: 28, alignment: .trailing)
 
                 if !self.isAlbum {
-                    CachedAsyncImage(url: self.track.thumbnailURL) { image in
+                    CachedAsyncImage(url: self.track.thumbnailURL, targetSize: CGSize(width: 40, height: 40)) { image in
                         image.resizable().aspectRatio(contentMode: .fill)
                     } placeholder: {
                         Rectangle().fill(.quaternary)

--- a/Sources/Kaset/Views/PodcastsView.swift
+++ b/Sources/Kaset/Views/PodcastsView.swift
@@ -150,7 +150,7 @@ private struct PodcastShowCard: View {
         Button(action: self.action) {
             VStack(alignment: .leading, spacing: 8) {
                 // Thumbnail
-                CachedAsyncImage(url: self.show.thumbnailURL) { image in
+                CachedAsyncImage(url: self.show.thumbnailURL, targetSize: CGSize(width: 160, height: 160)) { image in
                     image
                         .resizable()
                         .aspectRatio(contentMode: .fill)
@@ -193,7 +193,7 @@ private struct PodcastEpisodeCard: View {
             VStack(alignment: .leading, spacing: 8) {
                 // Thumbnail with play indicator
                 ZStack(alignment: .bottomTrailing) {
-                    CachedAsyncImage(url: self.episode.thumbnailURL) { image in
+                    CachedAsyncImage(url: self.episode.thumbnailURL, targetSize: CGSize(width: 200, height: 112)) { image in
                         image
                             .resizable()
                             .aspectRatio(contentMode: .fill)
@@ -331,7 +331,7 @@ struct PodcastShowView: View {
     private var headerView: some View {
         HStack(alignment: .top, spacing: 20) {
             // Artwork
-            CachedAsyncImage(url: self.show.thumbnailURL) { image in
+            CachedAsyncImage(url: self.show.thumbnailURL, targetSize: CGSize(width: 180, height: 180)) { image in
                 image
                     .resizable()
                     .aspectRatio(contentMode: .fill)
@@ -527,7 +527,7 @@ struct PodcastEpisodeRow: View {
         Button(action: self.action) {
             HStack(alignment: .top, spacing: 12) {
                 // Thumbnail
-                CachedAsyncImage(url: self.episode.thumbnailURL) { image in
+                CachedAsyncImage(url: self.episode.thumbnailURL, targetSize: CGSize(width: 80, height: 80)) { image in
                     image
                         .resizable()
                         .aspectRatio(contentMode: .fill)

--- a/Sources/Kaset/Views/PodcastsView.swift
+++ b/Sources/Kaset/Views/PodcastsView.swift
@@ -75,6 +75,16 @@ struct PodcastsView: View {
                 ForEach(self.viewModel.sections) { section in
                     self.sectionView(section)
                 }
+
+                if self.viewModel.hasMoreSections || self.viewModel.loadingState == .loadingMore {
+                    LoadMoreFooter(
+                        isLoading: self.viewModel.loadingState == .loadingMore,
+                        title: "Load More",
+                        loadingTitle: "Loading more..."
+                    ) {
+                        await self.viewModel.loadMore()
+                    }
+                }
             }
             // Edge-to-edge so shelves slide under the glass sidebar; resting
             // inset is restored per-shelf via contentInset.
@@ -305,7 +315,11 @@ struct PodcastShowView: View {
             String(localized: "Subscription Error"),
             isPresented: Binding(
                 get: { self.subscriptionError != nil },
-                set: { if !$0 { self.subscriptionError = nil } }
+                set: {
+                    if !$0 {
+                        self.subscriptionError = nil
+                    }
+                }
             )
         ) {
             Button(String(localized: "OK")) { self.subscriptionError = nil }

--- a/Sources/Kaset/Views/PodcastsView.swift
+++ b/Sources/Kaset/Views/PodcastsView.swift
@@ -81,7 +81,8 @@ struct PodcastsView: View {
                         isLoading: self.viewModel.loadingState == .loadingMore,
                         title: "Load More",
                         loadingTitle: "Loading more...",
-                        autoLoad: true
+                        autoLoad: true,
+                        autoLoadTrigger: self.viewModel.sections.count
                     ) {
                         await self.viewModel.loadMore()
                     }

--- a/Sources/Kaset/Views/PodcastsView.swift
+++ b/Sources/Kaset/Views/PodcastsView.swift
@@ -80,7 +80,8 @@ struct PodcastsView: View {
                     LoadMoreFooter(
                         isLoading: self.viewModel.loadingState == .loadingMore,
                         title: "Load More",
-                        loadingTitle: "Loading more..."
+                        loadingTitle: "Loading more...",
+                        autoLoad: true
                     ) {
                         await self.viewModel.loadMore()
                     }

--- a/Sources/Kaset/Views/QueueSidePanelView.swift
+++ b/Sources/Kaset/Views/QueueSidePanelView.swift
@@ -517,7 +517,9 @@ class DraggableTableView: NSTableView {
         case .changed:
             self.handleSwipeChanged(dx: dx, dy: dy)
         case .ended, .cancelled:
-            if self.handleSwipeEnded(event: event) { return }
+            if self.handleSwipeEnded(event: event) {
+                return
+            }
         default:
             if event.momentumPhase == .ended || event.momentumPhase == .cancelled {
                 self.horizontalSwipeAccumulator = 0
@@ -639,15 +641,21 @@ class DraggableTableView: NSTableView {
             }
         }
 
-        if CFAbsoluteTimeGetCurrent() < self.swipeRemoveCooldownUntil { return false }
+        if CFAbsoluteTimeGetCurrent() < self.swipeRemoveCooldownUntil {
+            return false
+        }
         guard abs(accH) >= Self.swipeRemoveDeltaThreshold,
               abs(accH) > abs(accV)
         else { return false }
         guard let coord = coordinator else { return false }
         let row = self.swipeRemoveTargetRow >= 0 ? self.swipeRemoveTargetRow : rowAtEnd
         self.swipeRemoveTargetRow = -1
-        if row < 0 { return false }
-        if row == coord.currentIndex { return false }
+        if row < 0 {
+            return false
+        }
+        if row == coord.currentIndex {
+            return false
+        }
         guard coord.entries[safe: row] != nil else { return false }
         let slideDirection: CGFloat = accH > 0 ? 1 : -1
         self.swipeRemoveCooldownUntil = CFAbsoluteTimeGetCurrent() + Self.swipeRemoveCooldown
@@ -718,19 +726,17 @@ private struct QueueFooterIconButton: View {
     let action: () -> Void
 
     var body: some View {
-        Group {
-            Button {
-                guard self.isEnabled else { return }
-                self.action()
-            } label: {
-                Image(systemName: self.systemImage)
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundStyle(self.tint)
-                    .frame(width: 20, height: 20)
-            }
-            .buttonStyle(.plain)
-            .opacity(self.isEnabled ? 1 : 0.45)
+        Button {
+            guard self.isEnabled else { return }
+            self.action()
+        } label: {
+            Image(systemName: self.systemImage)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(self.tint)
+                .frame(width: 20, height: 20)
         }
+        .buttonStyle(.plain)
+        .opacity(self.isEnabled ? 1 : 0.45)
         .help(self.helpText)
         .accessibilityLabel(self.accessibilityLabel)
     }

--- a/Sources/Kaset/Views/QueueSidePanelView.swift
+++ b/Sources/Kaset/Views/QueueSidePanelView.swift
@@ -1,3 +1,5 @@
+// swiftlint:disable file_length
+
 import AppKit
 import SwiftUI
 

--- a/Sources/Kaset/Views/SearchView.swift
+++ b/Sources/Kaset/Views/SearchView.swift
@@ -316,33 +316,32 @@ struct SearchView: View {
     }
 
     /// Load more view that triggers pagination when visible.
+    @ViewBuilder
     private var loadMoreView: some View {
-        Group {
-            if self.viewModel.loadingState == .loadingMore {
-                HStack {
-                    ProgressView()
-                        .controlSize(.small)
-                    Text("Loading more...", comment: "Shown while loading more search results")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                }
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 16)
-            } else {
-                Button {
-                    Task { await self.viewModel.loadMore() }
-                } label: {
-                    Text("Load More", comment: "Button to load more search results")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 16)
-                }
-                .buttonStyle(.plain)
-                .onAppear {
-                    // Auto-load more when this view appears (infinite scroll)
-                    Task { await self.viewModel.loadMore() }
-                }
+        if self.viewModel.loadingState == .loadingMore {
+            HStack {
+                ProgressView()
+                    .controlSize(.small)
+                Text("Loading more...", comment: "Shown while loading more search results")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 16)
+        } else {
+            Button {
+                Task { await self.viewModel.loadMore() }
+            } label: {
+                Text("Load More", comment: "Button to load more search results")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 16)
+            }
+            .buttonStyle(.plain)
+            .onAppear {
+                // Auto-load more when this view appears (infinite scroll)
+                Task { await self.viewModel.loadMore() }
             }
         }
     }
@@ -354,7 +353,7 @@ struct SearchView: View {
             } label: {
                 HStack(spacing: 12) {
                     // Thumbnail
-                    CachedAsyncImage(url: item.thumbnailURL?.highQualityThumbnailURL) { image in
+                    CachedAsyncImage(url: item.thumbnailURL?.highQualityThumbnailURL, targetSize: CGSize(width: 48, height: 48)) { image in
                         image
                             .resizable()
                             .aspectRatio(contentMode: .fill)
@@ -672,7 +671,9 @@ struct SearchView: View {
 
 extension SearchResultItem {
     var isArtist: Bool {
-        if case .artist = self { return true }
+        if case .artist = self {
+            return true
+        }
         return false
     }
 }

--- a/Sources/Kaset/Views/SharedViews/LoadMoreFooter.swift
+++ b/Sources/Kaset/Views/SharedViews/LoadMoreFooter.swift
@@ -34,6 +34,10 @@ struct LoadMoreFooter: View {
         .task {
             await self.autoLoadIfNeeded()
         }
+        .onChange(of: self.isLoading) { _, isLoading in
+            guard !isLoading else { return }
+            Task { await self.autoLoadIfNeeded() }
+        }
         .onDisappear {
             self.didAutoLoadForCurrentAppearance = false
         }

--- a/Sources/Kaset/Views/SharedViews/LoadMoreFooter.swift
+++ b/Sources/Kaset/Views/SharedViews/LoadMoreFooter.swift
@@ -4,10 +4,13 @@ struct LoadMoreFooter: View {
     let isLoading: Bool
     let title: LocalizedStringResource
     let loadingTitle: LocalizedStringResource
+    var autoLoad: Bool = false
     let action: @MainActor () async -> Void
 
+    @State private var didAutoLoadForCurrentAppearance = false
+
     var body: some View {
-        Group {
+        VStack(spacing: 0) {
             if self.isLoading {
                 HStack(spacing: 8) {
                     ProgressView()
@@ -28,5 +31,22 @@ struct LoadMoreFooter: View {
         .frame(maxWidth: .infinity)
         .padding(.horizontal, DetailContentLayout.horizontalInset)
         .padding(.vertical, 12)
+        .task {
+            await self.autoLoadIfNeeded()
+        }
+        .onDisappear {
+            self.didAutoLoadForCurrentAppearance = false
+        }
+    }
+
+    @MainActor
+    private func autoLoadIfNeeded() async {
+        guard self.autoLoad,
+              !self.isLoading,
+              !self.didAutoLoadForCurrentAppearance
+        else { return }
+
+        self.didAutoLoadForCurrentAppearance = true
+        await self.action()
     }
 }

--- a/Sources/Kaset/Views/SharedViews/LoadMoreFooter.swift
+++ b/Sources/Kaset/Views/SharedViews/LoadMoreFooter.swift
@@ -5,9 +5,10 @@ struct LoadMoreFooter: View {
     let title: LocalizedStringResource
     let loadingTitle: LocalizedStringResource
     var autoLoad: Bool = false
+    var autoLoadTrigger = 0
     let action: @MainActor () async -> Void
 
-    @State private var didAutoLoadForCurrentAppearance = false
+    @State private var lastAutoLoadTrigger: Int?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -31,7 +32,7 @@ struct LoadMoreFooter: View {
         .frame(maxWidth: .infinity)
         .padding(.horizontal, DetailContentLayout.horizontalInset)
         .padding(.vertical, 12)
-        .task {
+        .task(id: self.autoLoadTrigger) {
             await self.autoLoadIfNeeded()
         }
         .onChange(of: self.isLoading) { _, isLoading in
@@ -39,7 +40,7 @@ struct LoadMoreFooter: View {
             Task { await self.autoLoadIfNeeded() }
         }
         .onDisappear {
-            self.didAutoLoadForCurrentAppearance = false
+            self.lastAutoLoadTrigger = nil
         }
     }
 
@@ -47,10 +48,10 @@ struct LoadMoreFooter: View {
     private func autoLoadIfNeeded() async {
         guard self.autoLoad,
               !self.isLoading,
-              !self.didAutoLoadForCurrentAppearance
+              self.lastAutoLoadTrigger != self.autoLoadTrigger
         else { return }
 
-        self.didAutoLoadForCurrentAppearance = true
+        self.lastAutoLoadTrigger = self.autoLoadTrigger
         await self.action()
     }
 }

--- a/Sources/Kaset/Views/SharedViews/LoadMoreFooter.swift
+++ b/Sources/Kaset/Views/SharedViews/LoadMoreFooter.swift
@@ -9,10 +9,12 @@ struct LoadMoreFooter: View {
     let action: @MainActor () async -> Void
 
     @State private var lastAutoLoadTrigger: Int?
+    @State private var isAutoLoadAttemptInFlight = false
+    @State private var isVisible = false
 
     var body: some View {
         VStack(spacing: 0) {
-            if self.isLoading {
+            if self.shouldShowLoadingIndicator {
                 HStack(spacing: 8) {
                     ProgressView()
                         .controlSize(.small)
@@ -32,26 +34,55 @@ struct LoadMoreFooter: View {
         .frame(maxWidth: .infinity)
         .padding(.horizontal, DetailContentLayout.horizontalInset)
         .padding(.vertical, 12)
+        .onAppear {
+            self.isVisible = true
+            self.scheduleAutoLoadIfNeeded()
+        }
         .task(id: self.autoLoadTrigger) {
             await self.autoLoadIfNeeded()
         }
         .onChange(of: self.isLoading) { _, isLoading in
             guard !isLoading else { return }
-            Task { await self.autoLoadIfNeeded() }
+            self.scheduleAutoLoadIfNeeded()
         }
         .onDisappear {
+            self.isVisible = false
             self.lastAutoLoadTrigger = nil
+            self.isAutoLoadAttemptInFlight = false
         }
+    }
+
+    private var shouldShowLoadingIndicator: Bool {
+        self.isLoading
+            || self.isAutoLoadAttemptInFlight
+            || (self.autoLoad && self.lastAutoLoadTrigger != self.autoLoadTrigger)
+    }
+
+    @MainActor
+    private var canStartAutoLoad: Bool {
+        self.autoLoad
+            && self.isVisible
+            && !self.isLoading
+            && !self.isAutoLoadAttemptInFlight
+            && self.lastAutoLoadTrigger != self.autoLoadTrigger
     }
 
     @MainActor
     private func autoLoadIfNeeded() async {
-        guard self.autoLoad,
-              !self.isLoading,
-              self.lastAutoLoadTrigger != self.autoLoadTrigger
-        else { return }
+        guard self.canStartAutoLoad else { return }
 
         self.lastAutoLoadTrigger = self.autoLoadTrigger
+        self.isAutoLoadAttemptInFlight = true
+        defer {
+            self.isAutoLoadAttemptInFlight = false
+            self.scheduleAutoLoadIfNeeded()
+        }
         await self.action()
+    }
+
+    @MainActor
+    private func scheduleAutoLoadIfNeeded() {
+        guard self.canStartAutoLoad else { return }
+        Task { await self.autoLoadIfNeeded() }
     }
 }

--- a/Sources/Kaset/Views/SharedViews/LoadMoreFooter.swift
+++ b/Sources/Kaset/Views/SharedViews/LoadMoreFooter.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+struct LoadMoreFooter: View {
+    let isLoading: Bool
+    let title: LocalizedStringResource
+    let loadingTitle: LocalizedStringResource
+    let action: @MainActor () async -> Void
+
+    var body: some View {
+        Group {
+            if self.isLoading {
+                HStack(spacing: 8) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text(self.loadingTitle)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+            } else {
+                Button {
+                    Task { await self.action() }
+                } label: {
+                    Label(self.title, systemImage: "arrow.down.circle")
+                }
+                .buttonStyle(.borderless)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, DetailContentLayout.horizontalInset)
+        .padding(.vertical, 12)
+    }
+}

--- a/Sources/Kaset/Views/SidebarProfileView.swift
+++ b/Sources/Kaset/Views/SidebarProfileView.swift
@@ -215,7 +215,7 @@ struct SidebarProfileView: View {
     @ViewBuilder
     private func avatarView(for account: UserAccount) -> some View {
         if let thumbnailURL = account.thumbnailURL {
-            CachedAsyncImage(url: thumbnailURL, targetSize: CGSize(width: 64, height: 64)) { image in
+            CachedAsyncImage(url: thumbnailURL, targetSize: CGSize(width: 32, height: 32)) { image in
                 image
                     .resizable()
                     .aspectRatio(contentMode: .fill)

--- a/Sources/Kaset/Views/SingletonPlayerWebView+ObserverScript.swift
+++ b/Sources/Kaset/Views/SingletonPlayerWebView+ObserverScript.swift
@@ -267,9 +267,12 @@ extension SingletonPlayerWebView {
                 const boundaryDelay = nextBoundaryMs === null
                     ? null
                     : nextBoundaryMs - timeMs + 1;
+                const minBoundaryDelay = v && (v.paused || v.playbackRate === 0)
+                    ? LYRICS_MIN_POLL_INTERVAL_MS
+                    : 0;
                 const delay = boundaryDelay === null
                     ? LYRICS_MAX_POLL_INTERVAL_MS
-                    : Math.max(0, Math.min(LYRICS_MAX_POLL_INTERVAL_MS, boundaryDelay));
+                    : Math.max(minBoundaryDelay, Math.min(LYRICS_MAX_POLL_INTERVAL_MS, boundaryDelay));
                 lyricsPollTimeoutId = setTimeout(() => {
                     lyricsPollTimeoutId = null;
                     const nextBucket = sendLyricsLineUpdate(false);

--- a/Sources/Kaset/Views/SingletonPlayerWebView+ObserverScript.swift
+++ b/Sources/Kaset/Views/SingletonPlayerWebView+ObserverScript.swift
@@ -81,6 +81,7 @@ extension SingletonPlayerWebView {
                     video.addEventListener('playing', () => {
                         window.__kasetAutoplayPending = false;
                         enforceVolumeNow();
+                        restartLyricsPoll(false);
                     });
                     video.addEventListener('pause', stopPolling);
                     video.addEventListener('ended', () => {
@@ -88,7 +89,10 @@ extension SingletonPlayerWebView {
                         stopPolling();
                     });
                     video.addEventListener('waiting', () => sendUpdate(true)); // Buffer state
-                    video.addEventListener('seeked', () => sendUpdate(true)); // Seek completed
+                    video.addEventListener('seeked', () => {
+                        sendUpdate(true); // Seek completed
+                        restartLyricsPoll(true);
+                    });
 
                     // AirPlay state tracking
                     video.addEventListener('webkitcurrentplaybacktargetiswirelesschanged', () => {
@@ -214,25 +218,101 @@ extension SingletonPlayerWebView {
                 }
             }
 
-            let lyricsPollId = null;
-            window.startLyricsPoll = function() {
-                if (lyricsPollId) return;
-                lyricsPollId = setInterval(() => {
-                    const v = document.querySelector('video');
-                    if (v) {
-                        bridge.postMessage({
-                            type: 'LYRICS_TIME',
-                            time: v.currentTime
-                        });
+            let lyricsPollTimeoutId = null;
+            let lyricsPollActive = false;
+            let lyricsLineRanges = [];
+            let lastLyricsBucket = null;
+            const LYRICS_MAX_POLL_INTERVAL_MS = 250;
+            const LYRICS_MIN_POLL_INTERVAL_MS = 50;
+
+            function currentLyricsBucket(timeMs) {
+                if (!Array.isArray(lyricsLineRanges) || lyricsLineRanges.length === 0) {
+                    return { lineIndex: -1, bucket: -1, nextBoundaryMs: null };
+                }
+                for (let index = 0; index < lyricsLineRanges.length; index += 1) {
+                    const range = lyricsLineRanges[index];
+                    if (timeMs >= range.startMs && timeMs < range.endMs) {
+                        return { lineIndex: index, bucket: index, nextBoundaryMs: range.endMs };
                     }
-                }, 100);
+                    if (timeMs < range.startMs) {
+                        return { lineIndex: -1, bucket: -(index + 1), nextBoundaryMs: range.startMs };
+                    }
+                }
+                return { lineIndex: -1, bucket: -(lyricsLineRanges.length + 1), nextBoundaryMs: null };
+            }
+
+            function sendLyricsLineUpdate(force) {
+                const v = document.querySelector('video');
+                if (!v) return null;
+                const timeMs = Math.floor((v.currentTime || 0) * 1000);
+                const bucket = currentLyricsBucket(timeMs);
+                if (!force && bucket.bucket === lastLyricsBucket) return bucket;
+                lastLyricsBucket = bucket.bucket;
+                bridge.postMessage({
+                    type: 'LYRICS_LINE',
+                    lineIndex: bucket.lineIndex,
+                    bucket: bucket.bucket,
+                    timeMs: timeMs
+                });
+                return bucket;
+            }
+
+            function scheduleNextLyricsPoll(bucket) {
+                if (!lyricsPollActive || lyricsPollTimeoutId) return;
+                const v = document.querySelector('video');
+                const timeMs = v ? Math.floor((v.currentTime || 0) * 1000) : 0;
+                const nextBoundaryMs = bucket && typeof bucket.nextBoundaryMs === 'number'
+                    ? bucket.nextBoundaryMs
+                    : null;
+                const boundaryDelay = nextBoundaryMs === null
+                    ? null
+                    : nextBoundaryMs - timeMs + 1;
+                const delay = boundaryDelay === null
+                    ? LYRICS_MAX_POLL_INTERVAL_MS
+                    : Math.max(0, Math.min(LYRICS_MAX_POLL_INTERVAL_MS, boundaryDelay));
+                lyricsPollTimeoutId = setTimeout(() => {
+                    lyricsPollTimeoutId = null;
+                    const nextBucket = sendLyricsLineUpdate(false);
+                    scheduleNextLyricsPoll(nextBucket);
+                }, delay);
+            }
+
+
+            function restartLyricsPoll(force) {
+                if (!lyricsPollActive) return;
+                if (lyricsPollTimeoutId) {
+                    clearTimeout(lyricsPollTimeoutId);
+                    lyricsPollTimeoutId = null;
+                }
+                const bucket = sendLyricsLineUpdate(force);
+                scheduleNextLyricsPoll(bucket);
+            }
+
+            window.startLyricsPoll = function(lineRanges) {
+                lyricsPollActive = true;
+                if (lyricsPollTimeoutId) {
+                    clearTimeout(lyricsPollTimeoutId);
+                    lyricsPollTimeoutId = null;
+                }
+                const nextRanges = Array.isArray(lineRanges) ? lineRanges : [];
+                lyricsLineRanges.length = 0;
+                nextRanges.forEach(range => {
+                    if (!range || typeof range.startMs !== 'number' || typeof range.endMs !== 'number') return;
+                    if (!isFinite(range.startMs) || !isFinite(range.endMs)) return;
+                    lyricsLineRanges.push({ startMs: range.startMs, endMs: range.endMs });
+                });
+                lastLyricsBucket = null;
+                const bucket = sendLyricsLineUpdate(true);
+                scheduleNextLyricsPoll(bucket);
             };
 
             window.stopLyricsPoll = function() {
-                if (lyricsPollId) {
-                    clearInterval(lyricsPollId);
-                    lyricsPollId = null;
+                lyricsPollActive = false;
+                if (lyricsPollTimeoutId) {
+                    clearTimeout(lyricsPollTimeoutId);
+                    lyricsPollTimeoutId = null;
                 }
+                lastLyricsBucket = null;
             };
 
             function startPolling() {

--- a/Sources/Kaset/Views/SingletonPlayerWebView+PlaybackPreferences.swift
+++ b/Sources/Kaset/Views/SingletonPlayerWebView+PlaybackPreferences.swift
@@ -19,12 +19,9 @@ extension SingletonPlayerWebView {
 
     /// Re-asserts Kaset's `nexttrack`/`previoustrack` media-session override immediately.
     ///
-    /// YouTube Music periodically re-registers its own handlers. In `nextPreviousTrack`
-    /// mode the page keeps ownership via a `requestAnimationFrame` re-apply loop — but
-    /// WebKit freezes `requestAnimationFrame` while the app is backgrounded, so the
-    /// override is lost and a media-key press falls through to YouTube (which jumps to its
-    /// own recommendation; queue-drift recovery then restarts the current song from 0).
-    /// Driving the re-apply from a native timer keeps the override alive in the background.
+    /// The document-start `setActionHandler` wrapper keeps YouTube from overwriting
+    /// Kaset-owned next/previous handlers, so normal operation relies on bounded
+    /// event-driven refreshes instead of a steady animation-frame loop.
     func reassertMediaControlOverride() {
         guard self.mediaControlUsesNextPrev, let webView = self.webView else { return }
         webView.evaluateJavaScript(
@@ -33,24 +30,18 @@ extension SingletonPlayerWebView {
         )
     }
 
-    /// Starts a native timer that re-asserts the media-key override while the app is
-    /// backgrounded. Native run-loop timers keep firing in the background (active audio
-    /// playback prevents App Nap), unlike the page's frozen `requestAnimationFrame` loop.
+    /// Performs a bounded re-assertion when the app enters the background.
+    ///
+    /// YouTube handler writes are blocked by the document-start wrapper while Kaset owns
+    /// next/previous, so no steady background timer is needed.
     func beginBackgroundMediaControlReassertion() {
         guard self.mediaControlUsesNextPrev else { return }
         self.reassertMediaControlOverride()
-        guard self.mediaControlReassertTimer == nil else { return }
-        let timer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { [weak self] (_: Timer) in
-            MainActor.assumeIsolated {
-                self?.reassertMediaControlOverride()
-            }
-        }
-        timer.tolerance = 0.5
-        self.mediaControlReassertTimer = timer
+        self.mediaControlReassertTimer?.invalidate()
+        self.mediaControlReassertTimer = nil
     }
 
-    /// Stops the background re-assertion timer. The page's `requestAnimationFrame` loop
-    /// resumes ownership once the app is foreground again.
+    /// Clears any legacy background re-assertion timer.
     func endBackgroundMediaControlReassertion() {
         self.mediaControlReassertTimer?.invalidate()
         self.mediaControlReassertTimer = nil
@@ -64,18 +55,31 @@ extension SingletonPlayerWebView {
                     localStorage.setItem('kasetUseNextPrev', '\(jsBoolean)');
                 } catch (e) {}
                 window.__kasetUseNextPrev = \(jsBoolean);
-                // Wrap setActionHandler at document start so YouTube's seekforward/seekbackward
-                // registrations stay owned by the native remote command handlers. Without this,
-                // WebKit and MPRemoteCommandCenter can both handle the same 15s skip command.
+                // Wrap setActionHandler at document start so YouTube registrations cannot
+                // steal remote-command ownership. Seek handlers always stay native-owned;
+                // next/previous stay Kaset-owned in nextPrev mode unless Kaset is installing
+                // its own handlers under the temporary install flag.
                 try {
+                    if (typeof window.__kasetInstallingMediaControlHandlers !== 'boolean') {
+                        window.__kasetInstallingMediaControlHandlers = false;
+                    }
                     var ms = navigator.mediaSession;
                     if (ms && !ms.__kasetSetActionHandlerWrapped) {
                         var orig = ms.setActionHandler.bind(ms);
                         ms.setActionHandler = function(type, handler) {
-                            if (type === 'seekforward' || type === 'seekbackward'
-                                    || (!window.__kasetUseNextPrev
-                                        && (type === 'nexttrack' || type === 'previoustrack'))) {
+                            var isSeekSkip = type === 'seekforward' || type === 'seekbackward';
+                            var isNextPrevious = type === 'nexttrack' || type === 'previoustrack';
+                            if (isSeekSkip) {
                                 return orig(type, null);
+                            }
+                            if (isNextPrevious) {
+                                if (window.__kasetUseNextPrev) {
+                                    if (!window.__kasetInstallingMediaControlHandlers) {
+                                        return undefined;
+                                    }
+                                } else {
+                                    return orig(type, null);
+                                }
                             }
                             return orig(type, handler);
                         };
@@ -128,7 +132,15 @@ extension SingletonPlayerWebView {
                 }
             }
 
-            var overrideFrameId = null;
+            function withKasetMediaControlInstall(action) {
+                var previousFlag = window.__kasetInstallingMediaControlHandlers === true;
+                window.__kasetInstallingMediaControlHandlers = true;
+                try {
+                    action();
+                } finally {
+                    window.__kasetInstallingMediaControlHandlers = previousFlag;
+                }
+            }
 
             function applyOverride() {
                 if (!window.__kasetUseNextPrev) {
@@ -136,48 +148,35 @@ extension SingletonPlayerWebView {
                 }
                 try {
                     var ms = navigator.mediaSession;
-                    ms.setActionHandler('seekforward', null);
-                    ms.setActionHandler('seekbackward', null);
-                    ms.setActionHandler('nexttrack', function() {
-                        window.webkit.messageHandlers.singletonPlayer
-                            .postMessage({ type: 'REMOTE_NEXT' });
-                    });
-                    ms.setActionHandler('previoustrack', function() {
-                        window.webkit.messageHandlers.singletonPlayer
-                            .postMessage({ type: 'REMOTE_PREVIOUS' });
+                    withKasetMediaControlInstall(function() {
+                        ms.setActionHandler('seekforward', null);
+                        ms.setActionHandler('seekbackward', null);
+                        ms.setActionHandler('nexttrack', function() {
+                            window.webkit.messageHandlers.singletonPlayer
+                                .postMessage({ type: 'REMOTE_NEXT' });
+                        });
+                        ms.setActionHandler('previoustrack', function() {
+                            window.webkit.messageHandlers.singletonPlayer
+                                .postMessage({ type: 'REMOTE_PREVIOUS' });
+                        });
                     });
                 } catch (e) {}
             }
 
-            function scheduleOverrideLoop() {
-                if (overrideFrameId !== null || !window.__kasetUseNextPrev) {
-                    return;
-                }
-
-                overrideFrameId = requestAnimationFrame(function() {
-                    overrideFrameId = null;
-                    if (!window.__kasetUseNextPrev) {
-                        return;
-                    }
-                    applyOverride();
-                    scheduleOverrideLoop();
-                });
-            }
-
             window.__kasetRefreshMediaControlStyle = function() {
                 applyOverride();
-                scheduleOverrideLoop();
             };
 
             window.__kasetRefreshMediaControlStyle();
 
-            // Re-apply on video events where YouTube re-registers handlers.
+            // Re-apply on bounded page lifecycle events where YouTube recreates the player.
             function attachVideoOverride() {
                 var v = document.querySelector('video');
                 if (!v || v.__kasetOverrideAttached) return;
                 v.__kasetOverrideAttached = true;
                 ['playing','loadedmetadata','loadeddata','canplay','seeked']
                     .forEach(function(e) { v.addEventListener(e, applyOverride); });
+                applyOverride();
             }
 
             attachVideoOverride();

--- a/Sources/Kaset/Views/SingletonPlayerWebView+VideoMode.swift
+++ b/Sources/Kaset/Views/SingletonPlayerWebView+VideoMode.swift
@@ -224,6 +224,18 @@ extension SingletonPlayerWebView {
         }
     }
 
+    static var videoModeInjectionScriptForTesting: String {
+        videoContainerScriptInPlace()
+    }
+
+    static var videoModeRemovalScriptForTesting: String {
+        videoModeRemovalScript()
+    }
+
+    static var videoModeRefreshScriptForTesting: String {
+        videoModeRefreshScript()
+    }
+
     // swiftlint:disable function_body_length
     /// Generates the JavaScript to hide UI and show only video in-place.
     private static func videoContainerScriptInPlace() -> String {
@@ -284,40 +296,215 @@ extension SingletonPlayerWebView {
                 }
             `;
 
-            // 2. Identify the video and mark its ancestors
-            const markAncestors = () => {
+            const previousState = window.__kasetVideoModeState;
+            if (previousState && typeof previousState.stop === 'function') {
+                previousState.stop();
+            }
+
+            // 2. Use a bounded warmup plus event-driven enforcement. The first
+            // frames catch YouTube Music's delayed player construction, then the
+            // observers below re-apply only when the player tree/layout changes.
+            const maxWarmupFrames = 30;
+            const state = {
+                active: true,
+                markedElements: [],
+                scheduledFrame: null,
+                warmupFrame: null,
+                warmupFramesRemaining: maxWarmupFrames,
+                treeObserver: null,
+                markedObserver: null,
+                resizeObserver: null,
+                observedResizeElements: [],
+                resizeHandler: null
+            };
+
+            const requestFrame = callback => {
+                if (typeof requestAnimationFrame === 'function') {
+                    return requestAnimationFrame(callback);
+                }
+                return setTimeout(callback, 16);
+            };
+
+            const cancelFrame = frame => {
+                if (frame === null || frame === undefined) return;
+                if (typeof cancelAnimationFrame === 'function') {
+                    cancelAnimationFrame(frame);
+                } else {
+                    clearTimeout(frame);
+                }
+            };
+
+            const sameElements = (lhs, rhs) => {
+                if (lhs.length !== rhs.length) return false;
+                for (let index = 0; index < lhs.length; index += 1) {
+                    if (lhs[index] !== rhs[index]) return false;
+                }
+                return true;
+            };
+
+            const chainHasMarkers = elements => elements.every(el => el.classList.contains('kaset-visible'));
+
+            const reobserveMarkedElements = () => {
+                if (!state.markedObserver) return;
+                state.markedObserver.disconnect();
+                state.markedElements.forEach(el => {
+                    state.markedObserver.observe(el, {
+                        attributes: true,
+                        attributeFilter: ['class', 'style', 'hidden']
+                    });
+                });
+            };
+
+            const syncResizeObserver = elements => {
+                if (!state.resizeObserver) return;
+                if (sameElements(state.observedResizeElements, elements)) return;
+
+                state.resizeObserver.disconnect();
+                state.observedResizeElements = elements.slice();
+                elements.forEach(el => {
+                    try {
+                        state.resizeObserver.observe(el);
+                    } catch (_) {}
+                });
+            };
+
+            const videoChain = () => {
                 const video = document.querySelector('video');
-                if (!video) return;
+                if (!video) return [];
 
-                // Clear old marks
-                document.querySelectorAll('.kaset-visible').forEach(el => el.classList.remove('kaset-visible'));
-
-                // Mark current video and all its parents
+                const elements = [];
                 let current = video;
                 while (current && current !== document.documentElement) {
-                    current.classList.add('kaset-visible');
+                    elements.push(current);
                     current = current.parentElement;
+                }
+                return elements;
+            };
+
+            const markVideoChain = () => {
+                const nextElements = videoChain();
+
+                const existingMarkers = Array.from(document.querySelectorAll('.kaset-visible'));
+                const hasOnlyCurrentMarkers = existingMarkers.length === nextElements.length &&
+                    existingMarkers.every(el => nextElements.indexOf(el) !== -1);
+                if (sameElements(state.markedElements, nextElements) && chainHasMarkers(nextElements) && hasOnlyCurrentMarkers) {
+                    syncResizeObserver(nextElements);
+                    return;
+                }
+
+                if (state.markedObserver) {
+                    state.markedObserver.disconnect();
+                }
+
+                existingMarkers.forEach(el => {
+                    if (nextElements.indexOf(el) === -1) {
+                        el.classList.remove('kaset-visible');
+                    }
+                });
+
+                nextElements.forEach(el => {
+                    if (!el.classList.contains('kaset-visible')) {
+                        el.classList.add('kaset-visible');
+                    }
+                });
+
+                state.markedElements = nextElements;
+                reobserveMarkedElements();
+                syncResizeObserver(nextElements);
+            };
+
+            const clearVisibilityMarkers = () => {
+                document.querySelectorAll('.kaset-visible').forEach(el => el.classList.remove('kaset-visible'));
+                state.markedElements = [];
+            };
+
+            const enforceVideoMode = () => {
+                const playerPage = document.querySelector('ytmusic-player-page');
+                if (playerPage && playerPage.videoMode !== true) {
+                    playerPage.videoMode = true;
+                    if (typeof playerPage.onVideoModeChanged === 'function') {
+                        playerPage.onVideoModeChanged();
+                    }
                 }
             };
 
-            // 3. Continuous Enforcement Loop
-            const enforceVisibility = () => {
-                markAncestors();
-                const video = document.querySelector('video');
-                if (video && typeof window.__kasetVideoModeActive === 'boolean' && window.__kasetVideoModeActive) {
-                    // Force Video Mode via Redux/Property if needed
-                    const playerPage = document.querySelector('ytmusic-player-page');
-                    if (playerPage && playerPage.videoMode !== true) {
-                        playerPage.videoMode = true;
-                        if (typeof playerPage.onVideoModeChanged === 'function') playerPage.onVideoModeChanged();
-                    }
-                }
-                if (window.__kasetVideoModeActive) {
-                    requestAnimationFrame(enforceVisibility);
+            const enforce = () => {
+                if (!state.active) return;
+                enforceVideoMode();
+                markVideoChain();
+            };
+
+            const scheduleEnforcement = () => {
+                if (!state.active || state.scheduledFrame !== null) return;
+                state.scheduledFrame = requestFrame(() => {
+                    state.scheduledFrame = null;
+                    enforce();
+                });
+            };
+
+            const runWarmupFrame = () => {
+                state.warmupFrame = null;
+                if (!state.active) return;
+                enforce();
+                state.warmupFramesRemaining -= 1;
+                if (state.warmupFramesRemaining > 0) {
+                    state.warmupFrame = requestFrame(runWarmupFrame);
                 }
             };
+
+            state.restartWarmup = frameCount => {
+                if (!state.active) return;
+                state.warmupFramesRemaining = Math.max(1, frameCount || maxWarmupFrames);
+                if (state.warmupFrame === null) {
+                    state.warmupFrame = requestFrame(runWarmupFrame);
+                }
+            };
+
+            state.enforce = enforce;
+            state.scheduleEnforcement = scheduleEnforcement;
+            state.stop = () => {
+                state.active = false;
+                window.__kasetVideoModeActive = false;
+                cancelFrame(state.scheduledFrame);
+                cancelFrame(state.warmupFrame);
+                state.scheduledFrame = null;
+                state.warmupFrame = null;
+                if (state.treeObserver) state.treeObserver.disconnect();
+                if (state.markedObserver) state.markedObserver.disconnect();
+                if (state.resizeObserver) state.resizeObserver.disconnect();
+                if (state.resizeHandler && window.removeEventListener) {
+                    window.removeEventListener('resize', state.resizeHandler);
+                }
+                clearVisibilityMarkers();
+                state.treeObserver = null;
+                state.markedObserver = null;
+                state.resizeObserver = null;
+                state.observedResizeElements = [];
+            };
+
+            window.__kasetVideoModeState = state;
             window.__kasetVideoModeActive = true;
-            requestAnimationFrame(enforceVisibility);
+
+            if (typeof MutationObserver === 'function') {
+                const root = document.documentElement || document.body;
+                state.treeObserver = new MutationObserver(scheduleEnforcement);
+                if (root) {
+                    state.treeObserver.observe(root, { childList: true, subtree: true });
+                }
+                state.markedObserver = new MutationObserver(scheduleEnforcement);
+            }
+
+            if (typeof ResizeObserver === 'function') {
+                state.resizeObserver = new ResizeObserver(scheduleEnforcement);
+            }
+
+            if (window.addEventListener) {
+                state.resizeHandler = scheduleEnforcement;
+                window.addEventListener('resize', state.resizeHandler, { passive: true });
+            }
+
+            enforce();
+            state.restartWarmup(maxWarmupFrames);
 
             // Remove the extraction container if it exists from previous attempts
             const oldContainer = document.getElementById('kaset-video-container');
@@ -335,24 +522,28 @@ extension SingletonPlayerWebView {
         """
     }
 
-    // swiftlint:enable function_body_length
-
-    /// Removes the video container and restores the video to its original location.
-    func removeVideoModeCSS() {
-        guard let webView else { return }
-
-        let script = """
+    private static func videoModeRemovalScript() -> String {
+        """
             (function() {
                 // Remove blackout overlay
                 const blackout = document.getElementById('kaset-blackout');
                 if (blackout) blackout.remove();
 
+                const state = window.__kasetVideoModeState;
+                if (state && typeof state.stop === 'function') {
+                    state.stop();
+                }
+                delete window.__kasetVideoModeState;
+
                 // Remove the in-place style
                 const style = document.getElementById('kaset-video-mode-style-v2');
                 if (style) style.remove();
 
-                // Stop the enforcement loop
+                // Stop any older loop that predates the state object.
                 window.__kasetVideoModeActive = false;
+
+                // Remove all visibility markers.
+                document.querySelectorAll('.kaset-visible').forEach(el => el.classList.remove('kaset-visible'));
 
                 // Remove video styles manually too
                 const videos = document.querySelectorAll('video');
@@ -369,6 +560,45 @@ extension SingletonPlayerWebView {
                 document.body.style.background = '';
             })();
         """
+    }
+
+    private static func videoModeRefreshScript() -> String {
+        """
+            (function() {
+                const style = document.getElementById('kaset-video-mode-style-v2');
+                if (!style) return { success: false, error: 'no video-mode-style' };
+
+                const state = window.__kasetVideoModeState;
+                if (state && state.active && typeof state.enforce === 'function') {
+                    state.enforce();
+                    if (typeof state.restartWarmup === 'function') {
+                        state.restartWarmup(3);
+                    }
+                    return { success: true, method: 'state' };
+                }
+
+                // Re-apply videoMode property if it drifted. This preserves the
+                // old refresh behavior for pages injected before the state object.
+                const playerPage = document.querySelector('ytmusic-player-page');
+                if (playerPage && typeof playerPage.videoMode !== 'undefined' && playerPage.videoMode !== true) {
+                    playerPage.videoMode = true;
+                    if (typeof playerPage.onVideoModeChanged === 'function') {
+                        playerPage.onVideoModeChanged();
+                    }
+                }
+
+                return { success: true, method: 'fallback' };
+            })();
+        """
+    }
+
+    // swiftlint:enable function_body_length
+
+    /// Removes the video container and restores the video to its original location.
+    func removeVideoModeCSS() {
+        guard let webView else { return }
+
+        let script = Self.videoModeRemovalScript()
         webView.evaluateJavaScript(script, completionHandler: nil)
     }
 
@@ -385,23 +615,7 @@ extension SingletonPlayerWebView {
         guard width > 0, height > 0 else { return }
 
         // Update the video UI to ensure everything stays hidden and centered
-        let refreshScript = """
-            (function() {
-                const style = document.getElementById('kaset-video-mode-style-v2');
-                if (!style) return { success: false, error: 'no video-mode-style' };
-
-                // Re-apply videoMode property if it drifted
-                const playerPage = document.querySelector('ytmusic-player-page');
-                if (playerPage && typeof playerPage.videoMode !== 'undefined' && playerPage.videoMode !== true) {
-                    playerPage.videoMode = true;
-                    if (typeof playerPage.onVideoModeChanged === 'function') {
-                        playerPage.onVideoModeChanged();
-                    }
-                }
-
-                return { success: true };
-            })();
-        """
+        let refreshScript = Self.videoModeRefreshScript()
         webView.evaluateJavaScript(refreshScript) { result, _ in
             if let dict = result as? [String: Any],
                let success = dict["success"] as? Bool,

--- a/Sources/Kaset/Views/SyncedLyricsDisplayView.swift
+++ b/Sources/Kaset/Views/SyncedLyricsDisplayView.swift
@@ -20,8 +20,9 @@ struct SyncedLyricsDisplayView: View {
                 LazyVStack(alignment: .center, spacing: 20) {
                     Spacer().frame(height: 150) // Top padding
 
-                    ForEach(self.lyrics.lines) { line in
-                        let status = self.currentStatus(for: line)
+                    ForEach(self.lyrics.lines.indices, id: \.self) { lineIndex in
+                        let line = self.lyrics.lines[lineIndex]
+                        let status = self.currentStatus(for: line, at: lineIndex)
                         SyncedLineView(
                             line: line,
                             status: status,
@@ -52,11 +53,7 @@ struct SyncedLyricsDisplayView: View {
         }
     }
 
-    private func currentStatus(for line: SyncedLyricLine) -> SyncedLyrics.LineStatus {
-        guard let lineIndex = self.lyrics.lines.firstIndex(where: { $0.id == line.id }) else {
-            return .upcoming
-        }
-
+    private func currentStatus(for line: SyncedLyricLine, at lineIndex: Int) -> SyncedLyrics.LineStatus {
         if let currentLineIndex, self.lyrics.lines.indices.contains(currentLineIndex) {
             if lineIndex < currentLineIndex {
                 return .previous

--- a/Sources/Kaset/Views/SyncedLyricsDisplayView.swift
+++ b/Sources/Kaset/Views/SyncedLyricsDisplayView.swift
@@ -4,10 +4,15 @@ import SwiftUI
 
 struct SyncedLyricsDisplayView: View {
     let lyrics: SyncedLyrics
-    let currentTimeMs: Int
+    let currentLineIndex: Int?
+    let displayTimeMs: Int?
     let onSeek: (Int) -> Void
 
     @State private var currentLineId: UUID?
+
+    private var effectiveDisplayTimeMs: Int {
+        self.displayTimeMs ?? -1
+    }
 
     var body: some View {
         ScrollViewReader { proxy in
@@ -30,25 +35,39 @@ struct SyncedLyricsDisplayView: View {
                 .padding(.horizontal, 24)
             }
             .scrollIndicators(.hidden)
-            .onChange(of: self.currentTimeMs) { _, newTimeMs in
-                if let currentIdx = lyrics.currentLineIndex(at: newTimeMs) {
-                    let newId = self.lyrics.lines[currentIdx].id
-                    if newId != self.currentLineId {
-                        self.currentLineId = newId
-                        withAnimation(.spring(response: 0.8, dampingFraction: 0.8)) {
-                            // Target center for natural scrolling
-                            proxy.scrollTo(newId, anchor: .center)
-                        }
-                    }
+            .onChange(of: self.currentLineIndex, initial: true) { _, newLineIndex in
+                guard let newLineIndex,
+                      self.lyrics.lines.indices.contains(newLineIndex)
+                else { return }
+
+                let newId = self.lyrics.lines[newLineIndex].id
+                guard newId != self.currentLineId else { return }
+
+                self.currentLineId = newId
+                withAnimation(.spring(response: 0.8, dampingFraction: 0.8)) {
+                    // Target center for natural scrolling
+                    proxy.scrollTo(newId, anchor: .center)
                 }
             }
         }
     }
 
     private func currentStatus(for line: SyncedLyricLine) -> SyncedLyrics.LineStatus {
-        if line.timeInMs > self.currentTimeMs { return .upcoming }
-        if self.currentTimeMs - line.timeInMs >= line.duration, line.duration > 0 { return .previous }
-        return .current
+        guard let lineIndex = self.lyrics.lines.firstIndex(where: { $0.id == line.id }) else {
+            return .upcoming
+        }
+
+        if let currentLineIndex, self.lyrics.lines.indices.contains(currentLineIndex) {
+            if lineIndex < currentLineIndex {
+                return .previous
+            }
+            if lineIndex > currentLineIndex {
+                return .upcoming
+            }
+            return .current
+        }
+
+        return line.timeInMs <= self.effectiveDisplayTimeMs ? .previous : .upcoming
     }
 }
 

--- a/Sources/Kaset/Views/WhatsNewView.swift
+++ b/Sources/Kaset/Views/WhatsNewView.swift
@@ -256,7 +256,9 @@ private struct MarkdownContentView: View {
                     codeLines.append(lines[i])
                     i += 1
                 }
-                if i < lines.count { i += 1 } // skip closing ```
+                if i < lines.count {
+                    i += 1
+                } // skip closing ```
                 let code = codeLines.joined(separator: "\n")
                 result.append(AnyView(Self.codeBlock(code)))
             } else {

--- a/Sources/Kaset/Views/YouTube/AmbientVideoBackdrop.swift
+++ b/Sources/Kaset/Views/YouTube/AmbientVideoBackdrop.swift
@@ -45,16 +45,23 @@ struct AmbientVideoBackdrop: View {
     /// video's colors can never show through while a new load is in flight —
     /// regardless of how the async fetches interleave.
     @State private var loadedVideoId: String?
+    @State private var lowPowerModeEnabled = ProcessInfo.processInfo.isLowPowerModeEnabled
 
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
 
+    /// Slow ambient drift does not need display-link cadence. Eight samples per
+    /// second keeps the large blurred blobs moving smoothly enough while cutting
+    /// steady-state invalidations substantially compared with `.animation`.
+    nonisolated static let animatedTimelineInterval: TimeInterval = 1.0 / 8.0
+
     // MARK: Body
 
     var body: some View {
+        let style = self.effectiveStyle
         Group {
-            if self.style == .off {
+            if style == .off {
                 Color.clear
             } else if self.reduceTransparency {
                 // Reduce Transparency: flatten to a near-solid low tint, no glow.
@@ -67,7 +74,10 @@ struct AmbientVideoBackdrop: View {
             }
         }
         .animation(.easeInOut(duration: 0.6), value: self.palette)
-        .animation(.easeInOut(duration: 0.5), value: self.style)
+        .animation(.easeInOut(duration: 0.5), value: style)
+        .onReceive(NotificationCenter.default.publisher(for: Notification.Name.NSProcessInfoPowerStateDidChange)) { _ in
+            self.lowPowerModeEnabled = ProcessInfo.processInfo.isLowPowerModeEnabled
+        }
         .task(id: self.loadKey) {
             await self.load()
         }
@@ -76,7 +86,32 @@ struct AmbientVideoBackdrop: View {
     /// Re-runs the loader when the video, style, or storyboard availability
     /// changes (the spec arrives a beat after playback starts).
     private var loadKey: String {
-        "\(self.videoId ?? "-")|\(self.style.rawValue)|\(self.storyboardSpec != nil)"
+        let style = self.effectiveStyle
+        let hasStoryboardSpec = style == .live && self.storyboardSpec != nil
+        return "\(self.videoId ?? "-")|\(style.rawValue)|\(hasStoryboardSpec)"
+    }
+
+    /// Style actually rendered after energy/accessibility downgrades. `.live`
+    /// is the only style that fetches storyboard sheets and continuously
+    /// cross-fades with playback; under Low Power Mode or Reduce Motion, prefer
+    /// the static thumbnail-derived `.soft` glow instead.
+    private var effectiveStyle: AmbientBackdropStyle {
+        Self.effectiveStyle(
+            requestedStyle: self.style,
+            reduceMotion: self.reduceMotion,
+            lowPowerModeEnabled: self.lowPowerModeEnabled
+        )
+    }
+
+    nonisolated static func effectiveStyle(
+        requestedStyle style: AmbientBackdropStyle,
+        reduceMotion: Bool,
+        lowPowerModeEnabled: Bool
+    ) -> AmbientBackdropStyle {
+        if style == .live, reduceMotion || lowPowerModeEnabled {
+            return .soft
+        }
+        return style
     }
 
     // MARK: Ambient composition
@@ -86,10 +121,11 @@ struct AmbientVideoBackdrop: View {
     /// drift) so it reads as a calm version of the same glow.
     private var ambientContent: some View {
         GeometryReader { geo in
-            if self.style == .soft || self.reduceMotion {
+            let style = self.effectiveStyle
+            if style == .soft || self.reduceMotion {
                 self.auroraLayer(size: geo.size, time: nil)
             } else {
-                TimelineView(.animation) { timeline in
+                TimelineView(.periodic(from: .now, by: Self.animatedTimelineInterval)) { timeline in
                     self.auroraLayer(
                         size: geo.size,
                         time: timeline.date.timeIntervalSinceReferenceDate
@@ -105,7 +141,7 @@ struct AmbientVideoBackdrop: View {
     private func auroraLayer(size: CGSize, time: TimeInterval?) -> some View {
         let frames = self.renderFrames
         // `.soft` is the calm style: same colors, dimmer than the drifting glow.
-        let intensity: Double = self.style == .soft ? 0.7 : 1.0
+        let intensity: Double = self.effectiveStyle == .soft ? 0.7 : 1.0
         // Under Reduce Motion, collapse `.live` to a single static frame: the
         // blobs already stop drifting (time: nil) and the colors must not
         // cross-fade as playback advances either.
@@ -149,7 +185,7 @@ struct AmbientVideoBackdrop: View {
 
     /// The swatch set(s) feeding the aurora for the current style.
     private var renderFrames: [[Color]] {
-        switch self.style {
+        switch self.effectiveStyle {
         case .live where self.colorsAreCurrent && !self.frameSwatches.isEmpty:
             self.frameSwatches
         default:
@@ -238,7 +274,8 @@ struct AmbientVideoBackdrop: View {
     // MARK: Loading
 
     private func load() async {
-        guard self.style != .off else { return }
+        let style = self.effectiveStyle
+        guard style != .off else { return }
 
         // Resolve thumbnail colors, then publish — assigning defaults on
         // failure too, so a new video whose thumbnail is missing/fails can't
@@ -252,7 +289,9 @@ struct AmbientVideoBackdrop: View {
         } else {
             nil
         }
-        if Task.isCancelled { return }
+        if Task.isCancelled {
+            return
+        }
         let isNewVideo = self.loadedVideoId != self.videoId
         self.palette = resolved?.palette ?? .default
         self.thumbnailSwatches = resolved?.swatches ?? []
@@ -267,7 +306,7 @@ struct AmbientVideoBackdrop: View {
         // than a prior video's colors.
         self.loadedVideoId = self.videoId
 
-        guard self.style == .live else {
+        guard style == .live else {
             self.frameSwatches = []
             return
         }
@@ -280,7 +319,9 @@ struct AmbientVideoBackdrop: View {
            let sets = await Self.loadStoryboardSwatches(sheet: sheet),
            !sets.isEmpty
         {
-            if Task.isCancelled { return }
+            if Task.isCancelled {
+                return
+            }
             self.frameSwatches = sets
             return
         }
@@ -293,7 +334,9 @@ struct AmbientVideoBackdrop: View {
                 sets.append(swatches)
             }
         }
-        if Task.isCancelled { return }
+        if Task.isCancelled {
+            return
+        }
         self.frameSwatches = sets
     }
 

--- a/Sources/Kaset/Views/YouTube/YouTubeChannelView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeChannelView.swift
@@ -72,7 +72,7 @@ struct YouTubeChannelView: View {
         HStack(spacing: 16) {
             CachedAsyncImage(
                 url: channel.thumbnailURL,
-                targetSize: CGSize(width: 160, height: 160)
+                targetSize: CGSize(width: 80, height: 80)
             ) { image in
                 image
                     .resizable()

--- a/Sources/Kaset/Views/YouTube/YouTubeHistoryView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeHistoryView.swift
@@ -57,7 +57,7 @@ struct YouTubeHistoryView: View {
                 if self.viewModel.hasMoreVideos {
                     ProgressView()
                         .controlSize(.small)
-                        .task {
+                        .task(id: self.viewModel.paginationTrigger) {
                             await self.viewModel.loadMore()
                         }
                 }

--- a/Sources/Kaset/Views/YouTube/YouTubeHomeView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeHomeView.swift
@@ -28,7 +28,9 @@ struct YouTubeHomeView: View {
             case .loaded, .loadingMore:
                 if self.viewModel.sections.isEmpty,
                    self.viewModel.videos.isEmpty,
-                   !self.viewModel.hasMoreVideos
+                   !self.viewModel.hasMoreVideos,
+                   !self.viewModel.hasMoreTopicRails,
+                   !self.viewModel.isLoadingTopicRails
                 {
                     ContentUnavailableView {
                         Label(String(localized: "No recommendations yet"), systemImage: "play.rectangle")
@@ -72,6 +74,17 @@ struct YouTubeHomeView: View {
                 ForEach(self.viewModel.sections) { section in
                     self.sectionRail(section)
                         .transition(.opacity)
+                }
+
+                if self.viewModel.hasMoreTopicRails || self.viewModel.isLoadingTopicRails {
+                    LoadMoreFooter(
+                        isLoading: self.viewModel.isLoadingTopicRails,
+                        title: "Load more topics",
+                        loadingTitle: "Loading topics..."
+                    ) {
+                        await self.viewModel.loadMoreTopicRails()
+                    }
+                    .transition(.opacity)
                 }
 
                 // Render the grid whenever there are flat videos OR more pages

--- a/Sources/Kaset/Views/YouTube/YouTubeHomeView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeHomeView.swift
@@ -151,7 +151,7 @@ struct YouTubeHomeView: View {
                     ProgressView()
                         .controlSize(.small)
                         .gridCellColumns(1)
-                        .task {
+                        .task(id: self.viewModel.videos.count) {
                             await self.viewModel.loadMore()
                         }
                 }

--- a/Sources/Kaset/Views/YouTube/YouTubeHomeView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeHomeView.swift
@@ -80,7 +80,9 @@ struct YouTubeHomeView: View {
                     LoadMoreFooter(
                         isLoading: self.viewModel.isLoadingTopicRails,
                         title: "Load more topics",
-                        loadingTitle: "Loading topics..."
+                        loadingTitle: "Loading topics...",
+                        autoLoad: true,
+                        autoLoadTrigger: self.viewModel.sections.count
                     ) {
                         await self.viewModel.loadMoreTopicRails()
                     }

--- a/Sources/Kaset/Views/YouTube/YouTubeListRows.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeListRows.swift
@@ -51,7 +51,7 @@ struct ChannelRowView: View {
         HStack(spacing: 12) {
             CachedAsyncImage(
                 url: self.channel.thumbnailURL,
-                targetSize: CGSize(width: 96, height: 96)
+                targetSize: CGSize(width: 48, height: 48)
             ) { image in
                 image
                     .resizable()

--- a/Sources/Kaset/Views/YouTube/YouTubePlayerBar.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubePlayerBar.swift
@@ -118,12 +118,12 @@ struct YouTubePlayerBar: View {
                 cornerRadius: 6,
                 glowSources: self.currentVideoGlowSources,
                 glowIdentity: self.currentVideoGlowIdentity,
-                glowTargetSize: CGSize(width: 128, height: 72),
+                glowTargetSize: CGSize(width: 64, height: 36),
                 showsHoverOverlay: false
             ) {
                 CachedAsyncImage(
                     url: self.youtubePlayer.currentVideo?.thumbnailURL,
-                    targetSize: CGSize(width: 128, height: 72)
+                    targetSize: CGSize(width: 64, height: 36)
                 ) { image in
                     image
                         .resizable()

--- a/Sources/Kaset/Views/YouTube/YouTubeSearchView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeSearchView.swift
@@ -141,7 +141,7 @@ struct YouTubeSearchView: View {
                     ProgressView()
                         .controlSize(.small)
                         .frame(maxWidth: .infinity)
-                        .task {
+                        .task(id: self.viewModel.results.continuation) {
                             await self.viewModel.loadMore()
                         }
                 }

--- a/Sources/Kaset/Views/YouTube/YouTubeSubscriptionsView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeSubscriptionsView.swift
@@ -95,7 +95,7 @@ struct YouTubeSubscriptionsView: View {
                             VStack(spacing: 6) {
                                 CachedAsyncImage(
                                     url: channel.thumbnailURL,
-                                    targetSize: CGSize(width: 112, height: 112)
+                                    targetSize: CGSize(width: 56, height: 56)
                                 ) { image in
                                     image
                                         .resizable()

--- a/Sources/Kaset/Views/YouTube/YouTubeSubscriptionsView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeSubscriptionsView.swift
@@ -65,7 +65,7 @@ struct YouTubeSubscriptionsView: View {
                         if self.viewModel.hasMoreVideos {
                             ProgressView()
                                 .controlSize(.small)
-                                .task {
+                                .task(id: self.viewModel.paginationTrigger) {
                                     await self.viewModel.loadMore()
                                 }
                         }

--- a/Sources/Kaset/Views/YouTube/YouTubeWatchView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeWatchView.swift
@@ -254,7 +254,7 @@ struct YouTubeWatchView: View {
                         HStack(spacing: 10) {
                             CachedAsyncImage(
                                 url: channel.thumbnailURL,
-                                targetSize: CGSize(width: 72, height: 72)
+                                targetSize: CGSize(width: 36, height: 36)
                             ) { image in
                                 image
                                     .resizable()
@@ -643,7 +643,7 @@ private struct CommentRow: View {
     private var avatar: some View {
         CachedAsyncImage(
             url: self.comment.authorAvatarURL,
-            targetSize: CGSize(width: 56, height: 56)
+            targetSize: CGSize(width: 28, height: 28)
         ) { image in
             image
                 .resizable()

--- a/Sources/Kaset/Views/YouTube/YouTubeWatchWebView+Scripts.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeWatchWebView+Scripts.swift
@@ -195,12 +195,17 @@ extension YouTubeWatchWebView {
                 disableAutonav();
                 const video = videoEl();
                 if (!video) { return false; }
+                const videoId = currentVideoId();
                 if (video.__kasetAttached) {
                     applyPendingSeek(video);
-                    sendUpdate(true);
+                    if (videoId && video.__kasetAttachedVideoId !== videoId) {
+                        video.__kasetAttachedVideoId = videoId;
+                        sendUpdate(true);
+                    }
                     return true;
                 }
                 video.__kasetAttached = true;
+                video.__kasetAttachedVideoId = videoId || '';
                 attachRetryCount = 0;
 
                 ['play', 'playing'].forEach(function(evt) {

--- a/Sources/Kaset/Views/YouTube/YouTubeWatchWebView+Scripts.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeWatchWebView+Scripts.swift
@@ -5,16 +5,26 @@ import Foundation
 extension YouTubeWatchWebView {
     /// Observer script for youtube.com watch pages.
     ///
-    /// Posts `STATE_UPDATE` (1 Hz + media events) and `VIDEO_ENDED` to the
-    /// `youtubePlayer` bridge. Also enforces the Kaset-managed volume target
-    /// the same way the music observer does.
+    /// Posts event-driven `STATE_UPDATE` and `VIDEO_ENDED` messages to the
+    /// `youtubePlayer` bridge. Progress updates are driven by media events, with
+    /// forced final updates on pause/seek/end, so paused pages do not keep a 1 Hz
+    /// bridge loop alive. Also enforces the Kaset-managed volume target the same
+    /// way the music observer does.
     static var observerScript: String {
         """
         (function() {
             'use strict';
 
             const bridge = window.webkit.messageHandlers.youtubePlayer;
+            const UPDATE_THROTTLE_MS = 1000;
+            const MAX_ATTACH_RETRIES = 20;
             let lastVideoId = '';
+            let lastUpdateTime = 0;
+            let trailingUpdateTimeoutId = null;
+            let attachRetryCount = 0;
+            let attachRetryTimeoutId = null;
+            let attachDebounceTimeoutId = null;
+            let videoObserver = null;
 
             function moviePlayer() {
                 return document.getElementById('movie_player');
@@ -48,11 +58,36 @@ extension YouTubeWatchWebView {
                 return !!(player && player.classList && player.classList.contains('ad-showing'));
             }
 
-            function sendUpdate() {
+            function clearTrailingUpdate() {
+                if (trailingUpdateTimeoutId) {
+                    clearTimeout(trailingUpdateTimeoutId);
+                    trailingUpdateTimeoutId = null;
+                }
+            }
+
+            function sendUpdate(force) {
                 try {
                     const video = videoEl();
                     if (!video) { return; }
                     applyPendingSeek(video);
+
+                    if (force) {
+                        clearTrailingUpdate();
+                    } else {
+                        const now = Date.now();
+                        const elapsed = now - lastUpdateTime;
+                        if (elapsed < UPDATE_THROTTLE_MS) {
+                            if (!trailingUpdateTimeoutId && !video.paused && !video.ended) {
+                                trailingUpdateTimeoutId = setTimeout(function() {
+                                    trailingUpdateTimeoutId = null;
+                                    sendUpdate(true);
+                                }, UPDATE_THROTTLE_MS - elapsed);
+                            }
+                            return;
+                        }
+                    }
+                    lastUpdateTime = Date.now();
+
                     const videoId = currentVideoId();
                     if (videoId !== '') { lastVideoId = videoId; }
                     bridge.postMessage({
@@ -97,10 +132,10 @@ extension YouTubeWatchWebView {
 
             // Apply a pending resume-seek from a session-identity-switch reload.
             // The <video> is created by the player JS after navigation and may
-            // not be seekable immediately, so this is called from both attach()
-            // and the 1s sendUpdate tick and retries until metadata is ready.
-            // Scoped to this document: window.__kasetPendingSeek is re-injected
-            // per page load, so it cannot leak into a later video.
+            // not be seekable immediately, so this is called from attach() and
+            // media readiness/progress events until metadata is ready. Scoped to
+            // this document: window.__kasetPendingSeek is re-injected per page
+            // load, so it cannot leak into a later video.
             function applyPendingSeek(video) {
                 const target = window.__kasetPendingSeek;
                 if (typeof target !== 'number') { return; }
@@ -132,31 +167,90 @@ extension YouTubeWatchWebView {
                 } catch (e) {}
             }
 
-            function attach() {
+            function handlePlaybackStarted() {
+                const video = videoEl();
+                if (video) { enforceVolume(video); }
+                sendUpdate(true);
+            }
+
+            function handlePlaybackStopped() {
+                sendUpdate(true);
+            }
+
+            function handleTimelineUpdate() {
                 const video = videoEl();
                 if (!video) { return; }
-                if (video.__kasetAttached) { return; }
-                video.__kasetAttached = true;
+                applyPendingSeek(video);
+                if (!video.paused && !video.ended) {
+                    sendUpdate(false);
+                }
+            }
 
-                ['play', 'playing', 'pause', 'seeked', 'loadedmetadata'].forEach(function(evt) {
-                    video.addEventListener(evt, sendUpdate);
+            function handleEnded() {
+                sendUpdate(true);
+                sendEnded();
+            }
+
+            function attach() {
+                disableAutonav();
+                const video = videoEl();
+                if (!video) { return false; }
+                if (video.__kasetAttached) { return true; }
+                video.__kasetAttached = true;
+                attachRetryCount = 0;
+
+                ['play', 'playing'].forEach(function(evt) {
+                    video.addEventListener(evt, handlePlaybackStarted);
                 });
-                video.addEventListener('ended', sendEnded);
+                ['pause', 'seeked', 'loadedmetadata', 'durationchange', 'canplay', 'waiting'].forEach(function(evt) {
+                    video.addEventListener(evt, handlePlaybackStopped);
+                });
+                video.addEventListener('timeupdate', handleTimelineUpdate);
+                video.addEventListener('ended', handleEnded);
                 video.addEventListener('volumechange', function() {
                     enforceVolume(video);
                 });
 
-                disableAutonav();
                 enforceVolume(video);
                 applyPendingSeek(video);
-                sendUpdate();
+                sendUpdate(true);
+                return true;
             }
 
-            // Re-attach periodically: YouTube swaps <video> elements across
-            // SPA navigations and ad transitions.
-            setInterval(attach, 2000);
-            setInterval(sendUpdate, 1000);
-            attach();
+            function scheduleAttach() {
+                if (attachDebounceTimeoutId) { return; }
+                attachDebounceTimeoutId = setTimeout(function() {
+                    attachDebounceTimeoutId = null;
+                    attach();
+                }, 100);
+            }
+
+            function installVideoObserver() {
+                if (videoObserver || typeof MutationObserver !== 'function') { return false; }
+                const root = document.documentElement || document.body;
+                if (!root) { return false; }
+                videoObserver = new MutationObserver(scheduleAttach);
+                videoObserver.observe(root, { childList: true, subtree: true });
+                return true;
+            }
+
+            function attachWithBoundedRetry() {
+                if (attach()) { return; }
+                if (!installVideoObserver() && attachRetryCount < MAX_ATTACH_RETRIES && !attachRetryTimeoutId) {
+                    attachRetryCount += 1;
+                    attachRetryTimeoutId = setTimeout(function() {
+                        attachRetryTimeoutId = null;
+                        attachWithBoundedRetry();
+                    }, 500);
+                }
+            }
+
+            installVideoObserver();
+            if (document.readyState === 'loading') {
+                document.addEventListener('DOMContentLoaded', attachWithBoundedRetry);
+            } else {
+                attachWithBoundedRetry();
+            }
         })();
         """
     }
@@ -186,15 +280,18 @@ extension YouTubeWatchWebView {
     /// Same ancestor-chain visibility approach as the music video mode
     /// (`SingletonPlayerWebView+VideoMode`), targeting the watch-page DOM.
     /// Defines `window.__kasetExtractVideo()` and runs it; `didFinish` calls
-    /// it again for cached/fast loads.
+    /// it again for cached/fast loads. Enforcement uses bounded RAF bursts plus
+    /// a DOM observer so steady state does not keep a per-frame loop alive.
     static var extractionScript: String {
         """
         (function() {
             'use strict';
 
             const styleId = 'kaset-yt-video-style';
+            const MAX_ENFORCEMENT_FRAMES = 12;
+            const MUTATION_ENFORCEMENT_FRAMES = 6;
 
-            window.__kasetExtractVideo = function() {
+            function ensureStyle() {
                 let style = document.getElementById(styleId);
                 if (!style) {
                     style = document.createElement('style');
@@ -268,31 +365,141 @@ extension YouTubeWatchWebView {
                         visibility: visible !important;
                     }
                 `;
+            }
 
-                const markAncestors = function() {
-                    const video = document.querySelector('#movie_player video') || document.querySelector('video');
-                    if (!video) { return; }
+            function extractionState() {
+                if (!window.__kasetYTExtraction) {
+                    window.__kasetYTExtraction = {
+                        active: false,
+                        observer: null,
+                        markedObserver: null,
+                        markedElements: [],
+                        rafScheduled: false,
+                        rafHandle: null,
+                        remainingFrames: 0
+                    };
+                }
+                return window.__kasetYTExtraction;
+            }
 
-                    document.querySelectorAll('.kaset-visible').forEach(function(el) {
+            function clearMarkers() {
+                document.querySelectorAll('.kaset-visible').forEach(function(el) {
+                    el.classList.remove('kaset-visible');
+                });
+            }
+
+            function stopExtraction() {
+                const state = extractionState();
+                state.active = false;
+                window.__kasetYTVideoActive = false;
+                state.remainingFrames = 0;
+                if (state.observer) {
+                    state.observer.disconnect();
+                    state.observer = null;
+                }
+                if (state.markedObserver) {
+                    state.markedObserver.disconnect();
+                    state.markedObserver = null;
+                }
+                state.markedElements = [];
+                if (state.rafHandle !== null && typeof cancelAnimationFrame === 'function') {
+                    cancelAnimationFrame(state.rafHandle);
+                }
+                state.rafScheduled = false;
+                state.rafHandle = null;
+                clearMarkers();
+            }
+
+            function markAncestors() {
+                const state = extractionState();
+                if (!window.__kasetYTVideoActive) { return false; }
+                const video = document.querySelector('#movie_player video') || document.querySelector('video');
+                if (!video) { return false; }
+
+                const visibleChain = [];
+                let current = video;
+                while (current && current !== document.documentElement) {
+                    visibleChain.push(current);
+                    current = current.parentElement;
+                }
+
+                document.querySelectorAll('.kaset-visible').forEach(function(el) {
+                    if (visibleChain.indexOf(el) === -1) {
                         el.classList.remove('kaset-visible');
+                    }
+                });
+                visibleChain.forEach(function(el) {
+                    el.classList.add('kaset-visible');
+                });
+                state.markedElements = visibleChain;
+                reobserveMarkedElements();
+                return true;
+            }
+
+            function reobserveMarkedElements() {
+                const state = extractionState();
+                if (!state.markedObserver) { return; }
+                state.markedObserver.disconnect();
+                state.markedElements.forEach(function(el) {
+                    state.markedObserver.observe(el, {
+                        attributes: true,
+                        attributeFilter: ['class', 'style', 'hidden']
                     });
+                });
+            }
 
-                    let current = video;
-                    while (current && current !== document.documentElement) {
-                        current.classList.add('kaset-visible');
-                        current = current.parentElement;
+            function runEnforcementFrame() {
+                const state = extractionState();
+                state.rafScheduled = false;
+                state.rafHandle = null;
+                if (!state.active || !window.__kasetYTVideoActive) { return; }
+                markAncestors();
+                state.remainingFrames -= 1;
+                if (state.remainingFrames > 0) {
+                    scheduleEnforcement(0);
+                }
+            }
+
+            function scheduleEnforcement(frameCount) {
+                const state = extractionState();
+                if (!state.active || !window.__kasetYTVideoActive) { return; }
+                state.remainingFrames = Math.max(state.remainingFrames, frameCount);
+                if (state.rafScheduled) { return; }
+                state.rafScheduled = true;
+                state.rafHandle = requestAnimationFrame(runEnforcementFrame);
+            }
+
+            function installObserver() {
+                const state = extractionState();
+                if (state.observer || typeof MutationObserver !== 'function') { return; }
+                const root = document.documentElement || document.body;
+                if (!root) { return; }
+                state.observer = new MutationObserver(function() {
+                    if (state.active && window.__kasetYTVideoActive) {
+                        scheduleEnforcement(MUTATION_ENFORCEMENT_FRAMES);
                     }
-                };
-
-                const enforce = function() {
-                    markAncestors();
-                    if (window.__kasetYTVideoActive) {
-                        requestAnimationFrame(enforce);
+                });
+                state.observer.observe(root, { childList: true, subtree: true });
+                state.markedObserver = new MutationObserver(function() {
+                    if (state.active && window.__kasetYTVideoActive) {
+                        scheduleEnforcement(1);
                     }
-                };
+                });
+                reobserveMarkedElements();
+            }
 
+            window.__kasetStopYTExtraction = stopExtraction;
+
+            window.__kasetExtractVideo = function() {
+                if (window.__kasetYTExtraction && window.__kasetYTExtraction.active) {
+                    stopExtraction();
+                }
+                ensureStyle();
+                const state = extractionState();
+                state.active = true;
                 window.__kasetYTVideoActive = true;
-                requestAnimationFrame(enforce);
+                installObserver();
+                scheduleEnforcement(MAX_ENFORCEMENT_FRAMES);
                 return { success: true };
             };
 

--- a/Sources/Kaset/Views/YouTube/YouTubeWatchWebView+Scripts.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeWatchWebView+Scripts.swift
@@ -195,7 +195,11 @@ extension YouTubeWatchWebView {
                 disableAutonav();
                 const video = videoEl();
                 if (!video) { return false; }
-                if (video.__kasetAttached) { return true; }
+                if (video.__kasetAttached) {
+                    applyPendingSeek(video);
+                    sendUpdate(true);
+                    return true;
+                }
                 video.__kasetAttached = true;
                 attachRetryCount = 0;
 

--- a/Sources/Kaset/Views/YouTube/YouTubeWatchWebView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeWatchWebView.swift
@@ -174,7 +174,7 @@ final class YouTubeWatchWebView {
         self.logger.info("Tearing down YouTube watch WebView")
         self.loadGeneration += 1
         self.currentVideoId = nil
-        webView.evaluateJavaScript("document.querySelector('video')?.pause()") { _, _ in }
+        webView.evaluateJavaScript("window.__kasetStopYTExtraction?.(); document.querySelector('video')?.pause()") { _, _ in }
         webView.loadHTMLString("", baseURL: nil)
         webView.removeFromSuperview()
         self.webKitManager?.extensionHostWebViewDidDeactivate(role: .youtubeWatch)

--- a/Tests/KasetTests/AccountServiceTests.swift
+++ b/Tests/KasetTests/AccountServiceTests.swift
@@ -924,7 +924,9 @@ struct AccountServiceTests {
         count: Int
     ) async {
         for _ in 0 ..< 1000 {
-            if mockWebKit.switchSessionIdentityCompletedBrandIds.count >= count { return }
+            if mockWebKit.switchSessionIdentityCompletedBrandIds.count >= count {
+                return
+            }
             await Task.yield()
         }
         Issue.record("Timed out waiting for switch session identity completions")
@@ -983,7 +985,9 @@ private actor AsyncReleaseGate {
     private var waiters: [UUID: CheckedContinuation<Void, Never>] = [:]
 
     func wait() async {
-        if self.released { return }
+        if self.released {
+            return
+        }
         let id = UUID()
         await withTaskCancellationHandler {
             await withCheckedContinuation { continuation in

--- a/Tests/KasetTests/AppDelegateDockMenuTests.swift
+++ b/Tests/KasetTests/AppDelegateDockMenuTests.swift
@@ -22,7 +22,9 @@ struct AppDelegateDockMenuTests {
 
     private func waitUntil(_ condition: @escaping @MainActor () -> Bool) async {
         for _ in 0 ..< 20 {
-            if condition() { return }
+            if condition() {
+                return
+            }
             try? await Task.sleep(for: .milliseconds(50))
         }
     }

--- a/Tests/KasetTests/ChartsViewModelTests.swift
+++ b/Tests/KasetTests/ChartsViewModelTests.swift
@@ -86,36 +86,41 @@ struct ChartsViewModelTests {
 
     // MARK: - Continuation Tests
 
-    @Test("Load triggers background continuation loading")
-    func loadTriggersBackgroundContinuation() async {
-        let initialSections = [TestFixtures.makeHomeSection(title: "Initial")]
-        let continuationSections = [TestFixtures.makeHomeSection(title: "More Charts")]
-
-        self.mockClient.chartsResponse = HomeResponse(sections: initialSections)
-        self.mockClient.chartsContinuationSections = [continuationSections]
+    @Test("Initial load does not drain chart continuations")
+    func initialLoadDoesNotDrainChartContinuations() async {
+        self.mockClient.chartsResponse = HomeResponse(sections: [TestFixtures.makeHomeSection(title: "Initial")])
+        self.mockClient.chartsContinuationSections = [[TestFixtures.makeHomeSection(title: "More Charts")]]
 
         await self.viewModel.load()
 
-        // Wait for background loading to complete
-        try? await Task.sleep(for: .milliseconds(500))
-
-        #expect(self.viewModel.sections.count == 2)
-        #expect(self.viewModel.sections[1].title == "More Charts")
+        #expect(self.viewModel.sections.map(\.title) == ["Initial"])
+        #expect(self.viewModel.hasMoreSections == true)
+        #expect(self.mockClient.getChartsContinuationCallCount == 0)
     }
 
-    @Test("hasMoreSections updates after continuations")
-    func hasMoreSectionsUpdatesAfterContinuations() async {
-        let initialSections = [TestFixtures.makeHomeSection(title: "Initial")]
+    @Test("Load more appends one charts continuation per demand")
+    func loadMoreAppendsOneChartsContinuationPerDemand() async {
+        self.mockClient.chartsResponse = HomeResponse(sections: [TestFixtures.makeHomeSection(title: "Initial")])
+        self.mockClient.chartsContinuationSections = [
+            [TestFixtures.makeHomeSection(title: "More Charts")],
+        ]
 
-        self.mockClient.chartsResponse = HomeResponse(sections: initialSections)
-        // No continuation sections
+        await self.viewModel.load()
+        await self.viewModel.loadMore()
+
+        #expect(self.viewModel.sections.map(\.title) == ["Initial", "More Charts"])
+        #expect(self.viewModel.hasMoreSections == false)
+        #expect(self.mockClient.getChartsContinuationCallCount == 1)
+    }
+
+    @Test("hasMoreSections is false without chart continuations")
+    func hasMoreSectionsIsFalseWithoutChartContinuations() async {
+        self.mockClient.chartsResponse = HomeResponse(sections: [TestFixtures.makeHomeSection(title: "Initial")])
 
         await self.viewModel.load()
 
-        // Wait for background loading to complete
-        try? await Task.sleep(for: .milliseconds(500))
-
         #expect(self.viewModel.hasMoreSections == false)
+        #expect(self.mockClient.getChartsContinuationCallCount == 0)
     }
 
     // MARK: - Refresh Tests
@@ -148,9 +153,8 @@ struct ChartsViewModelTests {
         ]
 
         await self.viewModel.load()
-        try? await Task.sleep(for: .milliseconds(500))
+        await self.viewModel.loadMore()
 
-        // After load, hasMoreSections should be false (continuations exhausted)
         #expect(self.viewModel.hasMoreSections == false)
 
         // Reset continuation for refresh

--- a/Tests/KasetTests/ColorExtractorTests.swift
+++ b/Tests/KasetTests/ColorExtractorTests.swift
@@ -63,6 +63,31 @@ struct ColorExtractorTests {
         #expect(requestCount == 2)
     }
 
+    @Test("Palette cache evicts least recently used entries at its count limit")
+    func paletteCacheEvictsLeastRecentlyUsedEntriesAtCountLimit() async throws {
+        let harness = try Self.makeHarness(path: "evict-a.png", maximumPaletteCount: 2)
+        defer { harness.cleanup() }
+        let responses = try [
+            #require(URL(string: "https://example.com/evict-a.png")): harness.data,
+            #require(URL(string: "https://example.com/evict-b.png")): Self.pngData(color: NSColor(calibratedRed: 0.10, green: 0.70, blue: 0.20, alpha: 1)),
+            #require(URL(string: "https://example.com/evict-c.png")): Self.pngData(color: NSColor(calibratedRed: 0.20, green: 0.30, blue: 0.80, alpha: 1)),
+        ]
+        MockURLProtocol.setRequestHandler(for: harness.session) { request in
+            let url = try #require(request.url)
+            return try Self.response(url: url, data: #require(responses[url]))
+        }
+
+        let secondURL = try #require(URL(string: "https://example.com/evict-b.png"))
+        let thirdURL = try #require(URL(string: "https://example.com/evict-c.png"))
+
+        _ = await harness.paletteCache.palette(for: harness.url, targetSize: CGSize(width: 32, height: 32))
+        _ = await harness.paletteCache.palette(for: secondURL, targetSize: CGSize(width: 32, height: 32))
+        _ = await harness.paletteCache.palette(for: harness.url, targetSize: CGSize(width: 32, height: 32))
+        _ = await harness.paletteCache.palette(for: thirdURL, targetSize: CGSize(width: 32, height: 32))
+
+        #expect(await harness.paletteCache.cachedPaletteCountForTesting == 2)
+    }
+
     private struct Harness {
         let data: Data
         let directPalette: ColorExtractor.ColorPalette
@@ -77,7 +102,7 @@ struct ColorExtractorTests {
         }
     }
 
-    private static func makeHarness(path: String) throws -> Harness {
+    private static func makeHarness(path: String, maximumPaletteCount: Int = 200) throws -> Harness {
         let data = try Self.pngData(color: NSColor(calibratedRed: 0.78, green: 0.20, blue: 0.12, alpha: 1))
         let image = try #require(NSImage(data: data))
         let directPalette = ColorExtractor.extractPalette(from: image)
@@ -95,7 +120,7 @@ struct ColorExtractorTests {
             directPalette: directPalette,
             url: url,
             session: session,
-            paletteCache: ColorPaletteCache(imageCache: imageCache),
+            paletteCache: ColorPaletteCache(imageCache: imageCache, maximumPaletteCount: maximumPaletteCount),
             directory: directory
         )
     }

--- a/Tests/KasetTests/ColorExtractorTests.swift
+++ b/Tests/KasetTests/ColorExtractorTests.swift
@@ -1,0 +1,153 @@
+import AppKit
+import Foundation
+import Testing
+@testable import Kaset
+
+@Suite("ColorExtractor")
+struct ColorExtractorTests {
+    @Test("Concurrent cached palette requests coalesce the image download")
+    func concurrentCachedPaletteRequestsCoalesceDownload() async throws {
+        let harness = try Self.makeHarness(path: "coalesce.png")
+        defer { harness.cleanup() }
+        nonisolated(unsafe) var requestCount = 0
+        MockURLProtocol.setRequestHandler(for: harness.session) { request in
+            requestCount += 1
+            if requestCount == 1 {
+                Thread.sleep(forTimeInterval: 0.05)
+            }
+            return try Self.response(url: #require(request.url), data: harness.data)
+        }
+
+        async let first = harness.paletteCache.palette(for: harness.url, targetSize: CGSize(width: 32, height: 32))
+        async let second = harness.paletteCache.palette(for: harness.url, targetSize: CGSize(width: 32, height: 32))
+        let palettes = await [first, second]
+
+        #expect(palettes == [harness.directPalette, harness.directPalette])
+        #expect(requestCount == 1)
+    }
+
+    @Test("Warm cached palette request does not hit the image loader again")
+    func warmCachedPaletteRequestAvoidsImageReload() async throws {
+        let harness = try Self.makeHarness(path: "warm.png")
+        defer { harness.cleanup() }
+        nonisolated(unsafe) var requestCount = 0
+        MockURLProtocol.setRequestHandler(for: harness.session) { request in
+            requestCount += 1
+            return try Self.response(url: #require(request.url), data: harness.data)
+        }
+
+        let first = await harness.paletteCache.palette(for: harness.url, targetSize: CGSize(width: 32, height: 32))
+        let second = await harness.paletteCache.palette(for: harness.url, targetSize: CGSize(width: 32, height: 32))
+
+        #expect(first == harness.directPalette)
+        #expect(second == first)
+        #expect(requestCount == 1)
+    }
+
+    @Test("Failed palette image load retries instead of caching default")
+    func failedPaletteImageLoadRetries() async throws {
+        let harness = try Self.makeHarness(path: "retry.png")
+        defer { harness.cleanup() }
+        nonisolated(unsafe) var requestCount = 0
+        MockURLProtocol.setRequestHandler(for: harness.session) { request in
+            requestCount += 1
+            let statusCode = requestCount == 1 ? 500 : 200
+            return try Self.response(url: #require(request.url), data: harness.data, statusCode: statusCode)
+        }
+
+        let first = await harness.paletteCache.palette(for: harness.url, targetSize: CGSize(width: 32, height: 32))
+        let second = await harness.paletteCache.palette(for: harness.url, targetSize: CGSize(width: 32, height: 32))
+
+        #expect(first == .default)
+        #expect(second == harness.directPalette)
+        #expect(requestCount == 2)
+    }
+
+    private struct Harness {
+        let data: Data
+        let directPalette: ColorExtractor.ColorPalette
+        let url: URL
+        let session: URLSession
+        let paletteCache: ColorPaletteCache
+        let directory: URL
+
+        func cleanup() {
+            MockURLProtocol.reset(session: self.session)
+            try? FileManager.default.removeItem(at: self.directory)
+        }
+    }
+
+    private static func makeHarness(path: String) throws -> Harness {
+        let data = try Self.pngData(color: NSColor(calibratedRed: 0.78, green: 0.20, blue: 0.12, alpha: 1))
+        let image = try #require(NSImage(data: data))
+        let directPalette = ColorExtractor.extractPalette(from: image)
+        let url = try #require(URL(string: "https://example.com/\(path)"))
+        let session = MockURLProtocol.makeMockSession()
+        let directory = try Self.makeTemporaryDirectory()
+        let imageCache = ImageCache(
+            diskCacheURL: directory,
+            startsEvictionTask: false,
+            monitorsMemoryPressure: false,
+            session: session
+        )
+        return Harness(
+            data: data,
+            directPalette: directPalette,
+            url: url,
+            session: session,
+            paletteCache: ColorPaletteCache(imageCache: imageCache),
+            directory: directory
+        )
+    }
+
+    private static func response(url: URL, data: Data, statusCode: Int = 200) throws -> (HTTPURLResponse, Data) {
+        let response = try #require(HTTPURLResponse(
+            url: url,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: ["Content-Type": "image/png"]
+        ))
+        return (response, data)
+    }
+
+    private static func makeTemporaryDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ColorExtractorTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    private static func pngData(color: NSColor) throws -> Data {
+        let size = 16
+        guard let rep = NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: size,
+            pixelsHigh: size,
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: size * 4,
+            bitsPerPixel: 32
+        ) else {
+            throw TestError.imageCreationFailed
+        }
+
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = NSGraphicsContext(bitmapImageRep: rep)
+        color.setFill()
+        NSRect(x: 0, y: 0, width: size, height: size).fill()
+        NSGraphicsContext.restoreGraphicsState()
+
+        guard let data = rep.representation(using: .png, properties: [:]) else {
+            throw TestError.imageEncodingFailed
+        }
+        return data
+    }
+
+    private enum TestError: Error {
+        case imageCreationFailed
+        case imageEncodingFailed
+    }
+}

--- a/Tests/KasetTests/ColorExtractorTests.swift
+++ b/Tests/KasetTests/ColorExtractorTests.swift
@@ -9,10 +9,9 @@ struct ColorExtractorTests {
     func concurrentCachedPaletteRequestsCoalesceDownload() async throws {
         let harness = try Self.makeHarness(path: "coalesce.png")
         defer { harness.cleanup() }
-        nonisolated(unsafe) var requestCount = 0
+        let requestCount = LockedCounter()
         MockURLProtocol.setRequestHandler(for: harness.session) { request in
-            requestCount += 1
-            if requestCount == 1 {
+            if requestCount.increment() == 1 {
                 Thread.sleep(forTimeInterval: 0.05)
             }
             return try Self.response(url: #require(request.url), data: harness.data)
@@ -23,16 +22,16 @@ struct ColorExtractorTests {
         let palettes = await [first, second]
 
         #expect(palettes == [harness.directPalette, harness.directPalette])
-        #expect(requestCount == 1)
+        #expect(requestCount.count == 1)
     }
 
     @Test("Warm cached palette request does not hit the image loader again")
     func warmCachedPaletteRequestAvoidsImageReload() async throws {
         let harness = try Self.makeHarness(path: "warm.png")
         defer { harness.cleanup() }
-        nonisolated(unsafe) var requestCount = 0
+        let requestCount = LockedCounter()
         MockURLProtocol.setRequestHandler(for: harness.session) { request in
-            requestCount += 1
+            requestCount.increment()
             return try Self.response(url: #require(request.url), data: harness.data)
         }
 
@@ -41,17 +40,16 @@ struct ColorExtractorTests {
 
         #expect(first == harness.directPalette)
         #expect(second == first)
-        #expect(requestCount == 1)
+        #expect(requestCount.count == 1)
     }
 
     @Test("Failed palette image load retries instead of caching default")
     func failedPaletteImageLoadRetries() async throws {
         let harness = try Self.makeHarness(path: "retry.png")
         defer { harness.cleanup() }
-        nonisolated(unsafe) var requestCount = 0
+        let requestCount = LockedCounter()
         MockURLProtocol.setRequestHandler(for: harness.session) { request in
-            requestCount += 1
-            let statusCode = requestCount == 1 ? 500 : 200
+            let statusCode = requestCount.increment() == 1 ? 500 : 200
             return try Self.response(url: #require(request.url), data: harness.data, statusCode: statusCode)
         }
 
@@ -60,7 +58,7 @@ struct ColorExtractorTests {
 
         #expect(first == .default)
         #expect(second == harness.directPalette)
-        #expect(requestCount == 2)
+        #expect(requestCount.count == 2)
     }
 
     @Test("Palette cache evicts least recently used entries at its count limit")

--- a/Tests/KasetTests/ExploreViewModelTests.swift
+++ b/Tests/KasetTests/ExploreViewModelTests.swift
@@ -56,6 +56,43 @@ struct ExploreViewModelTests {
         #expect(self.viewModel.sections.map(\.title) == ["Public explore"])
     }
 
+    @Test("Initial load does not drain explore continuations")
+    func initialLoadDoesNotDrainExploreContinuations() async {
+        self.mockClient.exploreResponse = HomeResponse(sections: [TestFixtures.makeHomeSection(title: "Initial")])
+        self.mockClient.exploreContinuationSections = [[TestFixtures.makeHomeSection(title: "Continuation")]]
+
+        await self.viewModel.load()
+
+        #expect(self.viewModel.sections.map(\.title) == ["Initial"])
+        #expect(self.viewModel.hasMoreSections == true)
+        #expect(self.mockClient.getExploreContinuationCallCount == 0)
+    }
+
+    @Test("Load more appends one filtered explore continuation per demand")
+    func loadMoreAppendsOneFilteredExploreContinuationPerDemand() async {
+        self.mockClient.exploreResponse = HomeResponse(sections: [TestFixtures.makeHomeSection(title: "Initial")])
+        self.mockClient.exploreContinuationSections = [
+            [
+                TestFixtures.makeHomeSection(title: "Charts"),
+                TestFixtures.makeHomeSection(title: "Continuation 1"),
+            ],
+            [TestFixtures.makeHomeSection(title: "Continuation 2")],
+        ]
+
+        await self.viewModel.load()
+        await self.viewModel.loadMore()
+
+        #expect(self.viewModel.sections.map(\.title) == ["Initial", "Continuation 1"])
+        #expect(self.viewModel.hasMoreSections == true)
+        #expect(self.mockClient.getExploreContinuationCallCount == 1)
+
+        await self.viewModel.loadMore()
+
+        #expect(self.viewModel.sections.map(\.title) == ["Initial", "Continuation 1", "Continuation 2"])
+        #expect(self.viewModel.hasMoreSections == false)
+        #expect(self.mockClient.getExploreContinuationCallCount == 2)
+    }
+
     @Test("Load error sets error state")
     func loadError() async {
         self.mockClient.shouldThrowError = YTMusicError.networkError(underlying: URLError(.timedOut))

--- a/Tests/KasetTests/Helpers/AsyncGate.swift
+++ b/Tests/KasetTests/Helpers/AsyncGate.swift
@@ -6,7 +6,9 @@ actor AsyncGate {
     private var waiters: [CheckedContinuation<Void, Never>] = []
 
     func wait() async {
-        if self.isOpen { return }
+        if self.isOpen {
+            return
+        }
         await withCheckedContinuation { continuation in
             self.waiters.append(continuation)
         }

--- a/Tests/KasetTests/Helpers/LockedCounter.swift
+++ b/Tests/KasetTests/Helpers/LockedCounter.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+final class LockedCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value = 0
+
+    @discardableResult
+    func increment() -> Int {
+        self.lock.withLock {
+            self.value += 1
+            return self.value
+        }
+    }
+
+    var count: Int {
+        self.lock.withLock { self.value }
+    }
+
+    var isEmpty: Bool {
+        self.lock.withLock { self.value == 0 }
+    }
+}

--- a/Tests/KasetTests/Helpers/MockYTMusicClient.swift
+++ b/Tests/KasetTests/Helpers/MockYTMusicClient.swift
@@ -76,6 +76,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     var unsubscribeFromArtistDelay: Duration?
     var rateSongDelay: Duration?
     var getSongDelay: Duration?
+    var getHistoryDelay: Duration?
     var getPodcastsDelay: Duration?
     var getPlaylistDelay: Duration?
     var playlistContinuationDelay: Duration?
@@ -405,6 +406,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     func getHistory() async throws -> HomeResponse {
         self.getHistoryCallCount += 1
         self._historyContinuationIndex = 0
+        if let getHistoryDelay {
+            try? await Task.sleep(for: getHistoryDelay)
+        }
         if let error = shouldThrowError {
             throw error
         }
@@ -1215,6 +1219,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.unsubscribeFromArtistDelay = nil
         self.rateSongDelay = nil
         self.getSongDelay = nil
+        self.getHistoryDelay = nil
         self.mixQueueDelay = nil
         self.getRadioQueueDelay = nil
         self.mixQueueResult = RadioQueueResult(songs: [], continuationToken: nil)

--- a/Tests/KasetTests/Helpers/MockYTMusicClient.swift
+++ b/Tests/KasetTests/Helpers/MockYTMusicClient.swift
@@ -171,6 +171,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     private(set) var getPersonalizedRecommendationsCallCount = 0
     private(set) var getPersonalizedRecommendationsContinuationCalled = false
     private(set) var getPersonalizedRecommendationsContinuationCallCount = 0
+    private(set) var getPodcastsContinuationCallCount = 0
     private(set) var getExploreCalled = false
     private(set) var getExploreCallCount = 0
     private(set) var getHistoryCallCount = 0
@@ -407,6 +408,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     }
 
     func getPodcastsContinuation() async throws -> [PodcastSection]? {
+        self.getPodcastsContinuationCallCount += 1
         if let error = shouldThrowError { throw error }
         guard self._podcastsContinuationIndex < self.podcastsContinuationSections.count else {
             return nil
@@ -1013,6 +1015,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.getPersonalizedRecommendationsCallCount = 0
         self.getPersonalizedRecommendationsContinuationCalled = false
         self.getPersonalizedRecommendationsContinuationCallCount = 0
+        self.getPodcastsContinuationCallCount = 0
         self._personalizedRecommendationsContinuationIndex = 0
         self.getExploreCalled = false
         self.getExploreCallCount = 0

--- a/Tests/KasetTests/Helpers/MockYTMusicClient.swift
+++ b/Tests/KasetTests/Helpers/MockYTMusicClient.swift
@@ -178,6 +178,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     private(set) var getExploreContinuationCallCount = 0
     private(set) var getChartsCalled = false
     private(set) var getChartsCallCount = 0
+    private(set) var getChartsContinuationCallCount = 0
+    private(set) var getMoodsAndGenresContinuationCallCount = 0
+    private(set) var getNewReleasesContinuationCallCount = 0
     private(set) var searchCalled = false
     private(set) var searchQueries: [String] = []
     private(set) var completedSearchEndpoints: [SearchEndpoint] = []
@@ -329,6 +332,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     }
 
     func getChartsContinuation() async throws -> [HomeSection]? {
+        self.getChartsContinuationCallCount += 1
         if let error = shouldThrowError { throw error }
         guard self._chartsContinuationIndex < self.chartsContinuationSections.count else {
             return nil
@@ -345,6 +349,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     }
 
     func getMoodsAndGenresContinuation() async throws -> [HomeSection]? {
+        self.getMoodsAndGenresContinuationCallCount += 1
         if let error = shouldThrowError { throw error }
         guard self._moodsAndGenresContinuationIndex < self.moodsAndGenresContinuationSections.count else {
             return nil
@@ -361,6 +366,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     }
 
     func getNewReleasesContinuation() async throws -> [HomeSection]? {
+        self.getNewReleasesContinuationCallCount += 1
         if let error = shouldThrowError { throw error }
         guard self._newReleasesContinuationIndex < self.newReleasesContinuationSections.count else {
             return nil
@@ -1015,6 +1021,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self._exploreContinuationIndex = 0
         self.getChartsCalled = false
         self.getChartsCallCount = 0
+        self.getChartsContinuationCallCount = 0
+        self.getMoodsAndGenresContinuationCallCount = 0
+        self.getNewReleasesContinuationCallCount = 0
         self._chartsContinuationIndex = 0
         self._moodsAndGenresContinuationIndex = 0
         self._newReleasesContinuationIndex = 0

--- a/Tests/KasetTests/Helpers/MockYTMusicClient.swift
+++ b/Tests/KasetTests/Helpers/MockYTMusicClient.swift
@@ -72,6 +72,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     var onGetLibraryContent: (@MainActor () -> Void)?
     var onGetPodcasts: (@MainActor () -> Void)?
     var beforeGetHomeReturn: (@MainActor () async -> Void)?
+    var beforeGetHomeContinuationReturn: (@MainActor () async -> Void)?
     var subscribeToArtistDelay: Duration?
     var unsubscribeFromArtistDelay: Duration?
     var rateSongDelay: Duration?
@@ -279,6 +280,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     func getHomeContinuation() async throws -> [HomeSection]? {
         self.getHomeContinuationCalled = true
         self.getHomeContinuationCallCount += 1
+        await self.beforeGetHomeContinuationReturn?()
         if let error = shouldThrowError {
             throw error
         }
@@ -1178,6 +1180,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         }
         self.onGetLibraryContent = nil
         self.beforeGetHomeReturn = nil
+        self.beforeGetHomeContinuationReturn = nil
         self.getLibraryPlaylistsCalled = false
         self.getLikedSongsCalled = false
         self.getLikedSongsContinuationCalled = false

--- a/Tests/KasetTests/Helpers/MockYTMusicClient.swift
+++ b/Tests/KasetTests/Helpers/MockYTMusicClient.swift
@@ -175,6 +175,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     private(set) var getExploreCalled = false
     private(set) var getExploreCallCount = 0
     private(set) var getHistoryCallCount = 0
+    private(set) var getHistoryContinuationCallCount = 0
     private(set) var getExploreContinuationCalled = false
     private(set) var getExploreContinuationCallCount = 0
     private(set) var getChartsCalled = false
@@ -388,6 +389,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     }
 
     func getHistoryContinuation() async throws -> [HomeSection]? {
+        self.getHistoryContinuationCallCount += 1
         if let error = shouldThrowError { throw error }
         guard self._historyContinuationIndex < self.historyContinuationSections.count else {
             return nil
@@ -1027,6 +1029,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.getChartsContinuationCallCount = 0
         self.getMoodsAndGenresContinuationCallCount = 0
         self.getNewReleasesContinuationCallCount = 0
+        self.getHistoryContinuationCallCount = 0
         self._chartsContinuationIndex = 0
         self._moodsAndGenresContinuationIndex = 0
         self._newReleasesContinuationIndex = 0

--- a/Tests/KasetTests/Helpers/MockYTMusicClient.swift
+++ b/Tests/KasetTests/Helpers/MockYTMusicClient.swift
@@ -71,6 +71,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     var defaultAddToPlaylistMenu = AddToPlaylistMenu(title: nil, options: [], canCreatePlaylist: false)
     var onGetLibraryContent: (@MainActor () -> Void)?
     var onGetPodcasts: (@MainActor () -> Void)?
+    var beforeGetHomeReturn: (@MainActor () async -> Void)?
     var subscribeToArtistDelay: Duration?
     var unsubscribeFromArtistDelay: Duration?
     var rateSongDelay: Duration?
@@ -261,8 +262,10 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.getHomeCalled = true
         self.getHomeCallCount += 1
         self._homeContinuationIndex = 0
+        let response = self.homeResponse
+        await self.beforeGetHomeReturn?()
         if let error = shouldThrowError { throw error }
-        return self.homeResponse
+        return response
     }
 
     func getHomeContinuation() async throws -> [HomeSection]? {
@@ -1033,6 +1036,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
             self.libraryContentResponseContinuations.removeFirst().resume()
         }
         self.onGetLibraryContent = nil
+        self.beforeGetHomeReturn = nil
         self.getLibraryPlaylistsCalled = false
         self.getLikedSongsCalled = false
         self.getLikedSongsContinuationCalled = false

--- a/Tests/KasetTests/Helpers/MockYTMusicClient.swift
+++ b/Tests/KasetTests/Helpers/MockYTMusicClient.swift
@@ -269,14 +269,18 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self._homeContinuationIndex = 0
         let response = self.homeResponse
         await self.beforeGetHomeReturn?()
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return response
     }
 
     func getHomeContinuation() async throws -> [HomeSection]? {
         self.getHomeContinuationCalled = true
         self.getHomeContinuationCallCount += 1
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         guard self._homeContinuationIndex < self.homeContinuationSections.count else {
             return nil
         }
@@ -289,14 +293,18 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.getPersonalizedRecommendationsCalled = true
         self.getPersonalizedRecommendationsCallCount += 1
         self._personalizedRecommendationsContinuationIndex = 0
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return self.personalizedRecommendationsResponse
     }
 
     func getPersonalizedRecommendationsContinuation() async throws -> [HomeSection]? {
         self.getPersonalizedRecommendationsContinuationCalled = true
         self.getPersonalizedRecommendationsContinuationCallCount += 1
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         guard self._personalizedRecommendationsContinuationIndex < self.personalizedRecommendationsContinuationSections.count else {
             return nil
         }
@@ -309,14 +317,18 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.getExploreCalled = true
         self.getExploreCallCount += 1
         self._exploreContinuationIndex = 0
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return self.exploreResponse
     }
 
     func getExploreContinuation() async throws -> [HomeSection]? {
         self.getExploreContinuationCalled = true
         self.getExploreContinuationCallCount += 1
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         guard self._exploreContinuationIndex < self.exploreContinuationSections.count else {
             return nil
         }
@@ -329,13 +341,17 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.getChartsCalled = true
         self.getChartsCallCount += 1
         self._chartsContinuationIndex = 0
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return self.chartsResponse
     }
 
     func getChartsContinuation() async throws -> [HomeSection]? {
         self.getChartsContinuationCallCount += 1
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         guard self._chartsContinuationIndex < self.chartsContinuationSections.count else {
             return nil
         }
@@ -346,13 +362,17 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
 
     func getMoodsAndGenres() async throws -> HomeResponse {
         self._moodsAndGenresContinuationIndex = 0
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return self.moodsAndGenresResponse
     }
 
     func getMoodsAndGenresContinuation() async throws -> [HomeSection]? {
         self.getMoodsAndGenresContinuationCallCount += 1
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         guard self._moodsAndGenresContinuationIndex < self.moodsAndGenresContinuationSections.count else {
             return nil
         }
@@ -363,13 +383,17 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
 
     func getNewReleases() async throws -> HomeResponse {
         self._newReleasesContinuationIndex = 0
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return self.newReleasesResponse
     }
 
     func getNewReleasesContinuation() async throws -> [HomeSection]? {
         self.getNewReleasesContinuationCallCount += 1
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         guard self._newReleasesContinuationIndex < self.newReleasesContinuationSections.count else {
             return nil
         }
@@ -381,7 +405,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     func getHistory() async throws -> HomeResponse {
         self.getHistoryCallCount += 1
         self._historyContinuationIndex = 0
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         if !self.historyResponseSequence.isEmpty {
             return self.historyResponseSequence.removeFirst()
         }
@@ -390,7 +416,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
 
     func getHistoryContinuation() async throws -> [HomeSection]? {
         self.getHistoryContinuationCallCount += 1
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         guard self._historyContinuationIndex < self.historyContinuationSections.count else {
             return nil
         }
@@ -405,13 +433,17 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         if let delay = self.getPodcastsDelay {
             try await Task.sleep(for: delay)
         }
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return self.podcastsSections
     }
 
     func getPodcastsContinuation() async throws -> [PodcastSection]? {
         self.getPodcastsContinuationCallCount += 1
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         guard self._podcastsContinuationIndex < self.podcastsContinuationSections.count else {
             return nil
         }
@@ -421,7 +453,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     }
 
     func getPodcastShow(browseId _: String) async throws -> PodcastShowDetail {
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return PodcastShowDetail(
             show: PodcastShow(id: "test", title: "Test Show", author: nil, description: nil, thumbnailURL: nil, episodeCount: nil),
             episodes: [],
@@ -431,7 +465,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     }
 
     func getPodcastEpisodesContinuation(token _: String) async throws -> PodcastEpisodesContinuation {
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return PodcastEpisodesContinuation(episodes: [], continuationToken: nil)
     }
 
@@ -441,7 +477,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self._searchContinuationIndex = 0
         await self.waitBeforeSearchReturn(query: query, endpoint: .mixed)
         defer { self.completedSearchEndpoints.append(.mixed) }
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return self.mixedSearchResponse ?? self.searchResponse
     }
 
@@ -450,7 +488,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.searchQueries.append(query)
         await self.waitBeforeSearchReturn(query: query, endpoint: .songs)
         defer { self.completedSearchEndpoints.append(.songs) }
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return (self.songsSearchResponse ?? self.searchResponse).songs
     }
 
@@ -460,7 +500,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self._searchContinuationIndex = 0
         await self.waitBeforeSearchReturn(query: query, endpoint: .songsWithPagination)
         defer { self.completedSearchEndpoints.append(.songsWithPagination) }
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         let hasMore = !self.searchContinuationResponses.isEmpty
         let response = self.songsSearchResponse ?? self.searchResponse
         return SearchResponse(
@@ -478,7 +520,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self._searchContinuationIndex = 0
         await self.waitBeforeSearchReturn(query: query, endpoint: .albums)
         defer { self.completedSearchEndpoints.append(.albums) }
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         let hasMore = !self.searchContinuationResponses.isEmpty
         let response = self.albumsSearchResponse ?? self.searchResponse
         return SearchResponse(
@@ -496,7 +540,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self._searchContinuationIndex = 0
         await self.waitBeforeSearchReturn(query: query, endpoint: .artists)
         defer { self.completedSearchEndpoints.append(.artists) }
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         let hasMore = !self.searchContinuationResponses.isEmpty
         let response = self.artistsSearchResponse ?? self.searchResponse
         return SearchResponse(
@@ -514,7 +560,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self._searchContinuationIndex = 0
         await self.waitBeforeSearchReturn(query: query, endpoint: .playlists)
         defer { self.completedSearchEndpoints.append(.playlists) }
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         let hasMore = !self.searchContinuationResponses.isEmpty
         let response = self.playlistsSearchResponse ?? self.searchResponse
         return SearchResponse(
@@ -532,7 +580,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self._searchContinuationIndex = 0
         await self.waitBeforeSearchReturn(query: query, endpoint: .featuredPlaylists)
         defer { self.completedSearchEndpoints.append(.featuredPlaylists) }
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         let hasMore = !self.searchContinuationResponses.isEmpty
         let response = self.featuredPlaylistsSearchResponse ?? self.searchResponse
         return SearchResponse(
@@ -550,7 +600,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self._searchContinuationIndex = 0
         await self.waitBeforeSearchReturn(query: query, endpoint: .communityPlaylists)
         defer { self.completedSearchEndpoints.append(.communityPlaylists) }
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         let hasMore = !self.searchContinuationResponses.isEmpty
         let response = self.communityPlaylistsSearchResponse ?? self.searchResponse
         return SearchResponse(
@@ -568,7 +620,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self._searchContinuationIndex = 0
         await self.waitBeforeSearchReturn(query: query, endpoint: .podcasts)
         defer { self.completedSearchEndpoints.append(.podcasts) }
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         let hasMore = !self.searchContinuationResponses.isEmpty
         let response = self.podcastsSearchResponse ?? self.searchResponse
         return SearchResponse(
@@ -582,7 +636,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     }
 
     func getSearchContinuation() async throws -> SearchResponse? {
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         guard self._searchContinuationIndex < self.searchContinuationResponses.count else {
             return nil
         }
@@ -612,13 +668,17 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     func getSearchSuggestions(query: String) async throws -> [SearchSuggestion] {
         self.getSearchSuggestionsCalled = true
         self.getSearchSuggestionsQueries.append(query)
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return self.searchSuggestions
     }
 
     func getLibraryPlaylists() async throws -> [Playlist] {
         self.getLibraryPlaylistsCalled = true
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return self.libraryPlaylists
     }
 
@@ -635,7 +695,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
             let delay = self.libraryContentResponseDelays.removeFirst()
             try? await Task.sleep(for: delay)
         }
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         if !self.libraryContentResponses.isEmpty {
             return self.libraryContentResponses.removeFirst()
         }
@@ -655,7 +717,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     func getLikedSongs() async throws -> LikedSongsResponse {
         self.getLikedSongsCalled = true
         self._likedSongsContinuationIndex = 0
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         let hasMore = !self.likedSongsContinuationSongs.isEmpty
         return LikedSongsResponse(songs: self.likedSongs, continuationToken: hasMore ? "mock-token" : nil)
     }
@@ -663,7 +727,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     func getLikedSongsContinuation() async throws -> LikedSongsResponse? {
         self.getLikedSongsContinuationCalled = true
         self.getLikedSongsContinuationCallCount += 1
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         guard self._likedSongsContinuationIndex < self.likedSongsContinuationSongs.count else {
             return nil
         }
@@ -679,7 +745,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         if let getPlaylistDelay {
             try? await Task.sleep(for: getPlaylistDelay)
         }
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         guard let detail = playlistDetails[id] else {
             throw YTMusicError.parseError(message: "Playlist not found: \(id)")
         }
@@ -701,7 +769,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         if let playlistContinuationDelay {
             try? await Task.sleep(for: playlistContinuationDelay)
         }
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         guard let (playlistId, index) = Self.parsePlaylistContinuationToken(token),
               let continuations = playlistContinuationTracks[playlistId],
               index < continuations.count
@@ -718,7 +788,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     }
 
     func getPlaylistAllTracks(playlistId: String) async throws -> [Song] {
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         if let tracks = self.playlistAllTracks[playlistId] {
             return tracks
         }
@@ -737,7 +809,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     func getArtist(id: String) async throws -> ArtistDetail {
         self.getArtistCalled = true
         self.getArtistIds.append(id)
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         guard let detail = artistDetails[id] else {
             throw YTMusicError.parseError(message: "Artist not found: \(id)")
         }
@@ -747,7 +821,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     func getArtistSongs(browseId: String, params _: String?) async throws -> [Song] {
         self.getArtistSongsCalled = true
         self.getArtistSongsBrowseIds.append(browseId)
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         // Return artistSongsResponse if set, otherwise fall back to dictionary lookup
         if !self.artistSongsResponse.isEmpty {
             return self.artistSongsResponse
@@ -756,12 +832,16 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     }
 
     func getArtistDiscography(browseId _: String, params _: String?) async throws -> [Album] {
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return []
     }
 
     func getArtistEpisodesList(browseId _: String, params _: String?) async throws -> [ArtistEpisode] {
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return []
     }
 
@@ -772,19 +852,25 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         if let rateSongDelay = self.rateSongDelay {
             try? await Task.sleep(for: rateSongDelay)
         }
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
     }
 
     func editSongLibraryStatus(feedbackTokens: [String]) async throws {
         self.editSongLibraryStatusCalled = true
         self.editSongLibraryStatusTokens.append(feedbackTokens)
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
     }
 
     func subscribeToPlaylist(playlistId: String) async throws {
         self.subscribeToPlaylistCalled = true
         self.subscribeToPlaylistIds.append(playlistId)
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
 
         let playlistKey = LibraryContentIdentity.playlistKey(for: playlistId)
         if self.shouldAutoUpdatePlaylistLibraryOnMutation,
@@ -797,7 +883,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     func deletePlaylist(playlistId: String) async throws {
         self.deletePlaylistCalled = true
         self.deletePlaylistIds.append(playlistId)
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
 
         let playlistKey = LibraryContentIdentity.playlistKey(for: playlistId)
         if self.shouldAutoUpdatePlaylistLibraryOnMutation {
@@ -811,7 +899,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
 
     func getAddToPlaylistOptions(videoId: String) async throws -> AddToPlaylistMenu {
         self.getAddToPlaylistOptionsVideoIds.append(videoId)
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return self.addToPlaylistMenus[videoId] ?? self.defaultAddToPlaylistMenu
     }
 
@@ -827,13 +917,17 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
             privacyStatus: privacyStatus,
             videoIds: videoIds
         ))
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return "PLCREATED"
     }
 
     func addSongToPlaylist(videoId: String, playlistId: String, allowDuplicate: Bool) async throws {
         self.addSongToPlaylistCalls.append(AddSongToPlaylistCall(videoId: videoId, playlistId: playlistId, allowDuplicate: allowDuplicate))
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
 
         let playlistKey = LibraryContentIdentity.playlistKey(for: playlistId)
         guard self.shouldAutoUpdatePlaylistLibraryOnMutation,
@@ -862,7 +956,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     func unsubscribeFromPlaylist(playlistId: String) async throws {
         self.unsubscribeFromPlaylistCalled = true
         self.unsubscribeFromPlaylistIds.append(playlistId)
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
 
         let playlistKey = LibraryContentIdentity.playlistKey(for: playlistId)
         if self.shouldAutoUpdatePlaylistLibraryOnMutation {
@@ -871,7 +967,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     }
 
     func subscribeToPodcast(showId: String) async throws {
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         // Validate podcast show ID format (mirrors real YTMusicClient behavior)
         if showId.hasPrefix("MPSPP") {
             let suffix = String(showId.dropFirst(5))
@@ -891,7 +989,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     }
 
     func unsubscribeFromPodcast(showId: String) async throws {
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         // Validate podcast show ID format (mirrors real YTMusicClient behavior)
         if showId.hasPrefix("MPSPP") {
             let suffix = String(showId.dropFirst(5))
@@ -914,7 +1014,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         if let delay = self.subscribeToArtistDelay {
             try? await Task.sleep(for: delay)
         }
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
 
         let artistKey = LibraryContentIdentity.artistKey(for: channelId)
         let artist = self.artistDetails.values.first(where: { $0.channelId == channelId })?.artist
@@ -933,7 +1035,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         if let delay = self.unsubscribeFromArtistDelay {
             try? await Task.sleep(for: delay)
         }
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
 
         let artistKey = LibraryContentIdentity.artistKey(for: channelId)
         if self.shouldAutoUpdateArtistLibraryOnMutation {
@@ -944,12 +1048,16 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     func getLyrics(videoId: String) async throws -> Lyrics {
         self.getLyricsCalled = true
         self.getLyricsVideoIds.append(videoId)
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return self.lyricsResponses[videoId] ?? .unavailable
     }
 
     func getTimedLyrics(videoId _: String) async throws -> LyricResult {
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return .unavailable
     }
 
@@ -959,7 +1067,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         if let getSongDelay = self.getSongDelay {
             try? await Task.sleep(for: getSongDelay)
         }
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return self.songResponses[videoId] ?? Song(
             id: videoId,
             title: "Mock Song",
@@ -974,8 +1084,12 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         if let getRadioQueueDelay {
             try? await Task.sleep(for: getRadioQueueDelay)
         }
-        if let error = shouldThrowError { throw error }
-        if let error = radioQueueErrors[videoId] { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
+        if let error = radioQueueErrors[videoId] {
+            throw error
+        }
         return self.radioQueueSongs[videoId] ?? []
     }
 
@@ -983,24 +1097,32 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         if let mixQueueDelay {
             try? await Task.sleep(for: mixQueueDelay)
         }
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return self.mixQueueResult
     }
 
     func getMixQueueContinuation(continuationToken _: String) async throws -> RadioQueueResult {
         self.getMixQueueContinuationCallCount += 1
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return self.mixQueueContinuationResult
     }
 
     func getMoodCategory(browseId _: String, params _: String?) async throws -> HomeResponse {
         self.moodCategoryCalled = true
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return self.moodCategoryResponse
     }
 
     func fetchAccountsList() async throws -> AccountsListResponse {
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return self.accountsListResponse
     }
 

--- a/Tests/KasetTests/Helpers/MockYouTubeClient.swift
+++ b/Tests/KasetTests/Helpers/MockYouTubeClient.swift
@@ -60,13 +60,17 @@ final class MockYouTubeClient: YouTubeClientProtocol {
     // MARK: - YouTubeClientProtocol
 
     func getHomeFeed() async throws -> YouTubeFeed {
-        if let error { throw error }
+        if let error {
+            throw error
+        }
         self.homeFeedCallCount += 1
         return self.homeFeed
     }
 
     func getHomeBundle() async throws -> YouTubeHomeBundle {
-        if let error { throw error }
+        if let error {
+            throw error
+        }
         // One call stands in for the single coalesced fetch: count it like a
         // home-feed fetch so call-count assertions read naturally, and assemble
         // the bundle from the same fixtures the individual getters use.
@@ -84,7 +88,9 @@ final class MockYouTubeClient: YouTubeClientProtocol {
     var beforeContinuationReturn: (@Sendable () async -> Void)?
 
     func getHomeFeedContinuation() async throws -> YouTubeFeed? {
-        if let error { throw error }
+        if let error {
+            throw error
+        }
         if let beforeContinuationReturn {
             await beforeContinuationReturn()
         }
@@ -100,13 +106,17 @@ final class MockYouTubeClient: YouTubeClientProtocol {
     private(set) var requestedTopicContinuations: [String] = []
 
     func getHomeChips() async throws -> [YouTubeHomeChip] {
-        if let error { throw error }
+        if let error {
+            throw error
+        }
         self.homeChipsCallCount += 1
         return self.homeChips
     }
 
     func getHomeShelves() async throws -> [YouTubeHomeSection] {
-        if let error { throw error }
+        if let error {
+            throw error
+        }
         return self.homeShelves
     }
 
@@ -116,7 +126,9 @@ final class MockYouTubeClient: YouTubeClientProtocol {
     var beforeTopicReturn: (@Sendable (String) async -> Void)?
 
     func getHomeTopicFeed(continuation: String) async throws -> YouTubeFeed {
-        if let error { throw error }
+        if let error {
+            throw error
+        }
         self.requestedTopicContinuations.append(continuation)
         if let beforeTopicReturn {
             await beforeTopicReturn(continuation)
@@ -132,7 +144,9 @@ final class MockYouTubeClient: YouTubeClientProtocol {
     var beforeSearchReturn: (@Sendable (String, YouTubeSearchFilter) async -> Void)?
 
     func search(query: String, filter: YouTubeSearchFilter) async throws -> YouTubeSearchResponse {
-        if let error { throw error }
+        if let error {
+            throw error
+        }
         self.searchCallCount += 1
         self.lastSearchQuery = query
         self.lastSearchFilter = filter
@@ -153,7 +167,9 @@ final class MockYouTubeClient: YouTubeClientProtocol {
     }
 
     func getSearchContinuation(continuation _: String) async throws -> YouTubeSearchResponse? {
-        if let error { throw error }
+        if let error {
+            throw error
+        }
         let response = self.searchContinuation
         if let beforeSearchContinuationReturn {
             await beforeSearchContinuationReturn()
@@ -165,7 +181,9 @@ final class MockYouTubeClient: YouTubeClientProtocol {
     }
 
     func getWatchNext(videoId _: String) async throws -> WatchNextData {
-        if let error { throw error }
+        if let error {
+            throw error
+        }
         return self.watchNextData
     }
 
@@ -174,26 +192,36 @@ final class MockYouTubeClient: YouTubeClientProtocol {
     private(set) var lastCommentsContinuation: String?
 
     func getComments(continuation: String) async throws -> YouTubeCommentsPage {
-        if let error { throw error }
+        if let error {
+            throw error
+        }
         self.lastCommentsContinuation = continuation
         return self.commentsPage
     }
 
     func postComment(text: String, createCommentParams: String) async throws {
-        if let error { throw error }
+        if let error {
+            throw error
+        }
         self.postedComments.append((text, createCommentParams))
     }
 
     private(set) var performedCommentActions: [String] = []
 
     func performCommentAction(_ action: String) async throws {
-        if let error { throw error }
+        if let error {
+            throw error
+        }
         self.performedCommentActions.append(action)
     }
 
     func getChannel(channelId: String) async throws -> YouTubeChannelDetail {
-        if let error { throw error }
-        if let channelDetail { return channelDetail }
+        if let error {
+            throw error
+        }
+        if let channelDetail {
+            return channelDetail
+        }
         return YouTubeChannelDetail(
             channel: YouTubeChannel(channelId: channelId, name: "Mock Channel"),
             videos: []
@@ -201,8 +229,12 @@ final class MockYouTubeClient: YouTubeClientProtocol {
     }
 
     func getPlaylist(playlistId: String) async throws -> YouTubePlaylistDetail {
-        if let error { throw error }
-        if let playlistDetail { return playlistDetail }
+        if let error {
+            throw error
+        }
+        if let playlistDetail {
+            return playlistDetail
+        }
         return YouTubePlaylistDetail(
             playlist: YouTubePlaylist(playlistId: playlistId, title: "Mock Playlist"),
             videos: []
@@ -228,20 +260,26 @@ final class MockYouTubeClient: YouTubeClientProtocol {
     var shorts: [YouTubeVideo] = []
 
     func getDestinationFeed(_ destination: YouTubeDestination) async throws -> YouTubeFeed {
-        if let error { throw error }
+        if let error {
+            throw error
+        }
         self.destinationFeedCallCount += 1
         self.lastDestination = destination
         return self.destinationFeed
     }
 
     func getShorts() async throws -> [YouTubeVideo] {
-        if let error { throw error }
+        if let error {
+            throw error
+        }
         self.shortsCallCount += 1
         return self.shorts
     }
 
     func getFeedContinuation(continuation: String) async throws -> YouTubeFeed {
-        if let error { throw error }
+        if let error {
+            throw error
+        }
         self.lastFeedContinuation = continuation
         return self.feedContinuation
     }
@@ -251,12 +289,16 @@ final class MockYouTubeClient: YouTubeClientProtocol {
     }
 
     func getSubscriptionsFeed() async throws -> YouTubeFeed {
-        if let error { throw error }
+        if let error {
+            throw error
+        }
         return self.subscriptionsFeed
     }
 
     func getSubscribedChannels() async throws -> [YouTubeChannel] {
-        if let error { throw error }
+        if let error {
+            throw error
+        }
         return self.subscribedChannels
     }
 
@@ -282,7 +324,9 @@ final class MockYouTubeClient: YouTubeClientProtocol {
     var historyForceRefreshFeed: YouTubeFeed?
 
     func getHistory(forceRefresh: Bool) async throws -> YouTubeFeed {
-        if let error { throw error }
+        if let error {
+            throw error
+        }
         self.getHistoryCallCount += 1
         if forceRefresh {
             self.getHistoryForceRefreshCount += 1
@@ -300,27 +344,37 @@ final class MockYouTubeClient: YouTubeClientProtocol {
     }
 
     func getUserPlaylists() async throws -> [YouTubePlaylist] {
-        if let error { throw error }
+        if let error {
+            throw error
+        }
         return self.userPlaylists
     }
 
     func rateVideo(videoId: String, rating: YouTubeRating) async throws {
-        if let error { throw error }
+        if let error {
+            throw error
+        }
         self.ratedVideos.append((videoId, rating))
     }
 
     func setSubscribed(_ subscribed: Bool, channelId: String) async throws {
-        if let error { throw error }
+        if let error {
+            throw error
+        }
         self.subscriptionChanges.append((channelId, subscribed))
     }
 
     func addToWatchLater(videoId: String) async throws {
-        if let error { throw error }
+        if let error {
+            throw error
+        }
         self.watchLaterAdds.append(videoId)
     }
 
     func removeFromWatchLater(videoId: String) async throws {
-        if let error { throw error }
+        if let error {
+            throw error
+        }
         self.watchLaterRemovals.append(videoId)
     }
 

--- a/Tests/KasetTests/Helpers/MockYouTubeClient.swift
+++ b/Tests/KasetTests/Helpers/MockYouTubeClient.swift
@@ -11,9 +11,11 @@ final class MockYouTubeClient: YouTubeClientProtocol {
     var homeChips: [YouTubeHomeChip] = []
     var homeShelves: [YouTubeHomeSection] = []
     /// Topic feeds keyed by chip continuation; `getHomeTopicFeed` returns the
-    /// match (or `.empty`). Set `homeTopicError` to make one continuation throw.
+    /// match (or `.empty`). Configure one or more continuation-specific errors
+    /// to exercise partial and batch-wide failures.
     var homeTopicFeeds: [String: YouTubeFeed] = [:]
     var homeTopicError: (continuation: String, error: Error)?
+    var homeTopicErrors: [String: Error] = [:]
     var searchResponse = YouTubeSearchResponse.empty
     var searchResponsesByRequest: [String: YouTubeSearchResponse] = [:]
     var searchContinuation: YouTubeSearchResponse?
@@ -132,6 +134,9 @@ final class MockYouTubeClient: YouTubeClientProtocol {
         self.requestedTopicContinuations.append(continuation)
         if let beforeTopicReturn {
             await beforeTopicReturn(continuation)
+        }
+        if let error = self.homeTopicErrors[continuation] {
+            throw error
         }
         if let homeTopicError, homeTopicError.continuation == continuation {
             throw homeTopicError.error

--- a/Tests/KasetTests/HistoryViewModelTests.swift
+++ b/Tests/KasetTests/HistoryViewModelTests.swift
@@ -168,6 +168,31 @@ struct HistoryViewModelTests {
         #expect(self.mockClient.getHistoryContinuationCallCount == 3)
     }
 
+    @Test("Load more is blocked while refresh rewinds the history cursor")
+    func loadMoreBlockedWhileRefreshRewindsHistoryCursor() async {
+        let initialSection = TestFixtures.makeHomeSection(id: "today", title: "Today")
+        let yesterdaySection = TestFixtures.makeHomeSection(id: "yesterday", title: "Yesterday")
+        let olderSection = TestFixtures.makeHomeSection(id: "older", title: "Older")
+        self.mockClient.historyResponse = HomeResponse(sections: [initialSection])
+        self.mockClient.historyContinuationSections = [[yesterdaySection], [olderSection]]
+
+        await self.viewModel.load()
+        await self.viewModel.loadMore()
+        #expect(self.viewModel.sections.map(\.title) == ["Today", "Yesterday"])
+
+        self.mockClient.getHistoryDelay = .milliseconds(100)
+        let refreshTask = Task { await self.viewModel.refresh() }
+        await self.waitForHistoryRefresh {
+            self.mockClient.getHistoryCallCount == 2
+        }
+
+        await self.viewModel.loadMore()
+        _ = await refreshTask.value
+
+        #expect(self.mockClient.getHistoryContinuationCallCount == 1)
+        #expect(self.viewModel.sections.map(\.title) == ["Today", "Yesterday"])
+    }
+
     @Test("Empty history retry leaves loading state loaded")
     func emptyHistoryRetryLeavesLoadedState() async {
         self.mockClient.shouldThrowError = YTMusicError.networkError(underlying: URLError(.notConnectedToInternet))

--- a/Tests/KasetTests/HistoryViewModelTests.swift
+++ b/Tests/KasetTests/HistoryViewModelTests.swift
@@ -16,23 +16,6 @@ struct HistoryViewModelTests {
         HistoryViewModel.playbackRefreshRetryDelay = .seconds(2)
     }
 
-    private func waitForBackgroundLoading(
-        timeout: Duration = .seconds(3),
-        until condition: @escaping () -> Bool
-    ) async {
-        let clock = ContinuousClock()
-        let deadline = clock.now + timeout
-
-        while clock.now < deadline {
-            if condition() {
-                return
-            }
-            try? await Task.sleep(for: .milliseconds(25))
-        }
-
-        Issue.record("Timed out waiting for background history loading")
-    }
-
     private func waitForHistoryRefresh(
         timeout: Duration = .seconds(3),
         until condition: @escaping () -> Bool
@@ -72,6 +55,42 @@ struct HistoryViewModelTests {
         #expect(self.viewModel.sections[1].title == "Yesterday")
     }
 
+    @Test("Initial load does not drain history continuations")
+    func initialLoadDoesNotDrainHistoryContinuations() async {
+        let initialSection = TestFixtures.makeHomeSection(id: "today", title: "Today")
+        let paginatedSection = TestFixtures.makeHomeSection(id: "yesterday", title: "Yesterday")
+        self.mockClient.historyResponse = HomeResponse(sections: [initialSection])
+        self.mockClient.historyContinuationSections = [[paginatedSection]]
+
+        await self.viewModel.load()
+
+        #expect(self.viewModel.sections.map(\.title) == ["Today"])
+        #expect(self.viewModel.hasMoreSections == true)
+        #expect(self.mockClient.getHistoryContinuationCallCount == 0)
+    }
+
+    @Test("Load more appends one history continuation per demand")
+    func loadMoreAppendsOneHistoryContinuationPerDemand() async {
+        let initialSection = TestFixtures.makeHomeSection(id: "today", title: "Today")
+        let yesterdaySection = TestFixtures.makeHomeSection(id: "yesterday", title: "Yesterday")
+        let olderSection = TestFixtures.makeHomeSection(id: "older", title: "Older")
+        self.mockClient.historyResponse = HomeResponse(sections: [initialSection])
+        self.mockClient.historyContinuationSections = [[yesterdaySection], [olderSection]]
+
+        await self.viewModel.load()
+        await self.viewModel.loadMore()
+
+        #expect(self.viewModel.sections.map(\.title) == ["Today", "Yesterday"])
+        #expect(self.viewModel.hasMoreSections == true)
+        #expect(self.mockClient.getHistoryContinuationCallCount == 1)
+
+        await self.viewModel.loadMore()
+
+        #expect(self.viewModel.sections.map(\.title) == ["Today", "Yesterday", "Older"])
+        #expect(self.viewModel.hasMoreSections == false)
+        #expect(self.mockClient.getHistoryContinuationCallCount == 2)
+    }
+
     @Test("Load error sets error state")
     func loadError() async {
         self.mockClient.shouldThrowError = YTMusicError.networkError(underlying: URLError(.notConnectedToInternet))
@@ -107,35 +126,34 @@ struct HistoryViewModelTests {
         self.mockClient.historyContinuationSections = [[paginatedSection]]
 
         await self.viewModel.load()
-        await self.waitForBackgroundLoading {
-            self.viewModel.sections.map(\.title) == ["Today", "Yesterday"] &&
-                self.viewModel.hasMoreSections == false
-        }
+        await self.viewModel.loadMore()
 
         #expect(self.viewModel.sections.map(\.title) == ["Today", "Yesterday"])
         #expect(self.viewModel.hasMoreSections == false)
+        #expect(self.mockClient.getHistoryContinuationCallCount == 1)
 
         let changed = await self.viewModel.refresh()
 
         #expect(changed == false)
         #expect(self.viewModel.loadingState == .loaded)
+        #expect(self.viewModel.hasMoreSections == true)
         #expect(self.viewModel.sections.map(\.title) == ["Today", "Yesterday"])
+        #expect(self.mockClient.getHistoryContinuationCallCount == 1)
     }
 
-    @Test("Refresh restarts background pagination after history cursor rewind")
-    func refreshRestartsBackgroundPaginationAfterCursorRewind() async {
+    @Test("Load more after unchanged refresh skips preserved cursor pages")
+    func loadMoreAfterUnchangedRefreshSkipsPreservedCursorPages() async {
         let initialSection = TestFixtures.makeHomeSection(id: "today", title: "Today")
-        let paginatedSection = TestFixtures.makeHomeSection(id: "yesterday", title: "Yesterday")
+        let yesterdaySection = TestFixtures.makeHomeSection(id: "yesterday", title: "Yesterday")
+        let olderSection = TestFixtures.makeHomeSection(id: "older", title: "Older")
         self.mockClient.historyResponse = HomeResponse(sections: [initialSection])
-        self.mockClient.historyContinuationSections = [[paginatedSection]]
+        self.mockClient.historyContinuationSections = [[yesterdaySection], [olderSection]]
 
         await self.viewModel.load()
-        await self.waitForBackgroundLoading {
-            self.viewModel.sections.map(\.title) == ["Today", "Yesterday"] &&
-                self.viewModel.hasMoreSections == false
-        }
+        await self.viewModel.loadMore()
 
-        #expect(self.viewModel.hasMoreSections == false)
+        #expect(self.viewModel.sections.map(\.title) == ["Today", "Yesterday"])
+        #expect(self.viewModel.hasMoreSections == true)
 
         let changed = await self.viewModel.refresh()
 
@@ -143,13 +161,11 @@ struct HistoryViewModelTests {
         #expect(self.viewModel.hasMoreSections == true)
         #expect(self.viewModel.sections.map(\.title) == ["Today", "Yesterday"])
 
-        await self.waitForBackgroundLoading {
-            self.viewModel.hasMoreSections == false &&
-                self.viewModel.sections.map(\.title) == ["Today", "Yesterday"]
-        }
+        await self.viewModel.loadMore()
 
+        #expect(self.viewModel.sections.map(\.title) == ["Today", "Yesterday", "Older"])
         #expect(self.viewModel.hasMoreSections == false)
-        #expect(self.viewModel.sections.map(\.title) == ["Today", "Yesterday"])
+        #expect(self.mockClient.getHistoryContinuationCallCount == 3)
     }
 
     @Test("Empty history retry leaves loading state loaded")

--- a/Tests/KasetTests/HomeViewModelTests.swift
+++ b/Tests/KasetTests/HomeViewModelTests.swift
@@ -77,6 +77,31 @@ struct HomeViewModelTests {
         #expect(self.mockClient.getHomeContinuationCallCount == 2)
     }
 
+    @Test("Load does not overlap an in-flight home continuation")
+    func loadDoesNotOverlapInFlightContinuation() async {
+        let continuationGate = AsyncGate()
+        self.mockClient.homeResponse = HomeResponse(sections: [TestFixtures.makeHomeSection(title: "Initial")])
+        self.mockClient.homeContinuationSections = [
+            [TestFixtures.makeHomeSection(title: "Continuation")],
+        ]
+        self.mockClient.beforeGetHomeContinuationReturn = {
+            await continuationGate.wait()
+        }
+
+        await self.viewModel.load()
+        let continuationLoad = Task { await self.viewModel.loadMore() }
+        while self.mockClient.getHomeContinuationCallCount == 0 {
+            await Task.yield()
+        }
+
+        await self.viewModel.load()
+
+        #expect(self.mockClient.getHomeCallCount == 1)
+        await continuationGate.open()
+        await continuationLoad.value
+        #expect(self.viewModel.sections.map(\.title) == ["Initial", "Continuation"])
+    }
+
     @Test("Load error sets error state")
     func loadError() async {
         self.mockClient.shouldThrowError = YTMusicError.networkError(underlying: URLError(.notConnectedToInternet))
@@ -143,5 +168,62 @@ struct HomeViewModelTests {
         #expect(self.viewModel.loadingState == .loaded)
         #expect(self.viewModel.sections.map(\.title) == ["Refreshed"])
         #expect(self.mockClient.getHomeCallCount == 2)
+    }
+
+    @Test("Concurrent refreshes coalesce after an in-flight home load")
+    func concurrentRefreshesCoalesceAfterInFlightLoad() async {
+        let initialLoadGate = AsyncGate()
+        self.mockClient.homeResponse = HomeResponse(sections: [TestFixtures.makeHomeSection(title: "Initial")])
+        self.mockClient.beforeGetHomeReturn = { [mockClient = self.mockClient] in
+            if mockClient.getHomeCallCount == 1 {
+                await initialLoadGate.wait()
+            }
+        }
+
+        let initialLoad = Task { await self.viewModel.load() }
+        while self.mockClient.getHomeCallCount == 0 {
+            await Task.yield()
+        }
+
+        self.mockClient.homeResponse = HomeResponse(sections: [TestFixtures.makeHomeSection(title: "Refreshed")])
+        let firstRefresh = Task { await self.viewModel.refresh() }
+        let secondRefresh = Task { await self.viewModel.refresh() }
+
+        await initialLoadGate.open()
+        await firstRefresh.value
+        await secondRefresh.value
+        await initialLoad.value
+
+        #expect(self.viewModel.loadingState == .loaded)
+        #expect(self.viewModel.sections.map(\.title) == ["Refreshed"])
+        #expect(self.mockClient.getHomeCallCount == 2)
+    }
+
+    @Test("Refresh requested after an active refresh fetch runs a follow-up")
+    func laterRefreshDuringActiveRefreshRunsFollowUp() async {
+        let firstRefreshGate = AsyncGate()
+        self.mockClient.homeResponse = HomeResponse(sections: [TestFixtures.makeHomeSection(title: "Old Account")])
+        self.mockClient.beforeGetHomeReturn = { [mockClient = self.mockClient] in
+            if mockClient.getHomeCallCount == 1 {
+                await firstRefreshGate.wait()
+            }
+        }
+
+        let firstRefresh = Task { await self.viewModel.refresh() }
+        while self.mockClient.getHomeCallCount == 0 {
+            await Task.yield()
+        }
+
+        self.mockClient.homeResponse = HomeResponse(sections: [TestFixtures.makeHomeSection(title: "New Account")])
+        let laterRefresh = Task { await self.viewModel.refresh() }
+        await Task.yield()
+        #expect(self.mockClient.getHomeCallCount == 1)
+
+        await firstRefreshGate.open()
+        await firstRefresh.value
+        await laterRefresh.value
+
+        #expect(self.mockClient.getHomeCallCount == 2)
+        #expect(self.viewModel.sections.map(\.title) == ["New Account"])
     }
 }

--- a/Tests/KasetTests/HomeViewModelTests.swift
+++ b/Tests/KasetTests/HomeViewModelTests.swift
@@ -37,6 +37,46 @@ struct HomeViewModelTests {
         #expect(self.viewModel.sections[1].title == "Recommended")
     }
 
+    @Test("Initial home load does not drain continuations in the background")
+    func initialLoadDoesNotDrainContinuationsInBackground() async {
+        self.mockClient.homeResponse = HomeResponse(sections: [TestFixtures.makeHomeSection(title: "Initial")])
+        self.mockClient.homeContinuationSections = [
+            [TestFixtures.makeHomeSection(title: "Continuation 1")],
+            [TestFixtures.makeHomeSection(title: "Continuation 2")],
+        ]
+
+        await self.viewModel.load()
+
+        #expect(self.viewModel.loadingState == .loaded)
+        #expect(self.viewModel.sections.map(\.title) == ["Initial"])
+        #expect(self.viewModel.hasMoreSections == true)
+        #expect(self.mockClient.getHomeContinuationCallCount == 0)
+    }
+
+    @Test("Load more fetches one home continuation per demand")
+    func loadMoreFetchesOneHomeContinuationPerDemand() async {
+        self.mockClient.homeResponse = HomeResponse(sections: [TestFixtures.makeHomeSection(title: "Initial")])
+        self.mockClient.homeContinuationSections = [
+            [TestFixtures.makeHomeSection(title: "Continuation 1")],
+            [TestFixtures.makeHomeSection(title: "Continuation 2")],
+        ]
+
+        await self.viewModel.load()
+        await self.viewModel.loadMore()
+
+        #expect(self.viewModel.loadingState == .loaded)
+        #expect(self.viewModel.sections.map(\.title) == ["Initial", "Continuation 1"])
+        #expect(self.viewModel.hasMoreSections == true)
+        #expect(self.mockClient.getHomeContinuationCallCount == 1)
+
+        await self.viewModel.loadMore()
+
+        #expect(self.viewModel.loadingState == .loaded)
+        #expect(self.viewModel.sections.map(\.title) == ["Initial", "Continuation 1", "Continuation 2"])
+        #expect(self.viewModel.hasMoreSections == false)
+        #expect(self.mockClient.getHomeContinuationCallCount == 2)
+    }
+
     @Test("Load error sets error state")
     func loadError() async {
         self.mockClient.shouldThrowError = YTMusicError.networkError(underlying: URLError(.notConnectedToInternet))
@@ -73,6 +113,35 @@ struct HomeViewModelTests {
         await self.viewModel.refresh()
 
         #expect(self.viewModel.sections.count == 3)
+        #expect(self.mockClient.getHomeCallCount == 2)
+    }
+
+    @Test("Refresh replaces an in-flight home load")
+    func refreshReplacesInFlightHomeLoad() async {
+        let firstLoadGate = AsyncGate()
+        self.mockClient.homeResponse = HomeResponse(sections: [TestFixtures.makeHomeSection(title: "Initial")])
+        self.mockClient.beforeGetHomeReturn = { [mockClient = self.mockClient] in
+            if mockClient.getHomeCallCount == 1 {
+                await firstLoadGate.wait()
+            }
+        }
+
+        let firstLoad = Task { await self.viewModel.load() }
+        while self.mockClient.getHomeCallCount == 0 {
+            await Task.yield()
+        }
+
+        self.mockClient.homeResponse = HomeResponse(sections: [TestFixtures.makeHomeSection(title: "Refreshed")])
+        let refresh = Task { await self.viewModel.refresh() }
+        await Task.yield()
+        #expect(self.mockClient.getHomeCallCount == 1)
+
+        await firstLoadGate.open()
+        await refresh.value
+        await firstLoad.value
+
+        #expect(self.viewModel.loadingState == .loaded)
+        #expect(self.viewModel.sections.map(\.title) == ["Refreshed"])
         #expect(self.mockClient.getHomeCallCount == 2)
     }
 }

--- a/Tests/KasetTests/ImageCacheDiskEvictionTests.swift
+++ b/Tests/KasetTests/ImageCacheDiskEvictionTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+@Suite(.serialized, .tags(.service))
+struct ImageCacheDiskEvictionTests {
+    @Test("Under-limit disk writes update estimate without rescanning directory")
+    func underLimitWritesAvoidFullScans() async throws {
+        let directory = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let cache = ImageCache(
+            diskCacheURL: directory,
+            maxDiskCacheSize: 10000,
+            initialEstimatedDiskCacheSize: 0,
+            diskEvictionWriteThreshold: 100,
+            startsEvictionTask: false,
+            monitorsMemoryPressure: false
+        )
+        let initialScans = await cache.diskCacheSizeScanCountForTesting
+
+        for index in 0 ..< 5 {
+            try await cache.saveToDiskForTesting(
+                url: #require(URL(string: "https://example.com/image-\(index).jpg")),
+                data: Data(repeating: UInt8(index), count: 100)
+            )
+        }
+
+        #expect(await cache.diskCacheSizeScanCountForTesting == initialScans)
+        #expect(await cache.estimatedDiskCacheSizeForTesting() == 500)
+    }
+
+    @Test("Write threshold periodically reconciles estimated disk size")
+    func writeThresholdReconcilesEstimate() async throws {
+        let directory = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let cache = ImageCache(
+            diskCacheURL: directory,
+            maxDiskCacheSize: 10000,
+            initialEstimatedDiskCacheSize: 0,
+            diskEvictionWriteThreshold: 3,
+            startsEvictionTask: false,
+            monitorsMemoryPressure: false
+        )
+        let initialScans = await cache.diskCacheSizeScanCountForTesting
+
+        for index in 0 ..< 3 {
+            try await cache.saveToDiskForTesting(
+                url: #require(URL(string: "https://example.com/reconcile-\(index).jpg")),
+                data: Data(repeating: UInt8(index), count: 100)
+            )
+        }
+        await cache.waitForScheduledDiskEvictionForTesting()
+
+        #expect(await cache.diskCacheSizeScanCountForTesting == initialScans + 1)
+        #expect(await cache.estimatedDiskCacheSizeForTesting() == 300)
+    }
+
+    @Test("Forced eviction updates estimate and removes oldest files over limit")
+    func forcedEvictionRemovesOldestFiles() async throws {
+        let directory = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let cache = ImageCache(
+            diskCacheURL: directory,
+            maxDiskCacheSize: 250,
+            initialEstimatedDiskCacheSize: 0,
+            diskEvictionWriteThreshold: 100,
+            startsEvictionTask: false,
+            monitorsMemoryPressure: false
+        )
+        let urls = try (0 ..< 4).map { index in
+            try #require(URL(string: "https://example.com/evict-\(index).jpg"))
+        }
+
+        for (index, url) in urls.enumerated() {
+            let path = await cache.diskCachePathForTesting(url: url)
+            try Data(repeating: UInt8(index), count: 100).write(to: path, options: .atomic)
+            try FileManager.default.setAttributes(
+                [.modificationDate: Date(timeIntervalSince1970: TimeInterval(index))],
+                ofItemAtPath: path.path
+            )
+        }
+
+        await cache.evictDiskCacheIfNeededForTesting(force: true)
+
+        let finalSize = await cache.diskCacheSize()
+        let firstPath = await cache.diskCachePathForTesting(url: urls[0])
+        let secondPath = await cache.diskCachePathForTesting(url: urls[1])
+        #expect(finalSize <= 250)
+        #expect(await cache.estimatedDiskCacheSizeForTesting() == finalSize)
+        #expect(!FileManager.default.fileExists(atPath: firstPath.path))
+        #expect(!FileManager.default.fileExists(atPath: secondPath.path))
+    }
+
+    private static func makeTemporaryDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ImageCacheDiskEvictionTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+}

--- a/Tests/KasetTests/ImageCacheNetworkCoalescingTests.swift
+++ b/Tests/KasetTests/ImageCacheNetworkCoalescingTests.swift
@@ -12,10 +12,9 @@ struct ImageCacheNetworkCoalescingTests {
         let imageData = try Self.makePNGData()
         let url = try #require(URL(string: "https://example.com/artwork.png"))
         let session = MockURLProtocol.makeMockSession()
-        nonisolated(unsafe) var requestCount = 0
+        let requestCount = LockedCounter()
         MockURLProtocol.setRequestHandler(for: session) { request in
-            requestCount += 1
-            if requestCount == 1 {
+            if requestCount.increment() == 1 {
                 Thread.sleep(forTimeInterval: 0.1)
             }
             let response = HTTPURLResponse(
@@ -40,7 +39,7 @@ struct ImageCacheNetworkCoalescingTests {
         let images = await [small, large]
 
         #expect(images.allSatisfy { $0 != nil })
-        #expect(requestCount == 1)
+        #expect(requestCount.count == 1)
     }
 
     @Test("Failed raw download clears in-flight entry and retries later")
@@ -50,10 +49,9 @@ struct ImageCacheNetworkCoalescingTests {
         let imageData = try Self.makePNGData()
         let url = try #require(URL(string: "https://example.com/retry.png"))
         let session = MockURLProtocol.makeMockSession()
-        nonisolated(unsafe) var requestCount = 0
+        let requestCount = LockedCounter()
         MockURLProtocol.setRequestHandler(for: session) { request in
-            requestCount += 1
-            let statusCode = requestCount == 1 ? 500 : 200
+            let statusCode = requestCount.increment() == 1 ? 500 : 200
             let response = HTTPURLResponse(
                 url: request.url!,
                 statusCode: statusCode,
@@ -76,7 +74,7 @@ struct ImageCacheNetworkCoalescingTests {
 
         #expect(first == nil)
         #expect(second != nil)
-        #expect(requestCount == 2)
+        #expect(requestCount.count == 2)
     }
 
     @Test("Warm disk data decodes multiple target sizes without network")
@@ -86,9 +84,9 @@ struct ImageCacheNetworkCoalescingTests {
         let imageData = try Self.makePNGData()
         let url = try #require(URL(string: "https://example.com/warm.png"))
         let session = MockURLProtocol.makeMockSession()
-        nonisolated(unsafe) var requestCount = 0
+        let requestCount = LockedCounter()
         MockURLProtocol.setRequestHandler(for: session) { request in
-            requestCount += 1
+            requestCount.increment()
             let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
             return (response, imageData)
         }
@@ -107,7 +105,7 @@ struct ImageCacheNetworkCoalescingTests {
 
         #expect(small != nil)
         #expect(large != nil)
-        #expect(requestCount == 0)
+        #expect(requestCount.isEmpty)
     }
 
     private static func makeTemporaryDirectory() throws -> URL {

--- a/Tests/KasetTests/ImageCacheNetworkCoalescingTests.swift
+++ b/Tests/KasetTests/ImageCacheNetworkCoalescingTests.swift
@@ -1,0 +1,131 @@
+import AppKit
+import Foundation
+import Testing
+@testable import Kaset
+
+@Suite(.serialized, .tags(.service))
+struct ImageCacheNetworkCoalescingTests {
+    @Test("Same URL at different target sizes shares one cold download")
+    func sameURLDifferentSizesShareOneColdDownload() async throws {
+        let directory = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let imageData = try Self.makePNGData()
+        let url = try #require(URL(string: "https://example.com/artwork.png"))
+        let session = MockURLProtocol.makeMockSession()
+        nonisolated(unsafe) var requestCount = 0
+        MockURLProtocol.setRequestHandler(for: session) { request in
+            requestCount += 1
+            if requestCount == 1 {
+                Thread.sleep(forTimeInterval: 0.1)
+            }
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "image/png"]
+            )!
+            return (response, imageData)
+        }
+        defer { MockURLProtocol.reset(session: session) }
+
+        let cache = ImageCache(
+            diskCacheURL: directory,
+            startsEvictionTask: false,
+            monitorsMemoryPressure: false,
+            session: session
+        )
+
+        async let small = cache.image(for: url, targetSize: CGSize(width: 40, height: 40))
+        async let large = cache.image(for: url, targetSize: CGSize(width: 320, height: 180))
+        let images = await [small, large]
+
+        #expect(images.allSatisfy { $0 != nil })
+        #expect(requestCount == 1)
+    }
+
+    @Test("Failed raw download clears in-flight entry and retries later")
+    func failedRawDownloadClearsInFlightAndRetries() async throws {
+        let directory = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let imageData = try Self.makePNGData()
+        let url = try #require(URL(string: "https://example.com/retry.png"))
+        let session = MockURLProtocol.makeMockSession()
+        nonisolated(unsafe) var requestCount = 0
+        MockURLProtocol.setRequestHandler(for: session) { request in
+            requestCount += 1
+            let statusCode = requestCount == 1 ? 500 : 200
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: statusCode,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "image/png"]
+            )!
+            return (response, imageData)
+        }
+        defer { MockURLProtocol.reset(session: session) }
+
+        let cache = ImageCache(
+            diskCacheURL: directory,
+            startsEvictionTask: false,
+            monitorsMemoryPressure: false,
+            session: session
+        )
+
+        let first = await cache.image(for: url, targetSize: CGSize(width: 40, height: 40))
+        let second = await cache.image(for: url, targetSize: CGSize(width: 40, height: 40))
+
+        #expect(first == nil)
+        #expect(second != nil)
+        #expect(requestCount == 2)
+    }
+
+    @Test("Warm disk data decodes multiple target sizes without network")
+    func warmDiskDataDecodesMultipleTargetSizesWithoutNetwork() async throws {
+        let directory = try Self.makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let imageData = try Self.makePNGData()
+        let url = try #require(URL(string: "https://example.com/warm.png"))
+        let session = MockURLProtocol.makeMockSession()
+        nonisolated(unsafe) var requestCount = 0
+        MockURLProtocol.setRequestHandler(for: session) { request in
+            requestCount += 1
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, imageData)
+        }
+        defer { MockURLProtocol.reset(session: session) }
+
+        let cache = ImageCache(
+            diskCacheURL: directory,
+            startsEvictionTask: false,
+            monitorsMemoryPressure: false,
+            session: session
+        )
+        await cache.saveToDiskForTesting(url: url, data: imageData)
+
+        let small = await cache.image(for: url, targetSize: CGSize(width: 40, height: 40))
+        let large = await cache.image(for: url, targetSize: CGSize(width: 320, height: 180))
+
+        #expect(small != nil)
+        #expect(large != nil)
+        #expect(requestCount == 0)
+    }
+
+    private static func makeTemporaryDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ImageCacheNetworkCoalescingTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    private static func makePNGData() throws -> Data {
+        let size = NSSize(width: 32, height: 32)
+        let image = NSImage(size: size)
+        image.lockFocus()
+        NSColor.systemBlue.setFill()
+        NSRect(origin: .zero, size: size).fill()
+        image.unlockFocus()
+        let tiff = try #require(image.tiffRepresentation)
+        let bitmap = try #require(NSBitmapImageRep(data: tiff))
+        return try #require(bitmap.representation(using: .png, properties: [:]))
+    }
+}

--- a/Tests/KasetTests/MediaControlScriptTests.swift
+++ b/Tests/KasetTests/MediaControlScriptTests.swift
@@ -2,6 +2,8 @@ import JavaScriptCore
 import Testing
 @testable import Kaset
 
+// MARK: - MediaControlScriptTests
+
 /// Tests for singleton media-control script generation and scheduling.
 @Suite(.serialized, .tags(.service))
 @MainActor
@@ -27,8 +29,8 @@ struct MediaControlScriptTests {
         #expect(windowPreference == "true")
     }
 
-    @Test("Bootstrap wrapper blocks seekforward/seekbackward registrations when nextPrev is enabled")
-    func bootstrapWrapperBlocksSeekHandlersInNextPrevMode() throws {
+    @Test("Bootstrap wrapper blocks YouTube-owned handlers when nextPrev is enabled")
+    func bootstrapWrapperBlocksYouTubeHandlersInNextPrevMode() throws {
         let context = try #require(self.makeBootstrapWrapperContext())
 
         self.evaluate(SingletonPlayerWebView.mediaControlStyleBootstrapScript(useNextPrev: true), in: context)
@@ -37,12 +39,13 @@ struct MediaControlScriptTests {
             navigator.mediaSession.setActionHandler('seekforward', function() {});
             navigator.mediaSession.setActionHandler('seekbackward', function() {});
             navigator.mediaSession.setActionHandler('nexttrack', function() {});
+            navigator.mediaSession.setActionHandler('previoustrack', function() {});
             """,
             in: context
         )
 
         let calls = context.evaluateScript("mediaSessionCalls.join(',')")?.toString() ?? ""
-        #expect(calls == "seekforward:clear,seekbackward:clear,nexttrack:set")
+        #expect(calls == "seekforward:clear,seekbackward:clear")
     }
 
     @Test("Bootstrap wrapper clears seekforward/seekbackward when skip mode uses native handlers")
@@ -105,23 +108,30 @@ struct MediaControlScriptTests {
         #expect(clearCount == 1)
     }
 
-    @Test("Bootstrap wrapper preserves passed-through handler reference for nexttrack")
-    func bootstrapWrapperPreservesHandlerReference() throws {
+    @Test("Bootstrap wrapper allows Kaset-owned nexttrack install under flag")
+    func bootstrapWrapperAllowsKasetOwnedHandlerInstall() throws {
         let context = try #require(self.makeBootstrapWrapperContext())
 
         self.evaluate(SingletonPlayerWebView.mediaControlStyleBootstrapScript(useNextPrev: true), in: context)
         self.evaluate(
             """
             window.__handlerInvoked = false;
-            navigator.mediaSession.setActionHandler('nexttrack', function() {
-                window.__handlerInvoked = true;
-            });
+            window.__kasetInstallingMediaControlHandlers = true;
+            try {
+                navigator.mediaSession.setActionHandler('nexttrack', function() {
+                    window.__handlerInvoked = true;
+                });
+            } finally {
+                window.__kasetInstallingMediaControlHandlers = false;
+            }
             mediaSessionHandlers.nexttrack();
             """,
             in: context
         )
 
+        let calls = context.evaluateScript("mediaSessionCalls.join(',')")?.toString() ?? ""
         let invoked = context.evaluateScript("String(window.__handlerInvoked)")?.toString()
+        #expect(calls == "nexttrack:set")
         #expect(invoked == "true")
     }
 
@@ -131,11 +141,12 @@ struct MediaControlScriptTests {
 
         self.evaluate(SingletonPlayerWebView.mediaControlStyleBootstrapScript(useNextPrev: true), in: context)
         self.evaluate(SingletonPlayerWebView.mediaControlOverrideScript, in: context)
-        self.evaluate("runNextAnimationFrame();", in: context)
         self.evaluate(
             """
             navigator.mediaSession.setActionHandler('seekforward', function() {});
             navigator.mediaSession.setActionHandler('seekbackward', function() {});
+            navigator.mediaSession.setActionHandler('nexttrack', function() {});
+            navigator.mediaSession.setActionHandler('previoustrack', function() {});
             """,
             in: context
         )
@@ -146,25 +157,51 @@ struct MediaControlScriptTests {
         let seekForwardSetCount = context.evaluateScript("""
             mediaSessionCalls.filter(function(c) { return c === 'seekforward:set'; }).length
         """)?.toInt32() ?? -1
+        let nextTrackSetCount = context.evaluateScript("""
+            mediaSessionCalls.filter(function(c) { return c === 'nexttrack:set'; }).length
+        """)?.toInt32() ?? -1
+        let previousTrackSetCount = context.evaluateScript("""
+            mediaSessionCalls.filter(function(c) { return c === 'previoustrack:set'; }).length
+        """)?.toInt32() ?? -1
         #expect(seekForwardClearCount > 0)
         #expect(seekForwardSetCount == 0)
+        #expect(nextTrackSetCount > 0)
+        #expect(previousTrackSetCount > 0)
     }
 
-    @Test("Override script keeps a single animation-frame loop active")
-    func overrideScriptKeepsSingleAnimationFrameLoop() throws {
+    @Test("Override script installs Kaset handlers through bootstrap wrapper")
+    func overrideScriptInstallsKasetHandlersThroughBootstrapWrapper() throws {
+        let context = try #require(self.makeOverrideScriptContext(useNextPrev: true))
+
+        self.evaluate(SingletonPlayerWebView.mediaControlStyleBootstrapScript(useNextPrev: true), in: context)
+        self.evaluate(SingletonPlayerWebView.mediaControlOverrideScript, in: context)
+        self.evaluate("mediaSessionHandlers.nexttrack(); mediaSessionHandlers.previoustrack();", in: context)
+
+        let calls = context.evaluateScript("mediaSessionCalls.join(',')")?.toString() ?? ""
+        let firstMessageType = context.evaluateScript("postedMessages[0].type")?.toString()
+        let secondMessageType = context.evaluateScript("postedMessages[1].type")?.toString()
+
+        #expect(calls.contains("nexttrack:set"))
+        #expect(calls.contains("previoustrack:set"))
+        #expect(firstMessageType == "REMOTE_NEXT")
+        #expect(secondMessageType == "REMOTE_PREVIOUS")
+    }
+
+    @Test("Override script uses event-driven reassertion without endless animation-frame loop")
+    func overrideScriptUsesEventDrivenReassertionWithoutEndlessAnimationFrameLoop() throws {
         let context = try #require(self.makeOverrideScriptContext(useNextPrev: true))
 
         self.evaluate(SingletonPlayerWebView.mediaControlOverrideScript, in: context)
 
         let initialPendingCallbacks = context.evaluateScript("pendingRafCallbacks.length")?.toInt32() ?? -1
-        let nextTrackSetCount = context.evaluateScript("""
+        let initialNextTrackSetCount = context.evaluateScript("""
             mediaSessionCalls.filter(function(call) {
                 return call === 'nexttrack:set';
             }).length
         """)?.toInt32() ?? 0
 
-        #expect(initialPendingCallbacks == 1)
-        #expect(nextTrackSetCount > 0)
+        #expect(initialPendingCallbacks == 0)
+        #expect(initialNextTrackSetCount > 0)
 
         self.evaluate("""
             videoListeners.playing();
@@ -172,14 +209,18 @@ struct MediaControlScriptTests {
             videoListeners.loadeddata();
             videoListeners.canplay();
             videoListeners.seeked();
+            if (mutationCallback) { mutationCallback(); }
         """, in: context)
 
-        let callbacksAfterVideoEvents = context.evaluateScript("pendingRafCallbacks.length")?.toInt32() ?? -1
-        #expect(callbacksAfterVideoEvents == 1)
+        let callbacksAfterEvents = context.evaluateScript("pendingRafCallbacks.length")?.toInt32() ?? -1
+        let nextTrackSetCountAfterEvents = context.evaluateScript("""
+            mediaSessionCalls.filter(function(call) {
+                return call === 'nexttrack:set';
+            }).length
+        """)?.toInt32() ?? 0
 
-        self.evaluate("runNextAnimationFrame();", in: context)
-        let callbacksAfterFrameDrain = context.evaluateScript("pendingRafCallbacks.length")?.toInt32() ?? -1
-        #expect(callbacksAfterFrameDrain == 1)
+        #expect(callbacksAfterEvents == 0)
+        #expect(nextTrackSetCountAfterEvents > initialNextTrackSetCount)
     }
 
     @Test("Playback audio quality bootstrap script stores selected quality")
@@ -611,8 +652,10 @@ struct MediaControlScriptTests {
         #expect(pendingAfterDrain == 0)
         #expect(audioQualityCallCount == 2)
     }
+}
 
-    private func makeBootstrapWrapperContext() -> JSContext? {
+private extension MediaControlScriptTests {
+    func makeBootstrapWrapperContext() -> JSContext? {
         guard let context = JSContext() else { return nil }
 
         self.evaluate(
@@ -646,7 +689,7 @@ struct MediaControlScriptTests {
         return context
     }
 
-    private func evaluateBootstrapStateScript(in context: JSContext) {
+    func evaluateBootstrapStateScript(in context: JSContext) {
         self.evaluate(
             """
             var localStorageValues = {};
@@ -666,7 +709,7 @@ struct MediaControlScriptTests {
         )
     }
 
-    private func makeOverrideScriptContext(useNextPrev: Bool) -> JSContext? {
+    func makeOverrideScriptContext(useNextPrev: Bool) -> JSContext? {
         guard let context = JSContext() else { return nil }
 
         self.evaluate(
@@ -684,10 +727,12 @@ struct MediaControlScriptTests {
                 }
             }
             var mediaSessionCalls = [];
+            var mediaSessionHandlers = {};
             var navigator = {
                 mediaSession: {
                     setActionHandler: function(name, handler) {
                         mediaSessionCalls.push(name + ':' + (handler ? 'set' : 'clear'));
+                        mediaSessionHandlers[name] = handler;
                     }
                 }
             };
@@ -717,7 +762,9 @@ struct MediaControlScriptTests {
                     return null;
                 }
             };
+            var mutationCallback = null;
             function MutationObserver(callback) {
+                mutationCallback = callback;
                 this.callback = callback;
             }
             MutationObserver.prototype.observe = function() {};
@@ -740,7 +787,7 @@ struct MediaControlScriptTests {
         return context
     }
 
-    private func evaluate(_ script: String, in context: JSContext) {
+    func evaluate(_ script: String, in context: JSContext) {
         context.exception = nil
         _ = context.evaluateScript(script)
 

--- a/Tests/KasetTests/MoodsAndGenresViewModelTests.swift
+++ b/Tests/KasetTests/MoodsAndGenresViewModelTests.swift
@@ -80,8 +80,8 @@ struct MoodsAndGenresViewModelTests {
 
     // MARK: - Background Continuation Tests
 
-    @Test("Load sets hasMore based on continuation availability")
-    func loadSetsHasMoreBasedOnContinuations() async {
+    @Test("Initial load does not drain continuations")
+    func initialLoadDoesNotDrainContinuations() async {
         self.mockClient.moodsAndGenresResponse = HomeResponse(sections: [
             TestFixtures.makeHomeSection(title: "Initial"),
         ])
@@ -91,10 +91,33 @@ struct MoodsAndGenresViewModelTests {
 
         await self.viewModel.load()
 
-        // After initial load, hasMore should reflect continuation availability
-        // Background loading may or may not have completed yet
-        #expect(self.viewModel.sections.count >= 1)
-        #expect(self.viewModel.loadingState == .loaded)
+        #expect(self.viewModel.sections.map(\.title) == ["Initial"])
+        #expect(self.viewModel.hasMoreSections == true)
+        #expect(self.mockClient.getMoodsAndGenresContinuationCallCount == 0)
+    }
+
+    @Test("Load more appends one continuation per demand")
+    func loadMoreAppendsOneContinuationPerDemand() async {
+        self.mockClient.moodsAndGenresResponse = HomeResponse(sections: [
+            TestFixtures.makeHomeSection(title: "Initial"),
+        ])
+        self.mockClient.moodsAndGenresContinuationSections = [
+            [TestFixtures.makeHomeSection(title: "Continuation 1")],
+            [TestFixtures.makeHomeSection(title: "Continuation 2")],
+        ]
+
+        await self.viewModel.load()
+        await self.viewModel.loadMore()
+
+        #expect(self.viewModel.sections.map(\.title) == ["Initial", "Continuation 1"])
+        #expect(self.viewModel.hasMoreSections == true)
+        #expect(self.mockClient.getMoodsAndGenresContinuationCallCount == 1)
+
+        await self.viewModel.loadMore()
+
+        #expect(self.viewModel.sections.map(\.title) == ["Initial", "Continuation 1", "Continuation 2"])
+        #expect(self.viewModel.hasMoreSections == false)
+        #expect(self.mockClient.getMoodsAndGenresContinuationCallCount == 2)
     }
 
     @Test("No continuations means no more sections after load")

--- a/Tests/KasetTests/NewReleasesViewModelTests.swift
+++ b/Tests/KasetTests/NewReleasesViewModelTests.swift
@@ -80,8 +80,8 @@ struct NewReleasesViewModelTests {
 
     // MARK: - Background Continuation Tests
 
-    @Test("Load sets hasMore based on continuation availability")
-    func loadSetsHasMoreBasedOnContinuations() async {
+    @Test("Initial load does not drain continuations")
+    func initialLoadDoesNotDrainContinuations() async {
         self.mockClient.newReleasesResponse = HomeResponse(sections: [
             TestFixtures.makeHomeSection(title: "Initial"),
         ])
@@ -91,10 +91,33 @@ struct NewReleasesViewModelTests {
 
         await self.viewModel.load()
 
-        // After initial load, hasMore should reflect continuation availability
-        // Background loading may or may not have completed yet
-        #expect(self.viewModel.sections.count >= 1)
-        #expect(self.viewModel.loadingState == .loaded)
+        #expect(self.viewModel.sections.map(\.title) == ["Initial"])
+        #expect(self.viewModel.hasMoreSections == true)
+        #expect(self.mockClient.getNewReleasesContinuationCallCount == 0)
+    }
+
+    @Test("Load more appends one continuation per demand")
+    func loadMoreAppendsOneContinuationPerDemand() async {
+        self.mockClient.newReleasesResponse = HomeResponse(sections: [
+            TestFixtures.makeHomeSection(title: "Initial"),
+        ])
+        self.mockClient.newReleasesContinuationSections = [
+            [TestFixtures.makeHomeSection(title: "Continuation 1")],
+            [TestFixtures.makeHomeSection(title: "Continuation 2")],
+        ]
+
+        await self.viewModel.load()
+        await self.viewModel.loadMore()
+
+        #expect(self.viewModel.sections.map(\.title) == ["Initial", "Continuation 1"])
+        #expect(self.viewModel.hasMoreSections == true)
+        #expect(self.mockClient.getNewReleasesContinuationCallCount == 1)
+
+        await self.viewModel.loadMore()
+
+        #expect(self.viewModel.sections.map(\.title) == ["Initial", "Continuation 1", "Continuation 2"])
+        #expect(self.viewModel.hasMoreSections == false)
+        #expect(self.mockClient.getNewReleasesContinuationCallCount == 2)
     }
 
     @Test("No continuations means no more sections after load")

--- a/Tests/KasetTests/NotificationServiceTests.swift
+++ b/Tests/KasetTests/NotificationServiceTests.swift
@@ -14,45 +14,62 @@ struct NotificationServiceTests {
         self.notificationService = NotificationService(playerService: self.playerService)
     }
 
-    private func waitForPollingCycle() async {
-        // Wait for the 500ms polling interval plus a small margin.
-        try? await Task.sleep(for: .milliseconds(700))
+    private func waitForObservationDelivery() async {
+        // Event-driven observation should deliver on the next main-actor turns,
+        // without waiting for the old 500ms polling interval.
+        for _ in 0 ..< 5 {
+            await Task.yield()
+        }
+        try? await Task.sleep(for: .milliseconds(50))
     }
 
     // MARK: - Observation Lifecycle
 
-    @Test("observation task is active after init")
+    @Test("observation is active after init")
     func observationActiveAfterInit() {
         #expect(self.notificationService.isObserving)
     }
 
-    @Test("stopObserving cancels observation task")
-    func stopObservingCancelsTask() {
+    @Test("stopObserving disables observation")
+    func stopObservingDisablesObservation() {
         self.notificationService.stopObserving()
         #expect(!self.notificationService.isObserving)
     }
 
     // MARK: - Track Change Detection
 
-    @Test("detects track change and updates lastNotifiedTrackId when playback is active")
-    func detectsTrackChange() async {
+    @Test("detects track change without polling delay when playback is active")
+    func detectsTrackChangeWithoutPollingDelay() async {
         self.playerService.currentTrack = TestFixtures.makeSong(id: "song-1", title: "First Song")
         self.playerService.state = .playing
 
-        await self.waitForPollingCycle()
+        await self.waitForObservationDelivery()
 
         #expect(self.notificationService.lastNotifiedTrackId == "song-1")
+    }
+
+    @Test("notifies already playing track on initial observation")
+    func notifiesAlreadyPlayingTrackOnInitialObservation() async {
+        let playerService = PlayerService()
+        playerService.currentTrack = TestFixtures.makeSong(id: "initial-song", title: "Initial Song")
+        playerService.state = .playing
+
+        let notificationService = NotificationService(playerService: playerService)
+        await self.waitForObservationDelivery()
+
+        #expect(notificationService.lastNotifiedTrackId == "initial-song")
+        notificationService.stopObserving()
     }
 
     @Test("detects multiple track changes while playing")
     func detectsMultipleTrackChanges() async {
         self.playerService.currentTrack = TestFixtures.makeSong(id: "song-1", title: "First Song")
         self.playerService.state = .playing
-        await self.waitForPollingCycle()
+        await self.waitForObservationDelivery()
         #expect(self.notificationService.lastNotifiedTrackId == "song-1")
 
         self.playerService.currentTrack = TestFixtures.makeSong(id: "song-2", title: "Second Song")
-        await self.waitForPollingCycle()
+        await self.waitForObservationDelivery()
         #expect(self.notificationService.lastNotifiedTrackId == "song-2")
     }
 
@@ -61,7 +78,7 @@ struct NotificationServiceTests {
         self.playerService.currentTrack = TestFixtures.makeSong(id: "song-1", title: "Restored Song")
         self.playerService.state = .paused
 
-        await self.waitForPollingCycle()
+        await self.waitForObservationDelivery()
 
         #expect(self.notificationService.lastNotifiedTrackId == nil)
     }
@@ -71,12 +88,12 @@ struct NotificationServiceTests {
         self.playerService.currentTrack = TestFixtures.makeSong(id: "song-1", title: "Restored Song")
         self.playerService.state = .paused
 
-        await self.waitForPollingCycle()
+        await self.waitForObservationDelivery()
         #expect(self.notificationService.lastNotifiedTrackId == nil)
 
         self.playerService.state = .playing
 
-        await self.waitForPollingCycle()
+        await self.waitForObservationDelivery()
         #expect(self.notificationService.lastNotifiedTrackId == "song-1")
     }
 
@@ -84,12 +101,12 @@ struct NotificationServiceTests {
     func doesNotNotifyForSameTrackTwice() async {
         self.playerService.currentTrack = TestFixtures.makeSong(id: "song-1", title: "First Song")
         self.playerService.state = .playing
-        await self.waitForPollingCycle()
+        await self.waitForObservationDelivery()
         #expect(self.notificationService.lastNotifiedTrackId == "song-1")
 
         // Set a different track, then back to the same one
         self.playerService.currentTrack = TestFixtures.makeSong(id: "song-2", title: "Second Song")
-        await self.waitForPollingCycle()
+        await self.waitForObservationDelivery()
 
         // The lastNotifiedTrackId should now be song-2, meaning song-1 wasn't skipped
         #expect(self.notificationService.lastNotifiedTrackId == "song-2")
@@ -99,7 +116,7 @@ struct NotificationServiceTests {
     func skipsLoadingTracks() async {
         self.playerService.currentTrack = TestFixtures.makeSong(id: "loading-track", title: "Loading...")
         self.playerService.state = .playing
-        await self.waitForPollingCycle()
+        await self.waitForObservationDelivery()
 
         #expect(self.notificationService.lastNotifiedTrackId == nil)
     }
@@ -109,37 +126,62 @@ struct NotificationServiceTests {
         // First set loading placeholder
         self.playerService.currentTrack = TestFixtures.makeSong(id: "song-1", title: "Loading...")
         self.playerService.state = .loading
-        await self.waitForPollingCycle()
+        await self.waitForObservationDelivery()
         #expect(self.notificationService.lastNotifiedTrackId == nil)
 
         // The resolved metadata should notify once playback actually starts.
         self.playerService.currentTrack = TestFixtures.makeSong(id: "song-1", title: "Real Song")
         self.playerService.state = .playing
 
-        await self.waitForPollingCycle()
+        await self.waitForObservationDelivery()
+        #expect(self.notificationService.lastNotifiedTrackId == "song-1")
+    }
+
+    @Test("notifies when loading track resolves while already playing")
+    func notifiesWhenLoadingTrackResolvesWhilePlaying() async {
+        self.playerService.currentTrack = TestFixtures.makeSong(id: "song-1", title: "Loading...")
+        self.playerService.state = .playing
+        await self.waitForObservationDelivery()
+        #expect(self.notificationService.lastNotifiedTrackId == nil)
+
+        self.playerService.currentTrack = TestFixtures.makeSong(id: "song-1", title: "Real Song")
+
+        await self.waitForObservationDelivery()
         #expect(self.notificationService.lastNotifiedTrackId == "song-1")
     }
 
     @Test("no notification when track is nil")
     func noNotificationWhenTrackIsNil() async {
         self.playerService.currentTrack = nil
-        await self.waitForPollingCycle()
+        await self.waitForObservationDelivery()
 
         #expect(self.notificationService.lastNotifiedTrackId == nil)
     }
 
+    @Test("stopObserving prevents future notifications")
+    func stopObservingPreventsFutureNotifications() async {
+        self.playerService.currentTrack = TestFixtures.makeSong(id: "song-1", title: "First Song")
+        self.playerService.state = .playing
+        await self.waitForObservationDelivery()
+        #expect(self.notificationService.lastNotifiedTrackId == "song-1")
+
+        self.notificationService.stopObserving()
+        self.playerService.currentTrack = TestFixtures.makeSong(id: "song-2", title: "Second Song")
+        await self.waitForObservationDelivery()
+
+        #expect(self.notificationService.lastNotifiedTrackId == "song-1")
+    }
+
     // MARK: - Service Retention
 
-    @Test("service remains active after multiple polling cycles")
-    func serviceRemainsActiveAfterPolling() async {
-        // Verify the observation task survives multiple cycles
-        try? await Task.sleep(for: .seconds(2))
+    @Test("service remains active between event-driven notifications")
+    func serviceRemainsActiveBetweenEvents() async {
         #expect(self.notificationService.isObserving)
 
-        // And still detects changes
+        // And still detects changes without a polling delay.
         self.playerService.currentTrack = TestFixtures.makeSong(id: "late-song", title: "Late Song")
         self.playerService.state = .playing
-        await self.waitForPollingCycle()
+        await self.waitForObservationDelivery()
         #expect(self.notificationService.lastNotifiedTrackId == "late-song")
     }
 }

--- a/Tests/KasetTests/PerformanceTests/ColorExtractorPerformanceTests.swift
+++ b/Tests/KasetTests/PerformanceTests/ColorExtractorPerformanceTests.swift
@@ -1,0 +1,73 @@
+import AppKit
+import XCTest
+@testable import Kaset
+
+/// Performance tests for image color extraction paths used by accent backgrounds.
+final class ColorExtractorPerformanceTests: XCTestCase {
+    func testCachedPaletteRepeatAccessPerformance() throws {
+        let url = try Self.writePNG(color: NSColor(calibratedRed: 0.72, green: 0.18, blue: 0.11, alpha: 1))
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        // Warm the ImageCache + palette cache once; the measured path represents
+        // repeated accent backgrounds for the same artwork during navigation.
+        self.waitForAsync { _ = await ColorExtractor.cachedPalette(for: url, targetSize: CGSize(width: 32, height: 32)) }
+
+        let options = XCTMeasureOptions()
+        options.iterationCount = 5
+        self.measure(metrics: [XCTClockMetric()], options: options) {
+            self.waitForAsync {
+                for _ in 0 ..< 2000 {
+                    _ = await ColorExtractor.cachedPalette(for: url, targetSize: CGSize(width: 32, height: 32))
+                }
+            }
+        }
+    }
+
+    private func waitForAsync(_ operation: @escaping @Sendable () async -> Void) {
+        let expectation = self.expectation(description: "async palette operation")
+        Task {
+            await operation()
+            expectation.fulfill()
+        }
+        self.wait(for: [expectation], timeout: 10)
+    }
+
+    private static func writePNG(color: NSColor) throws -> URL {
+        let size = 16
+        guard let rep = NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: size,
+            pixelsHigh: size,
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: size * 4,
+            bitsPerPixel: 32
+        ) else {
+            throw TestError.imageCreationFailed
+        }
+
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = NSGraphicsContext(bitmapImageRep: rep)
+        color.setFill()
+        NSRect(x: 0, y: 0, width: size, height: size).fill()
+        NSGraphicsContext.restoreGraphicsState()
+
+        guard let data = rep.representation(using: .png, properties: [:]) else {
+            throw TestError.imageEncodingFailed
+        }
+
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kaset-color-extractor-perf-\(UUID().uuidString)")
+            .appendingPathExtension("png")
+        try data.write(to: url)
+        return url
+    }
+
+    private enum TestError: Error {
+        case imageCreationFailed
+        case imageEncodingFailed
+    }
+}

--- a/Tests/KasetTests/PerformanceTests/YouTubeHomeFanoutPerformanceTests.swift
+++ b/Tests/KasetTests/PerformanceTests/YouTubeHomeFanoutPerformanceTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+@testable import Kaset
+
+/// Performance coverage for YouTube Home cold-load topic rail fanout.
+final class YouTubeHomeFanoutPerformanceTests: XCTestCase {
+    func testColdLoadWithEightTopicChipsPerformance() {
+        let options = XCTMeasureOptions()
+        options.iterationCount = 5
+
+        self.measure(metrics: [XCTClockMetric()], options: options) {
+            self.waitForAsyncOnMainActor {
+                let mockClient = MockYouTubeClient()
+                mockClient.homeFeed = YouTubeFeed(
+                    videos: MockYouTubeClient.makeVideos(count: 12),
+                    continuation: nil
+                )
+                mockClient.homeChips = (0 ..< 8).map { index in
+                    YouTubeHomeChip(title: "Topic \(index)", continuation: "tok-\(index)")
+                }
+                mockClient.homeTopicFeeds = Dictionary(uniqueKeysWithValues: (0 ..< 8).map { index in
+                    (
+                        "tok-\(index)",
+                        YouTubeFeed(videos: MockYouTubeClient.makeVideos(count: 8), continuation: nil)
+                    )
+                })
+
+                let sut = YouTubeHomeViewModel(client: mockClient)
+                await sut.load()
+
+                XCTAssertEqual(mockClient.homeFeedCallCount, 1)
+                XCTAssertEqual(mockClient.requestedTopicContinuations.count, 2)
+                XCTAssertEqual(Set(mockClient.requestedTopicContinuations), Set(["tok-0", "tok-1"]))
+                XCTAssertTrue(sut.hasMoreTopicRails)
+                XCTAssertFalse(sut.isLoadingTopicRails)
+            }
+        }
+    }
+
+    private func waitForAsyncOnMainActor(_ operation: @escaping @MainActor () async -> Void) {
+        let expectation = self.expectation(description: "main actor async operation")
+        Task { @MainActor in
+            await operation()
+            expectation.fulfill()
+        }
+        self.wait(for: [expectation], timeout: 10)
+    }
+}

--- a/Tests/KasetTests/PlayerServiceLibraryTests.swift
+++ b/Tests/KasetTests/PlayerServiceLibraryTests.swift
@@ -82,7 +82,10 @@ struct PlayerServiceLibraryTests {
 
     @Test("likeCurrentTrack reverts on API failure")
     func likeCurrentTrackRevertsOnFailure() async {
-        self.playerService.currentTrack = TestFixtures.makeSong(id: "test-video")
+        let accountID = "like-failure-\(UUID().uuidString)"
+        SongLikeStatusManager.shared.setActiveAccountID(accountID)
+        defer { SongLikeStatusManager.shared.setActiveAccountID(nil) }
+        self.playerService.currentTrack = TestFixtures.makeSong(id: "like-failure-video")
         self.playerService.currentTrackLikeStatus = .indifferent
         self.mockClient.shouldThrowError = YTMusicError.networkError(underlying: URLError(.notConnectedToInternet))
 
@@ -98,6 +101,9 @@ struct PlayerServiceLibraryTests {
 
     @Test("likeCurrentTrack rolls back to visible status when manager cache is stale")
     func likeCurrentTrackRollsBackToVisibleStatusWhenManagerCacheIsStale() async {
+        let accountID = "stale-like-cache-\(UUID().uuidString)"
+        SongLikeStatusManager.shared.setActiveAccountID(accountID)
+        defer { SongLikeStatusManager.shared.setActiveAccountID(nil) }
         let song = TestFixtures.makeSong(id: "stale-like-cache-video")
         self.playerService.currentTrack = song
         self.playerService.currentTrackLikeStatus = .indifferent
@@ -151,6 +157,10 @@ struct PlayerServiceLibraryTests {
     @Test("likeCurrentTrack clears optimistic status when active account changes before completion")
     func likeCurrentTrackClearsOptimisticStatusWhenActiveAccountChangesBeforeCompletion() async {
         self.mockClient.rateSongDelay = .milliseconds(50)
+        let originalAccountID = "account-switch-original-\(UUID().uuidString)"
+        let switchedAccountID = "account-switch-new-\(UUID().uuidString)"
+        SongLikeStatusManager.shared.setActiveAccountID(originalAccountID)
+        defer { SongLikeStatusManager.shared.setActiveAccountID(nil) }
         var song = TestFixtures.makeSong(id: "account-switch-video")
         song.likeStatus = .like
         self.playerService.currentTrack = song
@@ -159,8 +169,7 @@ struct PlayerServiceLibraryTests {
         self.playerService.likeCurrentTrack()
         #expect(self.playerService.currentTrackLikeStatus == .like)
 
-        SongLikeStatusManager.shared.setActiveAccountID("brand-account")
-        defer { SongLikeStatusManager.shared.setActiveAccountID(nil) }
+        SongLikeStatusManager.shared.setActiveAccountID(switchedAccountID)
 
         let reverted = await self.waitUntilLikeStatus(.indifferent)
         #expect(reverted)
@@ -240,7 +249,10 @@ struct PlayerServiceLibraryTests {
 
     @Test("dislikeCurrentTrack reverts on API failure")
     func dislikeCurrentTrackRevertsOnFailure() async {
-        self.playerService.currentTrack = TestFixtures.makeSong(id: "test-video")
+        let accountID = "dislike-failure-\(UUID().uuidString)"
+        SongLikeStatusManager.shared.setActiveAccountID(accountID)
+        defer { SongLikeStatusManager.shared.setActiveAccountID(nil) }
+        self.playerService.currentTrack = TestFixtures.makeSong(id: "dislike-failure-video")
         self.playerService.currentTrackLikeStatus = .indifferent
         self.mockClient.shouldThrowError = YTMusicError.networkError(underlying: URLError(.notConnectedToInternet))
 

--- a/Tests/KasetTests/PlayerServiceLibraryTests.swift
+++ b/Tests/KasetTests/PlayerServiceLibraryTests.swift
@@ -96,6 +96,21 @@ struct PlayerServiceLibraryTests {
         #expect(reverted)
     }
 
+    @Test("likeCurrentTrack rolls back to visible status when manager cache is stale")
+    func likeCurrentTrackRollsBackToVisibleStatusWhenManagerCacheIsStale() async {
+        let song = TestFixtures.makeSong(id: "stale-like-cache-video")
+        self.playerService.currentTrack = song
+        self.playerService.currentTrackLikeStatus = .indifferent
+        SongLikeStatusManager.shared.setStatus(.like, for: song.videoId)
+        self.mockClient.shouldThrowError = YTMusicError.networkError(underlying: URLError(.notConnectedToInternet))
+
+        self.playerService.likeCurrentTrack()
+        #expect(self.playerService.currentTrackLikeStatus == .like)
+
+        let reverted = await self.waitUntilLikeStatus(.indifferent)
+        #expect(reverted)
+    }
+
     @Test("likeCurrentTrack ignores stale completion after current track changes")
     func likeCurrentTrackIgnoresStaleCompletionAfterTrackChange() async {
         self.mockClient.rateSongDelay = .milliseconds(200)
@@ -131,6 +146,24 @@ struct PlayerServiceLibraryTests {
 
         #expect(self.mockClient.rateSongRatings.first == .indifferent)
         #expect(replacementClient.rateSongCalled == false)
+    }
+
+    @Test("likeCurrentTrack clears optimistic status when active account changes before completion")
+    func likeCurrentTrackClearsOptimisticStatusWhenActiveAccountChangesBeforeCompletion() async {
+        self.mockClient.rateSongDelay = .milliseconds(50)
+        var song = TestFixtures.makeSong(id: "account-switch-video")
+        song.likeStatus = .like
+        self.playerService.currentTrack = song
+        self.playerService.currentTrackLikeStatus = .indifferent
+
+        self.playerService.likeCurrentTrack()
+        #expect(self.playerService.currentTrackLikeStatus == .like)
+
+        SongLikeStatusManager.shared.setActiveAccountID("brand-account")
+        defer { SongLikeStatusManager.shared.setActiveAccountID(nil) }
+
+        let reverted = await self.waitUntilLikeStatus(.indifferent)
+        #expect(reverted)
     }
 
     @Test("likeCurrentTrack is ignored while signed out")

--- a/Tests/KasetTests/PlayerServiceQueueEnrichmentTests.swift
+++ b/Tests/KasetTests/PlayerServiceQueueEnrichmentTests.swift
@@ -1,0 +1,234 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+@Suite(.serialized, .tags(.service))
+@MainActor
+struct PlayerServiceQueueEnrichmentTests {
+    init() {
+        UserDefaults.standard.removeObject(forKey: "kaset.saved.queue")
+        UserDefaults.standard.removeObject(forKey: "kaset.saved.queueIndex")
+        UserDefaults.standard.removeObject(forKey: "kaset.saved.playbackSession")
+        SingletonPlayerWebView.shared.currentVideoId = nil
+    }
+
+    @Test("Queue enrichment does not schedule without a YTMusic client")
+    func noScheduleWithoutClient() {
+        let playerService = PlayerService()
+        playerService.queueEnrichmentInitialDelay = .milliseconds(5)
+
+        playerService.setQueue([Self.incompleteSong(videoId: "needs-client")])
+
+        #expect(playerService.enrichmentTask == nil)
+    }
+
+    @Test("Queue enrichment skips complete queues")
+    func noScheduleForCompleteQueue() {
+        let playerService = PlayerService()
+        let mockClient = MockYTMusicClient()
+        playerService.queueEnrichmentInitialDelay = .seconds(10)
+        playerService.setYTMusicClient(mockClient)
+
+        playerService.setQueue([TestFixtures.makeSong(id: "complete")])
+
+        #expect(playerService.enrichmentTask == nil)
+        #expect(mockClient.getSongVideoIds.isEmpty)
+    }
+
+    @Test("Queue enrichment schedules once when a client can enrich an incomplete queue")
+    func schedulesOneShotAndStopsAfterEnriching() async {
+        let playerService = PlayerService()
+        let mockClient = MockYTMusicClient()
+        playerService.queueEnrichmentInitialDelay = .milliseconds(5)
+        mockClient.songResponses["needs-enrichment"] = TestFixtures.makeSong(
+            id: "needs-enrichment",
+            title: "Enriched Song",
+            artistName: "Enriched Artist"
+        )
+
+        playerService.setYTMusicClient(mockClient)
+        playerService.setQueue([Self.incompleteSong(videoId: "needs-enrichment")])
+
+        #expect(playerService.enrichmentTask != nil)
+
+        await Self.waitUntil {
+            playerService.enrichmentTask == nil && playerService.queue.first?.title == "Enriched Song"
+        }
+
+        #expect(mockClient.getSongVideoIds == ["needs-enrichment"])
+        #expect(playerService.identifySongsNeedingEnrichment().isEmpty)
+    }
+
+    @Test("Queue enrichment retries incomplete entries after a transient failure")
+    func retriesAfterTransientFailure() async {
+        let playerService = PlayerService()
+        let mockClient = MockYTMusicClient()
+        playerService.queueEnrichmentInitialDelay = .milliseconds(5)
+        playerService.queueEnrichmentRetryDelay = .milliseconds(50)
+        mockClient.shouldThrowError = NSError(domain: "Transient", code: 500)
+        mockClient.songResponses["retry-me"] = TestFixtures.makeSong(
+            id: "retry-me",
+            title: "Recovered Song",
+            artistName: "Recovered Artist"
+        )
+
+        playerService.setYTMusicClient(mockClient)
+        playerService.setQueue([Self.incompleteSong(videoId: "retry-me")])
+
+        await Self.waitUntil {
+            mockClient.getSongVideoIds.count == 1 && playerService.enrichmentTask != nil
+        }
+        mockClient.shouldThrowError = nil
+
+        await Self.waitUntil {
+            playerService.enrichmentTask == nil && playerService.queue.first?.title == "Recovered Song"
+        }
+
+        #expect(mockClient.getSongVideoIds == ["retry-me", "retry-me"])
+        #expect(playerService.identifySongsNeedingEnrichment().isEmpty)
+    }
+
+    @Test("Queue enrichment can reschedule after canceling a running pass")
+    func reschedulesAfterRunningPassCancellation() async {
+        let playerService = PlayerService()
+        let mockClient = MockYTMusicClient()
+        playerService.queueEnrichmentInitialDelay = .milliseconds(5)
+        mockClient.getSongDelay = .milliseconds(100)
+        mockClient.songResponses["slow-cancelled"] = TestFixtures.makeSong(
+            id: "slow-cancelled",
+            title: "Cancelled Song",
+            artistName: "Cancelled Artist"
+        )
+        mockClient.songResponses["new-entry"] = TestFixtures.makeSong(
+            id: "new-entry",
+            title: "Newly Enriched Song",
+            artistName: "New Artist"
+        )
+
+        playerService.setYTMusicClient(mockClient)
+        playerService.setQueue([Self.incompleteSong(videoId: "slow-cancelled")])
+
+        await Self.waitUntil {
+            mockClient.getSongVideoIds == ["slow-cancelled"] && playerService.isQueueEnrichmentRunning
+        }
+
+        playerService.setQueue([TestFixtures.makeSong(id: "complete-cancels-running")])
+        #expect(playerService.enrichmentTask == nil)
+        #expect(!playerService.isQueueEnrichmentRunning)
+
+        playerService.setQueue([Self.incompleteSong(videoId: "new-entry")])
+        #expect(playerService.enrichmentTask != nil)
+
+        await Self.waitUntil(timeout: .seconds(2)) {
+            playerService.enrichmentTask == nil && playerService.queue.first?.title == "Newly Enriched Song"
+        }
+
+        #expect(mockClient.getSongVideoIds.contains("new-entry"))
+        #expect(playerService.identifySongsNeedingEnrichment().isEmpty)
+    }
+
+    @Test("Queue enrichment external re-arm replaces sleeping retry backoff")
+    func externalRearmReplacesSleepingRetryBackoff() async {
+        let playerService = PlayerService()
+        let mockClient = MockYTMusicClient()
+        playerService.queueEnrichmentInitialDelay = .milliseconds(5)
+        playerService.queueEnrichmentRetryDelay = .seconds(10)
+        mockClient.shouldThrowError = NSError(domain: "Transient", code: 500)
+        mockClient.songResponses["backoff-rearm"] = TestFixtures.makeSong(
+            id: "backoff-rearm",
+            title: "Backoff Rearmed Song",
+            artistName: "Backoff Artist"
+        )
+
+        playerService.setYTMusicClient(mockClient)
+        playerService.setQueue([Self.incompleteSong(videoId: "backoff-rearm")])
+
+        await Self.waitUntil(timeout: .seconds(2)) {
+            mockClient.getSongVideoIds == ["backoff-rearm"] &&
+                playerService.enrichmentTask != nil &&
+                !playerService.isQueueEnrichmentRunning
+        }
+
+        mockClient.shouldThrowError = nil
+        playerService.setYTMusicClient(mockClient)
+
+        await Self.waitUntil(timeout: .seconds(2)) {
+            playerService.enrichmentTask == nil && playerService.queue.first?.title == "Backoff Rearmed Song"
+        }
+
+        #expect(mockClient.getSongVideoIds == ["backoff-rearm", "backoff-rearm"])
+        #expect(playerService.identifySongsNeedingEnrichment().isEmpty)
+    }
+
+    @Test("Queue enrichment re-arms bounded attempts after client replacement")
+    func reArmsAttemptsAfterClientReplacement() async {
+        let playerService = PlayerService()
+        let mockClient = MockYTMusicClient()
+        playerService.queueEnrichmentInitialDelay = .milliseconds(5)
+        playerService.queueEnrichmentRetryDelay = .milliseconds(5)
+        mockClient.shouldThrowError = NSError(domain: "Transient", code: 500)
+        mockClient.songResponses["rearm-me"] = TestFixtures.makeSong(
+            id: "rearm-me",
+            title: "Rearmed Song",
+            artistName: "Rearmed Artist"
+        )
+
+        playerService.setYTMusicClient(mockClient)
+        playerService.setQueue([Self.incompleteSong(videoId: "rearm-me")])
+
+        await Self.waitUntil(timeout: .seconds(2)) {
+            playerService.enrichmentTask == nil && mockClient.getSongVideoIds.count == PlayerService.maxQueueEnrichmentAttempts
+        }
+        #expect(playerService.queue.first?.title == "Loading...")
+
+        mockClient.shouldThrowError = nil
+        playerService.setYTMusicClient(mockClient)
+
+        await Self.waitUntil(timeout: .seconds(2)) {
+            playerService.enrichmentTask == nil && playerService.queue.first?.title == "Rearmed Song"
+        }
+
+        #expect(mockClient.getSongVideoIds.count == PlayerService.maxQueueEnrichmentAttempts + 1)
+        #expect(playerService.identifySongsNeedingEnrichment().isEmpty)
+    }
+
+    @Test("Queue enrichment cancels a pending pass when the queue becomes complete")
+    func cancelsPendingPassWhenQueueBecomesComplete() async {
+        let playerService = PlayerService()
+        let mockClient = MockYTMusicClient()
+        playerService.queueEnrichmentInitialDelay = .seconds(10)
+        playerService.setYTMusicClient(mockClient)
+
+        playerService.setQueue([Self.incompleteSong(videoId: "was-incomplete")])
+        #expect(playerService.enrichmentTask != nil)
+
+        playerService.setQueue([TestFixtures.makeSong(id: "now-complete")])
+
+        #expect(playerService.enrichmentTask == nil)
+        try? await Task.sleep(for: .milliseconds(25))
+        #expect(mockClient.getSongVideoIds.isEmpty)
+    }
+
+    private static func incompleteSong(videoId: String) -> Song {
+        Song(
+            id: videoId,
+            title: "Loading...",
+            artists: [],
+            videoId: videoId
+        )
+    }
+
+    private static func waitUntil(
+        timeout: Duration = .seconds(1),
+        condition: @escaping @MainActor () -> Bool
+    ) async {
+        let clock = ContinuousClock()
+        let deadline = clock.now + timeout
+        while clock.now < deadline {
+            if condition() {
+                return
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+    }
+}

--- a/Tests/KasetTests/PlayerServiceQueueEnrichmentTests.swift
+++ b/Tests/KasetTests/PlayerServiceQueueEnrichmentTests.swift
@@ -88,6 +88,74 @@ struct PlayerServiceQueueEnrichmentTests {
         #expect(playerService.identifySongsNeedingEnrichment().isEmpty)
     }
 
+    @Test("Successful incomplete enrichment responses keep bounded retry identity")
+    func successfulIncompleteResponsesKeepBoundedRetryIdentity() async {
+        let playerService = PlayerService()
+        let mockClient = MockYTMusicClient()
+        let entryID = UUID()
+        playerService.queueEnrichmentInitialDelay = .milliseconds(5)
+        playerService.queueEnrichmentRetryDelay = .milliseconds(5)
+        mockClient.songResponses["still-incomplete"] = Song(
+            id: "still-incomplete",
+            title: "Known Title",
+            artists: [Artist(id: "known-artist", name: "Known Artist")],
+            videoId: "still-incomplete"
+        )
+
+        playerService.setYTMusicClient(mockClient)
+        playerService.setQueue(entries: [
+            QueueEntry(id: entryID, song: Self.incompleteSong(videoId: "still-incomplete")),
+        ])
+
+        await Self.waitUntil(timeout: .seconds(2)) {
+            playerService.enrichmentTask == nil &&
+                mockClient.getSongVideoIds.count == PlayerService.maxQueueEnrichmentAttempts
+        }
+        try? await Task.sleep(for: .milliseconds(25))
+
+        #expect(playerService.queueEntryIDs == [entryID])
+        #expect(playerService.queueEnrichmentAttemptsByEntryID[entryID] == PlayerService.maxQueueEnrichmentAttempts)
+        #expect(mockClient.getSongVideoIds.count == PlayerService.maxQueueEnrichmentAttempts)
+        #expect(!playerService.identifySongsNeedingEnrichment().isEmpty)
+    }
+
+    @Test("Client replacement invalidates a running enrichment response")
+    func clientReplacementInvalidatesRunningResponse() async {
+        let playerService = PlayerService()
+        let oldClient = MockYTMusicClient()
+        let newClient = MockYTMusicClient()
+        playerService.queueEnrichmentInitialDelay = .milliseconds(5)
+        oldClient.getSongDelay = .milliseconds(100)
+        oldClient.songResponses["shared-video"] = TestFixtures.makeSong(
+            id: "shared-video",
+            title: "Stale Metadata",
+            artistName: "Old Account"
+        )
+        newClient.songResponses["shared-video"] = TestFixtures.makeSong(
+            id: "shared-video",
+            title: "Fresh Metadata",
+            artistName: "New Account"
+        )
+
+        playerService.setYTMusicClient(oldClient)
+        playerService.setQueue([Self.incompleteSong(videoId: "shared-video")])
+        await Self.waitUntil {
+            oldClient.getSongVideoIds == ["shared-video"] && playerService.isQueueEnrichmentRunning
+        }
+
+        playerService.setYTMusicClient(newClient)
+
+        await Self.waitUntil(timeout: .seconds(2)) {
+            playerService.enrichmentTask == nil && playerService.queue.first?.title == "Fresh Metadata"
+        }
+        try? await Task.sleep(for: .milliseconds(125))
+
+        #expect(oldClient.getSongVideoIds == ["shared-video"])
+        #expect(newClient.getSongVideoIds == ["shared-video"])
+        #expect(playerService.queue.first?.title == "Fresh Metadata")
+        #expect(playerService.queue.first?.artists.first?.name == "New Account")
+    }
+
     @Test("Queue enrichment can reschedule after canceling a running pass")
     func reschedulesAfterRunningPassCancellation() async {
         let playerService = PlayerService()

--- a/Tests/KasetTests/PlayerServiceQueueTests.swift
+++ b/Tests/KasetTests/PlayerServiceQueueTests.swift
@@ -592,6 +592,37 @@ struct PlayerServiceQueueTests {
         #expect(self.playerService.shouldAutoloadPendingVideo == true)
     }
 
+    @Test("Repeated unchanged queue persistence skips redundant UserDefaults writes")
+    func repeatedUnchangedQueuePersistenceSkipsWrites() async {
+        let songs = TestFixtures.makeSongs(count: 3)
+        await self.playerService.playQueue(songs, startingAt: 1)
+        self.playerService.saveQueueForPersistence()
+        let firstWriteCount = self.playerService.queuePersistenceWriteCountForTesting
+
+        self.playerService.saveQueueForPersistence()
+        self.playerService.saveQueueForPersistence()
+
+        #expect(firstWriteCount == 1)
+        #expect(self.playerService.queuePersistenceWriteCountForTesting == firstWriteCount)
+    }
+
+    @Test("Unchanged queue persistence writes again when backing defaults are missing")
+    func unchangedQueuePersistenceWritesWhenBackingDefaultsAreMissing() async {
+        let songs = TestFixtures.makeSongs(count: 3)
+        await self.playerService.playQueue(songs, startingAt: 1)
+        self.playerService.saveQueueForPersistence()
+        let firstWriteCount = self.playerService.queuePersistenceWriteCountForTesting
+
+        UserDefaults.standard.removeObject(forKey: "kaset.saved.queue")
+        UserDefaults.standard.removeObject(forKey: "kaset.saved.queueIndex")
+        UserDefaults.standard.removeObject(forKey: "kaset.saved.playbackSession")
+        self.playerService.saveQueueForPersistence()
+
+        #expect(firstWriteCount == 1)
+        #expect(self.playerService.queuePersistenceWriteCountForTesting == firstWriteCount + 1)
+        #expect(UserDefaults.standard.data(forKey: "kaset.saved.playbackSession") != nil)
+    }
+
     @Test("Clear saved queue removes persistence data")
     func clearSavedQueue() async {
         // Arrange

--- a/Tests/KasetTests/PlayerServiceSmartShuffleTests.swift
+++ b/Tests/KasetTests/PlayerServiceSmartShuffleTests.swift
@@ -7,10 +7,14 @@ import Testing
 struct PlayerServiceSmartShuffleTests {
     var playerService: PlayerService
     var mockClient: MockYTMusicClient
+    let persistenceNamespace: String
 
     init() {
+        self.persistenceNamespace = "PlayerServiceSmartShuffleTests-\(UUID().uuidString)"
         self.mockClient = MockYTMusicClient()
         self.playerService = PlayerService()
+        self.playerService.useQueuePersistenceNamespaceForTesting(self.persistenceNamespace)
+        self.playerService.clearSavedQueue()
         self.playerService.setYTMusicClient(self.mockClient)
         self.playerService.confirmPlaybackStarted()
     }
@@ -231,6 +235,7 @@ struct PlayerServiceSmartShuffleTests {
         defer { self.playerService.clearSavedQueue() }
 
         let restored = PlayerService()
+        restored.useQueuePersistenceNamespaceForTesting(self.persistenceNamespace)
         #expect(restored.restoreQueueFromPersistence())
         #expect(restored.queue.map(\.videoId) == ["video-before", "rec-current", "video-after"])
         #expect(restored.queueEntries.map(\.source) == [.queued, .suggested, .queued])
@@ -255,6 +260,7 @@ struct PlayerServiceSmartShuffleTests {
         // suggestions. They are regenerated from live playback context, never persisted. (No client
         // is attached and we assert synchronously, so no top-up can run before the checks.)
         let restored = PlayerService()
+        restored.useQueuePersistenceNamespaceForTesting(self.persistenceNamespace)
         #expect(restored.restoreQueueFromPersistence())
         #expect(restored.queueEntries.allSatisfy { $0.source == .queued })
         #expect(Set(restored.queue.map(\.videoId)) == originalIds)

--- a/Tests/KasetTests/PlayerServiceSmartShuffleTests.swift
+++ b/Tests/KasetTests/PlayerServiceSmartShuffleTests.swift
@@ -342,7 +342,9 @@ struct PlayerServiceSmartShuffleTests {
             TestFixtures.makeSong(id: "video-4"),
             TestFixtures.makeSong(id: "video-5"),
         ])
-        if let loadGeneration { await self.playerService.endQueueLoading(loadGeneration) }
+        if let loadGeneration {
+            await self.playerService.endQueueLoading(loadGeneration)
+        }
 
         let videoIds = self.playerService.queue.map(\.videoId)
         let suggested = self.playerService.queueEntries.filter { $0.source == .suggested }.map(\.song.videoId)
@@ -364,7 +366,9 @@ struct PlayerServiceSmartShuffleTests {
             TestFixtures.makeSong(id: "video-1"),
             TestFixtures.makeSong(id: "video-2"),
         ])
-        if let loadGeneration { await self.playerService.endQueueLoading(loadGeneration) }
+        if let loadGeneration {
+            await self.playerService.endQueueLoading(loadGeneration)
+        }
 
         #expect(self.playerService.queue.map(\.videoId) == ["video-0", "video-1", "video-1", "video-2"])
     }
@@ -377,7 +381,9 @@ struct PlayerServiceSmartShuffleTests {
 
         let remaining = (4 ..< 24).map { TestFixtures.makeSong(id: "video-\($0)") }
         self.playerService.appendOriginalTracks(remaining)
-        if let loadGeneration { await self.playerService.endQueueLoading(loadGeneration) }
+        if let loadGeneration {
+            await self.playerService.endQueueLoading(loadGeneration)
+        }
 
         let originalOrder = (0 ..< 24).map { "video-\($0)" }
         #expect(Set(self.playerService.queue.map(\.videoId)) == Set(originalOrder))
@@ -392,7 +398,9 @@ struct PlayerServiceSmartShuffleTests {
         let initial = TestFixtures.makeSongs(count: 4)
         let loadGeneration = await self.playerService.playQueue(initial, startingAt: 0, deferringSmartShuffleFill: true)
         self.playerService.appendOriginalTracks((4 ..< 8).map { TestFixtures.makeSong(id: "video-\($0)") })
-        if let loadGeneration { await self.playerService.endQueueLoading(loadGeneration) }
+        if let loadGeneration {
+            await self.playerService.endQueueLoading(loadGeneration)
+        }
 
         #expect(self.playerService.queue.map(\.videoId) == (0 ..< 8).map { "video-\($0)" })
         #expect(!self.playerService.queueEntries.contains { $0.source == .suggested })

--- a/Tests/KasetTests/PlaylistDetailViewModelTests.swift
+++ b/Tests/KasetTests/PlaylistDetailViewModelTests.swift
@@ -50,7 +50,9 @@ struct PlaylistDetailViewModelTests {
         let deadline = clock.now + timeout
 
         while clock.now < deadline {
-            if condition() { return }
+            if condition() {
+                return
+            }
             try? await Task.sleep(for: .milliseconds(10))
         }
 
@@ -132,8 +134,8 @@ struct PlaylistDetailViewModelTests {
         #expect(SongLikeStatusManager.shared.status(for: "liked-2") == .like)
     }
 
-    @Test("Liked Music load fetches every continuation")
-    func likedMusicLoadFetchesEveryContinuation() async {
+    @Test("Liked Music loadAllRemaining fetches every continuation")
+    func likedMusicLoadAllRemainingFetchesEveryContinuation() async {
         let initialTracks = [
             TestFixtures.makeSong(id: "liked-1", title: "Liked 1"),
             TestFixtures.makeSong(id: "liked-2", title: "Liked 2"),
@@ -150,10 +152,10 @@ struct PlaylistDetailViewModelTests {
         ]
 
         await likedMusicViewModel.load()
-        await self.waitUntil(
-            self.mockClient.getPlaylistContinuationCallCount == 2 && likedMusicViewModel.playlistDetail?.tracks.count == 5,
-            description: "Liked Music background continuation drain"
-        )
+        #expect(self.mockClient.getPlaylistContinuationCallCount == 0)
+        #expect(likedMusicViewModel.playlistDetail?.tracks.count == 2)
+
+        await likedMusicViewModel.loadAllRemaining()
 
         #expect(self.mockClient.getPlaylistContinuationCallCount == 2)
         #expect(likedMusicViewModel.playlistDetail?.tracks.map(\.videoId) == [
@@ -167,8 +169,8 @@ struct PlaylistDetailViewModelTests {
         #expect(likedMusicViewModel.hasMore == false)
     }
 
-    @Test("Liked Music load returns before delayed continuation drain")
-    func likedMusicLoadReturnsBeforeDelayedContinuationDrain() async {
+    @Test("Liked Music load keeps delayed continuation lazy")
+    func likedMusicLoadKeepsDelayedContinuationLazy() async {
         let initialTracks = [
             TestFixtures.makeSong(id: "liked-1", title: "Liked 1"),
             TestFixtures.makeSong(id: "liked-2", title: "Liked 2"),
@@ -184,16 +186,19 @@ struct PlaylistDetailViewModelTests {
         #expect(likedMusicViewModel.playlistDetail?.tracks.map(\.videoId) == ["liked-1", "liked-2"])
         #expect(self.mockClient.getPlaylistContinuationReturnCount == 0)
 
-        await self.waitUntil(
-            likedMusicViewModel.playlistDetail?.tracks.map(\.videoId) == ["liked-1", "liked-2", "liked-3"],
-            description: "Liked Music delayed continuation drain"
-        )
+        try? await Task.sleep(for: .milliseconds(250))
+        #expect(likedMusicViewModel.playlistDetail?.tracks.map(\.videoId) == ["liked-1", "liked-2"])
+        #expect(self.mockClient.getPlaylistContinuationReturnCount == 0)
+        #expect(likedMusicViewModel.hasMore == true)
+
+        await likedMusicViewModel.loadAllRemaining()
+        #expect(likedMusicViewModel.playlistDetail?.tracks.map(\.videoId) == ["liked-1", "liked-2", "liked-3"])
         #expect(likedMusicViewModel.playlistDetail?.tracks.allSatisfy { $0.likeStatus == .like } == true)
         #expect(likedMusicViewModel.hasMore == false)
     }
 
-    @Test("Large playlist load fetches every continuation")
-    func largePlaylistLoadFetchesEveryContinuation() async {
+    @Test("Large playlist loadAllRemaining fetches every continuation")
+    func largePlaylistLoadAllRemainingFetchesEveryContinuation() async {
         let playlist = Playlist(
             id: "VL-test-playlist",
             title: "Large Playlist",
@@ -215,10 +220,10 @@ struct PlaylistDetailViewModelTests {
         ]
 
         await self.viewModel.load()
-        await self.waitUntil(
-            self.mockClient.getPlaylistContinuationCallCount == 2 && self.viewModel.playlistDetail?.tracks.count == 125,
-            description: "large playlist background continuation drain"
-        )
+        #expect(self.mockClient.getPlaylistContinuationCallCount == 0)
+        #expect(self.viewModel.playlistDetail?.tracks.count == 100)
+
+        await self.viewModel.loadAllRemaining()
 
         #expect(self.mockClient.getPlaylistContinuationCallCount == 2)
         #expect(self.viewModel.playlistDetail?.tracks.count == 125)
@@ -226,8 +231,8 @@ struct PlaylistDetailViewModelTests {
         #expect(self.viewModel.hasMore == false)
     }
 
-    @Test("Large playlist load returns before delayed full continuation drain")
-    func largePlaylistLoadReturnsBeforeDelayedFullContinuationDrain() async {
+    @Test("Large playlist load keeps delayed continuation lazy")
+    func largePlaylistLoadKeepsDelayedContinuationLazy() async {
         let playlist = Playlist(
             id: "VL-test-playlist",
             title: "Large Playlist",
@@ -251,10 +256,13 @@ struct PlaylistDetailViewModelTests {
         #expect(self.viewModel.playlistDetail?.tracks.count == 100)
         #expect(self.mockClient.getPlaylistContinuationReturnCount == 0)
 
-        await self.waitUntil(
-            self.viewModel.playlistDetail?.tracks.count == 125,
-            description: "large playlist delayed continuation drain"
-        )
+        try? await Task.sleep(for: .milliseconds(250))
+        #expect(self.viewModel.playlistDetail?.tracks.count == 100)
+        #expect(self.mockClient.getPlaylistContinuationReturnCount == 0)
+        #expect(self.viewModel.hasMore == true)
+
+        await self.viewModel.loadAllRemaining()
+        #expect(self.viewModel.playlistDetail?.tracks.count == 125)
         #expect(self.viewModel.hasMore == false)
     }
 
@@ -279,16 +287,18 @@ struct PlaylistDetailViewModelTests {
         self.mockClient.playlistContinuationDelay = .milliseconds(200)
 
         await self.viewModel.load()
+        let drainTask = Task { await self.viewModel.loadAllRemaining() }
         await self.waitUntil(
             self.mockClient.getPlaylistContinuationCallCount == 1,
-            description: "large playlist background drain to start"
+            description: "large playlist explicit drain to start"
         )
 
         await self.viewModel.loadMore()
+        await drainTask.value
 
         await self.waitUntil(
             self.viewModel.playlistDetail?.tracks.count == 125,
-            description: "large playlist background drain after manual load more"
+            description: "large playlist explicit drain after manual load more"
         )
         #expect(self.mockClient.getPlaylistContinuationCallCount == 1)
         #expect(self.viewModel.hasMore == false)
@@ -315,17 +325,19 @@ struct PlaylistDetailViewModelTests {
         self.mockClient.playlistContinuationDelay = .milliseconds(200)
 
         await self.viewModel.load()
+        let drainTask = Task { await self.viewModel.loadAllRemaining() }
         await self.waitUntil(
             self.viewModel.loadingState == .loadingMore,
-            description: "background continuation drain to enter loadingMore"
+            description: "explicit continuation drain to enter loadingMore"
         )
 
         await self.viewModel.load()
 
         #expect(self.mockClient.getPlaylistIds == [playlist.id])
+        await drainTask.value
         await self.waitUntil(
             self.viewModel.playlistDetail?.tracks.count == 125,
-            description: "background drain after repeated load"
+            description: "explicit drain after repeated load"
         )
     }
 
@@ -342,6 +354,7 @@ struct PlaylistDetailViewModelTests {
         self.mockClient.playlistContinuationDelay = .milliseconds(200)
 
         await likedMusicViewModel.load()
+        let drainTask = Task { await likedMusicViewModel.loadAllRemaining() }
         await self.waitUntil(
             self.mockClient.getPlaylistContinuationCallCount == 1,
             description: "overlapping delayed continuation to start"
@@ -351,6 +364,7 @@ struct PlaylistDetailViewModelTests {
             LikeStatusEvent(videoId: "liked-1", status: .indifferent, song: nil)
         )
 
+        await drainTask.value
         await self.waitUntil(
             likedMusicViewModel.playlistDetail?.tracks.map(\.videoId) == ["liked-2"],
             description: "continuation drain to skip loaded unlike overlap"
@@ -371,6 +385,7 @@ struct PlaylistDetailViewModelTests {
         self.mockClient.playlistContinuationDelay = .milliseconds(200)
 
         await likedMusicViewModel.load()
+        let drainTask = Task { await likedMusicViewModel.loadAllRemaining() }
         await self.waitUntil(
             self.mockClient.getPlaylistContinuationCallCount == 1,
             description: "first delayed continuation to start"
@@ -380,6 +395,7 @@ struct PlaylistDetailViewModelTests {
             LikeStatusEvent(videoId: "future-unliked", status: .indifferent, song: nil)
         )
 
+        await drainTask.value
         await self.waitUntil(
             self.mockClient.getPlaylistContinuationCallCount == 2 && likedMusicViewModel.playlistDetail?.tracks.map(\.videoId).contains("liked-3") == true,
             description: "continuation drain to skip not-yet-loaded unlike"
@@ -403,14 +419,16 @@ struct PlaylistDetailViewModelTests {
         self.mockClient.playlistContinuationDelay = .milliseconds(200)
 
         await likedMusicViewModel.load()
+        self.mockClient.shouldThrowError = YTMusicError.networkError(underlying: URLError(.timedOut))
+        let failingDrainTask = Task { await likedMusicViewModel.loadAllRemaining() }
         await self.waitUntil(
             self.mockClient.getPlaylistContinuationCallCount == 1,
-            description: "failed background continuation to start"
+            description: "failed explicit continuation to start"
         )
-        self.mockClient.shouldThrowError = YTMusicError.networkError(underlying: URLError(.timedOut))
+        await failingDrainTask.value
         await self.waitUntil(
-            self.mockClient.getPlaylistContinuationReturnCount == 1 && likedMusicViewModel.loadingState == .loaded,
-            description: "failed background continuation to return"
+            self.mockClient.getPlaylistContinuationReturnCount >= 1 && likedMusicViewModel.loadingState == .loaded,
+            description: "failed explicit continuation to return"
         )
         self.mockClient.shouldThrowError = nil
         self.mockClient.playlistContinuationDelay = nil
@@ -442,6 +460,7 @@ struct PlaylistDetailViewModelTests {
         self.mockClient.playlistContinuationDelay = .milliseconds(200)
 
         await likedMusicViewModel.load()
+        let drainTask = Task { await likedMusicViewModel.loadAllRemaining() }
         await self.waitUntil(
             self.mockClient.getPlaylistContinuationCallCount == 1,
             description: "first delayed continuation to start"
@@ -455,6 +474,7 @@ struct PlaylistDetailViewModelTests {
             )
         )
 
+        await drainTask.value
         await self.waitUntil(
             self.mockClient.getPlaylistContinuationCallCount == 2 && likedMusicViewModel.playlistDetail?.tracks.map(\.videoId).contains("liked-3") == true,
             description: "continuation drain to advance past live-synced duplicate"
@@ -476,9 +496,10 @@ struct PlaylistDetailViewModelTests {
         self.mockClient.playlistContinuationDelay = .milliseconds(200)
 
         await self.viewModel.load()
+        let drainTask = Task { await self.viewModel.loadAllRemaining() }
         await self.waitUntil(
             self.mockClient.getPlaylistContinuationCallCount == 1,
-            description: "stale background drain to start"
+            description: "stale explicit drain to start"
         )
 
         let refreshedPlaylist = Playlist(
@@ -496,14 +517,63 @@ struct PlaylistDetailViewModelTests {
         )
 
         await self.viewModel.refresh()
+        await drainTask.value
         await self.waitUntil(
             self.mockClient.getPlaylistContinuationReturnCount == 1,
-            description: "stale background drain to return"
+            description: "stale explicit drain to return"
         )
 
         let videoIds = self.viewModel.playlistDetail?.tracks.map(\.videoId) ?? []
         #expect(videoIds == ["video-0", "video-1", "video-2"])
         #expect(videoIds.contains("stale-continuation") == false)
+    }
+
+    @Test("Explicit full drain can run again after refresh cancels stale drain")
+    func explicitFullDrainRunsAfterRefreshCancelsStaleDrain() async {
+        let playlist = TestFixtures.makePlaylist(id: "VL-test-playlist", title: "Refresh Playlist")
+        self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(
+            playlist: playlist,
+            tracks: TestFixtures.makeSongs(count: 100),
+            duration: nil
+        )
+        self.mockClient.playlistContinuationTracks[playlist.id] = [
+            [TestFixtures.makeSong(id: "stale-continuation", title: "Stale")],
+        ]
+        self.mockClient.playlistContinuationDelay = .milliseconds(200)
+
+        await self.viewModel.load()
+        let staleDrain = Task { await self.viewModel.loadAllRemaining() }
+        await self.waitUntil(
+            self.mockClient.getPlaylistContinuationCallCount == 1,
+            description: "stale explicit drain to start before refresh"
+        )
+
+        let refreshedPlaylist = Playlist(
+            id: playlist.id,
+            title: playlist.title,
+            description: playlist.description,
+            thumbnailURL: playlist.thumbnailURL,
+            trackCount: 4,
+            author: playlist.author
+        )
+        self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(
+            playlist: refreshedPlaylist,
+            tracks: TestFixtures.makeSongs(count: 3),
+            duration: nil
+        )
+        self.mockClient.playlistContinuationTracks[playlist.id] = [
+            [TestFixtures.makeSong(id: "fresh-continuation", title: "Fresh")],
+        ]
+        self.mockClient.playlistContinuationDelay = nil
+
+        await self.viewModel.refresh()
+        await staleDrain.value
+        await self.viewModel.loadAllRemaining()
+
+        let videoIds = self.viewModel.playlistDetail?.tracks.map(\.videoId) ?? []
+        #expect(videoIds == ["video-0", "video-1", "video-2", "fresh-continuation"])
+        #expect(videoIds.contains("stale-continuation") == false)
+        #expect(self.viewModel.hasMore == false)
     }
 
     @Test("Concurrent paging callers coalesce: full load, no stall, no duplicate fetch")
@@ -543,6 +613,41 @@ struct PlaylistDetailViewModelTests {
         // Each of the 3 continuation batches is fetched exactly once — no batch skipped, and no
         // duplicate fetch from a coalesced caller advancing the token twice.
         #expect(self.mockClient.getPlaylistContinuationCallCount == 3)
+    }
+
+    @Test("Large playlist load keeps continuation lazy until explicitly requested")
+    func largePlaylistLoadKeepsContinuationLazy() async {
+        let playlist = Playlist(
+            id: "VL-test-playlist",
+            title: "Large Test Playlist",
+            description: nil,
+            thumbnailURL: nil,
+            trackCount: 150,
+            author: Artist.inline(name: "Test User", namespace: "playlist-author")
+        )
+        let viewModel = PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
+        let playlistDetail = PlaylistDetail(
+            playlist: playlist,
+            tracks: TestFixtures.makeSongs(count: 100),
+            duration: nil
+        )
+        self.mockClient.playlistDetails["VL-test-playlist"] = playlistDetail
+        self.mockClient.playlistContinuationTracks["VL-test-playlist"] = [
+            (100 ..< 150).map { TestFixtures.makeSong(id: "cont-\($0)") },
+        ]
+
+        await viewModel.load()
+
+        #expect(self.mockClient.getPlaylistContinuationCalled == false)
+        #expect(self.mockClient.getPlaylistContinuationCallCount == 0)
+        #expect(viewModel.playlistDetail?.tracks.count == 100)
+        #expect(viewModel.hasMore == true)
+
+        await viewModel.loadAllRemaining()
+
+        #expect(self.mockClient.getPlaylistContinuationCallCount == 1)
+        #expect(viewModel.playlistDetail?.tracks.count == 150)
+        #expect(viewModel.hasMore == false)
     }
 
     @Test("Small playlist load keeps continuation lazy")
@@ -755,6 +860,7 @@ struct PlaylistDetailViewModelTests {
         self.mockClient.playlistContinuationTracks["VL-test-playlist"] = [continuationTracks]
 
         await self.viewModel.load()
+        await self.viewModel.loadAllRemaining()
         await self.waitUntil(
             self.viewModel.playlistDetail?.tracks.count == 150,
             description: "reported total count continuation drain"

--- a/Tests/KasetTests/PodcastsAvailabilityServiceTests.swift
+++ b/Tests/KasetTests/PodcastsAvailabilityServiceTests.swift
@@ -256,7 +256,9 @@ private final class AsyncSignal {
     }
 
     func wait() async {
-        if self.isSignalled { return }
+        if self.isSignalled {
+            return
+        }
 
         await withCheckedContinuation { continuation in
             if self.isSignalled {

--- a/Tests/KasetTests/PodcastsViewModelTests.swift
+++ b/Tests/KasetTests/PodcastsViewModelTests.swift
@@ -121,7 +121,7 @@ struct PodcastsViewModelTests {
     // MARK: - Continuation Loading
 
     @Test
-    func hasMoreSectionsReflectsClientState() async {
+    func initialLoadDoesNotDrainContinuations() async {
         let testSection = PodcastSection(id: UUID().uuidString, title: "Main", items: [])
         self.mockClient.podcastsSections = [testSection]
         self.mockClient.podcastsContinuationSections = [
@@ -130,43 +130,44 @@ struct PodcastsViewModelTests {
 
         await self.viewModel.load()
 
-        // Background loading starts automatically; wait for it to complete
-        try? await Task.sleep(for: .milliseconds(500))
-
-        // After background loading, continuation should have been consumed
-        #expect(self.viewModel.sections.count >= 1)
+        #expect(self.viewModel.sections.map(\.title) == ["Main"])
+        #expect(self.viewModel.hasMoreSections == true)
+        #expect(self.mockClient.getPodcastsContinuationCallCount == 0)
     }
 
     @Test
-    func loadAppendsContinuationInBackground() async {
+    func loadMoreAppendsOneContinuationPerDemand() async {
         let mainSection = PodcastSection(id: UUID().uuidString, title: "Main", items: [])
-        let continuationSection = PodcastSection(id: UUID().uuidString, title: "Continuation", items: [])
+        let firstContinuation = PodcastSection(id: UUID().uuidString, title: "Continuation 1", items: [])
+        let secondContinuation = PodcastSection(id: UUID().uuidString, title: "Continuation 2", items: [])
 
         self.mockClient.podcastsSections = [mainSection]
-        self.mockClient.podcastsContinuationSections = [[continuationSection]]
+        self.mockClient.podcastsContinuationSections = [[firstContinuation], [secondContinuation]]
 
         await self.viewModel.load()
+        await self.viewModel.loadMore()
 
-        // Wait for background loading to complete (300ms delay + processing)
-        try? await Task.sleep(for: .milliseconds(600))
+        #expect(self.viewModel.sections.map(\.title) == ["Main", "Continuation 1"])
+        #expect(self.viewModel.hasMoreSections == true)
+        #expect(self.mockClient.getPodcastsContinuationCallCount == 1)
 
-        #expect(self.viewModel.sections.count == 2)
-        #expect(self.viewModel.sections[1].title == "Continuation")
+        await self.viewModel.loadMore()
+
+        #expect(self.viewModel.sections.map(\.title) == ["Main", "Continuation 1", "Continuation 2"])
+        #expect(self.viewModel.hasMoreSections == false)
+        #expect(self.mockClient.getPodcastsContinuationCallCount == 2)
     }
 
     @Test
     func loadWithNoContinuationDoesNotAddMore() async {
         let testSection = PodcastSection(id: UUID().uuidString, title: "Only Section", items: [])
         self.mockClient.podcastsSections = [testSection]
-        // No continuation sections
 
         await self.viewModel.load()
 
-        // Wait for any background loading attempt
-        try? await Task.sleep(for: .milliseconds(500))
-
         #expect(self.viewModel.sections.count == 1)
         #expect(self.viewModel.hasMoreSections == false)
+        #expect(self.mockClient.getPodcastsContinuationCallCount == 0)
     }
 
     // MARK: - Empty State

--- a/Tests/KasetTests/ScrobblingCoordinatorTests.swift
+++ b/Tests/KasetTests/ScrobblingCoordinatorTests.swift
@@ -263,6 +263,64 @@ struct ScrobblingCoordinatorTests {
         #expect(decoded.id == track.id)
     }
 
+    @Test("Queue flush is not scheduled without an eligible service")
+    func queueFlushDormantWithoutEligibleService() throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let queue = ScrobbleQueue(directory: dir)
+        queue.enqueue(self.makeTrack(title: "Queued"))
+
+        let mockService = MockScrobbleService()
+        mockService.authState = .disconnected
+
+        let playerService = PlayerService()
+        let settings = SettingsManager.shared
+        settings.setServiceEnabled("Mock", true)
+        defer { settings.setServiceEnabled("Mock", false) }
+
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [mockService],
+            queue: queue
+        )
+
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+
+        #expect(!coordinator.isQueueFlushScheduled)
+    }
+
+    @Test("Queue flush is one-shot scheduled only when service is eligible and queue has work")
+    func queueFlushScheduledForEligiblePendingQueue() throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let queue = ScrobbleQueue(directory: dir)
+        queue.enqueue(self.makeTrack(title: "Queued"))
+
+        let mockService = MockScrobbleService()
+        mockService.authState = .connected(username: "testuser")
+
+        let playerService = PlayerService()
+        let settings = SettingsManager.shared
+        settings.setServiceEnabled("Mock", true)
+        defer { settings.setServiceEnabled("Mock", false) }
+
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [mockService],
+            queue: queue
+        )
+
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+
+        #expect(coordinator.isQueueFlushScheduled)
+    }
+
     // MARK: - Fix #1: Only accepted tracks removed from queue
 
     @Test("FlushQueue only marks accepted tracks as completed, rejected stay in queue")

--- a/Tests/KasetTests/SearchViewModelTests.swift
+++ b/Tests/KasetTests/SearchViewModelTests.swift
@@ -42,7 +42,9 @@ struct SearchViewModelTests {
         let deadline = clock.now + timeout
 
         while clock.now < deadline {
-            if condition() { return }
+            if condition() {
+                return
+            }
             try? await Task.sleep(for: .milliseconds(10))
         }
 
@@ -50,7 +52,9 @@ struct SearchViewModelTests {
     }
 
     private var isErrorLoadingState: Bool {
-        if case .error = self.viewModel.loadingState { return true }
+        if case .error = self.viewModel.loadingState {
+            return true
+        }
         return false
     }
 
@@ -256,11 +260,9 @@ struct SearchViewModelTests {
         #expect(self.mockClient.searchQueries.count == 7)
     }
 
-    @Test("All filter publishes mixed results before category searches complete")
-    func allFilterPublishesMixedResultsBeforeCategorySearchesComplete() async {
-        let categoryGate = AsyncGate()
+    @Test("All filter uses mixed response without category fanout when mixed has results")
+    func allFilterUsesMixedResponseWithoutCategoryFanout() async {
         let mixedSong = TestFixtures.makeSong(id: "mixed-song", title: "Mixed Song")
-        let categorySong = TestFixtures.makeSong(id: "category-song", title: "Category Song")
         self.mockClient.mixedSearchResponse = SearchResponse(
             songs: [mixedSong],
             albums: [],
@@ -268,7 +270,7 @@ struct SearchViewModelTests {
             playlists: []
         )
         self.mockClient.songsSearchResponse = SearchResponse(
-            songs: [categorySong],
+            songs: [TestFixtures.makeSong(id: "category-song", title: "Category Song")],
             albums: [],
             artists: [],
             playlists: []
@@ -279,11 +281,6 @@ struct SearchViewModelTests {
             artists: [],
             playlists: []
         )
-        self.mockClient.beforeSearchReturn = { _, endpoint in
-            if endpoint != .mixed {
-                await categoryGate.wait()
-            }
-        }
 
         self.viewModel.query = "lofi"
         self.viewModel.selectedFilter = .all
@@ -291,38 +288,24 @@ struct SearchViewModelTests {
 
         await self.waitUntil(
             self.viewModel.results.songs.map(\.id) == ["mixed-song"] && self.viewModel.loadingState == .loaded,
-            description: "mixed results first paint"
+            description: "mixed-only all-filter results"
         )
+
         #expect(self.viewModel.results.albums.isEmpty)
-        #expect(self.viewModel.shouldShowFilters == false)
-        #expect(self.mockClient.completedSearchEndpoints == [.mixed])
-
-        await categoryGate.open()
-        await self.waitUntil(
-            self.viewModel.results.songs.map(\.id).contains("category-song") && self.viewModel.results.albums.count == 1,
-            description: "category-enriched all-filter results"
-        )
-
-        #expect(self.viewModel.results.songs.map(\.id) == ["mixed-song", "category-song"])
-        #expect(self.viewModel.results.albums.map(\.id) == ["MPRE-category"])
         #expect(self.viewModel.shouldShowFilters == true)
-        #expect(self.mockClient.searchQueries.count == 7)
+        #expect(self.mockClient.completedSearchEndpoints == [.mixed])
+        #expect(self.mockClient.searchQueries.count == 1)
     }
 
-    @Test("All filter discards delayed category results after query changes")
-    func allFilterDiscardsDelayedCategoryResultsAfterQueryChanges() async {
+    @Test("All filter discards delayed fallback category results after query changes")
+    func allFilterDiscardsDelayedFallbackCategoryResultsAfterQueryChanges() async {
         let oldCategoryGate = AsyncGate()
         self.mockClient.beforeSearchReturn = { query, endpoint in
             if query == "old", endpoint != .mixed {
                 await oldCategoryGate.wait()
             }
         }
-        self.mockClient.mixedSearchResponse = SearchResponse(
-            songs: [TestFixtures.makeSong(id: "old-mixed", title: "Old Mixed")],
-            albums: [],
-            artists: [],
-            playlists: []
-        )
+        self.mockClient.mixedSearchResponse = .empty
         self.mockClient.songsSearchResponse = SearchResponse(
             songs: [TestFixtures.makeSong(id: "old-category", title: "Old Category")],
             albums: [],
@@ -334,8 +317,8 @@ struct SearchViewModelTests {
         self.viewModel.selectedFilter = .all
         self.viewModel.searchImmediately()
         await self.waitUntil(
-            self.viewModel.results.songs.map(\.id) == ["old-mixed"],
-            description: "old mixed first paint"
+            self.mockClient.completedSearchEndpoints == [.mixed],
+            description: "old mixed empty fallback started"
         )
 
         self.mockClient.mixedSearchResponse = SearchResponse(
@@ -344,17 +327,11 @@ struct SearchViewModelTests {
             artists: [],
             playlists: []
         )
-        self.mockClient.songsSearchResponse = SearchResponse(
-            songs: [TestFixtures.makeSong(id: "new-category", title: "New Category")],
-            albums: [],
-            artists: [],
-            playlists: []
-        )
         self.viewModel.query = "new"
         self.viewModel.searchImmediately()
         await self.waitUntil(
-            self.viewModel.results.songs.map(\.id).contains("new-category"),
-            description: "new all-filter final results"
+            self.viewModel.results.songs.map(\.id) == ["new-mixed"],
+            description: "new mixed-only all-filter results"
         )
 
         await oldCategoryGate.open()
@@ -362,7 +339,7 @@ struct SearchViewModelTests {
             await Task.yield()
         }
 
-        #expect(self.viewModel.results.songs.map(\.id) == ["new-mixed", "new-category"])
+        #expect(self.viewModel.results.songs.map(\.id) == ["new-mixed"])
         #expect(self.viewModel.results.songs.map(\.id).contains("old-category") == false)
         #expect(self.viewModel.loadingState == .loaded)
     }

--- a/Tests/KasetTests/SingletonPlayerVideoModeScriptTests.swift
+++ b/Tests/KasetTests/SingletonPlayerVideoModeScriptTests.swift
@@ -1,0 +1,258 @@
+import JavaScriptCore
+import Testing
+@testable import Kaset
+
+// MARK: - SingletonPlayerVideoModeScriptTests
+
+@Suite(.serialized, .tags(.service))
+@MainActor
+struct SingletonPlayerVideoModeScriptTests {
+    @Test("Video mode warmup is bounded and stops steady RAF scheduling")
+    func videoModeWarmupIsBounded() throws {
+        let context = try #require(self.makeContext())
+
+        try self.evaluate(SingletonPlayerWebView.videoModeInjectionScriptForTesting, in: context)
+
+        let initialActive = context.evaluateScript("window.__kasetVideoModeActive")?.toBool() ?? false
+        let initialQueueCount = context.evaluateScript("rafQueue.length")?.toInt32() ?? -1
+        #expect(initialActive)
+        #expect(initialQueueCount == 1)
+
+        try self.evaluate("drainAnimationFrames(100);", in: context)
+
+        let remainingQueueCount = context.evaluateScript("rafQueue.length")?.toInt32() ?? -1
+        let scheduledCount = context.evaluateScript("rafScheduledCount")?.toInt32() ?? -1
+        let videoMarked = context.evaluateScript("video.classList.contains('kaset-visible')")?.toBool() ?? false
+        let playerMarked = context.evaluateScript("player.classList.contains('kaset-visible')")?.toBool() ?? false
+
+        #expect(remainingQueueCount == 0)
+        #expect(scheduledCount == 30)
+        #expect(videoMarked)
+        #expect(playerMarked)
+    }
+
+    @Test("Video mode schedules only one event-driven enforcement frame")
+    func eventDrivenEnforcementCoalescesFrames() throws {
+        let context = try #require(self.makeContext())
+
+        try self.evaluate(SingletonPlayerWebView.videoModeInjectionScriptForTesting, in: context)
+        try self.evaluate("drainAnimationFrames(100);", in: context)
+        let before = context.evaluateScript("rafScheduledCount")?.toInt32() ?? -1
+
+        try self.evaluate("mutationCallbacks[0](); mutationCallbacks[0](); mutationCallbacks[1]();", in: context)
+
+        let pendingAfterMutations = context.evaluateScript("rafQueue.length")?.toInt32() ?? -1
+        #expect(pendingAfterMutations == 1)
+
+        try self.evaluate("drainAnimationFrames(10);", in: context)
+
+        let after = context.evaluateScript("rafScheduledCount")?.toInt32() ?? -1
+        let pendingAfterDrain = context.evaluateScript("rafQueue.length")?.toInt32() ?? -1
+        #expect(after == before + 1)
+        #expect(pendingAfterDrain == 0)
+    }
+
+    @Test("Video mode event enforcement removes stale extra visibility markers")
+    func eventEnforcementRemovesStaleExtraMarkers() throws {
+        let context = try #require(self.makeContext())
+
+        try self.evaluate(SingletonPlayerWebView.videoModeInjectionScriptForTesting, in: context)
+        try self.evaluate("drainAnimationFrames(100);", in: context)
+        try self.evaluate(
+            """
+            var stale = makeElement('stale', body);
+            allElements.push(stale);
+            stale.classList.add('kaset-visible');
+            mutationCallbacks[0]();
+            """,
+            in: context
+        )
+        #expect(context.evaluateScript("rafQueue.length")?.toInt32() == 1)
+
+        try self.evaluate("drainAnimationFrames(10);", in: context)
+
+        let staleStillVisible = context.evaluateScript("stale.classList.contains('kaset-visible')")?.toBool() ?? true
+        let videoMarked = context.evaluateScript("video.classList.contains('kaset-visible')")?.toBool() ?? false
+
+        #expect(!staleStillVisible)
+        #expect(videoMarked)
+    }
+
+    @Test("Video mode reinjection clears stale visibility markers")
+    func reinjectionClearsStaleVisibilityMarkers() throws {
+        let context = try #require(self.makeContext())
+
+        try self.evaluate(SingletonPlayerWebView.videoModeInjectionScriptForTesting, in: context)
+        try self.evaluate("drainAnimationFrames(100);", in: context)
+        try self.evaluate(
+            """
+            var stale = makeElement('stale', body);
+            allElements.push(stale);
+            stale.classList.add('kaset-visible');
+            """,
+            in: context
+        )
+        #expect(context.evaluateScript("stale.classList.contains('kaset-visible')")?.toBool() ?? false)
+
+        try self.evaluate(SingletonPlayerWebView.videoModeInjectionScriptForTesting, in: context)
+        try self.evaluate("drainAnimationFrames(100);", in: context)
+
+        let staleStillVisible = context.evaluateScript("stale.classList.contains('kaset-visible')")?.toBool() ?? true
+        let videoMarked = context.evaluateScript("video.classList.contains('kaset-visible')")?.toBool() ?? false
+
+        #expect(!staleStillVisible)
+        #expect(videoMarked)
+    }
+
+    @Test("Video mode removal stops pending enforcement and clears markers")
+    func removalStopsPendingEnforcement() throws {
+        let context = try #require(self.makeContext())
+
+        try self.evaluate(SingletonPlayerWebView.videoModeInjectionScriptForTesting, in: context)
+        try self.evaluate(SingletonPlayerWebView.videoModeRemovalScriptForTesting, in: context)
+        try self.evaluate("drainAnimationFrames(100);", in: context)
+
+        let active = context.evaluateScript("window.__kasetVideoModeActive")?.toBool() ?? true
+        let stateExists = context.evaluateScript("typeof window.__kasetVideoModeState !== 'undefined'")?.toBool() ?? true
+        let pending = context.evaluateScript("rafQueue.length")?.toInt32() ?? -1
+        let markedCount = context.evaluateScript("document.querySelectorAll('.kaset-visible').length")?.toInt32() ?? -1
+
+        #expect(!active)
+        #expect(!stateExists)
+        #expect(pending == 0)
+        #expect(markedCount == 0)
+    }
+
+    // swiftlint:disable function_body_length
+    private func makeContext() -> JSContext? {
+        guard let context = JSContext() else { return nil }
+        context.exceptionHandler = { _, exception in
+            Issue.record("JavaScript exception: \(exception?.toString() ?? "unknown")")
+        }
+        context.evaluateScript(
+            """
+            var console = { log: function() {} };
+            var window = {
+                listeners: {},
+                addEventListener: function(name, handler) { this.listeners[name] = handler; },
+                removeEventListener: function(name) { delete this.listeners[name]; }
+            };
+
+            function makeClassList(element) {
+                return {
+                    add: function(name) { element.classes[name] = true; },
+                    remove: function(name) { delete element.classes[name]; },
+                    contains: function(name) { return element.classes[name] === true; }
+                };
+            }
+
+            function makeElement(name, parent) {
+                var element = {
+                    nodeName: name,
+                    parentElement: parent || null,
+                    children: [],
+                    classes: {},
+                    style: { setProperty: function() {} },
+                    textContent: '',
+                    id: '',
+                    appendChild: function(child) {
+                        child.parentElement = element;
+                        element.children.push(child);
+                        if (child.id) { elementsById[child.id] = child; }
+                    },
+                    remove: function() {
+                        if (element.id) { delete elementsById[element.id]; }
+                    },
+                    querySelector: function(selector) {
+                        if (selector === 'video') { return video; }
+                        return null;
+                    }
+                };
+                element.classList = makeClassList(element);
+                return element;
+            }
+
+            var elementsById = {};
+            var html = makeElement('html', null);
+            var body = makeElement('body', html);
+            var playerPage = makeElement('ytmusic-player-page', body);
+            playerPage.videoMode = false;
+            playerPage.onVideoModeChangedCount = 0;
+            playerPage.onVideoModeChanged = function() { this.onVideoModeChangedCount += 1; };
+            var player = makeElement('ytmusic-player', playerPage);
+            var video = makeElement('video', player);
+            var allElements = [html, body, playerPage, player, video];
+
+            var document = {
+                documentElement: html,
+                body: body,
+                head: { appendChild: function(element) { if (element.id) { elementsById[element.id] = element; } } },
+                createElement: function(name) {
+                    var element = makeElement(name, null);
+                    allElements.push(element);
+                    return element;
+                },
+                getElementById: function(id) { return elementsById[id] || null; },
+                querySelector: function(selector) {
+                    if (selector === 'video') { return video; }
+                    if (selector === 'ytmusic-player-page') { return playerPage; }
+                    return null;
+                },
+                querySelectorAll: function(selector) {
+                    if (selector === '.kaset-visible') {
+                        return allElements.filter(function(element) { return element.classList.contains('kaset-visible'); });
+                    }
+                    if (selector === 'video') { return [video]; }
+                    return [];
+                }
+            };
+
+            var mutationCallbacks = [];
+            function MutationObserver(callback) { this.callback = callback; mutationCallbacks.push(callback); }
+            MutationObserver.prototype.observe = function() {};
+            MutationObserver.prototype.disconnect = function() {};
+
+            function ResizeObserver(callback) { this.callback = callback; mutationCallbacks.push(callback); }
+            ResizeObserver.prototype.observe = function() {};
+            ResizeObserver.prototype.disconnect = function() {};
+
+            var rafQueue = [];
+            var rafScheduledCount = 0;
+            var canceledRafs = {};
+            function requestAnimationFrame(callback) {
+                rafScheduledCount += 1;
+                rafQueue.push({ id: rafScheduledCount, callback: callback });
+                return rafScheduledCount;
+            }
+            function cancelAnimationFrame(id) { canceledRafs[id] = true; }
+            function drainAnimationFrames(limit) {
+                var ran = 0;
+                while (rafQueue.length > 0 && ran < limit) {
+                    var item = rafQueue.shift();
+                    if (!canceledRafs[item.id]) { item.callback(); }
+                    ran += 1;
+                }
+                return ran;
+            }
+            """
+        )
+        return context
+    }
+
+    // swiftlint:enable function_body_length
+
+    private func evaluate(_ script: String, in context: JSContext) throws {
+        context.exception = nil
+        _ = context.evaluateScript(script)
+        if let exception = context.exception?.toString() {
+            Issue.record("JavaScript exception: \(exception)")
+            throw TestScriptError.javaScriptException(exception)
+        }
+    }
+}
+
+// MARK: - TestScriptError
+
+private enum TestScriptError: Error {
+    case javaScriptException(String)
+}

--- a/Tests/KasetTests/StoryboardSheetTests.swift
+++ b/Tests/KasetTests/StoryboardSheetTests.swift
@@ -164,4 +164,49 @@ struct AmbientBackdropStyleTests {
             #expect(!style.debugLabel.isEmpty)
         }
     }
+
+    @Test("Default ambient style favors the steady low-energy glow")
+    func defaultAmbientStyleIsSteady() {
+        #expect(SettingsManager.defaultAmbientBackdropStyle == .soft)
+    }
+
+    @Test("Resolved ambient style only reflects stored user preference")
+    func resolvedAmbientStyleReflectsStoredPreference() {
+        #expect(SettingsManager.resolveAmbientStyle(
+            enabled: false,
+            preferredStyle: .live
+        ) == .off)
+        #expect(SettingsManager.resolveAmbientStyle(
+            enabled: true,
+            preferredStyle: .live
+        ) == .live)
+        #expect(SettingsManager.resolveAmbientStyle(
+            enabled: true,
+            preferredStyle: .glow
+        ) == .glow)
+    }
+
+    @Test("Ambient rendering downgrades live for Reduce Motion or Low Power Mode")
+    func ambientRenderingDowngradesLiveForEnergyAndAccessibility() {
+        #expect(AmbientVideoBackdrop.effectiveStyle(
+            requestedStyle: .live,
+            reduceMotion: true,
+            lowPowerModeEnabled: false
+        ) == .soft)
+        #expect(AmbientVideoBackdrop.effectiveStyle(
+            requestedStyle: .live,
+            reduceMotion: false,
+            lowPowerModeEnabled: true
+        ) == .soft)
+        #expect(AmbientVideoBackdrop.effectiveStyle(
+            requestedStyle: .glow,
+            reduceMotion: true,
+            lowPowerModeEnabled: false
+        ) == .glow)
+    }
+
+    @Test("Animated ambient cadence is periodic rather than display-link paced")
+    func animatedAmbientCadenceIsThrottled() {
+        #expect(AmbientVideoBackdrop.animatedTimelineInterval >= 0.1)
+    }
 }

--- a/Tests/KasetTests/SyncedLyricsBridgeScriptTests.swift
+++ b/Tests/KasetTests/SyncedLyricsBridgeScriptTests.swift
@@ -1,0 +1,293 @@
+import JavaScriptCore
+import Testing
+@testable import Kaset
+
+// MARK: - SyncedLyricsBridgeScriptTests
+
+@Suite(.serialized, .tags(.service))
+struct SyncedLyricsBridgeScriptTests {
+    @Test("Synced lyrics display bucket follows current line")
+    func displayBucketFollowsCurrentLine() {
+        let lyrics = SyncedLyrics(lines: [
+            SyncedLyricLine(timeInMs: 0, duration: 1000, text: "A", words: nil),
+            SyncedLyricLine(timeInMs: 1000, duration: 1000, text: "B", words: nil),
+            SyncedLyricLine(timeInMs: 2000, duration: 1000, text: "C", words: nil),
+        ], source: "Test")
+
+        #expect(lyrics.displayBucket(at: -1) == -1)
+        #expect(lyrics.displayBucket(at: 0) == 0)
+        #expect(lyrics.displayBucket(at: 999) == 0)
+        #expect(lyrics.displayBucket(at: 1000) == 1)
+        #expect(lyrics.displayBucket(at: 2500) == 2)
+        #expect(lyrics.displayBucket(at: 3000) == -4)
+        #expect(lyrics.bridgeLineRanges[0] == ["startMs": 0, "endMs": 1000])
+
+        let zeroDuration = SyncedLyrics(lines: [
+            SyncedLyricLine(timeInMs: 0, duration: 0, text: "A", words: nil),
+            SyncedLyricLine(timeInMs: 1000, duration: 0, text: "B", words: nil),
+        ], source: "Test")
+        #expect(zeroDuration.bridgeLineRanges[0] == ["startMs": 0, "endMs": 1000])
+        #expect(zeroDuration.displayBucket(at: 500) == 0)
+        #expect(zeroDuration.displayBucket(at: 1000) == 1)
+
+        let gapped = SyncedLyrics(lines: [
+            SyncedLyricLine(timeInMs: 0, duration: 500, text: "A", words: nil),
+            SyncedLyricLine(timeInMs: 1000, duration: 500, text: "B", words: nil),
+        ], source: "Test")
+        #expect(gapped.displayBucket(at: 750) == -2)
+        #expect(gapped.displayBucket(at: 1750) == -3)
+
+        let overlapping = SyncedLyrics(lines: [
+            SyncedLyricLine(timeInMs: 0, duration: 3000, text: "A", words: nil),
+            SyncedLyricLine(timeInMs: 2000, duration: 1000, text: "B", words: nil),
+        ], source: "Test")
+        #expect(overlapping.bridgeLineRanges[0] == ["startMs": 0, "endMs": 2000])
+        #expect(overlapping.displayBucket(at: 2500) == 1)
+    }
+
+    @Test("Lyrics bridge posts only when the current line changes")
+    func bridgePostsOnlyLineChanges() throws {
+        let context = try #require(JSContext())
+        try self.evaluate(Self.fixtureScript, in: context)
+        try self.evaluate(SingletonPlayerWebView.observerScript, in: context)
+
+        try self.evaluate(
+            """
+            window.startLyricsPoll([
+                { startMs: 0, endMs: 500 },
+                { startMs: 1000, endMs: 1500 },
+                { startMs: 2000, endMs: 2500 }
+            ]);
+            video.currentTime = 0.5;
+            timeoutCalls[timeoutCalls.length - 1].callback();
+            video.currentTime = 1.0;
+            timeoutCalls[timeoutCalls.length - 1].callback();
+            video.currentTime = 1.5;
+            timeoutCalls[timeoutCalls.length - 1].callback();
+            video.currentTime = 2.0;
+            timeoutCalls[timeoutCalls.length - 1].callback();
+            video.currentTime = 2.5;
+            timeoutCalls[timeoutCalls.length - 1].callback();
+            video.currentTime = 3.0;
+            timeoutCalls[timeoutCalls.length - 1].callback();
+            """,
+            in: context
+        )
+
+        let messageCount = context.evaluateScript("postedMessages.filter(function(m) { return m.type === 'LYRICS_LINE'; }).length")?.toInt32() ?? -1
+        let lineIndexes = context.evaluateScript("postedMessages.filter(function(m) { return m.type === 'LYRICS_LINE'; }).map(function(m) { return String(m.lineIndex); }).join(',')")?.toString()
+        let timeValues = context.evaluateScript("postedMessages.filter(function(m) { return m.type === 'LYRICS_LINE'; }).map(function(m) { return String(m.timeMs); }).join(',')")?.toString()
+        let lyricsIntervalCount = context.evaluateScript("intervalCalls.filter(function(call) { return call.milliseconds === 250; }).length")?.toInt32() ?? -1
+
+        #expect(messageCount == 6)
+        #expect(lineIndexes == "0,-1,1,-1,2,-1")
+        #expect(timeValues == "0,500,1000,1500,2000,2500")
+        #expect(lyricsIntervalCount == 0)
+    }
+
+    @Test("Lyrics bridge schedules short ranges at their next boundary")
+    func bridgeSchedulesShortRangesAtBoundary() throws {
+        let context = try #require(JSContext())
+        try self.evaluate(Self.fixtureScript, in: context)
+        try self.evaluate(SingletonPlayerWebView.observerScript, in: context)
+
+        try self.evaluate(
+            """
+            video.currentTime = 1.0;
+            window.startLyricsPoll([
+                { startMs: 1100, endMs: 1200 }
+            ]);
+            """,
+            in: context
+        )
+
+        let lyricsDelay = context.evaluateScript("timeoutCalls[timeoutCalls.length - 1].milliseconds")?.toInt32() ?? -1
+        #expect(lyricsDelay == 101)
+    }
+
+    @Test("Lyrics bridge allows sub-50ms boundary scheduling for very short ranges")
+    func bridgeAllowsSub50msBoundaryScheduling() throws {
+        let context = try #require(JSContext())
+        try self.evaluate(Self.fixtureScript, in: context)
+        try self.evaluate(SingletonPlayerWebView.observerScript, in: context)
+
+        try self.evaluate(
+            """
+            video.currentTime = 1.09;
+            window.startLyricsPoll([
+                { startMs: 1100, endMs: 1120 }
+            ]);
+            """,
+            in: context
+        )
+
+        let lyricsDelay = context.evaluateScript("timeoutCalls[timeoutCalls.length - 1].milliseconds")?.toInt32() ?? -1
+        #expect(lyricsDelay == 11)
+    }
+
+    @Test("Lyrics bridge reschedules when line ranges are replaced")
+    func bridgeReschedulesWhenRangesAreReplaced() throws {
+        let context = try #require(JSContext())
+        try self.evaluate(Self.fixtureScript, in: context)
+        try self.evaluate(SingletonPlayerWebView.observerScript, in: context)
+
+        try self.evaluate(
+            """
+            video.currentTime = 0;
+            window.startLyricsPoll([
+                { startMs: 0, endMs: 10000 }
+            ]);
+            const firstTimeoutId = timeoutCalls.length;
+            video.currentTime = 1.0;
+            window.startLyricsPoll([
+                { startMs: 1100, endMs: 1200 }
+            ]);
+            """,
+            in: context
+        )
+
+        let clearedTimeout = context.evaluateScript("clearedTimeoutIds.indexOf(1) !== -1")?.toBool() ?? false
+        let latestDelay = context.evaluateScript("timeoutCalls[timeoutCalls.length - 1].milliseconds")?.toInt32() ?? -1
+
+        #expect(clearedTimeout)
+        #expect(latestDelay == 101)
+    }
+
+    @Test("Lyrics bridge emits sought short line immediately")
+    func bridgeEmitsSoughtShortLineImmediately() throws {
+        let context = try #require(JSContext())
+        try self.evaluate(Self.fixtureScript, in: context)
+        try self.evaluate(SingletonPlayerWebView.observerScript, in: context)
+
+        try self.evaluate(
+            """
+            window.startLyricsPoll([
+                { startMs: 1100, endMs: 1200 }
+            ]);
+            postedMessages = [];
+            video.currentTime = 1.1;
+            videoListeners.seeked();
+            """,
+            in: context
+        )
+
+        let lineMessages = context.evaluateScript("postedMessages.filter(function(m) { return m.type === 'LYRICS_LINE'; })")
+        let count = lineMessages?.forProperty("length")?.toInt32() ?? -1
+        let lineIndex = context.evaluateScript("postedMessages.filter(function(m) { return m.type === 'LYRICS_LINE'; })[0].lineIndex")?.toInt32() ?? -1
+        let timeMs = context.evaluateScript("postedMessages.filter(function(m) { return m.type === 'LYRICS_LINE'; })[0].timeMs")?.toInt32() ?? -1
+
+        #expect(count == 1)
+        #expect(lineIndex == 0)
+        #expect(timeMs == 1100)
+    }
+
+    @Test("Lyrics bridge does not restart after stop or before start")
+    func bridgeDoesNotRestartWhenInactive() throws {
+        let context = try #require(JSContext())
+        try self.evaluate(Self.fixtureScript, in: context)
+        try self.evaluate(SingletonPlayerWebView.observerScript, in: context)
+
+        try self.evaluate(
+            """
+            video.currentTime = 1.1;
+            videoListeners.seeked();
+            const timeoutCountBeforeStart = timeoutCalls.length;
+            window.startLyricsPoll([
+                { startMs: 1000, endMs: 2000 }
+            ]);
+            window.stopLyricsPoll();
+            video.currentTime = 1.2;
+            videoListeners.seeked();
+            """,
+            in: context
+        )
+
+        let timeoutCountBeforeStart = context.evaluateScript("timeoutCountBeforeStart")?.toInt32() ?? -1
+        let finalTimeoutCount = context.evaluateScript("timeoutCalls.length")?.toInt32() ?? -1
+        let lineMessageCount = context.evaluateScript("postedMessages.filter(function(m) { return m.type === 'LYRICS_LINE'; }).length")?.toInt32() ?? -1
+
+        #expect(timeoutCountBeforeStart == 0)
+        #expect(finalTimeoutCount == 1) // explicit start only; seek after stop adds none
+        #expect(lineMessageCount == 1)
+    }
+
+    private static var fixtureScript: String {
+        """
+        var postedMessages = [];
+        var intervalCalls = [];
+        var timeoutCalls = [];
+        var clearedTimeoutIds = [];
+        function setInterval(callback, milliseconds) {
+            intervalCalls.push({ callback: callback, milliseconds: milliseconds });
+            return intervalCalls.length;
+        }
+        function clearInterval(id) {}
+        function setTimeout(callback, milliseconds) {
+            timeoutCalls.push({ callback: callback, milliseconds: milliseconds });
+            return timeoutCalls.length;
+        }
+        function clearTimeout(id) { clearedTimeoutIds.push(id); }
+        var bridge = {
+            postMessage: function(message) { postedMessages.push(message); }
+        };
+        var window = {
+            location: { href: 'https://music.youtube.com/watch?v=abc' },
+            webkit: { messageHandlers: { singletonPlayer: bridge } },
+            __kasetTargetVolume: 1.0,
+            __kasetAutoplayPending: false,
+            addEventListener: function() {}
+        };
+        var localStorage = { getItem: function() { return null; }, setItem: function() {} };
+        var videoListeners = {};
+        var video = {
+            currentTime: 0,
+            paused: true,
+            ended: false,
+            volume: 1.0,
+            readyState: 4,
+            addEventListener: function(name, handler) { videoListeners[name] = handler; }
+        };
+        var playerBar = { attributes: {}, childNodes: [] };
+        var playerApi = {
+            getVideoData: function() { return { video_id: 'abc', title: 'Title', author: 'Artist' }; }
+        };
+        var ytmusicPlayer = { playerApi: playerApi };
+        var moviePlayer = { getVideoData: playerApi.getVideoData };
+        var document = {
+            readyState: 'complete',
+            body: {},
+            querySelector: function(selector) {
+                if (selector === 'ytmusic-player-bar') return playerBar;
+                if (selector === 'video') return video;
+                if (selector === 'ytmusic-player') return ytmusicPlayer;
+                if (selector === '#progress-bar') return null;
+                return null;
+            },
+            getElementById: function(id) {
+                if (id === 'movie_player') return moviePlayer;
+                return null;
+            },
+            querySelectorAll: function() { return []; },
+            addEventListener: function(_, handler) { handler(); }
+        };
+        function MutationObserver(callback) { this.callback = callback; }
+        MutationObserver.prototype.observe = function() {};
+        MutationObserver.prototype.disconnect = function() {};
+        """
+    }
+
+    private func evaluate(_ script: String, in context: JSContext) throws {
+        context.exception = nil
+        _ = context.evaluateScript(script)
+        if let exception = context.exception?.toString() {
+            Issue.record("JavaScript exception: \(exception)")
+            throw TestScriptError.javaScriptException(exception)
+        }
+    }
+}
+
+// MARK: - TestScriptError
+
+private enum TestScriptError: Error {
+    case javaScriptException(String)
+}

--- a/Tests/KasetTests/SyncedLyricsBridgeScriptTests.swift
+++ b/Tests/KasetTests/SyncedLyricsBridgeScriptTests.swift
@@ -105,14 +105,15 @@ struct SyncedLyricsBridgeScriptTests {
         #expect(lyricsDelay == 101)
     }
 
-    @Test("Lyrics bridge allows sub-50ms boundary scheduling for very short ranges")
-    func bridgeAllowsSub50msBoundaryScheduling() throws {
+    @Test("Lyrics bridge allows sub-50ms boundary scheduling while playing")
+    func bridgeAllowsSub50msBoundarySchedulingWhilePlaying() throws {
         let context = try #require(JSContext())
         try self.evaluate(Self.fixtureScript, in: context)
         try self.evaluate(SingletonPlayerWebView.observerScript, in: context)
 
         try self.evaluate(
             """
+            video.paused = false;
             video.currentTime = 1.09;
             window.startLyricsPoll([
                 { startMs: 1100, endMs: 1120 }
@@ -123,6 +124,27 @@ struct SyncedLyricsBridgeScriptTests {
 
         let lyricsDelay = context.evaluateScript("timeoutCalls[timeoutCalls.length - 1].milliseconds")?.toInt32() ?? -1
         #expect(lyricsDelay == 11)
+    }
+
+    @Test("Lyrics bridge clamps paused near-boundary scheduling to the minimum interval")
+    func bridgeClampsPausedNearBoundarySchedulingToMinimumInterval() throws {
+        let context = try #require(JSContext())
+        try self.evaluate(Self.fixtureScript, in: context)
+        try self.evaluate(SingletonPlayerWebView.observerScript, in: context)
+
+        try self.evaluate(
+            """
+            video.paused = true;
+            video.currentTime = 1.09;
+            window.startLyricsPoll([
+                { startMs: 1100, endMs: 1120 }
+            ]);
+            """,
+            in: context
+        )
+
+        let lyricsDelay = context.evaluateScript("timeoutCalls[timeoutCalls.length - 1].milliseconds")?.toInt32() ?? -1
+        #expect(lyricsDelay == 50)
     }
 
     @Test("Lyrics bridge reschedules when line ranges are replaced")

--- a/Tests/KasetTests/WebKitAuthMaterialTests.swift
+++ b/Tests/KasetTests/WebKitAuthMaterialTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+@Suite(.tags(.service))
+struct WebKitAuthMaterialTests {
+    @Test("Auth material derives header and SAPISID from one snapshot")
+    func authMaterialFromSnapshot() throws {
+        let cookies = try [
+            Self.cookie(name: "PREF", value: "test-pref", domain: ".youtube.com"),
+            Self.cookie(name: "__Secure-3PAPISID", value: "mock-secure-token", domain: ".youtube.com"),
+            Self.cookie(name: "SID", value: "ignored", domain: ".google.com"),
+        ]
+
+        let material = WebKitManager.authMaterial(from: cookies, domain: "youtube.com")
+
+        #expect(material.totalCookieCount == 3)
+        #expect(material.domainCookieCount == 2)
+        #expect(material.cookieHeader?.contains("PREF=test-pref") == true)
+        #expect(material.cookieHeader?.contains("__Secure-3PAPISID=mock-secure-token") == true)
+        #expect(material.cookieHeader?.contains("SID=ignored") == false)
+        #expect(material.sapisid == "mock-secure-token")
+    }
+
+    @Test("Expired secure auth cookie does not fall back to another auth cookie")
+    func expiredSecureCookieDoesNotFallback() throws {
+        let cookies = try [
+            Self.cookie(
+                name: "__Secure-3PAPISID",
+                value: "expired-secure-token",
+                domain: ".youtube.com",
+                expires: Date(timeIntervalSince1970: 1)
+            ),
+            Self.cookie(name: "SAPISID", value: "fallback-token", domain: ".youtube.com"),
+        ]
+
+        let material = WebKitManager.authMaterial(
+            from: cookies,
+            domain: "youtube.com",
+            now: Date(timeIntervalSince1970: 2)
+        )
+
+        #expect(material.cookieHeader != nil)
+        #expect(material.sapisid == nil)
+    }
+
+    @Test("Domain matching includes subdomains and leading-dot domains")
+    func domainMatchingIncludesSubdomains() throws {
+        let cookies = try [
+            Self.cookie(name: "A", value: "1", domain: ".youtube.com"),
+            Self.cookie(name: "B", value: "2", domain: "youtube.com"),
+            Self.cookie(name: "C", value: "3", domain: "music.youtube.com"),
+            Self.cookie(name: "D", value: "4", domain: "example.com"),
+        ]
+
+        let matched = WebKitManager.cookies(cookies, matching: "music.youtube.com")
+            .map(\.name)
+            .sorted()
+
+        #expect(matched == ["A", "B", "C"])
+    }
+
+    private static func cookie(
+        name: String,
+        value: String,
+        domain: String,
+        expires: Date? = nil
+    ) throws -> HTTPCookie {
+        var properties: [HTTPCookiePropertyKey: Any] = [
+            .name: name,
+            .value: value,
+            .domain: domain,
+            .path: "/",
+        ]
+        if let expires {
+            properties[.expires] = expires
+        }
+        return try #require(HTTPCookie(properties: properties))
+    }
+}

--- a/Tests/KasetTests/YTMusicClientTests.swift
+++ b/Tests/KasetTests/YTMusicClientTests.swift
@@ -281,10 +281,10 @@ struct YTMusicAPIKeyResolverTests {
     func fetchesAndCachesAPIKeyFromHTML() async throws {
         let session = MockURLProtocol.makeMockSession()
         let html = #"ytcfg.set({"INNERTUBE_API_KEY":"mock-token"});"#
-        nonisolated(unsafe) var requestCount = 0
+        let requestCount = LockedCounter()
 
         MockURLProtocol.setRequestHandler(for: session) { request in
-            requestCount += 1
+            requestCount.increment()
             guard let url = request.url,
                   let response = HTTPURLResponse(
                       url: url,
@@ -309,7 +309,7 @@ struct YTMusicAPIKeyResolverTests {
 
         #expect(first == "mock-token")
         #expect(second == "mock-token")
-        #expect(requestCount == 1)
+        #expect(requestCount.count == 1)
     }
 
     @Test("Concurrent cold resolves share one web client fetch")
@@ -318,11 +318,10 @@ struct YTMusicAPIKeyResolverTests {
         let session = MockURLProtocol.makeMockSession()
         let html = #"ytcfg.set({"INNERTUBE_API_KEY":"mock-token"});"#
         let firstRequestGate = DispatchSemaphore(value: 0)
-        nonisolated(unsafe) var requestCount = 0
+        let requestCount = LockedCounter()
 
         MockURLProtocol.setRequestHandler(for: session) { request in
-            requestCount += 1
-            if requestCount == 1 {
+            if requestCount.increment() == 1 {
                 _ = firstRequestGate.wait(timeout: .now() + 5)
             }
             guard let url = request.url,
@@ -346,7 +345,7 @@ struct YTMusicAPIKeyResolverTests {
         let resolver = YTMusicAPIKeyResolver(session: session, environment: { _ in nil })
 
         async let first = resolver.resolve()
-        while requestCount == 0 {
+        while requestCount.isEmpty {
             await Task.yield()
         }
         async let second = resolver.resolve()
@@ -356,7 +355,7 @@ struct YTMusicAPIKeyResolverTests {
         let results = try await [first, second, third]
 
         #expect(results == ["mock-token", "mock-token", "mock-token"])
-        #expect(requestCount == 1)
+        #expect(requestCount.count == 1)
     }
 
     @Test("API key fetch is cookieless and sends consent cookie")
@@ -480,8 +479,8 @@ struct YTMusicClientContinuationResetTests {
     @Test("Stale home continuation cannot repopulate page cursor after reset")
     func staleHomeContinuationCannotRepopulatePageCursorAfterReset() async throws {
         let session = MockURLProtocol.makeMockSession()
-        nonisolated(unsafe) var requestCount = 0
-        nonisolated(unsafe) var continuationRequestCount = 0
+        let requestCount = LockedCounter()
+        let continuationRequestCount = LockedCounter()
 
         MockURLProtocol.setRequestHandler(for: session) { request in
             guard let url = request.url else { throw URLError(.badURL) }
@@ -498,10 +497,10 @@ struct YTMusicClientContinuationResetTests {
                 return (response, Data(#"ytcfg.set({"INNERTUBE_API_KEY":"mock-token"});"#.utf8))
             }
 
-            requestCount += 1
+            let currentRequestCount = requestCount.increment()
             let payload: [String: Any]
-            if requestCount == 2 {
-                continuationRequestCount += 1
+            if currentRequestCount == 2 {
+                continuationRequestCount.increment()
                 Thread.sleep(forTimeInterval: 0.15)
                 payload = Self.homeContinuationPayload(nextCursor: "page-2")
             } else {
@@ -534,7 +533,7 @@ struct YTMusicClientContinuationResetTests {
 
         #expect(staleResult == nil)
         #expect(secondResult == nil)
-        #expect(continuationRequestCount == 1)
+        #expect(continuationRequestCount.count == 1)
     }
 
     // swiftlint:disable:next modifier_order

--- a/Tests/KasetTests/YTMusicClientTests.swift
+++ b/Tests/KasetTests/YTMusicClientTests.swift
@@ -312,6 +312,53 @@ struct YTMusicAPIKeyResolverTests {
         #expect(requestCount == 1)
     }
 
+    @Test("Concurrent cold resolves share one web client fetch")
+    @MainActor
+    func concurrentColdResolvesShareOneWebClientFetch() async throws {
+        let session = MockURLProtocol.makeMockSession()
+        let html = #"ytcfg.set({"INNERTUBE_API_KEY":"mock-token"});"#
+        let firstRequestGate = DispatchSemaphore(value: 0)
+        nonisolated(unsafe) var requestCount = 0
+
+        MockURLProtocol.setRequestHandler(for: session) { request in
+            requestCount += 1
+            if requestCount == 1 {
+                _ = firstRequestGate.wait(timeout: .now() + 5)
+            }
+            guard let url = request.url,
+                  let response = HTTPURLResponse(
+                      url: url,
+                      statusCode: 200,
+                      httpVersion: nil,
+                      headerFields: ["Content-Type": "text/html"]
+                  )
+            else {
+                throw URLError(.badURL)
+            }
+
+            return (response, Data(html.utf8))
+        }
+        defer {
+            firstRequestGate.signal()
+            MockURLProtocol.reset(session: session)
+        }
+
+        let resolver = YTMusicAPIKeyResolver(session: session, environment: { _ in nil })
+
+        async let first = resolver.resolve()
+        while requestCount == 0 {
+            await Task.yield()
+        }
+        async let second = resolver.resolve()
+        async let third = resolver.resolve()
+
+        firstRequestGate.signal()
+        let results = try await [first, second, third]
+
+        #expect(results == ["mock-token", "mock-token", "mock-token"])
+        #expect(requestCount == 1)
+    }
+
     @Test("API key fetch is cookieless and sends consent cookie")
     @MainActor
     func apiKeyFetchIsCookielessAndSendsConsentCookie() async throws {

--- a/Tests/KasetTests/YouTubeHomeContinueWatchingRefreshTests.swift
+++ b/Tests/KasetTests/YouTubeHomeContinueWatchingRefreshTests.swift
@@ -42,7 +42,9 @@ struct YouTubeHomeContinueWatchingRefreshTests {
     /// under load, bounded (~2s) so a genuine bug still fails fast.
     private func waitForCondition(_ condition: () -> Bool) async {
         for _ in 0 ..< 200 {
-            if condition() { return }
+            if condition() {
+                return
+            }
             try? await Task.sleep(for: .milliseconds(10))
         }
     }
@@ -537,7 +539,9 @@ private actor RefreshTestGate {
     private var waiters: [CheckedContinuation<Void, Never>] = []
 
     func wait() async {
-        if self.isOpen { return }
+        if self.isOpen {
+            return
+        }
         await withCheckedContinuation { continuation in
             self.waiters.append(continuation)
         }

--- a/Tests/KasetTests/YouTubeHomeViewModelTests.swift
+++ b/Tests/KasetTests/YouTubeHomeViewModelTests.swift
@@ -290,6 +290,85 @@ struct YouTubeHomeViewModelTests {
         #expect(self.sut.hasMoreTopicRails == false)
     }
 
+    @Test("Deferred topic auto-load skips empty batches")
+    func deferredTopicAutoLoadSkipsEmptyBatches() async {
+        self.mockClient.homeFeed = YouTubeFeed(
+            videos: MockYouTubeClient.makeVideos(count: 3),
+            continuation: nil
+        )
+        self.mockClient.homeChips = (0 ..< 6).map { index in
+            YouTubeHomeChip(title: "Topic \(index)", continuation: "tok-\(index)")
+        }
+        self.mockClient.homeTopicFeeds = [
+            "tok-0": YouTubeFeed(videos: MockYouTubeClient.makeVideos(count: 2), continuation: nil),
+            "tok-1": YouTubeFeed(videos: MockYouTubeClient.makeVideos(count: 2), continuation: nil),
+            "tok-2": .empty,
+            "tok-3": .empty,
+            "tok-4": YouTubeFeed(videos: MockYouTubeClient.makeVideos(count: 2), continuation: nil),
+            "tok-5": YouTubeFeed(videos: MockYouTubeClient.makeVideos(count: 2), continuation: nil),
+        ]
+
+        await self.sut.load()
+        await self.sut.loadMoreTopicRails()
+
+        #expect(Set(self.mockClient.requestedTopicContinuations) == Set([
+            "tok-0",
+            "tok-1",
+            "tok-2",
+            "tok-3",
+            "tok-4",
+            "tok-5",
+        ]))
+        #expect(self.mockClient.requestedTopicContinuations.count == 6)
+        #expect(self.sut.sections.filter { $0.kind == .topic }.map(\.title) == [
+            "Topic 0",
+            "Topic 1",
+            "Topic 4",
+            "Topic 5",
+        ])
+        #expect(self.sut.hasMoreTopicRails == false)
+    }
+
+    @Test("Deferred topic auto-load preserves failed batch for retry")
+    func deferredTopicAutoLoadPreservesFailedBatchForRetry() async {
+        self.mockClient.homeFeed = YouTubeFeed(
+            videos: MockYouTubeClient.makeVideos(count: 3),
+            continuation: nil
+        )
+        self.mockClient.homeChips = (0 ..< 6).map { index in
+            YouTubeHomeChip(title: "Topic \(index)", continuation: "tok-\(index)")
+        }
+        self.mockClient.homeTopicFeeds = Dictionary(uniqueKeysWithValues: (0 ..< 6).map { index in
+            ("tok-\(index)", YouTubeFeed(videos: MockYouTubeClient.makeVideos(count: 2), continuation: nil))
+        })
+        self.mockClient.homeTopicError = (
+            continuation: "tok-2",
+            error: YTMusicError.networkError(underlying: URLError(.timedOut))
+        )
+
+        await self.sut.load()
+        await self.sut.loadMoreTopicRails()
+
+        #expect(Set(self.mockClient.requestedTopicContinuations) == Set(["tok-0", "tok-1", "tok-2", "tok-3"]))
+        #expect(self.mockClient.requestedTopicContinuations.count == 4)
+        #expect(self.sut.sections.filter { $0.kind == .topic }.map(\.title) == ["Topic 0", "Topic 1"])
+        #expect(self.sut.hasMoreTopicRails)
+
+        self.mockClient.homeTopicError = nil
+        await self.sut.loadMoreTopicRails()
+
+        #expect(self.mockClient.requestedTopicContinuations.filter { $0 == "tok-2" }.count == 2)
+        #expect(self.mockClient.requestedTopicContinuations.filter { $0 == "tok-3" }.count == 2)
+        #expect(self.mockClient.requestedTopicContinuations.contains("tok-4") == false)
+        #expect(self.sut.sections.filter { $0.kind == .topic }.map(\.title) == [
+            "Topic 0",
+            "Topic 1",
+            "Topic 2",
+            "Topic 3",
+        ])
+        #expect(self.sut.hasMoreTopicRails)
+    }
+
     @Test("Empty first topic batch walks queued chips before falling back")
     func emptyFirstTopicBatchWalksQueuedChips() async {
         self.mockClient.homeFeed = .empty

--- a/Tests/KasetTests/YouTubeHomeViewModelTests.swift
+++ b/Tests/KasetTests/YouTubeHomeViewModelTests.swift
@@ -226,6 +226,93 @@ struct YouTubeHomeViewModelTests {
         #expect(self.sut.sections.map(\.title) == ["Gaming", "Music"])
     }
 
+    @Test("Cold load fetches only the first topic batch")
+    func coldLoadFetchesOnlyFirstTopicBatch() async {
+        self.mockClient.homeFeed = YouTubeFeed(
+            videos: MockYouTubeClient.makeVideos(count: 3),
+            continuation: nil
+        )
+        self.mockClient.homeChips = (0 ..< 8).map { index in
+            YouTubeHomeChip(title: "Topic \(index)", continuation: "tok-\(index)")
+        }
+        self.mockClient.homeTopicFeeds = Dictionary(uniqueKeysWithValues: (0 ..< 8).map { index in
+            ("tok-\(index)", YouTubeFeed(videos: MockYouTubeClient.makeVideos(count: 2), continuation: nil))
+        })
+
+        await self.sut.load()
+
+        #expect(Set(self.mockClient.requestedTopicContinuations) == Set(["tok-0", "tok-1"]))
+        #expect(self.mockClient.requestedTopicContinuations.count == 2)
+        #expect(self.sut.sections.filter { $0.kind == .topic }.map(\.title) == ["Topic 0", "Topic 1"])
+        #expect(self.sut.hasMoreTopicRails)
+        #expect(self.sut.isLoadingTopicRails == false)
+    }
+
+    @Test("Deferred topic rails load in explicit batches without duplicate requests")
+    func deferredTopicRailsLoadInBatches() async {
+        self.mockClient.homeFeed = YouTubeFeed(
+            videos: MockYouTubeClient.makeVideos(count: 3),
+            continuation: nil
+        )
+        self.mockClient.homeChips = (0 ..< 6).map { index in
+            YouTubeHomeChip(title: "Topic \(index)", continuation: "tok-\(index)")
+        }
+        self.mockClient.homeTopicFeeds = Dictionary(uniqueKeysWithValues: (0 ..< 6).map { index in
+            ("tok-\(index)", YouTubeFeed(videos: MockYouTubeClient.makeVideos(count: 2), continuation: nil))
+        })
+
+        await self.sut.load()
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask { await self.sut.loadMoreTopicRails() }
+            group.addTask { await self.sut.loadMoreTopicRails() }
+        }
+
+        #expect(Set(self.mockClient.requestedTopicContinuations) == Set(["tok-0", "tok-1", "tok-2", "tok-3"]))
+        #expect(self.mockClient.requestedTopicContinuations.count == 4)
+        #expect(self.sut.sections.filter { $0.kind == .topic }.map(\.title) == [
+            "Topic 0",
+            "Topic 1",
+            "Topic 2",
+            "Topic 3",
+        ])
+        #expect(self.sut.hasMoreTopicRails)
+
+        await self.sut.loadMoreTopicRails()
+        #expect(Set(self.mockClient.requestedTopicContinuations) == Set([
+            "tok-0",
+            "tok-1",
+            "tok-2",
+            "tok-3",
+            "tok-4",
+            "tok-5",
+        ]))
+        #expect(self.mockClient.requestedTopicContinuations.count == 6)
+        #expect(self.sut.hasMoreTopicRails == false)
+    }
+
+    @Test("Empty first topic batch walks queued chips before falling back")
+    func emptyFirstTopicBatchWalksQueuedChips() async {
+        self.mockClient.homeFeed = .empty
+        self.mockClient.homeChips = (0 ..< 4).map { index in
+            YouTubeHomeChip(title: "Topic \(index)", continuation: "tok-\(index)")
+        }
+        self.mockClient.homeTopicFeeds = [
+            "tok-0": .empty,
+            "tok-1": .empty,
+            "tok-2": YouTubeFeed(videos: MockYouTubeClient.makeVideos(count: 2), continuation: nil),
+            "tok-3": YouTubeFeed(videos: MockYouTubeClient.makeVideos(count: 2), continuation: nil),
+        ]
+
+        await self.sut.load()
+
+        #expect(self.sut.loadingState == .loaded)
+        #expect(self.sut.sections.filter { $0.kind == .topic }.map(\.title) == ["Topic 2", "Topic 3"])
+        #expect(Set(self.mockClient.requestedTopicContinuations) == Set(["tok-0", "tok-1", "tok-2", "tok-3"]))
+        #expect(self.mockClient.requestedTopicContinuations.count == 4)
+        #expect(self.mockClient.destinationFeedCallCount == 0)
+        #expect(self.sut.hasMoreTopicRails == false)
+    }
+
     @Test("Grid, shelves, and chips come from a single coalesced home fetch")
     func homeFetchedOncePerLoad() async {
         // The grid, the titled shelves, and the chips that drive the topic rails

--- a/Tests/KasetTests/YouTubeHomeViewModelTests.swift
+++ b/Tests/KasetTests/YouTubeHomeViewModelTests.swift
@@ -356,8 +356,8 @@ struct YouTubeHomeViewModelTests {
 
         await self.sut.loadMoreTopicRails()
 
-        #expect(self.mockClient.requestedTopicContinuations.filter { $0 == "tok-2" }.count == 1)
-        #expect(self.mockClient.requestedTopicContinuations.filter { $0 == "tok-3" }.count == 1)
+        #expect(self.mockClient.requestedTopicContinuations.count(where: { $0 == "tok-2" }) == 1)
+        #expect(self.mockClient.requestedTopicContinuations.count(where: { $0 == "tok-3" }) == 1)
         #expect(self.mockClient.requestedTopicContinuations.contains("tok-4"))
         #expect(self.mockClient.requestedTopicContinuations.contains("tok-5"))
         #expect(self.sut.sections.filter { $0.kind == .topic }.map(\.title) == [
@@ -372,8 +372,8 @@ struct YouTubeHomeViewModelTests {
         self.mockClient.homeTopicError = nil
         await self.sut.loadMoreTopicRails()
 
-        #expect(self.mockClient.requestedTopicContinuations.filter { $0 == "tok-2" }.count == 2)
-        #expect(self.mockClient.requestedTopicContinuations.filter { $0 == "tok-3" }.count == 1)
+        #expect(self.mockClient.requestedTopicContinuations.count(where: { $0 == "tok-2" }) == 2)
+        #expect(self.mockClient.requestedTopicContinuations.count(where: { $0 == "tok-3" }) == 1)
         #expect(self.sut.sections.filter { $0.kind == .topic }.map(\.title) == [
             "Topic 0",
             "Topic 1",

--- a/Tests/KasetTests/YouTubeHomeViewModelTests.swift
+++ b/Tests/KasetTests/YouTubeHomeViewModelTests.swift
@@ -329,8 +329,8 @@ struct YouTubeHomeViewModelTests {
         #expect(self.sut.hasMoreTopicRails == false)
     }
 
-    @Test("Deferred topic auto-load preserves failed batch for retry")
-    func deferredTopicAutoLoadPreservesFailedBatchForRetry() async {
+    @Test("Deferred topic auto-load preserves successes and retries only failed chips")
+    func deferredTopicAutoLoadPreservesSuccessesAndRetriesOnlyFailedChips() async {
         self.mockClient.homeFeed = YouTubeFeed(
             videos: MockYouTubeClient.makeVideos(count: 3),
             continuation: nil
@@ -351,21 +351,68 @@ struct YouTubeHomeViewModelTests {
 
         #expect(Set(self.mockClient.requestedTopicContinuations) == Set(["tok-0", "tok-1", "tok-2", "tok-3"]))
         #expect(self.mockClient.requestedTopicContinuations.count == 4)
-        #expect(self.sut.sections.filter { $0.kind == .topic }.map(\.title) == ["Topic 0", "Topic 1"])
+        #expect(self.sut.sections.filter { $0.kind == .topic }.map(\.title) == ["Topic 0", "Topic 1", "Topic 3"])
+        #expect(self.sut.hasMoreTopicRails)
+
+        await self.sut.loadMoreTopicRails()
+
+        #expect(self.mockClient.requestedTopicContinuations.filter { $0 == "tok-2" }.count == 1)
+        #expect(self.mockClient.requestedTopicContinuations.filter { $0 == "tok-3" }.count == 1)
+        #expect(self.mockClient.requestedTopicContinuations.contains("tok-4"))
+        #expect(self.mockClient.requestedTopicContinuations.contains("tok-5"))
+        #expect(self.sut.sections.filter { $0.kind == .topic }.map(\.title) == [
+            "Topic 0",
+            "Topic 1",
+            "Topic 3",
+            "Topic 4",
+            "Topic 5",
+        ])
         #expect(self.sut.hasMoreTopicRails)
 
         self.mockClient.homeTopicError = nil
         await self.sut.loadMoreTopicRails()
 
         #expect(self.mockClient.requestedTopicContinuations.filter { $0 == "tok-2" }.count == 2)
-        #expect(self.mockClient.requestedTopicContinuations.filter { $0 == "tok-3" }.count == 2)
-        #expect(self.mockClient.requestedTopicContinuations.contains("tok-4") == false)
+        #expect(self.mockClient.requestedTopicContinuations.filter { $0 == "tok-3" }.count == 1)
         #expect(self.sut.sections.filter { $0.kind == .topic }.map(\.title) == [
             "Topic 0",
             "Topic 1",
-            "Topic 2",
             "Topic 3",
+            "Topic 4",
+            "Topic 5",
+            "Topic 2",
         ])
+        #expect(self.sut.hasMoreTopicRails == false)
+    }
+
+    @Test("Deferred topic auto-load stops after a batch-wide request failure")
+    func deferredTopicAutoLoadStopsAfterBatchWideFailure() async {
+        self.mockClient.homeFeed = YouTubeFeed(
+            videos: MockYouTubeClient.makeVideos(count: 3),
+            continuation: nil
+        )
+        self.mockClient.homeChips = (0 ..< 6).map { index in
+            YouTubeHomeChip(title: "Topic \(index)", continuation: "tok-\(index)")
+        }
+        self.mockClient.homeTopicFeeds = Dictionary(uniqueKeysWithValues: (0 ..< 6).map { index in
+            ("tok-\(index)", YouTubeFeed(videos: MockYouTubeClient.makeVideos(count: 2), continuation: nil))
+        })
+
+        await self.sut.load()
+        let requestError = YTMusicError.networkError(underlying: URLError(.notConnectedToInternet))
+        self.mockClient.homeTopicErrors = [
+            "tok-2": requestError,
+            "tok-3": requestError,
+            "tok-4": requestError,
+            "tok-5": requestError,
+        ]
+        await self.sut.loadMoreTopicRails()
+
+        #expect(Set(self.mockClient.requestedTopicContinuations) == Set(["tok-0", "tok-1", "tok-2", "tok-3"]))
+        #expect(self.mockClient.requestedTopicContinuations.count == 4)
+        #expect(self.mockClient.requestedTopicContinuations.contains("tok-4") == false)
+        #expect(self.mockClient.requestedTopicContinuations.contains("tok-5") == false)
+        #expect(self.sut.sections.filter { $0.kind == .topic }.map(\.title) == ["Topic 0", "Topic 1"])
         #expect(self.sut.hasMoreTopicRails)
     }
 

--- a/Tests/KasetTests/YouTubeLibraryViewModelTests.swift
+++ b/Tests/KasetTests/YouTubeLibraryViewModelTests.swift
@@ -49,6 +49,23 @@ struct YouTubeSubscriptionsViewModelTests {
         #expect(sut.hasMoreVideos == false)
     }
 
+    @Test("LoadMore advances pagination trigger for duplicate-only pages")
+    func loadMoreAdvancesPaginationTriggerForDuplicateOnlyPage() async {
+        let client = MockYouTubeClient()
+        let duplicate = MockYouTubeClient.makeVideo(videoId: "video-0")
+        client.subscriptionsFeed = YouTubeFeed(videos: [duplicate], continuation: "token-1")
+        client.feedContinuation = YouTubeFeed(videos: [duplicate], continuation: "token-2")
+        let sut = YouTubeSubscriptionsViewModel(client: client)
+        await sut.load()
+        let triggerAfterLoad = sut.paginationTrigger
+
+        await sut.loadMore()
+
+        #expect(sut.videos.map(\.videoId) == ["video-0"])
+        #expect(sut.hasMoreVideos)
+        #expect(sut.paginationTrigger > triggerAfterLoad)
+    }
+
     @Test("Feed failure surfaces an error even if the rail succeeds")
     func feedFailureSurfacesError() async {
         let client = MockYouTubeClient()
@@ -84,6 +101,23 @@ struct YouTubeHistoryViewModelTests {
         #expect(sut.loadingState == .loaded)
         #expect(sut.videos.count == 3)
         #expect(sut.hasMoreVideos == false)
+    }
+
+    @Test("LoadMore advances pagination trigger for duplicate-only pages")
+    func loadMoreAdvancesPaginationTriggerForDuplicateOnlyPage() async {
+        let client = MockYouTubeClient()
+        let duplicate = MockYouTubeClient.makeVideo(videoId: "video-0")
+        client.historyFeed = YouTubeFeed(videos: [duplicate], continuation: "token-1")
+        client.feedContinuation = YouTubeFeed(videos: [duplicate], continuation: "token-2")
+        let sut = YouTubeHistoryViewModel(client: client)
+        await sut.load()
+        let triggerAfterLoad = sut.paginationTrigger
+
+        await sut.loadMore()
+
+        #expect(sut.videos.map(\.videoId) == ["video-0"])
+        #expect(sut.hasMoreVideos)
+        #expect(sut.paginationTrigger > triggerAfterLoad)
     }
 }
 

--- a/Tests/KasetTests/YouTubePlayerServiceTests.swift
+++ b/Tests/KasetTests/YouTubePlayerServiceTests.swift
@@ -90,8 +90,12 @@ private final class MockYouTubeWatchPlaybackController: YouTubeWatchPlaybackCont
         self.selectedQuality = level
     }
 
-    func storyboardSpec(expectedVideoId _: String?) async -> String? {
-        nil
+    var storyboardSpecResponse: String?
+    private(set) var storyboardSpecRequests: [String?] = []
+
+    func storyboardSpec(expectedVideoId: String?) async -> String? {
+        self.storyboardSpecRequests.append(expectedVideoId)
+        return self.storyboardSpecResponse
     }
 
     func tearDown() {
@@ -892,6 +896,51 @@ struct YouTubePlayerServiceTests {
 
         self.sut.consumePopInRequest()
         #expect(self.sut.popInRequest == nil)
+    }
+
+    @Test("Storyboard refresh task starts once while in-flight and once resolved")
+    func storyboardRefreshTaskStartIsGuarded() async throws {
+        self.controller.storyboardSpecResponse = "mock-storyboard-spec"
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+
+        #expect(self.sut.startStoryboardSpecRefreshIfNeeded())
+        #expect(!self.sut.startStoryboardSpecRefreshIfNeeded())
+
+        try await Task.sleep(for: .milliseconds(20))
+
+        #expect(self.controller.storyboardSpecRequests == ["abc"])
+        #expect(self.sut.storyboardSpec == "mock-storyboard-spec")
+        #expect(!self.sut.startStoryboardSpecRefreshIfNeeded())
+    }
+
+    @Test("Playback tick skips storyboard refresh unless live ambient is active")
+    func playbackTickSkipsStoryboardRefreshForSteadyAmbient() async throws {
+        let settings = SettingsManager.shared
+        let originalEnabled = settings.ambientBackdropEnabled
+        let originalStyle = settings.ambientBackdropStyle
+        defer {
+            settings.ambientBackdropEnabled = originalEnabled
+            settings.ambientBackdropStyle = originalStyle
+        }
+
+        settings.ambientBackdropEnabled = true
+        settings.ambientBackdropStyle = .soft
+        self.controller.storyboardSpecResponse = "mock-storyboard-spec"
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 1,
+            duration: 60,
+            videoId: "abc",
+            title: nil,
+            isAd: false
+        ))
+
+        try await Task.sleep(for: .milliseconds(20))
+
+        #expect(self.controller.storyboardSpecRequests.isEmpty)
+        #expect(self.sut.storyboardSpec == nil)
     }
 
     @Test("Stop resets everything and tears down the WebView")

--- a/Tests/KasetTests/YouTubeSearchViewModelTests.swift
+++ b/Tests/KasetTests/YouTubeSearchViewModelTests.swift
@@ -292,7 +292,9 @@ struct YouTubeSearchViewModelTests {
 
     private func waitUntil(_ condition: @autoclosure () -> Bool) async {
         for _ in 0 ..< 1000 {
-            if condition() { return }
+            if condition() {
+                return
+            }
             await Task.yield()
         }
         Issue.record("Timed out waiting for condition")

--- a/Tests/KasetTests/YouTubeSingleFlightViewModelTests.swift
+++ b/Tests/KasetTests/YouTubeSingleFlightViewModelTests.swift
@@ -224,7 +224,9 @@ struct YouTubeSingleFlightViewModelTests {
 
     private func waitUntil(_ condition: @autoclosure () -> Bool, _ description: String) async {
         for _ in 0 ..< 1000 {
-            if condition() { return }
+            if condition() {
+                return
+            }
             await Task.yield()
         }
         Issue.record("Timed out waiting for \(description)")
@@ -347,14 +349,18 @@ private final class SingleFlightYouTubeClient: YouTubeClientProtocol {
     func getChannel(channelId: String) async throws -> YouTubeChannelDetail {
         self.channelCallCount += 1
         try await self.waitIfNeeded()
-        if let channelDetail { return channelDetail }
+        if let channelDetail {
+            return channelDetail
+        }
         return YouTubeChannelDetail(channel: YouTubeChannel(channelId: channelId, name: "Mock Channel"), videos: [])
     }
 
     func getPlaylist(playlistId: String) async throws -> YouTubePlaylistDetail {
         self.playlistCallCount += 1
         try await self.waitIfNeeded()
-        if let playlistDetail { return playlistDetail }
+        if let playlistDetail {
+            return playlistDetail
+        }
         return YouTubePlaylistDetail(playlist: YouTubePlaylist(playlistId: playlistId, title: "Mock Playlist"), videos: [])
     }
 

--- a/Tests/KasetTests/YouTubeWatchScriptTests.swift
+++ b/Tests/KasetTests/YouTubeWatchScriptTests.swift
@@ -126,6 +126,35 @@ struct YouTubeWatchScriptTests {
         #expect(context.evaluateScript("postedMessages[0].isPlaying").toBool() == false)
     }
 
+    @Test("Rediscovered attached video only posts when video identity changes")
+    func rediscoveredAttachedVideoPostsOnlyWhenIdentityChanges() throws {
+        let context = try self.makeObserverContext(paused: true)
+        try self.evaluate(YouTubeWatchWebView.observerScript, in: context)
+
+        try self.evaluate(
+            """
+            postedMessages = [];
+            mutationCallbacks[0]();
+            timeoutCalls[0].callback();
+            """,
+            in: context
+        )
+
+        #expect(context.evaluateScript("postedMessages.length").toInt32() == 0)
+
+        try self.evaluate(
+            """
+            moviePlayer.getVideoData = function() { return { video_id: 'def456', title: 'Next Video' }; };
+            mutationCallbacks[0]();
+            timeoutCalls[1].callback();
+            """,
+            in: context
+        )
+
+        #expect(context.evaluateScript("postedMessages.length").toInt32() == 1)
+        #expect(context.evaluateScript("postedMessages[0].videoId").toString() == "def456")
+    }
+
     @Test("Extraction observer re-marks the video chain after attribute-only marker loss")
     func extractionObserverRepairsAttributeMarkerLoss() throws {
         let context = try self.makeExtractionContext()

--- a/Tests/KasetTests/YouTubeWatchScriptTests.swift
+++ b/Tests/KasetTests/YouTubeWatchScriptTests.swift
@@ -1,6 +1,9 @@
 import Foundation
+import JavaScriptCore
 import Testing
 @testable import Kaset
+
+// MARK: - YouTubeWatchScriptTests
 
 @Suite("YouTubeWatchWebView scripts", .tags(.service))
 @MainActor
@@ -91,4 +94,277 @@ struct YouTubeWatchScriptTests {
         webView.loadVideo(videoId: "different-video")
         #expect(webView.pendingSeek == nil)
     }
+
+    @Test("Paused observer steady state does not install an interval update loop")
+    func pausedObserverDoesNotInstallIntervalLoop() throws {
+        let context = try self.makeObserverContext(paused: true)
+
+        try self.evaluate(YouTubeWatchWebView.observerScript, in: context)
+
+        #expect(context.evaluateScript("intervalCalls.length").toInt32() == 0)
+        #expect(context.evaluateScript("postedMessages.length").toInt32() == 1)
+        #expect(context.evaluateScript("postedMessages[0].type").toString() == "STATE_UPDATE")
+        #expect(context.evaluateScript("postedMessages[0].isPlaying").toBool() == false)
+    }
+
+    @Test("Pause event sends one final forced state update without starting an interval")
+    func pauseEventSendsFinalUpdateWithoutInterval() throws {
+        let context = try self.makeObserverContext(paused: false)
+        try self.evaluate(YouTubeWatchWebView.observerScript, in: context)
+        try self.evaluate(
+            """
+            postedMessages = [];
+            video.paused = true;
+            fireVideoEvent('pause');
+            """,
+            in: context
+        )
+
+        #expect(context.evaluateScript("intervalCalls.length").toInt32() == 0)
+        #expect(context.evaluateScript("postedMessages.length").toInt32() == 1)
+        #expect(context.evaluateScript("postedMessages[0].type").toString() == "STATE_UPDATE")
+        #expect(context.evaluateScript("postedMessages[0].isPlaying").toBool() == false)
+    }
+
+    @Test("Extraction observer re-marks the video chain after attribute-only marker loss")
+    func extractionObserverRepairsAttributeMarkerLoss() throws {
+        let context = try self.makeExtractionContext()
+
+        try self.evaluate(YouTubeWatchWebView.extractionScript, in: context)
+        try self.evaluate("window.__kasetExtractVideo(); drainAnimationFrames(100);", in: context)
+        #expect(context.evaluateScript("video.classList.contains('kaset-visible')").toBool())
+
+        try self.evaluate(
+            """
+            video.classList.remove('kaset-visible');
+            mutationCallbacks[1]();
+            """,
+            in: context
+        )
+        #expect(context.evaluateScript("rafQueue.length").toInt32() == 1)
+
+        try self.evaluate("drainAnimationFrames(10);", in: context)
+        #expect(context.evaluateScript("video.classList.contains('kaset-visible')").toBool())
+    }
+
+    @Test("Extraction stop prevents later mutation enforcement and clears markers")
+    func extractionStopPreventsLaterMutationEnforcement() throws {
+        let context = try self.makeExtractionContext()
+
+        try self.evaluate(YouTubeWatchWebView.extractionScript, in: context)
+        try self.evaluate("window.__kasetExtractVideo(); drainAnimationFrames(100);", in: context)
+        #expect(context.evaluateScript("document.querySelectorAll('.kaset-visible').length").toInt32() > 0)
+
+        try self.evaluate(
+            """
+            window.__kasetStopYTExtraction();
+            mutationCallbacks[0]();
+            """,
+            in: context
+        )
+
+        #expect(context.evaluateScript("window.__kasetYTVideoActive").toBool() == false)
+        #expect(context.evaluateScript("rafQueue.length").toInt32() == 0)
+        #expect(context.evaluateScript("document.querySelectorAll('.kaset-visible').length").toInt32() == 0)
+    }
+
+    @Test("Extraction enforcement drains bounded RAF work instead of scheduling forever")
+    func extractionEnforcementDoesNotScheduleEndlessRAF() throws {
+        let context = try self.makeExtractionContext()
+
+        try self.evaluate(YouTubeWatchWebView.extractionScript, in: context)
+        try self.evaluate("window.__kasetExtractVideo(); drainAnimationFrames(100);", in: context)
+
+        #expect(context.evaluateScript("rafQueue.length").toInt32() == 0)
+        #expect(context.evaluateScript("rafScheduledCount").toInt32() <= 16)
+
+        try self.evaluate(
+            """
+            mutationCallbacks[0]();
+            drainAnimationFrames(100);
+            """,
+            in: context
+        )
+
+        #expect(context.evaluateScript("rafQueue.length").toInt32() == 0)
+        #expect(context.evaluateScript("rafScheduledCount").toInt32() <= 32)
+    }
+}
+
+private extension YouTubeWatchScriptTests {
+    func makeObserverContext(paused: Bool) throws -> JSContext {
+        let context = try #require(JSContext())
+        try self.evaluate(
+            """
+            var postedMessages = [];
+            var intervalCalls = [];
+            var timeoutCalls = [];
+            var now = 1000;
+            Date.now = function() { return now; };
+
+            function setInterval(callback, milliseconds) {
+                intervalCalls.push({ callback: callback, milliseconds: milliseconds });
+                return intervalCalls.length;
+            }
+            function clearInterval(id) {}
+            function setTimeout(callback, milliseconds) {
+                timeoutCalls.push({ callback: callback, milliseconds: milliseconds });
+                return timeoutCalls.length;
+            }
+            function clearTimeout(id) {}
+
+            var window = {
+                webkit: {
+                    messageHandlers: {
+                        youtubePlayer: {
+                            postMessage: function(message) { postedMessages.push(message); }
+                        }
+                    }
+                }
+            };
+            var console = { log: function() {} };
+
+            var videoListeners = {};
+            var video = {
+                paused: \(paused ? "true" : "false"),
+                ended: false,
+                currentTime: 12,
+                duration: 120,
+                readyState: 4,
+                muted: false,
+                volume: 1,
+                addEventListener: function(name, handler) {
+                    if (!videoListeners[name]) { videoListeners[name] = []; }
+                    videoListeners[name].push(handler);
+                }
+            };
+            function fireVideoEvent(name) {
+                (videoListeners[name] || []).forEach(function(handler) { handler(); });
+            }
+
+            var moviePlayer = {
+                classList: { contains: function() { return false; } },
+                getVideoData: function() { return { video_id: 'abc123', title: 'Test Video' }; },
+                unMute: function() {}
+            };
+            var documentListeners = {};
+            var document = {
+                title: 'Test Video - YouTube',
+                readyState: 'complete',
+                body: {},
+                documentElement: {},
+                getElementById: function(id) { return id === 'movie_player' ? moviePlayer : null; },
+                querySelector: function(selector) {
+                    if (selector === '#movie_player video' || selector === 'video') { return video; }
+                    if (selector === '.ytp-autonav-toggle-button') { return null; }
+                    return null;
+                },
+                addEventListener: function(name, handler) { documentListeners[name] = handler; }
+            };
+            var mutationCallbacks = [];
+            function MutationObserver(callback) {
+                this.callback = callback;
+                mutationCallbacks.push(callback);
+            }
+            MutationObserver.prototype.observe = function() {};
+            MutationObserver.prototype.disconnect = function() {};
+            """,
+            in: context
+        )
+        return context
+    }
+
+    func makeExtractionContext() throws -> JSContext {
+        let context = try #require(JSContext())
+        try self.evaluate(
+            """
+            var window = {};
+            var console = { log: function() {} };
+
+            function makeElement(name, parent) {
+                var element = { name: name, parentElement: parent, classes: {}, id: '', textContent: '' };
+                element.classList = {
+                    add: function(value) { element.classes[value] = true; },
+                    remove: function(value) { delete element.classes[value]; },
+                    contains: function(value) { return !!element.classes[value]; }
+                };
+                return element;
+            }
+
+            var elementsById = {};
+            var html = makeElement('html', null);
+            var body = makeElement('body', html);
+            var player = makeElement('movie_player', body);
+            var video = makeElement('video', player);
+            var allElements = [html, body, player, video];
+
+            var document = {
+                documentElement: html,
+                body: body,
+                head: {
+                    appendChild: function(element) {
+                        if (element.id) { elementsById[element.id] = element; }
+                    }
+                },
+                createElement: function(name) {
+                    var element = makeElement(name, null);
+                    return element;
+                },
+                getElementById: function(id) { return elementsById[id] || null; },
+                querySelector: function(selector) {
+                    if (selector === '#movie_player video' || selector === 'video') { return video; }
+                    return null;
+                },
+                querySelectorAll: function(selector) {
+                    if (selector !== '.kaset-visible') { return []; }
+                    return allElements.filter(function(element) {
+                        return element.classList.contains('kaset-visible');
+                    });
+                }
+            };
+
+            var mutationCallbacks = [];
+            function MutationObserver(callback) {
+                this.callback = callback;
+                mutationCallbacks.push(callback);
+            }
+            MutationObserver.prototype.observe = function() {};
+            MutationObserver.prototype.disconnect = function() {};
+
+            var rafQueue = [];
+            var rafScheduledCount = 0;
+            function requestAnimationFrame(callback) {
+                rafScheduledCount += 1;
+                rafQueue.push(callback);
+                return rafScheduledCount;
+            }
+            function drainAnimationFrames(limit) {
+                var ran = 0;
+                while (rafQueue.length && ran < limit) {
+                    var callback = rafQueue.shift();
+                    callback();
+                    ran += 1;
+                }
+                return ran;
+            }
+            """,
+            in: context
+        )
+        return context
+    }
+
+    func evaluate(_ script: String, in context: JSContext) throws {
+        context.exception = nil
+        _ = context.evaluateScript(script)
+        if let exception = context.exception?.toString() {
+            Issue.record("JavaScript exception: \(exception)")
+            throw TestScriptError.javaScriptException(exception)
+        }
+    }
+}
+
+// MARK: - TestScriptError
+
+private enum TestScriptError: Error {
+    case javaScriptException(String)
 }


### PR DESCRIPTION
## Summary

This PR improves Kaset energy efficiency across playback, data loading, image handling, and UI rendering paths. The main changes are:

- Reduce idle/background wakeups in playback, notifications, scrobbling, queue enrichment, video rendering, and lyrics updates.
- Convert background continuation drains into explicit demand loading across Home, Search, Playlist, Charts, Explore, Moods & Genres, New Releases, Podcasts, and History.
- Coalesce repeated API/key/auth/image work, including YouTube Music API key resolution, auth cookie snapshots, raw image downloads, and palette extraction.
- Right-size image decode targets for visible artwork surfaces and cache accent palette extraction through `ImageCache`.
- Reduce YouTube Home cold-start fanout by loading only the first topic-rail batch initially and deferring the rest behind explicit “Load more topics”.
- Add focused tests and performance coverage for new single-flight/demand-loading/cache behavior.

## Impact

- YouTube Home topic-rail cold fanout drops from up to 8 topic continuation browses to 2 initial topic requests; the remaining rails are explicit-demand batches.
- Accent backgrounds no longer issue independent `URLSession` artwork downloads for palette extraction; they reuse `ImageCache` and coalesce palette work.
- Many continuation/background drains now do zero network work until the user explicitly requests more.
- Several idle/rendering/persistence paths avoid unnecessary timers, writes, decode work, or per-frame loops.

## Validation

Representative final checks from the completed slices:

- `swift build` — passed
- `swiftlint --strict` — passed, 0 violations
- `swift test --skip KasetUITests` — passed, final palette slice: 1752 tests in 148 suites
- Focused tests:
  - `YouTubeHomeViewModelTests`
  - `YouTubeHomeContinueWatchingRefreshTests`
  - `YouTubeHomeFanoutPerformanceTests`
  - `ColorExtractorTests`
  - `ColorExtractorPerformanceTests`
  - `ImageCacheNetworkCoalescingTests`
  - `ImageCacheDiskEvictionTests`
- Benchmarks via `Scripts/benchmark-xctest.sh`:
  - `ParserPerformanceTests`
  - `DataFlowPerformanceTests`
  - `YouTubeHomeFanoutPerformanceTests`
  - `ColorExtractorPerformanceTests`
- Packaged mock launch Time Profiler runs via `xcrun xctrace` completed for major slices.
- `$autoreview` completed clean for non-trivial slices, including final topic-rail and palette-cache slices.

## Notes

- No UI tests were run.
- `Cache-before-auth` was intentionally deferred because the auth-expiration safety risk outweighed the likely energy gain without a deeper auth-state design.
- Detailed slice-by-slice measurements and artifact paths are tracked locally in `/tmp/energy-kaset.md`.
