### PR TITLE
docs: clarify extension installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ A native macOS client for YouTube Music and YouTube, built with Swift and SwiftU
 - 📣 **Share** — Share songs, playlists, albums, and artists via the native macOS share sheet
 - 🔗 **[URL Scheme](docs/url-scheme.md)** — Open songs directly with `kaset://play?v=VIDEO_ID`; app-targeted YouTube watch and `youtu.be` links play in YouTube mode
 - 🤖 **[AppleScript Support](docs/applescript.md)** — Automate playback with scripts, Raycast, Alfred, and Shortcuts
-- 🧩 **[Extensions](docs/extensions.md)** — Load WebKit Web Extensions, including [uBlock Origin Lite](https://github.com/uBlockOrigin/uBOL-home)
+- 🧩 **[Extensions](docs/extensions.md)** — Load WebKit Web Extensions, including [uBlock Origin Lite](https://github.com/uBlockOrigin/uBOL-home) and [SponsorBlock](https://github.com/ajayyy/SponsorBlock)
 
 ## Requirements
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1,6 +1,6 @@
 # Extensions
 
-Kaset supports user-installed WebKit-compatible browser extensions. No extensions are pre-installed, so you're in full control.
+Kaset can load browser extensions that work with Safari/WebKit. No extensions are included by default, so you choose what to add.
 
 ## Managing Extensions
 
@@ -9,11 +9,66 @@ Open **Settings** (⌘,) and navigate to the **Extensions** tab.
 ### Adding an Extension
 
 1. Click the **+** button in the Extensions tab header.
-2. Choose the **root directory** of a WebKit-compatible extension — the folder that contains `manifest.json`.
-3. Kaset reads the extension name from `manifest.json` and adds it to the list.
+2. Choose the extension folder that contains `manifest.json`.
+3. Kaset adds the extension to the list.
 4. Restart Kaset to load it.
 
-> **Compatibility:** Extensions must use the [WebKit Web Extensions API](https://developer.apple.com/documentation/webkit/wkwebextension). Standard Manifest V3 extensions (Chrome/Firefox) may work if they don't rely on browser-specific APIs. Extensions built specifically for Safari/WebKit are the best starting point.
+> **Compatibility:** Use a Safari/WebKit version of an extension when one is available. Chrome versions can sometimes work, but not always.
+
+### Installing Common Extensions
+
+Kaset adds extension **folders**. It cannot install directly from the Safari App Store, Chrome Web Store, or a downloaded extension package. You need to choose a folder that contains a file named `manifest.json`.
+
+Only use extensions from sources you trust.
+
+#### Best option: use a Safari/WebKit version
+
+If the extension offers a Safari/WebKit download, use that first. Download it, unzip it if needed, then add the folder that contains `manifest.json` in **Settings → Extensions**.
+
+Useful official release pages:
+
+- uBlock Origin Lite: <https://github.com/uBlockOrigin/uBOL-home/releases>
+- SponsorBlock: <https://github.com/ajayyy/SponsorBlock/releases>
+
+> **Note:** Safari extensions from the Mac App Store are usually installed as apps. Kaset cannot add those apps directly. Kaset needs the extension folder itself.
+
+#### Fallback: copy the extension from Chrome, Edge, or Brave
+
+Use this if you cannot find a Safari/WebKit version.
+
+1. Install the extension in Chrome, Edge, or Brave:
+   - [uBlock Origin Lite](https://chromewebstore.google.com/detail/ublock-origin-lite/ddkjiahejlhfcafbddmgiahcphecmpfh)
+   - [SponsorBlock for YouTube](https://chromewebstore.google.com/detail/sponsorblock-for-youtube/mnjggcdmjocbbbhaepdhchncahnbgone)
+2. Find the browser profile folder:
+   - Chrome: open `chrome://version` and copy **Profile Path**. It is usually `~/Library/Application Support/Google/Chrome/Default`.
+   - Microsoft Edge: usually `~/Library/Application Support/Microsoft Edge/Default`.
+   - Brave: usually `~/Library/Application Support/BraveSoftware/Brave-Browser/Default`.
+3. In Finder, choose **Go → Go to Folder…** and open the extension folder:
+
+   ```text
+   <Profile Path>/Extensions/<extension-id>/
+   ```
+
+   Use these extension IDs:
+
+   | Extension | ID |
+   |---|---|
+   | uBlock Origin Lite | `ddkjiahejlhfcafbddmgiahcphecmpfh` |
+   | SponsorBlock | `mnjggcdmjocbbbhaepdhchncahnbgone` |
+
+4. Open the newest version folder inside it. The folder name usually looks like `2026.1.1.0_0` or similar.
+5. Make sure that folder contains `manifest.json`.
+6. In Kaset, open **Settings → Extensions**, click **+**, and choose that version folder.
+7. Restart Kaset when prompted.
+
+> **Tip:** If Kaset shows a version number instead of the extension name, copy that version folder somewhere else, rename the copy to something readable like `uBlock Origin Lite`, then add the renamed copy to Kaset.
+
+### What to expect
+
+- Extensions only affect Kaset. They do not change Safari, Chrome, or other browsers.
+- YouTube extensions usually affect the YouTube video player. They may not affect YouTube Music unless the extension supports `music.youtube.com`.
+- If an extension does not work, try a Safari/WebKit version if one exists.
+- Kaset copies the folder you choose. If the extension updates later, remove it from Kaset and add the newer version folder.
 
 ### Enabling / Disabling an Extension
 
@@ -23,19 +78,19 @@ Toggle the switch next to any extension. The change takes effect after a restart
 
 Click the **trash** icon next to any extension, then restart Kaset.
 
-## How It Works
+## Behind the Scenes
 
-- **Storage:** The list is saved as JSON at `~/Library/Application Support/Kaset/extensions.json`.
-- **Imported files:** Kaset copies each added extension into `~/Library/Application Support/Kaset/ManagedExtensions/` and loads that local snapshot.
-- **Security:** Kaset may store a local security-scoped bookmark for the copied extension folder when WebKit needs sandbox-friendly access.
-- **Loading:** At launch, `WebKitManager` loads all enabled extensions in order via `WKWebExtensionController`, granting them all requested permissions.
-- **Playback hosting:** Kaset registers its long-lived YouTube Music and YouTube watch WebViews as lightweight WebKit extension tabs/windows so content scripts and tab-scoped extension APIs can resolve the playback page WebView.
+- Kaset keeps its extension list in `~/Library/Application Support/Kaset/extensions.json`.
+- When you add an extension, Kaset copies that folder into `~/Library/Application Support/Kaset/ManagedExtensions/`.
+- Kaset loads enabled extensions when the app starts.
+- Extensions run inside Kaset's YouTube and YouTube Music web players.
 
 ## Troubleshooting
 
-- **Extension not loading:** Open Console.app, filter by subsystem `com.sertacozercan.Kaset` and category `Extensions` or `WebKit`.
-- **Extension updates not appearing:** Re-import the extension after changing the original source folder, since Kaset loads the copied snapshot in Application Support.
-- **Manifest not found:** Ensure your extension directory contains a `manifest.json` at its root.
+- **Manifest not found:** Make sure you selected the folder that contains `manifest.json`.
+- **Extension not loading:** Restart Kaset after adding or enabling it.
+- **Extension updates not appearing:** Remove the extension from Kaset, then add the newer version folder.
+- **Still stuck:** Open Console.app and filter by `com.sertacozercan.Kaset`, then look for `Extensions` or `WebKit` messages.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
- Clarify how users can add extensions to Kaset.
- Prefer Safari/WebKit-compatible extension builds when available.
- Add simpler fallback steps for copying uBlock Origin Lite or SponsorBlock from Chrome, Edge, or Brave.
- Link to the official release pages for uBlock Origin Lite and SponsorBlock.

## Validation
- `git diff --check`

