### PR TITLE
feat: drag and drop tracks onto sidebar playlists

### DIFF
--- a/Sources/Kaset/Models/PlaylistDropTarget.swift
+++ b/Sources/Kaset/Models/PlaylistDropTarget.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+// MARK: - PlaylistDropTarget
+
+/// Where a song is being added, classified once so eligibility and routing can never disagree.
+///
+/// Liked Music is the LM auto-playlist — membership there means "liked", so it routes through the
+/// like flow instead of `edit_playlist`, which never applies to LM. Classifying up front (via
+/// `LikedMusicPlaylist.matches(id:)`, which folds the `VL` browse-ID prefix) keeps that rule in one
+/// place: a pinned Liked Music row exposed as `VLLM` still resolves to `.likedMusic`.
+enum PlaylistDropTarget: Hashable {
+    case likedMusic
+    case editable(playlistId: String)
+
+    init(playlistId: String) {
+        self = LikedMusicPlaylist.matches(id: playlistId) ? .likedMusic : .editable(playlistId: playlistId)
+    }
+}

--- a/Sources/Kaset/Models/SidebarPinnedItem.swift
+++ b/Sources/Kaset/Models/SidebarPinnedItem.swift
@@ -60,6 +60,19 @@ struct SidebarPinnedItem: Identifiable, Codable, Hashable {
         }
     }
 
+    /// Whether song drops onto this pinned item should be accepted. Followed/non-owned
+    /// playlists are excluded since `edit_playlist` always fails on them; Liked Music is
+    /// an auto-playlist accepted regardless of `canDelete`. Reads the same `PlaylistDropTarget`
+    /// classifier the drop handler routes on, so eligibility and routing never disagree.
+    var acceptsSongDrops: Bool {
+        switch self.itemType {
+        case .album:
+            false
+        case let .playlist(playlist):
+            playlist.canDelete || PlaylistDropTarget(playlistId: playlist.id) == .likedMusic
+        }
+    }
+
     var playlistRoute: Playlist {
         switch self.itemType {
         case let .album(album):

--- a/Sources/Kaset/Services/Library/LibraryMutationActions.swift
+++ b/Sources/Kaset/Services/Library/LibraryMutationActions.swift
@@ -2,6 +2,16 @@
 
 import Foundation
 
+// MARK: - AddSongOutcome
+
+/// The result of adding a song to a `PlaylistDropTarget`, for callers to map to their own feedback
+/// (haptics, a confirmation badge). The mutation, cache invalidation, and logging are already done.
+enum AddSongOutcome: Equatable {
+    case added
+    case liked
+    case failed
+}
+
 /// Orchestrates Library mutations that need optimistic UI updates, cache invalidation,
 /// and eventual-consistency reconciliation after YouTube Music accepts a change.
 @MainActor
@@ -280,32 +290,72 @@ enum LibraryMutationActions {
             task.cancel()
         }
     }
+    /// Adds a song to a drop target, routing Liked Music through the like flow and every other
+    /// (editable) playlist through `edit_playlist`. Owns cache invalidation and logging; returns an
+    /// outcome so callers can render feedback. This is the single entry both the sidebar drop and
+    /// the context menu use, so the "adding to Liked Music means liking" rule lives in one place.
+    @discardableResult
+    static func addSong(
+        _ song: Song,
+        to target: PlaylistDropTarget,
+        client: any YTMusicClientProtocol,
+        likeStatusManager: SongLikeStatusManager = .shared
+    ) async -> AddSongOutcome {
+        let boundaryGeneration = self.accountBoundaryGeneration
 
-    /// Adds a song to a playlist.
+        switch target {
+        case .likedMusic:
+            do {
+                try await self.runTrackedAccountBoundaryMutation {
+                    try self.checkAccountBoundary(boundaryGeneration)
+                    let status = await likeStatusManager.like(song, client: client)
+                    try self.checkAccountBoundary(boundaryGeneration)
+                    guard status == .like else {
+                        DiagnosticsLogger.api.error("Failed to like song: '\(song.title)'")
+                        return
+                    }
+                    DiagnosticsLogger.api.info("Added song to Liked Music: '\(song.title)'")
+                }
+                return .liked
+            } catch is CancellationError {
+                return .failed
+            } catch {
+                guard self.isAccountBoundaryCurrent(boundaryGeneration) else { return .failed }
+                DiagnosticsLogger.api.error("Failed to like song: '\(song.title)'")
+                return .failed
+            }
+
+        case let .editable(playlistId):
+            do {
+                try await self.runTrackedAccountBoundaryMutation {
+                    try self.checkAccountBoundary(boundaryGeneration)
+                    try await client.addSongToPlaylist(
+                        videoId: song.videoId,
+                        playlistId: playlistId,
+                        allowDuplicate: false
+                    )
+                    try self.checkAccountBoundary(boundaryGeneration)
+                    self.invalidateResponseCaches()
+                    DiagnosticsLogger.api.info("Added song '\(song.title)' to playlist \(playlistId)")
+                }
+                return .added
+            } catch is CancellationError {
+                return .failed
+            } catch {
+                guard self.isAccountBoundaryCurrent(boundaryGeneration) else { return .failed }
+                DiagnosticsLogger.api.error("Failed to add song '\(song.title)' to playlist: \(error.localizedDescription)")
+                return .failed
+            }
+        }
+    }
+
+    /// Adds a song to a playlist chosen from the add-to-playlist menu.
     static func addSongToPlaylist(
         _ song: Song,
         playlist: AddToPlaylistOption,
         client: any YTMusicClientProtocol
     ) async {
-        let boundaryGeneration = self.accountBoundaryGeneration
-        do {
-            try await self.runTrackedAccountBoundaryMutation {
-                try self.checkAccountBoundary(boundaryGeneration)
-                try await client.addSongToPlaylist(
-                    videoId: song.videoId,
-                    playlistId: playlist.playlistId,
-                    allowDuplicate: false
-                )
-                try self.checkAccountBoundary(boundaryGeneration)
-                self.invalidateResponseCaches()
-                DiagnosticsLogger.api.info("Added song '\(song.title)' to playlist '\(playlist.title)'")
-            }
-        } catch is CancellationError {
-            return
-        } catch {
-            guard self.isAccountBoundaryCurrent(boundaryGeneration) else { return }
-            DiagnosticsLogger.api.error("Failed to add song to playlist: \(error.localizedDescription)")
-        }
+        await self.addSong(song, to: PlaylistDropTarget(playlistId: playlist.playlistId), client: client)
     }
 
     /// Removes a song from the playlist currently loaded in `viewModel`. The row is removed

--- a/Sources/Kaset/Services/Library/LibraryMutationActions.swift
+++ b/Sources/Kaset/Services/Library/LibraryMutationActions.swift
@@ -12,6 +12,8 @@ enum AddSongOutcome: Equatable {
     case failed
 }
 
+// MARK: - LibraryMutationActions
+
 /// Orchestrates Library mutations that need optimistic UI updates, cache invalidation,
 /// and eventual-consistency reconciliation after YouTube Music accepts a change.
 @MainActor
@@ -290,6 +292,7 @@ enum LibraryMutationActions {
             task.cancel()
         }
     }
+
     /// Adds a song to a drop target, routing Liked Music through the like flow and every other
     /// (editable) playlist through `edit_playlist`. Owns cache invalidation and logging; returns an
     /// outcome so callers can render feedback. This is the single entry both the sidebar drop and

--- a/Sources/Kaset/Views/ArtistDetailView.swift
+++ b/Sources/Kaset/Views/ArtistDetailView.swift
@@ -329,7 +329,7 @@ struct ArtistDetailView: View { // swiftlint:disable:this type_body_length
 
     /// Song row for top songs section - fetches all songs and plays as queue.
     private func topSongRow(_ song: Song, index: Int) -> some View {
-        HoverObservingRow { isHovered in
+        HoverObservingRow(song: song) { isHovered in
             Button {
                 self.playTopSong(song, displayedIndex: index)
             } label: {

--- a/Sources/Kaset/Views/HistoryView.swift
+++ b/Sources/Kaset/Views/HistoryView.swift
@@ -183,7 +183,7 @@ struct HistoryView: View {
     // MARK: - Song Row
 
     private func songRow(_ song: Song, allSongs: [Song], index: Int) -> some View {
-        HoverObservingRow { isHovered in
+        HoverObservingRow(song: song) { isHovered in
             Button {
                 Task {
                     await self.playerService.playQueue(allSongs, startingAt: index)

--- a/Sources/Kaset/Views/PlaylistDetailView.swift
+++ b/Sources/Kaset/Views/PlaylistDetailView.swift
@@ -814,6 +814,7 @@ private struct PlaylistTrackRow<Menu: View>: View {
         }
         .buttonStyle(.interactiveRow(cornerRadius: 6))
         .disabled(!self.track.isPlayable)
+        .songDraggable(self.track)
         .onHover { hovering in self.isHovered = hovering }
         .contextMenu { self.menu() }
     }

--- a/Sources/Kaset/Views/SearchView.swift
+++ b/Sources/Kaset/Views/SearchView.swift
@@ -348,7 +348,12 @@ struct SearchView: View {
     }
 
     private func resultRow(_ item: SearchResultItem, index: Int) -> some View {
-        HoverObservingRow { isHovered in
+        let draggableSong: Song? = if case let .song(song) = item {
+            song
+        } else {
+            nil
+        }
+        return HoverObservingRow(song: draggableSong) { isHovered in
             Button {
                 self.handleItemTap(item)
             } label: {

--- a/Sources/Kaset/Views/SharedViews/HomeSectionItemCard.swift
+++ b/Sources/Kaset/Views/SharedViews/HomeSectionItemCard.swift
@@ -32,6 +32,11 @@ struct HomeSectionItemCard: View {
     }
 
     var body: some View {
+        self.cardBody.songDraggable(self.draggableSong)
+    }
+
+    @ViewBuilder
+    private var cardBody: some View {
         if self.supportsPlaylistPlayAction {
             self.cardContent
                 .accessibilityAction(named: Text("Play \(self.item.title)")) {
@@ -39,6 +44,15 @@ struct HomeSectionItemCard: View {
                 }
         } else {
             self.cardContent
+        }
+    }
+
+    /// A song card is a drag source whether or not it also exposes a play action.
+    private var draggableSong: Song? {
+        if case let .song(song) = self.item {
+            song
+        } else {
+            nil
         }
     }
 

--- a/Sources/Kaset/Views/SharedViews/KasetSidebarRow.swift
+++ b/Sources/Kaset/Views/SharedViews/KasetSidebarRow.swift
@@ -14,6 +14,7 @@ struct KasetSidebarRow: View {
     let title: String
     let systemImage: String
     let isSelected: Bool
+    var isDropTargeted: Bool = false
     let action: () -> Void
 
     var body: some View {
@@ -24,7 +25,8 @@ struct KasetSidebarRow: View {
                     .foregroundStyle(.primary)
             } icon: {
                 Image(systemName: self.systemImage)
-                    .foregroundStyle(PackageResourceLookup.brandAccent)
+                    .foregroundStyle(self.isDropTargeted ? .white : PackageResourceLookup.brandAccent)
+                    .symbolEffect(.bounce, value: self.isDropTargeted)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, 10)
@@ -39,7 +41,14 @@ struct KasetSidebarRow: View {
 
     @ViewBuilder
     private var selectionBackground: some View {
-        if self.isSelected {
+        if self.isDropTargeted {
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(PackageResourceLookup.brandAccent.opacity(0.3))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        .strokeBorder(PackageResourceLookup.brandAccent, lineWidth: 1.5)
+                )
+        } else if self.isSelected {
             RoundedRectangle(cornerRadius: 8, style: .continuous)
                 .fill(Color.secondary.opacity(0.22))
         }

--- a/Sources/Kaset/Views/SharedViews/LikeButton.swift
+++ b/Sources/Kaset/Views/SharedViews/LikeButton.swift
@@ -64,10 +64,16 @@ struct LikeButton: View {
 /// Wraps a row's body and provides per-row hover state via closure.
 /// Use to drive `LikeButton.isRowHovered` and any other hover-only chrome.
 struct HoverObservingRow<Content: View>: View {
+    /// When set, the row acts as a drag source for this song (e.g. to drop onto a sidebar playlist).
+    var song: Song?
     @ViewBuilder let content: (Bool) -> Content
     @State private var isHovered: Bool = false
 
     var body: some View {
+        self.hoverContent.songDraggable(self.song)
+    }
+
+    private var hoverContent: some View {
         self.content(self.isHovered)
             .onHover { hovering in self.isHovered = hovering }
     }

--- a/Sources/Kaset/Views/SharedViews/SongDraggable.swift
+++ b/Sources/Kaset/Views/SharedViews/SongDraggable.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+extension View {
+    /// Marks this view as a drag source for `song` — e.g. to drop onto a sidebar playlist.
+    ///
+    /// The single seam for song drag behaviour: every song row and card routes through here, so a
+    /// shared drag preview (or any change to how a song drags) has one place to live. Passing `nil`
+    /// leaves the view undraggable.
+    @ViewBuilder
+    func songDraggable(_ song: Song?) -> some View {
+        if let song {
+            self.draggable(song)
+        } else {
+            self
+        }
+    }
+}

--- a/Sources/Kaset/Views/Sidebar.swift
+++ b/Sources/Kaset/Views/Sidebar.swift
@@ -16,8 +16,16 @@ struct Sidebar: View {
     @Environment(PlayerService.self) private var playerService
     @Environment(SidebarPinnedItemsManager.self) private var sidebarPinnedItemsManager
     @Environment(PodcastsAvailabilityService.self) private var podcastsAvailability
+    @Environment(SongLikeStatusManager.self) private var likeStatusManager
     @State private var isCreatingPlaylist = false
     @State private var isHoveringPlaylistsHeader = false
+
+    /// Drop key for the Collection "Liked Music" row, distinct from the pinned LM
+    /// playlist row so only the hovered row highlights.
+    private static let likedMusicNavDropKey = "collection-liked-music"
+
+    @State private var dropTargetPlaylistId: String?
+    @State private var dropFeedbackPlaylistId: String?
 
     var body: some View {
         List {
@@ -56,7 +64,7 @@ struct Sidebar: View {
                     self.navigationRow(.library)
                         .accessibilityIdentifier(AccessibilityID.Sidebar.libraryItem)
 
-                    self.navigationRow(.likedMusic)
+                    self.likedMusicNavigationRow
                         .accessibilityIdentifier(AccessibilityID.Sidebar.likedMusicItem)
 
                     self.navigationRow(.history)
@@ -103,14 +111,36 @@ struct Sidebar: View {
         return nil
     }
 
-    private func navigationRow(_ item: NavigationItem) -> some View {
+    private func navigationRow(_ item: NavigationItem, isDropTargeted: Bool = false) -> some View {
         KasetSidebarRow(
             title: item.displayName,
             systemImage: item.icon,
-            isSelected: self.currentSidebarSelection == .navigation(item)
+            isSelected: self.currentSidebarSelection == .navigation(item),
+            isDropTargeted: isDropTargeted
         ) {
             self.selectNavigationItem(item)
         }
+    }
+
+    /// The Collection "Liked Music" row also accepts song drops: Liked Music is the LM
+    /// auto-playlist, where membership means "liked", so drops rate the song instead of
+    /// editing a playlist.
+    private var likedMusicNavigationRow: some View {
+        self.navigationRow(.likedMusic, isDropTargeted: self.dropTargetPlaylistId == Self.likedMusicNavDropKey)
+            .overlay(alignment: .trailing) {
+                self.dropSuccessBadge(show: self.dropFeedbackPlaylistId == Self.likedMusicNavDropKey)
+            }
+            .animation(AppAnimation.bouncy, value: self.dropFeedbackPlaylistId == Self.likedMusicNavDropKey)
+            .dropDestination(for: Song.self) { droppedSongs, _ in
+                self.handleDroppedSongs(
+                    droppedSongs,
+                    target: .likedMusic,
+                    feedbackKey: Self.likedMusicNavDropKey
+                )
+                return true
+            } isTargeted: { targeted in
+                self.updateDropTarget(key: Self.likedMusicNavDropKey, targeted: targeted)
+            }
     }
 
     private func selectNavigationItem(_ item: NavigationItem) {
@@ -200,13 +230,91 @@ struct Sidebar: View {
         )
     }
 
+    /// Adds each dropped song to the target through Library Mutation Orchestration, then maps the
+    /// outcome to haptics and the confirmation badge. Liked Music routing lives in the orchestrator.
+    private func handleDroppedSongs(
+        _ songs: [Song],
+        target: PlaylistDropTarget,
+        feedbackKey: String
+    ) {
+        for song in songs {
+            Task {
+                let outcome = await LibraryMutationActions.addSong(
+                    song,
+                    to: target,
+                    client: self.client,
+                    likeStatusManager: self.likeStatusManager
+                )
+                switch outcome {
+                case .added, .liked:
+                    HapticService.success()
+                    self.flashDropFeedback(for: feedbackKey)
+                case .failed:
+                    HapticService.error()
+                }
+            }
+        }
+    }
+
+    private func updateDropTarget(key: String, targeted: Bool) {
+        self.dropTargetPlaylistId = targeted ? key : (self.dropTargetPlaylistId == key ? nil : self.dropTargetPlaylistId)
+    }
+
+    @ViewBuilder
+    private func dropSuccessBadge(show: Bool) -> some View {
+        if show {
+            Image(systemName: "checkmark")
+                .font(.system(size: 11, weight: .bold))
+                .foregroundStyle(.white)
+                .frame(width: 22, height: 22)
+                .compatGlass(tint: .green, in: Circle())
+                .shadow(color: .black.opacity(0.25), radius: 3, y: 1)
+                .padding(.trailing, 6)
+                .transition(.scale(scale: 0.4, anchor: .trailing).combined(with: .opacity))
+                .accessibilityHidden(true)
+        }
+    }
+
+    /// Briefly shows a green checkmark badge on the playlist row to confirm
+    /// a successful drag-and-drop.
+    private func flashDropFeedback(for playlistId: String) {
+        self.dropFeedbackPlaylistId = playlistId
+        Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(900))
+            if self.dropFeedbackPlaylistId == playlistId {
+                self.dropFeedbackPlaylistId = nil
+            }
+        }
+    }
+
     private func sidebarPinnedRow(_ item: SidebarPinnedItem) -> some View {
-        KasetSidebarRow(
+        let isDropEligible = item.acceptsSongDrops
+        let isDropTargeted = self.dropTargetPlaylistId == item.contentId
+        let showDropFeedback = self.dropFeedbackPlaylistId == item.contentId
+
+        return KasetSidebarRow(
             title: item.title,
             systemImage: item.systemImage,
-            isSelected: self.currentSidebarSelection == .pinned(item)
+            isSelected: self.currentSidebarSelection == .pinned(item),
+            isDropTargeted: isDropEligible && isDropTargeted
         ) {
             self.selectPinnedItem(item)
+        }
+        .overlay(alignment: .trailing) {
+            self.dropSuccessBadge(show: isDropEligible && showDropFeedback)
+        }
+        .animation(AppAnimation.bouncy, value: showDropFeedback)
+        .dropDestination(for: Song.self) { droppedSongs, _ in
+            guard isDropEligible else { return false }
+            self.handleDroppedSongs(
+                droppedSongs,
+                target: PlaylistDropTarget(playlistId: item.contentId),
+                feedbackKey: item.contentId
+            )
+            return true
+        } isTargeted: { targeted in
+            guard isDropEligible else { return }
+            self.updateDropTarget(key: item.contentId, targeted: targeted)
         }
         .contextMenu {
             Button {
@@ -249,7 +357,11 @@ struct Sidebar: View {
 
 #Preview {
     let authService = AuthService()
-    let client = YTMusicClient(authService: authService, webKitManager: .shared)
+    let client: any YTMusicClientProtocol = if UITestConfig.isUITestMode {
+        MockUITestYTMusicClient()
+    } else {
+        YTMusicClient(authService: authService, webKitManager: .shared)
+    }
     Sidebar(selection: .constant(.home), pinnedSelection: .constant(nil), client: client)
         .frame(width: 220)
         .environment(authService)

--- a/Sources/Kaset/Views/TopSongsView.swift
+++ b/Sources/Kaset/Views/TopSongsView.swift
@@ -75,7 +75,7 @@ struct TopSongsView: View {
     // MARK: - Song Row
 
     private func songRow(_ song: Song, index: Int) -> some View {
-        HoverObservingRow { isHovered in
+        HoverObservingRow(song: song) { isHovered in
             Button {
                 self.playSongInQueue(startingAt: index)
             } label: {

--- a/Tests/KasetTests/LibraryMutationActionsTests.swift
+++ b/Tests/KasetTests/LibraryMutationActionsTests.swift
@@ -49,6 +49,57 @@ extension LibraryMutationSerialTests {
             ])
         }
 
+        @Test("addSong to an editable target adds and reports .added")
+        func addSongToEditableTargetReportsAdded() async {
+            let song = TestFixtures.makeSong(id: "song-add", title: "Song Add")
+
+            let outcome = await LibraryMutationActions.addSong(
+                song,
+                to: .editable(playlistId: "PL_owned"),
+                client: self.mockClient
+            )
+
+            #expect(outcome == .added)
+            #expect(self.mockClient.addSongToPlaylistCalls == [
+                MockYTMusicClient.AddSongToPlaylistCall(
+                    videoId: "song-add",
+                    playlistId: "PL_owned",
+                    allowDuplicate: false
+                ),
+            ])
+        }
+
+        @Test("addSong to an editable target reports .failed when the client throws")
+        func addSongToEditableTargetReportsFailure() async {
+            self.mockClient.shouldThrowError = YTMusicError.authExpired
+            let song = TestFixtures.makeSong(id: "song-fail")
+
+            let outcome = await LibraryMutationActions.addSong(
+                song,
+                to: .editable(playlistId: "PL_owned"),
+                client: self.mockClient
+            )
+
+            #expect(outcome == .failed)
+        }
+
+        @Test("addSong to Liked Music likes the song instead of editing a playlist")
+        func addSongToLikedMusicLikes() async {
+            let song = TestFixtures.makeSong(id: "song-liked-\(#line)")
+
+            let outcome = await LibraryMutationActions.addSong(
+                song,
+                to: .likedMusic,
+                client: self.mockClient,
+                likeStatusManager: SongLikeStatusManager.shared
+            )
+
+            #expect(outcome == .liked)
+            #expect(self.mockClient.rateSongCalled)
+            #expect(self.mockClient.rateSongRatings.first == .like)
+            #expect(self.mockClient.addSongToPlaylistCalls.isEmpty)
+        }
+
         @Test("Remove song from playlist delegates to client and removes it from the loaded list")
         func removeSongFromPlaylistDelegatesToClient() async {
             let song = Song(id: "song-1", title: "Song 1", artists: [], videoId: "song-1", playlistSetVideoId: "set-1")

--- a/Tests/KasetTests/LibraryMutationActionsTests.swift
+++ b/Tests/KasetTests/LibraryMutationActionsTests.swift
@@ -91,7 +91,7 @@ extension LibraryMutationSerialTests {
                 song,
                 to: .likedMusic,
                 client: self.mockClient,
-                likeStatusManager: SongLikeStatusManager.shared
+                likeStatusManager: SongLikeStatusManager()
             )
 
             #expect(outcome == .liked)

--- a/Tests/KasetTests/ModelTests.swift
+++ b/Tests/KasetTests/ModelTests.swift
@@ -357,6 +357,75 @@ struct ModelTests {
         #expect(playlist == nil)
     }
 
+    // MARK: - SidebarPinnedItem Tests
+
+    @Test("SidebarPinnedItem rejects song drops for non-owned playlists")
+    func sidebarPinnedItemRejectsDropsForFollowedPlaylist() {
+        let playlist = Playlist(
+            id: "PL_followed",
+            title: "Followed Playlist",
+            description: nil,
+            thumbnailURL: nil,
+            trackCount: 5,
+            canDelete: false
+        )
+
+        let item = SidebarPinnedItem.from(playlist)
+        #expect(!item.acceptsSongDrops)
+    }
+
+    @Test("SidebarPinnedItem accepts song drops for owned playlists")
+    func sidebarPinnedItemAcceptsDropsForOwnedPlaylist() {
+        let playlist = Playlist(
+            id: "PL_owned",
+            title: "My Playlist",
+            description: nil,
+            thumbnailURL: nil,
+            trackCount: 5,
+            canDelete: true
+        )
+
+        let item = SidebarPinnedItem.from(playlist)
+        #expect(item.acceptsSongDrops)
+    }
+
+    @Test("SidebarPinnedItem accepts song drops for Liked Music regardless of canDelete")
+    func sidebarPinnedItemAcceptsDropsForLikedMusic() {
+        let item = SidebarPinnedItem.from(LikedMusicPlaylist.playlist)
+        #expect(item.acceptsSongDrops)
+    }
+
+    @Test("SidebarPinnedItem accepts song drops for VL-prefixed Liked Music regardless of canDelete")
+    func sidebarPinnedItemAcceptsDropsForBrowseIdLikedMusic() {
+        let playlist = Playlist(
+            id: LikedMusicPlaylist.browseID,
+            title: "Liked Music",
+            description: nil,
+            thumbnailURL: nil,
+            trackCount: nil,
+            canDelete: false
+        )
+
+        let item = SidebarPinnedItem.from(playlist)
+        #expect(item.acceptsSongDrops)
+        #expect(PlaylistDropTarget(playlistId: item.contentId) == .likedMusic)
+    }
+
+    @Test("SidebarPinnedItem rejects song drops for albums")
+    func sidebarPinnedItemRejectsDropsForAlbum() {
+        let album = Album(
+            id: "OLAK5abc",
+            title: "Test Album",
+            artists: nil,
+            thumbnailURL: nil,
+            year: nil,
+            trackCount: 10
+        )
+
+        let item = SidebarPinnedItem.from(album)
+        #expect(!item.acceptsSongDrops)
+    }
+
     // MARK: - PlaylistDetail Tests
 
     @Test("Creates PlaylistDetail from Playlist")

--- a/Tests/KasetTests/PlaylistDropTargetTests.swift
+++ b/Tests/KasetTests/PlaylistDropTargetTests.swift
@@ -1,0 +1,20 @@
+import Testing
+@testable import Kaset
+
+@Suite("PlaylistDropTarget", .tags(.model))
+struct PlaylistDropTargetTests {
+    @Test("Classifies the raw Liked Music id as Liked Music")
+    func classifiesLikedMusicId() {
+        #expect(PlaylistDropTarget(playlistId: LikedMusicPlaylist.id) == .likedMusic)
+    }
+
+    @Test("Classifies the VL-prefixed Liked Music browse id as Liked Music")
+    func classifiesLikedMusicBrowseId() {
+        #expect(PlaylistDropTarget(playlistId: LikedMusicPlaylist.browseID) == .likedMusic)
+    }
+
+    @Test("Classifies an ordinary playlist id as editable")
+    func classifiesOrdinaryPlaylist() {
+        #expect(PlaylistDropTarget(playlistId: "PL_owned") == .editable(playlistId: "PL_owned"))
+    }
+}


### PR DESCRIPTION
## Description

Adds drag-and-drop of tracks onto playlists in the sidebar. Any track row (search results, history, home sections, playlist detail, etc.) can be dragged onto an owned playlist in the sidebar to add it. The target playlist highlights while dragging over it, and a brief success badge confirms the drop.

## AI Prompt (Optional)

<details>
<summary>🤖 AI Prompt Used</summary>

```
Developed interactively with Claude Code across multiple sessions; the original
initiating prompt was not preserved. Gist: "Add drag and drop so I can drag any
track row onto a playlist in the sidebar to add it to that playlist. Only owned
playlists should accept drops, show visual feedback while hovering a valid
target, and confirm success."
```

**AI Tool:** Claude Code

</details>

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Related Issues

<!-- none -->

## Changes Made

- Every rendered `Song` is a drag source (via the existing `Transferable` conformance), attached at the shared wrappers rather than per view: playlist track rows, `HoverObservingRow` (search, history, artist pages, top songs), and `HomeSectionItemCard` song cards (home, explore, charts, moods, new releases)
- `.dropDestination(for: Song.self, action:isTargeted:)` on owned sidebar playlist rows; drops call `YTMusicClient.addSongToPlaylist`
- Drag-over highlight on the targeted playlist row; transient success badge after a completed drop
- Dropping onto **Liked Music** (Collection row or pinned LM playlist) likes the song instead — LM is the auto-playlist where membership means "liked", so drops route through `SongLikeStatusManager` (optimistic, broadcasts so like buttons update everywhere, rollback on failure)
- Error handling with user-facing feedback when the add fails

## Testing

- [x] Unit tests pass (`swift test --skip KasetUITests`) — 1774 passed, 148 suites
- [x] Manual testing performed — dragged tracks from search/history/playlist views onto sidebar playlists
- [x] UI tested on macOS 26+

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `swiftlint --strict && swiftformat .`
- [ ] I have added tests that prove my fix/feature works (view-layer only; no service changes)
- [x] New and existing unit tests pass locally
- [ ] I have updated documentation if needed
- [x] I have checked for any performance implications
- [x] My changes generate no new warnings

## Screenshots

https://github.com/user-attachments/assets/3b227aaf-7bb7-4cc8-95fd-53e0a43a0102

## Additional Notes

View-layer only: no API or model changes. The drop path reuses the existing add-to-playlist client call (and the existing like flow for Liked Music).
