### PR TITLE
feat: Remove from Playlist context-menu action

### DIFF
--- a/Sources/APIExplorer/main.swift
+++ b/Sources/APIExplorer/main.swift
@@ -523,6 +523,54 @@ func rendererHistogram(_ data: [String: Any], limit: Int = 25) -> String {
     return output
 }
 
+// MARK: - PlaylistSetVideoIdSourceCounts
+
+private struct PlaylistSetVideoIdSourceCounts {
+    var playlistItemData = 0
+    var playlistEditEndpoint = 0
+}
+
+private func countPlaylistSetVideoIdSources(in value: Any, counts: inout PlaylistSetVideoIdSourceCounts) {
+    if let dictionary = value as? [String: Any] {
+        if let playlistItemData = dictionary["playlistItemData"] as? [String: Any],
+           let setVideoId = playlistItemData["playlistSetVideoId"] as? String,
+           !setVideoId.isEmpty
+        {
+            counts.playlistItemData += 1
+        }
+
+        if let editEndpoint = dictionary["playlistEditEndpoint"] as? [String: Any],
+           let actions = editEndpoint["actions"] as? [[String: Any]]
+        {
+            counts.playlistEditEndpoint += actions.count { action in
+                action["action"] as? String == "ACTION_REMOVE_VIDEO"
+                    && (action["setVideoId"] as? String)?.isEmpty == false
+            }
+        }
+
+        for nestedValue in dictionary.values {
+            countPlaylistSetVideoIdSources(in: nestedValue, counts: &counts)
+        }
+    } else if let array = value as? [Any] {
+        for item in array {
+            countPlaylistSetVideoIdSources(in: item, counts: &counts)
+        }
+    }
+}
+
+private func playlistSetVideoIdSourceSummary(_ data: [String: Any]) -> String {
+    var counts = PlaylistSetVideoIdSourceCounts()
+    countPlaylistSetVideoIdSources(in: data, counts: &counts)
+    guard counts.playlistItemData > 0 || counts.playlistEditEndpoint > 0 else { return "" }
+
+    return """
+
+    🧩 Playlist occurrence ID sources:
+      • playlistItemData.playlistSetVideoId: \(counts.playlistItemData)
+      • playlistEditEndpoint ACTION_REMOVE_VIDEO setVideoId: \(counts.playlistEditEndpoint)
+    """
+}
+
 // MARK: - ChapterProbeItem
 
 private struct ChapterProbeItem: Hashable {
@@ -850,6 +898,8 @@ func analyzeResponse(_ data: [String: Any], verbose: Bool = false) -> String {
     if let playlistSummary = playlistBrowseSummary(data) {
         output += playlistSummary
     }
+
+    output += playlistSetVideoIdSourceSummary(data)
 
     output += chapterProbeSummary(data)
 

--- a/Sources/Kaset/Models/Song.swift
+++ b/Sources/Kaset/Models/Song.swift
@@ -33,6 +33,11 @@ struct Song: Identifiable, Codable, Hashable {
     /// Whether this song carries an explicit-content badge (nil if unknown).
     var isExplicit: Bool?
 
+    /// This track's occurrence-specific identifier within a playlist, required to remove
+    /// the correct instance (the same song can appear more than once in a playlist).
+    /// Only populated when the song was parsed from a playlist's track list.
+    var playlistSetVideoId: String?
+
     private enum CodingKeys: String, CodingKey {
         case id
         case title
@@ -48,6 +53,7 @@ struct Song: Identifiable, Codable, Hashable {
         case isInLibrary
         case feedbackTokens
         case isExplicit
+        case playlistSetVideoId
     }
 
     /// Memberwise initializer with default values for mutable properties.
@@ -65,7 +71,8 @@ struct Song: Identifiable, Codable, Hashable {
         likeStatus: LikeStatus? = nil,
         isInLibrary: Bool? = nil,
         feedbackTokens: FeedbackTokens? = nil,
-        isExplicit: Bool? = nil
+        isExplicit: Bool? = nil,
+        playlistSetVideoId: String? = nil
     ) {
         self.id = id
         self.title = title
@@ -81,6 +88,7 @@ struct Song: Identifiable, Codable, Hashable {
         self.isInLibrary = isInLibrary
         self.feedbackTokens = feedbackTokens
         self.isExplicit = isExplicit
+        self.playlistSetVideoId = playlistSetVideoId
     }
 
     init(from decoder: any Decoder) throws {
@@ -99,6 +107,7 @@ struct Song: Identifiable, Codable, Hashable {
         self.isInLibrary = try container.decodeIfPresent(Bool.self, forKey: .isInLibrary)
         self.feedbackTokens = try container.decodeIfPresent(FeedbackTokens.self, forKey: .feedbackTokens)
         self.isExplicit = try container.decodeIfPresent(Bool.self, forKey: .isExplicit)
+        self.playlistSetVideoId = try container.decodeIfPresent(String.self, forKey: .playlistSetVideoId)
     }
 
     func encode(to encoder: any Encoder) throws {
@@ -117,6 +126,7 @@ struct Song: Identifiable, Codable, Hashable {
         try container.encodeIfPresent(self.isInLibrary, forKey: .isInLibrary)
         try container.encodeIfPresent(self.feedbackTokens, forKey: .feedbackTokens)
         try container.encodeIfPresent(self.isExplicit, forKey: .isExplicit)
+        try container.encodeIfPresent(self.playlistSetVideoId, forKey: .playlistSetVideoId)
     }
 
     /// Display string for artists (comma-separated).

--- a/Sources/Kaset/Services/API/MockUITestYTMusicClient.swift
+++ b/Sources/Kaset/Services/API/MockUITestYTMusicClient.swift
@@ -389,6 +389,10 @@ final class MockUITestYTMusicClient: YTMusicClientProtocol {
         // No-op for UI tests
     }
 
+    func removeSongFromPlaylist(videoId _: String, setVideoId _: String, playlistId _: String) async throws {
+        // No-op for UI tests
+    }
+
     func unsubscribeFromPlaylist(playlistId _: String) async throws {
         // No-op for UI tests
     }

--- a/Sources/Kaset/Services/API/Parsers/ParsingHelpers+Playlist.swift
+++ b/Sources/Kaset/Services/API/Parsers/ParsingHelpers+Playlist.swift
@@ -1,0 +1,45 @@
+// MARK: - Playlist Parsing
+
+extension ParsingHelpers {
+    /// Extracts the playlist-item-specific `setVideoId`, required to remove the correct
+    /// occurrence of a track from a playlist (the same song can appear more than once).
+    /// Only present on playlist track rows, not search results or other song contexts.
+    static func extractPlaylistSetVideoId(from data: [String: Any]) -> String? {
+        if let playlistItemData = data["playlistItemData"] as? [String: Any],
+           let playlistSetVideoId = playlistItemData["playlistSetVideoId"] as? String,
+           !playlistSetVideoId.isEmpty
+        {
+            return playlistSetVideoId
+        }
+
+        return Self.extractPlaylistSetVideoIdFromEditEndpoint(in: data)
+    }
+
+    private static func extractPlaylistSetVideoIdFromEditEndpoint(in value: Any) -> String? {
+        if let dictionary = value as? [String: Any] {
+            if let editEndpoint = dictionary["playlistEditEndpoint"] as? [String: Any],
+               let actions = editEndpoint["actions"] as? [[String: Any]]
+            {
+                for action in actions where action["action"] as? String == "ACTION_REMOVE_VIDEO" {
+                    if let setVideoId = action["setVideoId"] as? String, !setVideoId.isEmpty {
+                        return setVideoId
+                    }
+                }
+            }
+
+            for nestedValue in dictionary.values {
+                if let setVideoId = Self.extractPlaylistSetVideoIdFromEditEndpoint(in: nestedValue) {
+                    return setVideoId
+                }
+            }
+        } else if let array = value as? [Any] {
+            for item in array {
+                if let setVideoId = Self.extractPlaylistSetVideoIdFromEditEndpoint(in: item) {
+                    return setVideoId
+                }
+            }
+        }
+
+        return nil
+    }
+}

--- a/Sources/Kaset/Services/API/Parsers/ParsingHelpers.swift
+++ b/Sources/Kaset/Services/API/Parsers/ParsingHelpers.swift
@@ -354,6 +354,16 @@ enum ParsingHelpers {
         return nil
     }
 
+    /// Extracts the playlist-item-specific `setVideoId`, required to remove the correct
+    /// occurrence of a track from a playlist (the same song can appear more than once).
+    /// Only present on playlist track rows, not search results or other song contexts.
+    static func extractPlaylistSetVideoId(from data: [String: Any]) -> String? {
+        guard let playlistItemData = data["playlistItemData"] as? [String: Any] else {
+            return nil
+        }
+        return playlistItemData["playlistSetVideoId"] as? String
+    }
+
     /// Extracts the YouTube Music video type from watch endpoint metadata.
     static func extractMusicVideoType(from data: [String: Any]) -> MusicVideoType? {
         if let endpoint = data["navigationEndpoint"] as? [String: Any],

--- a/Sources/Kaset/Services/API/Parsers/ParsingHelpers.swift
+++ b/Sources/Kaset/Services/API/Parsers/ParsingHelpers.swift
@@ -354,16 +354,6 @@ enum ParsingHelpers {
         return nil
     }
 
-    /// Extracts the playlist-item-specific `setVideoId`, required to remove the correct
-    /// occurrence of a track from a playlist (the same song can appear more than once).
-    /// Only present on playlist track rows, not search results or other song contexts.
-    static func extractPlaylistSetVideoId(from data: [String: Any]) -> String? {
-        guard let playlistItemData = data["playlistItemData"] as? [String: Any] else {
-            return nil
-        }
-        return playlistItemData["playlistSetVideoId"] as? String
-    }
-
     /// Extracts the YouTube Music video type from watch endpoint metadata.
     static func extractMusicVideoType(from data: [String: Any]) -> MusicVideoType? {
         if let endpoint = data["navigationEndpoint"] as? [String: Any],

--- a/Sources/Kaset/Services/API/Parsers/PlaylistParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/PlaylistParser.swift
@@ -1070,6 +1070,7 @@ enum PlaylistParser {
         let album = ParsingHelpers.extractAlbumFromFlexColumns(responsiveRenderer)
         let isPlayable = ParsingHelpers.isPlayableMusicItem(from: responsiveRenderer)
         let isExplicit = ParsingHelpers.extractIsExplicit(from: responsiveRenderer)
+        let playlistSetVideoId = ParsingHelpers.extractPlaylistSetVideoId(from: responsiveRenderer)
 
         return Song(
             id: videoId,
@@ -1080,7 +1081,8 @@ enum PlaylistParser {
             thumbnailURL: thumbnailURL,
             videoId: videoId,
             isPlayable: isPlayable,
-            isExplicit: isExplicit
+            isExplicit: isExplicit,
+            playlistSetVideoId: playlistSetVideoId
         )
     }
 

--- a/Sources/Kaset/Services/API/YTMusicClient.swift
+++ b/Sources/Kaset/Services/API/YTMusicClient.swift
@@ -1524,6 +1524,32 @@ final class YTMusicClient: YTMusicClientProtocol {
         APICache.shared.invalidateMutationCaches()
     }
 
+    /// Removes a song from a playlist.
+    /// - Parameters:
+    ///   - videoId: The video ID to remove
+    ///   - setVideoId: The playlist-item-specific identifier YouTube Music assigns to
+    ///     each track occurrence, required to remove the correct instance (a song can
+    ///     appear more than once in a playlist).
+    ///   - playlistId: The playlist ID to remove from
+    func removeSongFromPlaylist(videoId: String, setVideoId: String, playlistId: String) async throws {
+        self.logger.info("Removing song \(videoId) from playlist \(playlistId)")
+
+        let cleanPlaylistId = playlistId.hasPrefix("VL") ? String(playlistId.dropFirst(2)) : playlistId
+        let body: [String: Any] = [
+            "playlistId": cleanPlaylistId,
+            "actions": [[
+                "action": "ACTION_REMOVE_VIDEO",
+                "removedVideoId": videoId,
+                "setVideoId": setVideoId,
+            ]],
+        ]
+
+        _ = try await self.request("browse/edit_playlist", body: body)
+        self.logger.info("Successfully removed song \(videoId) from playlist \(playlistId)")
+
+        APICache.shared.invalidateMutationCaches()
+    }
+
     /// Removes a playlist from the user's library using the like/removelike endpoint.
     /// This is equivalent to the "Remove from Library" action in YouTube Music.
     /// - Parameter playlistId: The playlist ID to remove from library

--- a/Sources/Kaset/Services/Library/LibraryMutationActions.swift
+++ b/Sources/Kaset/Services/Library/LibraryMutationActions.swift
@@ -27,6 +27,35 @@ enum LibraryMutationActions {
         }
     }
 
+    /// Removes a song from the playlist currently loaded in `viewModel`. Removes it from
+    /// the loaded list optimistically, then rolls back if the API call fails.
+    static func removeSongFromPlaylist(
+        _ song: Song,
+        from viewModel: PlaylistDetailViewModel,
+        client: any YTMusicClientProtocol
+    ) async {
+        guard let setVideoId = song.playlistSetVideoId,
+              let playlistId = viewModel.playlistDetail?.id
+        else {
+            DiagnosticsLogger.api.error("Cannot remove '\(song.title)' from playlist: missing setVideoId")
+            HapticService.error()
+            return
+        }
+
+        guard let removed = viewModel.removeTrackOptimistically(setVideoId: setVideoId) else { return }
+
+        do {
+            try await client.removeSongFromPlaylist(videoId: song.videoId, setVideoId: setVideoId, playlistId: playlistId)
+            self.invalidateResponseCaches()
+            HapticService.success()
+            DiagnosticsLogger.api.info("Removed song '\(song.title)' from playlist")
+        } catch {
+            viewModel.reinsertTrack(removed.song, at: removed.index)
+            HapticService.error()
+            DiagnosticsLogger.api.error("Failed to remove song from playlist: \(error.localizedDescription)")
+        }
+    }
+
     /// Adds a playlist to the library.
     static func addPlaylistToLibrary(
         _ playlist: Playlist,

--- a/Sources/Kaset/Services/Library/LibraryMutationActions.swift
+++ b/Sources/Kaset/Services/Library/LibraryMutationActions.swift
@@ -27,30 +27,35 @@ enum LibraryMutationActions {
         }
     }
 
-    /// Removes a song from the playlist currently loaded in `viewModel`. Removes it from
-    /// the loaded list optimistically, then rolls back if the API call fails.
+    /// Removes a song from the playlist currently loaded in `viewModel`, then reconciles
+    /// the successful server mutation into the current list and any in-flight loads.
     static func removeSongFromPlaylist(
         _ song: Song,
         from viewModel: PlaylistDetailViewModel,
         client: any YTMusicClientProtocol
     ) async {
-        guard let setVideoId = song.playlistSetVideoId,
-              let playlistId = viewModel.playlistDetail?.id
-        else {
+        guard let setVideoId = song.playlistSetVideoId else {
             DiagnosticsLogger.api.error("Cannot remove '\(song.title)' from playlist: missing setVideoId")
             HapticService.error()
             return
         }
-
-        guard let removed = viewModel.removeTrackOptimistically(setVideoId: setVideoId) else { return }
+        guard viewModel.reservePlaylistRemoval(setVideoId: setVideoId) else { return }
+        defer { viewModel.releasePlaylistRemoval(setVideoId: setVideoId) }
 
         do {
-            try await client.removeSongFromPlaylist(videoId: song.videoId, setVideoId: setVideoId, playlistId: playlistId)
-            self.invalidateResponseCaches()
+            try Task.checkCancellation()
+            try await client.removeSongFromPlaylist(
+                videoId: song.videoId,
+                setVideoId: setVideoId,
+                playlistId: viewModel.playlistID
+            )
+            Self.invalidateResponseCaches()
+            await viewModel.commitSuccessfulTrackRemoval(setVideoId: setVideoId)
             HapticService.success()
             DiagnosticsLogger.api.info("Removed song '\(song.title)' from playlist")
+        } catch is CancellationError {
+            return
         } catch {
-            viewModel.reinsertTrack(removed.song, at: removed.index)
             HapticService.error()
             DiagnosticsLogger.api.error("Failed to remove song from playlist: \(error.localizedDescription)")
         }

--- a/Sources/Kaset/Services/Library/LibraryMutationActions.swift
+++ b/Sources/Kaset/Services/Library/LibraryMutationActions.swift
@@ -27,8 +27,8 @@ enum LibraryMutationActions {
         }
     }
 
-    /// Removes a song from the playlist currently loaded in `viewModel`, then reconciles
-    /// the successful server mutation into the current list and any in-flight loads.
+    /// Removes a song from the playlist currently loaded in `viewModel`. The row is removed
+    /// optimistically and restored if the server mutation fails.
     static func removeSongFromPlaylist(
         _ song: Song,
         from viewModel: PlaylistDetailViewModel,
@@ -39,8 +39,7 @@ enum LibraryMutationActions {
             HapticService.error()
             return
         }
-        guard viewModel.reservePlaylistRemoval(setVideoId: setVideoId) else { return }
-        defer { viewModel.releasePlaylistRemoval(setVideoId: setVideoId) }
+        guard let removal = viewModel.beginOptimisticTrackRemoval(setVideoId: setVideoId) else { return }
 
         do {
             try Task.checkCancellation()
@@ -50,12 +49,14 @@ enum LibraryMutationActions {
                 playlistId: viewModel.playlistID
             )
             Self.invalidateResponseCaches()
-            await viewModel.commitSuccessfulTrackRemoval(setVideoId: setVideoId)
+            viewModel.confirmTrackRemoval(removal)
             HapticService.success()
             DiagnosticsLogger.api.info("Removed song '\(song.title)' from playlist")
         } catch is CancellationError {
+            await viewModel.rollbackTrackRemoval(removal)
             return
         } catch {
+            await viewModel.rollbackTrackRemoval(removal)
             HapticService.error()
             DiagnosticsLogger.api.error("Failed to remove song from playlist: \(error.localizedDescription)")
         }

--- a/Sources/Kaset/Services/Player/PlaylistPlaybackActions.swift
+++ b/Sources/Kaset/Services/Player/PlaylistPlaybackActions.swift
@@ -121,6 +121,29 @@ enum PlaylistPlaybackActions {
         }
     }
 
+    /// Returns full-playlist tracks that were not already put in the initial queue.
+    /// Uses occurrence counts per video ID so authored duplicates remain intact while
+    /// user removals from the playlist do not shift a fragile numeric offset.
+    static func remainingTracks(after initialTracks: [Song], in fullTracks: [Song]) -> [Song] {
+        var unmatchedInitialCounts: [String: Int] = [:]
+        for track in initialTracks {
+            unmatchedInitialCounts[self.playlistOccurrenceIdentity(for: track), default: 0] += 1
+        }
+
+        return fullTracks.filter { track in
+            let identity = self.playlistOccurrenceIdentity(for: track)
+            guard let remainingCount = unmatchedInitialCounts[identity], remainingCount > 0 else {
+                return true
+            }
+            if remainingCount == 1 {
+                unmatchedInitialCounts.removeValue(forKey: identity)
+            } else {
+                unmatchedInitialCounts[identity] = remainingCount - 1
+            }
+            return false
+        }
+    }
+
     @MainActor
     static func appendContinuations(_ context: ContinuationContext) async {
         var nextContinuation = context.continuationToken
@@ -172,7 +195,15 @@ enum PlaylistPlaybackActions {
             likeStatus: song.likeStatus,
             isInLibrary: song.isInLibrary,
             feedbackTokens: carried,
-            isExplicit: song.isExplicit
+            isExplicit: song.isExplicit,
+            playlistSetVideoId: song.playlistSetVideoId
         )
+    }
+
+    private static func playlistOccurrenceIdentity(for song: Song) -> String {
+        if let setVideoId = song.playlistSetVideoId, !setVideoId.isEmpty {
+            return "set:\(setVideoId)"
+        }
+        return "video:\(song.videoId)"
     }
 }

--- a/Sources/Kaset/Services/Protocols.swift
+++ b/Sources/Kaset/Services/Protocols.swift
@@ -230,6 +230,11 @@ protocol YTMusicClientProtocol: Sendable {
     /// Adds a song to an existing playlist.
     func addSongToPlaylist(videoId: String, playlistId: String, allowDuplicate: Bool) async throws
 
+    /// Removes a song from a playlist.
+    /// - Parameter setVideoId: The playlist-item-specific identifier (from `Song.playlistSetVideoId`)
+    ///   identifying which occurrence of the song to remove.
+    func removeSongFromPlaylist(videoId: String, setVideoId: String, playlistId: String) async throws
+
     /// Creates a playlist and optionally seeds it with songs.
     func createPlaylist(
         title: String,

--- a/Sources/Kaset/ViewModels/PlaylistDetailViewModel.swift
+++ b/Sources/Kaset/ViewModels/PlaylistDetailViewModel.swift
@@ -480,6 +480,39 @@ final class PlaylistDetailViewModel {
         await self.load(restartingInFlightLoad: true)
     }
 
+    /// Optimistically removes the track matching `setVideoId` from the loaded list, ahead
+    /// of the API call actually removing it. Returns the removed song and its original
+    /// index so a failed removal can be undone via `reinsertTrack(_:at:)`.
+    @discardableResult
+    func removeTrackOptimistically(setVideoId: String) -> (song: Song, index: Int)? {
+        guard let detail = self.playlistDetail,
+              let index = detail.tracks.firstIndex(where: { $0.playlistSetVideoId == setVideoId })
+        else { return nil }
+
+        var tracks = detail.tracks
+        let removedSong = tracks.remove(at: index)
+        self.replacePlaylistDetail(self.updatedPlaylistDetail(
+            from: detail,
+            tracks: tracks,
+            trackCount: detail.trackCount.map { max(0, $0 - 1) }
+        ))
+        return (removedSong, index)
+    }
+
+    /// Reinserts a track at its original index, undoing an optimistic removal after the
+    /// API call to actually remove it failed.
+    func reinsertTrack(_ song: Song, at index: Int) {
+        guard let detail = self.playlistDetail else { return }
+
+        var tracks = detail.tracks
+        tracks.insert(song, at: min(index, tracks.count))
+        self.replacePlaylistDetail(self.updatedPlaylistDetail(
+            from: detail,
+            tracks: tracks,
+            trackCount: detail.trackCount.map { $0 + 1 }
+        ))
+    }
+
     private func cancelFullLoadTask() {
         self.fullLoadTask?.cancel()
         self.fullLoadTask = nil

--- a/Sources/Kaset/ViewModels/PlaylistDetailViewModel.swift
+++ b/Sources/Kaset/ViewModels/PlaylistDetailViewModel.swift
@@ -19,6 +19,15 @@ final class PlaylistDetailViewModel {
         let requiresAuth: Bool
     }
 
+    struct PlaylistTrackRemovalSnapshot {
+        let song: Song
+        let index: Int
+        let loadGeneration: Int
+        let detailBeforeRemoval: PlaylistDetail
+        let hadMoreTracks: Bool
+        let continuationToken: String?
+    }
+
     /// Current loading state.
     private(set) var loadingState: LoadingState = .idle
 
@@ -53,10 +62,12 @@ final class PlaylistDetailViewModel {
     private var confirmedRemovedPlaylistSetVideoIDs: Set<String> = []
 
     @ObservationIgnored
-    private var countedConfirmedRemovedPlaylistSetVideoIDs: Set<String> = []
+    private var countedPlaylistRemovalSetVideoIDs: Set<String> = []
 
     @ObservationIgnored
-    private var reservedPlaylistSetVideoIDs: Set<String> = []
+    private var pendingRemovedPlaylistSetVideoID: String?
+
+    private(set) var isRemovingTrack = false
 
     private var isLikedMusicPlaylist: Bool {
         LikedMusicPlaylist.matches(id: self.playlist.id)
@@ -105,6 +116,7 @@ final class PlaylistDetailViewModel {
     @ObservationIgnored private var loadTask: Task<Void, Never>?
     @ObservationIgnored private var fullLoadTask: Task<Void, Never>?
     @ObservationIgnored private var pagingTask: Task<Bool, Never>?
+    @ObservationIgnored private var trackRemovalWaiters: [CheckedContinuation<Void, Never>] = []
 
     /// Runs the initial load (including full-playlist paging) once, coalescing concurrent
     /// callers so a player can await the complete track set before finalizing the queue.
@@ -162,7 +174,7 @@ final class PlaylistDetailViewModel {
         self.cancelFullLoadTask()
         self.loadGeneration += 1
         let generation = self.loadGeneration
-        self.countedConfirmedRemovedPlaylistSetVideoIDs = []
+        self.countedPlaylistRemovalSetVideoIDs = []
         self.removedLikedMusicVideoIDs = []
         self.countedRemovedLikedMusicVideoIDs = []
         self.insertedLikedMusicVideoIDs = []
@@ -261,7 +273,7 @@ final class PlaylistDetailViewModel {
                 detail = self.normalizeLikedMusicDetail(detail)
             }
 
-            detail = self.filterConfirmedPlaylistRemovals(from: detail)
+            detail = self.filterPlaylistRemovals(from: detail)
 
             self.playlistDetail = detail
             self.continuationToken = self.hasMore ? nextContinuationToken : nil
@@ -321,15 +333,15 @@ final class PlaylistDetailViewModel {
             : []
         let skippedConfirmedPlaylistRemovalCount = response.tracks.reduce(into: 0) { count, track in
             guard let setVideoId = track.playlistSetVideoId,
-                  self.confirmedRemovedPlaylistSetVideoIDs.contains(setVideoId),
-                  self.countedConfirmedRemovedPlaylistSetVideoIDs.insert(setVideoId).inserted
+                  self.isPlaylistRemovalTombstoned(setVideoId: setVideoId),
+                  self.countedPlaylistRemovalSetVideoIDs.insert(setVideoId).inserted
             else { return }
             count += 1
         }
         let skippedRemovalCount = skippedRemovedVideoIDs.count + skippedConfirmedPlaylistRemovalCount
         let playlistFilteredTracks = response.tracks.filter { track in
             guard let setVideoId = track.playlistSetVideoId else { return true }
-            return !self.confirmedRemovedPlaylistSetVideoIDs.contains(setVideoId)
+            return !self.isPlaylistRemovalTombstoned(setVideoId: setVideoId)
         }
         let candidateTracks = batch.isLikedMusicPlaylist
             ? playlistFilteredTracks.filter { !self.removedLikedMusicVideoIDs.contains($0.videoId) }
@@ -504,6 +516,11 @@ final class PlaylistDetailViewModel {
     /// Refreshes the playlist.
     @discardableResult
     func refresh() async -> Bool {
+        guard !self.isRemovingTrack else { return false }
+        return await self.performRefresh()
+    }
+
+    private func performRefresh() async -> Bool {
         self.cancelAllLiveSyncTasks()
         self.replacePlaylistDetail(nil)
         self.hasMore = false
@@ -512,35 +529,77 @@ final class PlaylistDetailViewModel {
         return self.loadingState == .loaded && self.playlistDetail != nil
     }
 
-    func reservePlaylistRemoval(setVideoId: String) -> Bool {
-        guard !self.confirmedRemovedPlaylistSetVideoIDs.contains(setVideoId) else { return false }
-        return self.reservedPlaylistSetVideoIDs.insert(setVideoId).inserted
+    func beginOptimisticTrackRemoval(setVideoId: String) -> PlaylistTrackRemovalSnapshot? {
+        guard !self.isRemovingTrack,
+              !self.confirmedRemovedPlaylistSetVideoIDs.contains(setVideoId),
+              let detail = self.playlistDetail,
+              let index = detail.tracks.firstIndex(where: { $0.playlistSetVideoId == setVideoId })
+        else { return nil }
+
+        self.isRemovingTrack = true
+        self.pendingRemovedPlaylistSetVideoID = setVideoId
+        self.countedPlaylistRemovalSetVideoIDs.insert(setVideoId)
+
+        var tracks = detail.tracks
+        let removedSong = tracks.remove(at: index)
+        self.replacePlaylistDetail(self.updatedPlaylistDetail(
+            from: detail,
+            tracks: tracks,
+            trackCount: detail.trackCount.map { max(0, $0 - 1) }
+        ))
+
+        return PlaylistTrackRemovalSnapshot(
+            song: removedSong,
+            index: index,
+            loadGeneration: self.loadGeneration,
+            detailBeforeRemoval: detail,
+            hadMoreTracks: self.hasMore,
+            continuationToken: self.continuationToken
+        )
     }
 
-    func releasePlaylistRemoval(setVideoId: String) {
-        self.reservedPlaylistSetVideoIDs.remove(setVideoId)
-    }
+    func confirmTrackRemoval(_ removal: PlaylistTrackRemovalSnapshot) {
+        guard let setVideoId = removal.song.playlistSetVideoId,
+              self.pendingRemovedPlaylistSetVideoID == setVideoId
+        else { return }
 
-    /// Commits a successful server-side removal to the current list. If a concurrent refresh
-    /// paged the occurrence out, wait for any full drain before reconciling from the server.
-    func commitSuccessfulTrackRemoval(setVideoId: String) async {
         self.confirmedRemovedPlaylistSetVideoIDs.insert(setVideoId)
-        if self.removeConfirmedPlaylistTrackIfLoaded(setVideoId: setVideoId) {
+        self.finishTrackRemoval()
+    }
+
+    func rollbackTrackRemoval(_ removal: PlaylistTrackRemovalSnapshot) async {
+        guard let setVideoId = removal.song.playlistSetVideoId,
+              self.pendingRemovedPlaylistSetVideoID == setVideoId
+        else { return }
+
+        self.countedPlaylistRemovalSetVideoIDs.remove(setVideoId)
+        self.pendingRemovedPlaylistSetVideoID = nil
+        defer { self.finishTrackRemoval() }
+
+        if removal.loadGeneration == self.loadGeneration, let detail = self.playlistDetail {
+            guard !detail.tracks.contains(where: { $0.playlistSetVideoId == setVideoId }) else { return }
+            var tracks = detail.tracks
+            tracks.insert(removal.song, at: min(removal.index, tracks.count))
+            self.replacePlaylistDetail(self.updatedPlaylistDetail(
+                from: detail,
+                tracks: tracks,
+                trackCount: detail.trackCount.map { $0 + 1 }
+            ))
             return
         }
 
-        let activeFullLoadTask = self.fullLoadTask
-        await activeFullLoadTask?.value
+        let restoredDetail = self.filterPlaylistRemovals(from: removal.detailBeforeRemoval)
+        self.replacePlaylistDetail(restoredDetail)
+        self.hasMore = removal.hadMoreTracks
+        self.continuationToken = removal.continuationToken
+        self.loadingState = .loaded
+    }
 
-        if self.countedConfirmedRemovedPlaylistSetVideoIDs.contains(setVideoId) {
-            return
+    func waitForTrackRemovalToFinish() async {
+        guard self.isRemovingTrack else { return }
+        await withCheckedContinuation { continuation in
+            self.trackRemovalWaiters.append(continuation)
         }
-
-        if self.removeConfirmedPlaylistTrackIfLoaded(setVideoId: setVideoId) {
-            return
-        }
-
-        await self.refresh()
     }
 
     private func cancelFullLoadTask() {
@@ -565,17 +624,17 @@ final class PlaylistDetailViewModel {
         )
     }
 
-    private func filterConfirmedPlaylistRemovals(from detail: PlaylistDetail) -> PlaylistDetail {
+    private func filterPlaylistRemovals(from detail: PlaylistDetail) -> PlaylistDetail {
         var countedSetVideoIDs: Set<String> = []
         let filteredTracks = detail.tracks.filter { track in
             guard let setVideoId = track.playlistSetVideoId,
-                  self.confirmedRemovedPlaylistSetVideoIDs.contains(setVideoId)
+                  self.isPlaylistRemovalTombstoned(setVideoId: setVideoId)
             else { return true }
             countedSetVideoIDs.insert(setVideoId)
             return false
         }
         let removedTrackCount = detail.tracks.count - filteredTracks.count
-        self.countedConfirmedRemovedPlaylistSetVideoIDs.formUnion(countedSetVideoIDs)
+        self.countedPlaylistRemovalSetVideoIDs.formUnion(countedSetVideoIDs)
         guard removedTrackCount > 0 else { return detail }
 
         return self.updatedPlaylistDetail(
@@ -585,21 +644,17 @@ final class PlaylistDetailViewModel {
         )
     }
 
-    @discardableResult
-    private func removeConfirmedPlaylistTrackIfLoaded(setVideoId: String) -> Bool {
-        guard let detail = self.playlistDetail,
-              let index = detail.tracks.firstIndex(where: { $0.playlistSetVideoId == setVideoId })
-        else { return false }
+    private func isPlaylistRemovalTombstoned(setVideoId: String) -> Bool {
+        self.confirmedRemovedPlaylistSetVideoIDs.contains(setVideoId)
+            || self.pendingRemovedPlaylistSetVideoID == setVideoId
+    }
 
-        var tracks = detail.tracks
-        tracks.remove(at: index)
-        self.countedConfirmedRemovedPlaylistSetVideoIDs.insert(setVideoId)
-        self.replacePlaylistDetail(self.updatedPlaylistDetail(
-            from: detail,
-            tracks: tracks,
-            trackCount: detail.trackCount.map { max(0, $0 - 1) }
-        ))
-        return true
+    private func finishTrackRemoval() {
+        self.pendingRemovedPlaylistSetVideoID = nil
+        self.isRemovingTrack = false
+        let waiters = self.trackRemovalWaiters
+        self.trackRemovalWaiters.removeAll()
+        waiters.forEach { $0.resume() }
     }
 
     private func markSongsAsLiked(_ tracks: [Song], deduplicating: Bool = false) -> [Song] {

--- a/Sources/Kaset/ViewModels/PlaylistDetailViewModel.swift
+++ b/Sources/Kaset/ViewModels/PlaylistDetailViewModel.swift
@@ -53,6 +53,9 @@ final class PlaylistDetailViewModel {
     private var confirmedRemovedPlaylistSetVideoIDs: Set<String> = []
 
     @ObservationIgnored
+    private var countedConfirmedRemovedPlaylistSetVideoIDs: Set<String> = []
+
+    @ObservationIgnored
     private var reservedPlaylistSetVideoIDs: Set<String> = []
 
     private var isLikedMusicPlaylist: Bool {
@@ -159,6 +162,7 @@ final class PlaylistDetailViewModel {
         self.cancelFullLoadTask()
         self.loadGeneration += 1
         let generation = self.loadGeneration
+        self.countedConfirmedRemovedPlaylistSetVideoIDs = []
         self.removedLikedMusicVideoIDs = []
         self.countedRemovedLikedMusicVideoIDs = []
         self.insertedLikedMusicVideoIDs = []
@@ -315,6 +319,14 @@ final class PlaylistDetailViewModel {
                 return song.videoId
             }
             : []
+        let skippedConfirmedPlaylistRemovalCount = response.tracks.reduce(into: 0) { count, track in
+            guard let setVideoId = track.playlistSetVideoId,
+                  self.confirmedRemovedPlaylistSetVideoIDs.contains(setVideoId),
+                  self.countedConfirmedRemovedPlaylistSetVideoIDs.insert(setVideoId).inserted
+            else { return }
+            count += 1
+        }
+        let skippedRemovalCount = skippedRemovedVideoIDs.count + skippedConfirmedPlaylistRemovalCount
         let playlistFilteredTracks = response.tracks.filter { track in
             guard let setVideoId = track.playlistSetVideoId else { return true }
             return !self.confirmedRemovedPlaylistSetVideoIDs.contains(setVideoId)
@@ -340,7 +352,7 @@ final class PlaylistDetailViewModel {
                 return false
             }
 
-            self.applySkippedLikedMusicRemovalCount(skippedRemovedVideoIDs.count, to: latestDetail)
+            self.applySkippedRemovalCount(skippedRemovalCount, to: latestDetail)
             self.continuationToken = response.continuationToken
             self.hasMore = response.hasMore
             self.loadingState = .loaded
@@ -357,7 +369,7 @@ final class PlaylistDetailViewModel {
         var allTracks = latestDetail.tracks
         allTracks.reserveCapacity(latestDetail.tracks.count + normalizedNewTracks.count)
         allTracks.append(contentsOf: normalizedNewTracks)
-        let adjustedTrackCount = self.adjustedTrackCount(latestDetail.trackCount, skippedRemovalCount: skippedRemovedVideoIDs.count)
+        let adjustedTrackCount = self.adjustedTrackCount(latestDetail.trackCount, skippedRemovalCount: skippedRemovalCount)
         let preservedTrackCount = max(allTracks.count, adjustedTrackCount ?? 0)
         let updatedPlaylist = Playlist(
             id: latestDetail.id,
@@ -391,7 +403,7 @@ final class PlaylistDetailViewModel {
         return max(0, trackCount - skippedRemovalCount)
     }
 
-    private func applySkippedLikedMusicRemovalCount(_ skippedRemovalCount: Int, to detail: PlaylistDetail) {
+    private func applySkippedRemovalCount(_ skippedRemovalCount: Int, to detail: PlaylistDetail) {
         guard let adjustedTrackCount = self.adjustedTrackCount(detail.trackCount, skippedRemovalCount: skippedRemovalCount),
               adjustedTrackCount != detail.trackCount
         else { return }
@@ -520,6 +532,10 @@ final class PlaylistDetailViewModel {
         let activeFullLoadTask = self.fullLoadTask
         await activeFullLoadTask?.value
 
+        if self.countedConfirmedRemovedPlaylistSetVideoIDs.contains(setVideoId) {
+            return
+        }
+
         if self.removeConfirmedPlaylistTrackIfLoaded(setVideoId: setVideoId) {
             return
         }
@@ -550,11 +566,16 @@ final class PlaylistDetailViewModel {
     }
 
     private func filterConfirmedPlaylistRemovals(from detail: PlaylistDetail) -> PlaylistDetail {
+        var countedSetVideoIDs: Set<String> = []
         let filteredTracks = detail.tracks.filter { track in
-            guard let setVideoId = track.playlistSetVideoId else { return true }
-            return !self.confirmedRemovedPlaylistSetVideoIDs.contains(setVideoId)
+            guard let setVideoId = track.playlistSetVideoId,
+                  self.confirmedRemovedPlaylistSetVideoIDs.contains(setVideoId)
+            else { return true }
+            countedSetVideoIDs.insert(setVideoId)
+            return false
         }
         let removedTrackCount = detail.tracks.count - filteredTracks.count
+        self.countedConfirmedRemovedPlaylistSetVideoIDs.formUnion(countedSetVideoIDs)
         guard removedTrackCount > 0 else { return detail }
 
         return self.updatedPlaylistDetail(
@@ -572,6 +593,7 @@ final class PlaylistDetailViewModel {
 
         var tracks = detail.tracks
         tracks.remove(at: index)
+        self.countedConfirmedRemovedPlaylistSetVideoIDs.insert(setVideoId)
         self.replacePlaylistDetail(self.updatedPlaylistDetail(
             from: detail,
             tracks: tracks,

--- a/Sources/Kaset/ViewModels/PlaylistDetailViewModel.swift
+++ b/Sources/Kaset/ViewModels/PlaylistDetailViewModel.swift
@@ -47,6 +47,14 @@ final class PlaylistDetailViewModel {
     private var countedRemovedLikedMusicVideoIDs: Set<String> = []
     private var insertedLikedMusicVideoIDs: Set<String> = []
 
+    /// Successful occurrence removals remain tombstoned for this view model's lifetime so
+    /// stale refreshes and continuation responses cannot restore them.
+    @ObservationIgnored
+    private var confirmedRemovedPlaylistSetVideoIDs: Set<String> = []
+
+    @ObservationIgnored
+    private var reservedPlaylistSetVideoIDs: Set<String> = []
+
     private var isLikedMusicPlaylist: Bool {
         LikedMusicPlaylist.matches(id: self.playlist.id)
     }
@@ -54,6 +62,10 @@ final class PlaylistDetailViewModel {
     init(playlist: Playlist, client: any YTMusicClientProtocol) {
         self.playlist = playlist
         self.client = client
+    }
+
+    var playlistID: String {
+        self.playlist.id
     }
 
     deinit {
@@ -245,6 +257,8 @@ final class PlaylistDetailViewModel {
                 detail = self.normalizeLikedMusicDetail(detail)
             }
 
+            detail = self.filterConfirmedPlaylistRemovals(from: detail)
+
             self.playlistDetail = detail
             self.continuationToken = self.hasMore ? nextContinuationToken : nil
             self.loadingState = .loaded
@@ -301,9 +315,13 @@ final class PlaylistDetailViewModel {
                 return song.videoId
             }
             : []
+        let playlistFilteredTracks = response.tracks.filter { track in
+            guard let setVideoId = track.playlistSetVideoId else { return true }
+            return !self.confirmedRemovedPlaylistSetVideoIDs.contains(setVideoId)
+        }
         let candidateTracks = batch.isLikedMusicPlaylist
-            ? response.tracks.filter { !self.removedLikedMusicVideoIDs.contains($0.videoId) }
-            : response.tracks
+            ? playlistFilteredTracks.filter { !self.removedLikedMusicVideoIDs.contains($0.videoId) }
+            : playlistFilteredTracks
         let skippedLiveRemovedTracks = candidateTracks.count != response.tracks.count
         let responseContainsLiveInsertedTrack = batch.isLikedMusicPlaylist && response.tracks.contains { self.insertedLikedMusicVideoIDs.contains($0.videoId) }
         let originalExistingVideoIds = Set(batch.currentDetail.tracks.map(\.videoId))
@@ -472,45 +490,41 @@ final class PlaylistDetailViewModel {
     }
 
     /// Refreshes the playlist.
-    func refresh() async {
+    @discardableResult
+    func refresh() async -> Bool {
         self.cancelAllLiveSyncTasks()
         self.replacePlaylistDetail(nil)
         self.hasMore = false
         self.continuationToken = nil
         await self.load(restartingInFlightLoad: true)
+        return self.loadingState == .loaded && self.playlistDetail != nil
     }
 
-    /// Optimistically removes the track matching `setVideoId` from the loaded list, ahead
-    /// of the API call actually removing it. Returns the removed song and its original
-    /// index so a failed removal can be undone via `reinsertTrack(_:at:)`.
-    @discardableResult
-    func removeTrackOptimistically(setVideoId: String) -> (song: Song, index: Int)? {
-        guard let detail = self.playlistDetail,
-              let index = detail.tracks.firstIndex(where: { $0.playlistSetVideoId == setVideoId })
-        else { return nil }
-
-        var tracks = detail.tracks
-        let removedSong = tracks.remove(at: index)
-        self.replacePlaylistDetail(self.updatedPlaylistDetail(
-            from: detail,
-            tracks: tracks,
-            trackCount: detail.trackCount.map { max(0, $0 - 1) }
-        ))
-        return (removedSong, index)
+    func reservePlaylistRemoval(setVideoId: String) -> Bool {
+        guard !self.confirmedRemovedPlaylistSetVideoIDs.contains(setVideoId) else { return false }
+        return self.reservedPlaylistSetVideoIDs.insert(setVideoId).inserted
     }
 
-    /// Reinserts a track at its original index, undoing an optimistic removal after the
-    /// API call to actually remove it failed.
-    func reinsertTrack(_ song: Song, at index: Int) {
-        guard let detail = self.playlistDetail else { return }
+    func releasePlaylistRemoval(setVideoId: String) {
+        self.reservedPlaylistSetVideoIDs.remove(setVideoId)
+    }
 
-        var tracks = detail.tracks
-        tracks.insert(song, at: min(index, tracks.count))
-        self.replacePlaylistDetail(self.updatedPlaylistDetail(
-            from: detail,
-            tracks: tracks,
-            trackCount: detail.trackCount.map { $0 + 1 }
-        ))
+    /// Commits a successful server-side removal to the current list. If a concurrent refresh
+    /// paged the occurrence out, wait for any full drain before reconciling from the server.
+    func commitSuccessfulTrackRemoval(setVideoId: String) async {
+        self.confirmedRemovedPlaylistSetVideoIDs.insert(setVideoId)
+        if self.removeConfirmedPlaylistTrackIfLoaded(setVideoId: setVideoId) {
+            return
+        }
+
+        let activeFullLoadTask = self.fullLoadTask
+        await activeFullLoadTask?.value
+
+        if self.removeConfirmedPlaylistTrackIfLoaded(setVideoId: setVideoId) {
+            return
+        }
+
+        await self.refresh()
     }
 
     private func cancelFullLoadTask() {
@@ -533,6 +547,37 @@ final class PlaylistDetailViewModel {
             tracks: likedTracks,
             trackCount: resolvedTrackCount
         )
+    }
+
+    private func filterConfirmedPlaylistRemovals(from detail: PlaylistDetail) -> PlaylistDetail {
+        let filteredTracks = detail.tracks.filter { track in
+            guard let setVideoId = track.playlistSetVideoId else { return true }
+            return !self.confirmedRemovedPlaylistSetVideoIDs.contains(setVideoId)
+        }
+        let removedTrackCount = detail.tracks.count - filteredTracks.count
+        guard removedTrackCount > 0 else { return detail }
+
+        return self.updatedPlaylistDetail(
+            from: detail,
+            tracks: filteredTracks,
+            trackCount: detail.trackCount.map { max(filteredTracks.count, $0 - removedTrackCount) }
+        )
+    }
+
+    @discardableResult
+    private func removeConfirmedPlaylistTrackIfLoaded(setVideoId: String) -> Bool {
+        guard let detail = self.playlistDetail,
+              let index = detail.tracks.firstIndex(where: { $0.playlistSetVideoId == setVideoId })
+        else { return false }
+
+        var tracks = detail.tracks
+        tracks.remove(at: index)
+        self.replacePlaylistDetail(self.updatedPlaylistDetail(
+            from: detail,
+            tracks: tracks,
+            trackCount: detail.trackCount.map { max(0, $0 - 1) }
+        ))
+        return true
     }
 
     private func markSongsAsLiked(_ tracks: [Song], deduplicating: Bool = false) -> [Song] {

--- a/Sources/Kaset/Views/PlaylistDetailView.swift
+++ b/Sources/Kaset/Views/PlaylistDetailView.swift
@@ -451,7 +451,27 @@ struct PlaylistDetailView: View {
                     Label("Go to Album", systemImage: "square.stack")
                 }
             }
+
+            if self.canRemoveTrack(track) {
+                Divider()
+
+                Button(role: .destructive) {
+                    Task {
+                        await LibraryMutationActions.removeSongFromPlaylist(track, from: self.viewModel, client: self.viewModel.client)
+                    }
+                } label: {
+                    Label("Remove from Playlist", systemImage: "minus.circle")
+                }
+            }
         }
+    }
+
+    /// Whether `track` can be removed from the currently loaded playlist: the user must
+    /// own the playlist (not an album, not the uploaded-songs surface), and the track
+    /// must carry the playlist-item identifier a removal call requires.
+    private func canRemoveTrack(_ track: Song) -> Bool {
+        guard let detail = self.viewModel.playlistDetail else { return false }
+        return detail.canDelete && !detail.isAlbum && !detail.isUploadedSongs && track.playlistSetVideoId != nil
     }
 
     private func playTrackInQueue(

--- a/Sources/Kaset/Views/PlaylistDetailView.swift
+++ b/Sources/Kaset/Views/PlaylistDetailView.swift
@@ -473,7 +473,11 @@ struct PlaylistDetailView: View {
     /// must carry the playlist-item identifier a removal call requires.
     private func canRemoveTrack(_ track: Song) -> Bool {
         guard let detail = self.viewModel.playlistDetail else { return false }
-        return detail.canDelete && !detail.isAlbum && !detail.isUploadedSongs && track.playlistSetVideoId != nil
+        return !self.viewModel.isRemovingTrack
+            && detail.canDelete
+            && !detail.isAlbum
+            && !detail.isUploadedSongs
+            && track.playlistSetVideoId != nil
     }
 
     private func playTrackInQueue(
@@ -512,7 +516,6 @@ struct PlaylistDetailView: View {
         initial cleanedTracks: [Song], startingAt index: Int,
         fallbackArtist: String?, fallbackAlbum: Album?
     ) {
-        let initiallyLoadedCount = cleanedTracks.count
         Task { @MainActor in
             let willDeferLoad = self.viewModel.hasMore
             let loadGeneration = await self.playerService.playQueue(
@@ -522,6 +525,7 @@ struct PlaylistDetailView: View {
             guard let loadGeneration else { return }
 
             await self.viewModel.loadAllRemaining()
+            await self.viewModel.waitForTrackRemovalToFinish()
 
             // Stand down if a *different* playback superseded this load while it paged. (User edits
             // such as removing a track keep the same load generation, so loading continues.)
@@ -531,7 +535,10 @@ struct PlaylistDetailView: View {
                 self.viewModel.playlistDetail?.tracks ?? [],
                 fallbackArtist: fallbackArtist, fallbackAlbum: fallbackAlbum
             )
-            let remaining = Array(fullTracks.dropFirst(initiallyLoadedCount))
+            let remaining = PlaylistPlaybackActions.remainingTracks(
+                after: cleanedTracks,
+                in: fullTracks
+            )
             self.playerService.appendOriginalTracks(remaining)
             await self.playerService.endQueueLoading(loadGeneration)
         }
@@ -599,7 +606,8 @@ struct PlaylistDetailView: View {
                 duration: song.duration,
                 thumbnailURL: finalThumbnail,
                 videoId: song.videoId,
-                isPlayable: song.isPlayable
+                isPlayable: song.isPlayable,
+                playlistSetVideoId: song.playlistSetVideoId
             )
         }
     }

--- a/Sources/Kaset/Views/PlaylistDetailView.swift
+++ b/Sources/Kaset/Views/PlaylistDetailView.swift
@@ -451,17 +451,19 @@ struct PlaylistDetailView: View {
                     Label("Go to Album", systemImage: "square.stack")
                 }
             }
+        }
 
-            if self.canRemoveTrack(track) {
+        if self.canRemoveTrack(track) {
+            if track.isPlayable {
                 Divider()
+            }
 
-                Button(role: .destructive) {
-                    Task {
-                        await LibraryMutationActions.removeSongFromPlaylist(track, from: self.viewModel, client: self.viewModel.client)
-                    }
-                } label: {
-                    Label("Remove from Playlist", systemImage: "minus.circle")
+            Button(role: .destructive) {
+                Task {
+                    await LibraryMutationActions.removeSongFromPlaylist(track, from: self.viewModel, client: self.viewModel.client)
                 }
+            } label: {
+                Label("Remove from Playlist", systemImage: "minus.circle")
             }
         }
     }

--- a/Tests/KasetTests/Helpers/MockYTMusicClient.swift
+++ b/Tests/KasetTests/Helpers/MockYTMusicClient.swift
@@ -241,8 +241,15 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         let allowDuplicate: Bool
     }
 
+    struct RemoveSongFromPlaylistCall: Equatable {
+        let videoId: String
+        let setVideoId: String
+        let playlistId: String
+    }
+
     private(set) var createPlaylistCalls: [CreatePlaylistCall] = []
     private(set) var addSongToPlaylistCalls: [AddSongToPlaylistCall] = []
+    private(set) var removeSongFromPlaylistCalls: [RemoveSongFromPlaylistCall] = []
     private(set) var unsubscribeFromPlaylistCalled = false
     private(set) var unsubscribeFromPlaylistIds: [String] = []
     private(set) var subscribeToArtistCalled = false
@@ -956,6 +963,32 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
                     duration: detail.duration
                 )
             }
+        }
+    }
+
+    func removeSongFromPlaylist(videoId: String, setVideoId: String, playlistId: String) async throws {
+        self.removeSongFromPlaylistCalls.append(RemoveSongFromPlaylistCall(videoId: videoId, setVideoId: setVideoId, playlistId: playlistId))
+        if let error = shouldThrowError {
+            throw error
+        }
+
+        let playlistKey = LibraryContentIdentity.playlistKey(for: playlistId)
+        guard self.shouldAutoUpdatePlaylistLibraryOnMutation else { return }
+
+        for (key, detail) in self.playlistDetails where LibraryContentIdentity.playlistKey(for: key) == playlistKey || LibraryContentIdentity.playlistKey(for: detail.id) == playlistKey {
+            let playlist = Playlist(
+                id: detail.id,
+                title: detail.title,
+                description: detail.description,
+                thumbnailURL: detail.thumbnailURL,
+                trackCount: detail.trackCount.map { max(0, $0 - 1) },
+                author: detail.author
+            )
+            self.playlistDetails[key] = PlaylistDetail(
+                playlist: playlist,
+                tracks: detail.tracks.filter { $0.playlistSetVideoId != setVideoId },
+                duration: detail.duration
+            )
         }
     }
 

--- a/Tests/KasetTests/Helpers/MockYTMusicClient.swift
+++ b/Tests/KasetTests/Helpers/MockYTMusicClient.swift
@@ -80,7 +80,10 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     var getHistoryDelay: Duration?
     var getPodcastsDelay: Duration?
     var getPlaylistDelay: Duration?
+    var getPlaylistError: Error?
     var playlistContinuationDelay: Duration?
+    var shouldWaitForRemoveSongFromPlaylistResponse = false
+    var removeSongFromPlaylistError: Error?
     var mixQueueDelay: Duration?
     var getRadioQueueDelay: Duration?
     var mixQueueResult = RadioQueueResult(songs: [], continuationToken: nil)
@@ -250,6 +253,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     private(set) var createPlaylistCalls: [CreatePlaylistCall] = []
     private(set) var addSongToPlaylistCalls: [AddSongToPlaylistCall] = []
     private(set) var removeSongFromPlaylistCalls: [RemoveSongFromPlaylistCall] = []
+    private var removeSongFromPlaylistResponseContinuations: [CheckedContinuation<Void, Never>] = []
     private(set) var unsubscribeFromPlaylistCalled = false
     private(set) var unsubscribeFromPlaylistIds: [String] = []
     private(set) var subscribeToArtistCalled = false
@@ -758,6 +762,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         if let getPlaylistDelay {
             try? await Task.sleep(for: getPlaylistDelay)
         }
+        if let getPlaylistError {
+            throw getPlaylistError
+        }
         if let error = shouldThrowError {
             throw error
         }
@@ -968,6 +975,14 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
 
     func removeSongFromPlaylist(videoId: String, setVideoId: String, playlistId: String) async throws {
         self.removeSongFromPlaylistCalls.append(RemoveSongFromPlaylistCall(videoId: videoId, setVideoId: setVideoId, playlistId: playlistId))
+        if self.shouldWaitForRemoveSongFromPlaylistResponse {
+            await withCheckedContinuation { continuation in
+                self.removeSongFromPlaylistResponseContinuations.append(continuation)
+            }
+        }
+        if let removeSongFromPlaylistError {
+            throw removeSongFromPlaylistError
+        }
         if let error = shouldThrowError {
             throw error
         }
@@ -990,6 +1005,11 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
                 duration: detail.duration
             )
         }
+    }
+
+    func resumeNextRemoveSongFromPlaylistResponse() {
+        guard !self.removeSongFromPlaylistResponseContinuations.isEmpty else { return }
+        self.removeSongFromPlaylistResponseContinuations.removeFirst().resume()
     }
 
     func unsubscribeFromPlaylist(playlistId: String) async throws {

--- a/Tests/KasetTests/LibraryMutationActionsTests.swift
+++ b/Tests/KasetTests/LibraryMutationActionsTests.swift
@@ -39,6 +39,43 @@ struct LibraryMutationActionsTests {
         ])
     }
 
+    @Test("Remove song from playlist delegates to client and removes it from the loaded list")
+    func removeSongFromPlaylistDelegatesToClient() async {
+        let song = Song(id: "song-1", title: "Song 1", artists: [], videoId: "song-1", playlistSetVideoId: "set-1")
+        let playlist = Playlist(
+            id: "VL-test-playlist", title: "Test Playlist", description: nil,
+            thumbnailURL: nil, trackCount: 1, canDelete: true
+        )
+        self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(playlist: playlist, tracks: [song], duration: nil)
+        let viewModel = PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
+        await viewModel.load()
+
+        await LibraryMutationActions.removeSongFromPlaylist(song, from: viewModel, client: self.mockClient)
+
+        #expect(self.mockClient.removeSongFromPlaylistCalls == [
+            MockYTMusicClient.RemoveSongFromPlaylistCall(videoId: "song-1", setVideoId: "set-1", playlistId: "VL-test-playlist"),
+        ])
+        #expect(viewModel.playlistDetail?.tracks.isEmpty == true)
+    }
+
+    @Test("Remove song from playlist rolls back the optimistic removal when the API call fails")
+    func removeSongFromPlaylistRollsBackOnFailure() async {
+        let song = Song(id: "song-1", title: "Song 1", artists: [], videoId: "song-1", playlistSetVideoId: "set-1")
+        let playlist = Playlist(
+            id: "VL-test-playlist", title: "Test Playlist", description: nil,
+            thumbnailURL: nil, trackCount: 1, canDelete: true
+        )
+        self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(playlist: playlist, tracks: [song], duration: nil)
+        let viewModel = PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
+        await viewModel.load()
+        self.mockClient.shouldThrowError = YTMusicError.networkError(underlying: URLError(.notConnectedToInternet))
+
+        await LibraryMutationActions.removeSongFromPlaylist(song, from: viewModel, client: self.mockClient)
+
+        #expect(viewModel.playlistDetail?.tracks.map(\.videoId) == ["song-1"])
+        #expect(viewModel.playlistDetail?.trackCount == 1)
+    }
+
     @Test("Subscribe to artist applies optimistic library state while request is in flight")
     func subscribeToArtistAppliesOptimisticState() async throws {
         let artist = TestFixtures.makeArtist(id: "MPLAUC-channel-123", name: "Test Artist")

--- a/Tests/KasetTests/LibraryMutationActionsTests.swift
+++ b/Tests/KasetTests/LibraryMutationActionsTests.swift
@@ -58,8 +58,8 @@ struct LibraryMutationActionsTests {
         #expect(viewModel.playlistDetail?.tracks.isEmpty == true)
     }
 
-    @Test("Remove song from playlist leaves the list unchanged when the API call fails")
-    func removeSongFromPlaylistLeavesListUnchangedOnFailure() async {
+    @Test("Remove song from playlist rolls back the optimistic change when the API call fails")
+    func removeSongFromPlaylistRollsBackOnFailure() async {
         let song = Song(id: "song-1", title: "Song 1", artists: [], videoId: "song-1", playlistSetVideoId: "set-1")
         let playlist = Playlist(
             id: "VL-test-playlist", title: "Test Playlist", description: nil,
@@ -68,16 +68,32 @@ struct LibraryMutationActionsTests {
         self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(playlist: playlist, tracks: [song], duration: nil)
         let viewModel = PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
         await viewModel.load()
+        self.mockClient.shouldWaitForRemoveSongFromPlaylistResponse = true
         self.mockClient.removeSongFromPlaylistError = YTMusicError.networkError(underlying: URLError(.notConnectedToInternet))
 
-        await LibraryMutationActions.removeSongFromPlaylist(song, from: viewModel, client: self.mockClient)
+        let removalTask = Task {
+            await LibraryMutationActions.removeSongFromPlaylist(song, from: viewModel, client: self.mockClient)
+        }
+        let requestStarted = await self.waitUntil(self.mockClient.removeSongFromPlaylistCalls.count == 1)
+        #expect(requestStarted)
+        guard requestStarted else {
+            self.mockClient.shouldWaitForRemoveSongFromPlaylistResponse = false
+            removalTask.cancel()
+            return
+        }
+
+        #expect(viewModel.playlistDetail?.tracks.isEmpty == true)
+        #expect(viewModel.playlistDetail?.trackCount == 0)
+
+        self.mockClient.resumeNextRemoveSongFromPlaylistResponse()
+        await removalTask.value
 
         #expect(viewModel.playlistDetail?.tracks.map(\.videoId) == ["song-1"])
         #expect(viewModel.playlistDetail?.trackCount == 1)
     }
 
-    @Test("Successful removal wins over a stale refresh completed while the request is pending")
-    func successfulRemovalReconcilesAfterPendingRefresh() async {
+    @Test("Optimistic removal stays applied while refresh is requested")
+    func optimisticRemovalBlocksRefreshUntilCompletion() async {
         let songs = [
             Song(id: "song-a", title: "A", artists: [], videoId: "song-a", playlistSetVideoId: "set-a"),
             Song(id: "song-b", title: "B", artists: [], videoId: "song-b", playlistSetVideoId: "set-b"),
@@ -102,14 +118,20 @@ struct LibraryMutationActionsTests {
             return
         }
 
-        await viewModel.refresh()
-        #expect(viewModel.playlistDetail?.tracks.map(\.videoId) == ["song-a", "song-b"])
+        #expect(viewModel.playlistDetail?.tracks.map(\.videoId) == ["song-b"])
+        #expect(viewModel.playlistDetail?.trackCount == 1)
+        #expect(viewModel.isRemovingTrack)
+
+        let refreshed = await viewModel.refresh()
+        #expect(!refreshed)
+        #expect(viewModel.playlistDetail?.tracks.map(\.videoId) == ["song-b"])
 
         self.mockClient.resumeNextRemoveSongFromPlaylistResponse()
         await removalTask.value
 
         #expect(viewModel.playlistDetail?.tracks.map(\.videoId) == ["song-b"])
         #expect(viewModel.playlistDetail?.trackCount == 1)
+        #expect(!viewModel.isRemovingTrack)
     }
 
     @Test("Duplicate removal requests for one occurrence call the API once")
@@ -202,98 +224,6 @@ struct LibraryMutationActionsTests {
         #expect(viewModel.playlistDetail?.tracks.map(\.videoId) == ["song-b", "song-c", "song-d"])
         #expect(viewModel.playlistDetail?.trackCount == 3)
         #expect(!viewModel.hasMore)
-    }
-
-    @Test("Successful off-page removal reconciles after a refresh pages the row out")
-    func successfulOffPageRemovalReconciles() async {
-        let songs = [
-            Song(id: "song-a", title: "A", artists: [], videoId: "song-a", playlistSetVideoId: "set-a"),
-            Song(id: "song-b", title: "B", artists: [], videoId: "song-b", playlistSetVideoId: "set-b"),
-            Song(id: "song-c", title: "C", artists: [], videoId: "song-c", playlistSetVideoId: "set-c"),
-            Song(id: "song-d", title: "D", artists: [], videoId: "song-d", playlistSetVideoId: "set-d"),
-        ]
-        let playlist = Playlist(
-            id: "VL-test-playlist", title: "Test Playlist", description: nil,
-            thumbnailURL: nil, trackCount: songs.count, canDelete: true
-        )
-        self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(
-            playlist: playlist,
-            tracks: Array(songs.prefix(2)),
-            duration: nil
-        )
-        self.mockClient.playlistContinuationTracks[playlist.id] = [Array(songs.suffix(2))]
-        let viewModel = PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
-        await viewModel.load()
-        await viewModel.loadMore()
-        self.mockClient.shouldWaitForRemoveSongFromPlaylistResponse = true
-
-        let removalTask = Task {
-            await LibraryMutationActions.removeSongFromPlaylist(songs[3], from: viewModel, client: self.mockClient)
-        }
-        let requestStarted = await self.waitUntil(self.mockClient.removeSongFromPlaylistCalls.count == 1)
-        #expect(requestStarted)
-        guard requestStarted else {
-            self.mockClient.shouldWaitForRemoveSongFromPlaylistResponse = false
-            removalTask.cancel()
-            return
-        }
-
-        await viewModel.refresh()
-        self.mockClient.resumeNextRemoveSongFromPlaylistResponse()
-        await removalTask.value
-
-        #expect(viewModel.playlistDetail?.tracks.map(\.videoId) == ["song-a", "song-b"])
-        #expect(viewModel.playlistDetail?.trackCount == 3)
-
-        await viewModel.loadMore()
-        #expect(viewModel.playlistDetail?.tracks.map(\.videoId) == ["song-a", "song-b", "song-c"])
-        #expect(!viewModel.hasMore)
-    }
-
-    @Test("Off-page success leaves a retryable error when reconciliation refresh fails")
-    func successfulOffPageRemovalLeavesRefreshError() async {
-        let songs = [
-            Song(id: "song-a", title: "A", artists: [], videoId: "song-a", playlistSetVideoId: "set-a"),
-            Song(id: "song-b", title: "B", artists: [], videoId: "song-b", playlistSetVideoId: "set-b"),
-            Song(id: "song-c", title: "C", artists: [], videoId: "song-c", playlistSetVideoId: "set-c"),
-            Song(id: "song-d", title: "D", artists: [], videoId: "song-d", playlistSetVideoId: "set-d"),
-        ]
-        let playlist = Playlist(
-            id: "VL-test-playlist", title: "Test Playlist", description: nil,
-            thumbnailURL: nil, trackCount: songs.count, canDelete: true
-        )
-        self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(
-            playlist: playlist,
-            tracks: Array(songs.prefix(2)),
-            duration: nil
-        )
-        self.mockClient.playlistContinuationTracks[playlist.id] = [Array(songs.suffix(2))]
-        let viewModel = PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
-        await viewModel.load()
-        await viewModel.loadMore()
-        self.mockClient.shouldWaitForRemoveSongFromPlaylistResponse = true
-
-        let removalTask = Task {
-            await LibraryMutationActions.removeSongFromPlaylist(songs[3], from: viewModel, client: self.mockClient)
-        }
-        let requestStarted = await self.waitUntil(self.mockClient.removeSongFromPlaylistCalls.count == 1)
-        #expect(requestStarted)
-        guard requestStarted else {
-            self.mockClient.shouldWaitForRemoveSongFromPlaylistResponse = false
-            removalTask.cancel()
-            return
-        }
-
-        await viewModel.refresh()
-        self.mockClient.getPlaylistError = YTMusicError.networkError(underlying: URLError(.notConnectedToInternet))
-        self.mockClient.resumeNextRemoveSongFromPlaylistResponse()
-        await removalTask.value
-
-        if case .error = viewModel.loadingState {
-        } else {
-            Issue.record("Expected reconciliation refresh error")
-        }
-        #expect(viewModel.playlistDetail == nil)
     }
 
     @Test("Subscribe to artist applies optimistic library state while request is in flight")

--- a/Tests/KasetTests/LibraryMutationActionsTests.swift
+++ b/Tests/KasetTests/LibraryMutationActionsTests.swift
@@ -58,8 +58,8 @@ struct LibraryMutationActionsTests {
         #expect(viewModel.playlistDetail?.tracks.isEmpty == true)
     }
 
-    @Test("Remove song from playlist rolls back the optimistic removal when the API call fails")
-    func removeSongFromPlaylistRollsBackOnFailure() async {
+    @Test("Remove song from playlist leaves the list unchanged when the API call fails")
+    func removeSongFromPlaylistLeavesListUnchangedOnFailure() async {
         let song = Song(id: "song-1", title: "Song 1", artists: [], videoId: "song-1", playlistSetVideoId: "set-1")
         let playlist = Playlist(
             id: "VL-test-playlist", title: "Test Playlist", description: nil,
@@ -68,12 +68,232 @@ struct LibraryMutationActionsTests {
         self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(playlist: playlist, tracks: [song], duration: nil)
         let viewModel = PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
         await viewModel.load()
-        self.mockClient.shouldThrowError = YTMusicError.networkError(underlying: URLError(.notConnectedToInternet))
+        self.mockClient.removeSongFromPlaylistError = YTMusicError.networkError(underlying: URLError(.notConnectedToInternet))
 
         await LibraryMutationActions.removeSongFromPlaylist(song, from: viewModel, client: self.mockClient)
 
         #expect(viewModel.playlistDetail?.tracks.map(\.videoId) == ["song-1"])
         #expect(viewModel.playlistDetail?.trackCount == 1)
+    }
+
+    @Test("Successful removal wins over a stale refresh completed while the request is pending")
+    func successfulRemovalReconcilesAfterPendingRefresh() async {
+        let songs = [
+            Song(id: "song-a", title: "A", artists: [], videoId: "song-a", playlistSetVideoId: "set-a"),
+            Song(id: "song-b", title: "B", artists: [], videoId: "song-b", playlistSetVideoId: "set-b"),
+        ]
+        let playlist = Playlist(
+            id: "VL-test-playlist", title: "Test Playlist", description: nil,
+            thumbnailURL: nil, trackCount: songs.count, canDelete: true
+        )
+        self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(playlist: playlist, tracks: songs, duration: nil)
+        let viewModel = PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
+        await viewModel.load()
+        self.mockClient.shouldWaitForRemoveSongFromPlaylistResponse = true
+
+        let removalTask = Task {
+            await LibraryMutationActions.removeSongFromPlaylist(songs[0], from: viewModel, client: self.mockClient)
+        }
+        let requestStarted = await self.waitUntil(self.mockClient.removeSongFromPlaylistCalls.count == 1)
+        #expect(requestStarted)
+        guard requestStarted else {
+            self.mockClient.shouldWaitForRemoveSongFromPlaylistResponse = false
+            removalTask.cancel()
+            return
+        }
+
+        await viewModel.refresh()
+        #expect(viewModel.playlistDetail?.tracks.map(\.videoId) == ["song-a", "song-b"])
+
+        self.mockClient.resumeNextRemoveSongFromPlaylistResponse()
+        await removalTask.value
+
+        #expect(viewModel.playlistDetail?.tracks.map(\.videoId) == ["song-b"])
+        #expect(viewModel.playlistDetail?.trackCount == 1)
+    }
+
+    @Test("Duplicate removal requests for one occurrence call the API once")
+    func duplicateRemovalRequestsAreDeduplicated() async {
+        let song = Song(id: "song-a", title: "A", artists: [], videoId: "song-a", playlistSetVideoId: "set-a")
+        let playlist = Playlist(
+            id: "VL-test-playlist", title: "Test Playlist", description: nil,
+            thumbnailURL: nil, trackCount: 1, canDelete: true
+        )
+        self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(playlist: playlist, tracks: [song], duration: nil)
+        let viewModel = PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
+        await viewModel.load()
+        self.mockClient.shouldWaitForRemoveSongFromPlaylistResponse = true
+
+        let firstRemoval = Task {
+            await LibraryMutationActions.removeSongFromPlaylist(song, from: viewModel, client: self.mockClient)
+        }
+        let requestStarted = await self.waitUntil(self.mockClient.removeSongFromPlaylistCalls.count == 1)
+        #expect(requestStarted)
+        guard requestStarted else {
+            self.mockClient.shouldWaitForRemoveSongFromPlaylistResponse = false
+            firstRemoval.cancel()
+            return
+        }
+
+        let duplicateRemoval = Task {
+            await LibraryMutationActions.removeSongFromPlaylist(song, from: viewModel, client: self.mockClient)
+        }
+        await Task.yield()
+
+        self.mockClient.resumeNextRemoveSongFromPlaylistResponse()
+        await firstRemoval.value
+        await duplicateRemoval.value
+
+        #expect(self.mockClient.removeSongFromPlaylistCalls.count == 1)
+        #expect(viewModel.playlistDetail?.tracks.isEmpty == true)
+    }
+
+    @Test("A stale action cannot remove an occurrence already confirmed deleted")
+    func confirmedRemovalRejectsStaleRetry() async {
+        let song = Song(id: "song-a", title: "A", artists: [], videoId: "song-a", playlistSetVideoId: "set-a")
+        let playlist = Playlist(
+            id: "VL-test-playlist", title: "Test Playlist", description: nil,
+            thumbnailURL: nil, trackCount: 1, canDelete: true
+        )
+        self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(playlist: playlist, tracks: [song], duration: nil)
+        let viewModel = PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
+        await viewModel.load()
+
+        await LibraryMutationActions.removeSongFromPlaylist(song, from: viewModel, client: self.mockClient)
+        await LibraryMutationActions.removeSongFromPlaylist(song, from: viewModel, client: self.mockClient)
+
+        #expect(self.mockClient.removeSongFromPlaylistCalls.count == 1)
+        #expect(viewModel.playlistDetail?.tracks.isEmpty == true)
+    }
+
+    @Test("Track removal does not interrupt an awaited full-playlist drain")
+    func removalDoesNotInterruptFullPlaylistDrain() async {
+        let songs = [
+            Song(id: "song-a", title: "A", artists: [], videoId: "song-a", playlistSetVideoId: "set-a"),
+            Song(id: "song-b", title: "B", artists: [], videoId: "song-b", playlistSetVideoId: "set-b"),
+            Song(id: "song-c", title: "C", artists: [], videoId: "song-c", playlistSetVideoId: "set-c"),
+            Song(id: "song-d", title: "D", artists: [], videoId: "song-d", playlistSetVideoId: "set-d"),
+        ]
+        let playlist = Playlist(
+            id: "VL-test-playlist", title: "Test Playlist", description: nil,
+            thumbnailURL: nil, trackCount: songs.count, canDelete: true
+        )
+        self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(
+            playlist: playlist,
+            tracks: Array(songs.prefix(2)),
+            duration: nil
+        )
+        self.mockClient.playlistContinuationTracks[playlist.id] = [Array(songs.suffix(2))]
+        self.mockClient.playlistContinuationDelay = .milliseconds(250)
+        let viewModel = PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
+        await viewModel.load()
+
+        let drainTask = Task { await viewModel.loadAllRemaining() }
+        let continuationStarted = await self.waitUntil(self.mockClient.getPlaylistContinuationCallCount == 1)
+        #expect(continuationStarted)
+        guard continuationStarted else {
+            drainTask.cancel()
+            return
+        }
+
+        await LibraryMutationActions.removeSongFromPlaylist(songs[0], from: viewModel, client: self.mockClient)
+        await drainTask.value
+
+        #expect(viewModel.playlistDetail?.tracks.map(\.videoId) == ["song-b", "song-c", "song-d"])
+        #expect(viewModel.playlistDetail?.trackCount == 3)
+        #expect(!viewModel.hasMore)
+    }
+
+    @Test("Successful off-page removal reconciles after a refresh pages the row out")
+    func successfulOffPageRemovalReconciles() async {
+        let songs = [
+            Song(id: "song-a", title: "A", artists: [], videoId: "song-a", playlistSetVideoId: "set-a"),
+            Song(id: "song-b", title: "B", artists: [], videoId: "song-b", playlistSetVideoId: "set-b"),
+            Song(id: "song-c", title: "C", artists: [], videoId: "song-c", playlistSetVideoId: "set-c"),
+            Song(id: "song-d", title: "D", artists: [], videoId: "song-d", playlistSetVideoId: "set-d"),
+        ]
+        let playlist = Playlist(
+            id: "VL-test-playlist", title: "Test Playlist", description: nil,
+            thumbnailURL: nil, trackCount: songs.count, canDelete: true
+        )
+        self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(
+            playlist: playlist,
+            tracks: Array(songs.prefix(2)),
+            duration: nil
+        )
+        self.mockClient.playlistContinuationTracks[playlist.id] = [Array(songs.suffix(2))]
+        let viewModel = PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
+        await viewModel.load()
+        await viewModel.loadMore()
+        self.mockClient.shouldWaitForRemoveSongFromPlaylistResponse = true
+
+        let removalTask = Task {
+            await LibraryMutationActions.removeSongFromPlaylist(songs[3], from: viewModel, client: self.mockClient)
+        }
+        let requestStarted = await self.waitUntil(self.mockClient.removeSongFromPlaylistCalls.count == 1)
+        #expect(requestStarted)
+        guard requestStarted else {
+            self.mockClient.shouldWaitForRemoveSongFromPlaylistResponse = false
+            removalTask.cancel()
+            return
+        }
+
+        await viewModel.refresh()
+        self.mockClient.resumeNextRemoveSongFromPlaylistResponse()
+        await removalTask.value
+
+        #expect(viewModel.playlistDetail?.tracks.map(\.videoId) == ["song-a", "song-b"])
+        #expect(viewModel.playlistDetail?.trackCount == 3)
+
+        await viewModel.loadMore()
+        #expect(viewModel.playlistDetail?.tracks.map(\.videoId) == ["song-a", "song-b", "song-c"])
+        #expect(!viewModel.hasMore)
+    }
+
+    @Test("Off-page success leaves a retryable error when reconciliation refresh fails")
+    func successfulOffPageRemovalLeavesRefreshError() async {
+        let songs = [
+            Song(id: "song-a", title: "A", artists: [], videoId: "song-a", playlistSetVideoId: "set-a"),
+            Song(id: "song-b", title: "B", artists: [], videoId: "song-b", playlistSetVideoId: "set-b"),
+            Song(id: "song-c", title: "C", artists: [], videoId: "song-c", playlistSetVideoId: "set-c"),
+            Song(id: "song-d", title: "D", artists: [], videoId: "song-d", playlistSetVideoId: "set-d"),
+        ]
+        let playlist = Playlist(
+            id: "VL-test-playlist", title: "Test Playlist", description: nil,
+            thumbnailURL: nil, trackCount: songs.count, canDelete: true
+        )
+        self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(
+            playlist: playlist,
+            tracks: Array(songs.prefix(2)),
+            duration: nil
+        )
+        self.mockClient.playlistContinuationTracks[playlist.id] = [Array(songs.suffix(2))]
+        let viewModel = PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
+        await viewModel.load()
+        await viewModel.loadMore()
+        self.mockClient.shouldWaitForRemoveSongFromPlaylistResponse = true
+
+        let removalTask = Task {
+            await LibraryMutationActions.removeSongFromPlaylist(songs[3], from: viewModel, client: self.mockClient)
+        }
+        let requestStarted = await self.waitUntil(self.mockClient.removeSongFromPlaylistCalls.count == 1)
+        #expect(requestStarted)
+        guard requestStarted else {
+            self.mockClient.shouldWaitForRemoveSongFromPlaylistResponse = false
+            removalTask.cancel()
+            return
+        }
+
+        await viewModel.refresh()
+        self.mockClient.getPlaylistError = YTMusicError.networkError(underlying: URLError(.notConnectedToInternet))
+        self.mockClient.resumeNextRemoveSongFromPlaylistResponse()
+        await removalTask.value
+
+        if case .error = viewModel.loadingState {
+        } else {
+            Issue.record("Expected reconciliation refresh error")
+        }
+        #expect(viewModel.playlistDetail == nil)
     }
 
     @Test("Subscribe to artist applies optimistic library state while request is in flight")
@@ -113,5 +333,17 @@ struct LibraryMutationActionsTests {
         #expect(self.mockClient.deletePlaylistCalled)
         #expect(self.mockClient.deletePlaylistIds == ["VL-owned"])
         #expect(!self.libraryViewModel.isInLibrary(playlistId: "VL-owned"))
+    }
+
+    private func waitUntil(_ condition: @autoclosure () -> Bool, timeout: Duration = .seconds(1)) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+
+        while !condition() {
+            guard clock.now < deadline else { return condition() }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+
+        return true
     }
 }

--- a/Tests/KasetTests/NotificationServiceTests.swift
+++ b/Tests/KasetTests/NotificationServiceTests.swift
@@ -23,6 +23,20 @@ struct NotificationServiceTests {
         try? await Task.sleep(for: .milliseconds(50))
     }
 
+    /// Polls until `condition` holds, bounded by a deadline that tolerates slow CI
+    /// runners — a fixed wait races with Observation delivery and the service's
+    /// loading-resolution poll loop.
+    private func waitForObservationDelivery(until condition: @autoclosure @MainActor () -> Bool) async {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(2))
+        while !condition(), clock.now < deadline {
+            for _ in 0 ..< 5 {
+                await Task.yield()
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+    }
+
     // MARK: - Observation Lifecycle
 
     @Test("observation is active after init")
@@ -43,7 +57,7 @@ struct NotificationServiceTests {
         self.playerService.currentTrack = TestFixtures.makeSong(id: "song-1", title: "First Song")
         self.playerService.state = .playing
 
-        await self.waitForObservationDelivery()
+        await self.waitForObservationDelivery(until: self.notificationService.lastNotifiedTrackId == "song-1")
 
         #expect(self.notificationService.lastNotifiedTrackId == "song-1")
     }
@@ -55,7 +69,7 @@ struct NotificationServiceTests {
         playerService.state = .playing
 
         let notificationService = NotificationService(playerService: playerService)
-        await self.waitForObservationDelivery()
+        await self.waitForObservationDelivery(until: notificationService.lastNotifiedTrackId == "initial-song")
 
         #expect(notificationService.lastNotifiedTrackId == "initial-song")
         notificationService.stopObserving()
@@ -65,11 +79,11 @@ struct NotificationServiceTests {
     func detectsMultipleTrackChanges() async {
         self.playerService.currentTrack = TestFixtures.makeSong(id: "song-1", title: "First Song")
         self.playerService.state = .playing
-        await self.waitForObservationDelivery()
+        await self.waitForObservationDelivery(until: self.notificationService.lastNotifiedTrackId == "song-1")
         #expect(self.notificationService.lastNotifiedTrackId == "song-1")
 
         self.playerService.currentTrack = TestFixtures.makeSong(id: "song-2", title: "Second Song")
-        await self.waitForObservationDelivery()
+        await self.waitForObservationDelivery(until: self.notificationService.lastNotifiedTrackId == "song-2")
         #expect(self.notificationService.lastNotifiedTrackId == "song-2")
     }
 
@@ -93,7 +107,7 @@ struct NotificationServiceTests {
 
         self.playerService.state = .playing
 
-        await self.waitForObservationDelivery()
+        await self.waitForObservationDelivery(until: self.notificationService.lastNotifiedTrackId == "song-1")
         #expect(self.notificationService.lastNotifiedTrackId == "song-1")
     }
 
@@ -101,12 +115,12 @@ struct NotificationServiceTests {
     func doesNotNotifyForSameTrackTwice() async {
         self.playerService.currentTrack = TestFixtures.makeSong(id: "song-1", title: "First Song")
         self.playerService.state = .playing
-        await self.waitForObservationDelivery()
+        await self.waitForObservationDelivery(until: self.notificationService.lastNotifiedTrackId == "song-1")
         #expect(self.notificationService.lastNotifiedTrackId == "song-1")
 
         // Set a different track, then back to the same one
         self.playerService.currentTrack = TestFixtures.makeSong(id: "song-2", title: "Second Song")
-        await self.waitForObservationDelivery()
+        await self.waitForObservationDelivery(until: self.notificationService.lastNotifiedTrackId == "song-2")
 
         // The lastNotifiedTrackId should now be song-2, meaning song-1 wasn't skipped
         #expect(self.notificationService.lastNotifiedTrackId == "song-2")
@@ -133,7 +147,7 @@ struct NotificationServiceTests {
         self.playerService.currentTrack = TestFixtures.makeSong(id: "song-1", title: "Real Song")
         self.playerService.state = .playing
 
-        await self.waitForObservationDelivery()
+        await self.waitForObservationDelivery(until: self.notificationService.lastNotifiedTrackId == "song-1")
         #expect(self.notificationService.lastNotifiedTrackId == "song-1")
     }
 
@@ -146,7 +160,7 @@ struct NotificationServiceTests {
 
         self.playerService.currentTrack = TestFixtures.makeSong(id: "song-1", title: "Real Song")
 
-        await self.waitForObservationDelivery()
+        await self.waitForObservationDelivery(until: self.notificationService.lastNotifiedTrackId == "song-1")
         #expect(self.notificationService.lastNotifiedTrackId == "song-1")
     }
 
@@ -162,7 +176,7 @@ struct NotificationServiceTests {
     func stopObservingPreventsFutureNotifications() async {
         self.playerService.currentTrack = TestFixtures.makeSong(id: "song-1", title: "First Song")
         self.playerService.state = .playing
-        await self.waitForObservationDelivery()
+        await self.waitForObservationDelivery(until: self.notificationService.lastNotifiedTrackId == "song-1")
         #expect(self.notificationService.lastNotifiedTrackId == "song-1")
 
         self.notificationService.stopObserving()
@@ -181,7 +195,7 @@ struct NotificationServiceTests {
         // And still detects changes without a polling delay.
         self.playerService.currentTrack = TestFixtures.makeSong(id: "late-song", title: "Late Song")
         self.playerService.state = .playing
-        await self.waitForObservationDelivery()
+        await self.waitForObservationDelivery(until: self.notificationService.lastNotifiedTrackId == "late-song")
         #expect(self.notificationService.lastNotifiedTrackId == "late-song")
     }
 }

--- a/Tests/KasetTests/ParsingHelpersTests.swift
+++ b/Tests/KasetTests/ParsingHelpersTests.swift
@@ -88,6 +88,65 @@ struct ParsingHelpersTests {
         #expect(result == "https://example.com/image.jpg")
     }
 
+    // MARK: - Playlist Occurrence ID Extraction
+
+    @Test("Playlist occurrence ID prefers playlistItemData")
+    func extractPlaylistSetVideoIdFromPlaylistItemData() {
+        let data: [String: Any] = [
+            "playlistItemData": ["playlistSetVideoId": "set-direct"],
+            "menu": [
+                "playlistEditEndpoint": [
+                    "actions": [[
+                        "action": "ACTION_REMOVE_VIDEO",
+                        "setVideoId": "set-menu",
+                    ]],
+                ],
+            ],
+        ]
+
+        #expect(ParsingHelpers.extractPlaylistSetVideoId(from: data) == "set-direct")
+    }
+
+    @Test("Playlist occurrence ID falls back to a nested remove endpoint")
+    func extractPlaylistSetVideoIdFromEditEndpoint() {
+        let data: [String: Any] = [
+            "menu": [
+                "menuRenderer": [
+                    "items": [[
+                        "menuServiceItemRenderer": [
+                            "serviceEndpoint": [
+                                "playlistEditEndpoint": [
+                                    "playlistId": "playlist-placeholder",
+                                    "actions": [[
+                                        "action": "ACTION_REMOVE_VIDEO",
+                                        "removedVideoId": "video-placeholder",
+                                        "setVideoId": "set-from-menu",
+                                    ]],
+                                ],
+                            ],
+                        ],
+                    ]],
+                ],
+            ],
+        ]
+
+        #expect(ParsingHelpers.extractPlaylistSetVideoId(from: data) == "set-from-menu")
+    }
+
+    @Test("Playlist occurrence ID does not treat removedVideoId as setVideoId")
+    func extractPlaylistSetVideoIdIgnoresRemovedVideoId() {
+        let data: [String: Any] = [
+            "playlistEditEndpoint": [
+                "actions": [[
+                    "action": "ACTION_REMOVE_VIDEO",
+                    "removedVideoId": "video-placeholder",
+                ]],
+            ],
+        ]
+
+        #expect(ParsingHelpers.extractPlaylistSetVideoId(from: data) == nil)
+    }
+
     // MARK: - Thumbnail Extraction
 
     @Test("Extract thumbnails from musicThumbnailRenderer")

--- a/Tests/KasetTests/PlaylistDetailViewModelTests.swift
+++ b/Tests/KasetTests/PlaylistDetailViewModelTests.swift
@@ -87,6 +87,53 @@ struct PlaylistDetailViewModelTests {
         #expect(self.viewModel.playlistDetail?.tracks.count == 10)
     }
 
+    // MARK: - Track Removal Tests
+
+    @Test("Remove track optimistically removes the matching track and updates track count")
+    func removeTrackOptimisticallyRemovesMatch() async {
+        let songs = [
+            Song(id: "a", title: "A", artists: [], videoId: "a", playlistSetVideoId: "set-a"),
+            Song(id: "b", title: "B", artists: [], videoId: "b", playlistSetVideoId: "set-b"),
+            Song(id: "c", title: "C", artists: [], videoId: "c", playlistSetVideoId: "set-c"),
+        ]
+        let playlist = Playlist(
+            id: "VL-removal-test", title: "Test Playlist", description: nil,
+            thumbnailURL: nil, trackCount: 3, canDelete: true
+        )
+        self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(playlist: playlist, tracks: songs, duration: nil)
+        let viewModel = PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
+        await viewModel.load()
+
+        let removed = viewModel.removeTrackOptimistically(setVideoId: "set-b")
+
+        #expect(removed?.song.videoId == "b")
+        #expect(removed?.index == 1)
+        #expect(viewModel.playlistDetail?.tracks.map(\.videoId) == ["a", "c"])
+        #expect(viewModel.playlistDetail?.trackCount == 2)
+    }
+
+    @Test("Reinsert track restores it at its original index and track count")
+    func reinsertTrackRestoresOriginalPosition() async throws {
+        let songs = [
+            Song(id: "a", title: "A", artists: [], videoId: "a", playlistSetVideoId: "set-a"),
+            Song(id: "b", title: "B", artists: [], videoId: "b", playlistSetVideoId: "set-b"),
+            Song(id: "c", title: "C", artists: [], videoId: "c", playlistSetVideoId: "set-c"),
+        ]
+        let playlist = Playlist(
+            id: "VL-reinsert-test", title: "Test Playlist", description: nil,
+            thumbnailURL: nil, trackCount: 3, canDelete: true
+        )
+        self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(playlist: playlist, tracks: songs, duration: nil)
+        let viewModel = PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
+        await viewModel.load()
+        let removed = try #require(viewModel.removeTrackOptimistically(setVideoId: "set-b"))
+
+        viewModel.reinsertTrack(removed.song, at: removed.index)
+
+        #expect(viewModel.playlistDetail?.tracks.map(\.videoId) == ["a", "b", "c"])
+        #expect(viewModel.playlistDetail?.trackCount == 3)
+    }
+
     @Test("Load error sets error state")
     func loadError() async {
         self.mockClient.shouldThrowError = YTMusicError.networkError(underlying: URLError(.notConnectedToInternet))

--- a/Tests/KasetTests/PlaylistDetailViewModelTests.swift
+++ b/Tests/KasetTests/PlaylistDetailViewModelTests.swift
@@ -120,6 +120,94 @@ struct PlaylistDetailViewModelTests {
         #expect(self.viewModel.reservePlaylistRemoval(setVideoId: "set-a"))
     }
 
+    @Test("Continuation tombstone decrements an off-page removal count once")
+    func continuationTombstoneAdjustsTrackCount() async {
+        let songs = [
+            Song(id: "a", title: "A", artists: [], videoId: "a", playlistSetVideoId: "set-a"),
+            Song(id: "b", title: "B", artists: [], videoId: "b", playlistSetVideoId: "set-b"),
+            Song(id: "c", title: "C", artists: [], videoId: "c", playlistSetVideoId: "set-c"),
+            Song(id: "d", title: "D", artists: [], videoId: "d", playlistSetVideoId: "set-d"),
+        ]
+        let playlist = Playlist(
+            id: "VL-continuation-removal", title: "Test Playlist", description: nil,
+            thumbnailURL: nil, trackCount: songs.count, canDelete: true
+        )
+        self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(
+            playlist: playlist,
+            tracks: Array(songs.prefix(2)),
+            duration: nil
+        )
+        self.mockClient.playlistContinuationTracks[playlist.id] = [Array(songs.suffix(2))]
+        self.mockClient.playlistContinuationDelay = .milliseconds(250)
+        let viewModel = PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
+        await viewModel.load()
+
+        let drainTask = Task { await viewModel.loadAllRemaining() }
+        await self.waitUntil(
+            self.mockClient.getPlaylistContinuationCallCount == 1,
+            description: "continuation request to start"
+        )
+
+        let reconciledPlaylist = Playlist(
+            id: playlist.id, title: playlist.title, description: nil,
+            thumbnailURL: nil, trackCount: 3, canDelete: true
+        )
+        self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(
+            playlist: reconciledPlaylist,
+            tracks: Array(songs.prefix(2)),
+            duration: nil
+        )
+        let commitTask = Task {
+            await viewModel.commitSuccessfulTrackRemoval(setVideoId: "set-d")
+        }
+
+        await drainTask.value
+
+        #expect(viewModel.playlistDetail?.tracks.map(\.videoId) == ["a", "b", "c"])
+        #expect(viewModel.playlistDetail?.trackCount == 3)
+
+        await commitTask.value
+        #expect(viewModel.playlistDetail?.tracks.map(\.videoId) == ["a", "b", "c"])
+        #expect(viewModel.playlistDetail?.trackCount == 3)
+    }
+
+    @Test("Stale refresh counts an off-page tombstone when its continuation arrives")
+    func staleRefreshCountsOffPageTombstoneOnContinuation() async {
+        let songs = [
+            Song(id: "a", title: "A", artists: [], videoId: "a", playlistSetVideoId: "set-a"),
+            Song(id: "b", title: "B", artists: [], videoId: "b", playlistSetVideoId: "set-b"),
+            Song(id: "c", title: "C", artists: [], videoId: "c", playlistSetVideoId: "set-c"),
+            Song(id: "d", title: "D", artists: [], videoId: "d", playlistSetVideoId: "set-d"),
+        ]
+        let playlist = Playlist(
+            id: "VL-stale-continuation-removal", title: "Test Playlist", description: nil,
+            thumbnailURL: nil, trackCount: songs.count, canDelete: true
+        )
+        self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(
+            playlist: playlist,
+            tracks: songs,
+            duration: nil
+        )
+        let viewModel = PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
+        await viewModel.load()
+        await viewModel.commitSuccessfulTrackRemoval(setVideoId: "set-d")
+
+        self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(
+            playlist: playlist,
+            tracks: Array(songs.prefix(2)),
+            duration: nil
+        )
+        self.mockClient.playlistContinuationTracks[playlist.id] = [Array(songs.suffix(2))]
+
+        await viewModel.refresh()
+        #expect(viewModel.playlistDetail?.trackCount == 4)
+
+        await viewModel.loadMore()
+
+        #expect(viewModel.playlistDetail?.tracks.map(\.videoId) == ["a", "b", "c"])
+        #expect(viewModel.playlistDetail?.trackCount == 3)
+    }
+
     @Test("Load error sets error state")
     func loadError() async {
         self.mockClient.shouldThrowError = YTMusicError.networkError(underlying: URLError(.notConnectedToInternet))

--- a/Tests/KasetTests/PlaylistDetailViewModelTests.swift
+++ b/Tests/KasetTests/PlaylistDetailViewModelTests.swift
@@ -89,8 +89,8 @@ struct PlaylistDetailViewModelTests {
 
     // MARK: - Track Removal Tests
 
-    @Test("Remove track optimistically removes the matching track and updates track count")
-    func removeTrackOptimisticallyRemovesMatch() async {
+    @Test("Successful track removal commit removes the matching track and updates track count")
+    func successfulTrackRemovalCommitRemovesMatch() async {
         let songs = [
             Song(id: "a", title: "A", artists: [], videoId: "a", playlistSetVideoId: "set-a"),
             Song(id: "b", title: "B", artists: [], videoId: "b", playlistSetVideoId: "set-b"),
@@ -104,34 +104,20 @@ struct PlaylistDetailViewModelTests {
         let viewModel = PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
         await viewModel.load()
 
-        let removed = viewModel.removeTrackOptimistically(setVideoId: "set-b")
+        await viewModel.commitSuccessfulTrackRemoval(setVideoId: "set-b")
 
-        #expect(removed?.song.videoId == "b")
-        #expect(removed?.index == 1)
         #expect(viewModel.playlistDetail?.tracks.map(\.videoId) == ["a", "c"])
         #expect(viewModel.playlistDetail?.trackCount == 2)
     }
 
-    @Test("Reinsert track restores it at its original index and track count")
-    func reinsertTrackRestoresOriginalPosition() async throws {
-        let songs = [
-            Song(id: "a", title: "A", artists: [], videoId: "a", playlistSetVideoId: "set-a"),
-            Song(id: "b", title: "B", artists: [], videoId: "b", playlistSetVideoId: "set-b"),
-            Song(id: "c", title: "C", artists: [], videoId: "c", playlistSetVideoId: "set-c"),
-        ]
-        let playlist = Playlist(
-            id: "VL-reinsert-test", title: "Test Playlist", description: nil,
-            thumbnailURL: nil, trackCount: 3, canDelete: true
-        )
-        self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(playlist: playlist, tracks: songs, duration: nil)
-        let viewModel = PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
-        await viewModel.load()
-        let removed = try #require(viewModel.removeTrackOptimistically(setVideoId: "set-b"))
+    @Test("Playlist removal reservations deduplicate and can be released")
+    func playlistRemovalReservationsDeduplicate() {
+        #expect(self.viewModel.reservePlaylistRemoval(setVideoId: "set-a"))
+        #expect(!self.viewModel.reservePlaylistRemoval(setVideoId: "set-a"))
 
-        viewModel.reinsertTrack(removed.song, at: removed.index)
+        self.viewModel.releasePlaylistRemoval(setVideoId: "set-a")
 
-        #expect(viewModel.playlistDetail?.tracks.map(\.videoId) == ["a", "b", "c"])
-        #expect(viewModel.playlistDetail?.trackCount == 3)
+        #expect(self.viewModel.reservePlaylistRemoval(setVideoId: "set-a"))
     }
 
     @Test("Load error sets error state")

--- a/Tests/KasetTests/PlaylistDetailViewModelTests.swift
+++ b/Tests/KasetTests/PlaylistDetailViewModelTests.swift
@@ -89,8 +89,8 @@ struct PlaylistDetailViewModelTests {
 
     // MARK: - Track Removal Tests
 
-    @Test("Successful track removal commit removes the matching track and updates track count")
-    func successfulTrackRemovalCommitRemovesMatch() async {
+    @Test("Optimistic track removal removes the matching track and confirms successfully")
+    func optimisticTrackRemovalRemovesMatch() async throws {
         let songs = [
             Song(id: "a", title: "A", artists: [], videoId: "a", playlistSetVideoId: "set-a"),
             Song(id: "b", title: "B", artists: [], videoId: "b", playlistSetVideoId: "set-b"),
@@ -104,32 +104,49 @@ struct PlaylistDetailViewModelTests {
         let viewModel = PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
         await viewModel.load()
 
-        await viewModel.commitSuccessfulTrackRemoval(setVideoId: "set-b")
+        let removal = try #require(viewModel.beginOptimisticTrackRemoval(setVideoId: "set-b"))
 
         #expect(viewModel.playlistDetail?.tracks.map(\.videoId) == ["a", "c"])
         #expect(viewModel.playlistDetail?.trackCount == 2)
+        #expect(viewModel.isRemovingTrack)
+
+        viewModel.confirmTrackRemoval(removal)
+
+        #expect(!viewModel.isRemovingTrack)
     }
 
-    @Test("Playlist removal reservations deduplicate and can be released")
-    func playlistRemovalReservationsDeduplicate() {
-        #expect(self.viewModel.reservePlaylistRemoval(setVideoId: "set-a"))
-        #expect(!self.viewModel.reservePlaylistRemoval(setVideoId: "set-a"))
+    @Test("Only one optimistic playlist removal can be active")
+    func optimisticTrackRemovalIsSingleFlight() async throws {
+        let songs = [
+            Song(id: "a", title: "A", artists: [], videoId: "a", playlistSetVideoId: "set-a"),
+            Song(id: "b", title: "B", artists: [], videoId: "b", playlistSetVideoId: "set-b"),
+        ]
+        let playlist = Playlist(
+            id: "VL-single-flight-removal", title: "Test Playlist", description: nil,
+            thumbnailURL: nil, trackCount: songs.count, canDelete: true
+        )
+        self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(playlist: playlist, tracks: songs, duration: nil)
+        let viewModel = PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
+        await viewModel.load()
 
-        self.viewModel.releasePlaylistRemoval(setVideoId: "set-a")
+        let firstRemoval = try #require(viewModel.beginOptimisticTrackRemoval(setVideoId: "set-a"))
+        #expect(viewModel.beginOptimisticTrackRemoval(setVideoId: "set-b") == nil)
 
-        #expect(self.viewModel.reservePlaylistRemoval(setVideoId: "set-a"))
+        await viewModel.rollbackTrackRemoval(firstRemoval)
+
+        let secondRemoval = try #require(viewModel.beginOptimisticTrackRemoval(setVideoId: "set-b"))
+        await viewModel.rollbackTrackRemoval(secondRemoval)
     }
 
-    @Test("Continuation tombstone decrements an off-page removal count once")
-    func continuationTombstoneAdjustsTrackCount() async {
+    @Test("Generation-mismatched rollback restores the full pre-removal snapshot")
+    func generationMismatchRollbackRestoresSnapshot() async throws {
         let songs = [
             Song(id: "a", title: "A", artists: [], videoId: "a", playlistSetVideoId: "set-a"),
             Song(id: "b", title: "B", artists: [], videoId: "b", playlistSetVideoId: "set-b"),
             Song(id: "c", title: "C", artists: [], videoId: "c", playlistSetVideoId: "set-c"),
-            Song(id: "d", title: "D", artists: [], videoId: "d", playlistSetVideoId: "set-d"),
         ]
         let playlist = Playlist(
-            id: "VL-continuation-removal", title: "Test Playlist", description: nil,
+            id: "VL-async-rollback", title: "Test Playlist", description: nil,
             thumbnailURL: nil, trackCount: songs.count, canDelete: true
         )
         self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(
@@ -137,42 +154,60 @@ struct PlaylistDetailViewModelTests {
             tracks: Array(songs.prefix(2)),
             duration: nil
         )
-        self.mockClient.playlistContinuationTracks[playlist.id] = [Array(songs.suffix(2))]
-        self.mockClient.playlistContinuationDelay = .milliseconds(250)
+        self.mockClient.playlistContinuationTracks[playlist.id] = [[songs[2]]]
+        self.mockClient.playlistContinuationDelay = .milliseconds(150)
         let viewModel = PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
         await viewModel.load()
+        let removal = try #require(viewModel.beginOptimisticTrackRemoval(setVideoId: "set-a"))
 
-        let drainTask = Task { await viewModel.loadAllRemaining() }
+        let loadMoreTask = Task { await viewModel.loadMore() }
         await self.waitUntil(
-            self.mockClient.getPlaylistContinuationCallCount == 1,
-            description: "continuation request to start"
+            viewModel.loadingState == .loadingMore,
+            description: "continuation load to start"
+        )
+        loadMoreTask.cancel()
+        await loadMoreTask.value
+        await self.waitUntil(
+            viewModel.loadingState == .loaded,
+            description: "cancelled continuation to settle"
         )
 
-        let reconciledPlaylist = Playlist(
-            id: playlist.id, title: playlist.title, description: nil,
-            thumbnailURL: nil, trackCount: 3, canDelete: true
+        await viewModel.rollbackTrackRemoval(removal)
+
+        #expect(!viewModel.isRemovingTrack)
+        #expect(viewModel.playlistDetail?.tracks.map(\.videoId) == ["a", "b"])
+        let nextRemoval = try #require(viewModel.beginOptimisticTrackRemoval(setVideoId: "set-b"))
+        await viewModel.rollbackTrackRemoval(nextRemoval)
+    }
+
+    @Test("Track removal waiters resume only after the optimistic mutation finishes")
+    func trackRemovalWaitersResumeAfterCompletion() async throws {
+        let song = Song(id: "a", title: "A", artists: [], videoId: "a", playlistSetVideoId: "set-a")
+        let playlist = Playlist(
+            id: "VL-removal-waiter", title: "Test Playlist", description: nil,
+            thumbnailURL: nil, trackCount: 1, canDelete: true
         )
-        self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(
-            playlist: reconciledPlaylist,
-            tracks: Array(songs.prefix(2)),
-            duration: nil
-        )
-        let commitTask = Task {
-            await viewModel.commitSuccessfulTrackRemoval(setVideoId: "set-d")
+        self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(playlist: playlist, tracks: [song], duration: nil)
+        let viewModel = PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
+        await viewModel.load()
+        let removal = try #require(viewModel.beginOptimisticTrackRemoval(setVideoId: "set-a"))
+        var waiterFinished = false
+        let waiter = Task { @MainActor in
+            await viewModel.waitForTrackRemovalToFinish()
+            waiterFinished = true
         }
+        await Task.yield()
 
-        await drainTask.value
+        #expect(!waiterFinished)
 
-        #expect(viewModel.playlistDetail?.tracks.map(\.videoId) == ["a", "b", "c"])
-        #expect(viewModel.playlistDetail?.trackCount == 3)
+        viewModel.confirmTrackRemoval(removal)
+        await waiter.value
 
-        await commitTask.value
-        #expect(viewModel.playlistDetail?.tracks.map(\.videoId) == ["a", "b", "c"])
-        #expect(viewModel.playlistDetail?.trackCount == 3)
+        #expect(waiterFinished)
     }
 
     @Test("Stale refresh counts an off-page tombstone when its continuation arrives")
-    func staleRefreshCountsOffPageTombstoneOnContinuation() async {
+    func staleRefreshCountsOffPageTombstoneOnContinuation() async throws {
         let songs = [
             Song(id: "a", title: "A", artists: [], videoId: "a", playlistSetVideoId: "set-a"),
             Song(id: "b", title: "B", artists: [], videoId: "b", playlistSetVideoId: "set-b"),
@@ -190,7 +225,8 @@ struct PlaylistDetailViewModelTests {
         )
         let viewModel = PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
         await viewModel.load()
-        await viewModel.commitSuccessfulTrackRemoval(setVideoId: "set-d")
+        let removal = try #require(viewModel.beginOptimisticTrackRemoval(setVideoId: "set-d"))
+        viewModel.confirmTrackRemoval(removal)
 
         self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(
             playlist: playlist,

--- a/Tests/KasetTests/PlaylistPlaybackActionsTests.swift
+++ b/Tests/KasetTests/PlaylistPlaybackActionsTests.swift
@@ -73,6 +73,65 @@ struct PlaylistPlaybackActionsTests {
         #expect(songs.first?.isExplicit == true)
     }
 
+    @Test("Remaining playlist tracks tolerate removal from the initially queued prefix")
+    func remainingTracksTolerateInitialRemoval() {
+        let initial = [
+            TestFixtures.makeSong(id: "a"),
+            TestFixtures.makeSong(id: "b"),
+        ]
+        let full = [
+            TestFixtures.makeSong(id: "b"),
+            TestFixtures.makeSong(id: "c"),
+            TestFixtures.makeSong(id: "d"),
+        ]
+
+        let remaining = PlaylistPlaybackActions.remainingTracks(after: initial, in: full)
+
+        #expect(remaining.map(\.videoId) == ["c", "d"])
+    }
+
+    @Test("Remaining playlist tracks preserve authored duplicates")
+    func remainingTracksPreserveDuplicates() {
+        let initial = [TestFixtures.makeSong(id: "duplicate")]
+        let full = [
+            TestFixtures.makeSong(id: "duplicate"),
+            TestFixtures.makeSong(id: "duplicate"),
+            TestFixtures.makeSong(id: "tail"),
+        ]
+
+        let remaining = PlaylistPlaybackActions.remainingTracks(after: initial, in: full)
+
+        #expect(remaining.map(\.videoId) == ["duplicate", "tail"])
+    }
+
+    @Test("Remaining playlist tracks distinguish duplicate occurrences")
+    func remainingTracksUsePlaylistOccurrenceIdentity() {
+        let initial = [
+            Song(
+                id: "duplicate",
+                title: "Duplicate",
+                artists: [],
+                videoId: "duplicate",
+                playlistSetVideoId: "set-1"
+            ),
+        ]
+        let full = [
+            Song(
+                id: "duplicate",
+                title: "Duplicate",
+                artists: [],
+                videoId: "duplicate",
+                playlistSetVideoId: "set-2"
+            ),
+            TestFixtures.makeSong(id: "tail"),
+        ]
+
+        let remaining = PlaylistPlaybackActions.remainingTracks(after: initial, in: full)
+
+        #expect(remaining.map(\.playlistSetVideoId) == ["set-2", nil])
+        #expect(remaining.map(\.videoId) == ["duplicate", "tail"])
+    }
+
     @Test("Playlist playback continuation auth uses loaded ownership")
     func playlistPlaybackContinuationAuthUsesLoadedOwnership() async {
         let routePlaylist = TestFixtures.makePlaylist(


### PR DESCRIPTION
## Description

Adds a "Remove from Playlist" context-menu action on playlist track rows, for playlists the user owns. Removal is optimistic (row disappears immediately) with rollback + error feedback if the API call fails.

## AI Prompt (Optional)

<details>
<summary>🤖 AI Prompt Used</summary>

```
Add a "Remove from Playlist" action to the track context menu in playlist detail.
Requirements:
- Use the browse/edit_playlist endpoint (ACTION_REMOVE_VIDEO) via YTMusicClient
- Remove the correct occurrence when the same song appears multiple times in a
  playlist (setVideoId), threaded through the playlist parser
- Optimistic removal with rollback on failure, haptic feedback
- Only offer the action on playlists the user owns (not albums / uploads)
- Unit tests for the mutation action and view model
```

**AI Tool:** Claude Code

</details>

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Related Issues

<!-- none -->

## Changes Made

- `Song.playlistSetVideoId` — occurrence-specific id, parsed from `playlistItemData` (`ParsingHelpers.extractPlaylistSetVideoId`, threaded through `PlaylistParser`); needed to remove the right instance of a duplicated track
- `YTMusicClient.removeSongFromPlaylist` — `browse/edit_playlist` with `ACTION_REMOVE_VIDEO`; protocol + mock conformances
- `LibraryMutationActions.removeSongFromPlaylist` — optimistic removal via `PlaylistDetailViewModel.removeTrackOptimistically`, rollback via `reinsertTrack` on failure, haptic feedback
- "Remove from Playlist" in `PlaylistTrackRow`'s context menu, gated to `canDelete && !isAlbum && !isUploadedSongs`
- 4 new unit tests (`LibraryMutationActionsTests`, `PlaylistDetailViewModelTests`)

## Testing

- [x] Unit tests pass (`swift test --skip KasetUITests`) — 1778 passed, 148 suites
- [x] Manual testing performed — removed tracks (incl. duplicated tracks) from owned playlists; verified rollback on failure
- [x] UI tested on macOS 26+

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `swiftlint --strict && swiftformat .`
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally
- [ ] I have updated documentation if needed
- [x] I have checked for any performance implications
- [x] My changes generate no new warnings

## Screenshots

https://github.com/user-attachments/assets/c274bfca-f165-4e02-93c0-e35b1ea53911

## Additional Notes

Independent of, but complementary to, the drag-and-drop PR — together they complete add/remove playlist management from the UI.

