### PR TITLE
feat: per-sub-track scrobbling for long mixes

### DIFF
--- a/Sources/Kaset/AppDelegate.swift
+++ b/Sources/Kaset/AppDelegate.swift
@@ -10,6 +10,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Reference to the PlayerService for dock menu actions.
     /// Set by KasetApp after initialization.
     weak var playerService: PlayerService?
+    weak var scrobblingCoordinator: ScrobblingCoordinator?
 
     /// Reference to the main window for reliable reopen behavior.
     /// Using strong reference to prevent deallocation when window is hidden.
@@ -17,6 +18,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     /// Tracks when the app is quitting so we can allow window closures.
     private var isTerminating = false
+    private var isPreparingTermination = false
 
     func applicationDidFinishLaunching(_: Notification) {
         DiagnosticsLogger.app.info("AppDelegate: applicationDidFinishLaunching")
@@ -49,9 +51,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         DiagnosticsLogger.player.info("Application will terminate - saved queue for persistence")
     }
 
-    func applicationShouldTerminate(_: NSApplication) -> NSApplication.TerminateReply {
+    func applicationShouldTerminate(_ application: NSApplication) -> NSApplication.TerminateReply {
         self.isTerminating = true
-        return .terminateNow
+        guard let scrobblingCoordinator else { return .terminateNow }
+        guard !self.isPreparingTermination else { return .terminateLater }
+
+        self.isPreparingTermination = true
+        Task { @MainActor in
+            await scrobblingCoordinator.prepareForTermination()
+            self.playerService?.saveQueueForPersistence()
+            application.reply(toApplicationShouldTerminate: true)
+        }
+        return .terminateLater
     }
 
     /// Registers for system sleep and wake notifications to handle playback appropriately.

--- a/Sources/Kaset/KasetApp.swift
+++ b/Sources/Kaset/KasetApp.swift
@@ -150,6 +150,7 @@ struct KasetApp: App {
         // Wire up PlayerService to AppDelegate immediately (not in onAppear)
         // This ensures playerService is available for lifecycle events like queue restoration
         self.appDelegate.playerService = player
+        self.appDelegate.scrobblingCoordinator = scrobblingCoordinator
 
         if UITestConfig.isUITestMode {
             DiagnosticsLogger.ui.info("App launched in UI Test mode")

--- a/Sources/Kaset/KasetApp.swift
+++ b/Sources/Kaset/KasetApp.swift
@@ -135,11 +135,13 @@ struct KasetApp: App {
         _notificationService = State(initialValue: NotificationService(playerService: player))
         _accountService = State(initialValue: account)
 
-        // Create scrobbling coordinator
+        // Create scrobbling coordinator with mix tracklist parser
         let lastFMService = LastFMService(credentialStore: KeychainCredentialStore())
+        let mixTracklistParser = MixTracklistParser(youTubeClient: youtubeClient)
         let scrobblingCoordinator = ScrobblingCoordinator(
             playerService: player,
-            services: [lastFMService]
+            services: [lastFMService],
+            mixTracklistParser: mixTracklistParser
         )
         scrobblingCoordinator.restoreAuthState()
         scrobblingCoordinator.startMonitoring()

--- a/Sources/Kaset/Models/MixTracklist.swift
+++ b/Sources/Kaset/Models/MixTracklist.swift
@@ -27,7 +27,7 @@ struct MixTrackEntry: Identifiable, Hashable {
     /// Duration of this sub-track in seconds, if end time is known.
     var duration: TimeInterval? {
         guard let endTime else { return nil }
-        return endTime - startTime
+        return endTime - self.startTime
     }
 
     init(
@@ -50,18 +50,25 @@ struct MixTrackEntry: Identifiable, Hashable {
     /// If the title has no dash, the full title is used as the track title
     /// and the artist is left nil (caller should provide a fallback).
     init(fromChapterTitle title: String, startTime: TimeInterval, endTime: TimeInterval?) {
+        let parsed = Self.parseArtistTitle(from: title)
         self.id = UUID()
         self.startTime = startTime
         self.endTime = endTime
         self.source = .chapters
+        self.artist = parsed.artist
+        self.title = parsed.title
+    }
 
-        if let dashRange = title.range(of: " - ") {
-            self.artist = String(title[..<dashRange.lowerBound])
-            self.title = String(title[dashRange.upperBound...])
-        } else {
-            self.artist = nil
-            self.title = title
+    /// Splits a chapter/description label like "Artist - Title" into its parts, trimming whitespace.
+    /// Splits on the FIRST " - "; if absent, the whole string is the title and the artist is nil
+    /// (the caller supplies a fallback). Shared by the chapter and description tracklist tiers.
+    static func parseArtistTitle(from raw: String) -> (artist: String?, title: String) {
+        guard let dashRange = raw.range(of: " - ") else {
+            return (nil, raw.trimmingCharacters(in: .whitespaces))
         }
+        let artist = raw[..<dashRange.lowerBound].trimmingCharacters(in: .whitespaces)
+        let title = raw[dashRange.upperBound...].trimmingCharacters(in: .whitespaces)
+        return (artist.isEmpty ? nil : artist, title)
     }
 }
 
@@ -89,16 +96,16 @@ struct MixTracklist: Hashable {
     /// is before the first entry.
     func entry(at progress: TimeInterval) -> MixTrackEntry? {
         // Binary search for the last entry with startTime <= progress
-        guard !entries.isEmpty else { return nil }
-        guard progress >= entries.first!.startTime else { return nil }
+        guard !self.entries.isEmpty else { return nil }
+        guard progress >= self.entries.first!.startTime else { return nil }
 
         var low = 0
-        var high = entries.count - 1
+        var high = self.entries.count - 1
         var result = 0
 
         while low <= high {
             let mid = (low + high) / 2
-            if entries[mid].startTime <= progress {
+            if self.entries[mid].startTime <= progress {
                 result = mid
                 low = mid + 1
             } else {
@@ -106,12 +113,15 @@ struct MixTracklist: Hashable {
             }
         }
 
-        return entries[result]
+        return self.entries[result]
     }
 
-    /// Whether this tracklist has enough entries to be treated as a mix.
+    /// Minimum entry count for a tracklist to be treated as a mix.
     /// A single track with 2 chapters is not a mix; 3+ entries indicates a real tracklist.
+    static let minEntryCount = 3
+
+    /// Whether this tracklist has enough entries to be treated as a mix.
     var isMix: Bool {
-        entries.count >= 3
+        self.entries.count >= Self.minEntryCount
     }
 }

--- a/Sources/Kaset/Models/MixTracklist.swift
+++ b/Sources/Kaset/Models/MixTracklist.swift
@@ -59,15 +59,24 @@ struct MixTrackEntry: Identifiable, Hashable {
         self.title = parsed.title
     }
 
+    /// Separator tokens recognized between artist and title. An unspaced ASCII hyphen is NOT
+    /// a separator — it appears inside names like "Anne-Marie" or "T-Pain".
+    private static let artistTitleSeparators = [" - ", " – ", " — ", "–", "—"]
+
     /// Splits a chapter/description label like "Artist - Title" into its parts, trimming whitespace.
-    /// Splits on the FIRST " - "; if absent, the whole string is the title and the artist is nil
-    /// (the caller supplies a fallback). Shared by the chapter and description tracklist tiers.
+    /// The LEFTMOST separator occurrence wins — the artist boundary precedes any dash inside the
+    /// title (e.g. "DJ Rashad – Itwerk - Percussion Mix"). If none is present, the whole string is
+    /// the title and the artist is nil (the caller supplies a fallback). Shared by the chapter and
+    /// description tracklist tiers.
     static func parseArtistTitle(from raw: String) -> (artist: String?, title: String) {
-        guard let dashRange = raw.range(of: " - ") else {
+        let match = self.artistTitleSeparators
+            .compactMap { raw.range(of: $0) }
+            .min { $0.lowerBound < $1.lowerBound }
+        guard let range = match else {
             return (nil, raw.trimmingCharacters(in: .whitespaces))
         }
-        let artist = raw[..<dashRange.lowerBound].trimmingCharacters(in: .whitespaces)
-        let title = raw[dashRange.upperBound...].trimmingCharacters(in: .whitespaces)
+        let artist = raw[..<range.lowerBound].trimmingCharacters(in: .whitespaces)
+        let title = raw[range.upperBound...].trimmingCharacters(in: .whitespaces)
         return (artist.isEmpty ? nil : artist, title)
     }
 }
@@ -93,7 +102,8 @@ struct MixTracklist: Hashable {
 
     /// Find the entry active at a given playback position (seconds from start).
     /// Returns the last entry whose startTime is <= progress, or nil if progress
-    /// is before the first entry.
+    /// is before the first entry or at/past the matched entry's explicit endTime
+    /// (e.g. an outro section after the final chapter's bound).
     func entry(at progress: TimeInterval) -> MixTrackEntry? {
         // Binary search for the last entry with startTime <= progress
         guard !self.entries.isEmpty else { return nil }
@@ -113,15 +123,27 @@ struct MixTracklist: Hashable {
             }
         }
 
-        return self.entries[result]
+        let entry = self.entries[result]
+        if let endTime = entry.endTime, progress >= endTime {
+            return nil
+        }
+        return entry
     }
 
     /// Minimum entry count for a tracklist to be treated as a mix.
     /// A single track with 2 chapters is not a mix; 3+ entries indicates a real tracklist.
     static let minEntryCount = 3
 
-    /// Whether this tracklist has enough entries to be treated as a mix.
+    /// Minimum fraction of entries that must carry a parsed artist for the tracklist to be
+    /// treated as a mix. Navigation chapters ("Intro", "Verse", "Outro") have no artist part,
+    /// so a chapter count alone would misclassify ordinary chaptered videos as mixes.
+    static let minParsedArtistRatio = 0.5
+
+    /// Whether this tracklist has enough entries — and enough parseable artist/title
+    /// entries — to be treated as a mix.
     var isMix: Bool {
-        self.entries.count >= Self.minEntryCount
+        guard self.entries.count >= Self.minEntryCount else { return false }
+        let parsedArtistCount = self.entries.count { $0.artist != nil }
+        return Double(parsedArtistCount) >= Double(self.entries.count) * Self.minParsedArtistRatio
     }
 }

--- a/Sources/Kaset/Models/MixTracklist.swift
+++ b/Sources/Kaset/Models/MixTracklist.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+// MARK: - MixTrackEntry
+
+/// A single sub-track within a long mix video (e.g., a DJ set or compilation).
+/// Each entry maps a time range within the video to an artist and title,
+/// enabling per-sub-track scrobbling instead of scrobbling the entire mix as one track.
+struct MixTrackEntry: Identifiable, Hashable {
+    let id: UUID
+    /// Start time in seconds from the beginning of the video.
+    let startTime: TimeInterval
+    /// End time in seconds. Nil means "until the next entry or end of video."
+    let endTime: TimeInterval?
+    /// Track title (without the artist prefix).
+    let title: String
+    /// Artist name, if parsed from the chapter title or description.
+    /// Falls back to the mix uploader name when parsing can't separate artist from title.
+    let artist: String?
+    /// Where this entry was parsed from.
+    let source: Source
+
+    enum Source: String, Hashable {
+        case chapters
+        case description
+    }
+
+    /// Duration of this sub-track in seconds, if end time is known.
+    var duration: TimeInterval? {
+        guard let endTime else { return nil }
+        return endTime - startTime
+    }
+
+    init(
+        id: UUID = UUID(),
+        startTime: TimeInterval,
+        endTime: TimeInterval?,
+        title: String,
+        artist: String?,
+        source: Source
+    ) {
+        self.id = id
+        self.startTime = startTime
+        self.endTime = endTime
+        self.title = title
+        self.artist = artist
+        self.source = source
+    }
+
+    /// Creates a MixTrackEntry from a YouTubeChapter title by splitting on " - ".
+    /// If the title has no dash, the full title is used as the track title
+    /// and the artist is left nil (caller should provide a fallback).
+    init(fromChapterTitle title: String, startTime: TimeInterval, endTime: TimeInterval?) {
+        self.id = UUID()
+        self.startTime = startTime
+        self.endTime = endTime
+        self.source = .chapters
+
+        if let dashRange = title.range(of: " - ") {
+            self.artist = String(title[..<dashRange.lowerBound])
+            self.title = String(title[dashRange.upperBound...])
+        } else {
+            self.artist = nil
+            self.title = title
+        }
+    }
+}
+
+// MARK: - MixTracklist
+
+/// A parsed tracklist for a long mix video, containing sub-tracks with timestamps.
+/// Used by `ScrobblingCoordinator` to scrobble individual tracks within a mix
+/// instead of scrobbling the entire video as a single entry.
+struct MixTracklist: Hashable {
+    /// The YouTube video ID this tracklist belongs to.
+    let videoId: String
+    /// Sub-tracks sorted by start time.
+    let entries: [MixTrackEntry]
+    /// Where the tracklist was parsed from.
+    let source: MixTrackEntry.Source
+
+    init(videoId: String, entries: [MixTrackEntry], source: MixTrackEntry.Source) {
+        self.videoId = videoId
+        self.entries = entries.sorted { $0.startTime < $1.startTime }
+        self.source = source
+    }
+
+    /// Find the entry active at a given playback position (seconds from start).
+    /// Returns the last entry whose startTime is <= progress, or nil if progress
+    /// is before the first entry.
+    func entry(at progress: TimeInterval) -> MixTrackEntry? {
+        // Binary search for the last entry with startTime <= progress
+        guard !entries.isEmpty else { return nil }
+        guard progress >= entries.first!.startTime else { return nil }
+
+        var low = 0
+        var high = entries.count - 1
+        var result = 0
+
+        while low <= high {
+            let mid = (low + high) / 2
+            if entries[mid].startTime <= progress {
+                result = mid
+                low = mid + 1
+            } else {
+                high = mid - 1
+            }
+        }
+
+        return entries[result]
+    }
+
+    /// Whether this tracklist has enough entries to be treated as a mix.
+    /// A single track with 2 chapters is not a mix; 3+ entries indicates a real tracklist.
+    var isMix: Bool {
+        entries.count >= 3
+    }
+}

--- a/Sources/Kaset/Models/MixTracklist.swift
+++ b/Sources/Kaset/Models/MixTracklist.swift
@@ -94,13 +94,27 @@ struct MixTracklist: Hashable {
     let entries: [MixTrackEntry]
     /// Where the tracklist was parsed from.
     let source: MixTrackEntry.Source
+    /// Whether an explicit Tracklist/Setlist heading established description-list intent.
+    let hasExplicitTracklistSignal: Bool
 
-    init(videoId: String, entries: [MixTrackEntry], source: MixTrackEntry.Source) {
+    init(
+        videoId: String,
+        entries: [MixTrackEntry],
+        source: MixTrackEntry.Source,
+        hasExplicitTracklistSignal: Bool = false
+    ) {
         self.videoId = videoId
+        let preservesHeadedDescriptionTitles = source == .description && hasExplicitTracklistSignal
         self.entries = entries
-            .filter { !$0.title.isEmpty && ($0.artist != nil || !Self.isGenericNavigationTitle($0.title)) }
+            .filter {
+                !$0.title.isEmpty
+                    && ($0.artist != nil
+                        || preservesHeadedDescriptionTitles
+                        || !Self.isGenericNavigationTitle($0.title))
+            }
             .sorted { $0.startTime < $1.startTime }
         self.source = source
+        self.hasExplicitTracklistSignal = hasExplicitTracklistSignal
     }
 
     /// Greatest timestamp established by the tracklist itself. This is a lower bound for the
@@ -177,6 +191,9 @@ struct MixTracklist: Hashable {
     /// Whether this tracklist has enough entries and a sufficiently strong artist/title signal.
     var isMix: Bool {
         guard self.entries.count >= Self.minEntryCount else { return false }
+        if self.source == .description, self.hasExplicitTracklistSignal {
+            return true
+        }
         let parsedArtistCount = self.entries.count { $0.artist != nil }
         return parsedArtistCount * 2 >= self.entries.count
     }

--- a/Sources/Kaset/Models/MixTracklist.swift
+++ b/Sources/Kaset/Models/MixTracklist.swift
@@ -5,7 +5,7 @@ import Foundation
 /// A single sub-track within a long mix video (e.g., a DJ set or compilation).
 /// Each entry maps a time range within the video to an artist and title,
 /// enabling per-sub-track scrobbling instead of scrobbling the entire mix as one track.
-struct MixTrackEntry: Identifiable, Hashable, Sendable {
+struct MixTrackEntry: Identifiable, Hashable {
     let id: UUID
     /// Start time in seconds from the beginning of the video.
     let startTime: TimeInterval
@@ -19,7 +19,7 @@ struct MixTrackEntry: Identifiable, Hashable, Sendable {
     /// Where this entry was parsed from.
     let source: Source
 
-    enum Source: String, Hashable, Sendable {
+    enum Source: String, Hashable {
         case chapters
         case description
     }
@@ -87,7 +87,7 @@ struct MixTrackEntry: Identifiable, Hashable, Sendable {
 /// A parsed tracklist for a long mix video, containing sub-tracks with timestamps.
 /// Used by `ScrobblingCoordinator` to scrobble individual tracks within a mix
 /// instead of scrobbling the entire video as a single entry.
-struct MixTracklist: Hashable, Sendable {
+struct MixTracklist: Hashable {
     /// The YouTube video ID this tracklist belongs to.
     let videoId: String
     /// Sub-tracks sorted by start time.

--- a/Sources/Kaset/Models/MixTracklist.swift
+++ b/Sources/Kaset/Models/MixTracklist.swift
@@ -5,7 +5,7 @@ import Foundation
 /// A single sub-track within a long mix video (e.g., a DJ set or compilation).
 /// Each entry maps a time range within the video to an artist and title,
 /// enabling per-sub-track scrobbling instead of scrobbling the entire mix as one track.
-struct MixTrackEntry: Identifiable, Hashable {
+struct MixTrackEntry: Identifiable, Hashable, Sendable {
     let id: UUID
     /// Start time in seconds from the beginning of the video.
     let startTime: TimeInterval
@@ -19,7 +19,7 @@ struct MixTrackEntry: Identifiable, Hashable {
     /// Where this entry was parsed from.
     let source: Source
 
-    enum Source: String, Hashable {
+    enum Source: String, Hashable, Sendable {
         case chapters
         case description
     }
@@ -46,7 +46,7 @@ struct MixTrackEntry: Identifiable, Hashable {
         self.source = source
     }
 
-    /// Creates a MixTrackEntry from a YouTubeChapter title by splitting on " - ".
+    /// Creates a MixTrackEntry from a YouTubeChapter title by splitting on a common dash separator.
     /// If the title has no dash, the full title is used as the track title
     /// and the artist is left nil (caller should provide a fallback).
     init(fromChapterTitle title: String, startTime: TimeInterval, endTime: TimeInterval?) {
@@ -59,24 +59,25 @@ struct MixTrackEntry: Identifiable, Hashable {
         self.title = parsed.title
     }
 
-    /// Separator tokens recognized between artist and title. An unspaced ASCII hyphen is NOT
-    /// a separator — it appears inside names like "Anne-Marie" or "T-Pain".
-    private static let artistTitleSeparators = [" - ", " – ", " — ", "–", "—"]
-
     /// Splits a chapter/description label like "Artist - Title" into its parts, trimming whitespace.
-    /// The LEFTMOST separator occurrence wins — the artist boundary precedes any dash inside the
-    /// title (e.g. "DJ Rashad – Itwerk - Percussion Mix"). If none is present, the whole string is
-    /// the title and the artist is nil (the caller supplies a fallback). Shared by the chapter and
-    /// description tracklist tiers.
+    /// Recognizes spaced ASCII plus en-dash, em-dash, and minus-sign separators with or without
+    /// spaces. A bare ASCII hyphen stays ambiguous (`Part-1` is not necessarily artist/title). If
+    /// no separator is found, the whole string is the title and the artist is nil (the caller
+    /// supplies a fallback). Shared by the chapter and description tracklist tiers.
     static func parseArtistTitle(from raw: String) -> (artist: String?, title: String) {
-        let match = self.artistTitleSeparators
+        let spacedSeparators = [" - ", " – ", " — ", " − "]
+        let unspacedUnicodeSeparators = ["–", "—", "−"]
+        let spacedRange = spacedSeparators
             .compactMap { raw.range(of: $0) }
             .min { $0.lowerBound < $1.lowerBound }
-        guard let range = match else {
+        let fallbackRange = unspacedUnicodeSeparators
+            .compactMap { raw.range(of: $0) }
+            .min { $0.lowerBound < $1.lowerBound }
+        guard let dashRange = spacedRange ?? fallbackRange else {
             return (nil, raw.trimmingCharacters(in: .whitespaces))
         }
-        let artist = raw[..<range.lowerBound].trimmingCharacters(in: .whitespaces)
-        let title = raw[range.upperBound...].trimmingCharacters(in: .whitespaces)
+        let artist = raw[..<dashRange.lowerBound].trimmingCharacters(in: .whitespaces)
+        let title = raw[dashRange.upperBound...].trimmingCharacters(in: .whitespaces)
         return (artist.isEmpty ? nil : artist, title)
     }
 }
@@ -86,7 +87,7 @@ struct MixTrackEntry: Identifiable, Hashable {
 /// A parsed tracklist for a long mix video, containing sub-tracks with timestamps.
 /// Used by `ScrobblingCoordinator` to scrobble individual tracks within a mix
 /// instead of scrobbling the entire video as a single entry.
-struct MixTracklist: Hashable {
+struct MixTracklist: Hashable, Sendable {
     /// The YouTube video ID this tracklist belongs to.
     let videoId: String
     /// Sub-tracks sorted by start time.
@@ -96,18 +97,27 @@ struct MixTracklist: Hashable {
 
     init(videoId: String, entries: [MixTrackEntry], source: MixTrackEntry.Source) {
         self.videoId = videoId
-        self.entries = entries.sorted { $0.startTime < $1.startTime }
+        self.entries = entries
+            .filter { !$0.title.isEmpty && ($0.artist != nil || !Self.isGenericNavigationTitle($0.title)) }
+            .sorted { $0.startTime < $1.startTime }
         self.source = source
+    }
+
+    /// Greatest timestamp established by the tracklist itself. This is a lower bound for the
+    /// parent video's duration: a chapter starting or ending after a threshold proves the video is
+    /// at least that long even when the player has not published its duration yet.
+    var knownDurationLowerBound: TimeInterval? {
+        self.entries
+            .map { max($0.startTime, $0.endTime ?? $0.startTime) }
+            .max()
     }
 
     /// Find the entry active at a given playback position (seconds from start).
     /// Returns the last entry whose startTime is <= progress, or nil if progress
-    /// is before the first entry or at/past the matched entry's explicit endTime
-    /// (e.g. an outro section after the final chapter's bound).
+    /// is before the first entry.
     func entry(at progress: TimeInterval) -> MixTrackEntry? {
         // Binary search for the last entry with startTime <= progress
-        guard !self.entries.isEmpty else { return nil }
-        guard progress >= self.entries.first!.startTime else { return nil }
+        guard let firstEntry = self.entries.first, progress >= firstEntry.startTime else { return nil }
 
         var low = 0
         var high = self.entries.count - 1
@@ -130,20 +140,75 @@ struct MixTracklist: Hashable {
         return entry
     }
 
-    /// Minimum entry count for a tracklist to be treated as a mix.
-    /// A single track with 2 chapters is not a mix; 3+ entries indicates a real tracklist.
+    /// Resolves duration from an explicit end, the next entry, or the parent video's final bound.
+    func effectiveDuration(for entry: MixTrackEntry, videoDuration: TimeInterval?) -> TimeInterval? {
+        guard let endTime = self.effectiveEndTime(for: entry, videoDuration: videoDuration) else { return nil }
+        return endTime - entry.startTime
+    }
+
+    /// Resolves an entry's playback boundary from its explicit end, next entry, or parent video.
+    func effectiveEndTime(for entry: MixTrackEntry, videoDuration: TimeInterval?) -> TimeInterval? {
+        if let endTime = entry.endTime {
+            return endTime
+        }
+
+        if let index = self.entries.firstIndex(where: { $0.id == entry.id }),
+           self.entries.indices.contains(index + 1)
+        {
+            let nextStart = self.entries[index + 1].startTime
+            if nextStart > entry.startTime {
+                return nextStart
+            }
+        }
+
+        guard self.entries.last?.id == entry.id,
+              let videoDuration,
+              videoDuration > entry.startTime
+        else { return nil }
+
+        return videoDuration
+    }
+
+    /// Minimum entry and identified-track count for a tracklist to be treated as a mix.
+    /// Requiring structured artist/title labels avoids scrobbling generic intro/verse/outro or
+    /// podcast-navigation chapters as if they were individual songs.
     static let minEntryCount = 3
 
-    /// Minimum fraction of entries that must carry a parsed artist for the tracklist to be
-    /// treated as a mix. Navigation chapters ("Intro", "Verse", "Outro") have no artist part,
-    /// so a chapter count alone would misclassify ordinary chaptered videos as mixes.
-    static let minParsedArtistRatio = 0.5
-
-    /// Whether this tracklist has enough entries — and enough parseable artist/title
-    /// entries — to be treated as a mix.
+    /// Whether this tracklist has enough entries and a sufficiently strong artist/title signal.
     var isMix: Bool {
         guard self.entries.count >= Self.minEntryCount else { return false }
         let parsedArtistCount = self.entries.count { $0.artist != nil }
-        return Double(parsedArtistCount) >= Double(self.entries.count) * Self.minParsedArtistRatio
+        return parsedArtistCount * 2 >= self.entries.count
+    }
+
+    private static func isGenericNavigationTitle(_ title: String) -> Bool {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalized = trimmed.lowercased()
+        let exactLabels: Set = [
+            "intro", "introduction", "outro", "verse", "chorus", "bridge", "interlude",
+            "opening", "closing", "credits", "main section", "q&a", "qa",
+        ]
+        if exactLabels.contains(normalized) {
+            return true
+        }
+        for prefix in [
+            "chapter ", "chapter-", "part ", "part-", "section ", "section-",
+            "segment ", "segment-", "topic ", "topic-",
+        ] where normalized.hasPrefix(prefix) {
+            let suffix = trimmed.dropFirst(prefix.count).trimmingCharacters(in: .whitespaces)
+            if Int(suffix) != nil {
+                return true
+            }
+            if !suffix.isEmpty,
+               suffix == suffix.uppercased(),
+               suffix.range(
+                   of: #"^M{0,3}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})$"#,
+                   options: .regularExpression
+               ) != nil
+            {
+                return true
+            }
+        }
+        return false
     }
 }

--- a/Sources/Kaset/Models/YouTube/YouTubeFeed.swift
+++ b/Sources/Kaset/Models/YouTube/YouTubeFeed.swift
@@ -168,7 +168,7 @@ struct WatchNextData {
     let related: [YouTubeVideo]
     /// Navigation chapters for the current video, when YouTube exposes them.
     let chapters: [YouTubeChapter]
-    /// Plain-text video description, when the watch page exposes it.
+    /// Full watch-page description text, from the structured panel or secondary-info fallback.
     let descriptionText: String?
     /// Whether the signed-in user is subscribed to the video's channel
     /// (nil when the page did not expose a subscribe button).

--- a/Sources/Kaset/Models/YouTube/YouTubeFeed.swift
+++ b/Sources/Kaset/Models/YouTube/YouTubeFeed.swift
@@ -168,6 +168,8 @@ struct WatchNextData {
     let related: [YouTubeVideo]
     /// Navigation chapters for the current video, when YouTube exposes them.
     let chapters: [YouTubeChapter]
+    /// Plain-text video description, when the watch page exposes it.
+    let descriptionText: String?
     /// Whether the signed-in user is subscribed to the video's channel
     /// (nil when the page did not expose a subscribe button).
     var isSubscribed: Bool?
@@ -181,6 +183,7 @@ struct WatchNextData {
         channel: YouTubeChannel?,
         related: [YouTubeVideo],
         chapters: [YouTubeChapter] = [],
+        descriptionText: String? = nil,
         isSubscribed: Bool? = nil,
         commentsContinuation: String? = nil
     ) {
@@ -190,6 +193,7 @@ struct WatchNextData {
         self.channel = channel
         self.related = related
         self.chapters = chapters
+        self.descriptionText = descriptionText
         self.isSubscribed = isSubscribed
         self.commentsContinuation = commentsContinuation
     }

--- a/Sources/Kaset/Services/API/Parsers/YouTube/WatchNextParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/YouTube/WatchNextParser.swift
@@ -13,6 +13,7 @@ enum WatchNextParser {
         var publishedText: String?
         var channel: YouTubeChannel?
         var isSubscribed: Bool?
+        var descriptionText: String?
 
         let primaryContents = (
             (results?["results"] as? [String: Any])?["results"] as? [String: Any]
@@ -28,6 +29,11 @@ enum WatchNextParser {
             }
 
             if let secondaryInfo = content["videoSecondaryInfoRenderer"] as? [String: Any] {
+                if let content = (secondaryInfo["attributedDescription"] as? [String: Any])?["content"]
+                    as? String, !content.isEmpty
+                {
+                    descriptionText = content
+                }
                 if let owner = (secondaryInfo["owner"] as? [String: Any])?["videoOwnerRenderer"]
                     as? [String: Any]
                 {
@@ -61,6 +67,7 @@ enum WatchNextParser {
             channel: channel,
             related: YouTubeFeedParser.deduplicate(related),
             chapters: chapters,
+            descriptionText: descriptionText ?? Self.engagementPanelDescription(of: data),
             isSubscribed: isSubscribed,
             commentsContinuation: Self.commentsContinuation(of: data)
         )
@@ -86,6 +93,39 @@ enum WatchNextParser {
             return deduplicatedMacroMarkers
         }
         return self.mergingEndTimes(in: canonical, from: deduplicatedMacroMarkers)
+    }
+
+    /// Description text from the structured-description engagement panel.
+    /// Guest watch-next responses carry the same text in both
+    /// `videoSecondaryInfoRenderer.attributedDescription` and this panel
+    /// (confirmed via API exploration, 2026-07-11); the panel is the fallback
+    /// for layouts that omit the secondary-info copy.
+    static func engagementPanelDescription(of data: [String: Any]) -> String? {
+        guard let panels = data["engagementPanels"] as? [Any] else { return nil }
+        return self.findDescriptionBodyContent(in: panels)
+    }
+
+    private static func findDescriptionBodyContent(in value: Any) -> String? {
+        if let dict = value as? [String: Any] {
+            if let body = dict["expandableVideoDescriptionBodyRenderer"] as? [String: Any],
+               let text = body["attributedDescriptionBodyText"] as? [String: Any],
+               let content = text["content"] as? String
+            {
+                return content
+            }
+            for nested in dict.values {
+                if let content = Self.findDescriptionBodyContent(in: nested) {
+                    return content
+                }
+            }
+        } else if let array = value as? [Any] {
+            for element in array {
+                if let content = Self.findDescriptionBodyContent(in: element) {
+                    return content
+                }
+            }
+        }
+        return nil
     }
 
     /// The continuation token for the watch page's comments section

--- a/Sources/Kaset/Services/API/Parsers/YouTube/WatchNextParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/YouTube/WatchNextParser.swift
@@ -78,13 +78,14 @@ enum WatchNextParser {
         var chapterRenderers: [YouTubeChapter] = []
         self.collectChapterRenderers(in: data, videoId: videoId, chapters: &chapterRenderers)
         let canonical = self.deduplicateChapters(chapterRenderers)
-        if !canonical.isEmpty {
-            return canonical
-        }
 
         var macroMarkers: [YouTubeChapter] = []
         self.collectMacroMarkerRenderers(in: data, fallbackVideoId: videoId, chapters: &macroMarkers)
-        return self.deduplicateChapters(macroMarkers)
+        let deduplicatedMacroMarkers = self.deduplicateChapters(macroMarkers)
+        guard !canonical.isEmpty else {
+            return deduplicatedMacroMarkers
+        }
+        return self.mergingEndTimes(in: canonical, from: deduplicatedMacroMarkers)
     }
 
     /// The continuation token for the watch page's comments section
@@ -313,12 +314,18 @@ enum WatchNextParser {
     }
 
     private static func deduplicateChapters(_ chapters: [YouTubeChapter]) -> [YouTubeChapter] {
-        var seen: Set<String> = []
+        var indexByKey: [String: Int] = [:]
         var result: [YouTubeChapter] = []
 
         for chapter in chapters {
-            let key = "\(chapter.videoId ?? "")|\(Int((chapter.startTime * 1000).rounded()))|\(chapter.title)"
-            guard seen.insert(key).inserted else { continue }
+            let key = self.chapterKey(chapter)
+            if let index = indexByKey[key] {
+                if result[index].endTime == nil, chapter.endTime != nil {
+                    result[index] = self.mergingEndTime(in: result[index], from: chapter)
+                }
+                continue
+            }
+            indexByKey[key] = result.count
             result.append(chapter)
         }
 
@@ -328,6 +335,39 @@ enum WatchNextParser {
             }
             return lhs.title < rhs.title
         }
+    }
+
+    private static func mergingEndTimes(
+        in chapters: [YouTubeChapter],
+        from boundedChapters: [YouTubeChapter]
+    ) -> [YouTubeChapter] {
+        let boundsByKey = Dictionary(uniqueKeysWithValues: boundedChapters.map {
+            (self.chapterKey($0), $0)
+        })
+        return chapters.map { chapter in
+            guard chapter.endTime == nil, let boundedChapter = boundsByKey[self.chapterKey(chapter)] else {
+                return chapter
+            }
+            return self.mergingEndTime(in: chapter, from: boundedChapter)
+        }
+    }
+
+    private static func mergingEndTime(
+        in chapter: YouTubeChapter,
+        from boundedChapter: YouTubeChapter
+    ) -> YouTubeChapter {
+        YouTubeChapter(
+            videoId: chapter.videoId,
+            title: chapter.title,
+            startTime: chapter.startTime,
+            endTime: boundedChapter.endTime,
+            timeText: chapter.timeText,
+            thumbnailURL: chapter.thumbnailURL
+        )
+    }
+
+    private static func chapterKey(_ chapter: YouTubeChapter) -> String {
+        "\(chapter.videoId ?? "")|\(Int((chapter.startTime * 1000).rounded()))|\(chapter.title)"
     }
 
     // MARK: - Private

--- a/Sources/Kaset/Services/API/Parsers/YouTube/WatchNextParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/YouTube/WatchNextParser.swift
@@ -13,7 +13,7 @@ enum WatchNextParser {
         var publishedText: String?
         var channel: YouTubeChannel?
         var isSubscribed: Bool?
-        var descriptionText: String?
+        var secondaryDescriptionText: String?
 
         let primaryContents = (
             (results?["results"] as? [String: Any])?["results"] as? [String: Any]
@@ -30,9 +30,9 @@ enum WatchNextParser {
 
             if let secondaryInfo = content["videoSecondaryInfoRenderer"] as? [String: Any] {
                 if let content = (secondaryInfo["attributedDescription"] as? [String: Any])?["content"]
-                    as? String, !content.isEmpty
+                    as? String, !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                 {
-                    descriptionText = content
+                    secondaryDescriptionText = content
                 }
                 if let owner = (secondaryInfo["owner"] as? [String: Any])?["videoOwnerRenderer"]
                     as? [String: Any]
@@ -67,7 +67,7 @@ enum WatchNextParser {
             channel: channel,
             related: YouTubeFeedParser.deduplicate(related),
             chapters: chapters,
-            descriptionText: descriptionText ?? Self.engagementPanelDescription(of: data),
+            descriptionText: Self.descriptionText(of: data) ?? secondaryDescriptionText,
             isSubscribed: isSubscribed,
             commentsContinuation: Self.commentsContinuation(of: data)
         )
@@ -95,37 +95,10 @@ enum WatchNextParser {
         return self.mergingEndTimes(in: canonical, from: deduplicatedMacroMarkers)
     }
 
-    /// Description text from the structured-description engagement panel.
-    /// Guest watch-next responses carry the same text in both
-    /// `videoSecondaryInfoRenderer.attributedDescription` and this panel
-    /// (confirmed via API exploration, 2026-07-11); the panel is the fallback
-    /// for layouts that omit the secondary-info copy.
-    static func engagementPanelDescription(of data: [String: Any]) -> String? {
+    /// Full watch-page description carried by the structured-description engagement panel.
+    static func descriptionText(of data: [String: Any]) -> String? {
         guard let panels = data["engagementPanels"] as? [Any] else { return nil }
-        return self.findDescriptionBodyContent(in: panels)
-    }
-
-    private static func findDescriptionBodyContent(in value: Any) -> String? {
-        if let dict = value as? [String: Any] {
-            if let body = dict["expandableVideoDescriptionBodyRenderer"] as? [String: Any],
-               let text = body["attributedDescriptionBodyText"] as? [String: Any],
-               let content = text["content"] as? String
-            {
-                return content
-            }
-            for nested in dict.values {
-                if let content = Self.findDescriptionBodyContent(in: nested) {
-                    return content
-                }
-            }
-        } else if let array = value as? [Any] {
-            for element in array {
-                if let content = Self.findDescriptionBodyContent(in: element) {
-                    return content
-                }
-            }
-        }
-        return nil
+        return self.findDescriptionText(in: panels)
     }
 
     /// The continuation token for the watch page's comments section
@@ -150,6 +123,35 @@ enum WatchNextParser {
             for element in array {
                 if let token = Self.findCommentsSectionToken(in: element) {
                     return token
+                }
+            }
+        }
+        return nil
+    }
+
+    private static func findDescriptionText(in value: Any) -> String? {
+        if let dict = value as? [String: Any] {
+            if let attributed = dict["attributedDescriptionBodyText"] as? [String: Any],
+               let content = attributed["content"] as? String,
+               !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            {
+                return content
+            }
+            if let descriptionBody = dict["descriptionBodyText"] as? [String: Any],
+               let content = YouTubeItemParser.text(from: descriptionBody),
+               !content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            {
+                return content
+            }
+            for nested in dict.values {
+                if let description = self.findDescriptionText(in: nested) {
+                    return description
+                }
+            }
+        } else if let array = value as? [Any] {
+            for element in array {
+                if let description = self.findDescriptionText(in: element) {
+                    return description
                 }
             }
         }

--- a/Sources/Kaset/Services/Player/PlayerService+PlaybackControls.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+PlaybackControls.swift
@@ -595,6 +595,7 @@ extension PlayerService {
         self.currentTrack = nil
         self.pendingPlayVideoId = nil
         self.progress = 0
+        self.setPlaybackStateVideoId(nil)
         self.currentLyricsLineIndex = nil
         self.currentLyricsDisplayTimeMs = nil
         self.duration = 0
@@ -632,6 +633,7 @@ extension PlayerService {
         self.currentTrack = nil
         self.progress = 0
         self.duration = 0
+        self.setPlaybackStateVideoId(nil)
     }
 
     /// Show the AirPlay picker for selecting audio output devices.

--- a/Sources/Kaset/Services/Player/PlayerService+PlaybackRestoration.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+PlaybackRestoration.swift
@@ -6,7 +6,23 @@ import Foundation
 extension PlayerService {
     /// Updates playback state from the persistent WebView observer.
     func updatePlaybackState(isPlaying: Bool, progress: Double, duration: Double) {
+        self.updatePlaybackState(
+            isPlaying: isPlaying,
+            progress: progress,
+            duration: duration,
+            observedVideoId: self.currentTrack?.videoId
+        )
+    }
+
+    /// Updates playback state with the video identity carried by the same WebView observation.
+    func updatePlaybackState(
+        isPlaying: Bool,
+        progress: Double,
+        duration: Double,
+        observedVideoId: String?
+    ) {
         let previousProgress = self.progress
+        self.recordPlaybackStateObservation(videoId: observedVideoId)
 
         guard !self.isRestoringPlaybackSession else {
             self.reconcileRestoredPlaybackState(

--- a/Sources/Kaset/Services/Player/PlayerService.swift
+++ b/Sources/Kaset/Services/Player/PlayerService.swift
@@ -91,6 +91,23 @@ final class PlayerService: NSObject, PlayerServiceProtocol {
     /// Total duration of current track in seconds.
     var duration: TimeInterval = 0
 
+    /// Video ID carried by the latest playback-state bridge update. This gives consumers
+    /// provenance for `progress`/`duration`, which can otherwise remain stale across track changes.
+    private(set) var playbackStateVideoId: String?
+
+    /// Monotonic identity for playback-state bridge observations. Consumers use this to distinguish
+    /// a fresh same-video sample from progress/duration left behind by an earlier metadata identity.
+    private(set) var playbackStateObservationSequence = 0
+
+    func setPlaybackStateVideoId(_ videoId: String?) {
+        self.playbackStateVideoId = videoId
+    }
+
+    func recordPlaybackStateObservation(videoId: String?) {
+        self.playbackStateObservationSequence &+= 1
+        self.playbackStateVideoId = videoId
+    }
+
     /// Current volume (0.0 - 1.0).
     var volume: Double = 1.0
 

--- a/Sources/Kaset/Services/Scrobbling/MixTracklistParser.swift
+++ b/Sources/Kaset/Services/Scrobbling/MixTracklistParser.swift
@@ -34,9 +34,9 @@ final class MixTracklistParser {
             return tracklist
         }
 
-        // Tier 2: Description parsing (deferred — needs WatchNextParser extension for description extraction)
-        // TODO: Extract description text from engagementPanels in the next response,
-        // then regex parse for timestamp patterns, then Foundation Models fallback.
+        // Tier 2 (not yet implemented): description parsing. Would extract description text from
+        // the next response's engagementPanels, regex-parse timestamp patterns, then fall back to
+        // Foundation Models. Requires a WatchNextParser extension for description extraction.
 
         return nil
     }
@@ -49,17 +49,13 @@ final class MixTracklistParser {
             let watchNextData = try await self.youTubeClient.getWatchNext(videoId: videoId)
             let chapters = watchNextData.chapters
 
-            // Only treat as a mix if there are 3+ chapters
-            guard chapters.count >= 3 else { return nil }
-
             // Convert chapters to MixTrackEntry, computing endTime from the next chapter's startTime
             let entries = chapters.enumerated().map { index, chapter -> MixTrackEntry in
-                let endTime: TimeInterval?
-                if index + 1 < chapters.count {
-                    endTime = chapters[index + 1].startTime
+                let endTime: TimeInterval? = if index + 1 < chapters.count {
+                    chapters[index + 1].startTime
                 } else {
                     // Last chapter — endTime stays nil (until end of video)
-                    endTime = nil
+                    nil
                 }
 
                 return MixTrackEntry(
@@ -69,7 +65,10 @@ final class MixTracklistParser {
                 )
             }
 
-            return MixTracklist(videoId: videoId, entries: entries, source: .chapters)
+            // A handful of chapters (intro/outro) isn't a real tracklist — MixTracklist.isMix decides.
+            let tracklist = MixTracklist(videoId: videoId, entries: entries, source: .chapters)
+            guard tracklist.isMix else { return nil }
+            return tracklist
         } catch {
             self.logger.debug("Chapter extraction failed for \(videoId): \(error.localizedDescription)")
             return nil

--- a/Sources/Kaset/Services/Scrobbling/MixTracklistParser.swift
+++ b/Sources/Kaset/Services/Scrobbling/MixTracklistParser.swift
@@ -1,0 +1,90 @@
+import Foundation
+import os
+
+// MARK: - MixTracklistParser
+
+/// Parses tracklists for long mix videos using a two-tier approach:
+/// 1. YouTube chapters (structured API data, no LLM needed)
+/// 2. Description timestamps (regex first, then Foundation Models fallback)
+///
+/// Chapters are fetched via `YouTubeClient.getWatchNext(videoId:)`, which calls
+/// the regular YouTube `next` endpoint. The YTMusic `next` endpoint does NOT
+/// return chapter data (confirmed via API exploration, 2026-07-10).
+@MainActor
+final class MixTracklistParser {
+    private let youTubeClient: any YouTubeClientProtocol
+    private var cache: [String: MixTracklist] = [:]
+    private let logger = DiagnosticsLogger.scrobbling
+
+    init(youTubeClient: any YouTubeClientProtocol) {
+        self.youTubeClient = youTubeClient
+    }
+
+    /// Parse a tracklist for a video. Returns nil if no tracklist is available.
+    /// Results are cached by video ID for the lifetime of this parser instance.
+    func parseTracklist(videoId: String) async -> MixTracklist? {
+        if let cached = self.cache[videoId] {
+            return cached
+        }
+
+        // Tier 1: YouTube chapters via the regular YouTube next endpoint
+        if let tracklist = await self.parseFromChapters(videoId: videoId) {
+            self.cache[videoId] = tracklist
+            self.logger.info("Mix tracklist parsed from chapters: \(tracklist.entries.count) entries for \(videoId)")
+            return tracklist
+        }
+
+        // Tier 2: Description parsing (deferred — needs WatchNextParser extension for description extraction)
+        // TODO: Extract description text from engagementPanels in the next response,
+        // then regex parse for timestamp patterns, then Foundation Models fallback.
+
+        return nil
+    }
+
+    // MARK: - Tier 1: Chapter Extraction
+
+    /// Extract tracklist from YouTube chapters via `YouTubeClient.getWatchNext`.
+    private func parseFromChapters(videoId: String) async -> MixTracklist? {
+        do {
+            let watchNextData = try await self.youTubeClient.getWatchNext(videoId: videoId)
+            let chapters = watchNextData.chapters
+
+            // Only treat as a mix if there are 3+ chapters
+            guard chapters.count >= 3 else { return nil }
+
+            // Convert chapters to MixTrackEntry, computing endTime from the next chapter's startTime
+            let entries = chapters.enumerated().map { index, chapter -> MixTrackEntry in
+                let endTime: TimeInterval?
+                if index + 1 < chapters.count {
+                    endTime = chapters[index + 1].startTime
+                } else {
+                    // Last chapter — endTime stays nil (until end of video)
+                    endTime = nil
+                }
+
+                return MixTrackEntry(
+                    fromChapterTitle: chapter.title,
+                    startTime: chapter.startTime,
+                    endTime: endTime
+                )
+            }
+
+            return MixTracklist(videoId: videoId, entries: entries, source: .chapters)
+        } catch {
+            self.logger.debug("Chapter extraction failed for \(videoId): \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    // MARK: - Cache Management
+
+    /// Clears the cache for a specific video, forcing a re-parse on next access.
+    func invalidate(videoId: String) {
+        self.cache.removeValue(forKey: videoId)
+    }
+
+    /// Clears all cached tracklists.
+    func invalidateAll() {
+        self.cache.removeAll()
+    }
+}

--- a/Sources/Kaset/Services/Scrobbling/MixTracklistParser.swift
+++ b/Sources/Kaset/Services/Scrobbling/MixTracklistParser.swift
@@ -54,8 +54,10 @@ final class MixTracklistParser {
                 let endTime: TimeInterval? = if index + 1 < chapters.count {
                     chapters[index + 1].startTime
                 } else {
-                    // Last chapter — endTime stays nil (until end of video)
-                    nil
+                    // The final chapter has no following start time, but macro-marker data may
+                    // still carry its explicit bound. Keep it so short closing tracks can qualify
+                    // via the normal percentage threshold instead of requiring minSeconds.
+                    chapter.endTime
                 }
 
                 return MixTrackEntry(

--- a/Sources/Kaset/Services/Scrobbling/MixTracklistParser.swift
+++ b/Sources/Kaset/Services/Scrobbling/MixTracklistParser.swift
@@ -4,23 +4,18 @@ import os
 // MARK: - MixTracklistParser
 
 /// Parses tracklists for long mix videos using a two-tier approach:
-/// 1. YouTube chapters (structured API data, no LLM needed)
-/// 2. Description timestamps (regex first, then Foundation Models fallback)
+/// 1. YouTube chapters (structured API data)
+/// 2. Description timestamps (regex over timestamped tracklist lines)
 ///
-/// Chapters are fetched via `YouTubeClient.getWatchNext(videoId:)`, which calls
-/// the regular YouTube `next` endpoint. The YTMusic `next` endpoint does NOT
-/// return chapter data (confirmed via API exploration, 2026-07-10).
+/// Both tiers read the same `YouTubeClient.getWatchNext(videoId:)` response,
+/// which calls the regular YouTube `next` endpoint. The YTMusic `next`
+/// endpoint does NOT return chapter or description data (confirmed via API
+/// exploration, 2026-07-10).
 @MainActor
 final class MixTracklistParser {
     private enum CacheEntry {
         case tracklist(MixTracklist)
         case noTracklist
-    }
-
-    private enum ChapterParseResult {
-        case tracklist(MixTracklist)
-        case noTracklist
-        case failed
     }
 
     private let youTubeClient: any YouTubeClientProtocol
@@ -32,7 +27,8 @@ final class MixTracklistParser {
     }
 
     /// Parse a tracklist for a video. Returns nil if no tracklist is available.
-    /// Results are cached by video ID for the lifetime of this parser instance.
+    /// Results (including confirmed misses) are cached by video ID for the lifetime
+    /// of this parser instance; transient fetch failures are not cached.
     func parseTracklist(videoId: String) async -> MixTracklist? {
         if let cached = self.cache[videoId] {
             return switch cached {
@@ -43,60 +39,165 @@ final class MixTracklistParser {
             }
         }
 
-        // Tier 1: YouTube chapters via the regular YouTube next endpoint
-        switch await self.parseFromChapters(videoId: videoId) {
-        case let .tracklist(tracklist):
+        let watchNextData: WatchNextData
+        do {
+            watchNextData = try await self.youTubeClient.getWatchNext(videoId: videoId)
+        } catch {
+            self.logger.debug("Tracklist fetch failed for \(videoId): \(error.localizedDescription)")
+            return nil
+        }
+
+        // Tier 1: YouTube chapters
+        if let tracklist = self.tracklist(fromChapters: watchNextData.chapters, videoId: videoId) {
             self.cache[videoId] = .tracklist(tracklist)
             self.logger.info("Mix tracklist parsed from chapters: \(tracklist.entries.count) entries for \(videoId)")
             return tracklist
-        case .noTracklist:
-            self.cache[videoId] = .noTracklist
-        case .failed:
-            break
         }
 
-        // Tier 2 (not yet implemented): description parsing. Would extract description text from
-        // the next response's engagementPanels, regex-parse timestamp patterns, then fall back to
-        // Foundation Models. Requires a WatchNextParser extension for description extraction.
+        // Tier 2: description timestamps
+        if let description = watchNextData.descriptionText,
+           let tracklist = self.tracklist(fromDescription: description, videoId: videoId)
+        {
+            self.cache[videoId] = .tracklist(tracklist)
+            self.logger.info("Mix tracklist parsed from description: \(tracklist.entries.count) entries for \(videoId)")
+            return tracklist
+        }
 
+        self.cache[videoId] = .noTracklist
         return nil
     }
 
     // MARK: - Tier 1: Chapter Extraction
 
-    /// Extract tracklist from YouTube chapters via `YouTubeClient.getWatchNext`.
-    private func parseFromChapters(videoId: String) async -> ChapterParseResult {
-        do {
-            let watchNextData = try await self.youTubeClient.getWatchNext(videoId: videoId)
-            let chapters = watchNextData.chapters
-
-            // Convert chapters to MixTrackEntry, computing endTime from the next chapter's startTime
-            let entries = chapters.enumerated().map { index, chapter -> MixTrackEntry in
-                let endTime: TimeInterval? = if index + 1 < chapters.count {
-                    chapter.endTime.map { min($0, chapters[index + 1].startTime) }
-                        ?? chapters[index + 1].startTime
-                } else {
-                    // The final chapter has no following start time, but macro-marker data may
-                    // still carry its explicit bound. Keep it so short closing tracks can qualify
-                    // via the normal percentage threshold instead of requiring minSeconds.
-                    chapter.endTime
-                }
-
-                return MixTrackEntry(
-                    fromChapterTitle: chapter.title,
-                    startTime: chapter.startTime,
-                    endTime: endTime
-                )
+    private func tracklist(fromChapters chapters: [YouTubeChapter], videoId: String) -> MixTracklist? {
+        // Convert chapters to MixTrackEntry, computing endTime from the next chapter's startTime
+        let entries = chapters.enumerated().map { index, chapter -> MixTrackEntry in
+            let endTime: TimeInterval? = if index + 1 < chapters.count {
+                chapter.endTime.map { min($0, chapters[index + 1].startTime) }
+                    ?? chapters[index + 1].startTime
+            } else {
+                // The final chapter has no following start time, but macro-marker data may
+                // still carry its explicit bound. Keep it so short closing tracks can qualify
+                // via the normal percentage threshold instead of requiring minSeconds.
+                chapter.endTime
             }
 
-            // A handful of chapters (intro/outro) isn't a real tracklist — MixTracklist.isMix decides.
-            let tracklist = MixTracklist(videoId: videoId, entries: entries, source: .chapters)
-            guard tracklist.isMix else { return .noTracklist }
-            return .tracklist(tracklist)
-        } catch {
-            self.logger.debug("Chapter extraction failed for \(videoId): \(error.localizedDescription)")
-            return .failed
+            return MixTrackEntry(
+                fromChapterTitle: chapter.title,
+                startTime: chapter.startTime,
+                endTime: endTime
+            )
         }
+
+        // A handful of chapters (intro/outro) isn't a real tracklist — MixTracklist.isMix decides.
+        let tracklist = MixTracklist(videoId: videoId, entries: entries, source: .chapters)
+        return tracklist.isMix ? tracklist : nil
+    }
+
+    // MARK: - Tier 2: Description Timestamps
+
+    private func tracklist(fromDescription description: String, videoId: String) -> MixTracklist? {
+        let entries = Self.descriptionEntries(from: description)
+        let tracklist = MixTracklist(videoId: videoId, entries: entries, source: .description)
+        return tracklist.isMix ? tracklist : nil
+    }
+
+    /// Extracts timestamped tracklist entries from a video description.
+    ///
+    /// Each line contributes at most one entry: its first plausible `H:MM:SS` or `M:SS`
+    /// timestamp becomes the start time and the rest of the line (minus wrapping brackets,
+    /// leading list numbering, and separator punctuation) becomes the artist/title label.
+    /// Because descriptions often contain unrelated timestamps (premiere times, social
+    /// links), only the longest run of consecutive lines with strictly increasing start
+    /// times is kept — a real tracklist is monotonic, stray mentions are not.
+    static func descriptionEntries(from description: String) -> [MixTrackEntry] {
+        let timestampRegex = /(?:(\d{1,2}):)?(\d{1,2}):([0-5]\d)(?![\d:])/
+        var candidates: [(startTime: TimeInterval, label: String)] = []
+
+        for rawLine in description.split(whereSeparator: \.isNewline) {
+            let line = String(rawLine)
+            // Swift Regex has no lookbehind; reject matches glued to preceding digits/colons or
+            // trailing letters ("3:45pm") manually, and skip past invalid H:MM:SS minutes so a
+            // bogus first match doesn't drop a line that also carries the real timestamp.
+            let matches = line.matches(of: timestampRegex)
+            guard let matchIndex = matches.firstIndex(where: { candidate in
+                if candidate.range.lowerBound > line.startIndex {
+                    let before = line[line.index(before: candidate.range.lowerBound)]
+                    guard !before.isNumber, before != ":" else { return false }
+                }
+                if candidate.range.upperBound < line.endIndex, line[candidate.range.upperBound].isLetter {
+                    return false
+                }
+                if candidate.output.1 != nil, let minutes = Int(candidate.output.2), minutes >= 60 {
+                    return false
+                }
+                return true
+            }) else { continue }
+            let match = matches[matchIndex]
+            let hours = match.output.1.flatMap { Int($0) } ?? 0
+            guard let minutes = Int(match.output.2), let seconds = Int(match.output.3) else { continue }
+
+            // When an earlier candidate was rejected, the text before the accepted match still
+            // contains that bogus fragment — keep only the suffix so it can't leak into the label.
+            let label = Self.label(
+                byRemoving: match.range,
+                from: line,
+                includePrefix: matchIndex == matches.startIndex
+            )
+            guard !label.isEmpty else { continue }
+            candidates.append((TimeInterval(hours * 3600 + minutes * 60 + seconds), label))
+        }
+
+        guard !candidates.isEmpty else { return [] }
+
+        var bestStart = 0
+        var bestCount = 1
+        var runStart = 0
+        for index in 1 ..< candidates.count {
+            if candidates[index].startTime <= candidates[index - 1].startTime {
+                runStart = index
+            }
+            if index - runStart + 1 > bestCount {
+                bestCount = index - runStart + 1
+                bestStart = runStart
+            }
+        }
+
+        let run = candidates[bestStart ..< bestStart + bestCount]
+        return run.indices.map { index in
+            let candidate = run[index]
+            let parsed = MixTrackEntry.parseArtistTitle(from: candidate.label)
+            return MixTrackEntry(
+                startTime: candidate.startTime,
+                endTime: index + 1 < run.endIndex ? run[index + 1].startTime : nil,
+                title: parsed.title,
+                artist: parsed.artist,
+                source: .description
+            )
+        }
+    }
+
+    /// Removes a matched timestamp (plus any wrapping brackets), leading list numbering,
+    /// and leftover separator punctuation from a description line.
+    private static func label(
+        byRemoving timestampRange: Range<String.Index>,
+        from line: String,
+        includePrefix: Bool
+    ) -> String {
+        var lower = timestampRange.lowerBound
+        var upper = timestampRange.upperBound
+        if lower > line.startIndex, upper < line.endIndex {
+            let before = line[line.index(before: lower)]
+            let after = line[upper]
+            if (before == "[" && after == "]") || (before == "(" && after == ")") {
+                lower = line.index(before: lower)
+                upper = line.index(after: upper)
+            }
+        }
+
+        return String(includePrefix ? line[..<lower] + line[upper...] : line[upper...])
+            .replacingOccurrences(of: #"^\s*\d{1,3}[.)]\s+"#, with: "", options: .regularExpression)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "-–—−|:•>~ \t"))
     }
 
     // MARK: - Cache Management

--- a/Sources/Kaset/Services/Scrobbling/MixTracklistParser.swift
+++ b/Sources/Kaset/Services/Scrobbling/MixTracklistParser.swift
@@ -12,8 +12,19 @@ import os
 /// return chapter data (confirmed via API exploration, 2026-07-10).
 @MainActor
 final class MixTracklistParser {
+    private enum CacheEntry {
+        case tracklist(MixTracklist)
+        case noTracklist
+    }
+
+    private enum ChapterParseResult {
+        case tracklist(MixTracklist)
+        case noTracklist
+        case failed
+    }
+
     private let youTubeClient: any YouTubeClientProtocol
-    private var cache: [String: MixTracklist] = [:]
+    private var cache: [String: CacheEntry] = [:]
     private let logger = DiagnosticsLogger.scrobbling
 
     init(youTubeClient: any YouTubeClientProtocol) {
@@ -24,14 +35,24 @@ final class MixTracklistParser {
     /// Results are cached by video ID for the lifetime of this parser instance.
     func parseTracklist(videoId: String) async -> MixTracklist? {
         if let cached = self.cache[videoId] {
-            return cached
+            return switch cached {
+            case let .tracklist(tracklist):
+                tracklist
+            case .noTracklist:
+                nil
+            }
         }
 
         // Tier 1: YouTube chapters via the regular YouTube next endpoint
-        if let tracklist = await self.parseFromChapters(videoId: videoId) {
-            self.cache[videoId] = tracklist
+        switch await self.parseFromChapters(videoId: videoId) {
+        case let .tracklist(tracklist):
+            self.cache[videoId] = .tracklist(tracklist)
             self.logger.info("Mix tracklist parsed from chapters: \(tracklist.entries.count) entries for \(videoId)")
             return tracklist
+        case .noTracklist:
+            self.cache[videoId] = .noTracklist
+        case .failed:
+            break
         }
 
         // Tier 2 (not yet implemented): description parsing. Would extract description text from
@@ -44,7 +65,7 @@ final class MixTracklistParser {
     // MARK: - Tier 1: Chapter Extraction
 
     /// Extract tracklist from YouTube chapters via `YouTubeClient.getWatchNext`.
-    private func parseFromChapters(videoId: String) async -> MixTracklist? {
+    private func parseFromChapters(videoId: String) async -> ChapterParseResult {
         do {
             let watchNextData = try await self.youTubeClient.getWatchNext(videoId: videoId)
             let chapters = watchNextData.chapters
@@ -70,11 +91,11 @@ final class MixTracklistParser {
 
             // A handful of chapters (intro/outro) isn't a real tracklist — MixTracklist.isMix decides.
             let tracklist = MixTracklist(videoId: videoId, entries: entries, source: .chapters)
-            guard tracklist.isMix else { return nil }
-            return tracklist
+            guard tracklist.isMix else { return .noTracklist }
+            return .tracklist(tracklist)
         } catch {
             self.logger.debug("Chapter extraction failed for \(videoId): \(error.localizedDescription)")
-            return nil
+            return .failed
         }
     }
 

--- a/Sources/Kaset/Services/Scrobbling/MixTracklistParser.swift
+++ b/Sources/Kaset/Services/Scrobbling/MixTracklistParser.swift
@@ -109,13 +109,25 @@ final class MixTracklistParser {
     /// leading list numbering, and separator punctuation) becomes the artist/title label.
     /// Because descriptions often contain unrelated timestamps (premiere times, social
     /// links), only the longest run of consecutive lines with strictly increasing start
-    /// times is kept — a real tracklist is monotonic, stray mentions are not.
+    /// times is kept — a real tracklist is a monotonic block, stray mentions scattered
+    /// across prose are not. Blank lines don't break a block (some tracklists space
+    /// their entries); any other non-timestamped line does.
     static func descriptionEntries(from description: String) -> [MixTrackEntry] {
-        let timestampRegex = /(?:(\d{1,2}):)?(\d{1,2}):([0-5]\d)(?![\d:])/
-        var candidates: [(startTime: TimeInterval, label: String)] = []
+        struct Candidate {
+            let startTime: TimeInterval
+            let label: String
+            let block: Int
+        }
 
-        for rawLine in description.split(whereSeparator: \.isNewline) {
+        let timestampRegex = /(?:(\d{1,2}):)?(\d{1,2}):([0-5]\d)(?![\d:])/
+        var candidates: [Candidate] = []
+        var block = 0
+
+        for rawLine in description.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline) {
             let line = String(rawLine)
+            if line.trimmingCharacters(in: .whitespaces).isEmpty {
+                continue
+            }
             // Swift Regex has no lookbehind; reject matches glued to preceding digits/colons or
             // trailing letters ("3:45pm") manually, and skip past invalid H:MM:SS minutes so a
             // bogus first match doesn't drop a line that also carries the real timestamp.
@@ -132,10 +144,16 @@ final class MixTracklistParser {
                     return false
                 }
                 return true
-            }) else { continue }
+            }) else {
+                block += 1
+                continue
+            }
             let match = matches[matchIndex]
             let hours = match.output.1.flatMap { Int($0) } ?? 0
-            guard let minutes = Int(match.output.2), let seconds = Int(match.output.3) else { continue }
+            guard let minutes = Int(match.output.2), let seconds = Int(match.output.3) else {
+                block += 1
+                continue
+            }
 
             // When an earlier candidate was rejected, the text before the accepted match still
             // contains that bogus fragment — keep only the suffix so it can't leak into the label.
@@ -144,8 +162,15 @@ final class MixTracklistParser {
                 from: line,
                 includePrefix: matchIndex == matches.startIndex
             )
-            guard !label.isEmpty else { continue }
-            candidates.append((TimeInterval(hours * 3600 + minutes * 60 + seconds), label))
+            guard !label.isEmpty else {
+                block += 1
+                continue
+            }
+            candidates.append(Candidate(
+                startTime: TimeInterval(hours * 3600 + minutes * 60 + seconds),
+                label: label,
+                block: block
+            ))
         }
 
         guard !candidates.isEmpty else { return [] }
@@ -154,7 +179,9 @@ final class MixTracklistParser {
         var bestCount = 1
         var runStart = 0
         for index in 1 ..< candidates.count {
-            if candidates[index].startTime <= candidates[index - 1].startTime {
+            if candidates[index].block != candidates[index - 1].block
+                || candidates[index].startTime <= candidates[index - 1].startTime
+            {
                 runStart = index
             }
             if index - runStart + 1 > bestCount {

--- a/Sources/Kaset/Services/Scrobbling/MixTracklistParser.swift
+++ b/Sources/Kaset/Services/Scrobbling/MixTracklistParser.swift
@@ -47,17 +47,17 @@ final class MixTracklistParser {
             return nil
         }
 
-        // Tier 1: YouTube chapters
-        if let tracklist = self.tracklist(fromChapters: watchNextData.chapters, videoId: videoId) {
+        if let tracklist = self.parseFromChapters(watchNextData, videoId: videoId) {
             self.cache[videoId] = .tracklist(tracklist)
             self.logger.info("Mix tracklist parsed from chapters: \(tracklist.entries.count) entries for \(videoId)")
             return tracklist
         }
 
-        // Tier 2: description timestamps
-        if let description = watchNextData.descriptionText,
-           let tracklist = self.tracklist(fromDescription: description, videoId: videoId)
-        {
+        if let tracklist = self.parseFromDescription(
+            watchNextData.descriptionText,
+            videoTitle: watchNextData.videoTitle,
+            videoId: videoId
+        ) {
             self.cache[videoId] = .tracklist(tracklist)
             self.logger.info("Mix tracklist parsed from description: \(tracklist.entries.count) entries for \(videoId)")
             return tracklist
@@ -69,16 +69,16 @@ final class MixTracklistParser {
 
     // MARK: - Tier 1: Chapter Extraction
 
-    private func tracklist(fromChapters chapters: [YouTubeChapter], videoId: String) -> MixTracklist? {
-        // Convert chapters to MixTrackEntry, computing endTime from the next chapter's startTime
+    private func parseFromChapters(
+        _ watchNextData: WatchNextData,
+        videoId: String
+    ) -> MixTracklist? {
+        let chapters = watchNextData.chapters
         let entries = chapters.enumerated().map { index, chapter -> MixTrackEntry in
             let endTime: TimeInterval? = if index + 1 < chapters.count {
                 chapter.endTime.map { min($0, chapters[index + 1].startTime) }
                     ?? chapters[index + 1].startTime
             } else {
-                // The final chapter has no following start time, but macro-marker data may
-                // still carry its explicit bound. Keep it so short closing tracks can qualify
-                // via the normal percentage threshold instead of requiring minSeconds.
                 chapter.endTime
             }
 
@@ -89,124 +89,228 @@ final class MixTracklistParser {
             )
         }
 
-        // A handful of chapters (intro/outro) isn't a real tracklist — MixTracklist.isMix decides.
         let tracklist = MixTracklist(videoId: videoId, entries: entries, source: .chapters)
         return tracklist.isMix ? tracklist : nil
     }
 
-    // MARK: - Tier 2: Description Timestamps
+    // MARK: - Tier 2: Description Timestamp Extraction
 
-    private func tracklist(fromDescription description: String, videoId: String) -> MixTracklist? {
-        let entries = Self.descriptionEntries(from: description)
-        let tracklist = MixTracklist(videoId: videoId, entries: entries, source: .description)
-        return tracklist.isMix ? tracklist : nil
+    private struct DescriptionLine {
+        let lineIndex: Int
+        let startTime: TimeInterval
+        let title: String
+        let artist: String?
+        let hasInlineHeading: Bool
     }
 
-    /// Extracts timestamped tracklist entries from a video description.
-    ///
-    /// Each line contributes at most one entry: its first plausible `H:MM:SS` or `M:SS`
-    /// timestamp becomes the start time and the rest of the line (minus wrapping brackets,
-    /// leading list numbering, and separator punctuation) becomes the artist/title label.
-    /// Because descriptions often contain unrelated timestamps (premiere times, social
-    /// links), only the longest run of consecutive lines with strictly increasing start
-    /// times is kept — a real tracklist is a monotonic block, stray mentions scattered
-    /// across prose are not. Blank lines don't break a block (some tracklists space
-    /// their entries); any other non-timestamped line does.
-    static func descriptionEntries(from description: String) -> [MixTrackEntry] {
-        struct Candidate {
-            let startTime: TimeInterval
-            let label: String
-            let block: Int
-        }
+    private struct DescriptionBlock {
+        let startLineIndex: Int
+        let lines: [DescriptionLine]
+        let hasHeading: Bool
+    }
 
-        let timestampRegex = /(?:(\d{1,2}):)?(\d{1,2}):([0-5]\d)(?![\d:])/
-        var candidates: [Candidate] = []
-        var block = 0
+    private func parseFromDescription(
+        _ description: String?,
+        videoTitle: String?,
+        videoId: String
+    ) -> MixTracklist? {
+        guard let description,
+              let regex = try? NSRegularExpression(
+                  pattern: #"(?:(\d+):)?(\d+):([0-5]\d)(?![\d:])"#
+              ),
+              let block = self.bestDescriptionTracklistBlock(
+                  in: description,
+                  videoTitle: videoTitle,
+                  regex: regex
+              )
+        else { return nil }
+        let lines = block.lines
 
-        for rawLine in description.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline) {
-            let line = String(rawLine)
-            if line.trimmingCharacters(in: .whitespaces).isEmpty {
-                continue
-            }
-            // Swift Regex has no lookbehind; reject matches glued to preceding digits/colons or
-            // trailing letters ("3:45pm") manually, and skip past invalid H:MM:SS minutes so a
-            // bogus first match doesn't drop a line that also carries the real timestamp.
-            let matches = line.matches(of: timestampRegex)
-            guard let matchIndex = matches.firstIndex(where: { candidate in
-                if candidate.range.lowerBound > line.startIndex {
-                    let before = line[line.index(before: candidate.range.lowerBound)]
-                    guard !before.isNumber, before != ":" else { return false }
-                }
-                if candidate.range.upperBound < line.endIndex, line[candidate.range.upperBound].isLetter {
-                    return false
-                }
-                if candidate.output.1 != nil, let minutes = Int(candidate.output.2), minutes >= 60 {
-                    return false
-                }
-                return true
-            }) else {
-                block += 1
-                continue
-            }
-            let match = matches[matchIndex]
-            let hours = match.output.1.flatMap { Int($0) } ?? 0
-            guard let minutes = Int(match.output.2), let seconds = Int(match.output.3) else {
-                block += 1
-                continue
-            }
-
-            // When an earlier candidate was rejected, the text before the accepted match still
-            // contains that bogus fragment — keep only the suffix so it can't leak into the label.
-            let label = Self.label(
-                byRemoving: match.range,
-                from: line,
-                includePrefix: matchIndex == matches.startIndex
-            )
-            guard !label.isEmpty else {
-                block += 1
-                continue
-            }
-            candidates.append(Candidate(
-                startTime: TimeInterval(hours * 3600 + minutes * 60 + seconds),
-                label: label,
-                block: block
-            ))
-        }
-
-        guard !candidates.isEmpty else { return [] }
-
-        var bestStart = 0
-        var bestCount = 1
-        var runStart = 0
-        for index in 1 ..< candidates.count {
-            if candidates[index].block != candidates[index - 1].block
-                || candidates[index].startTime <= candidates[index - 1].startTime
-            {
-                runStart = index
-            }
-            if index - runStart + 1 > bestCount {
-                bestCount = index - runStart + 1
-                bestStart = runStart
-            }
-        }
-
-        let run = candidates[bestStart ..< bestStart + bestCount]
-        return run.indices.map { index in
-            let candidate = run[index]
-            let parsed = MixTrackEntry.parseArtistTitle(from: candidate.label)
+        let entries = lines.enumerated().map { index, line in
+            // The final entry intentionally remains unbounded here. MixTracklist.effectiveDuration
+            // resolves it against the current video's duration during live/provisional playback.
+            let endTime = lines.indices.contains(index + 1) ? lines[index + 1].startTime : nil
             return MixTrackEntry(
-                startTime: candidate.startTime,
-                endTime: index + 1 < run.endIndex ? run[index + 1].startTime : nil,
-                title: parsed.title,
-                artist: parsed.artist,
+                startTime: line.startTime,
+                endTime: endTime,
+                title: line.title,
+                artist: line.artist,
                 source: .description
             )
         }
+        let tracklist = MixTracklist(
+            videoId: videoId,
+            entries: entries,
+            source: .description,
+            hasExplicitTracklistSignal: block.hasHeading
+        )
+        return tracklist.isMix ? tracklist : nil
+    }
+
+    private func bestDescriptionTracklistBlock(
+        in description: String,
+        videoTitle: String?,
+        regex: NSRegularExpression
+    ) -> DescriptionBlock? {
+        let rawLines = description.components(separatedBy: .newlines)
+        let blocks = self.descriptionBlocks(in: rawLines, regex: regex).flatMap { block in
+            let runs = self.increasingRuns(in: block.lines)
+            let headedRunIndex = block.hasHeading
+                ? runs.firstIndex(where: { $0.count >= MixTracklist.minEntryCount })
+                : nil
+            return runs.enumerated().compactMap { runIndex, lines -> DescriptionBlock? in
+                guard lines.count >= MixTracklist.minEntryCount else { return nil }
+                let hasHeading = runIndex == headedRunIndex
+                let artistCount = lines.count(where: { $0.artist != nil })
+                let agendaLineCount = lines.count(where: self.isLikelyAgendaLine)
+                let genericArtistCount = lines.count(where: { self.isGenericPresenterArtist($0.artist) })
+                let hasUnambiguousArtistStructure = artistCount == lines.count
+                    && genericArtistCount == 0
+                let hasAmbiguousAgendaSignal = !hasUnambiguousArtistStructure
+                    && agendaLineCount * 2 >= lines.count
+                let hasPresentationAgendaSignal = self.hasPresentationSignal(in: videoTitle)
+                    && agendaLineCount * 4 >= lines.count * 3
+                let hasStrongHeadinglessSignal = artistCount * 2 >= lines.count
+                    && !hasAmbiguousAgendaSignal
+                    && !hasPresentationAgendaSignal
+                guard hasHeading || hasStrongHeadinglessSignal else { return nil }
+                return DescriptionBlock(
+                    startLineIndex: lines[0].lineIndex,
+                    lines: lines,
+                    hasHeading: hasHeading
+                )
+            }
+        }
+
+        return blocks.max(by: { lhs, rhs in
+            if lhs.hasHeading != rhs.hasHeading {
+                return !lhs.hasHeading && rhs.hasHeading
+            }
+            if lhs.lines.count != rhs.lines.count {
+                return lhs.lines.count < rhs.lines.count
+            }
+            let lhsArtistCount = lhs.lines.count(where: { $0.artist != nil })
+            let rhsArtistCount = rhs.lines.count(where: { $0.artist != nil })
+            if lhsArtistCount != rhsArtistCount {
+                return lhsArtistCount < rhsArtistCount
+            }
+            return lhs.startLineIndex < rhs.startLineIndex
+        })
+    }
+
+    private func descriptionBlocks(
+        in rawLines: [String],
+        regex: NSRegularExpression
+    ) -> [DescriptionBlock] {
+        var blocks: [DescriptionBlock] = []
+        var currentLines: [DescriptionLine] = []
+        var currentStartIndex = 0
+        var currentHasHeading = false
+
+        for (index, rawLine) in rawLines.enumerated() {
+            if let line = self.descriptionLine(from: rawLine, lineIndex: index, regex: regex) {
+                if line.hasInlineHeading, !currentLines.isEmpty {
+                    blocks.append(DescriptionBlock(
+                        startLineIndex: currentStartIndex,
+                        lines: currentLines,
+                        hasHeading: currentHasHeading
+                    ))
+                    currentLines.removeAll(keepingCapacity: true)
+                }
+                if currentLines.isEmpty {
+                    currentStartIndex = index
+                    currentHasHeading = line.hasInlineHeading
+                        || self.hasTracklistHeading(before: index, in: rawLines)
+                }
+                currentLines.append(line)
+            } else if !currentLines.isEmpty,
+                      rawLine.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            {
+                continue
+            } else if !currentLines.isEmpty {
+                blocks.append(DescriptionBlock(
+                    startLineIndex: currentStartIndex,
+                    lines: currentLines,
+                    hasHeading: currentHasHeading
+                ))
+                currentLines.removeAll(keepingCapacity: true)
+                currentHasHeading = false
+            }
+        }
+        if !currentLines.isEmpty {
+            blocks.append(DescriptionBlock(
+                startLineIndex: currentStartIndex,
+                lines: currentLines,
+                hasHeading: currentHasHeading
+            ))
+        }
+        return blocks
+    }
+
+    private func increasingRuns(in lines: [DescriptionLine]) -> [[DescriptionLine]] {
+        guard let first = lines.first else { return [] }
+        var runs: [[DescriptionLine]] = []
+        var current = [first]
+
+        for line in lines.dropFirst() {
+            if let previous = current.last, line.startTime <= previous.startTime {
+                runs.append(current)
+                current = [line]
+            } else {
+                current.append(line)
+            }
+        }
+        runs.append(current)
+        return runs
+    }
+
+    private func descriptionLine(
+        from rawLine: String,
+        lineIndex: Int,
+        regex: NSRegularExpression
+    ) -> DescriptionLine? {
+        let searchRange = NSRange(rawLine.startIndex..., in: rawLine)
+        let matches = regex.matches(in: rawLine, range: searchRange)
+        guard let matchIndex = matches.firstIndex(where: { match in
+            guard let timestampRange = Range(match.range, in: rawLine) else { return false }
+            if timestampRange.lowerBound > rawLine.startIndex {
+                let before = rawLine[rawLine.index(before: timestampRange.lowerBound)]
+                guard !before.isNumber, before != ":" else { return false }
+            }
+            if timestampRange.upperBound < rawLine.endIndex,
+               rawLine[timestampRange.upperBound].isLetter
+            {
+                return false
+            }
+            return self.timeInterval(from: String(rawLine[timestampRange])) != nil
+        }) else { return nil }
+
+        let match = matches[matchIndex]
+        guard let timestampRange = Range(match.range, in: rawLine),
+              let startTime = self.timeInterval(from: String(rawLine[timestampRange]))
+        else { return nil }
+        let prefix = String(rawLine[..<timestampRange.lowerBound])
+        let hasInlineHeading = matchIndex == matches.startIndex
+            && self.isTracklistHeading(prefix)
+        let label = self.label(
+            byRemoving: timestampRange,
+            from: rawLine,
+            includePrefix: matchIndex == matches.startIndex && !hasInlineHeading
+        )
+        guard !label.isEmpty else { return nil }
+        let parsed = MixTrackEntry.parseArtistTitle(from: label)
+        return DescriptionLine(
+            lineIndex: lineIndex,
+            startTime: startTime,
+            title: parsed.title,
+            artist: parsed.artist,
+            hasInlineHeading: hasInlineHeading
+        )
     }
 
     /// Removes a matched timestamp (plus any wrapping brackets), leading list numbering,
     /// and leftover separator punctuation from a description line.
-    private static func label(
+    private func label(
         byRemoving timestampRange: Range<String.Index>,
         from line: String,
         includePrefix: Bool
@@ -225,6 +329,108 @@ final class MixTracklistParser {
         return String(includePrefix ? line[..<lower] + line[upper...] : line[upper...])
             .replacingOccurrences(of: #"^\s*\d{1,3}[.)]\s+"#, with: "", options: .regularExpression)
             .trimmingCharacters(in: CharacterSet(charactersIn: "-–—−|:•>~ \t"))
+    }
+
+    private func hasTracklistHeading(before startIndex: Int, in rawLines: [String]) -> Bool {
+        var index = startIndex
+        while index > rawLines.startIndex {
+            index -= 1
+            let line = rawLines[index]
+            if line.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                continue
+            }
+            return self.isTracklistHeading(line)
+        }
+        return false
+    }
+
+    private func isTracklistHeading(_ line: String) -> Bool {
+        let words = line.lowercased()
+            .components(separatedBy: CharacterSet.letters.inverted)
+            .filter { !$0.isEmpty }
+        return words == ["tracklist"]
+            || words == ["track", "list"]
+            || words == ["setlist"]
+            || words == ["set", "list"]
+    }
+
+    private func hasPresentationSignal(in title: String?) -> Bool {
+        guard let title else { return false }
+        let words = Set(
+            title.lowercased()
+                .components(separatedBy: CharacterSet.alphanumerics.inverted)
+                .filter { !$0.isEmpty }
+        )
+        let presentationWords: Set = [
+            "agenda", "conference", "course", "discussion", "interview", "keynote", "lecture",
+            "lesson", "panel", "podcast", "seminar", "summit", "talk", "tutorial", "webinar",
+            "workshop",
+        ]
+        return !words.isDisjoint(with: presentationWords)
+    }
+
+    private func isGenericPresenterArtist(_ artist: String?) -> Bool {
+        guard let normalizedArtist = artist?
+            .lowercased()
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        else { return false }
+        let genericArtists: Set = [
+            "guest", "host", "moderator", "panel", "presenter", "speaker", "sponsor",
+        ]
+        return genericArtists.contains(normalizedArtist)
+    }
+
+    private func isLikelyAgendaLine(_ line: DescriptionLine) -> Bool {
+        if self.isGenericPresenterArtist(line.artist) {
+            return true
+        }
+
+        let titleWords = Set(line.title.lowercased()
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { !$0.isEmpty })
+        let genericTitleWords: Set = [
+            "agenda", "chapter", "closing", "context", "demo", "discussion", "introduction",
+            "keynote", "opening", "panel", "questions", "remarks", "session", "sponsor", "topic",
+            "welcome",
+        ]
+        return !titleWords.isDisjoint(with: genericTitleWords)
+    }
+
+    private func timeInterval(from timestamp: String) -> TimeInterval? {
+        let rawComponents = timestamp.split(separator: ":", omittingEmptySubsequences: false)
+        guard rawComponents.count == 2 || rawComponents.count == 3 else { return nil }
+        var components: [Int64] = []
+        for rawComponent in rawComponents {
+            guard let component = Int64(rawComponent) else { return nil }
+            components.append(component)
+        }
+        guard components.count == 2 || components.count == 3,
+              components.last.map({ $0 < 60 }) == true
+        else { return nil }
+
+        if components.count == 3 {
+            guard components[1] < 60 else { return nil }
+            guard let hours = self.checkedProduct(components[0], 3600),
+                  let minutes = self.checkedProduct(components[1], 60),
+                  let subtotal = self.checkedSum(hours, minutes),
+                  let total = self.checkedSum(subtotal, components[2])
+            else { return nil }
+            return TimeInterval(total)
+        }
+        guard let minutes = self.checkedProduct(components[0], 60),
+              let total = self.checkedSum(minutes, components[1])
+        else { return nil }
+        return TimeInterval(total)
+    }
+
+    private func checkedProduct(_ lhs: Int64, _ rhs: Int64) -> Int64? {
+        let result = lhs.multipliedReportingOverflow(by: rhs)
+        return result.overflow ? nil : result.partialValue
+    }
+
+    private func checkedSum(_ lhs: Int64, _ rhs: Int64) -> Int64? {
+        let result = lhs.addingReportingOverflow(rhs)
+        return result.overflow ? nil : result.partialValue
     }
 
     // MARK: - Cache Management

--- a/Sources/Kaset/Services/Scrobbling/MixTracklistParser.swift
+++ b/Sources/Kaset/Services/Scrobbling/MixTracklistParser.swift
@@ -52,7 +52,8 @@ final class MixTracklistParser {
             // Convert chapters to MixTrackEntry, computing endTime from the next chapter's startTime
             let entries = chapters.enumerated().map { index, chapter -> MixTrackEntry in
                 let endTime: TimeInterval? = if index + 1 < chapters.count {
-                    chapters[index + 1].startTime
+                    chapter.endTime.map { min($0, chapters[index + 1].startTime) }
+                        ?? chapters[index + 1].startTime
                 } else {
                     // The final chapter has no following start time, but macro-marker data may
                     // still carry its explicit bound. Keep it so short closing tracks can qualify

--- a/Sources/Kaset/Services/Scrobbling/PlaybackScrobbleTracker.swift
+++ b/Sources/Kaset/Services/Scrobbling/PlaybackScrobbleTracker.swift
@@ -51,13 +51,14 @@ struct PlaybackScrobbleTracker {
     /// Records a progress observation. Counts only small positive deltas that also fall within a
     /// small wall-clock window, so seeks and suspend/resume gaps can't inflate play time. Pausing
     /// (isPlaying == false) drops the wall-clock baseline so the paused span isn't counted on resume.
-    mutating func accumulate(progress: TimeInterval, isPlaying: Bool, now: Date) {
+    @discardableResult
+    mutating func accumulate(progress: TimeInterval, isPlaying: Bool, now: Date) -> TimeInterval {
         defer {
             self.lastProgress = progress
             self.lastProgressTime = isPlaying ? now : nil
         }
 
-        guard isPlaying, let lastTime = self.lastProgressTime else { return }
+        guard isPlaying, let lastTime = self.lastProgressTime else { return 0 }
 
         let wallClockDelta = now.timeIntervalSince(lastTime)
         let progressDelta = progress - self.lastProgress
@@ -65,23 +66,42 @@ struct PlaybackScrobbleTracker {
         // A normal playback tick advances ~1s or less; anything larger is a seek or a gap.
         if progressDelta > 0, progressDelta < 2.0, wallClockDelta < 2.0 {
             self.accumulatedPlayTime += progressDelta
+            return progressDelta
         }
+        return 0
     }
 
     /// Whether accumulated play time has reached the scrobble threshold for the given duration.
     /// Pure — the coordinator calls this each poll with the item's current best-known duration
     /// (which for whole tracks may only become available after playback starts).
     func meetsThreshold(duration: TimeInterval?, thresholds: Thresholds) -> Bool {
+        Self.meetsThreshold(
+            accumulatedPlayTime: self.accumulatedPlayTime,
+            duration: duration,
+            thresholds: thresholds
+        )
+    }
+
+    static func meetsThreshold(
+        accumulatedPlayTime: TimeInterval,
+        duration: TimeInterval?,
+        thresholds: Thresholds
+    ) -> Bool {
         let duration = duration ?? 0
 
         if duration <= 0 {
-            return thresholds.allowsUnknownDuration && self.accumulatedPlayTime >= thresholds.minSeconds
+            return thresholds.allowsUnknownDuration && accumulatedPlayTime >= thresholds.minSeconds
         }
 
         guard duration >= thresholds.minScrobbleDuration else { return false }
 
-        return self.accumulatedPlayTime >= duration * thresholds.percent
-            || self.accumulatedPlayTime >= thresholds.minSeconds
+        return accumulatedPlayTime >= duration * thresholds.percent
+            || accumulatedPlayTime >= thresholds.minSeconds
+    }
+
+    /// Adds already-verified playback (for example, samples captured while mix metadata loaded).
+    mutating func creditVerifiedPlayTime(_ duration: TimeInterval) {
+        self.accumulatedPlayTime += max(0, duration)
     }
 
     /// Latches the scrobbled flag once the coordinator has enqueued the scrobble.
@@ -89,16 +109,20 @@ struct PlaybackScrobbleTracker {
         self.hasScrobbled = true
     }
 
+    /// Clears a provisional latch after final duration data makes the earlier threshold invalid.
+    mutating func clearScrobbledLatch() {
+        self.hasScrobbled = false
+    }
+
     /// Latches the now-playing flag once the coordinator has sent the update.
     mutating func markNowPlayingSent() {
         self.hasSentNowPlaying = true
     }
 
-    /// Resets accumulation and both latches after a seek within the same item, so the threshold
-    /// clock restarts. Preserves `startTime` and `lastProgress`.
+    /// Resets accumulation after a seek within the same play, so skipped time cannot satisfy the
+    /// threshold. Preserves latches, `startTime`, and `lastProgress`; a confirmed replay must use
+    /// a fresh tracker so it receives a new timestamp and can scrobble independently.
     mutating func resetForSeek() {
         self.accumulatedPlayTime = 0
-        self.hasScrobbled = false
-        self.hasSentNowPlaying = false
     }
 }

--- a/Sources/Kaset/Services/Scrobbling/PlaybackScrobbleTracker.swift
+++ b/Sources/Kaset/Services/Scrobbling/PlaybackScrobbleTracker.swift
@@ -1,0 +1,104 @@
+import Foundation
+
+// MARK: - PlaybackScrobbleTracker
+
+/// Accumulates verified play time for a single playable item — a whole track or one sub-track
+/// within a mix — and decides when it has been played enough to scrobble.
+///
+/// This is a pure state machine: it owns no queue, no network, and no clock. The
+/// `ScrobblingCoordinator` drives it (feeding progress observations and the wall clock) and owns
+/// the side effects (enqueue, now-playing fan-out). It is the single source of truth for the
+/// accumulate / seek-rejection / threshold / latch logic that previously lived twice — once for
+/// single-track playback and once for mix sub-tracks — and had already drifted between the two.
+struct PlaybackScrobbleTracker {
+    /// Thresholds controlling when accumulated play time counts as a scrobble.
+    struct Thresholds {
+        /// Fraction of the item's duration that must be played (e.g. 0.5).
+        let percent: Double
+        /// Absolute play time that always qualifies, regardless of duration.
+        let minSeconds: TimeInterval
+        /// Minimum item duration Last.fm will accept (items shorter than this never scrobble).
+        var minScrobbleDuration: TimeInterval = 30
+        /// When true, an unknown/zero duration still qualifies via `minSeconds` alone. Mix
+        /// sub-tracks (whose final entry has no known end) rely on this; whole tracks always
+        /// have a duration and set it false.
+        var allowsUnknownDuration = false
+    }
+
+    /// When accumulation started — used as the scrobble timestamp.
+    let startTime: Date
+
+    /// Verified play time accumulated so far, in seconds.
+    private(set) var accumulatedPlayTime: TimeInterval = 0
+
+    /// Whether this item has already been scrobbled (latched to fire once).
+    private(set) var hasScrobbled = false
+
+    /// Whether a "now playing" update has been sent for this item (latched to fire once).
+    private(set) var hasSentNowPlaying = false
+
+    /// Last observed progress value — read by the coordinator for replay/seek detection.
+    private(set) var lastProgress: TimeInterval
+
+    /// Wall-clock time of the last counted progress update; nil while paused or before the first.
+    private var lastProgressTime: Date?
+
+    init(startTime: Date, initialProgress: TimeInterval = 0) {
+        self.startTime = startTime
+        self.lastProgress = initialProgress
+    }
+
+    /// Records a progress observation. Counts only small positive deltas that also fall within a
+    /// small wall-clock window, so seeks and suspend/resume gaps can't inflate play time. Pausing
+    /// (isPlaying == false) drops the wall-clock baseline so the paused span isn't counted on resume.
+    mutating func accumulate(progress: TimeInterval, isPlaying: Bool, now: Date) {
+        defer {
+            self.lastProgress = progress
+            self.lastProgressTime = isPlaying ? now : nil
+        }
+
+        guard isPlaying, let lastTime = self.lastProgressTime else { return }
+
+        let wallClockDelta = now.timeIntervalSince(lastTime)
+        let progressDelta = progress - self.lastProgress
+
+        // A normal playback tick advances ~1s or less; anything larger is a seek or a gap.
+        if progressDelta > 0, progressDelta < 2.0, wallClockDelta < 2.0 {
+            self.accumulatedPlayTime += progressDelta
+        }
+    }
+
+    /// Whether accumulated play time has reached the scrobble threshold for the given duration.
+    /// Pure — the coordinator calls this each poll with the item's current best-known duration
+    /// (which for whole tracks may only become available after playback starts).
+    func meetsThreshold(duration: TimeInterval?, thresholds: Thresholds) -> Bool {
+        let duration = duration ?? 0
+
+        if duration <= 0 {
+            return thresholds.allowsUnknownDuration && self.accumulatedPlayTime >= thresholds.minSeconds
+        }
+
+        guard duration >= thresholds.minScrobbleDuration else { return false }
+
+        return self.accumulatedPlayTime >= duration * thresholds.percent
+            || self.accumulatedPlayTime >= thresholds.minSeconds
+    }
+
+    /// Latches the scrobbled flag once the coordinator has enqueued the scrobble.
+    mutating func markScrobbled() {
+        self.hasScrobbled = true
+    }
+
+    /// Latches the now-playing flag once the coordinator has sent the update.
+    mutating func markNowPlayingSent() {
+        self.hasSentNowPlaying = true
+    }
+
+    /// Resets accumulation and both latches after a seek within the same item, so the threshold
+    /// clock restarts. Preserves `startTime` and `lastProgress`.
+    mutating func resetForSeek() {
+        self.accumulatedPlayTime = 0
+        self.hasScrobbled = false
+        self.hasSentNowPlaying = false
+    }
+}

--- a/Sources/Kaset/Services/Scrobbling/ProvisionalMixPlaybackHistory.swift
+++ b/Sources/Kaset/Services/Scrobbling/ProvisionalMixPlaybackHistory.swift
@@ -1,0 +1,193 @@
+import Foundation
+
+/// Verified playback captured while the coordinator is still determining whether a long video is
+/// a mix. Once chapters arrive, the progress ranges can be apportioned to their real sub-tracks.
+struct ProvisionalMixPlaybackHistory {
+    struct Credit {
+        var accumulatedPlayTime: TimeInterval = 0
+        var startTime: Date?
+        var endProgress: TimeInterval = 0
+        var hasScrobbled = false
+        var isActiveAtEnd = false
+    }
+
+    private struct Segment {
+        let startProgress: TimeInterval
+        var endProgress: TimeInterval
+        let startTime: Date
+        var isDiscontinuity = false
+    }
+
+    private var segments: [Segment] = []
+
+    var isEmpty: Bool {
+        self.segments.isEmpty
+    }
+
+    var hasPlayback: Bool {
+        self.segments.contains { !$0.isDiscontinuity && $0.endProgress > $0.startProgress }
+    }
+
+    mutating func record(
+        startProgress: TimeInterval,
+        endProgress: TimeInterval,
+        startTime: Date
+    ) {
+        let segment = Segment(
+            startProgress: startProgress,
+            endProgress: endProgress,
+            startTime: startTime
+        )
+        if let lastIndex = self.segments.indices.last {
+            let lastSegment = self.segments[lastIndex]
+            let expectedEndTime = lastSegment.startTime.addingTimeInterval(
+                lastSegment.endProgress - lastSegment.startProgress
+            )
+            let isProgressContiguous = abs(lastSegment.endProgress - segment.startProgress) < 0.001
+            let isTimeContiguous = abs(segment.startTime.timeIntervalSince(expectedEndTime)) < 2
+            if !lastSegment.isDiscontinuity, isProgressContiguous, isTimeContiguous {
+                self.segments[lastIndex].endProgress = segment.endProgress
+                return
+            }
+        }
+
+        self.segments.append(segment)
+    }
+
+    mutating func recordDiscontinuity(at progress: TimeInterval, startTime: Date) {
+        self.segments.append(Segment(
+            startProgress: progress,
+            endProgress: progress,
+            startTime: startTime,
+            isDiscontinuity: true
+        ))
+    }
+
+    mutating func removeAll() {
+        self.segments.removeAll()
+    }
+
+    func credits(
+        tracklist: MixTracklist,
+        videoDuration: TimeInterval?,
+        thresholds: PlaybackScrobbleTracker.Thresholds
+    ) -> [UUID: [Credit]] {
+        var credits: [UUID: [Credit]] = [:]
+
+        for (index, entry) in tracklist.entries.enumerated() {
+            let isFinalEntry = tracklist.entries.last?.id == entry.id
+            let nextEntryStart = tracklist.entries.indices.contains(index + 1)
+                ? tracklist.entries[index + 1].startTime
+                : nil
+            let boundedEntryEnd = entry.endTime ?? nextEntryStart ?? (isFinalEntry ? videoDuration : nil)
+            let duration = tracklist.effectiveDuration(for: entry, videoDuration: videoDuration)
+            var currentCredit: Credit?
+            var lastOverlapEnd: TimeInterval?
+            var completedScrobbledPlay = false
+
+            for segment in self.segments {
+                if segment.isDiscontinuity {
+                    if let finishedCredit = currentCredit {
+                        credits[entry.id, default: []].append(finishedCredit)
+                        completedScrobbledPlay = completedScrobbledPlay || finishedCredit.hasScrobbled
+                        currentCredit = nil
+                    }
+                    lastOverlapEnd = segment.startProgress
+                    continue
+                }
+
+                let entryEnd = boundedEntryEnd ?? (isFinalEntry ? segment.endProgress : nil)
+                guard let entryEnd, entryEnd > entry.startTime else { continue }
+                let overlapStart = max(segment.startProgress, entry.startTime)
+                let overlapEnd = min(segment.endProgress, entryEnd)
+                guard overlapEnd > overlapStart else {
+                    if let finishedCredit = currentCredit {
+                        credits[entry.id, default: []].append(finishedCredit)
+                        completedScrobbledPlay = completedScrobbledPlay || finishedCredit.hasScrobbled
+                        currentCredit = nil
+                        lastOverlapEnd = nil
+                    }
+                    continue
+                }
+
+                let overlapStartTime = segment.startTime.addingTimeInterval(overlapStart - segment.startProgress)
+                let progressJump = lastOverlapEnd.map { overlapStart - $0 } ?? 0
+                let isSignificantJump = abs(progressJump) > 5
+
+                if let credit = currentCredit, isSignificantJump {
+                    let isReplay = credit.hasScrobbled
+                        && progressJump < -5
+                        && overlapStart <= entry.startTime + 5
+                    if isReplay {
+                        credits[entry.id, default: []].append(credit)
+                        currentCredit = nil
+                    } else if credit.hasScrobbled {
+                        lastOverlapEnd = overlapEnd
+                        continue
+                    } else {
+                        currentCredit = nil
+                    }
+                }
+
+                if currentCredit == nil {
+                    if completedScrobbledPlay {
+                        guard overlapStart <= entry.startTime + 5 else {
+                            lastOverlapEnd = overlapEnd
+                            continue
+                        }
+                        completedScrobbledPlay = false
+                    }
+                    currentCredit = Credit(startTime: overlapStartTime, endProgress: overlapEnd)
+                }
+                currentCredit?.accumulatedPlayTime += overlapEnd - overlapStart
+                currentCredit?.endProgress = overlapEnd
+                if let accumulatedPlayTime = currentCredit?.accumulatedPlayTime {
+                    currentCredit?.hasScrobbled = PlaybackScrobbleTracker.meetsThreshold(
+                        accumulatedPlayTime: accumulatedPlayTime,
+                        duration: duration,
+                        thresholds: thresholds
+                    )
+                }
+                lastOverlapEnd = overlapEnd
+            }
+
+            if var currentCredit {
+                currentCredit.isActiveAtEnd = true
+                credits[entry.id, default: []].append(currentCredit)
+            }
+        }
+
+        return credits
+    }
+
+    func scrobbles(
+        tracklist: MixTracklist,
+        song: Song,
+        videoDuration: TimeInterval?,
+        thresholds: PlaybackScrobbleTracker.Thresholds
+    ) -> [ScrobbleTrack] {
+        let credits = self.credits(
+            tracklist: tracklist,
+            videoDuration: videoDuration,
+            thresholds: thresholds
+        )
+
+        var scrobbles: [ScrobbleTrack] = []
+        for entry in tracklist.entries {
+            let duration = tracklist.effectiveDuration(for: entry, videoDuration: videoDuration)
+            for credit in credits[entry.id] ?? [] {
+                guard credit.hasScrobbled, let startTime = credit.startTime else { continue }
+
+                scrobbles.append(ScrobbleTrack(
+                    title: entry.title,
+                    artist: entry.artist ?? song.artistsDisplay,
+                    album: nil,
+                    duration: duration,
+                    timestamp: startTime,
+                    videoId: song.videoId
+                ))
+            }
+        }
+        return scrobbles
+    }
+}

--- a/Sources/Kaset/Services/Scrobbling/ScrobblingCoordinator+DeferredFinalization.swift
+++ b/Sources/Kaset/Services/Scrobbling/ScrobblingCoordinator+DeferredFinalization.swift
@@ -1,0 +1,175 @@
+import Foundation
+
+extension ScrobblingCoordinator {
+    func prepareForTermination(timeout: Duration = .seconds(3)) async {
+        self.stopMonitoring(finalizeCurrentTrack: true)
+        let deadline = ContinuousClock.now + timeout
+        while !self.pendingMixFinalizations.isEmpty, ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(25))
+        }
+
+        guard !self.pendingMixFinalizations.isEmpty else { return }
+        for pending in self.pendingMixFinalizations.values {
+            pending.parseTask.cancel()
+            pending.finalizationTask.cancel()
+            for scrobble in pending.fallbackScrobbles {
+                self.queue.enqueue(scrobble)
+            }
+        }
+        self.pendingMixFinalizations.removeAll()
+    }
+
+    func deferPendingRegularTrackFinalizationIfNeeded() -> Bool {
+        guard case .parsing = self.mixDetectionState,
+              let parseTask = self.mixParseTask,
+              let tracker = self.trackTracker,
+              let song = self.trackedSong
+        else { return false }
+
+        let duration = self.trackedVideoDuration ?? song.duration.flatMap { $0 > 0 ? $0 : nil }
+        let provisionalMixHistory = self.provisionalMixHistory
+        let trackThresholds = self.trackThresholds
+        let mixEntryThresholds = self.mixEntryThresholds
+        let timeout = self.mixParseTimeout
+        var pendingWholeTrackPlays = self.pendingWholeTrackPlays
+        if let lastIndex = pendingWholeTrackPlays.indices.last,
+           pendingWholeTrackPlays[lastIndex].tracker.startTime == tracker.startTime
+        {
+            pendingWholeTrackPlays[lastIndex] = PendingWholeTrackPlay(
+                tracker: tracker,
+                song: pendingWholeTrackPlays[lastIndex].song
+            )
+        }
+        let currentWholeTrackEligible = !tracker.hasScrobbled
+            && tracker.meetsThreshold(duration: duration, thresholds: trackThresholds)
+        guard currentWholeTrackEligible
+            || !pendingWholeTrackPlays.isEmpty
+            || provisionalMixHistory.hasPlayback
+        else { return false }
+
+        self.mixParseGeneration += 1
+        self.mixParseMonitorTask?.cancel()
+        self.mixParseMonitorTask = nil
+        self.mixParseTimeoutTask?.cancel()
+        self.mixParseTimeoutTask = nil
+        self.mixParseTask = nil
+        self.mixParseStartedWithoutDuration = false
+        self.pendingWholeTrackPlays.removeAll()
+
+        var fallbackScrobbles = self.wholeTrackScrobbles(
+            from: pendingWholeTrackPlays,
+            duration: duration,
+            thresholds: trackThresholds
+        )
+        if currentWholeTrackEligible {
+            fallbackScrobbles.append(ScrobbleTrack(
+                title: song.title,
+                artist: song.artistsDisplay,
+                album: song.album?.title,
+                duration: duration,
+                timestamp: tracker.startTime,
+                videoId: song.videoId
+            ))
+        }
+
+        let id = UUID()
+        let queue = self.queue
+        let logger = DiagnosticsLogger.scrobbling
+        let finalizationTask = Task { @MainActor [weak self] in
+            let outcome = await Self.awaitDeferredMixParse(parseTask, timeout: timeout)
+            self?.pendingMixFinalizations.removeValue(forKey: id)
+            guard !Task.isCancelled else { return }
+
+            let tracklist: MixTracklist?
+            switch outcome {
+            case let .parsed(parsedTracklist):
+                tracklist = parsedTracklist
+            case .timedOut:
+                tracklist = nil
+                logger.warning("Deferred mix parse timed out; committing whole-track fallback for \(song.title)")
+            }
+
+            let shouldUseMixResult = Self.shouldUseDeferredMixResult(
+                tracklist,
+                songDuration: song.duration,
+                playerDuration: duration
+            )
+            if let tracklist, shouldUseMixResult {
+                let scrobbles = provisionalMixHistory.scrobbles(
+                    tracklist: tracklist,
+                    song: song,
+                    videoDuration: duration,
+                    thresholds: mixEntryThresholds
+                )
+                for scrobble in scrobbles {
+                    queue.enqueue(scrobble)
+                }
+                guard !scrobbles.isEmpty else { return }
+                logger.info("Deferred mix finalized after track exit: \(scrobbles.count) sub-tracks for \(song.title)")
+            } else {
+                for scrobble in fallbackScrobbles {
+                    queue.enqueue(scrobble)
+                }
+                guard !fallbackScrobbles.isEmpty else { return }
+                logger.info("Deferred whole-track scrobbles finalized after mix detection: \(song.title)")
+            }
+            self?.scheduleQueueFlushIfNeeded()
+        }
+        self.pendingMixFinalizations[id] = PendingMixFinalization(
+            parseTask: parseTask,
+            finalizationTask: finalizationTask,
+            fallbackScrobbles: fallbackScrobbles
+        )
+        return true
+    }
+
+    private static func shouldUseDeferredMixResult(
+        _ tracklist: MixTracklist?,
+        songDuration: TimeInterval?,
+        playerDuration: TimeInterval?
+    ) -> Bool {
+        guard let tracklist, tracklist.isMix else { return false }
+        let decision = Self.mixDurationDecision(
+            for: tracklist,
+            songDuration: songDuration,
+            playerDuration: playerDuration,
+            phase: .finalization
+        )
+        if case .mix = decision {
+            return true
+        }
+        return false
+    }
+
+    private static func awaitDeferredMixParse(
+        _ parseTask: Task<MixTracklist?, Never>,
+        timeout: Duration
+    ) async -> DeferredMixParseOutcome {
+        let pair = AsyncStream<DeferredMixParseOutcome>.makeStream(
+            bufferingPolicy: .bufferingNewest(1)
+        )
+        let parseWaiter = Task { @MainActor in
+            let tracklist = await parseTask.value
+            guard !Task.isCancelled else { return }
+            pair.continuation.yield(.parsed(tracklist))
+        }
+        let timeoutWaiter = Task { @MainActor in
+            do {
+                try await Task.sleep(for: timeout)
+            } catch {
+                return
+            }
+            pair.continuation.yield(.timedOut)
+        }
+
+        var iterator = pair.stream.makeAsyncIterator()
+        let outcome = await iterator.next() ?? .timedOut
+        parseWaiter.cancel()
+        timeoutWaiter.cancel()
+        pair.continuation.finish()
+        if case .timedOut = outcome {
+            parseTask.cancel()
+        }
+        return outcome
+    }
+}

--- a/Sources/Kaset/Services/Scrobbling/ScrobblingCoordinator+DetectionScheduling.swift
+++ b/Sources/Kaset/Services/Scrobbling/ScrobblingCoordinator+DetectionScheduling.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+extension ScrobblingCoordinator {
+    func scheduleMixParseTimeout(for track: Song, videoId: String, generation: Int) {
+        let timeout = self.mixParseTimeout
+        self.mixParseTimeoutTask = Task { @MainActor [weak self] in
+            do {
+                try await Task.sleep(for: timeout)
+            } catch {
+                return
+            }
+            guard let self,
+                  self.mixParseGeneration == generation,
+                  self.currentTrackVideoId == videoId,
+                  case .parsing = self.mixDetectionState
+            else { return }
+
+            self.mixParseGeneration += 1
+            self.mixParseTimeoutTask = nil
+            self.mixParseMonitorTask?.cancel()
+            self.mixParseMonitorTask = nil
+            self.mixParseTask?.cancel()
+            self.mixParseTask = nil
+            self.mixParseStartedWithoutDuration = false
+            self.logger.warning("Mix parse timed out; resuming whole-track scrobbling for \(track.title)")
+            self.resolveAsNotMix()
+            self.pollPlayerState()
+        }
+    }
+
+    func scheduleUnknownDurationParse(for track: Song) {
+        guard self.mixTracklistParser != nil else { return }
+        let videoId = track.videoId
+        let delay = self.unknownDurationParseDelay
+        self.unknownDurationParseTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: delay)
+            guard let self,
+                  !Task.isCancelled,
+                  self.currentTrackVideoId == videoId,
+                  case .unresolved = self.mixDetectionState,
+                  let parser = self.mixTracklistParser,
+                  let trackedSong = self.trackedSong
+            else { return }
+            guard self.requiredPlaybackStateSequence == nil else {
+                self.unknownDurationParseTask = nil
+                return
+            }
+            if let songDuration = trackedSong.duration, songDuration > 0 {
+                if songDuration > Self.mixMinimumVideoDuration {
+                    self.startMixParse(for: trackedSong, parser: parser, startedWithoutDuration: false)
+                } else {
+                    self.resolveAsNotMix()
+                    self.pollPlayerState()
+                }
+            } else {
+                self.startMixParse(for: trackedSong, parser: parser, startedWithoutDuration: true)
+            }
+        }
+    }
+
+    /// Gives authoritative duration metadata a short grace period after a fallback parse. Once the
+    /// grace period completes, later duration observations resolve directly without starting more
+    /// timers, while tracklist bounds can independently prove a long mix.
+    func scheduleAwaitingDurationConfirmation(for track: Song) {
+        let videoId = track.videoId
+        let expectedTitle = track.title
+        let expectedArtist = track.artistsDisplay
+        let delay = self.unknownDurationParseDelay
+        self.durationConfirmationTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: delay)
+            guard let self,
+                  !Task.isCancelled,
+                  self.currentTrackVideoId == videoId,
+                  case let .awaitingDuration(tracklist) = self.mixDetectionState,
+                  let currentTrack = self.playerService.currentTrack,
+                  currentTrack.videoId == videoId,
+                  currentTrack.title == expectedTitle,
+                  currentTrack.artistsDisplay == expectedArtist
+            else { return }
+
+            self.durationConfirmationTask = nil
+            self.durationConfirmationCompleted = true
+            let decision = Self.mixDurationDecision(
+                for: tracklist,
+                songDuration: currentTrack.duration,
+                playerDuration: self.scopedPlayerDuration(for: currentTrack),
+                phase: .activeAfterGrace
+            )
+            self.applyMixDurationDecision(decision, tracklist: tracklist)
+            self.pollPlayerState()
+        }
+    }
+}

--- a/Sources/Kaset/Services/Scrobbling/ScrobblingCoordinator+NowPlaying.swift
+++ b/Sources/Kaset/Services/Scrobbling/ScrobblingCoordinator+NowPlaying.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+extension ScrobblingCoordinator {
+    func cancelNowPlayingTasks() {
+        self.nowPlayingTasks.forEach { $0.cancel() }
+        self.nowPlayingTasks.removeAll()
+    }
+
+    /// Sends a "now playing" update for a mix sub-track.
+    func sendMixNowPlaying(_ entry: MixTrackEntry, song: Song) {
+        guard var tracker = self.mixEntryTracker else { return }
+        tracker.markNowPlayingSent()
+        self.mixEntryTracker = tracker
+        let duration = self.mixEntryDuration(entry, song: song)
+
+        let scrobbleTrack = ScrobbleTrack(
+            title: entry.title,
+            artist: entry.artist ?? song.artistsDisplay,
+            album: nil,
+            duration: duration,
+            timestamp: tracker.startTime,
+            videoId: song.videoId
+        )
+
+        // Cancel any in-flight now-playing tasks from a previous sub-track
+        self.cancelNowPlayingTasks()
+
+        for service in self.enabledConnectedServices {
+            let task = Task { @MainActor [weak self] in
+                guard let self else { return }
+                do {
+                    try await service.updateNowPlaying(scrobbleTrack)
+                } catch is CancellationError {
+                    // Expected when sub-track changes
+                } catch {
+                    self.logger.debug("Mix now playing failed for \(service.serviceName) (non-critical): \(error.localizedDescription)")
+                }
+            }
+            self.nowPlayingTasks.append(task)
+        }
+    }
+
+    // MARK: - Now Playing
+
+    func sendNowPlaying(_ track: Song) {
+        guard var tracker = self.trackTracker else { return }
+        tracker.markNowPlayingSent()
+        self.trackTracker = tracker
+
+        let scrobbleTrack = ScrobbleTrack(from: track, timestamp: tracker.startTime)
+
+        // Cancel any in-flight now-playing tasks from a previous track
+        self.cancelNowPlayingTasks()
+
+        // Send now-playing to all enabled+connected services
+        for service in self.enabledConnectedServices {
+            let task = Task { @MainActor [weak self] in
+                guard let self else { return }
+                do {
+                    try await service.updateNowPlaying(scrobbleTrack)
+                } catch is CancellationError {
+                    // Expected when coordinator stops or track changes
+                } catch {
+                    self.logger.debug("Now playing update failed for \(service.serviceName) (non-critical): \(error.localizedDescription)")
+                }
+            }
+            self.nowPlayingTasks.append(task)
+        }
+    }
+}

--- a/Sources/Kaset/Services/Scrobbling/ScrobblingCoordinator+PendingWholeTrack.swift
+++ b/Sources/Kaset/Services/Scrobbling/ScrobblingCoordinator+PendingWholeTrack.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+extension ScrobblingCoordinator {
+    func revalidatePendingWholeTrackLatchIfNeeded() {
+        switch self.mixDetectionState {
+        case .unresolved, .parsing, .awaitingDuration:
+            break
+        case .notMix, .mix:
+            return
+        }
+        guard var tracker = self.trackTracker,
+              tracker.hasScrobbled,
+              !tracker.meetsThreshold(
+                  duration: self.trackedVideoDuration,
+                  thresholds: self.trackThresholds
+              )
+        else { return }
+
+        tracker.clearScrobbledLatch()
+        self.trackTracker = tracker
+        self.pendingWholeTrackPlays.removeAll {
+            $0.tracker.startTime == tracker.startTime
+        }
+    }
+
+    func refreshPendingWholeTrackPlay(with tracker: PlaybackScrobbleTracker) {
+        guard let lastIndex = self.pendingWholeTrackPlays.indices.last,
+              self.pendingWholeTrackPlays[lastIndex].tracker.startTime == tracker.startTime
+        else { return }
+        self.pendingWholeTrackPlays[lastIndex] = PendingWholeTrackPlay(
+            tracker: tracker,
+            song: self.pendingWholeTrackPlays[lastIndex].song
+        )
+    }
+
+    func capturePendingWholeTrackScrobbleIfNeeded(_ track: Song) {
+        guard var tracker = self.trackTracker,
+              !tracker.hasScrobbled,
+              let duration = self.trackedVideoDuration,
+              tracker.meetsThreshold(duration: duration, thresholds: self.trackThresholds)
+        else { return }
+
+        tracker.markScrobbled()
+        self.trackTracker = tracker
+        self.pendingWholeTrackPlays.append(PendingWholeTrackPlay(tracker: tracker, song: track))
+    }
+
+    func commitPendingWholeTrackScrobbles() {
+        guard !self.pendingWholeTrackPlays.isEmpty else { return }
+        let duration = self.trackedVideoDuration
+        var plays = self.pendingWholeTrackPlays
+        if let tracker = self.trackTracker,
+           let lastIndex = plays.indices.last,
+           plays[lastIndex].tracker.startTime == tracker.startTime
+        {
+            plays[lastIndex] = PendingWholeTrackPlay(tracker: tracker, song: plays[lastIndex].song)
+        }
+        for scrobble in self.wholeTrackScrobbles(
+            from: plays,
+            duration: duration,
+            thresholds: self.trackThresholds
+        ) {
+            self.queue.enqueue(scrobble)
+        }
+        if var tracker = self.trackTracker,
+           tracker.hasScrobbled,
+           !tracker.meetsThreshold(duration: duration, thresholds: self.trackThresholds)
+        {
+            tracker.clearScrobbledLatch()
+            self.trackTracker = tracker
+        }
+        self.pendingWholeTrackPlays.removeAll()
+        self.scheduleQueueFlushIfNeeded()
+    }
+
+    func wholeTrackScrobbles(
+        from plays: [PendingWholeTrackPlay],
+        duration: TimeInterval?,
+        thresholds: PlaybackScrobbleTracker.Thresholds
+    ) -> [ScrobbleTrack] {
+        plays.compactMap { play in
+            guard play.tracker.meetsThreshold(duration: duration, thresholds: thresholds) else { return nil }
+            return ScrobbleTrack(
+                title: play.song.title,
+                artist: play.song.artistsDisplay,
+                album: play.song.album?.title,
+                duration: duration,
+                timestamp: play.tracker.startTime,
+                videoId: play.song.videoId
+            )
+        }
+    }
+}

--- a/Sources/Kaset/Services/Scrobbling/ScrobblingCoordinator+ProvisionalMix.swift
+++ b/Sources/Kaset/Services/Scrobbling/ScrobblingCoordinator+ProvisionalMix.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+extension ScrobblingCoordinator {
+    func consumeProvisionalPlayback(for tracklist: MixTracklist, song: Song?) {
+        guard let song, self.playerService.playbackStateVideoId == song.videoId else { return }
+        guard self.provisionalMixHistory.hasPlayback else {
+            self.provisionalMixHistory.removeAll()
+            return
+        }
+        defer { self.provisionalMixHistory.removeAll() }
+        let videoDuration = self.videoDuration(for: song)
+
+        let credits = self.provisionalMixHistory.credits(
+            tracklist: tracklist,
+            videoDuration: videoDuration,
+            thresholds: self.mixEntryThresholds
+        )
+        let activeEntryId = tracklist.entry(at: self.playerService.progress)?.id
+        var enqueuedCount = 0
+
+        for entry in tracklist.entries {
+            let duration = tracklist.effectiveDuration(for: entry, videoDuration: videoDuration)
+            let entryCredits = credits[entry.id] ?? []
+            for credit in entryCredits {
+                guard let startTime = credit.startTime else { continue }
+                if credit.hasScrobbled {
+                    self.queue.enqueue(ScrobbleTrack(
+                        title: entry.title,
+                        artist: entry.artist ?? song.artistsDisplay,
+                        album: nil,
+                        duration: duration,
+                        timestamp: startTime,
+                        videoId: song.videoId
+                    ))
+                    enqueuedCount += 1
+                }
+            }
+
+            let hasHistoricalScrobble = entryCredits.contains(where: \.hasScrobbled)
+            if entry.id == activeEntryId {
+                let lastCredit = entryCredits.last
+                let isContiguous = lastCredit.map {
+                    $0.isActiveAtEnd
+                        && abs($0.endProgress - self.playerService.progress) <= Self.mixReplayStartTolerance
+                } ?? false
+                if let lastCredit, isContiguous {
+                    self.provisionalCurrentMixCredit = (entry.id, lastCredit)
+                    if lastCredit.hasScrobbled {
+                        self.mixEntryScrobbledIds.insert(entry.id)
+                    } else {
+                        self.mixEntryScrobbledIds.remove(entry.id)
+                    }
+                } else if hasHistoricalScrobble,
+                          self.playerService.progress > entry.startTime + Self.mixReplayStartTolerance
+                {
+                    self.mixEntryScrobbledIds.insert(entry.id)
+                } else {
+                    self.mixEntryScrobbledIds.remove(entry.id)
+                }
+            } else if hasHistoricalScrobble {
+                self.mixEntryScrobbledIds.insert(entry.id)
+            }
+        }
+
+        if enqueuedCount > 0 {
+            self.scheduleQueueFlushIfNeeded()
+            self.logger.info("Mix detection credited \(enqueuedCount) sub-tracks from provisional playback")
+        }
+    }
+
+    func finalizeResidualMixHistoryIfNeeded() {
+        guard case let .mix(tracklist) = self.mixDetectionState,
+              self.provisionalMixHistory.hasPlayback,
+              let song = self.trackedSong
+        else { return }
+
+        let scrobbles = self.provisionalMixHistory.scrobbles(
+            tracklist: tracklist,
+            song: song,
+            videoDuration: self.trackedVideoDuration,
+            thresholds: self.mixEntryThresholds
+        )
+        for scrobble in scrobbles {
+            self.queue.enqueue(scrobble)
+        }
+        self.provisionalMixHistory.removeAll()
+        if !scrobbles.isEmpty {
+            self.scheduleQueueFlushIfNeeded()
+        }
+    }
+}

--- a/Sources/Kaset/Services/Scrobbling/ScrobblingCoordinator+State.swift
+++ b/Sources/Kaset/Services/Scrobbling/ScrobblingCoordinator+State.swift
@@ -1,0 +1,165 @@
+import Foundation
+
+extension ScrobblingCoordinator {
+    enum MixDetectionState {
+        case unresolved
+        case parsing
+        case awaitingDuration(MixTracklist)
+        case notMix
+        case mix(MixTracklist)
+    }
+
+    enum MixDurationDecisionPhase {
+        case activeBeforeGrace
+        case activeAfterGrace
+        case finalization
+    }
+
+    enum MixDurationDecision {
+        case unresolved
+        case provisionalNotMix
+        case notMix
+        case mix
+    }
+
+    enum DeferredMixParseOutcome: Sendable {
+        case parsed(MixTracklist?)
+        case timedOut
+    }
+
+    struct PendingMixFinalization {
+        let parseTask: Task<MixTracklist?, Never>
+        let finalizationTask: Task<Void, Never>
+        let fallbackScrobbles: [ScrobbleTrack]
+    }
+
+    func scopedDuration(for track: Song) -> TimeInterval? {
+        if let duration = track.duration, duration > 0 {
+            return duration
+        }
+        return self.scopedPlayerDuration(for: track)
+    }
+
+    func scopedPlayerDuration(for track: Song) -> TimeInterval? {
+        guard self.playerService.playbackStateVideoId == track.videoId,
+              self.playerService.duration > 0
+        else { return nil }
+        return self.playerService.duration
+    }
+
+    func videoDuration(for song: Song?) -> TimeInterval? {
+        if song?.videoId == self.currentTrackVideoId, let trackedVideoDuration {
+            return trackedVideoDuration
+        }
+        if let duration = song?.duration, duration > 0 {
+            return duration
+        }
+        return nil
+    }
+
+    func mixEntryDuration(_ entry: MixTrackEntry, song: Song?) -> TimeInterval? {
+        guard let tracklist = self.currentMixTracklist else { return entry.duration }
+        return tracklist.effectiveDuration(for: entry, videoDuration: self.videoDuration(for: song))
+    }
+
+    /// Accepts playback values only after their provenance belongs to the tracked metadata identity.
+    /// Same-video metadata transitions set a minimum observation sequence so stale progress and
+    /// duration cannot cross the transition boundary.
+    func acceptPlaybackState(for track: Song) -> Bool {
+        guard self.playerService.playbackStateVideoId == track.videoId else { return false }
+        if let requiredPlaybackStateSequence = self.requiredPlaybackStateSequence {
+            guard self.playerService.playbackStateObservationSequence >= requiredPlaybackStateSequence else {
+                return false
+            }
+            self.requiredPlaybackStateSequence = nil
+        }
+        return true
+    }
+
+    static func tracklistProvesMixDuration(_ tracklist: MixTracklist) -> Bool {
+        tracklist.knownDurationLowerBound.map { $0 > Self.mixMinimumVideoDuration } == true
+    }
+
+    /// Applies one duration-evidence precedence rule everywhere mix classification can finish:
+    /// authoritative Song duration, definitely-long player duration, then (after the grace period)
+    /// tracklist lower bounds before a provisional short player duration. At track exit, a parsed
+    /// mix with no duration evidence is accepted rather than dropped.
+    static func mixDurationDecision(
+        for tracklist: MixTracklist,
+        songDuration: TimeInterval?,
+        playerDuration: TimeInterval?,
+        phase: MixDurationDecisionPhase
+    ) -> MixDurationDecision {
+        if let songDuration, songDuration > 0 {
+            return songDuration > mixMinimumVideoDuration ? .mix : .notMix
+        }
+        if let playerDuration, playerDuration > Self.mixMinimumVideoDuration {
+            return .mix
+        }
+        guard phase != .activeBeforeGrace else { return .unresolved }
+        if Self.tracklistProvesMixDuration(tracklist) {
+            return .mix
+        }
+        if let playerDuration, playerDuration > 0 {
+            return phase == .finalization ? .notMix : .provisionalNotMix
+        }
+        return phase == .finalization ? .mix : .unresolved
+    }
+
+    @discardableResult
+    func applyMixDurationDecision(
+        _ decision: MixDurationDecision,
+        tracklist: MixTracklist
+    ) -> Bool {
+        switch decision {
+        case .unresolved, .provisionalNotMix:
+            return false
+        case .notMix:
+            self.resolveAsNotMix()
+        case .mix:
+            self.resolveAsMix(tracklist)
+        }
+        return true
+    }
+
+    func resolveAsMix(_ tracklist: MixTracklist) {
+        self.mixDetectionState = .mix(tracklist)
+        self.unknownDurationParseTask?.cancel()
+        self.unknownDurationParseTask = nil
+        self.durationConfirmationTask?.cancel()
+        self.durationConfirmationTask = nil
+        self.durationConfirmationCompleted = false
+        self.pendingWholeTrackPlays.removeAll()
+        self.consumeProvisionalPlayback(for: tracklist, song: self.trackedSong)
+    }
+
+    func resolveAsNotMix() {
+        self.mixDetectionState = .notMix
+        self.provisionalMixHistory.removeAll()
+        self.unknownDurationParseTask?.cancel()
+        self.unknownDurationParseTask = nil
+        self.durationConfirmationTask?.cancel()
+        self.durationConfirmationTask = nil
+        self.durationConfirmationCompleted = false
+        self.commitPendingWholeTrackScrobbles()
+    }
+
+    /// Commits a provisional parsed tracklist when playback ends. A reliable song duration wins;
+    /// otherwise tracklist bounds can prove a long mix, a current player duration can prove a short
+    /// regular track, and a completely duration-less parse falls back to its tracklist result.
+    func resolveAwaitingDurationForFinalization() {
+        guard case let .awaitingDuration(tracklist) = self.mixDetectionState else { return }
+        let decision = Self.mixDurationDecision(
+            for: tracklist,
+            songDuration: self.trackedSong?.duration,
+            playerDuration: self.trackedVideoDuration,
+            phase: .finalization
+        )
+        self.applyMixDurationDecision(decision, tracklist: tracklist)
+    }
+
+    struct PendingWholeTrackPlay {
+        let tracker: PlaybackScrobbleTracker
+        let song: Song
+    }
+}

--- a/Sources/Kaset/Services/Scrobbling/ScrobblingCoordinator+State.swift
+++ b/Sources/Kaset/Services/Scrobbling/ScrobblingCoordinator+State.swift
@@ -22,7 +22,7 @@ extension ScrobblingCoordinator {
         case mix
     }
 
-    enum DeferredMixParseOutcome: Sendable {
+    enum DeferredMixParseOutcome {
         case parsed(MixTracklist?)
         case timedOut
     }

--- a/Sources/Kaset/Services/Scrobbling/ScrobblingCoordinator.swift
+++ b/Sources/Kaset/Services/Scrobbling/ScrobblingCoordinator.swift
@@ -36,23 +36,8 @@ final class ScrobblingCoordinator {
     /// Snapshot of the tracked Song at the time tracking started (for finalization).
     private var trackedSong: Song?
 
-    /// When the current track started playing (for scrobble timestamp).
-    private var trackStartTime: Date?
-
-    /// Accumulated play time in seconds (only counts actual playback).
-    private var accumulatedPlayTime: TimeInterval = 0
-
-    /// Last observed progress value (for detecting seeks/pauses).
-    private var lastProgress: TimeInterval = 0
-
-    /// Last time we recorded a progress update.
-    private var lastProgressTime: Date?
-
-    /// Whether this track has already been scrobbled.
-    private var hasScrobbled = false
-
-    /// Whether "now playing" has been sent for this track.
-    private var hasSentNowPlaying = false
+    /// Play-time state machine for the whole track (single-track mode). Nil when nothing is tracked.
+    private var trackTracker: PlaybackScrobbleTracker?
 
     // MARK: - Mix-Mode State
 
@@ -63,23 +48,17 @@ final class ScrobblingCoordinator {
     /// The sub-track currently being tracked within the mix.
     private var currentMixEntry: MixTrackEntry?
 
-    /// When the current sub-track started playing.
-    private var mixEntryStartTime: Date?
-
-    /// Accumulated play time for the current sub-track.
-    private var mixEntryAccumulatedTime: TimeInterval = 0
-
-    /// Last observed progress for the current sub-track (for seek detection).
-    private var mixEntryLastProgress: TimeInterval = 0
-
-    /// Whether the current sub-track has been scrobbled.
-    private var mixEntryHasScrobbled = false
-
-    /// Whether "now playing" has been sent for the current sub-track.
-    private var mixEntryHasSentNowPlaying = false
+    /// Play-time state machine for the current mix sub-track. Nil between entries.
+    private var mixEntryTracker: PlaybackScrobbleTracker?
 
     /// Whether a tracklist parse is in progress for the current track.
     private var mixParseInProgress = false
+
+    /// Whether a tracklist fetch has already been attempted for the current track.
+    /// The fetch is gated on the track duration, which for YouTube playback is not yet
+    /// known at track-start — so the attempt is retried from the poll loop until duration
+    /// is available, then latched here to run exactly once per track.
+    private var mixParseAttempted = false
 
     // swiftformat:disable modifierOrder
     /// Queue flush task, cancelled in deinit.
@@ -249,12 +228,18 @@ final class ScrobblingCoordinator {
                 self.finalizeCurrentTrack()
                 self.startTrackingNewTrack(track)
             } else if track.videoId == self.currentTrackVideoId,
-                      self.hasScrobbled,
-                      progress < self.lastProgress - 5.0
+                      let tracker = self.trackTracker, tracker.hasScrobbled,
+                      progress < tracker.lastProgress - 5.0
             {
                 // Same track but progress jumped backward significantly — replay detected
                 self.finalizeCurrentTrack()
                 self.startTrackingNewTrack(track)
+            }
+
+            // Lazily attempt the mix-tracklist fetch — duration is often unknown at track-start,
+            // so this retries each poll (poll re-runs on duration changes) until it can run once.
+            if self.mixTracklist == nil {
+                self.attemptMixTracklistFetch(for: track)
             }
 
             // If a mix tracklist is available, switch to mix-mode scrobbling
@@ -263,21 +248,16 @@ final class ScrobblingCoordinator {
                 return
             }
 
-            // Accumulate play time (only when playing)
-            if isPlaying {
-                self.accumulatePlayTime(progress: progress)
-            } else {
-                // Reset progress tracking when paused
-                self.lastProgressTime = nil
-            }
+            // Accumulate play time (the tracker ignores seeks and paused spans internally)
+            self.trackTracker?.accumulate(progress: progress, isPlaying: isPlaying, now: Date())
 
             // Send "now playing" once per track
-            if !self.hasSentNowPlaying, isPlaying {
+            if self.trackTracker?.hasSentNowPlaying == false, isPlaying {
                 self.sendNowPlaying(track)
             }
 
             // Check scrobble threshold
-            if !self.hasScrobbled, duration > 0 {
+            if self.trackTracker?.hasScrobbled == false, duration > 0 {
                 self.checkScrobbleThreshold(track: track, duration: duration)
             }
         } else if self.currentTrackVideoId != nil {
@@ -293,48 +273,49 @@ final class ScrobblingCoordinator {
         self.currentTrackTitle = track.title
         self.currentTrackArtist = track.artistsDisplay
         self.trackedSong = track
-        self.trackStartTime = Date()
-        self.accumulatedPlayTime = 0
-        self.lastProgress = self.playerService.progress
-        self.lastProgressTime = Date()
-        self.hasScrobbled = false
-        self.hasSentNowPlaying = false
+        self.trackTracker = PlaybackScrobbleTracker(
+            startTime: Date(),
+            initialProgress: self.playerService.progress
+        )
 
         // Reset mix-mode state for the new track
         self.mixTracklist = nil
         self.currentMixEntry = nil
-        self.mixEntryStartTime = nil
-        self.mixEntryAccumulatedTime = 0
-        self.mixEntryLastProgress = 0
-        self.mixEntryHasScrobbled = false
-        self.mixEntryHasSentNowPlaying = false
+        self.mixEntryTracker = nil
+        self.mixParseAttempted = false
 
         self.logger.debug("Started tracking: \(track.title) by \(track.artistsDisplay)")
 
-        // If the track is long enough to be a mix and we have a parser, fetch the tracklist async.
-        // The tracklist may arrive after playback has already started — when it does,
-        // the coordinator switches from single-track mode to mix-mode on the next poll.
+        // The mix-tracklist fetch is gated on duration, which is often not yet known here
+        // (YouTube reports it a beat after the track object appears). The poll loop retries
+        // `attemptMixTracklistFetch(for:)` until duration is available.
+    }
+
+    /// Attempts to fetch a mix tracklist for the track, once duration is known to exceed the
+    /// mix threshold. Retried from the poll loop while `mixParseAttempted` is false, then latched
+    /// so it runs at most once per track. When a tracklist is found, the coordinator switches to
+    /// mix-mode on the next poll.
+    private func attemptMixTracklistFetch(for track: Song) {
+        guard let parser = self.mixTracklistParser, !self.mixParseInProgress, !self.mixParseAttempted else { return }
+
+        // Duration isn't reliably available at track-start; wait until it crosses the mix threshold.
         let duration = track.duration ?? self.playerService.duration
-        if let parser = self.mixTracklistParser, duration > 600, !self.mixParseInProgress {
-            self.mixParseInProgress = true
-            let videoId = track.videoId
-            Task { [weak self] in
-                guard let self else { return }
-                let tracklist = await parser.parseTracklist(videoId: videoId)
-                self.mixParseInProgress = false
-                // Only apply if we're still tracking the same track
-                guard self.currentTrackVideoId == videoId else { return }
-                if let tracklist, tracklist.isMix {
-                    self.mixTracklist = tracklist
-                    self.logger.info("Mix tracklist loaded: \(tracklist.entries.count) sub-tracks for \(track.title)")
-                    // If we already scrobbled the single track, don't switch to mix-mode
-                    // (the user may have seeked past the threshold before the tracklist arrived)
-                    if !self.hasScrobbled {
-                        // Reset single-track scrobble state — mix-mode takes over
-                        self.hasScrobbled = false
-                        self.hasSentNowPlaying = false
-                    }
-                }
+        guard duration > 600 else { return }
+
+        self.mixParseAttempted = true
+        self.mixParseInProgress = true
+        let videoId = track.videoId
+        Task { [weak self] in
+            guard let self else { return }
+            let tracklist = await parser.parseTracklist(videoId: videoId)
+            self.mixParseInProgress = false
+            // Only apply if we're still tracking the same track
+            guard self.currentTrackVideoId == videoId else { return }
+            if let tracklist, tracklist.isMix {
+                self.mixTracklist = tracklist
+                self.logger.info("Mix tracklist loaded: \(tracklist.entries.count) sub-tracks for \(track.title)")
+                // Mix-mode takes over from here: once mixTracklist is set the poll routes to
+                // handleMixPlayback and the single-track tracker is no longer consulted.
             }
         }
     }
@@ -349,87 +330,63 @@ final class ScrobblingCoordinator {
         guard self.currentTrackVideoId != nil else { return }
 
         // Final threshold check before discarding accumulated play time (single-track mode only)
-        if self.mixTracklist == nil, !self.hasScrobbled, let song = self.trackedSong {
+        if self.mixTracklist == nil, self.trackTracker?.hasScrobbled == false, let song = self.trackedSong {
             let duration = song.duration ?? self.playerService.duration
             if duration > 0 {
                 self.checkScrobbleThreshold(track: song, duration: duration)
             }
         }
 
-        self.logger.debug("Finalized track (accumulated: \(String(format: "%.1f", self.accumulatedPlayTime))s, scrobbled: \(self.hasScrobbled))")
+        self.logger.debug("Finalized track (accumulated: \(String(format: "%.1f", self.trackTracker?.accumulatedPlayTime ?? 0))s, scrobbled: \(self.trackTracker?.hasScrobbled ?? false))")
 
         // Reset tracking state
         self.currentTrackVideoId = nil
         self.currentTrackTitle = nil
         self.currentTrackArtist = nil
         self.trackedSong = nil
-        self.trackStartTime = nil
-        self.accumulatedPlayTime = 0
-        self.lastProgress = 0
-        self.lastProgressTime = nil
-        self.hasScrobbled = false
-        self.hasSentNowPlaying = false
+        self.trackTracker = nil
 
         // Reset mix-mode state
         self.mixTracklist = nil
         self.currentMixEntry = nil
-        self.mixEntryStartTime = nil
-        self.mixEntryAccumulatedTime = 0
-        self.mixEntryLastProgress = 0
-        self.mixEntryHasScrobbled = false
-        self.mixEntryHasSentNowPlaying = false
-    }
-
-    // MARK: - Play Time Accumulation
-
-    private func accumulatePlayTime(progress: TimeInterval) {
-        guard let lastTime = self.lastProgressTime else {
-            self.lastProgress = progress
-            self.lastProgressTime = Date()
-            return
-        }
-
-        let now = Date()
-        let wallClockDelta = now.timeIntervalSince(lastTime)
-        let progressDelta = progress - self.lastProgress
-
-        // Only count positive, small deltas (< 2s wall clock) to ignore seeks
-        // A normal playback progress update should show ~1s or less of progress.
-        if progressDelta > 0, progressDelta < 2.0, wallClockDelta < 2.0 {
-            self.accumulatedPlayTime += progressDelta
-        }
-
-        self.lastProgress = progress
-        self.lastProgressTime = now
+        self.mixEntryTracker = nil
+        self.mixParseAttempted = false
     }
 
     // MARK: - Scrobble Threshold
 
+    /// Scrobble thresholds for a whole track. Whole tracks always carry a duration, so an
+    /// unknown duration is treated as ineligible.
+    private var trackThresholds: PlaybackScrobbleTracker.Thresholds {
+        .init(
+            percent: self.settingsManager.scrobblePercentThreshold,
+            minSeconds: self.settingsManager.scrobbleMinSeconds,
+            allowsUnknownDuration: false
+        )
+    }
+
+    /// Scrobble thresholds for a mix sub-track. The final entry has no known end time, so an
+    /// unknown duration still qualifies via `minSeconds`.
+    private var mixEntryThresholds: PlaybackScrobbleTracker.Thresholds {
+        .init(
+            percent: self.settingsManager.scrobblePercentThreshold,
+            minSeconds: self.settingsManager.scrobbleMinSeconds,
+            allowsUnknownDuration: true
+        )
+    }
+
     private func checkScrobbleThreshold(track: Song, duration: TimeInterval) {
-        // Last.fm requires tracks to be at least 30 seconds long
-        guard duration >= 30 else { return }
+        guard var tracker = self.trackTracker,
+              tracker.meetsThreshold(duration: duration, thresholds: self.trackThresholds)
+        else { return }
 
-        let percentThreshold = self.settingsManager.scrobblePercentThreshold
-        let minSeconds = self.settingsManager.scrobbleMinSeconds
+        tracker.markScrobbled()
+        self.trackTracker = tracker
 
-        // Scrobble when: accumulatedPlayTime >= duration * threshold OR >= minSeconds
-        let thresholdMet: Bool = if duration > 0 {
-            self.accumulatedPlayTime >= duration * percentThreshold
-                || self.accumulatedPlayTime >= minSeconds
-        } else {
-            self.accumulatedPlayTime >= minSeconds
-        }
-
-        if thresholdMet {
-            self.hasScrobbled = true
-
-            guard let startTime = self.trackStartTime else { return }
-
-            let scrobbleTrack = ScrobbleTrack(from: track, timestamp: startTime)
-            self.queue.enqueue(scrobbleTrack)
-            self.scheduleQueueFlushIfNeeded()
-            self.logger.info("Scrobble threshold met for: \(track.title) (accumulated: \(String(format: "%.1f", self.accumulatedPlayTime))s)")
-        }
+        let scrobbleTrack = ScrobbleTrack(from: track, timestamp: tracker.startTime)
+        self.queue.enqueue(scrobbleTrack)
+        self.scheduleQueueFlushIfNeeded()
+        self.logger.info("Scrobble threshold met for: \(track.title) (accumulated: \(String(format: "%.1f", tracker.accumulatedPlayTime))s)")
     }
 
     // MARK: - Mix-Mode Playback Handling
@@ -452,7 +409,7 @@ final class ScrobblingCoordinator {
             }
 
             if let entry {
-                self.startMixEntry(entry, song: track, progress: progress, isPlaying: isPlaying)
+                self.startMixEntry(entry, progress: progress)
             } else {
                 // Between entries or before the first — clear current
                 self.currentMixEntry = nil
@@ -461,124 +418,80 @@ final class ScrobblingCoordinator {
 
         guard let entry, self.currentMixEntry?.id == entry.id else { return }
 
-        // Seek detection: if progress jumped backward or forward significantly,
-        // reset the sub-track's accumulated time
-        let progressDelta = progress - self.mixEntryLastProgress
-        if abs(progressDelta) > 5.0 {
-            // Seek detected — reset accumulated time for this sub-track
-            self.mixEntryAccumulatedTime = 0
-            self.mixEntryHasScrobbled = false
-            self.mixEntryHasSentNowPlaying = false
+        // Seek detection: reset the sub-track clock on a significant jump.
+        if let tracker = self.mixEntryTracker, abs(progress - tracker.lastProgress) > 5.0 {
+            self.mixEntryTracker?.resetForSeek()
             self.logger.debug("Mix seek detected at \(String(format: "%.1f", progress))s, resetting sub-track '\(entry.title)'")
         }
 
-        // Accumulate play time (only when playing)
-        if isPlaying {
-            self.accumulateMixEntryTime(progress: progress)
-        } else {
-            // Reset progress tracking when paused
-            // (mixEntryLastProgress is preserved for seek detection)
-        }
+        // Accumulate play time (the tracker ignores seeks and paused spans internally)
+        self.mixEntryTracker?.accumulate(progress: progress, isPlaying: isPlaying, now: Date())
 
         // Send "now playing" once per sub-track
-        if !self.mixEntryHasSentNowPlaying, isPlaying {
+        if self.mixEntryTracker?.hasSentNowPlaying == false, isPlaying {
             self.sendMixNowPlaying(entry, song: track)
         }
 
         // Check sub-track scrobble threshold
-        if !self.mixEntryHasScrobbled {
+        if self.mixEntryTracker?.hasScrobbled == false {
             self.checkMixEntryScrobbleThreshold(entry: entry, song: track)
         }
     }
 
     /// Starts tracking a new sub-track within the mix.
-    private func startMixEntry(_ entry: MixTrackEntry, song: Song, progress: TimeInterval, isPlaying: Bool) {
+    private func startMixEntry(_ entry: MixTrackEntry, progress: TimeInterval) {
         self.currentMixEntry = entry
-        self.mixEntryStartTime = Date()
-        self.mixEntryAccumulatedTime = 0
-        self.mixEntryLastProgress = progress
-        self.mixEntryHasScrobbled = false
-        self.mixEntryHasSentNowPlaying = false
+        self.mixEntryTracker = PlaybackScrobbleTracker(startTime: Date(), initialProgress: progress)
         self.logger.debug("Mix sub-track started: \(entry.artist ?? "?") - \(entry.title) at \(String(format: "%.1f", entry.startTime))s")
     }
 
     /// Finalizes a mix sub-track — checks threshold and scrobbles if met.
     private func finalizeMixEntry(_ entry: MixTrackEntry, song: Song?) {
-        guard !self.mixEntryHasScrobbled else { return }
-
-        // Final threshold check before the sub-track ends
-        self.checkMixEntryScrobbleThreshold(entry: entry, song: song)
-
-        self.logger.debug("Mix sub-track finalized: \(entry.artist ?? "?") - \(entry.title) (accumulated: \(String(format: "%.1f", self.mixEntryAccumulatedTime))s, scrobbled: \(self.mixEntryHasScrobbled))")
-
-        self.currentMixEntry = nil
-        self.mixEntryStartTime = nil
-        self.mixEntryAccumulatedTime = 0
-        self.mixEntryLastProgress = 0
-        self.mixEntryHasScrobbled = false
-        self.mixEntryHasSentNowPlaying = false
-    }
-
-    /// Accumulates play time for the current sub-track.
-    private func accumulateMixEntryTime(progress: TimeInterval) {
-        let now = Date()
-        let progressDelta = progress - self.mixEntryLastProgress
-
-        // Only count positive, small deltas (< 2s) to ignore seeks
-        if progressDelta > 0, progressDelta < 2.0 {
-            self.mixEntryAccumulatedTime += progressDelta
+        // Final threshold check before the sub-track ends (skip if it already scrobbled)
+        if self.mixEntryTracker?.hasScrobbled == false {
+            self.checkMixEntryScrobbleThreshold(entry: entry, song: song)
         }
 
-        self.mixEntryLastProgress = progress
+        self.logger.debug("Mix sub-track finalized: \(entry.artist ?? "?") - \(entry.title) (accumulated: \(String(format: "%.1f", self.mixEntryTracker?.accumulatedPlayTime ?? 0))s, scrobbled: \(self.mixEntryTracker?.hasScrobbled ?? false))")
+
+        self.currentMixEntry = nil
+        self.mixEntryTracker = nil
     }
 
     /// Checks whether the current sub-track has met the scrobble threshold.
     private func checkMixEntryScrobbleThreshold(entry: MixTrackEntry, song: Song?) {
-        // Use the sub-track's duration if available, otherwise fall back to minSeconds
-        let entryDuration = entry.duration ?? 0
+        guard var tracker = self.mixEntryTracker,
+              tracker.meetsThreshold(duration: entry.duration, thresholds: self.mixEntryThresholds)
+        else { return }
 
-        // Last.fm requires tracks to be at least 30 seconds long
-        guard entryDuration >= 30 || entryDuration == 0 else { return }
+        tracker.markScrobbled()
+        self.mixEntryTracker = tracker
 
-        let percentThreshold = self.settingsManager.scrobblePercentThreshold
-        let minSeconds = self.settingsManager.scrobbleMinSeconds
-
-        let thresholdMet: Bool = if entryDuration > 0 {
-            self.mixEntryAccumulatedTime >= entryDuration * percentThreshold
-                || self.mixEntryAccumulatedTime >= minSeconds
-        } else {
-            self.mixEntryAccumulatedTime >= minSeconds
-        }
-
-        if thresholdMet {
-            self.mixEntryHasScrobbled = true
-            guard let startTime = self.mixEntryStartTime else { return }
-
-            let scrobbleTrack = ScrobbleTrack(
-                title: entry.title,
-                artist: entry.artist ?? song?.artistsDisplay ?? "Unknown Artist",
-                album: nil,
-                duration: entry.duration,
-                timestamp: startTime,
-                videoId: song?.videoId
-            )
-            self.queue.enqueue(scrobbleTrack)
-            self.scheduleQueueFlushIfNeeded()
-            self.logger.info("Mix scrobble: \(entry.artist ?? "?") - \(entry.title) (accumulated: \(String(format: "%.1f", self.mixEntryAccumulatedTime))s)")
-        }
+        let scrobbleTrack = ScrobbleTrack(
+            title: entry.title,
+            artist: entry.artist ?? song?.artistsDisplay ?? "Unknown Artist",
+            album: nil,
+            duration: entry.duration,
+            timestamp: tracker.startTime,
+            videoId: song?.videoId
+        )
+        self.queue.enqueue(scrobbleTrack)
+        self.scheduleQueueFlushIfNeeded()
+        self.logger.info("Mix scrobble: \(entry.artist ?? "?") - \(entry.title) (accumulated: \(String(format: "%.1f", tracker.accumulatedPlayTime))s)")
     }
 
     /// Sends a "now playing" update for a mix sub-track.
     private func sendMixNowPlaying(_ entry: MixTrackEntry, song: Song) {
-        self.mixEntryHasSentNowPlaying = true
-        guard let startTime = self.mixEntryStartTime else { return }
+        guard var tracker = self.mixEntryTracker else { return }
+        tracker.markNowPlayingSent()
+        self.mixEntryTracker = tracker
 
         let scrobbleTrack = ScrobbleTrack(
             title: entry.title,
             artist: entry.artist ?? song.artistsDisplay,
             album: nil,
             duration: entry.duration,
-            timestamp: startTime,
+            timestamp: tracker.startTime,
             videoId: song.videoId
         )
 
@@ -604,11 +517,11 @@ final class ScrobblingCoordinator {
     // MARK: - Now Playing
 
     private func sendNowPlaying(_ track: Song) {
-        self.hasSentNowPlaying = true
+        guard var tracker = self.trackTracker else { return }
+        tracker.markNowPlayingSent()
+        self.trackTracker = tracker
 
-        guard let startTime = self.trackStartTime else { return }
-
-        let scrobbleTrack = ScrobbleTrack(from: track, timestamp: startTime)
+        let scrobbleTrack = ScrobbleTrack(from: track, timestamp: tracker.startTime)
 
         // Cancel any in-flight now-playing tasks from a previous track
         self.nowPlayingTasks.forEach { $0.cancel() }

--- a/Sources/Kaset/Services/Scrobbling/ScrobblingCoordinator.swift
+++ b/Sources/Kaset/Services/Scrobbling/ScrobblingCoordinator.swift
@@ -51,8 +51,11 @@ final class ScrobblingCoordinator {
     /// Play-time state machine for the current mix sub-track. Nil between entries.
     private var mixEntryTracker: PlaybackScrobbleTracker?
 
-    /// Whether a tracklist parse is in progress for the current track.
-    private var mixParseInProgress = false
+    /// In-flight tracklist parse for the current track. Cancelled on track changes and shutdown.
+    private var mixParseTask: Task<Void, Never>?
+
+    /// Monotonic token preventing a cancelled/stale parse from clearing or applying newer work.
+    private var mixParseGeneration = 0
 
     /// Whether a tracklist fetch has already been attempted for the current track.
     /// The fetch is gated on the track duration, which for YouTube playback is not yet
@@ -144,6 +147,8 @@ final class ScrobblingCoordinator {
         self.flushTaskGeneration += 1
         self.flushTask?.cancel()
         self.flushTask = nil
+        self.cancelMixTracklistFetch()
+        self.mixParseAttempted = false
         self.nowPlayingTasks.forEach { $0.cancel() }
         self.nowPlayingTasks.removeAll()
         self.isMonitoring = false
@@ -296,21 +301,25 @@ final class ScrobblingCoordinator {
     /// so it runs at most once per track. When a tracklist is found, the coordinator switches to
     /// mix-mode on the next poll.
     private func attemptMixTracklistFetch(for track: Song) {
-        guard let parser = self.mixTracklistParser, !self.mixParseInProgress, !self.mixParseAttempted else { return }
+        guard let parser = self.mixTracklistParser, self.mixParseTask == nil, !self.mixParseAttempted else { return }
 
         // Duration isn't reliably available at track-start; wait until it crosses the mix threshold.
         let duration = track.duration ?? self.playerService.duration
         guard duration > 600 else { return }
 
         self.mixParseAttempted = true
-        self.mixParseInProgress = true
+        self.mixParseGeneration += 1
+        let generation = self.mixParseGeneration
         let videoId = track.videoId
-        Task { [weak self] in
+        self.mixParseTask = Task { @MainActor [weak self] in
             guard let self else { return }
             let tracklist = await parser.parseTracklist(videoId: videoId)
-            self.mixParseInProgress = false
-            // Only apply if we're still tracking the same track
-            guard self.currentTrackVideoId == videoId else { return }
+
+            // A track change may have cancelled this request and started another. Only the task
+            // owning the current generation may clear the in-flight slot or publish its result.
+            guard self.mixParseGeneration == generation else { return }
+            self.mixParseTask = nil
+            guard !Task.isCancelled, self.currentTrackVideoId == videoId else { return }
             if let tracklist, tracklist.isMix {
                 self.mixTracklist = tracklist
                 self.logger.info("Mix tracklist loaded: \(tracklist.entries.count) sub-tracks for \(track.title)")
@@ -320,7 +329,16 @@ final class ScrobblingCoordinator {
         }
     }
 
+    private func cancelMixTracklistFetch() {
+        self.mixParseGeneration += 1
+        self.mixParseTask?.cancel()
+        self.mixParseTask = nil
+    }
+
     private func finalizeCurrentTrack() {
+        // Never let a slow request for the previous video block or overwrite the next track.
+        self.cancelMixTracklistFetch()
+
         // Finalize mix-mode sub-track if active
         if self.mixTracklist != nil, let entry = self.currentMixEntry {
             self.finalizeMixEntry(entry, song: self.trackedSong)
@@ -365,8 +383,8 @@ final class ScrobblingCoordinator {
         )
     }
 
-    /// Scrobble thresholds for a mix sub-track. The final entry has no known end time, so an
-    /// unknown duration still qualifies via `minSeconds`.
+    /// Scrobble thresholds for a mix sub-track. YouTube does not always expose chapter bounds,
+    /// so an unknown duration still qualifies via `minSeconds`.
     private var mixEntryThresholds: PlaybackScrobbleTracker.Thresholds {
         .init(
             percent: self.settingsManager.scrobblePercentThreshold,

--- a/Sources/Kaset/Services/Scrobbling/ScrobblingCoordinator.swift
+++ b/Sources/Kaset/Services/Scrobbling/ScrobblingCoordinator.swift
@@ -18,6 +18,10 @@ final class ScrobblingCoordinator {
     /// The offline scrobble queue.
     let queue: ScrobbleQueue
 
+    /// Parser for mix tracklists (chapters + description). Optional because
+    /// it requires a YouTubeClient, which may not be available in all contexts.
+    private let mixTracklistParser: MixTracklistParser?
+
     // MARK: - Tracking State
 
     /// The video ID of the track currently being tracked.
@@ -50,6 +54,33 @@ final class ScrobblingCoordinator {
     /// Whether "now playing" has been sent for this track.
     private var hasSentNowPlaying = false
 
+    // MARK: - Mix-Mode State
+
+    /// Tracklist for the current mix, if one was found. When non-nil,
+    /// the coordinator operates in mix-mode (per-sub-track scrobbling).
+    private var mixTracklist: MixTracklist?
+
+    /// The sub-track currently being tracked within the mix.
+    private var currentMixEntry: MixTrackEntry?
+
+    /// When the current sub-track started playing.
+    private var mixEntryStartTime: Date?
+
+    /// Accumulated play time for the current sub-track.
+    private var mixEntryAccumulatedTime: TimeInterval = 0
+
+    /// Last observed progress for the current sub-track (for seek detection).
+    private var mixEntryLastProgress: TimeInterval = 0
+
+    /// Whether the current sub-track has been scrobbled.
+    private var mixEntryHasScrobbled = false
+
+    /// Whether "now playing" has been sent for the current sub-track.
+    private var mixEntryHasSentNowPlaying = false
+
+    /// Whether a tracklist parse is in progress for the current track.
+    private var mixParseInProgress = false
+
     // swiftformat:disable modifierOrder
     /// Queue flush task, cancelled in deinit.
     private var flushTask: Task<Void, Never>?
@@ -75,16 +106,19 @@ final class ScrobblingCoordinator {
     ///   - settingsManager: Settings manager for threshold configuration.
     ///   - services: Scrobbling service backends to fan out scrobbles to.
     ///   - queue: Persistent scrobble queue (injectable for testing).
+    ///   - mixTracklistParser: Parser for mix video tracklists (optional).
     init(
         playerService: PlayerService,
         settingsManager: SettingsManager = .shared,
         services: [any ScrobbleServiceProtocol],
-        queue: ScrobbleQueue = ScrobbleQueue()
+        queue: ScrobbleQueue = ScrobbleQueue(),
+        mixTracklistParser: MixTracklistParser? = nil
     ) {
         self.playerService = playerService
         self.settingsManager = settingsManager
         self.services = services
         self.queue = queue
+        self.mixTracklistParser = mixTracklistParser
     }
 
     /// Note: Do not reference main actor properties here. All cleanup should be done in stopMonitoring().
@@ -223,6 +257,12 @@ final class ScrobblingCoordinator {
                 self.startTrackingNewTrack(track)
             }
 
+            // If a mix tracklist is available, switch to mix-mode scrobbling
+            if let tracklist = self.mixTracklist {
+                self.handleMixPlayback(track: track, tracklist: tracklist, progress: progress, isPlaying: isPlaying)
+                return
+            }
+
             // Accumulate play time (only when playing)
             if isPlaying {
                 self.accumulatePlayTime(progress: progress)
@@ -259,15 +299,57 @@ final class ScrobblingCoordinator {
         self.lastProgressTime = Date()
         self.hasScrobbled = false
         self.hasSentNowPlaying = false
+
+        // Reset mix-mode state for the new track
+        self.mixTracklist = nil
+        self.currentMixEntry = nil
+        self.mixEntryStartTime = nil
+        self.mixEntryAccumulatedTime = 0
+        self.mixEntryLastProgress = 0
+        self.mixEntryHasScrobbled = false
+        self.mixEntryHasSentNowPlaying = false
+
         self.logger.debug("Started tracking: \(track.title) by \(track.artistsDisplay)")
+
+        // If the track is long enough to be a mix and we have a parser, fetch the tracklist async.
+        // The tracklist may arrive after playback has already started — when it does,
+        // the coordinator switches from single-track mode to mix-mode on the next poll.
+        let duration = track.duration ?? self.playerService.duration
+        if let parser = self.mixTracklistParser, duration > 600, !self.mixParseInProgress {
+            self.mixParseInProgress = true
+            let videoId = track.videoId
+            Task { [weak self] in
+                guard let self else { return }
+                let tracklist = await parser.parseTracklist(videoId: videoId)
+                self.mixParseInProgress = false
+                // Only apply if we're still tracking the same track
+                guard self.currentTrackVideoId == videoId else { return }
+                if let tracklist, tracklist.isMix {
+                    self.mixTracklist = tracklist
+                    self.logger.info("Mix tracklist loaded: \(tracklist.entries.count) sub-tracks for \(track.title)")
+                    // If we already scrobbled the single track, don't switch to mix-mode
+                    // (the user may have seeked past the threshold before the tracklist arrived)
+                    if !self.hasScrobbled {
+                        // Reset single-track scrobble state — mix-mode takes over
+                        self.hasScrobbled = false
+                        self.hasSentNowPlaying = false
+                    }
+                }
+            }
+        }
     }
 
     private func finalizeCurrentTrack() {
+        // Finalize mix-mode sub-track if active
+        if self.mixTracklist != nil, let entry = self.currentMixEntry {
+            self.finalizeMixEntry(entry, song: self.trackedSong)
+        }
+
         // Nothing to finalize if no track was being tracked
         guard self.currentTrackVideoId != nil else { return }
 
-        // Final threshold check before discarding accumulated play time
-        if !self.hasScrobbled, let song = self.trackedSong {
+        // Final threshold check before discarding accumulated play time (single-track mode only)
+        if self.mixTracklist == nil, !self.hasScrobbled, let song = self.trackedSong {
             let duration = song.duration ?? self.playerService.duration
             if duration > 0 {
                 self.checkScrobbleThreshold(track: song, duration: duration)
@@ -287,6 +369,15 @@ final class ScrobblingCoordinator {
         self.lastProgressTime = nil
         self.hasScrobbled = false
         self.hasSentNowPlaying = false
+
+        // Reset mix-mode state
+        self.mixTracklist = nil
+        self.currentMixEntry = nil
+        self.mixEntryStartTime = nil
+        self.mixEntryAccumulatedTime = 0
+        self.mixEntryLastProgress = 0
+        self.mixEntryHasScrobbled = false
+        self.mixEntryHasSentNowPlaying = false
     }
 
     // MARK: - Play Time Accumulation
@@ -338,6 +429,175 @@ final class ScrobblingCoordinator {
             self.queue.enqueue(scrobbleTrack)
             self.scheduleQueueFlushIfNeeded()
             self.logger.info("Scrobble threshold met for: \(track.title) (accumulated: \(String(format: "%.1f", self.accumulatedPlayTime))s)")
+        }
+    }
+
+    // MARK: - Mix-Mode Playback Handling
+
+    /// Handles per-sub-track scrobbling within a mix. Called instead of the
+    /// single-track accumulation/threshold logic when a mix tracklist is available.
+    private func handleMixPlayback(
+        track: Song,
+        tracklist: MixTracklist,
+        progress: TimeInterval,
+        isPlaying: Bool
+    ) {
+        // Determine the sub-track at the current playback position
+        let entry = tracklist.entry(at: progress)
+
+        // Sub-track changed — finalize previous, start new
+        if entry?.id != self.currentMixEntry?.id {
+            if let prevEntry = self.currentMixEntry {
+                self.finalizeMixEntry(prevEntry, song: track)
+            }
+
+            if let entry {
+                self.startMixEntry(entry, song: track, progress: progress, isPlaying: isPlaying)
+            } else {
+                // Between entries or before the first — clear current
+                self.currentMixEntry = nil
+            }
+        }
+
+        guard let entry, self.currentMixEntry?.id == entry.id else { return }
+
+        // Seek detection: if progress jumped backward or forward significantly,
+        // reset the sub-track's accumulated time
+        let progressDelta = progress - self.mixEntryLastProgress
+        if abs(progressDelta) > 5.0 {
+            // Seek detected — reset accumulated time for this sub-track
+            self.mixEntryAccumulatedTime = 0
+            self.mixEntryHasScrobbled = false
+            self.mixEntryHasSentNowPlaying = false
+            self.logger.debug("Mix seek detected at \(String(format: "%.1f", progress))s, resetting sub-track '\(entry.title)'")
+        }
+
+        // Accumulate play time (only when playing)
+        if isPlaying {
+            self.accumulateMixEntryTime(progress: progress)
+        } else {
+            // Reset progress tracking when paused
+            // (mixEntryLastProgress is preserved for seek detection)
+        }
+
+        // Send "now playing" once per sub-track
+        if !self.mixEntryHasSentNowPlaying, isPlaying {
+            self.sendMixNowPlaying(entry, song: track)
+        }
+
+        // Check sub-track scrobble threshold
+        if !self.mixEntryHasScrobbled {
+            self.checkMixEntryScrobbleThreshold(entry: entry, song: track)
+        }
+    }
+
+    /// Starts tracking a new sub-track within the mix.
+    private func startMixEntry(_ entry: MixTrackEntry, song: Song, progress: TimeInterval, isPlaying: Bool) {
+        self.currentMixEntry = entry
+        self.mixEntryStartTime = Date()
+        self.mixEntryAccumulatedTime = 0
+        self.mixEntryLastProgress = progress
+        self.mixEntryHasScrobbled = false
+        self.mixEntryHasSentNowPlaying = false
+        self.logger.debug("Mix sub-track started: \(entry.artist ?? "?") - \(entry.title) at \(String(format: "%.1f", entry.startTime))s")
+    }
+
+    /// Finalizes a mix sub-track — checks threshold and scrobbles if met.
+    private func finalizeMixEntry(_ entry: MixTrackEntry, song: Song?) {
+        guard !self.mixEntryHasScrobbled else { return }
+
+        // Final threshold check before the sub-track ends
+        self.checkMixEntryScrobbleThreshold(entry: entry, song: song)
+
+        self.logger.debug("Mix sub-track finalized: \(entry.artist ?? "?") - \(entry.title) (accumulated: \(String(format: "%.1f", self.mixEntryAccumulatedTime))s, scrobbled: \(self.mixEntryHasScrobbled))")
+
+        self.currentMixEntry = nil
+        self.mixEntryStartTime = nil
+        self.mixEntryAccumulatedTime = 0
+        self.mixEntryLastProgress = 0
+        self.mixEntryHasScrobbled = false
+        self.mixEntryHasSentNowPlaying = false
+    }
+
+    /// Accumulates play time for the current sub-track.
+    private func accumulateMixEntryTime(progress: TimeInterval) {
+        let now = Date()
+        let progressDelta = progress - self.mixEntryLastProgress
+
+        // Only count positive, small deltas (< 2s) to ignore seeks
+        if progressDelta > 0, progressDelta < 2.0 {
+            self.mixEntryAccumulatedTime += progressDelta
+        }
+
+        self.mixEntryLastProgress = progress
+    }
+
+    /// Checks whether the current sub-track has met the scrobble threshold.
+    private func checkMixEntryScrobbleThreshold(entry: MixTrackEntry, song: Song?) {
+        // Use the sub-track's duration if available, otherwise fall back to minSeconds
+        let entryDuration = entry.duration ?? 0
+
+        // Last.fm requires tracks to be at least 30 seconds long
+        guard entryDuration >= 30 || entryDuration == 0 else { return }
+
+        let percentThreshold = self.settingsManager.scrobblePercentThreshold
+        let minSeconds = self.settingsManager.scrobbleMinSeconds
+
+        let thresholdMet: Bool = if entryDuration > 0 {
+            self.mixEntryAccumulatedTime >= entryDuration * percentThreshold
+                || self.mixEntryAccumulatedTime >= minSeconds
+        } else {
+            self.mixEntryAccumulatedTime >= minSeconds
+        }
+
+        if thresholdMet {
+            self.mixEntryHasScrobbled = true
+            guard let startTime = self.mixEntryStartTime else { return }
+
+            let scrobbleTrack = ScrobbleTrack(
+                title: entry.title,
+                artist: entry.artist ?? song?.artistsDisplay ?? "Unknown Artist",
+                album: nil,
+                duration: entry.duration,
+                timestamp: startTime,
+                videoId: song?.videoId
+            )
+            self.queue.enqueue(scrobbleTrack)
+            self.scheduleQueueFlushIfNeeded()
+            self.logger.info("Mix scrobble: \(entry.artist ?? "?") - \(entry.title) (accumulated: \(String(format: "%.1f", self.mixEntryAccumulatedTime))s)")
+        }
+    }
+
+    /// Sends a "now playing" update for a mix sub-track.
+    private func sendMixNowPlaying(_ entry: MixTrackEntry, song: Song) {
+        self.mixEntryHasSentNowPlaying = true
+        guard let startTime = self.mixEntryStartTime else { return }
+
+        let scrobbleTrack = ScrobbleTrack(
+            title: entry.title,
+            artist: entry.artist ?? song.artistsDisplay,
+            album: nil,
+            duration: entry.duration,
+            timestamp: startTime,
+            videoId: song.videoId
+        )
+
+        // Cancel any in-flight now-playing tasks from a previous sub-track
+        self.nowPlayingTasks.forEach { $0.cancel() }
+        self.nowPlayingTasks.removeAll()
+
+        for service in self.enabledConnectedServices {
+            let task = Task { @MainActor [weak self] in
+                guard let self else { return }
+                do {
+                    try await service.updateNowPlaying(scrobbleTrack)
+                } catch is CancellationError {
+                    // Expected when sub-track changes
+                } catch {
+                    self.logger.debug("Mix now playing failed for \(service.serviceName) (non-critical): \(error.localizedDescription)")
+                }
+            }
+            self.nowPlayingTasks.append(task)
         }
     }
 

--- a/Sources/Kaset/Services/Scrobbling/ScrobblingCoordinator.swift
+++ b/Sources/Kaset/Services/Scrobbling/ScrobblingCoordinator.swift
@@ -261,8 +261,10 @@ final class ScrobblingCoordinator {
                 self.sendNowPlaying(track)
             }
 
-            // Check scrobble threshold
-            if self.trackTracker?.hasScrobbled == false, duration > 0 {
+            // Check scrobble threshold. Deferred while a mix parse is in flight so a slow
+            // tracklist fetch can't let the whole mix scrobble once as one track and again
+            // per sub-track after the tracklist arrives.
+            if self.trackTracker?.hasScrobbled == false, duration > 0, self.mixParseTask == nil {
                 self.checkScrobbleThreshold(track: track, duration: duration)
             }
         } else if self.currentTrackVideoId != nil {
@@ -436,10 +438,19 @@ final class ScrobblingCoordinator {
 
         guard let entry, self.currentMixEntry?.id == entry.id else { return }
 
-        // Seek detection: reset the sub-track clock on a significant jump.
+        // Seek detection: a significant jump resets the sub-track clock. Once the entry has
+        // scrobbled, only a backward jump matters — that's a replay, restarted with a fresh
+        // tracker so a second scrobble carries a new timestamp instead of duplicating the first.
         if let tracker = self.mixEntryTracker, abs(progress - tracker.lastProgress) > 5.0 {
-            self.mixEntryTracker?.resetForSeek()
-            self.logger.debug("Mix seek detected at \(String(format: "%.1f", progress))s, resetting sub-track '\(entry.title)'")
+            if tracker.hasScrobbled {
+                if progress < tracker.lastProgress {
+                    self.startMixEntry(entry, progress: progress)
+                    self.logger.debug("Mix replay detected at \(String(format: "%.1f", progress))s, restarting sub-track '\(entry.title)'")
+                }
+            } else {
+                self.mixEntryTracker?.resetForSeek()
+                self.logger.debug("Mix seek detected at \(String(format: "%.1f", progress))s, resetting sub-track '\(entry.title)'")
+            }
         }
 
         // Accumulate play time (the tracker ignores seeks and paused spans internally)

--- a/Sources/Kaset/Services/Scrobbling/ScrobblingCoordinator.swift
+++ b/Sources/Kaset/Services/Scrobbling/ScrobblingCoordinator.swift
@@ -7,61 +7,82 @@ import Observation
 @MainActor
 @Observable
 final class ScrobblingCoordinator {
+    static let mixMinimumVideoDuration: TimeInterval = 600
+    static let mixReplayStartTolerance: TimeInterval = 5
+
     // MARK: - Dependencies
 
-    private let playerService: PlayerService
-    private let settingsManager: SettingsManager
+    let playerService: PlayerService
+    private let settingsManager: any ScrobblingSettingsProviding
     /// All registered scrobbling service backends.
     let services: [any ScrobbleServiceProtocol]
-    private let logger = DiagnosticsLogger.scrobbling
+    let logger = DiagnosticsLogger.scrobbling
 
     /// The offline scrobble queue.
     let queue: ScrobbleQueue
 
-    /// Parser for mix tracklists (chapters + description). Optional because
-    /// it requires a YouTubeClient, which may not be available in all contexts.
-    private let mixTracklistParser: MixTracklistParser?
+    /// Optional mix-tracklist parser; requires a YouTubeClient that some contexts do not provide.
+    let mixTracklistParser: MixTracklistParser?
+    let unknownDurationParseDelay: Duration
+    let mixParseTimeout: Duration
 
     // MARK: - Tracking State
 
     /// The video ID of the track currently being tracked.
-    private var currentTrackVideoId: String?
+    var currentTrackVideoId: String?
 
     /// Title of the track currently being tracked (for change detection when videoId is stale).
     private var currentTrackTitle: String?
 
     /// Artist of the track currently being tracked (for change detection when videoId is stale).
     private var currentTrackArtist: String?
+    var requiredPlaybackStateSequence: Int?
 
     /// Snapshot of the tracked Song at the time tracking started (for finalization).
-    private var trackedSong: Song?
+    var trackedSong: Song?
 
     /// Play-time state machine for the whole track (single-track mode). Nil when nothing is tracked.
-    private var trackTracker: PlaybackScrobbleTracker?
+    var trackTracker: PlaybackScrobbleTracker?
+    var pendingWholeTrackPlays: [PendingWholeTrackPlay] = []
+
+    /// Tracked-video duration retained across transitions so finalization never reads the next track.
+    var trackedVideoDuration: TimeInterval?
 
     // MARK: - Mix-Mode State
 
-    /// Tracklist for the current mix, if one was found. When non-nil,
-    /// the coordinator operates in mix-mode (per-sub-track scrobbling).
-    private var mixTracklist: MixTracklist?
+    /// Classification gate that defers whole-track side effects until mix detection resolves.
+    var mixDetectionState: MixDetectionState = .unresolved
 
     /// The sub-track currently being tracked within the mix.
     private var currentMixEntry: MixTrackEntry?
 
     /// Play-time state machine for the current mix sub-track. Nil between entries.
-    private var mixEntryTracker: PlaybackScrobbleTracker?
+    var mixEntryTracker: PlaybackScrobbleTracker?
+    var mixEntryScrobbledIds: Set<UUID> = []
 
-    /// In-flight tracklist parse for the current track. Cancelled on track changes and shutdown.
-    private var mixParseTask: Task<Void, Never>?
+    /// In-flight tracklist parse and its current-track result monitor.
+    var mixParseTask: Task<MixTracklist?, Never>?
+    var mixParseMonitorTask: Task<Void, Never>?
+    var mixParseTimeoutTask: Task<Void, Never>?
+    var unknownDurationParseTask: Task<Void, Never>?
+    var durationConfirmationTask: Task<Void, Never>?
+    var durationConfirmationCompleted = false
+    var mixParseStartedWithoutDuration = false
 
     /// Monotonic token preventing a cancelled/stale parse from clearing or applying newer work.
-    private var mixParseGeneration = 0
+    var mixParseGeneration = 0
 
-    /// Whether a tracklist fetch has already been attempted for the current track.
-    /// The fetch is gated on the track duration, which for YouTube playback is not yet
-    /// known at track-start — so the attempt is retried from the poll loop until duration
-    /// is available, then latched here to run exactly once per track.
-    private var mixParseAttempted = false
+    /// Eligible ended tracks whose parse may safely finish off the current-track path.
+    var pendingMixFinalizations: [UUID: PendingMixFinalization] = [:]
+
+    /// Verified progress ranges retained until delayed chapter metadata can credit real sub-tracks.
+    var provisionalMixHistory = ProvisionalMixPlaybackHistory()
+    var provisionalCurrentMixCredit: (entryId: UUID, credit: ProvisionalMixPlaybackHistory.Credit)?
+
+    var currentMixTracklist: MixTracklist? {
+        guard case let .mix(tracklist) = self.mixDetectionState else { return nil }
+        return tracklist
+    }
 
     // swiftformat:disable modifierOrder
     /// Queue flush task, cancelled in deinit.
@@ -71,7 +92,7 @@ final class ScrobblingCoordinator {
     private var flushTaskGeneration = 0
 
     /// Now-playing tasks, cancelled in stopMonitoring/deinit.
-    private var nowPlayingTasks: [Task<Void, Never>] = []
+    var nowPlayingTasks: [Task<Void, Never>] = []
     // swiftformat:enable modifierOrder
 
     /// Whether the coordinator is actively monitoring.
@@ -82,30 +103,28 @@ final class ScrobblingCoordinator {
 
     // MARK: - Init
 
-    /// Creates a ScrobblingCoordinator.
-    /// - Parameters:
-    ///   - playerService: The player service to monitor.
-    ///   - settingsManager: Settings manager for threshold configuration.
-    ///   - services: Scrobbling service backends to fan out scrobbles to.
-    ///   - queue: Persistent scrobble queue (injectable for testing).
-    ///   - mixTracklistParser: Parser for mix video tracklists (optional).
+    /// Creates a ScrobblingCoordinator with injectable services, settings, queue, and mix parser.
     init(
         playerService: PlayerService,
-        settingsManager: SettingsManager = .shared,
+        settingsManager: any ScrobblingSettingsProviding = SettingsManager.shared,
         services: [any ScrobbleServiceProtocol],
         queue: ScrobbleQueue = ScrobbleQueue(),
-        mixTracklistParser: MixTracklistParser? = nil
+        mixTracklistParser: MixTracklistParser? = nil,
+        unknownDurationParseDelay: Duration = .seconds(2),
+        mixParseTimeout: Duration = .seconds(10)
     ) {
         self.playerService = playerService
         self.settingsManager = settingsManager
         self.services = services
         self.queue = queue
         self.mixTracklistParser = mixTracklistParser
+        self.unknownDurationParseDelay = unknownDurationParseDelay
+        self.mixParseTimeout = mixParseTimeout
     }
 
-    /// Note: Do not reference main actor properties here. All cleanup should be done in stopMonitoring().
+    /// Permanent teardown must call stopMonitoring(finalizeCurrentTrack: true) first.
     deinit {
-        // All async tasks must be cancelled via stopMonitoring() before deinit.
+        // Main-actor state cannot be safely finalized from deinit.
     }
 
     // MARK: - Service Helpers
@@ -118,7 +137,7 @@ final class ScrobblingCoordinator {
     }
 
     /// All services that are currently enabled in settings and authenticated.
-    private var enabledConnectedServices: [any ScrobbleServiceProtocol] {
+    var enabledConnectedServices: [any ScrobbleServiceProtocol] {
         self.services.filter { service in
             self.settingsManager.isServiceEnabled(service.serviceName) && service.authState.isConnected
         }
@@ -126,8 +145,7 @@ final class ScrobblingCoordinator {
 
     // MARK: - Lifecycle
 
-    /// Must be called before deinit to ensure all async tasks are cancelled on the main actor.
-    /// Starts monitoring PlayerService for scrobble-worthy events.
+    /// Starts monitoring; must be paired with stopMonitoring() before deinit.
     func startMonitoring() {
         guard !self.isMonitoring else { return }
         self.isMonitoring = true
@@ -141,16 +159,20 @@ final class ScrobblingCoordinator {
         self.scheduleQueueFlushIfNeeded()
     }
 
-    /// Stops monitoring and cancels all tasks.
-    func stopMonitoring() {
+    /// Stops active monitoring. Set `finalizeCurrentTrack` only for permanent teardown.
+    func stopMonitoring(finalizeCurrentTrack: Bool = false) {
+        if finalizeCurrentTrack {
+            self.finalizeCurrentTrack()
+        }
         self.monitoringGeneration += 1
         self.flushTaskGeneration += 1
         self.flushTask?.cancel()
         self.flushTask = nil
         self.cancelMixTracklistFetch()
-        self.mixParseAttempted = false
-        self.nowPlayingTasks.forEach { $0.cancel() }
-        self.nowPlayingTasks.removeAll()
+        if case .parsing = self.mixDetectionState {
+            self.mixDetectionState = .unresolved
+        }
+        self.cancelNowPlayingTasks()
         self.isMonitoring = false
         self.logger.info("Scrobbling coordinator stopped monitoring")
     }
@@ -164,10 +186,7 @@ final class ScrobblingCoordinator {
 
     // MARK: - Observation
 
-    /// Re-arms Observation tracking for playback fields that affect scrobbling.
-    ///
-    /// Progress updates already arrive from the playback WebView while media is playing, so observing those
-    /// mutations avoids an independent app-lifetime 500 ms timer when the app is idle or scrobbling is disabled.
+    /// Re-arms observation for playback fields, avoiding an independent app-lifetime polling timer.
     private func observePlayerStateChanges(generation: Int) {
         guard self.isMonitoring(generation: generation) else { return }
 
@@ -178,6 +197,8 @@ final class ScrobblingCoordinator {
             _ = self.playerService.isPlaying
             _ = self.playerService.progress
             _ = self.playerService.duration
+            _ = self.playerService.playbackStateVideoId
+            _ = self.playerService.playbackStateObservationSequence
         } onChange: { [weak self] in
             Task { @MainActor [weak self] in
                 guard let self, self.isMonitoring(generation: generation) else { return }
@@ -187,8 +208,7 @@ final class ScrobblingCoordinator {
         }
     }
 
-    /// Re-arms Observation tracking for service auth/enablement. When no service is eligible, playback
-    /// observation remains cheap and `pollPlayerState()` returns immediately; queue flushes are unscheduled.
+    /// Re-arms service eligibility observation and unschedules queue work when none is active.
     private func observeMonitoringEligibilityChanges(generation: Int) {
         guard self.isMonitoring(generation: generation) else { return }
 
@@ -212,14 +232,13 @@ final class ScrobblingCoordinator {
     }
 
     /// Core scrobbling logic — driven by observed playback mutations instead of a periodic timer.
-    private func pollPlayerState() {
+    func pollPlayerState() {
         // Skip if no service is both enabled and connected
         guard self.hasAnyEnabledConnectedService else { return }
 
         let currentTrack = self.playerService.currentTrack
         let isPlaying = self.playerService.isPlaying
         let progress = self.playerService.progress
-        let duration = self.playerService.duration
 
         // Track change detection
         if let track = currentTrack {
@@ -230,41 +249,80 @@ final class ScrobblingCoordinator {
 
             if videoIdChanged || metadataChanged {
                 // Track changed — finalize previous, start tracking new
+                let requiredPlaybackStateSequence = metadataChanged && !videoIdChanged
+                    ? self.playerService.playbackStateObservationSequence &+ 1
+                    : nil
                 self.finalizeCurrentTrack()
-                self.startTrackingNewTrack(track)
-            } else if track.videoId == self.currentTrackVideoId,
-                      let tracker = self.trackTracker, tracker.hasScrobbled,
-                      progress < tracker.lastProgress - 5.0
+                self.startTrackingNewTrack(
+                    track,
+                    requiredPlaybackStateSequence: requiredPlaybackStateSequence
+                )
+            }
+
+            guard self.acceptPlaybackState(for: track) else { return }
+            self.updateTrackedVideoDuration(for: track)
+            self.revalidatePendingWholeTrackLatchIfNeeded()
+
+            if track.videoId == self.currentTrackVideoId,
+               let tracker = self.trackTracker, tracker.hasScrobbled,
+               progress < tracker.lastProgress - 5.0
             {
-                // Same track but progress jumped backward significantly — replay detected
-                self.finalizeCurrentTrack()
-                self.startTrackingNewTrack(track)
+                switch self.mixDetectionState {
+                case .notMix:
+                    self.finalizeCurrentTrack()
+                    self.startTrackingNewTrack(track)
+                case .unresolved, .parsing, .awaitingDuration:
+                    self.refreshPendingWholeTrackPlay(with: tracker)
+                    self.trackTracker = PlaybackScrobbleTracker(startTime: Date(), initialProgress: progress)
+                case .mix:
+                    break
+                }
             }
 
-            // Lazily attempt the mix-tracklist fetch — duration is often unknown at track-start,
-            // so this retries each poll (poll re-runs on duration changes) until it can run once.
-            if self.mixTracklist == nil {
-                self.attemptMixTracklistFetch(for: track)
-            }
-
-            // If a mix tracklist is available, switch to mix-mode scrobbling
-            if let tracklist = self.mixTracklist {
+            // Resolve whether this is a regular track or a mix. Duration is often unknown at
+            // track-start, so unresolved/parsing states keep provisional play time but suppress
+            // whole-track now-playing/scrobble side effects until classification completes.
+            self.resolveMixDetection(for: track)
+            switch self.mixDetectionState {
+            case .unresolved, .parsing, .awaitingDuration:
+                // Provisional whole-track accounting intentionally matches regular-track behavior:
+                // `accumulate` rejects the seek delta but preserves verified play time on both sides.
+                self.accumulateWholeTrack(
+                    progress: progress,
+                    isPlaying: isPlaying,
+                    recordProvisionalSegment: true
+                )
+                self.capturePendingWholeTrackScrobbleIfNeeded(track)
+                if case .awaitingDuration = self.mixDetectionState,
+                   self.durationConfirmationCompleted,
+                   self.trackTracker?.hasSentNowPlaying == false,
+                   isPlaying
+                {
+                    self.sendNowPlaying(track)
+                }
+                return
+            case let .mix(tracklist):
+                self.consumeProvisionalPlayback(for: tracklist, song: self.trackedSong)
                 self.handleMixPlayback(track: track, tracklist: tracklist, progress: progress, isPlaying: isPlaying)
                 return
+            case .notMix:
+                break
             }
 
             // Accumulate play time (the tracker ignores seeks and paused spans internally)
-            self.trackTracker?.accumulate(progress: progress, isPlaying: isPlaying, now: Date())
+            self.accumulateWholeTrack(
+                progress: progress,
+                isPlaying: isPlaying,
+                recordProvisionalSegment: false
+            )
 
             // Send "now playing" once per track
             if self.trackTracker?.hasSentNowPlaying == false, isPlaying {
                 self.sendNowPlaying(track)
             }
 
-            // Check scrobble threshold. Deferred while a mix parse is in flight so a slow
-            // tracklist fetch can't let the whole mix scrobble once as one track and again
-            // per sub-track after the tracklist arrives.
-            if self.trackTracker?.hasScrobbled == false, duration > 0, self.mixParseTask == nil {
+            // Check scrobble threshold
+            if self.trackTracker?.hasScrobbled == false, let duration = self.trackedVideoDuration {
                 self.checkScrobbleThreshold(track: track, duration: duration)
             }
         } else if self.currentTrackVideoId != nil {
@@ -275,7 +333,10 @@ final class ScrobblingCoordinator {
 
     // MARK: - Track Lifecycle
 
-    private func startTrackingNewTrack(_ track: Song) {
+    private func startTrackingNewTrack(
+        _ track: Song,
+        requiredPlaybackStateSequence: Int? = nil
+    ) {
         self.currentTrackVideoId = track.videoId
         self.currentTrackTitle = track.title
         self.currentTrackArtist = track.artistsDisplay
@@ -284,65 +345,250 @@ final class ScrobblingCoordinator {
             startTime: Date(),
             initialProgress: self.playerService.progress
         )
+        self.requiredPlaybackStateSequence = requiredPlaybackStateSequence
+        self.pendingWholeTrackPlays.removeAll()
+        self.trackedVideoDuration = track.duration.flatMap { $0 > 0 ? $0 : nil }
+        if requiredPlaybackStateSequence == nil {
+            self.updateTrackedVideoDuration(for: track)
+        }
 
         // Reset mix-mode state for the new track
-        self.mixTracklist = nil
+        self.mixDetectionState = .unresolved
         self.currentMixEntry = nil
         self.mixEntryTracker = nil
-        self.mixParseAttempted = false
+        self.mixEntryScrobbledIds.removeAll()
+        self.provisionalMixHistory.removeAll()
+        self.provisionalCurrentMixCredit = nil
+        self.durationConfirmationCompleted = false
+        self.mixParseStartedWithoutDuration = false
+        self.scheduleUnknownDurationParse(for: track)
 
         self.logger.debug("Started tracking: \(track.title) by \(track.artistsDisplay)")
 
-        // The mix-tracklist fetch is gated on duration, which is often not yet known here
-        // (YouTube reports it a beat after the track object appears). The poll loop retries
-        // `attemptMixTracklistFetch(for:)` until duration is available.
+        // Mix detection is gated on duration, which is often not yet known here. The poll loop
+        // retries `resolveMixDetection(for:)` until duration is available.
     }
 
-    /// Attempts to fetch a mix tracklist for the track, once duration is known to exceed the
-    /// mix threshold. Retried from the poll loop while `mixParseAttempted` is false, then latched
-    /// so it runs at most once per track. When a tracklist is found, the coordinator switches to
-    /// mix-mode on the next poll.
-    private func attemptMixTracklistFetch(for track: Song) {
-        guard let parser = self.mixTracklistParser, self.mixParseTask == nil, !self.mixParseAttempted else { return }
+    /// Resolves long tracks through parsing and short/no-parser tracks as whole-track mode.
+    private func resolveMixDetection(for track: Song) {
+        let scopedDuration = self.scopedDuration(for: track)
+        if case let .awaitingDuration(tracklist) = self.mixDetectionState {
+            let phase: MixDurationDecisionPhase = self.durationConfirmationCompleted
+                ? .activeAfterGrace
+                : .activeBeforeGrace
+            let decision = Self.mixDurationDecision(
+                for: tracklist,
+                songDuration: track.duration,
+                playerDuration: self.scopedPlayerDuration(for: track),
+                phase: phase
+            )
+            if self.applyMixDurationDecision(decision, tracklist: tracklist) {
+                return
+            }
+            if !self.durationConfirmationCompleted, self.durationConfirmationTask == nil {
+                self.scheduleAwaitingDurationConfirmation(for: track)
+            }
+            return
+        }
 
-        // Duration isn't reliably available at track-start; wait until it crosses the mix threshold.
-        let duration = track.duration ?? self.playerService.duration
-        guard duration > 600 else { return }
+        if case .parsing = self.mixDetectionState {
+            if let songDuration = track.duration,
+               songDuration > 0,
+               songDuration <= Self.mixMinimumVideoDuration
+            {
+                self.cancelMixTracklistFetch()
+                self.resolveAsNotMix()
+            } else if let songDuration = track.duration,
+                      songDuration > Self.mixMinimumVideoDuration,
+                      self.mixParseStartedWithoutDuration
+            {
+                self.mixParseStartedWithoutDuration = false
+            }
+            return
+        }
 
-        self.mixParseAttempted = true
+        guard case .unresolved = self.mixDetectionState else { return }
+        guard let parser = self.mixTracklistParser else {
+            self.resolveAsNotMix()
+            return
+        }
+        guard let scopedDuration else {
+            if self.unknownDurationParseTask == nil {
+                self.scheduleUnknownDurationParse(for: track)
+            }
+            return
+        }
+        guard scopedDuration > Self.mixMinimumVideoDuration else {
+            if let duration = track.duration, duration > 0 {
+                self.resolveAsNotMix()
+            } else if self.unknownDurationParseTask == nil {
+                self.scheduleUnknownDurationParse(for: track)
+            }
+            return
+        }
+
+        let lacksSongDuration = track.duration.map { $0 <= 0 } ?? true
+        self.startMixParse(for: track, parser: parser, startedWithoutDuration: lacksSongDuration)
+    }
+
+    func startMixParse(
+        for track: Song,
+        parser: MixTracklistParser,
+        startedWithoutDuration: Bool
+    ) {
+        guard case .unresolved = self.mixDetectionState else { return }
+        self.unknownDurationParseTask?.cancel()
+        self.unknownDurationParseTask = nil
+
+        self.mixDetectionState = .parsing
+        self.mixParseStartedWithoutDuration = startedWithoutDuration
         self.mixParseGeneration += 1
         let generation = self.mixParseGeneration
         let videoId = track.videoId
-        self.mixParseTask = Task { @MainActor [weak self] in
+        let parseTask = Task { @MainActor in
+            await parser.parseTracklist(videoId: videoId)
+        }
+        self.mixParseTask = parseTask
+        self.scheduleMixParseTimeout(for: track, videoId: videoId, generation: generation)
+        self.mixParseMonitorTask = Task { @MainActor [weak self] in
+            let tracklist = await parseTask.value
             guard let self else { return }
-            let tracklist = await parser.parseTracklist(videoId: videoId)
 
             // A track change may have cancelled this request and started another. Only the task
             // owning the current generation may clear the in-flight slot or publish its result.
             guard self.mixParseGeneration == generation else { return }
-            self.mixParseTask = nil
             guard !Task.isCancelled, self.currentTrackVideoId == videoId else { return }
-            if let tracklist, tracklist.isMix {
-                self.mixTracklist = tracklist
-                self.logger.info("Mix tracklist loaded: \(tracklist.entries.count) sub-tracks for \(track.title)")
-                // Mix-mode takes over from here: once mixTracklist is set the poll routes to
-                // handleMixPlayback and the single-track tracker is no longer consulted.
+            self.mixParseTimeoutTask?.cancel()
+            self.mixParseTimeoutTask = nil
+            guard let playerTrack = self.playerService.currentTrack else { return }
+            let currentTrackStillMatches = playerTrack.videoId == videoId
+                && playerTrack.title == track.title
+                && playerTrack.artistsDisplay == track.artistsDisplay
+            if !currentTrackStillMatches {
+                self.mixParseMonitorTask = nil
+                if !self.deferPendingRegularTrackFinalizationIfNeeded() {
+                    self.cancelMixTracklistFetch()
+                }
+                self.pollPlayerState()
+                return
             }
+
+            self.mixParseTask = nil
+            self.mixParseMonitorTask = nil
+            self.trackedSong = playerTrack
+            self.updateTrackedVideoDuration(for: playerTrack)
+            if let songDuration = playerTrack.duration,
+               songDuration > 0,
+               songDuration <= Self.mixMinimumVideoDuration
+            {
+                self.mixParseStartedWithoutDuration = false
+                self.resolveAsNotMix()
+                self.pollPlayerState()
+                return
+            }
+            let scopedDuration = self.scopedDuration(for: playerTrack)
+            let hasSongDuration = playerTrack.duration.map { $0 > 0 } ?? false
+            let stillAwaitingDuration = self.mixParseStartedWithoutDuration
+                && !hasSongDuration
+                && (scopedDuration.map { $0 <= Self.mixMinimumVideoDuration } ?? true)
+            self.mixParseStartedWithoutDuration = false
+            if let tracklist, tracklist.isMix {
+                if stillAwaitingDuration {
+                    self.mixDetectionState = .awaitingDuration(tracklist)
+                    self.durationConfirmationCompleted = false
+                } else {
+                    self.resolveAsMix(tracklist)
+                }
+                self.logger.info("Mix tracklist loaded: \(tracklist.entries.count) sub-tracks for \(playerTrack.title)")
+            } else {
+                self.resolveAsNotMix()
+            }
+            self.pollPlayerState()
         }
     }
 
     private func cancelMixTracklistFetch() {
         self.mixParseGeneration += 1
+        self.unknownDurationParseTask?.cancel()
+        self.unknownDurationParseTask = nil
+        self.durationConfirmationTask?.cancel()
+        self.durationConfirmationTask = nil
+        self.mixParseMonitorTask?.cancel()
+        self.mixParseMonitorTask = nil
+        self.mixParseTimeoutTask?.cancel()
+        self.mixParseTimeoutTask = nil
         self.mixParseTask?.cancel()
         self.mixParseTask = nil
+        self.durationConfirmationCompleted = false
+        self.mixParseStartedWithoutDuration = false
+    }
+
+    private func updateTrackedVideoDuration(for track: Song) {
+        if let duration = track.duration, duration > 0 {
+            self.trackedVideoDuration = duration
+        } else if self.playerService.playbackStateVideoId == track.videoId,
+                  self.playerService.duration > 0
+        {
+            self.trackedVideoDuration = self.playerService.duration
+        }
+    }
+
+    private func accumulateWholeTrack(
+        progress: TimeInterval,
+        isPlaying: Bool,
+        recordProvisionalSegment: Bool
+    ) {
+        guard var tracker = self.trackTracker else { return }
+        let segmentStart = tracker.lastProgress
+        let now = Date()
+        let credited = tracker.accumulate(progress: progress, isPlaying: isPlaying, now: now)
+        self.trackTracker = tracker
+
+        guard recordProvisionalSegment else { return }
+        if credited == 0, abs(progress - segmentStart) > 5 {
+            self.provisionalMixHistory.recordDiscontinuity(at: progress, startTime: now)
+            return
+        }
+        guard credited > 0 else { return }
+        self.provisionalMixHistory.record(
+            startProgress: segmentStart,
+            endProgress: progress,
+            startTime: now.addingTimeInterval(-credited)
+        )
     }
 
     private func finalizeCurrentTrack() {
-        // Never let a slow request for the previous video block or overwrite the next track.
-        self.cancelMixTracklistFetch()
+        self.cancelNowPlayingTasks()
+
+        if case .unresolved = self.mixDetectionState,
+           let song = self.trackedSong
+        {
+            let scopedDuration = self.scopedDuration(for: song)
+            if let scopedDuration, scopedDuration <= Self.mixMinimumVideoDuration {
+                self.resolveAsNotMix()
+            } else if let parser = self.mixTracklistParser,
+                      self.provisionalMixHistory.hasPlayback || !self.pendingWholeTrackPlays.isEmpty
+            {
+                self.startMixParse(
+                    for: song,
+                    parser: parser,
+                    startedWithoutDuration: scopedDuration == nil
+                )
+            }
+        }
+
+        self.resolveAwaitingDurationForFinalization()
+
+        // A qualifying regular track whose parse is still pending finalizes after that parse says
+        // it is not a mix. Detaching it keeps the next track's detection independent.
+        if !self.deferPendingRegularTrackFinalizationIfNeeded() {
+            self.cancelMixTracklistFetch()
+        }
+
+        self.finalizeResidualMixHistoryIfNeeded()
 
         // Finalize mix-mode sub-track if active
-        if self.mixTracklist != nil, let entry = self.currentMixEntry {
+        if self.currentMixTracklist != nil, let entry = self.currentMixEntry {
             self.finalizeMixEntry(entry, song: self.trackedSong)
         }
 
@@ -350,9 +596,11 @@ final class ScrobblingCoordinator {
         guard self.currentTrackVideoId != nil else { return }
 
         // Final threshold check before discarding accumulated play time (single-track mode only)
-        if self.mixTracklist == nil, self.trackTracker?.hasScrobbled == false, let song = self.trackedSong {
-            let duration = song.duration ?? self.playerService.duration
-            if duration > 0 {
+        if case .notMix = self.mixDetectionState,
+           self.trackTracker?.hasScrobbled == false,
+           let song = self.trackedSong
+        {
+            if let duration = self.trackedVideoDuration {
                 self.checkScrobbleThreshold(track: song, duration: duration)
             }
         }
@@ -363,21 +611,25 @@ final class ScrobblingCoordinator {
         self.currentTrackVideoId = nil
         self.currentTrackTitle = nil
         self.currentTrackArtist = nil
+        self.requiredPlaybackStateSequence = nil
         self.trackedSong = nil
         self.trackTracker = nil
+        self.trackedVideoDuration = nil
+        self.pendingWholeTrackPlays.removeAll()
 
         // Reset mix-mode state
-        self.mixTracklist = nil
+        self.mixDetectionState = .unresolved
         self.currentMixEntry = nil
         self.mixEntryTracker = nil
-        self.mixParseAttempted = false
+        self.mixEntryScrobbledIds.removeAll()
+        self.provisionalMixHistory.removeAll()
+        self.provisionalCurrentMixCredit = nil
     }
 
     // MARK: - Scrobble Threshold
 
-    /// Scrobble thresholds for a whole track. Whole tracks always carry a duration, so an
-    /// unknown duration is treated as ineligible.
-    private var trackThresholds: PlaybackScrobbleTracker.Thresholds {
+    /// Whole-track thresholds treat unknown duration as ineligible.
+    var trackThresholds: PlaybackScrobbleTracker.Thresholds {
         .init(
             percent: self.settingsManager.scrobblePercentThreshold,
             minSeconds: self.settingsManager.scrobbleMinSeconds,
@@ -385,9 +637,8 @@ final class ScrobblingCoordinator {
         )
     }
 
-    /// Scrobble thresholds for a mix sub-track. YouTube does not always expose chapter bounds,
-    /// so an unknown duration still qualifies via `minSeconds`.
-    private var mixEntryThresholds: PlaybackScrobbleTracker.Thresholds {
+    /// Mix sub-tracks with unknown chapter bounds can still qualify via `minSeconds`.
+    var mixEntryThresholds: PlaybackScrobbleTracker.Thresholds {
         .init(
             percent: self.settingsManager.scrobblePercentThreshold,
             minSeconds: self.settingsManager.scrobbleMinSeconds,
@@ -411,8 +662,7 @@ final class ScrobblingCoordinator {
 
     // MARK: - Mix-Mode Playback Handling
 
-    /// Handles per-sub-track scrobbling within a mix. Called instead of the
-    /// single-track accumulation/threshold logic when a mix tracklist is available.
+    /// Handles per-sub-track scrobbling when a mix tracklist is available.
     private func handleMixPlayback(
         track: Song,
         tracklist: MixTracklist,
@@ -425,6 +675,21 @@ final class ScrobblingCoordinator {
         // Sub-track changed — finalize previous, start new
         if entry?.id != self.currentMixEntry?.id {
             if let prevEntry = self.currentMixEntry {
+                if let endTime = tracklist.effectiveEndTime(
+                    for: prevEntry,
+                    videoDuration: self.videoDuration(for: track)
+                ),
+                    let tracker = self.mixEntryTracker
+                {
+                    let progressDelta = progress - tracker.lastProgress
+                    if progress >= endTime, progressDelta > 0, progressDelta < 2 {
+                        self.mixEntryTracker?.accumulate(
+                            progress: endTime,
+                            isPlaying: isPlaying,
+                            now: Date()
+                        )
+                    }
+                }
                 self.finalizeMixEntry(prevEntry, song: track)
             }
 
@@ -438,18 +703,20 @@ final class ScrobblingCoordinator {
 
         guard let entry, self.currentMixEntry?.id == entry.id else { return }
 
-        // Seek detection: a significant jump resets the sub-track clock. Once the entry has
-        // scrobbled, only a backward jump matters — that's a replay, restarted with a fresh
-        // tracker so a second scrobble carries a new timestamp instead of duplicating the first.
+        // A backward jump after scrobbling is a replay and gets a fresh timestamp. Other seeks
+        // only reset accumulated play time; already-sent latches remain set to prevent duplicates.
         if let tracker = self.mixEntryTracker, abs(progress - tracker.lastProgress) > 5.0 {
-            if tracker.hasScrobbled {
-                if progress < tracker.lastProgress {
-                    self.startMixEntry(entry, progress: progress)
-                    self.logger.debug("Mix replay detected at \(String(format: "%.1f", progress))s, restarting sub-track '\(entry.title)'")
-                }
+            let restartedNearEntryStart = progress <= entry.startTime + Self.mixReplayStartTolerance
+            if tracker.hasScrobbled,
+               progress < tracker.lastProgress - 5.0,
+               restartedNearEntryStart
+            {
+                self.mixEntryScrobbledIds.remove(entry.id)
+                self.mixEntryTracker = PlaybackScrobbleTracker(startTime: Date(), initialProgress: progress)
+                self.logger.debug("Mix replay detected at \(String(format: "%.1f", progress))s for sub-track '\(entry.title)'")
             } else {
                 self.mixEntryTracker?.resetForSeek()
-                self.logger.debug("Mix seek detected at \(String(format: "%.1f", progress))s, resetting sub-track '\(entry.title)'")
+                self.logger.debug("Mix seek detected at \(String(format: "%.1f", progress))s, resetting sub-track accumulation for '\(entry.title)'")
             }
         }
 
@@ -470,7 +737,31 @@ final class ScrobblingCoordinator {
     /// Starts tracking a new sub-track within the mix.
     private func startMixEntry(_ entry: MixTrackEntry, progress: TimeInterval) {
         self.currentMixEntry = entry
-        self.mixEntryTracker = PlaybackScrobbleTracker(startTime: Date(), initialProgress: progress)
+        let pendingCredit = self.provisionalCurrentMixCredit
+        self.provisionalCurrentMixCredit = nil
+        let provisionalCredit = pendingCredit.flatMap { credit in
+            credit.entryId == entry.id ? credit.credit : nil
+        }
+        let isConfirmedReplay = self.mixEntryScrobbledIds.contains(entry.id)
+            && progress <= entry.startTime + Self.mixReplayStartTolerance
+        if isConfirmedReplay {
+            self.mixEntryScrobbledIds.remove(entry.id)
+        }
+        var tracker = PlaybackScrobbleTracker(
+            startTime: provisionalCredit?.startTime ?? Date(),
+            initialProgress: progress
+        )
+        if let provisionalCredit {
+            tracker.creditVerifiedPlayTime(provisionalCredit.accumulatedPlayTime)
+            if provisionalCredit.hasScrobbled {
+                tracker.markScrobbled()
+                self.mixEntryScrobbledIds.insert(entry.id)
+            }
+        }
+        if self.mixEntryScrobbledIds.contains(entry.id) {
+            tracker.markScrobbled()
+        }
+        self.mixEntryTracker = tracker
         self.logger.debug("Mix sub-track started: \(entry.artist ?? "?") - \(entry.title) at \(String(format: "%.1f", entry.startTime))s")
     }
 
@@ -489,18 +780,20 @@ final class ScrobblingCoordinator {
 
     /// Checks whether the current sub-track has met the scrobble threshold.
     private func checkMixEntryScrobbleThreshold(entry: MixTrackEntry, song: Song?) {
+        let duration = self.mixEntryDuration(entry, song: song)
         guard var tracker = self.mixEntryTracker,
-              tracker.meetsThreshold(duration: entry.duration, thresholds: self.mixEntryThresholds)
+              tracker.meetsThreshold(duration: duration, thresholds: self.mixEntryThresholds)
         else { return }
 
         tracker.markScrobbled()
         self.mixEntryTracker = tracker
+        self.mixEntryScrobbledIds.insert(entry.id)
 
         let scrobbleTrack = ScrobbleTrack(
             title: entry.title,
             artist: entry.artist ?? song?.artistsDisplay ?? "Unknown Artist",
             album: nil,
-            duration: entry.duration,
+            duration: duration,
             timestamp: tracker.startTime,
             videoId: song?.videoId
         )
@@ -509,72 +802,9 @@ final class ScrobblingCoordinator {
         self.logger.info("Mix scrobble: \(entry.artist ?? "?") - \(entry.title) (accumulated: \(String(format: "%.1f", tracker.accumulatedPlayTime))s)")
     }
 
-    /// Sends a "now playing" update for a mix sub-track.
-    private func sendMixNowPlaying(_ entry: MixTrackEntry, song: Song) {
-        guard var tracker = self.mixEntryTracker else { return }
-        tracker.markNowPlayingSent()
-        self.mixEntryTracker = tracker
-
-        let scrobbleTrack = ScrobbleTrack(
-            title: entry.title,
-            artist: entry.artist ?? song.artistsDisplay,
-            album: nil,
-            duration: entry.duration,
-            timestamp: tracker.startTime,
-            videoId: song.videoId
-        )
-
-        // Cancel any in-flight now-playing tasks from a previous sub-track
-        self.nowPlayingTasks.forEach { $0.cancel() }
-        self.nowPlayingTasks.removeAll()
-
-        for service in self.enabledConnectedServices {
-            let task = Task { @MainActor [weak self] in
-                guard let self else { return }
-                do {
-                    try await service.updateNowPlaying(scrobbleTrack)
-                } catch is CancellationError {
-                    // Expected when sub-track changes
-                } catch {
-                    self.logger.debug("Mix now playing failed for \(service.serviceName) (non-critical): \(error.localizedDescription)")
-                }
-            }
-            self.nowPlayingTasks.append(task)
-        }
-    }
-
-    // MARK: - Now Playing
-
-    private func sendNowPlaying(_ track: Song) {
-        guard var tracker = self.trackTracker else { return }
-        tracker.markNowPlayingSent()
-        self.trackTracker = tracker
-
-        let scrobbleTrack = ScrobbleTrack(from: track, timestamp: tracker.startTime)
-
-        // Cancel any in-flight now-playing tasks from a previous track
-        self.nowPlayingTasks.forEach { $0.cancel() }
-        self.nowPlayingTasks.removeAll()
-
-        // Send now-playing to all enabled+connected services
-        for service in self.enabledConnectedServices {
-            let task = Task { @MainActor [weak self] in
-                guard let self else { return }
-                do {
-                    try await service.updateNowPlaying(scrobbleTrack)
-                } catch is CancellationError {
-                    // Expected when coordinator stops or track changes
-                } catch {
-                    self.logger.debug("Now playing update failed for \(service.serviceName) (non-critical): \(error.localizedDescription)")
-                }
-            }
-            self.nowPlayingTasks.append(task)
-        }
-    }
-
     // MARK: - Queue Flush
 
-    private func scheduleQueueFlushIfNeeded(after delay: Duration = .seconds(30)) {
+    func scheduleQueueFlushIfNeeded(after delay: Duration = .seconds(30)) {
         guard self.isMonitoring,
               self.hasAnyEnabledConnectedService,
               !self.queue.isEmpty

--- a/Sources/Kaset/Services/Scrobbling/ScrobblingSettingsProviding.swift
+++ b/Sources/Kaset/Services/Scrobbling/ScrobblingSettingsProviding.swift
@@ -1,0 +1,19 @@
+// MARK: - ScrobblingSettingsProviding
+
+import Foundation
+
+// MARK: - ScrobblingSettingsProviding
+
+/// Settings surface needed by scrobbling coordination. Keeping this narrow makes playback tests
+/// independent from the process-wide SettingsManager singleton.
+@MainActor
+protocol ScrobblingSettingsProviding: AnyObject {
+    var scrobblePercentThreshold: Double { get }
+    var scrobbleMinSeconds: TimeInterval { get }
+
+    func isServiceEnabled(_ serviceName: String) -> Bool
+}
+
+// MARK: - SettingsManager + ScrobblingSettingsProviding
+
+extension SettingsManager: ScrobblingSettingsProviding {}

--- a/Sources/Kaset/Views/MiniPlayerWebView.swift
+++ b/Sources/Kaset/Views/MiniPlayerWebView.swift
@@ -662,7 +662,8 @@ final class SingletonPlayerWebView {
                 self.playerService.updatePlaybackState(
                     isPlaying: isPlaying,
                     progress: Double(progress),
-                    duration: Double(duration)
+                    duration: Double(duration),
+                    observedVideoId: observedVideoId
                 )
 
                 // Update video availability

--- a/Tests/KasetTests/Helpers/MockScrobbleService.swift
+++ b/Tests/KasetTests/Helpers/MockScrobbleService.swift
@@ -24,6 +24,7 @@ final class MockScrobbleService: ScrobbleServiceProtocol {
     var shouldThrowOnAuthenticate: Error?
     var shouldThrowOnNowPlaying: Error?
     var shouldThrowOnScrobble: Error?
+    var beforeNowPlayingReturn: (@Sendable (ScrobbleTrack) async -> Void)?
     var scrobbleResults: [ScrobbleResult]?
     var validateSessionResult: Bool = true
 
@@ -47,6 +48,10 @@ final class MockScrobbleService: ScrobbleServiceProtocol {
     }
 
     func updateNowPlaying(_ track: ScrobbleTrack) async throws {
+        if let beforeNowPlayingReturn {
+            await beforeNowPlayingReturn(track)
+        }
+        try Task.checkCancellation()
         self.nowPlayingTracks.append(track)
         if let error = self.shouldThrowOnNowPlaying {
             throw error
@@ -81,6 +86,7 @@ final class MockScrobbleService: ScrobbleServiceProtocol {
         self.shouldThrowOnAuthenticate = nil
         self.shouldThrowOnNowPlaying = nil
         self.shouldThrowOnScrobble = nil
+        self.beforeNowPlayingReturn = nil
         self.scrobbleResults = nil
         self.validateSessionResult = true
         self.authState = .disconnected

--- a/Tests/KasetTests/Helpers/MockScrobblingSettings.swift
+++ b/Tests/KasetTests/Helpers/MockScrobblingSettings.swift
@@ -1,0 +1,27 @@
+import Foundation
+@testable import Kaset
+
+@MainActor
+final class MockScrobblingSettings: ScrobblingSettingsProviding {
+    var scrobblePercentThreshold: Double
+    var scrobbleMinSeconds: TimeInterval
+    private var enabledServices: [String: Bool]
+
+    init(
+        scrobblePercentThreshold: Double = 0.5,
+        scrobbleMinSeconds: TimeInterval = 240,
+        enabledServices: [String: Bool] = [:]
+    ) {
+        self.scrobblePercentThreshold = scrobblePercentThreshold
+        self.scrobbleMinSeconds = scrobbleMinSeconds
+        self.enabledServices = enabledServices
+    }
+
+    func isServiceEnabled(_ serviceName: String) -> Bool {
+        self.enabledServices[serviceName] ?? false
+    }
+
+    func setServiceEnabled(_ serviceName: String, _ enabled: Bool) {
+        self.enabledServices[serviceName] = enabled
+    }
+}

--- a/Tests/KasetTests/Helpers/MockYouTubeClient.swift
+++ b/Tests/KasetTests/Helpers/MockYouTubeClient.swift
@@ -185,7 +185,10 @@ final class MockYouTubeClient: YouTubeClientProtocol {
         return response
     }
 
+    private(set) var getWatchNextCallCount = 0
+
     func getWatchNext(videoId _: String) async throws -> WatchNextData {
+        self.getWatchNextCallCount += 1
         if let error {
             throw error
         }

--- a/Tests/KasetTests/Helpers/MockYouTubeClient.swift
+++ b/Tests/KasetTests/Helpers/MockYouTubeClient.swift
@@ -186,12 +186,22 @@ final class MockYouTubeClient: YouTubeClientProtocol {
     }
 
     private(set) var getWatchNextCallCount = 0
+    private(set) var requestedWatchNextVideoIds: [String] = []
 
-    func getWatchNext(videoId _: String) async throws -> WatchNextData {
+    /// Awaited inside `getWatchNext` before it returns, so a test can hold one mix parse open
+    /// while the coordinator switches tracks and starts a newer request.
+    var beforeWatchNextReturn: (@Sendable (String) async -> Void)?
+
+    func getWatchNext(videoId: String) async throws -> WatchNextData {
         self.getWatchNextCallCount += 1
+        self.requestedWatchNextVideoIds.append(videoId)
         if let error {
             throw error
         }
+        if let beforeWatchNextReturn {
+            await beforeWatchNextReturn(videoId)
+        }
+        try Task.checkCancellation()
         return self.watchNextData
     }
 

--- a/Tests/KasetTests/Helpers/MockYouTubeClient.swift
+++ b/Tests/KasetTests/Helpers/MockYouTubeClient.swift
@@ -186,6 +186,7 @@ final class MockYouTubeClient: YouTubeClientProtocol {
     }
 
     private(set) var getWatchNextCallCount = 0
+    private(set) var getWatchNextCompletionCount = 0
     private(set) var requestedWatchNextVideoIds: [String] = []
 
     /// Awaited inside `getWatchNext` before it returns, so a test can hold one mix parse open
@@ -202,6 +203,7 @@ final class MockYouTubeClient: YouTubeClientProtocol {
             await beforeWatchNextReturn(videoId)
         }
         try Task.checkCancellation()
+        self.getWatchNextCompletionCount += 1
         return self.watchNextData
     }
 

--- a/Tests/KasetTests/MixTracklistDescriptionParserTests.swift
+++ b/Tests/KasetTests/MixTracklistDescriptionParserTests.swift
@@ -1,0 +1,724 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+// MARK: - MixTracklistDescriptionParserTests
+
+@Suite(.tags(.model))
+struct MixTracklistDescriptionParserTests {
+    @MainActor
+    @Test("Description timestamp fallback builds a structured mix tracklist")
+    func parsesDescriptionTimestampFallback() async {
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = WatchNextData(
+            videoTitle: "Description Mix",
+            viewCountText: nil,
+            publishedText: nil,
+            channel: nil,
+            related: [],
+            descriptionText: """
+            Notes before the tracklist block.
+
+            Tracklist:
+            00:00 - Artist A - Track One
+            03:15 Artist B – Track Two
+            [06:30] Artist C — Track Three
+
+            More links after the tracklist.
+            """
+        )
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+
+        let tracklist = await parser.parseTracklist(videoId: "description-mix")
+
+        #expect(tracklist?.source == .description)
+        #expect(tracklist?.entries.map(\.startTime) == [0, 195, 390])
+        #expect(tracklist?.entries.map(\.endTime) == [195, 390, nil])
+        #expect(tracklist?.entries.map(\.artist) == ["Artist A", "Artist B", "Artist C"])
+        #expect(tracklist?.entries.map(\.title) == ["Track One", "Track Two", "Track Three"])
+        if let tracklist, let finalEntry = tracklist.entries.last {
+            #expect(tracklist.effectiveDuration(for: finalEntry, videoDuration: 450) == 60)
+        }
+        #expect(mockYouTube.getWatchNextCallCount == 1)
+    }
+
+    @MainActor
+    @Test("Description timestamp fallback preserves common timestamp layouts")
+    func preservesCommonDescriptionTimestampLayouts() async {
+        let descriptions = [
+            "0:00 A - One\n1:02:03 B - Two\n2:00:00 C - Three",
+            "A - One 0:00\nB - Two 1:02:03\nC - Three 2:00:00",
+            "[0:00] A - One\n[1:02:03] B - Two\n[2:00:00] C - Three",
+            "(0:00) A - One\n(1:02:03) B - Two\n(2:00:00) C - Three",
+            "1. A - One 0:00\n2. B - Two 1:02:03\n3. C - Three 2:00:00",
+        ]
+
+        for (index, description) in descriptions.enumerated() {
+            let mockYouTube = MockYouTubeClient()
+            mockYouTube.watchNextData = WatchNextData(
+                videoTitle: "Description Mix",
+                viewCountText: nil,
+                publishedText: nil,
+                channel: nil,
+                related: [],
+                descriptionText: "Tracklist:\n\(description)"
+            )
+
+            let tracklist = await MixTracklistParser(youTubeClient: mockYouTube)
+                .parseTracklist(videoId: "description-format-\(index)")
+
+            #expect(tracklist?.entries.map(\.startTime) == [0, 3723, 7200])
+            #expect(tracklist?.entries.map(\.artist) == ["A", "B", "C"])
+            #expect(tracklist?.entries.map(\.title) == ["One", "Two", "Three"])
+        }
+    }
+
+    @MainActor
+    @Test("Description timestamp fallback keeps the longest increasing run")
+    func keepsLongestIncreasingDescriptionRun() async {
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = WatchNextData(
+            videoTitle: "Techno Mix",
+            viewCountText: nil,
+            publishedText: nil,
+            channel: nil,
+            related: [],
+            descriptionText: """
+            Tracklist:
+            12:00 Premiere starts
+            00:00 Artist A - Track One
+            03:00 Artist B - Track Two
+            06:00 Artist C - Track Three
+            09:00 Artist D - Track Four
+            15:00 Artist E - Track Five
+            """
+        )
+
+        let tracklist = await MixTracklistParser(youTubeClient: mockYouTube)
+            .parseTracklist(videoId: "increasing-description-run")
+
+        #expect(tracklist?.entries.map(\.startTime) == [0, 180, 360, 540, 900])
+        #expect(tracklist?.entries.map(\.title) == [
+            "Track One", "Track Two", "Track Three", "Track Four", "Track Five",
+        ])
+    }
+
+    @MainActor
+    @Test("The longest valid description block wins before artist count")
+    func prefersLongestValidDescriptionBlock() async {
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = WatchNextData(
+            videoTitle: "Progressive Session",
+            viewCountText: nil,
+            publishedText: nil,
+            channel: nil,
+            related: [],
+            descriptionText: """
+            00:00 Short Artist A - Short One
+            04:00 Short Artist B - Short Two
+            08:00 Short Artist C - Short Three
+            12:00 Short Artist D - Short Four
+            16:00 Short Artist E - Short Five
+            Alternate sequence:
+            00:00 Long Artist A - Long One
+            03:00 Long Artist B - Long Two
+            06:00 Long Artist C - Long Three
+            09:00 Long Artist D - Long Four
+            12:00 Drift
+            15:00 Glow
+            18:00 Horizon
+            21:00 Finale
+            """
+        )
+        let tracklist = await MixTracklistParser(youTubeClient: mockYouTube)
+            .parseTracklist(videoId: "longest-valid-description-block")
+
+        #expect(tracklist?.entries.count == 8)
+        #expect(tracklist?.entries.first?.artist == "Long Artist A")
+        #expect(tracklist?.entries.last?.title == "Finale")
+    }
+
+    @MainActor
+    @Test("An invalid description timestamp does not hide a later valid timestamp")
+    func skipsInvalidTimestampWithinDescriptionLine() async {
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = WatchNextData(
+            videoTitle: "Description Mix",
+            viewCountText: nil,
+            publishedText: nil,
+            channel: nil,
+            related: [],
+            descriptionText: """
+            Tracklist:
+            1:75:00 typo then 0:00 A - One
+            1:00 B - Two
+            2:00 C - Three
+            """
+        )
+
+        let tracklist = await MixTracklistParser(youTubeClient: mockYouTube)
+            .parseTracklist(videoId: "invalid-then-valid-description-time")
+
+        #expect(tracklist?.entries.map(\.startTime) == [0, 60, 120])
+        #expect(tracklist?.entries.first?.artist == "A")
+        #expect(tracklist?.entries.first?.title == "One")
+    }
+
+    @MainActor
+    @Test("Description timestamp fallback prefers structured duplicate rows")
+    func prefersStructuredDuplicateDescriptionRows() async {
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = WatchNextData(
+            videoTitle: "Duplicated Description Mix",
+            viewCountText: nil,
+            publishedText: nil,
+            channel: nil,
+            related: [],
+            descriptionText: """
+            Summary:
+            00:00 Intro - Welcome
+            03:00 Host - Segment
+            06:00 Outro - Closing
+
+            Tracklist:
+            00:00 Artist A - Track One
+            03:00 Artist B - Track Two
+            06:00 Artist C - Track Three
+            """
+        )
+        let tracklist = await MixTracklistParser(youTubeClient: mockYouTube)
+            .parseTracklist(videoId: "duplicated-description-mix")
+
+        #expect(tracklist?.entries.map(\.artist) == ["Artist A", "Artist B", "Artist C"])
+        #expect(tracklist?.entries.map(\.title) == ["Track One", "Track Two", "Track Three"])
+    }
+
+    @MainActor
+    @Test("Description timestamp fallback supports cumulative minutes above 99")
+    func parsesCumulativeMinuteDescriptionTimestamps() async {
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = WatchNextData(
+            videoTitle: "Long Description Mix",
+            viewCountText: nil,
+            publishedText: nil,
+            channel: nil,
+            related: [],
+            descriptionText: """
+            Tracklist:
+            00:00 Artist A - Track One
+            99:59 Artist B - Track Two
+            100:05 Artist C - Track Three
+            """
+        )
+        let tracklist = await MixTracklistParser(youTubeClient: mockYouTube)
+            .parseTracklist(videoId: "long-description-mix")
+
+        #expect(tracklist?.entries.map(\.startTime) == [0, 5999, 6005])
+        #expect(tracklist?.entries.map(\.endTime) == [5999, 6005, nil])
+    }
+
+    @MainActor
+    @Test("Description timestamp fallback rejects non-track agendas")
+    func rejectsTimestampedAgenda() async {
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = WatchNextData(
+            videoTitle: "Conference Agenda",
+            viewCountText: nil,
+            publishedText: nil,
+            channel: nil,
+            related: [],
+            descriptionText: """
+            00:00 Introduction
+            01:00 Sponsor
+            02:00 Q&A
+            """
+        )
+        let tracklist = await MixTracklistParser(youTubeClient: mockYouTube)
+            .parseTracklist(videoId: "agenda")
+
+        #expect(tracklist == nil)
+    }
+
+    @MainActor
+    @Test("Description timestamp fallback accepts a headed title-only tracklist")
+    func acceptsHeadedTitleOnlyTracklist() async {
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = WatchNextData(
+            videoTitle: "Title-only Mix",
+            viewCountText: nil,
+            publishedText: nil,
+            channel: nil,
+            related: [],
+            descriptionText: """
+            Tracklist:
+            00:00 Intro
+            03:00 First Song
+            06:00 Finale
+            """
+        )
+        let tracklist = await MixTracklistParser(youTubeClient: mockYouTube)
+            .parseTracklist(videoId: "headed-title-only")
+
+        #expect(tracklist?.entries.map(\.title) == ["Intro", "First Song", "Finale"])
+        #expect(tracklist?.entries.allSatisfy { $0.artist == nil } == true)
+    }
+
+    @MainActor
+    @Test("Inline description tracklist headings permit title-only entries")
+    func acceptsInlineTracklistHeading() async {
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = WatchNextData(
+            videoTitle: "Inline Tracklist",
+            viewCountText: nil,
+            publishedText: nil,
+            channel: nil,
+            related: [],
+            descriptionText: """
+            Tracklist: 00:00 Intro
+            03:00 First Song
+            06:00 Finale
+            """
+        )
+        let tracklist = await MixTracklistParser(youTubeClient: mockYouTube)
+            .parseTracklist(videoId: "inline-tracklist-heading")
+
+        #expect(tracklist?.entries.map(\.title) == ["Intro", "First Song", "Finale"])
+        #expect(tracklist?.entries.allSatisfy { $0.artist == nil } == true)
+    }
+
+    @MainActor
+    @Test("A tracklist heading applies only to the first qualifying timestamp run")
+    func doesNotPropagateHeadingAcrossTimestampReset() async {
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = WatchNextData(
+            videoTitle: "Music and Talk",
+            viewCountText: nil,
+            publishedText: nil,
+            channel: nil,
+            related: [],
+            descriptionText: """
+            Tracklist:
+            00:00 Artist A - Song One
+            03:00 Artist B - Song Two
+            06:00 Artist C - Song Three
+            00:00 Welcome
+            10:00 Keynote
+            20:00 Q&A
+            30:00 Closing
+            """
+        )
+        let tracklist = await MixTracklistParser(youTubeClient: mockYouTube)
+            .parseTracklist(videoId: "heading-timestamp-reset")
+
+        #expect(tracklist?.entries.count == 3)
+        #expect(tracklist?.entries.map(\.artist) == ["Artist A", "Artist B", "Artist C"])
+        #expect(tracklist?.entries.map(\.title) == ["Song One", "Song Two", "Song Three"])
+    }
+
+    @MainActor
+    @Test("Description timestamp fallback ignores negated tracklist prose")
+    func ignoresNegatedTracklistProse() async {
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = WatchNextData(
+            videoTitle: "Conference Agenda",
+            viewCountText: nil,
+            publishedText: nil,
+            channel: nil,
+            related: [],
+            descriptionText: """
+            No tracklist is available.
+            00:00 Host - Welcome
+            10:00 Jane Doe - Keynote
+            30:00 Panel - Q&A
+            """
+        )
+        let tracklist = await MixTracklistParser(youTubeClient: mockYouTube)
+            .parseTracklist(videoId: "negated-tracklist-prose")
+
+        #expect(tracklist == nil)
+    }
+
+    @MainActor
+    @Test("Description tracklist headings do not cross intervening prose")
+    func rejectsHeadingSeparatedByProse() async {
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = WatchNextData(
+            videoTitle: "Conference Agenda",
+            viewCountText: nil,
+            publishedText: nil,
+            channel: nil,
+            related: [],
+            descriptionText: """
+            Tracklist:
+            Unavailable
+            00:00 Welcome
+            10:00 Keynote
+            30:00 Q&A
+            """
+        )
+        let tracklist = await MixTracklistParser(youTubeClient: mockYouTube)
+            .parseTracklist(videoId: "heading-separated-by-prose")
+
+        #expect(tracklist == nil)
+    }
+
+    @MainActor
+    @Test("Description timestamp fallback rejects dash-formatted agendas")
+    func rejectsDashFormattedAgenda() async {
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = WatchNextData(
+            videoTitle: "Conference Agenda",
+            viewCountText: nil,
+            publishedText: nil,
+            channel: nil,
+            related: [],
+            descriptionText: """
+            00:00 Host - Welcome
+            10:00 Jane Doe - Keynote
+            30:00 Panel - Q&A
+            """
+        )
+        let tracklist = await MixTracklistParser(youTubeClient: mockYouTube)
+            .parseTracklist(videoId: "dash-agenda")
+
+        #expect(tracklist == nil)
+    }
+
+    @MainActor
+    @Test("Description timestamp fallback rejects long dash-formatted agendas")
+    func rejectsLongDashFormattedAgenda() async {
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = WatchNextData(
+            videoTitle: "Conference Agenda",
+            viewCountText: nil,
+            publishedText: nil,
+            channel: nil,
+            related: [],
+            descriptionText: """
+            00:00 Host - Welcome
+            10:00 Jane Doe - Keynote
+            20:00 Panel - Q&A
+            30:00 Sponsor - Demo
+            40:00 Host - Closing
+            """
+        )
+        let tracklist = await MixTracklistParser(youTubeClient: mockYouTube)
+            .parseTracklist(videoId: "long-dash-agenda")
+
+        #expect(tracklist == nil)
+    }
+
+    @MainActor
+    @Test("Description timestamp fallback accepts a headingless music mix")
+    func acceptsHeadinglessMusicMix() async {
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = WatchNextData(
+            videoTitle: "Deep Progressive Techno #11",
+            viewCountText: nil,
+            publishedText: nil,
+            channel: nil,
+            related: [],
+            descriptionText: """
+            00:00 Artist A - Track One
+            08:40 Artist B - Track Two
+            15:15 Artist C - Track Three
+            23:00 Artist D - Track Four
+            30:00 Artist E - Track Five
+            """
+        )
+        let tracklist = await MixTracklistParser(youTubeClient: mockYouTube)
+            .parseTracklist(videoId: "headingless-techno-mix")
+
+        #expect(tracklist?.entries.count == 5)
+        #expect(tracklist?.entries.first?.artist == "Artist A")
+    }
+
+    @MainActor
+    @Test("Short localized description tracklists remain supported")
+    func acceptsShortLocalizedTracklist() async {
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = WatchNextData(
+            videoTitle: "Sesión progresiva",
+            viewCountText: nil,
+            publishedText: nil,
+            channel: nil,
+            related: [],
+            descriptionText: """
+            Lista de canciones:
+            00:00 Artista A - Canción Uno
+            04:00 Artista B - Canción Dos
+            08:00 Artista C - Canción Tres
+            """
+        )
+        let tracklist = await MixTracklistParser(youTubeClient: mockYouTube)
+            .parseTracklist(videoId: "short-localized-tracklist")
+
+        #expect(tracklist?.entries.count == MixTracklist.minEntryCount)
+        #expect(tracklist?.entries.map(\.artist) == ["Artista A", "Artista B", "Artista C"])
+    }
+
+    @MainActor
+    @Test("Presentation title words do not veto structured song rows")
+    func acceptsStructuredMusicPodcastTracklist() async {
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = WatchNextData(
+            videoTitle: "Progressive House Podcast #42",
+            viewCountText: nil,
+            publishedText: nil,
+            channel: nil,
+            related: [],
+            descriptionText: """
+            00:00 Artist A - Welcome Home
+            04:00 Artist B - Opening Night
+            08:00 Artist C - Night Drive
+            12:00 Artist D - Pulse
+            16:00 Artist E - Afterglow
+            """
+        )
+        let tracklist = await MixTracklistParser(youTubeClient: mockYouTube)
+            .parseTracklist(videoId: "structured-music-podcast")
+
+        #expect(tracklist?.entries.count == 5)
+        #expect(tracklist?.entries.map(\.title) == [
+            "Welcome Home", "Opening Night", "Night Drive", "Pulse", "Afterglow",
+        ])
+    }
+
+    @MainActor
+    @Test("Agenda-like song words do not veto unambiguous music rows")
+    func acceptsAgendaWordsInSongTitles() async {
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = WatchNextData(
+            videoTitle: "Deep House Mix",
+            viewCountText: nil,
+            publishedText: nil,
+            channel: nil,
+            related: [],
+            descriptionText: """
+            00:00 Artist A - Welcome Home
+            04:00 Artist B - Opening Night
+            08:00 Artist C - Closing Time
+            """
+        )
+        let tracklist = await MixTracklistParser(youTubeClient: mockYouTube)
+            .parseTracklist(videoId: "agenda-words-in-song-titles")
+
+        #expect(tracklist?.entries.count == MixTracklist.minEntryCount)
+        #expect(tracklist?.entries.map(\.title) == ["Welcome Home", "Opening Night", "Closing Time"])
+    }
+
+    @MainActor
+    @Test("Headingless description tracklists may contain blank lines")
+    func acceptsBlankSeparatedHeadinglessMix() async {
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = WatchNextData(
+            videoTitle: "Techno Mix",
+            viewCountText: nil,
+            publishedText: nil,
+            channel: nil,
+            related: [],
+            descriptionText: """
+            00:00 Artist A - Track One
+
+            08:40 Artist B - Track Two
+
+            15:15 Artist C - Track Three
+
+            23:00 Artist D - Track Four
+
+            30:00 Artist E - Track Five
+            """
+        )
+        let tracklist = await MixTracklistParser(youTubeClient: mockYouTube)
+            .parseTracklist(videoId: "blank-separated-headingless-mix")
+
+        #expect(tracklist?.entries.count == 5)
+        #expect(tracklist?.entries.last?.title == "Track Five")
+    }
+
+    @MainActor
+    @Test("Highly structured headingless tracklists do not require title keywords")
+    func acceptsHighlyStructuredHeadinglessMix() async {
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = WatchNextData(
+            videoTitle: "Progressive House Session",
+            viewCountText: nil,
+            publishedText: nil,
+            channel: nil,
+            related: [],
+            descriptionText: """
+            00:00 Artist A - Track One
+            05:00 Artist B - Track Two
+            10:00 Artist C - Track Three
+            15:00 Artist D - Track Four
+            20:00 Artist E - Track Five
+            25:00 Artist F - Track Six
+            30:00 Artist G - Track Seven
+            35:00 Artist H - Track Eight
+            """
+        )
+        let tracklist = await MixTracklistParser(youTubeClient: mockYouTube)
+            .parseTracklist(videoId: "structured-headingless-mix")
+
+        #expect(tracklist?.entries.count == 8)
+        #expect(tracklist?.entries.map(\.artist) == [
+            "Artist A", "Artist B", "Artist C", "Artist D",
+            "Artist E", "Artist F", "Artist G", "Artist H",
+        ])
+    }
+
+    @MainActor
+    @Test("Description timestamp fallback rejects music-topic agendas")
+    func rejectsMusicTopicAgenda() async {
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = WatchNextData(
+            videoTitle: "Techno Music Conference Discussion",
+            viewCountText: nil,
+            publishedText: nil,
+            channel: nil,
+            related: [],
+            descriptionText: """
+            00:00 Host - Welcome
+            05:00 Guest - Context
+            10:00 Panel - Discussion
+            15:00 Sponsor - Demo
+            20:00 Host - Closing
+            """
+        )
+        let tracklist = await MixTracklistParser(youTubeClient: mockYouTube)
+            .parseTracklist(videoId: "music-topic-agenda")
+
+        #expect(tracklist == nil)
+    }
+
+    @MainActor
+    @Test("Description timestamp fallback rejects electronic music workshops")
+    func rejectsElectronicMusicWorkshop() async {
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = WatchNextData(
+            videoTitle: "Electronic Music Workshop",
+            viewCountText: nil,
+            publishedText: nil,
+            channel: nil,
+            related: [],
+            descriptionText: """
+            00:00 Alice - Opening remarks
+            05:00 Bob - Production context
+            10:00 Carol - Sound design demo
+            15:00 Dave - Panel discussion
+            20:00 Alice - Closing remarks
+            """
+        )
+        let tracklist = await MixTracklistParser(youTubeClient: mockYouTube)
+            .parseTracklist(videoId: "electronic-music-workshop")
+
+        #expect(tracklist == nil)
+    }
+
+    @MainActor
+    @Test("Description timestamp fallback rejects partial timestamp components")
+    func rejectsPartialTimestampComponent() async {
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = WatchNextData(
+            videoTitle: "Description Mix",
+            viewCountText: nil,
+            publishedText: nil,
+            channel: nil,
+            related: [],
+            descriptionText: """
+            Tracklist:
+            00:00 Artist A - Track One
+            03:00 Artist B - Track Two
+            06:00 Artist C - Track Three
+            12:345 Fake Artist - Fake Track
+            """
+        )
+        let tracklist = await MixTracklistParser(youTubeClient: mockYouTube)
+            .parseTracklist(videoId: "partial-timestamp")
+
+        #expect(tracklist?.entries.map(\.startTime) == [0, 180, 360])
+        #expect(tracklist?.entries.map(\.title) == ["Track One", "Track Two", "Track Three"])
+    }
+
+    @MainActor
+    @Test("Description timestamp fallback keeps blank-separated headed groups together")
+    func keepsBlankSeparatedTracklistGroups() async {
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = WatchNextData(
+            videoTitle: "Description Mix",
+            viewCountText: nil,
+            publishedText: nil,
+            channel: nil,
+            related: [],
+            descriptionText: """
+            Tracklist:
+            00:00 Artist A - Track One
+            03:00 Artist B - Track Two
+            06:00 Artist C - Track Three
+
+            09:00 Artist D - Track Four
+            12:00 Artist E - Track Five
+            """
+        )
+        let tracklist = await MixTracklistParser(youTubeClient: mockYouTube)
+            .parseTracklist(videoId: "blank-separated-tracklist")
+
+        #expect(tracklist?.entries.count == 5)
+        #expect(tracklist?.entries.last?.title == "Track Five")
+    }
+
+    @MainActor
+    @Test("Description timestamp fallback prioritizes an explicit tracklist heading")
+    func prioritizesExplicitTracklistHeading() async {
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = WatchNextData(
+            videoTitle: "Techno Music Discussion",
+            viewCountText: nil,
+            publishedText: nil,
+            channel: nil,
+            related: [],
+            descriptionText: """
+            00:00 Host - Welcome
+            05:00 Guest - Context
+            10:00 Panel - Discussion
+            15:00 Sponsor - Demo
+            20:00 Host - Closing
+
+            Tracklist:
+            00:00 Artist A - Track One
+            08:00 Artist B - Track Two
+            16:00 Artist C - Track Three
+            """
+        )
+        let tracklist = await MixTracklistParser(youTubeClient: mockYouTube)
+            .parseTracklist(videoId: "headed-tracklist-priority")
+
+        #expect(tracklist?.entries.count == 3)
+        #expect(tracklist?.entries.map(\.artist) == ["Artist A", "Artist B", "Artist C"])
+    }
+
+    @MainActor
+    @Test("Description timestamp fallback rejects overflowing components atomically")
+    func rejectsOverflowingDescriptionTimestamp() async {
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = WatchNextData(
+            videoTitle: "Overflow Description",
+            viewCountText: nil,
+            publishedText: nil,
+            channel: nil,
+            related: [],
+            descriptionText: """
+            Tracklist:
+            00:00 Artist A - Track One
+            03:15 Artist B - Track Two
+            06:30 Artist C - Track Three
+            9223372036854775808:03:15 Fake Artist - Fake Track
+            """
+        )
+        let tracklist = await MixTracklistParser(youTubeClient: mockYouTube)
+            .parseTracklist(videoId: "overflow-description")
+
+        #expect(tracklist?.entries.map(\.startTime) == [0, 195, 390])
+        #expect(tracklist?.entries.map(\.title) == ["Track One", "Track Two", "Track Three"])
+    }
+}

--- a/Tests/KasetTests/MixTracklistTests.swift
+++ b/Tests/KasetTests/MixTracklistTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+@Suite(.tags(.model))
+struct MixTracklistTests {
+    // MARK: - Artist/Title Parsing
+
+    @Test("Chapter title splits into artist and title on the first ' - '")
+    func parsesArtistAndTitle() {
+        let parsed = MixTrackEntry.parseArtistTitle(from: "Deepbass - Canna (Luigi Tozzi rmx)")
+        #expect(parsed.artist == "Deepbass")
+        #expect(parsed.title == "Canna (Luigi Tozzi rmx)")
+    }
+
+    @Test("Only the first ' - ' separates artist from title")
+    func splitsOnFirstDashOnly() {
+        let parsed = MixTrackEntry.parseArtistTitle(from: "Octo Aeterna - Opath - Reprise")
+        #expect(parsed.artist == "Octo Aeterna")
+        #expect(parsed.title == "Opath - Reprise")
+    }
+
+    @Test("Title without a dash yields nil artist and the whole string as title")
+    func noDashLeavesArtistNil() {
+        let parsed = MixTrackEntry.parseArtistTitle(from: "Untitled Jam")
+        #expect(parsed.artist == nil)
+        #expect(parsed.title == "Untitled Jam")
+    }
+
+    @Test("Surrounding whitespace is trimmed from both parts")
+    func trimsWhitespace() {
+        let parsed = MixTrackEntry.parseArtistTitle(from: "  Skoll  -  Defenestration  ")
+        #expect(parsed.artist == "Skoll")
+        #expect(parsed.title == "Defenestration")
+    }
+
+    @Test("Empty artist side falls back to nil")
+    func emptyArtistFallsBackToNil() {
+        let parsed = MixTrackEntry.parseArtistTitle(from: " - Just A Title")
+        #expect(parsed.artist == nil)
+        #expect(parsed.title == "Just A Title")
+    }
+
+    @Test("Chapter-title initializer uses the shared parser")
+    func chapterInitParsesArtistTitle() {
+        let entry = MixTrackEntry(fromChapterTitle: "Einox - Monk", startTime: 100, endTime: 200)
+        #expect(entry.artist == "Einox")
+        #expect(entry.title == "Monk")
+        #expect(entry.source == .chapters)
+        #expect(entry.duration == 100)
+    }
+
+    // MARK: - isMix Threshold
+
+    @Test("Three or more entries is a mix; fewer is not")
+    func isMixThreshold() {
+        func tracklist(entryCount: Int) -> MixTracklist {
+            let entries = (0 ..< entryCount).map {
+                MixTrackEntry(
+                    startTime: TimeInterval($0) * 60, endTime: nil,
+                    title: "T\($0)", artist: "A\($0)", source: .chapters
+                )
+            }
+            return MixTracklist(videoId: "v", entries: entries, source: .chapters)
+        }
+
+        #expect(tracklist(entryCount: MixTracklist.minEntryCount - 1).isMix == false)
+        #expect(tracklist(entryCount: MixTracklist.minEntryCount).isMix == true)
+        #expect(tracklist(entryCount: MixTracklist.minEntryCount + 5).isMix == true)
+    }
+
+    // MARK: - entry(at:) Lookup
+
+    @Test("entry(at:) returns the active sub-track and nil before the first entry")
+    func entryLookupByProgress() {
+        let entries = [
+            MixTrackEntry(startTime: 0, endTime: 600, title: "A", artist: "1", source: .chapters),
+            MixTrackEntry(startTime: 600, endTime: 1200, title: "B", artist: "2", source: .chapters),
+            MixTrackEntry(startTime: 1200, endTime: nil, title: "C", artist: "3", source: .chapters),
+        ]
+        let list = MixTracklist(videoId: "v", entries: entries, source: .chapters)
+
+        #expect(list.entry(at: 0)?.title == "A")
+        #expect(list.entry(at: 599)?.title == "A")
+        #expect(list.entry(at: 600)?.title == "B")
+        #expect(list.entry(at: 5000)?.title == "C")
+    }
+}

--- a/Tests/KasetTests/MixTracklistTests.swift
+++ b/Tests/KasetTests/MixTracklistTests.swift
@@ -50,6 +50,30 @@ struct MixTracklistTests {
         #expect(entry.duration == 100)
     }
 
+    @MainActor
+    @Test("Chapter parser preserves the final chapter's explicit end time")
+    func finalChapterEndTime() async {
+        let chapters = [
+            YouTubeChapter(videoId: "mix", title: "A - One", startTime: 0, endTime: 100, timeText: nil, thumbnailURL: nil),
+            YouTubeChapter(videoId: "mix", title: "B - Two", startTime: 100, endTime: 200, timeText: nil, thumbnailURL: nil),
+            YouTubeChapter(videoId: "mix", title: "C - Three", startTime: 200, endTime: 290, timeText: nil, thumbnailURL: nil),
+        ]
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = WatchNextData(
+            videoTitle: "Mix",
+            viewCountText: nil,
+            publishedText: nil,
+            channel: nil,
+            related: [],
+            chapters: chapters
+        )
+
+        let tracklist = await MixTracklistParser(youTubeClient: mockYouTube).parseTracklist(videoId: "mix")
+
+        #expect(tracklist?.entries.last?.endTime == 290)
+        #expect(tracklist?.entries.last?.duration == 90)
+    }
+
     // MARK: - isMix Threshold
 
     @Test("Three or more entries is a mix; fewer is not")

--- a/Tests/KasetTests/MixTracklistTests.swift
+++ b/Tests/KasetTests/MixTracklistTests.swift
@@ -34,6 +34,36 @@ struct MixTracklistTests {
         #expect(parsed.title == "Defenestration")
     }
 
+    @Test("En dash and em dash separators split artist from title", arguments: [
+        "Boards of Canada – Roygbiv",
+        "Boards of Canada — Roygbiv",
+        "Boards of Canada–Roygbiv",
+        "Boards of Canada—Roygbiv",
+    ])
+    func parsesDashVariants(label: String) {
+        let parsed = MixTrackEntry.parseArtistTitle(from: label)
+        #expect(parsed.artist == "Boards of Canada")
+        #expect(parsed.title == "Roygbiv")
+    }
+
+    @Test("Unspaced ASCII hyphen is not a separator (hyphenated names stay intact)")
+    func unspacedHyphenNotASeparator() {
+        let parsed = MixTrackEntry.parseArtistTitle(from: "Anne-Marie 2002")
+        #expect(parsed.artist == nil)
+        #expect(parsed.title == "Anne-Marie 2002")
+    }
+
+    @Test("The leftmost separator wins when styles are mixed")
+    func leftmostSeparatorWins() {
+        let spacedFirst = MixTrackEntry.parseArtistTitle(from: "Kiasmos - Held—Reworked")
+        #expect(spacedFirst.artist == "Kiasmos")
+        #expect(spacedFirst.title == "Held—Reworked")
+
+        let dashFirst = MixTrackEntry.parseArtistTitle(from: "DJ Rashad – Itwerk - Percussion Mix")
+        #expect(dashFirst.artist == "DJ Rashad")
+        #expect(dashFirst.title == "Itwerk - Percussion Mix")
+    }
+
     @Test("Empty artist side falls back to nil")
     func emptyArtistFallsBackToNil() {
         let parsed = MixTrackEntry.parseArtistTitle(from: " - Just A Title")
@@ -93,6 +123,34 @@ struct MixTracklistTests {
         #expect(tracklist(entryCount: MixTracklist.minEntryCount + 5).isMix == true)
     }
 
+    @Test("Navigation chapters without parseable artists are not a mix")
+    func navigationChaptersAreNotAMix() {
+        let entries = ["Intro", "Verse", "Chorus", "Outro"].enumerated().map { index, title in
+            MixTrackEntry(
+                startTime: TimeInterval(index) * 300, endTime: nil,
+                title: title, artist: nil, source: .chapters
+            )
+        }
+        let list = MixTracklist(videoId: "v", entries: entries, source: .chapters)
+        #expect(list.isMix == false)
+    }
+
+    @Test("A majority of parsed artists qualifies as a mix; a minority does not")
+    func parsedArtistRatioThreshold() {
+        func tracklist(artistCount: Int, total: Int) -> MixTracklist {
+            let entries = (0 ..< total).map {
+                MixTrackEntry(
+                    startTime: TimeInterval($0) * 300, endTime: nil,
+                    title: "T\($0)", artist: $0 < artistCount ? "A\($0)" : nil, source: .chapters
+                )
+            }
+            return MixTracklist(videoId: "v", entries: entries, source: .chapters)
+        }
+
+        #expect(tracklist(artistCount: 2, total: 4).isMix == true)
+        #expect(tracklist(artistCount: 1, total: 4).isMix == false)
+    }
+
     // MARK: - entry(at:) Lookup
 
     @Test("entry(at:) returns the active sub-track and nil before the first entry")
@@ -108,5 +166,18 @@ struct MixTracklistTests {
         #expect(list.entry(at: 599)?.title == "A")
         #expect(list.entry(at: 600)?.title == "B")
         #expect(list.entry(at: 5000)?.title == "C")
+    }
+
+    @Test("entry(at:) returns nil past the final entry's explicit end time")
+    func entryLookupRespectsFinalEndTime() {
+        let entries = [
+            MixTrackEntry(startTime: 0, endTime: 600, title: "A", artist: "1", source: .chapters),
+            MixTrackEntry(startTime: 600, endTime: 1200, title: "B", artist: "2", source: .chapters),
+        ]
+        let list = MixTracklist(videoId: "v", entries: entries, source: .chapters)
+
+        #expect(list.entry(at: 1199)?.title == "B")
+        #expect(list.entry(at: 1200) == nil)
+        #expect(list.entry(at: 5000) == nil)
     }
 }

--- a/Tests/KasetTests/MixTracklistTests.swift
+++ b/Tests/KasetTests/MixTracklistTests.swift
@@ -252,6 +252,36 @@ struct MixTracklistTests {
     }
 
     @MainActor
+    @Test("Timestamps scattered across prose sections do not stitch into a tracklist")
+    func descriptionEntriesRequireContiguousLines() {
+        let description = """
+        Show starts 0:30 - doors open early
+        Thanks to everyone who joined the premiere chat.
+        Highlight at 5:00 - special guest appearance
+        Full VOD stays up all week for members.
+        Ends around 10:00 - afterparty on discord
+        """
+        let entries = MixTracklistParser.descriptionEntries(from: description)
+
+        #expect(entries.count == 1)
+    }
+
+    @MainActor
+    @Test("Blank lines between tracklist entries do not break the block")
+    func descriptionEntriesAllowBlankLinesWithinTracklist() {
+        let description = """
+        00:00 A - One
+
+        01:00 B - Two
+
+        02:00 C - Three
+        """
+        let entries = MixTracklistParser.descriptionEntries(from: description)
+
+        #expect(entries.map(\.title) == ["One", "Two", "Three"])
+    }
+
+    @MainActor
     @Test("Description without timestamped lines yields no entries")
     func descriptionEntriesEmptyWithoutTimestamps() {
         let entries = MixTracklistParser.descriptionEntries(from: "Just a regular description.\nNo tracklist here.")

--- a/Tests/KasetTests/MixTracklistTests.swift
+++ b/Tests/KasetTests/MixTracklistTests.swift
@@ -2,6 +2,8 @@ import Foundation
 import Testing
 @testable import Kaset
 
+// MARK: - MixTracklistTests
+
 @Suite(.tags(.model))
 struct MixTracklistTests {
     // MARK: - Artist/Title Parsing
@@ -166,207 +168,12 @@ struct MixTracklistTests {
         #expect(retried?.entries.count == 3)
         #expect(mockYouTube.getWatchNextCallCount == 2)
     }
+}
 
-    // MARK: - Description Timestamp Parsing
+// MARK: - MixTracklistModelBehaviorTests
 
-    @MainActor
-    @Test("Description tracklist lines parse into chained entries")
-    func descriptionEntriesParseTracklist() {
-        let description = """
-        Enjoy the vibes everyone!
-
-        Tracklist:
-        00:00 511Lazuli - Doors
-        01:10 ALISON - Subtract
-        06:15 Decisive Koala - Release
-
-        A mix of the best chillwave.
-        """
-        let entries = MixTracklistParser.descriptionEntries(from: description)
-
-        #expect(entries.count == 3)
-        #expect(entries[0].artist == "511Lazuli")
-        #expect(entries[0].title == "Doors")
-        #expect(entries[0].startTime == 0)
-        #expect(entries[0].endTime == 70)
-        #expect(entries[1].endTime == 375)
-        #expect(entries[2].startTime == 375)
-        #expect(entries[2].endTime == nil)
-        #expect(entries.allSatisfy { $0.source == .description })
-    }
-
-    @MainActor
-    @Test("Description timestamp formats are recognized", arguments: [
-        "0:00 A - One\n1:02:03 B - Two\n2:00:00 C - Three",
-        "A - One 0:00\nB - Two 1:02:03\nC - Three 2:00:00",
-        "[0:00] A - One\n[1:02:03] B - Two\n[2:00:00] C - Three",
-        "(0:00) A - One\n(1:02:03) B - Two\n(2:00:00) C - Three",
-        "1. A - One 0:00\n2. B - Two 1:02:03\n3. C - Three 2:00:00",
-    ])
-    func descriptionEntriesRecognizeCommonFormats(description: String) {
-        let entries = MixTracklistParser.descriptionEntries(from: description)
-
-        #expect(entries.map(\.startTime) == [0, 3723, 7200])
-        #expect(entries.map(\.artist) == ["A", "B", "C"])
-        #expect(entries.map(\.title) == ["One", "Two", "Three"])
-    }
-
-    @MainActor
-    @Test("Stray timestamps outside the monotonic tracklist run are ignored")
-    func descriptionEntriesKeepLongestMonotonicRun() {
-        let description = """
-        Premiere started at 12:00 sharp!
-        00:00 A - One
-        03:20 B - Two
-        07:45 C - Three
-        10:00 D - Four
-        Rebroadcast at 9:30 next week.
-        """
-        let entries = MixTracklistParser.descriptionEntries(from: description)
-
-        #expect(entries.map(\.title) == ["One", "Two", "Three", "Four"])
-        #expect(entries.first?.startTime == 0)
-    }
-
-    @MainActor
-    @Test("Clock times glued to letters are not tracklist timestamps")
-    func descriptionEntriesRejectClockTimes() {
-        let entries = MixTracklistParser.descriptionEntries(from: "Premiere at 3:45pm")
-        #expect(entries.isEmpty)
-    }
-
-    @MainActor
-    @Test("An invalid H:MM:SS timestamp does not hide a later valid one on the same line")
-    func descriptionEntriesSkipInvalidTimestampWithinLine() {
-        let description = """
-        1:75:00 typo then 0:00 A - One
-        1:00 B - Two
-        2:00 C - Three
-        """
-        let entries = MixTracklistParser.descriptionEntries(from: description)
-
-        #expect(entries.count == 3)
-        #expect(entries.first?.startTime == 0)
-        #expect(entries.first?.artist == "A")
-        #expect(entries.first?.title == "One")
-    }
-
-    @MainActor
-    @Test("Timestamps scattered across prose sections do not stitch into a tracklist")
-    func descriptionEntriesRequireContiguousLines() {
-        let description = """
-        Show starts 0:30 - doors open early
-        Thanks to everyone who joined the premiere chat.
-        Highlight at 5:00 - special guest appearance
-        Full VOD stays up all week for members.
-        Ends around 10:00 - afterparty on discord
-        """
-        let entries = MixTracklistParser.descriptionEntries(from: description)
-
-        #expect(entries.count == 1)
-    }
-
-    @MainActor
-    @Test("Blank lines between tracklist entries do not break the block")
-    func descriptionEntriesAllowBlankLinesWithinTracklist() {
-        let description = """
-        00:00 A - One
-
-        01:00 B - Two
-
-        02:00 C - Three
-        """
-        let entries = MixTracklistParser.descriptionEntries(from: description)
-
-        #expect(entries.map(\.title) == ["One", "Two", "Three"])
-    }
-
-    @MainActor
-    @Test("Description without timestamped lines yields no entries")
-    func descriptionEntriesEmptyWithoutTimestamps() {
-        let entries = MixTracklistParser.descriptionEntries(from: "Just a regular description.\nNo tracklist here.")
-        #expect(entries.isEmpty)
-    }
-
-    // MARK: - Tier 2: Description Fallback
-
-    @MainActor
-    @Test("Parser falls back to description timestamps when chapters are absent")
-    func descriptionFallbackParsesTracklist() async {
-        let mockYouTube = MockYouTubeClient()
-        mockYouTube.watchNextData = WatchNextData(
-            videoTitle: "Mix",
-            viewCountText: nil,
-            publishedText: nil,
-            channel: nil,
-            related: [],
-            chapters: [],
-            descriptionText: """
-            Tracklist:
-            00:00 A - One
-            10:00 B - Two
-            20:00 C - Three
-            """
-        )
-        let parser = MixTracklistParser(youTubeClient: mockYouTube)
-
-        let tracklist = await parser.parseTracklist(videoId: "mix")
-
-        #expect(tracklist?.source == .description)
-        #expect(tracklist?.entries.count == 3)
-        #expect(tracklist?.entries.first?.artist == "A")
-
-        _ = await parser.parseTracklist(videoId: "mix")
-        #expect(mockYouTube.getWatchNextCallCount == 1)
-    }
-
-    @MainActor
-    @Test("Qualifying chapters win over a description tracklist")
-    func chaptersTakePriorityOverDescription() async {
-        let mockYouTube = MockYouTubeClient()
-        mockYouTube.watchNextData = WatchNextData(
-            videoTitle: "Mix",
-            viewCountText: nil,
-            publishedText: nil,
-            channel: nil,
-            related: [],
-            chapters: [
-                YouTubeChapter(videoId: "mix", title: "A - One", startTime: 0, endTime: 60, timeText: nil, thumbnailURL: nil),
-                YouTubeChapter(videoId: "mix", title: "B - Two", startTime: 60, endTime: 120, timeText: nil, thumbnailURL: nil),
-                YouTubeChapter(videoId: "mix", title: "C - Three", startTime: 120, endTime: 180, timeText: nil, thumbnailURL: nil),
-            ],
-            descriptionText: "00:00 X - Other\n01:00 Y - Other\n02:00 Z - Other"
-        )
-
-        let tracklist = await MixTracklistParser(youTubeClient: mockYouTube).parseTracklist(videoId: "mix")
-
-        #expect(tracklist?.source == .chapters)
-        #expect(tracklist?.entries.first?.artist == "A")
-    }
-
-    @MainActor
-    @Test("Title-only description timestamps stay non-mix and cache the miss")
-    func titleOnlyDescriptionCachesMiss() async {
-        let mockYouTube = MockYouTubeClient()
-        mockYouTube.watchNextData = WatchNextData(
-            videoTitle: "Podcast",
-            viewCountText: nil,
-            publishedText: nil,
-            channel: nil,
-            related: [],
-            chapters: [],
-            descriptionText: "00:00 Welcome\n10:00 Interview\n50:00 Wrap up"
-        )
-        let parser = MixTracklistParser(youTubeClient: mockYouTube)
-
-        let first = await parser.parseTracklist(videoId: "podcast")
-        let second = await parser.parseTracklist(videoId: "podcast")
-
-        #expect(first == nil)
-        #expect(second == nil)
-        #expect(mockYouTube.getWatchNextCallCount == 1)
-    }
-
+@Suite(.tags(.model))
+struct MixTracklistModelBehaviorTests {
     // MARK: - isMix Threshold
 
     @Test("Three or more entries is a mix; fewer is not")
@@ -432,6 +239,27 @@ struct MixTracklistTests {
             )
         }
         #expect(!MixTracklist(videoId: "v", entries: entries, source: .description).isMix)
+    }
+
+    @Test("An explicit description tracklist signal permits title-only entries")
+    func explicitDescriptionTracklistSignalAllowsTitleOnlyEntries() {
+        let entries = ["Intro", "First Song", "Finale"].enumerated().map { index, title in
+            MixTrackEntry(
+                startTime: TimeInterval(index) * 60,
+                endTime: TimeInterval(index + 1) * 60,
+                title: title,
+                artist: nil,
+                source: .description
+            )
+        }
+        let list = MixTracklist(
+            videoId: "v",
+            entries: entries,
+            source: .description,
+            hasExplicitTracklistSignal: true
+        )
+        #expect(list.entries.count == 3)
+        #expect(list.isMix)
     }
 
     @Test("Structured description labels can establish a song mix")

--- a/Tests/KasetTests/MixTracklistTests.swift
+++ b/Tests/KasetTests/MixTracklistTests.swift
@@ -20,6 +20,13 @@ struct MixTracklistTests {
         #expect(parsed.title == "Opath - Reprise")
     }
 
+    @Test("A spaced separator wins over an earlier dash inside the artist")
+    func spacedSeparatorHasPriority() {
+        let parsed = MixTrackEntry.parseArtistTitle(from: "A–B - Song")
+        #expect(parsed.artist == "A–B")
+        #expect(parsed.title == "Song")
+    }
+
     @Test("Title without a dash yields nil artist and the whole string as title")
     func noDashLeavesArtistNil() {
         let parsed = MixTrackEntry.parseArtistTitle(from: "Untitled Jam")
@@ -34,34 +41,22 @@ struct MixTracklistTests {
         #expect(parsed.title == "Defenestration")
     }
 
-    @Test("En dash and em dash separators split artist from title", arguments: [
-        "Boards of Canada – Roygbiv",
-        "Boards of Canada — Roygbiv",
-        "Boards of Canada–Roygbiv",
-        "Boards of Canada—Roygbiv",
+    @Test("Common Unicode dash separators are recognized with or without spaces", arguments: [
+        "Artist – Title",
+        "Artist—Title",
+        "Artist−Title",
     ])
-    func parsesDashVariants(label: String) {
-        let parsed = MixTrackEntry.parseArtistTitle(from: label)
-        #expect(parsed.artist == "Boards of Canada")
-        #expect(parsed.title == "Roygbiv")
+    func parsesCommonDashSeparators(raw: String) {
+        let parsed = MixTrackEntry.parseArtistTitle(from: raw)
+        #expect(parsed.artist == "Artist")
+        #expect(parsed.title == "Title")
     }
 
-    @Test("Unspaced ASCII hyphen is not a separator (hyphenated names stay intact)")
-    func unspacedHyphenNotASeparator() {
-        let parsed = MixTrackEntry.parseArtistTitle(from: "Anne-Marie 2002")
+    @Test("An unspaced ASCII hyphen remains ambiguous rather than inventing an artist")
+    func unspacedASCIIHyphenIsNotASeparator() {
+        let parsed = MixTrackEntry.parseArtistTitle(from: "Part-1")
         #expect(parsed.artist == nil)
-        #expect(parsed.title == "Anne-Marie 2002")
-    }
-
-    @Test("The leftmost separator wins when styles are mixed")
-    func leftmostSeparatorWins() {
-        let spacedFirst = MixTrackEntry.parseArtistTitle(from: "Kiasmos - Held—Reworked")
-        #expect(spacedFirst.artist == "Kiasmos")
-        #expect(spacedFirst.title == "Held—Reworked")
-
-        let dashFirst = MixTrackEntry.parseArtistTitle(from: "DJ Rashad – Itwerk - Percussion Mix")
-        #expect(dashFirst.artist == "DJ Rashad")
-        #expect(dashFirst.title == "Itwerk - Percussion Mix")
+        #expect(parsed.title == "Part-1")
     }
 
     @Test("Empty artist side falls back to nil")
@@ -123,32 +118,133 @@ struct MixTracklistTests {
         #expect(tracklist(entryCount: MixTracklist.minEntryCount + 5).isMix == true)
     }
 
-    @Test("Navigation chapters without parseable artists are not a mix")
-    func navigationChaptersAreNotAMix() {
-        let entries = ["Intro", "Verse", "Chorus", "Outro"].enumerated().map { index, title in
-            MixTrackEntry(
-                startTime: TimeInterval(index) * 300, endTime: nil,
-                title: title, artist: nil, source: .chapters
-            )
-        }
-        let list = MixTracklist(videoId: "v", entries: entries, source: .chapters)
-        #expect(list.isMix == false)
-    }
-
-    @Test("A majority of parsed artists qualifies as a mix; a minority does not")
-    func parsedArtistRatioThreshold() {
-        func tracklist(artistCount: Int, total: Int) -> MixTracklist {
-            let entries = (0 ..< total).map {
+    @Test("Generic navigation chapters are not treated as a song mix")
+    func isMixRequiresStructuredTrackLabels() {
+        func tracklist(artists: [String?]) -> MixTracklist {
+            let entries = artists.enumerated().map { index, artist in
                 MixTrackEntry(
-                    startTime: TimeInterval($0) * 300, endTime: nil,
-                    title: "T\($0)", artist: $0 < artistCount ? "A\($0)" : nil, source: .chapters
+                    startTime: TimeInterval(index) * 60,
+                    endTime: TimeInterval(index + 1) * 60,
+                    title: artist == nil ? ["Intro", "Main section", "Outro"][index % 3] : "Track \(index)",
+                    artist: artist,
+                    source: .chapters
                 )
             }
             return MixTracklist(videoId: "v", entries: entries, source: .chapters)
         }
 
-        #expect(tracklist(artistCount: 2, total: 4).isMix == true)
-        #expect(tracklist(artistCount: 1, total: 4).isMix == false)
+        #expect(!tracklist(artists: [nil, nil, nil]).isMix)
+        #expect(tracklist(artists: ["A", "B", "C", nil, nil]).isMix)
+        #expect(tracklist(artists: ["A", "B", "C", nil, nil, nil, nil]).isMix)
+    }
+
+    @Test("Title-only chapter labels do not establish a song mix")
+    func titleOnlyChapterTracklistIsNotMix() {
+        let entries = ["Track One", "Track Two", "Track Three"].enumerated().map { index, title in
+            MixTrackEntry(
+                startTime: TimeInterval(index) * 60,
+                endTime: TimeInterval(index + 1) * 60,
+                title: title,
+                artist: nil,
+                source: .chapters
+            )
+        }
+        #expect(!MixTracklist(videoId: "v", entries: entries, source: .chapters).isMix)
+    }
+
+    @Test("Description timestamps alone do not establish a song mix")
+    func titleOnlyDescriptionTracklistIsNotMix() {
+        let entries = ["Track One", "Track Two", "Track Three"].enumerated().map { index, title in
+            MixTrackEntry(
+                startTime: TimeInterval(index) * 60,
+                endTime: TimeInterval(index + 1) * 60,
+                title: title,
+                artist: nil,
+                source: .description
+            )
+        }
+        #expect(!MixTracklist(videoId: "v", entries: entries, source: .description).isMix)
+    }
+
+    @Test("Structured description labels can establish a song mix")
+    func structuredDescriptionTracklistIsMix() {
+        let entries = [
+            MixTrackEntry(startTime: 0, endTime: 60, title: "One", artist: "Artist One", source: .description),
+            MixTrackEntry(startTime: 60, endTime: 120, title: "Two", artist: "Artist Two", source: .description),
+            MixTrackEntry(startTime: 120, endTime: 180, title: "Three", artist: nil, source: .description),
+        ]
+        #expect(MixTracklist(videoId: "v", entries: entries, source: .description).isMix)
+    }
+
+    @Test("Structured and title-only song labels can coexist in a mix")
+    func mixedTrackLabelFormatsAreMix() {
+        let entries = [
+            MixTrackEntry(startTime: 0, endTime: 60, title: "One", artist: "Artist One", source: .chapters),
+            MixTrackEntry(startTime: 60, endTime: 120, title: "Track Two", artist: "Artist Two", source: .chapters),
+            MixTrackEntry(startTime: 120, endTime: 180, title: "Track Three", artist: nil, source: .chapters),
+        ]
+        #expect(MixTracklist(videoId: "v", entries: entries, source: .chapters).isMix)
+    }
+
+    @Test("Artist-qualified generic-looking song titles are retained")
+    func artistQualifiedIntroIsRetained() {
+        let entries = ["Intro", "Song", "Outro"].enumerated().map { index, title in
+            MixTrackEntry(
+                startTime: TimeInterval(index) * 60,
+                endTime: TimeInterval(index + 1) * 60,
+                title: title,
+                artist: "Artist",
+                source: .chapters
+            )
+        }
+        let list = MixTracklist(videoId: "v", entries: entries, source: .chapters)
+        #expect(list.entries.count == 3)
+        #expect(list.isMix)
+    }
+
+    @Test("Generic title-only chapter names are not a mix")
+    func genericTitleOnlyChaptersAreNotMix() {
+        let entries = ["Setup", "Demo", "Questions"].enumerated().map { index, title in
+            MixTrackEntry(
+                startTime: TimeInterval(index) * 60,
+                endTime: TimeInterval(index + 1) * 60,
+                title: title,
+                artist: nil,
+                source: .chapters
+            )
+        }
+        #expect(!MixTracklist(videoId: "v", entries: entries, source: .chapters).isMix)
+    }
+
+    @Test("Navigation-like words in song titles are not removed without a numeric suffix")
+    func navigationWordSongTitlesAreRetained() {
+        let entries = ["Part Time Lover", "Chapter Civil", "Section Mild"].enumerated().map { index, title in
+            MixTrackEntry(
+                startTime: TimeInterval(index) * 60,
+                endTime: TimeInterval(index + 1) * 60,
+                title: title,
+                artist: nil,
+                source: .chapters
+            )
+        }
+        let list = MixTracklist(videoId: "v", entries: entries, source: .chapters)
+        #expect(list.entries.count == 3)
+        #expect(!list.isMix)
+    }
+
+    @Test("Canonical numeric navigation labels are still removed")
+    func canonicalNavigationLabelsAreRemoved() {
+        let entries = ["Part IV", "Chapter 2", "Actual Song"].enumerated().map { index, title in
+            MixTrackEntry(
+                startTime: TimeInterval(index) * 60,
+                endTime: TimeInterval(index + 1) * 60,
+                title: title,
+                artist: nil,
+                source: .chapters
+            )
+        }
+        let list = MixTracklist(videoId: "v", entries: entries, source: .chapters)
+        #expect(list.entries.map(\.title) == ["Actual Song"])
     }
 
     // MARK: - entry(at:) Lookup
@@ -168,16 +264,45 @@ struct MixTracklistTests {
         #expect(list.entry(at: 5000)?.title == "C")
     }
 
-    @Test("entry(at:) returns nil past the final entry's explicit end time")
-    func entryLookupRespectsFinalEndTime() {
+    @Test("entry(at:) respects explicit end times and gaps")
+    func entryLookupRespectsEndTimes() {
         let entries = [
-            MixTrackEntry(startTime: 0, endTime: 600, title: "A", artist: "1", source: .chapters),
-            MixTrackEntry(startTime: 600, endTime: 1200, title: "B", artist: "2", source: .chapters),
+            MixTrackEntry(startTime: 0, endTime: 100, title: "A", artist: "1", source: .chapters),
+            MixTrackEntry(startTime: 120, endTime: 200, title: "B", artist: "2", source: .chapters),
+            MixTrackEntry(startTime: 200, endTime: 250, title: "C", artist: "3", source: .chapters),
         ]
         let list = MixTracklist(videoId: "v", entries: entries, source: .chapters)
 
-        #expect(list.entry(at: 1199)?.title == "B")
-        #expect(list.entry(at: 1200) == nil)
+        #expect(list.entry(at: 99)?.title == "A")
+        #expect(list.entry(at: 100) == nil)
+        #expect(list.entry(at: 119) == nil)
+        #expect(list.entry(at: 120)?.title == "B")
+        #expect(list.entry(at: 250) == nil)
         #expect(list.entry(at: 5000) == nil)
+    }
+
+    @Test("Final entry duration falls back to the parent video duration")
+    func finalEntryDurationFallback() {
+        let first = MixTrackEntry(startTime: 0, endTime: 100, title: "A", artist: "1", source: .chapters)
+        let middle = MixTrackEntry(startTime: 100, endTime: nil, title: "B", artist: "2", source: .chapters)
+        let final = MixTrackEntry(startTime: 200, endTime: nil, title: "C", artist: "3", source: .chapters)
+        let list = MixTracklist(videoId: "v", entries: [first, middle, final], source: .chapters)
+
+        #expect(list.effectiveDuration(for: first, videoDuration: 290) == 100)
+        #expect(list.effectiveDuration(for: middle, videoDuration: 290) == 100)
+        #expect(list.effectiveDuration(for: final, videoDuration: 290) == 90)
+        #expect(list.effectiveDuration(for: final, videoDuration: 200) == nil)
+    }
+
+    @Test("Tracklist timestamps provide a parent-duration lower bound")
+    func knownDurationLowerBound() {
+        let entries = [
+            MixTrackEntry(startTime: 0, endTime: 100, title: "A", artist: "1", source: .chapters),
+            MixTrackEntry(startTime: 100, endTime: nil, title: "B", artist: "2", source: .chapters),
+            MixTrackEntry(startTime: 700, endTime: nil, title: "C", artist: "3", source: .chapters),
+        ]
+        let list = MixTracklist(videoId: "v", entries: entries, source: .chapters)
+
+        #expect(list.knownDurationLowerBound == 700)
     }
 }

--- a/Tests/KasetTests/MixTracklistTests.swift
+++ b/Tests/KasetTests/MixTracklistTests.swift
@@ -99,6 +99,74 @@ struct MixTracklistTests {
         #expect(tracklist?.entries.last?.duration == 90)
     }
 
+    @MainActor
+    @Test("Chapter parser caches non-mix results until invalidated")
+    func cachesNoTracklistResult() async {
+        let chapters = ["Setup", "Demo", "Questions"].enumerated().map { index, title in
+            YouTubeChapter(
+                videoId: "regular",
+                title: title,
+                startTime: TimeInterval(index) * 60,
+                endTime: TimeInterval(index + 1) * 60,
+                timeText: nil,
+                thumbnailURL: nil
+            )
+        }
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = WatchNextData(
+            videoTitle: "Regular Video",
+            viewCountText: nil,
+            publishedText: nil,
+            channel: nil,
+            related: [],
+            chapters: chapters
+        )
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+
+        let first = await parser.parseTracklist(videoId: "regular")
+        let second = await parser.parseTracklist(videoId: "regular")
+        #expect(first == nil)
+        #expect(second == nil)
+        #expect(mockYouTube.getWatchNextCallCount == 1)
+
+        parser.invalidate(videoId: "regular")
+        _ = await parser.parseTracklist(videoId: "regular")
+        #expect(mockYouTube.getWatchNextCallCount == 2)
+
+        parser.invalidateAll()
+        _ = await parser.parseTracklist(videoId: "regular")
+        #expect(mockYouTube.getWatchNextCallCount == 3)
+    }
+
+    @MainActor
+    @Test("Chapter parser does not cache transient request failures")
+    func transientFailureRemainsRetryable() async {
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.error = URLError(.timedOut)
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+
+        let first = await parser.parseTracklist(videoId: "mix")
+        #expect(first == nil)
+
+        mockYouTube.error = nil
+        mockYouTube.watchNextData = WatchNextData(
+            videoTitle: "Mix",
+            viewCountText: nil,
+            publishedText: nil,
+            channel: nil,
+            related: [],
+            chapters: [
+                YouTubeChapter(videoId: "mix", title: "A - One", startTime: 0, endTime: 60, timeText: nil, thumbnailURL: nil),
+                YouTubeChapter(videoId: "mix", title: "B - Two", startTime: 60, endTime: 120, timeText: nil, thumbnailURL: nil),
+                YouTubeChapter(videoId: "mix", title: "C - Three", startTime: 120, endTime: 180, timeText: nil, thumbnailURL: nil),
+            ]
+        )
+
+        let retried = await parser.parseTracklist(videoId: "mix")
+        #expect(retried?.entries.count == 3)
+        #expect(mockYouTube.getWatchNextCallCount == 2)
+    }
+
     // MARK: - isMix Threshold
 
     @Test("Three or more entries is a mix; fewer is not")

--- a/Tests/KasetTests/MixTracklistTests.swift
+++ b/Tests/KasetTests/MixTracklistTests.swift
@@ -167,6 +167,176 @@ struct MixTracklistTests {
         #expect(mockYouTube.getWatchNextCallCount == 2)
     }
 
+    // MARK: - Description Timestamp Parsing
+
+    @MainActor
+    @Test("Description tracklist lines parse into chained entries")
+    func descriptionEntriesParseTracklist() {
+        let description = """
+        Enjoy the vibes everyone!
+
+        Tracklist:
+        00:00 511Lazuli - Doors
+        01:10 ALISON - Subtract
+        06:15 Decisive Koala - Release
+
+        A mix of the best chillwave.
+        """
+        let entries = MixTracklistParser.descriptionEntries(from: description)
+
+        #expect(entries.count == 3)
+        #expect(entries[0].artist == "511Lazuli")
+        #expect(entries[0].title == "Doors")
+        #expect(entries[0].startTime == 0)
+        #expect(entries[0].endTime == 70)
+        #expect(entries[1].endTime == 375)
+        #expect(entries[2].startTime == 375)
+        #expect(entries[2].endTime == nil)
+        #expect(entries.allSatisfy { $0.source == .description })
+    }
+
+    @MainActor
+    @Test("Description timestamp formats are recognized", arguments: [
+        "0:00 A - One\n1:02:03 B - Two\n2:00:00 C - Three",
+        "A - One 0:00\nB - Two 1:02:03\nC - Three 2:00:00",
+        "[0:00] A - One\n[1:02:03] B - Two\n[2:00:00] C - Three",
+        "(0:00) A - One\n(1:02:03) B - Two\n(2:00:00) C - Three",
+        "1. A - One 0:00\n2. B - Two 1:02:03\n3. C - Three 2:00:00",
+    ])
+    func descriptionEntriesRecognizeCommonFormats(description: String) {
+        let entries = MixTracklistParser.descriptionEntries(from: description)
+
+        #expect(entries.map(\.startTime) == [0, 3723, 7200])
+        #expect(entries.map(\.artist) == ["A", "B", "C"])
+        #expect(entries.map(\.title) == ["One", "Two", "Three"])
+    }
+
+    @MainActor
+    @Test("Stray timestamps outside the monotonic tracklist run are ignored")
+    func descriptionEntriesKeepLongestMonotonicRun() {
+        let description = """
+        Premiere started at 12:00 sharp!
+        00:00 A - One
+        03:20 B - Two
+        07:45 C - Three
+        10:00 D - Four
+        Rebroadcast at 9:30 next week.
+        """
+        let entries = MixTracklistParser.descriptionEntries(from: description)
+
+        #expect(entries.map(\.title) == ["One", "Two", "Three", "Four"])
+        #expect(entries.first?.startTime == 0)
+    }
+
+    @MainActor
+    @Test("Clock times glued to letters are not tracklist timestamps")
+    func descriptionEntriesRejectClockTimes() {
+        let entries = MixTracklistParser.descriptionEntries(from: "Premiere at 3:45pm")
+        #expect(entries.isEmpty)
+    }
+
+    @MainActor
+    @Test("An invalid H:MM:SS timestamp does not hide a later valid one on the same line")
+    func descriptionEntriesSkipInvalidTimestampWithinLine() {
+        let description = """
+        1:75:00 typo then 0:00 A - One
+        1:00 B - Two
+        2:00 C - Three
+        """
+        let entries = MixTracklistParser.descriptionEntries(from: description)
+
+        #expect(entries.count == 3)
+        #expect(entries.first?.startTime == 0)
+        #expect(entries.first?.artist == "A")
+        #expect(entries.first?.title == "One")
+    }
+
+    @MainActor
+    @Test("Description without timestamped lines yields no entries")
+    func descriptionEntriesEmptyWithoutTimestamps() {
+        let entries = MixTracklistParser.descriptionEntries(from: "Just a regular description.\nNo tracklist here.")
+        #expect(entries.isEmpty)
+    }
+
+    // MARK: - Tier 2: Description Fallback
+
+    @MainActor
+    @Test("Parser falls back to description timestamps when chapters are absent")
+    func descriptionFallbackParsesTracklist() async {
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = WatchNextData(
+            videoTitle: "Mix",
+            viewCountText: nil,
+            publishedText: nil,
+            channel: nil,
+            related: [],
+            chapters: [],
+            descriptionText: """
+            Tracklist:
+            00:00 A - One
+            10:00 B - Two
+            20:00 C - Three
+            """
+        )
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+
+        let tracklist = await parser.parseTracklist(videoId: "mix")
+
+        #expect(tracklist?.source == .description)
+        #expect(tracklist?.entries.count == 3)
+        #expect(tracklist?.entries.first?.artist == "A")
+
+        _ = await parser.parseTracklist(videoId: "mix")
+        #expect(mockYouTube.getWatchNextCallCount == 1)
+    }
+
+    @MainActor
+    @Test("Qualifying chapters win over a description tracklist")
+    func chaptersTakePriorityOverDescription() async {
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = WatchNextData(
+            videoTitle: "Mix",
+            viewCountText: nil,
+            publishedText: nil,
+            channel: nil,
+            related: [],
+            chapters: [
+                YouTubeChapter(videoId: "mix", title: "A - One", startTime: 0, endTime: 60, timeText: nil, thumbnailURL: nil),
+                YouTubeChapter(videoId: "mix", title: "B - Two", startTime: 60, endTime: 120, timeText: nil, thumbnailURL: nil),
+                YouTubeChapter(videoId: "mix", title: "C - Three", startTime: 120, endTime: 180, timeText: nil, thumbnailURL: nil),
+            ],
+            descriptionText: "00:00 X - Other\n01:00 Y - Other\n02:00 Z - Other"
+        )
+
+        let tracklist = await MixTracklistParser(youTubeClient: mockYouTube).parseTracklist(videoId: "mix")
+
+        #expect(tracklist?.source == .chapters)
+        #expect(tracklist?.entries.first?.artist == "A")
+    }
+
+    @MainActor
+    @Test("Title-only description timestamps stay non-mix and cache the miss")
+    func titleOnlyDescriptionCachesMiss() async {
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = WatchNextData(
+            videoTitle: "Podcast",
+            viewCountText: nil,
+            publishedText: nil,
+            channel: nil,
+            related: [],
+            chapters: [],
+            descriptionText: "00:00 Welcome\n10:00 Interview\n50:00 Wrap up"
+        )
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+
+        let first = await parser.parseTracklist(videoId: "podcast")
+        let second = await parser.parseTracklist(videoId: "podcast")
+
+        #expect(first == nil)
+        #expect(second == nil)
+        #expect(mockYouTube.getWatchNextCallCount == 1)
+    }
+
     // MARK: - isMix Threshold
 
     @Test("Three or more entries is a mix; fewer is not")

--- a/Tests/KasetTests/PlaybackScrobbleTrackerTests.swift
+++ b/Tests/KasetTests/PlaybackScrobbleTrackerTests.swift
@@ -141,7 +141,7 @@ struct PlaybackScrobbleTrackerTests {
         #expect(tracker.hasSentNowPlaying)
     }
 
-    @Test("resetForSeek clears accumulation and latches but preserves startTime and lastProgress")
+    @Test("resetForSeek clears accumulation but preserves latches, startTime, and lastProgress")
     func resetForSeek() {
         var tracker = self.makeTracker()
         tracker.accumulate(progress: 0, isPlaying: true, now: self.epoch)
@@ -151,8 +151,8 @@ struct PlaybackScrobbleTrackerTests {
 
         tracker.resetForSeek()
         #expect(tracker.accumulatedPlayTime == 0)
-        #expect(!tracker.hasScrobbled)
-        #expect(!tracker.hasSentNowPlaying)
+        #expect(tracker.hasScrobbled)
+        #expect(tracker.hasSentNowPlaying)
         #expect(tracker.startTime == self.epoch)
         #expect(tracker.lastProgress == 1)
     }

--- a/Tests/KasetTests/PlaybackScrobbleTrackerTests.swift
+++ b/Tests/KasetTests/PlaybackScrobbleTrackerTests.swift
@@ -1,0 +1,159 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+@Suite(.tags(.service))
+struct PlaybackScrobbleTrackerTests {
+    private let epoch = Date(timeIntervalSince1970: 1_000_000)
+
+    private func makeTracker(initialProgress: TimeInterval = 0) -> PlaybackScrobbleTracker {
+        PlaybackScrobbleTracker(startTime: self.epoch, initialProgress: initialProgress)
+    }
+
+    private func thresholds(
+        percent: Double = 0.5,
+        minSeconds: TimeInterval = 240,
+        allowsUnknownDuration: Bool = false
+    ) -> PlaybackScrobbleTracker.Thresholds {
+        .init(percent: percent, minSeconds: minSeconds, allowsUnknownDuration: allowsUnknownDuration)
+    }
+
+    // MARK: - Accumulation
+
+    @Test("First observation establishes a baseline without accumulating")
+    func firstObservationIsBaseline() {
+        var tracker = self.makeTracker()
+        tracker.accumulate(progress: 1, isPlaying: true, now: self.epoch)
+        #expect(tracker.accumulatedPlayTime == 0)
+        #expect(tracker.lastProgress == 1)
+    }
+
+    @Test("Normal ticks accumulate the progress delta")
+    func normalTicksAccumulate() {
+        var tracker = self.makeTracker()
+        var now = self.epoch
+        tracker.accumulate(progress: 0, isPlaying: true, now: now)
+        for step in 1 ... 10 {
+            now = self.epoch.addingTimeInterval(TimeInterval(step))
+            tracker.accumulate(progress: TimeInterval(step), isPlaying: true, now: now)
+        }
+        #expect(abs(tracker.accumulatedPlayTime - 10) < 0.001)
+    }
+
+    @Test("A forward seek is not counted")
+    func forwardSeekIgnored() {
+        var tracker = self.makeTracker()
+        tracker.accumulate(progress: 10, isPlaying: true, now: self.epoch)
+        tracker.accumulate(progress: 100, isPlaying: true, now: self.epoch.addingTimeInterval(1))
+        #expect(tracker.accumulatedPlayTime == 0)
+    }
+
+    @Test("A backward seek is not counted")
+    func backwardSeekIgnored() {
+        var tracker = self.makeTracker()
+        tracker.accumulate(progress: 100, isPlaying: true, now: self.epoch)
+        tracker.accumulate(progress: 10, isPlaying: true, now: self.epoch.addingTimeInterval(1))
+        #expect(tracker.accumulatedPlayTime == 0)
+    }
+
+    @Test("A large wall-clock gap with a small progress delta is not counted")
+    func wallClockGapIgnored() {
+        var tracker = self.makeTracker()
+        tracker.accumulate(progress: 0, isPlaying: true, now: self.epoch)
+        // Only 1s of progress, but 60s of wall clock elapsed (app was suspended).
+        tracker.accumulate(progress: 1, isPlaying: true, now: self.epoch.addingTimeInterval(60))
+        #expect(tracker.accumulatedPlayTime == 0)
+    }
+
+    @Test("Pausing drops the baseline so the paused span isn't counted on resume")
+    func pauseDropsBaseline() {
+        var tracker = self.makeTracker()
+        tracker.accumulate(progress: 0, isPlaying: true, now: self.epoch)
+        tracker.accumulate(progress: 1, isPlaying: true, now: self.epoch.addingTimeInterval(1))
+        #expect(abs(tracker.accumulatedPlayTime - 1) < 0.001)
+
+        // Pause for a while.
+        tracker.accumulate(progress: 1, isPlaying: false, now: self.epoch.addingTimeInterval(2))
+        // Resume: the first tick after resume re-establishes the baseline, no jump counted.
+        tracker.accumulate(progress: 1.5, isPlaying: true, now: self.epoch.addingTimeInterval(120))
+        #expect(abs(tracker.accumulatedPlayTime - 1) < 0.001)
+    }
+
+    // MARK: - Threshold
+
+    @Test("Percent threshold qualifies at half of a known duration")
+    func percentThreshold() {
+        var tracker = self.makeTracker()
+        var now = self.epoch
+        // Accumulate 100s over a 200s track (>= 50%).
+        for step in 0 ... 100 {
+            now = self.epoch.addingTimeInterval(TimeInterval(step))
+            tracker.accumulate(progress: TimeInterval(step), isPlaying: true, now: now)
+        }
+        #expect(tracker.meetsThreshold(duration: 200, thresholds: self.thresholds()))
+    }
+
+    @Test("minSeconds cap qualifies a long track before the percent threshold")
+    func minSecondsCap() {
+        var tracker = self.makeTracker()
+        var now = self.epoch
+        // 240s accumulated on a 3600s track: below 50% but hits the 240s cap.
+        for step in 0 ... 240 {
+            now = self.epoch.addingTimeInterval(TimeInterval(step))
+            tracker.accumulate(progress: TimeInterval(step), isPlaying: true, now: now)
+        }
+        #expect(tracker.meetsThreshold(duration: 3600, thresholds: self.thresholds()))
+    }
+
+    @Test("Tracks shorter than the minimum scrobble duration never qualify")
+    func tooShortRejected() {
+        var tracker = self.makeTracker()
+        var now = self.epoch
+        for step in 1 ... 20 {
+            now = self.epoch.addingTimeInterval(TimeInterval(step))
+            tracker.accumulate(progress: TimeInterval(step), isPlaying: true, now: now)
+        }
+        #expect(tracker.meetsThreshold(duration: 20, thresholds: self.thresholds()) == false)
+    }
+
+    @Test("Unknown duration qualifies via minSeconds only when allowed")
+    func unknownDurationPolicy() {
+        var tracker = self.makeTracker()
+        var now = self.epoch
+        for step in 0 ... 240 {
+            now = self.epoch.addingTimeInterval(TimeInterval(step))
+            tracker.accumulate(progress: TimeInterval(step), isPlaying: true, now: now)
+        }
+        #expect(tracker.meetsThreshold(duration: nil, thresholds: self.thresholds(allowsUnknownDuration: false)) == false)
+        #expect(tracker.meetsThreshold(duration: nil, thresholds: self.thresholds(allowsUnknownDuration: true)))
+    }
+
+    // MARK: - Latches & Reset
+
+    @Test("Scrobbled and now-playing flags latch")
+    func latches() {
+        var tracker = self.makeTracker()
+        #expect(!tracker.hasScrobbled)
+        #expect(!tracker.hasSentNowPlaying)
+        tracker.markScrobbled()
+        tracker.markNowPlayingSent()
+        #expect(tracker.hasScrobbled)
+        #expect(tracker.hasSentNowPlaying)
+    }
+
+    @Test("resetForSeek clears accumulation and latches but preserves startTime and lastProgress")
+    func resetForSeek() {
+        var tracker = self.makeTracker()
+        tracker.accumulate(progress: 0, isPlaying: true, now: self.epoch)
+        tracker.accumulate(progress: 1, isPlaying: true, now: self.epoch.addingTimeInterval(1))
+        tracker.markScrobbled()
+        tracker.markNowPlayingSent()
+
+        tracker.resetForSeek()
+        #expect(tracker.accumulatedPlayTime == 0)
+        #expect(!tracker.hasScrobbled)
+        #expect(!tracker.hasSentNowPlaying)
+        #expect(tracker.startTime == self.epoch)
+        #expect(tracker.lastProgress == 1)
+    }
+}

--- a/Tests/KasetTests/ProvisionalMixPlaybackHistoryTests.swift
+++ b/Tests/KasetTests/ProvisionalMixPlaybackHistoryTests.swift
@@ -139,7 +139,7 @@ struct ProvisionalMixPlaybackHistoryTests {
             thresholds: .init(percent: 0.5, minSeconds: 240)
         )
 
-        #expect(scrobbles.filter { $0.title == "One" }.count == 1)
+        #expect(scrobbles.count(where: { $0.title == "One" }) == 1)
     }
 
     @Test("A new near-start replay keeps its own provisional latch")
@@ -175,7 +175,7 @@ struct ProvisionalMixPlaybackHistoryTests {
             thresholds: .init(percent: 0.01, minSeconds: 240)
         )
 
-        #expect(scrobbles.filter { $0.title == "One" }.count == 2)
+        #expect(scrobbles.count(where: { $0.title == "One" }) == 2)
     }
 
     @Test("Discontinuity markers alone are not playback")

--- a/Tests/KasetTests/ProvisionalMixPlaybackHistoryTests.swift
+++ b/Tests/KasetTests/ProvisionalMixPlaybackHistoryTests.swift
@@ -1,0 +1,215 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+@Suite(.tags(.service))
+struct ProvisionalMixPlaybackHistoryTests {
+    private let epoch = Date(timeIntervalSince1970: 1_700_000_000)
+
+    private func tracklist(finalEndTime: TimeInterval? = nil) -> MixTracklist {
+        MixTracklist(
+            videoId: "mix",
+            entries: [
+                MixTrackEntry(startTime: 0, endTime: 100, title: "One", artist: "A", source: .chapters),
+                MixTrackEntry(startTime: 100, endTime: 200, title: "Two", artist: "B", source: .chapters),
+                MixTrackEntry(startTime: 200, endTime: finalEndTime, title: "Three", artist: "C", source: .chapters),
+            ],
+            source: .chapters
+        )
+    }
+
+    private var song: Song {
+        TestFixtures.makeSong(id: "mix", title: "Whole Mix", duration: nil)
+    }
+
+    @Test("An unbounded final entry receives provisional credit without a parent duration")
+    func unboundedFinalEntryCredit() {
+        var history = ProvisionalMixPlaybackHistory()
+        history.record(startProgress: 210, endProgress: 260, startTime: self.epoch)
+
+        let scrobbles = history.scrobbles(
+            tracklist: self.tracklist(),
+            song: self.song,
+            videoDuration: nil,
+            thresholds: .init(percent: 0.5, minSeconds: 40, allowsUnknownDuration: true)
+        )
+
+        #expect(scrobbles.count == 1)
+        #expect(scrobbles.first?.title == "Three")
+        #expect(scrobbles.first?.duration == nil)
+    }
+
+    @Test("Discontinuous visits are evaluated independently")
+    func discontinuousVisitsStaySeparate() {
+        var subthresholdHistory = ProvisionalMixPlaybackHistory()
+        subthresholdHistory.record(startProgress: 0, endProgress: 30, startTime: self.epoch)
+        subthresholdHistory.record(startProgress: 0, endProgress: 30, startTime: self.epoch.addingTimeInterval(100))
+
+        let thresholds = PlaybackScrobbleTracker.Thresholds(percent: 0.5, minSeconds: 240)
+        #expect(subthresholdHistory.scrobbles(
+            tracklist: self.tracklist(),
+            song: self.song,
+            videoDuration: 300,
+            thresholds: thresholds
+        ).isEmpty)
+
+        var replayHistory = ProvisionalMixPlaybackHistory()
+        replayHistory.record(startProgress: 0, endProgress: 60, startTime: self.epoch)
+        replayHistory.record(startProgress: 0, endProgress: 60, startTime: self.epoch.addingTimeInterval(100))
+
+        let replayScrobbles = replayHistory.scrobbles(
+            tracklist: self.tracklist(),
+            song: self.song,
+            videoDuration: 300,
+            thresholds: thresholds
+        )
+        #expect(replayScrobbles.count == 2)
+        #expect(replayScrobbles[0].timestamp != replayScrobbles[1].timestamp)
+    }
+
+    @Test("A pause preserves one progress-contiguous visit")
+    func pauseKeepsVisitContiguous() {
+        var history = ProvisionalMixPlaybackHistory()
+        history.record(startProgress: 0, endProgress: 30, startTime: self.epoch)
+        history.record(startProgress: 30, endProgress: 60, startTime: self.epoch.addingTimeInterval(100))
+
+        let scrobbles = history.scrobbles(
+            tracklist: self.tracklist(),
+            song: self.song,
+            videoDuration: 300,
+            thresholds: .init(percent: 0.5, minSeconds: 240)
+        )
+
+        #expect(scrobbles.count == 1)
+        #expect(scrobbles.first?.title == "One")
+    }
+
+    @Test("A pause before a chapter boundary preserves the later chapter timestamp")
+    func pausePreservesChapterTimestamp() {
+        var history = ProvisionalMixPlaybackHistory()
+        history.record(startProgress: 90, endProgress: 100, startTime: self.epoch)
+        let resumedAt = self.epoch.addingTimeInterval(100)
+        history.record(startProgress: 100, endProgress: 110, startTime: resumedAt)
+
+        let list = self.tracklist()
+        let listCredits = history.credits(
+            tracklist: list,
+            videoDuration: 300,
+            thresholds: .init(percent: 0.05, minSeconds: 240)
+        )
+        #expect(listCredits[list.entries[1].id]?.first?.startTime == resumedAt)
+    }
+
+    @Test("The next chapter start bounds a non-final entry without endTime")
+    func nextChapterBoundsMissingEndTime() {
+        let list = MixTracklist(
+            videoId: "mix",
+            entries: [
+                MixTrackEntry(startTime: 0, endTime: nil, title: "One", artist: "A", source: .chapters),
+                MixTrackEntry(startTime: 100, endTime: 200, title: "Two", artist: "B", source: .chapters),
+                MixTrackEntry(startTime: 200, endTime: 300, title: "Three", artist: "C", source: .chapters),
+            ],
+            source: .chapters
+        )
+        var history = ProvisionalMixPlaybackHistory()
+        history.record(startProgress: 0, endProgress: 60, startTime: self.epoch)
+
+        let scrobbles = history.scrobbles(
+            tracklist: list,
+            song: self.song,
+            videoDuration: 300,
+            thresholds: .init(percent: 0.5, minSeconds: 240)
+        )
+
+        #expect(scrobbles.count == 1)
+        #expect(scrobbles.first?.title == "One")
+    }
+
+    @Test("Returning to a scrobbled entry's middle preserves one latch")
+    func middleReentryDoesNotCreateDuplicatePlay() {
+        var history = ProvisionalMixPlaybackHistory()
+        history.record(startProgress: 0, endProgress: 60, startTime: self.epoch)
+        history.record(startProgress: 100, endProgress: 110, startTime: self.epoch.addingTimeInterval(60))
+        history.record(startProgress: 50, endProgress: 100, startTime: self.epoch.addingTimeInterval(70))
+
+        let scrobbles = history.scrobbles(
+            tracklist: self.tracklist(),
+            song: self.song,
+            videoDuration: 300,
+            thresholds: .init(percent: 0.5, minSeconds: 240)
+        )
+
+        #expect(scrobbles.filter { $0.title == "One" }.count == 1)
+    }
+
+    @Test("A new near-start replay keeps its own provisional latch")
+    func activeReplayKeepsSeparateLatch() {
+        let list = self.tracklist()
+        var history = ProvisionalMixPlaybackHistory()
+        history.record(startProgress: 0, endProgress: 60, startTime: self.epoch)
+        history.record(startProgress: 0, endProgress: 10, startTime: self.epoch.addingTimeInterval(100))
+
+        let credits = history.credits(
+            tracklist: list,
+            videoDuration: 300,
+            thresholds: .init(percent: 0.5, minSeconds: 240)
+        )[list.entries[0].id]
+
+        #expect(credits?.count == 2)
+        #expect(credits?.first?.hasScrobbled == true)
+        #expect(credits?.last?.hasScrobbled == false)
+    }
+
+    @Test("Explicit seek markers preserve qualifying replay boundaries")
+    func seekMarkersPreserveReplayBoundary() {
+        var history = ProvisionalMixPlaybackHistory()
+        history.record(startProgress: 0, endProgress: 1, startTime: self.epoch)
+        history.recordDiscontinuity(at: 50, startTime: self.epoch.addingTimeInterval(1))
+        history.recordDiscontinuity(at: 0, startTime: self.epoch.addingTimeInterval(2))
+        history.record(startProgress: 0, endProgress: 1, startTime: self.epoch.addingTimeInterval(3))
+
+        let scrobbles = history.scrobbles(
+            tracklist: self.tracklist(),
+            song: self.song,
+            videoDuration: 300,
+            thresholds: .init(percent: 0.01, minSeconds: 240)
+        )
+
+        #expect(scrobbles.filter { $0.title == "One" }.count == 2)
+    }
+
+    @Test("Discontinuity markers alone are not playback")
+    func markersAreNotPlayback() {
+        var history = ProvisionalMixPlaybackHistory()
+        history.recordDiscontinuity(at: 50, startTime: self.epoch)
+        #expect(!history.hasPlayback)
+    }
+
+    @Test("Provisional active credit survives a small unrecorded progress delta")
+    @MainActor
+    func activeCreditSurvivesSmallProgressDelta() {
+        let playerService = PlayerService()
+        let song = self.song
+        playerService.currentTrack = song
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 13,
+            duration: 300,
+            observedVideoId: song.videoId
+        )
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: MockScrobblingSettings(),
+            services: []
+        )
+        var history = ProvisionalMixPlaybackHistory()
+        history.record(startProgress: 0, endProgress: 10, startTime: self.epoch)
+        coordinator.provisionalMixHistory = history
+        let list = self.tracklist()
+
+        coordinator.consumeProvisionalPlayback(for: list, song: song)
+
+        #expect(coordinator.provisionalCurrentMixCredit?.entryId == list.entries[0].id)
+        #expect(coordinator.provisionalCurrentMixCredit?.credit.accumulatedPlayTime == 10)
+    }
+}

--- a/Tests/KasetTests/ScrobblingCoordinatorLifecycleTests.swift
+++ b/Tests/KasetTests/ScrobblingCoordinatorLifecycleTests.swift
@@ -1,0 +1,248 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+@Suite(.serialized, .tags(.service))
+@MainActor
+struct ScrobblingCoordinatorLifecycleTests {
+    private func makeTemporaryDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ScrobblingCoordinatorLifecycleTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    private func cleanupDirectory(_ directory: URL) {
+        try? FileManager.default.removeItem(at: directory)
+    }
+
+    private func waitUntil(
+        timeout: Duration = .seconds(2),
+        _ condition: @MainActor () -> Bool
+    ) async {
+        let deadline = ContinuousClock.now + timeout
+        while !condition(), ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+    }
+
+    @Test("Track finalization cancels an in-flight now-playing request")
+    func trackFinalizationCancelsInFlightNowPlaying() async throws {
+        let directory = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(directory) }
+
+        let oldNowPlayingGate = AsyncGate()
+        let service = MockScrobbleService()
+        service.authState = .connected(username: "testuser")
+        service.beforeNowPlayingReturn = { track in
+            if track.title == "Old Track" {
+                await oldNowPlayingGate.wait()
+            }
+        }
+        let settings = MockScrobblingSettings()
+        settings.setServiceEnabled("Mock", true)
+        let parser = MixTracklistParser(youTubeClient: MockYouTubeClient())
+        let playerService = PlayerService()
+        playerService.currentTrack = TestFixtures.makeSong(id: "old", title: "Old Track", duration: 100)
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 0,
+            duration: 100,
+            observedVideoId: "old"
+        )
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [service],
+            queue: ScrobbleQueue(directory: directory),
+            mixTracklistParser: parser,
+            unknownDurationParseDelay: .seconds(1)
+        )
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+        await self.waitUntil { coordinator.nowPlayingTasks.count == 1 }
+
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 0,
+            duration: 0,
+            observedVideoId: "next"
+        )
+        playerService.currentTrack = TestFixtures.makeSong(id: "next", title: "Next Track", duration: nil)
+        coordinator.pollPlayerState()
+
+        #expect(coordinator.nowPlayingTasks.isEmpty)
+        await oldNowPlayingGate.open()
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(service.nowPlayingTracks.isEmpty)
+    }
+
+    @Test("A stalled deferred parse commits its fallback during normal runtime")
+    func deferredParseTimeoutCommitsFallback() async throws {
+        let directory = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(directory) }
+
+        let parseGate = AsyncGate()
+        let youtubeClient = MockYouTubeClient()
+        youtubeClient.watchNextData = .empty
+        youtubeClient.beforeWatchNextReturn = { _ in await parseGate.wait() }
+        let parser = MixTracklistParser(youTubeClient: youtubeClient)
+        let service = MockScrobbleService()
+        service.authState = .connected(username: "testuser")
+        let settings = MockScrobblingSettings(scrobblePercentThreshold: 0.001)
+        settings.setServiceEnabled("Mock", true)
+        let playerService = PlayerService()
+        playerService.currentTrack = TestFixtures.makeSong(
+            id: "regular",
+            title: "Long Regular Track",
+            duration: 700
+        )
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 0,
+            duration: 700,
+            observedVideoId: "regular"
+        )
+        let queue = ScrobbleQueue(directory: directory)
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [service],
+            queue: queue,
+            mixTracklistParser: parser,
+            mixParseTimeout: .milliseconds(200)
+        )
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+
+        await self.waitUntil { youtubeClient.getWatchNextCallCount == 1 }
+        playerService.progress = 1
+        await self.waitUntil { coordinator.pendingWholeTrackPlays.count == 1 }
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 0,
+            duration: 200,
+            observedVideoId: "next"
+        )
+        playerService.currentTrack = TestFixtures.makeSong(id: "next", title: "Next Track", duration: 200)
+        coordinator.pollPlayerState()
+
+        await self.waitUntil { !coordinator.pendingMixFinalizations.isEmpty }
+        await self.waitUntil { queue.count == 1 }
+        #expect(queue.pendingTracks.first?.title == "Long Regular Track")
+        #expect(coordinator.pendingMixFinalizations.isEmpty)
+
+        await parseGate.open()
+    }
+
+    @Test("An active fallback parse timeout resumes short-track handling")
+    func activeFallbackParseTimeoutResumesShortTrack() async throws {
+        let directory = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(directory) }
+
+        let parseGate = AsyncGate()
+        let youtubeClient = MockYouTubeClient()
+        youtubeClient.watchNextData = .empty
+        youtubeClient.beforeWatchNextReturn = { _ in await parseGate.wait() }
+        let parser = MixTracklistParser(youTubeClient: youtubeClient)
+        let service = MockScrobbleService()
+        service.authState = .connected(username: "testuser")
+        let settings = MockScrobblingSettings()
+        settings.setServiceEnabled("Mock", true)
+        let playerService = PlayerService()
+        playerService.currentTrack = TestFixtures.makeSong(
+            id: "short",
+            title: "Short Regular Track",
+            duration: nil
+        )
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 0,
+            duration: 240,
+            observedVideoId: "short"
+        )
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [service],
+            queue: ScrobbleQueue(directory: directory),
+            mixTracklistParser: parser,
+            unknownDurationParseDelay: .milliseconds(20),
+            mixParseTimeout: .milliseconds(20)
+        )
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+
+        await self.waitUntil { youtubeClient.getWatchNextCallCount == 1 }
+        await self.waitUntil { service.nowPlayingTracks.count == 1 }
+
+        #expect(service.nowPlayingTracks.first?.title == "Short Regular Track")
+        #expect(coordinator.mixParseTask == nil)
+        await parseGate.open()
+    }
+
+    @Test("Delayed fallback parsing waits for a fresh same-ID playback sample")
+    func delayedFallbackParseWaitsForFreshSameIDSample() async throws {
+        let directory = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(directory) }
+
+        let youtubeClient = MockYouTubeClient()
+        youtubeClient.watchNextData = .empty
+        let parser = MixTracklistParser(youTubeClient: youtubeClient)
+        let service = MockScrobbleService()
+        service.authState = .connected(username: "testuser")
+        let settings = MockScrobblingSettings()
+        settings.setServiceEnabled("Mock", true)
+        let playerService = PlayerService()
+        playerService.currentTrack = TestFixtures.makeSong(
+            id: "shared",
+            title: "Old Track",
+            artistName: "Old Artist",
+            duration: 100
+        )
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 0,
+            duration: 100,
+            observedVideoId: "shared"
+        )
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [service],
+            queue: ScrobbleQueue(directory: directory),
+            mixTracklistParser: parser,
+            unknownDurationParseDelay: .milliseconds(20)
+        )
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+        await self.waitUntil { service.nowPlayingTracks.count == 1 }
+
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 10,
+            duration: 100,
+            observedVideoId: "shared"
+        )
+        playerService.currentTrack = TestFixtures.makeSong(
+            id: "shared",
+            title: "New Track",
+            artistName: "New Artist",
+            duration: nil
+        )
+        coordinator.pollPlayerState()
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(youtubeClient.getWatchNextCallCount == 0)
+
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 0,
+            duration: 700,
+            observedVideoId: "shared"
+        )
+        coordinator.pollPlayerState()
+        await self.waitUntil { youtubeClient.getWatchNextCallCount == 1 }
+
+        #expect(youtubeClient.requestedWatchNextVideoIds == ["shared"])
+    }
+}

--- a/Tests/KasetTests/ScrobblingCoordinatorMixDurationResolutionTests.swift
+++ b/Tests/KasetTests/ScrobblingCoordinatorMixDurationResolutionTests.swift
@@ -1,0 +1,717 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+@Suite(.serialized, .tags(.service))
+@MainActor
+struct ScrobblingCoordinatorMixDurationResolutionTests {
+    private func makeTemporaryDirectory() throws -> URL {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ScrobblingCoordinatorMixDurationResolutionTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        return tempDir
+    }
+
+    private func cleanupDirectory(_ dir: URL) {
+        try? FileManager.default.removeItem(at: dir)
+    }
+
+    private func makeWatchNextData(chapters: [YouTubeChapter]) -> WatchNextData {
+        WatchNextData(
+            videoTitle: "Long Mix",
+            viewCountText: nil,
+            publishedText: nil,
+            channel: nil,
+            related: [],
+            chapters: chapters
+        )
+    }
+
+    private func makeMixChapters(
+        videoId: String = "mix1",
+        count: Int = 3,
+        entryDuration: TimeInterval = 600
+    ) -> [YouTubeChapter] {
+        (0 ..< count).map { index in
+            YouTubeChapter(
+                videoId: videoId,
+                title: "Artist \(index) - Track \(index)",
+                startTime: TimeInterval(index) * entryDuration,
+                endTime: TimeInterval(index + 1) * entryDuration,
+                timeText: nil,
+                thumbnailURL: nil
+            )
+        }
+    }
+
+    private func makeTracklist(
+        videoId: String,
+        entryDuration: TimeInterval
+    ) -> MixTracklist {
+        let entries = (0 ..< 3).map { index in
+            MixTrackEntry(
+                startTime: TimeInterval(index) * entryDuration,
+                endTime: TimeInterval(index + 1) * entryDuration,
+                title: "Track \(index)",
+                artist: "Artist \(index)",
+                source: .chapters
+            )
+        }
+        return MixTracklist(videoId: videoId, entries: entries, source: .chapters)
+    }
+
+    private func waitUntil(
+        timeout: Duration = .seconds(2),
+        _ condition: @MainActor () -> Bool
+    ) async {
+        let deadline = ContinuousClock.now + timeout
+        while !condition(), ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+    }
+
+    @Test("Pending whole-track scrobbles survive an awaiting-duration parse")
+    func awaitingDurationPreservesPendingWholeTrackScrobble() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let parseGate = AsyncGate()
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = self.makeWatchNextData(
+            chapters: self.makeMixChapters(videoId: "short1", entryDuration: 100)
+        )
+        mockYouTube.beforeWatchNextReturn = { _ in await parseGate.wait() }
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+        let mockService = MockScrobbleService()
+        mockService.authState = .connected(username: "testuser")
+        let settings = MockScrobblingSettings(scrobblePercentThreshold: 0.001)
+        settings.setServiceEnabled("Mock", true)
+
+        let playerService = PlayerService()
+        playerService.currentTrack = TestFixtures.makeSong(id: "short1", title: "Regular Song", duration: nil)
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 0,
+            duration: 240,
+            observedVideoId: "short1"
+        )
+        let queue = ScrobbleQueue(directory: dir)
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [mockService],
+            queue: queue,
+            mixTracklistParser: parser,
+            unknownDurationParseDelay: .milliseconds(100)
+        )
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+
+        await self.waitUntil { mockYouTube.getWatchNextCallCount == 1 }
+        playerService.progress = 1
+        await self.waitUntil { coordinator.pendingWholeTrackPlays.count == 1 }
+
+        await parseGate.open()
+        await self.waitUntil { mockYouTube.getWatchNextCompletionCount == 1 }
+
+        playerService.currentTrack = TestFixtures.makeSong(id: "short1", title: "Regular Song", duration: 240)
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 2,
+            duration: 240,
+            observedVideoId: "short1"
+        )
+        await self.waitUntil { queue.count == 1 }
+
+        #expect(queue.pendingTracks.first?.title == "Regular Song")
+    }
+
+    @Test("Exiting while duration is unconfirmed falls back to whole-track scrobbling")
+    func awaitingDurationExitUsesWholeTrackFallback() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let parseGate = AsyncGate()
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = self.makeWatchNextData(
+            chapters: self.makeMixChapters(videoId: "short1", entryDuration: 100)
+        )
+        mockYouTube.beforeWatchNextReturn = { _ in await parseGate.wait() }
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+        let mockService = MockScrobbleService()
+        mockService.authState = .connected(username: "testuser")
+        let settings = MockScrobblingSettings(scrobblePercentThreshold: 0.001)
+        settings.setServiceEnabled("Mock", true)
+
+        let playerService = PlayerService()
+        playerService.currentTrack = TestFixtures.makeSong(id: "short1", title: "Regular Song", duration: nil)
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 0,
+            duration: 240,
+            observedVideoId: "short1"
+        )
+        let queue = ScrobbleQueue(directory: dir)
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [mockService],
+            queue: queue,
+            mixTracklistParser: parser,
+            unknownDurationParseDelay: .milliseconds(100)
+        )
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+
+        await self.waitUntil { mockYouTube.getWatchNextCallCount == 1 }
+        playerService.progress = 1
+        await self.waitUntil { coordinator.pendingWholeTrackPlays.count == 1 }
+        await parseGate.open()
+        await self.waitUntil { mockYouTube.getWatchNextCompletionCount == 1 }
+
+        playerService.currentTrack = TestFixtures.makeSong(id: "next", title: "Next Song", duration: 200)
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 0,
+            duration: 200,
+            observedVideoId: "next"
+        )
+        await self.waitUntil { queue.count == 1 }
+
+        #expect(queue.pendingTracks.first?.title == "Regular Song")
+        #expect(!queue.pendingTracks.contains { $0.title == "Track 0" })
+    }
+
+    @Test("Tracklist bounds confirm a mix without a parent duration")
+    func tracklistBoundsResolveDurationlessMix() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = self.makeWatchNextData(chapters: self.makeMixChapters())
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+        let mockService = MockScrobbleService()
+        mockService.authState = .connected(username: "testuser")
+        let settings = MockScrobblingSettings()
+        settings.setServiceEnabled("Mock", true)
+
+        let playerService = PlayerService()
+        playerService.currentTrack = TestFixtures.makeSong(id: "mix1", title: "Long Mix", duration: nil)
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 0,
+            duration: 0,
+            observedVideoId: "mix1"
+        )
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [mockService],
+            queue: ScrobbleQueue(directory: dir),
+            mixTracklistParser: parser,
+            unknownDurationParseDelay: .milliseconds(20)
+        )
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+
+        await self.waitUntil { mockYouTube.getWatchNextCompletionCount == 1 }
+        await self.waitUntil { mockService.nowPlayingTracks.contains { $0.title == "Track 0" } }
+
+        #expect(mockService.nowPlayingTracks.contains { $0.title == "Track 0" })
+        #expect(!mockService.nowPlayingTracks.contains { $0.title == "Long Mix" })
+    }
+
+    @Test("Restarting monitoring reschedules unknown-duration parsing")
+    func monitoringRestartReschedulesDurationlessParse() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = .empty
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+        let mockService = MockScrobbleService()
+        mockService.authState = .connected(username: "testuser")
+        let settings = MockScrobblingSettings()
+        settings.setServiceEnabled("Mock", true)
+
+        let playerService = PlayerService()
+        playerService.currentTrack = TestFixtures.makeSong(id: "unknown", title: "Unknown Duration", duration: nil)
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 1,
+            duration: 0,
+            observedVideoId: "unknown"
+        )
+
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [mockService],
+            queue: ScrobbleQueue(directory: dir),
+            mixTracklistParser: parser,
+            unknownDurationParseDelay: .milliseconds(40)
+        )
+
+        coordinator.startMonitoring()
+        coordinator.stopMonitoring(finalizeCurrentTrack: false)
+        try await Task.sleep(for: .milliseconds(60))
+        #expect(mockYouTube.getWatchNextCallCount == 0)
+
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+        await self.waitUntil { mockYouTube.getWatchNextCompletionCount == 1 }
+        await self.waitUntil { mockService.nowPlayingTracks.count == 1 }
+
+        #expect(mockService.nowPlayingTracks.first?.title == "Unknown Duration")
+    }
+
+    @Test("Duration confirmation ignores a different player track")
+    func durationConfirmationIgnoresDifferentPlayerTrack() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let playerService = PlayerService()
+        let oldTrack = TestFixtures.makeSong(id: "old", title: "Old Track", duration: nil)
+        playerService.currentTrack = oldTrack
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 0,
+            duration: 0,
+            observedVideoId: "old"
+        )
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            services: [],
+            queue: ScrobbleQueue(directory: dir),
+            unknownDurationParseDelay: .milliseconds(20)
+        )
+        defer { coordinator.stopMonitoring() }
+        coordinator.currentTrackVideoId = oldTrack.videoId
+        coordinator.trackedSong = oldTrack
+        coordinator.mixDetectionState = .awaitingDuration(
+            self.makeTracklist(videoId: "old", entryDuration: 100)
+        )
+        coordinator.scheduleAwaitingDurationConfirmation(for: oldTrack)
+
+        playerService.currentTrack = TestFixtures.makeSong(id: "next", title: "Next Track", duration: 240)
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 0,
+            duration: 240,
+            observedVideoId: "next"
+        )
+        try await Task.sleep(for: .milliseconds(50))
+
+        let stillAwaiting = if case .awaitingDuration = coordinator.mixDetectionState {
+            true
+        } else {
+            false
+        }
+        #expect(stillAwaiting)
+        #expect(!coordinator.durationConfirmationCompleted)
+    }
+
+    @Test("A short duration arriving after the grace period resolves regular playback")
+    func lateShortDurationAfterGraceResolvesNotMix() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = self.makeWatchNextData(
+            chapters: self.makeMixChapters(videoId: "short1", entryDuration: 100)
+        )
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+        let mockService = MockScrobbleService()
+        mockService.authState = .connected(username: "testuser")
+        let settings = MockScrobblingSettings()
+        settings.setServiceEnabled("Mock", true)
+
+        let playerService = PlayerService()
+        playerService.currentTrack = TestFixtures.makeSong(id: "short1", title: "Regular Song", duration: nil)
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 0,
+            duration: 0,
+            observedVideoId: "short1"
+        )
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [mockService],
+            queue: ScrobbleQueue(directory: dir),
+            mixTracklistParser: parser,
+            unknownDurationParseDelay: .milliseconds(20)
+        )
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+
+        await self.waitUntil { mockYouTube.getWatchNextCompletionCount == 1 }
+        await self.waitUntil { coordinator.durationConfirmationCompleted }
+        await self.waitUntil { mockService.nowPlayingTracks.first?.title == "Regular Song" }
+        #expect(mockService.nowPlayingTracks.first?.title == "Regular Song")
+
+        playerService.currentTrack = TestFixtures.makeSong(
+            id: "short1",
+            title: "Regular Song",
+            duration: 240
+        )
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 1,
+            duration: 240,
+            observedVideoId: "short1"
+        )
+        await self.waitUntil {
+            if case .notMix = coordinator.mixDetectionState {
+                true
+            } else {
+                false
+            }
+        }
+
+        #expect(mockService.nowPlayingTracks.first?.title == "Regular Song")
+        #expect(mockService.nowPlayingTracks.count == 1)
+    }
+
+    @Test("Tracklist bounds outrank a provisional short player duration")
+    func tracklistBoundsOverrideProvisionalShortDuration() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = self.makeWatchNextData(chapters: self.makeMixChapters())
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+        let mockService = MockScrobbleService()
+        mockService.authState = .connected(username: "testuser")
+        let settings = MockScrobblingSettings()
+        settings.setServiceEnabled("Mock", true)
+
+        let playerService = PlayerService()
+        playerService.currentTrack = TestFixtures.makeSong(id: "mix1", title: "Long Mix", duration: nil)
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 0,
+            duration: 240,
+            observedVideoId: "mix1"
+        )
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [mockService],
+            queue: ScrobbleQueue(directory: dir),
+            mixTracklistParser: parser,
+            unknownDurationParseDelay: .milliseconds(20)
+        )
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+
+        await self.waitUntil { mockService.nowPlayingTracks.contains { $0.title == "Track 0" } }
+
+        #expect(mockService.nowPlayingTracks.contains { $0.title == "Track 0" })
+        #expect(!mockService.nowPlayingTracks.contains { $0.title == "Long Mix" })
+    }
+
+    @Test("Deferred finalization uses the same tracklist-bound precedence")
+    func deferredFinalizationUsesTracklistBoundPrecedence() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let parseGate = AsyncGate()
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = self.makeWatchNextData(chapters: self.makeMixChapters())
+        mockYouTube.beforeWatchNextReturn = { _ in await parseGate.wait() }
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+        let mockService = MockScrobbleService()
+        mockService.authState = .connected(username: "testuser")
+        let settings = MockScrobblingSettings(scrobblePercentThreshold: 0.001)
+        settings.setServiceEnabled("Mock", true)
+
+        let playerService = PlayerService()
+        playerService.currentTrack = TestFixtures.makeSong(id: "mix1", title: "Whole Mix", duration: nil)
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 0,
+            duration: 240,
+            observedVideoId: "mix1"
+        )
+        let queue = ScrobbleQueue(directory: dir)
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [mockService],
+            queue: queue,
+            mixTracklistParser: parser,
+            unknownDurationParseDelay: .milliseconds(20)
+        )
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+
+        await self.waitUntil { mockYouTube.getWatchNextCallCount == 1 }
+        playerService.progress = 1
+        await self.waitUntil { coordinator.pendingWholeTrackPlays.count == 1 }
+        playerService.currentTrack = TestFixtures.makeSong(id: "next", title: "Next Song", duration: 200)
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 0,
+            duration: 200,
+            observedVideoId: "next"
+        )
+
+        await parseGate.open()
+        await self.waitUntil { queue.count == 1 }
+
+        #expect(queue.pendingTracks.first?.title == "Track 0")
+        #expect(!queue.pendingTracks.contains { $0.title == "Whole Mix" })
+    }
+
+    @Test("A replay snapshots the completed provisional play before replacement")
+    func replaySnapshotsCompletedPendingWholeTrackPlay() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let parseGate = AsyncGate()
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = .empty
+        mockYouTube.beforeWatchNextReturn = { _ in await parseGate.wait() }
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+        let mockService = MockScrobbleService()
+        mockService.authState = .connected(username: "testuser")
+        let settings = MockScrobblingSettings(scrobblePercentThreshold: 0.01)
+        settings.setServiceEnabled("Mock", true)
+
+        let playerService = PlayerService()
+        playerService.currentTrack = TestFixtures.makeSong(
+            id: "regular",
+            title: "Regular Mix Candidate",
+            duration: nil
+        )
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 0,
+            duration: 40,
+            observedVideoId: "regular"
+        )
+        let queue = ScrobbleQueue(directory: dir)
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [mockService],
+            queue: queue,
+            mixTracklistParser: parser,
+            unknownDurationParseDelay: .milliseconds(20)
+        )
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+
+        await self.waitUntil { mockYouTube.getWatchNextCallCount == 1 }
+        for progress in 1 ... 9 {
+            playerService.progress = TimeInterval(progress)
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        await self.waitUntil { coordinator.pendingWholeTrackPlays.count == 1 }
+        #expect((coordinator.trackTracker?.accumulatedPlayTime ?? 0) >= 8)
+        let completedPlayTimestamp = coordinator.pendingWholeTrackPlays[0].tracker.startTime
+
+        playerService.progress = 0
+        await self.waitUntil { coordinator.trackTracker?.startTime != completedPlayTimestamp }
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 0,
+            duration: 700,
+            observedVideoId: "regular"
+        )
+        await parseGate.open()
+        await self.waitUntil { queue.count == 1 }
+
+        #expect(queue.pendingTracks.first?.title == "Regular Mix Candidate")
+        #expect(queue.pendingTracks.first?.timestamp == completedPlayTimestamp)
+    }
+
+    @Test("A metadata-only track transition waits for a fresh playback sample")
+    func metadataOnlyTrackTransitionWaitsForFreshPlaybackSample() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let mockService = MockScrobbleService()
+        mockService.authState = .connected(username: "testuser")
+        let settings = MockScrobblingSettings()
+        settings.setServiceEnabled("Mock", true)
+        let playerService = PlayerService()
+        playerService.currentTrack = TestFixtures.makeSong(
+            id: "shared",
+            title: "Old Track",
+            artistName: "Old Artist",
+            duration: 100
+        )
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 0,
+            duration: 100,
+            observedVideoId: "shared"
+        )
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [mockService],
+            queue: ScrobbleQueue(directory: dir)
+        )
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+        await self.waitUntil { mockService.nowPlayingTracks.count == 1 }
+
+        // A queued old-track sample advances the bridge sequence immediately before metadata changes.
+        // The new metadata identity must still require the next sample, not merely this latest one.
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 10,
+            duration: 100,
+            observedVideoId: "shared"
+        )
+        playerService.currentTrack = TestFixtures.makeSong(
+            id: "shared",
+            title: "New Track",
+            artistName: "New Artist",
+            duration: nil
+        )
+        coordinator.pollPlayerState()
+
+        #expect(coordinator.trackedSong?.title == "New Track")
+        #expect(mockService.nowPlayingTracks.count == 1)
+        #expect(coordinator.trackedVideoDuration == nil)
+
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 0,
+            duration: 200,
+            observedVideoId: "shared"
+        )
+        await self.waitUntil { mockService.nowPlayingTracks.count == 2 }
+
+        #expect(mockService.nowPlayingTracks.last?.title == "New Track")
+        #expect(coordinator.trackedVideoDuration == 200)
+    }
+
+    @Test("Async parse completion refreshes the current authoritative duration")
+    func asyncParseCompletionRefreshesCurrentDuration() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let parseGate = AsyncGate()
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = .empty
+        mockYouTube.beforeWatchNextReturn = { _ in await parseGate.wait() }
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+        let settings = MockScrobblingSettings(scrobblePercentThreshold: 0.01)
+        let playerService = PlayerService()
+        let initialTrack = TestFixtures.makeSong(
+            id: "regular",
+            title: "Regular Track",
+            duration: nil
+        )
+        playerService.currentTrack = initialTrack
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 1,
+            duration: 40,
+            observedVideoId: "regular"
+        )
+        let queue = ScrobbleQueue(directory: dir)
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [],
+            queue: queue,
+            mixTracklistParser: parser
+        )
+        defer { coordinator.stopMonitoring() }
+        coordinator.currentTrackVideoId = initialTrack.videoId
+        coordinator.trackedSong = initialTrack
+        coordinator.trackedVideoDuration = 40
+        coordinator.mixDetectionState = .unresolved
+        var tracker = PlaybackScrobbleTracker(startTime: Date(), initialProgress: 0)
+        tracker.creditVerifiedPlayTime(1)
+        tracker.markScrobbled()
+        coordinator.trackTracker = tracker
+        coordinator.pendingWholeTrackPlays = [
+            .init(tracker: tracker, song: initialTrack),
+        ]
+        coordinator.startMixParse(for: initialTrack, parser: parser, startedWithoutDuration: true)
+        await self.waitUntil { mockYouTube.getWatchNextCallCount == 1 }
+
+        let updatedTrack = TestFixtures.makeSong(
+            id: "regular",
+            title: "Regular Track",
+            duration: 700
+        )
+        playerService.currentTrack = updatedTrack
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 1,
+            duration: 700,
+            observedVideoId: "regular"
+        )
+        await parseGate.open()
+        await self.waitUntil {
+            if case .notMix = coordinator.mixDetectionState {
+                true
+            } else {
+                false
+            }
+        }
+
+        #expect(coordinator.trackedVideoDuration == 700)
+        #expect(coordinator.trackedSong?.duration == 700)
+        #expect(queue.isEmpty)
+        #expect(coordinator.trackTracker?.hasScrobbled == false)
+    }
+
+    @Test("A provisional short-duration decision upgrades when the player duration grows")
+    func provisionalShortDecisionUpgradesToMix() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let chapters = [
+            YouTubeChapter(videoId: "mix1", title: "Artist 0 - Track 0", startTime: 0, endTime: 100, timeText: nil, thumbnailURL: nil),
+            YouTubeChapter(videoId: "mix1", title: "Artist 1 - Track 1", startTime: 100, endTime: 200, timeText: nil, thumbnailURL: nil),
+            YouTubeChapter(videoId: "mix1", title: "Artist 2 - Track 2", startTime: 200, endTime: nil, timeText: nil, thumbnailURL: nil),
+        ]
+        let youtubeClient = MockYouTubeClient()
+        youtubeClient.watchNextData = self.makeWatchNextData(chapters: chapters)
+        let parser = MixTracklistParser(youTubeClient: youtubeClient)
+        let service = MockScrobbleService()
+        service.authState = .connected(username: "testuser")
+        let settings = MockScrobblingSettings()
+        settings.setServiceEnabled("Mock", true)
+        let playerService = PlayerService()
+        playerService.currentTrack = TestFixtures.makeSong(id: "mix1", title: "Long Mix", duration: nil)
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 0,
+            duration: 240,
+            observedVideoId: "mix1"
+        )
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [service],
+            queue: ScrobbleQueue(directory: dir),
+            mixTracklistParser: parser,
+            unknownDurationParseDelay: .milliseconds(20)
+        )
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+
+        await self.waitUntil { service.nowPlayingTracks.contains { $0.title == "Long Mix" } }
+        #expect(!service.nowPlayingTracks.contains { $0.title == "Track 0" })
+
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 1,
+            duration: 3600,
+            observedVideoId: "mix1"
+        )
+        await self.waitUntil { service.nowPlayingTracks.contains { $0.title == "Track 0" } }
+
+        #expect(service.nowPlayingTracks.map(\.title).contains("Track 0"))
+    }
+}

--- a/Tests/KasetTests/ScrobblingCoordinatorMixPlaybackTests.swift
+++ b/Tests/KasetTests/ScrobblingCoordinatorMixPlaybackTests.swift
@@ -1,0 +1,600 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+@Suite(.serialized, .tags(.service))
+@MainActor
+struct ScrobblingCoordinatorMixPlaybackTests {
+    private func makeTemporaryDirectory() throws -> URL {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ScrobblingCoordinatorMixPlaybackTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        return tempDir
+    }
+
+    private func cleanupDirectory(_ dir: URL) {
+        try? FileManager.default.removeItem(at: dir)
+    }
+
+    private func makeWatchNextData(chapters: [YouTubeChapter]) -> WatchNextData {
+        WatchNextData(
+            videoTitle: "Long Mix",
+            viewCountText: nil,
+            publishedText: nil,
+            channel: nil,
+            related: [],
+            chapters: chapters
+        )
+    }
+
+    private func makeMixChapters(videoId: String = "mix1", count: Int = 3) -> [YouTubeChapter] {
+        (0 ..< count).map { index in
+            YouTubeChapter(
+                videoId: videoId,
+                title: "Artist \(index) - Track \(index)",
+                startTime: TimeInterval(index) * 600,
+                endTime: TimeInterval(index + 1) * 600,
+                timeText: nil,
+                thumbnailURL: nil
+            )
+        }
+    }
+
+    private func waitUntil(
+        timeout: Duration = .seconds(2),
+        _ condition: @MainActor () -> Bool
+    ) async {
+        let deadline = ContinuousClock.now + timeout
+        while !condition(), ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+    }
+
+    @Test("A stale mix fetch does not block the next track's fetch")
+    func staleMixFetchDoesNotBlockNextTrack() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let firstRequestGate = AsyncGate()
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = self.makeWatchNextData(chapters: self.makeMixChapters())
+        mockYouTube.beforeWatchNextReturn = { videoId in
+            if videoId == "mix1" {
+                await firstRequestGate.wait()
+            }
+        }
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+
+        let mockService = MockScrobbleService()
+        mockService.authState = .connected(username: "testuser")
+        let settings = MockScrobblingSettings()
+        settings.setServiceEnabled("Mock", true)
+        defer { settings.setServiceEnabled("Mock", false) }
+
+        let playerService = PlayerService()
+        playerService.currentTrack = TestFixtures.makeSong(id: "mix1", title: "First Mix", duration: 3600)
+        playerService.state = .playing
+        playerService.duration = 3600
+        playerService.setPlaybackStateVideoId("mix1")
+
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [mockService],
+            queue: ScrobbleQueue(directory: dir),
+            mixTracklistParser: parser
+        )
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+
+        await self.waitUntil { mockYouTube.getWatchNextCallCount == 1 }
+        #expect(mockYouTube.requestedWatchNextVideoIds == ["mix1"])
+
+        // The first request remains suspended while playback moves to another long mix. The new
+        // track must start its own parse immediately rather than waiting for the stale request.
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 0,
+            duration: 3600,
+            observedVideoId: "mix2"
+        )
+        playerService.currentTrack = TestFixtures.makeSong(id: "mix2", title: "Second Mix", duration: 3600)
+        await self.waitUntil { mockYouTube.getWatchNextCallCount == 2 }
+
+        #expect(mockYouTube.requestedWatchNextVideoIds == ["mix1", "mix2"])
+        await firstRequestGate.open()
+    }
+
+    @Test("Forward seeks preserve a scrobbled mix latch while backward replays start fresh")
+    func mixSeekAndReplayLatches() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let chapters = [
+            YouTubeChapter(videoId: "mix1", title: "Artist 0 - Track 0", startTime: 0, endTime: 100, timeText: nil, thumbnailURL: nil),
+            YouTubeChapter(videoId: "mix1", title: "Artist 1 - Track 1", startTime: 100, endTime: 610, timeText: nil, thumbnailURL: nil),
+            YouTubeChapter(videoId: "mix1", title: "Artist 2 - Track 2", startTime: 610, endTime: nil, timeText: nil, thumbnailURL: nil),
+        ]
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = self.makeWatchNextData(chapters: chapters)
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+
+        let mockService = MockScrobbleService()
+        mockService.authState = .connected(username: "testuser")
+        let settings = MockScrobblingSettings()
+        let originalPercent = settings.scrobblePercentThreshold
+        let originalMinSeconds = settings.scrobbleMinSeconds
+        settings.scrobblePercentThreshold = 0.01
+        settings.scrobbleMinSeconds = 240
+        settings.setServiceEnabled("Mock", true)
+        defer {
+            settings.scrobblePercentThreshold = originalPercent
+            settings.scrobbleMinSeconds = originalMinSeconds
+            settings.setServiceEnabled("Mock", false)
+        }
+
+        let playerService = PlayerService()
+        playerService.currentTrack = TestFixtures.makeSong(id: "mix1", title: "Long Mix", duration: 700)
+        playerService.state = .playing
+        playerService.duration = 700
+        playerService.setPlaybackStateVideoId("mix1")
+        let queue = ScrobbleQueue(directory: dir)
+
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [mockService],
+            queue: queue,
+            mixTracklistParser: parser
+        )
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+
+        await self.waitUntil { mockYouTube.getWatchNextCompletionCount == 1 }
+        playerService.progress = 0.1
+        await self.waitUntil { mockService.nowPlayingTracks.count == 1 }
+        playerService.progress = 1.1
+        await self.waitUntil { queue.count == 1 }
+        #expect(coordinator.mixEntryScrobbledIds.count == 1)
+        let firstTimestamp = queue.pendingTracks.first?.timestamp
+
+        // Leaving the entry and seeking back into its middle preserves the original latch.
+        playerService.progress = 110
+        await self.waitUntil { mockService.nowPlayingTracks.count == 2 }
+        #expect(coordinator.mixEntryScrobbledIds.count == 1)
+        #expect(coordinator.trackTracker?.hasScrobbled == false)
+        playerService.progress = 50
+        try await Task.sleep(for: .milliseconds(20))
+        #expect(coordinator.mixEntryScrobbledIds.count == 1)
+        playerService.progress = 51
+        try await Task.sleep(for: .milliseconds(100))
+        #expect(queue.count == 1)
+        #expect(mockService.nowPlayingTracks.count == 3)
+
+        // A forward seek within the already-scrobbled entry must not re-arm it.
+        playerService.progress = 70
+        try await Task.sleep(for: .milliseconds(20))
+        playerService.progress = 71
+        try await Task.sleep(for: .milliseconds(100))
+        #expect(queue.count == 1)
+        #expect(mockService.nowPlayingTracks.count == 3)
+
+        // An ordinary rewind within the entry is still the same play and must preserve latches.
+        playerService.progress = 40
+        try await Task.sleep(for: .milliseconds(20))
+        playerService.progress = 41
+        try await Task.sleep(for: .milliseconds(100))
+        #expect(queue.count == 1)
+        #expect(mockService.nowPlayingTracks.count == 3)
+
+        // Restarting near the entry's beginning is a real replay: it gets a fresh tracker/timestamp
+        // and may scrobble the entry once more after meeting the threshold again.
+        playerService.progress = 1
+        try await Task.sleep(for: .milliseconds(20))
+        playerService.progress = 2
+        await self.waitUntil { queue.count == 2 }
+
+        #expect(mockService.nowPlayingTracks.count == 4)
+        #expect(queue.pendingTracks.last?.timestamp != firstTimestamp)
+    }
+
+    @Test("A seek before parsing completes does not seed pre-seek playback")
+    func pendingSeekDoesNotSeedOldCredit() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let parseGate = AsyncGate()
+        let chapters = [
+            YouTubeChapter(videoId: "mix1", title: "Artist 0 - Track 0", startTime: 0, endTime: 100, timeText: nil, thumbnailURL: nil),
+            YouTubeChapter(videoId: "mix1", title: "Artist 1 - Track 1", startTime: 100, endTime: 200, timeText: nil, thumbnailURL: nil),
+            YouTubeChapter(videoId: "mix1", title: "Artist 2 - Track 2", startTime: 200, endTime: 300, timeText: nil, thumbnailURL: nil),
+        ]
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = self.makeWatchNextData(chapters: chapters)
+        mockYouTube.beforeWatchNextReturn = { _ in await parseGate.wait() }
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+        let mockService = MockScrobbleService()
+        mockService.authState = .connected(username: "testuser")
+        let settings = MockScrobblingSettings(scrobblePercentThreshold: 0.015)
+        settings.setServiceEnabled("Mock", true)
+
+        let playerService = PlayerService()
+        playerService.currentTrack = TestFixtures.makeSong(id: "mix1", title: "Long Mix", duration: 700)
+        playerService.state = .playing
+        playerService.duration = 700
+        playerService.setPlaybackStateVideoId("mix1")
+        let queue = ScrobbleQueue(directory: dir)
+
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [mockService],
+            queue: queue,
+            mixTracklistParser: parser
+        )
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+
+        await self.waitUntil { mockYouTube.getWatchNextCallCount == 1 }
+        playerService.progress = 0.6
+        try await Task.sleep(for: .milliseconds(20))
+        playerService.progress = 50
+        try await Task.sleep(for: .milliseconds(20))
+        await parseGate.open()
+        await self.waitUntil { mockYouTube.getWatchNextCompletionCount == 1 }
+
+        playerService.progress = 51
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(queue.isEmpty)
+
+        playerService.progress = 52
+        await self.waitUntil { queue.count == 1 }
+        #expect(queue.pendingTracks.first?.title == "Track 0")
+    }
+
+    @Test("Final mix entry metadata uses the parent video duration when its end is missing")
+    func finalMixEntryDurationUsesVideoDuration() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let chapters = [
+            YouTubeChapter(videoId: "mix1", title: "Artist 0 - Track 0", startTime: 0, endTime: 300, timeText: nil, thumbnailURL: nil),
+            YouTubeChapter(videoId: "mix1", title: "Artist 1 - Track 1", startTime: 300, endTime: 610, timeText: nil, thumbnailURL: nil),
+            YouTubeChapter(videoId: "mix1", title: "Artist 2 - Track 2", startTime: 610, endTime: nil, timeText: nil, thumbnailURL: nil),
+        ]
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = self.makeWatchNextData(chapters: chapters)
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+
+        let mockService = MockScrobbleService()
+        mockService.authState = .connected(username: "testuser")
+        let settings = MockScrobblingSettings()
+        settings.setServiceEnabled("Mock", true)
+        defer { settings.setServiceEnabled("Mock", false) }
+
+        let playerService = PlayerService()
+        playerService.currentTrack = TestFixtures.makeSong(id: "mix1", title: "Long Mix", duration: nil)
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 0,
+            duration: 700,
+            observedVideoId: "mix1"
+        )
+
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [mockService],
+            queue: ScrobbleQueue(directory: dir),
+            mixTracklistParser: parser
+        )
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+
+        playerService.progress = 610.1
+        await self.waitUntil { mockYouTube.getWatchNextCompletionCount == 1 }
+        await self.waitUntil { mockService.nowPlayingTracks.count == 1 }
+
+        #expect(mockService.nowPlayingTracks.first?.title == "Track 2")
+        #expect(mockService.nowPlayingTracks.first?.duration == 90)
+    }
+
+    @Test("The final delta to an explicit chapter end is credited before a gap")
+    func chapterEndDeltaIsCredited() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let chapters = [
+            YouTubeChapter(videoId: "mix1", title: "Artist 0 - Track 0", startTime: 0, endTime: 100, timeText: nil, thumbnailURL: nil),
+            YouTubeChapter(videoId: "mix1", title: "Artist 1 - Track 1", startTime: 120, endTime: 220, timeText: nil, thumbnailURL: nil),
+            YouTubeChapter(videoId: "mix1", title: "Artist 2 - Track 2", startTime: 220, endTime: 320, timeText: nil, thumbnailURL: nil),
+        ]
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = self.makeWatchNextData(chapters: chapters)
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+        let mockService = MockScrobbleService()
+        mockService.authState = .connected(username: "testuser")
+        let settings = MockScrobblingSettings(scrobblePercentThreshold: 0.01)
+        settings.setServiceEnabled("Mock", true)
+
+        let playerService = PlayerService()
+        playerService.currentTrack = TestFixtures.makeSong(id: "mix1", title: "Long Mix", duration: 700)
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 99,
+            duration: 700,
+            observedVideoId: "mix1"
+        )
+        let queue = ScrobbleQueue(directory: dir)
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [mockService],
+            queue: queue,
+            mixTracklistParser: parser
+        )
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+
+        await self.waitUntil { mockService.nowPlayingTracks.count == 1 }
+        playerService.progress = 100
+        await self.waitUntil { queue.count == 1 }
+
+        #expect(queue.pendingTracks.first?.title == "Track 0")
+    }
+
+    @Test("A provisional short duration can grow before whole-track classification commits")
+    func playerDurationGrowthBeforeConfirmation() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = self.makeWatchNextData(chapters: self.makeMixChapters())
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+        let mockService = MockScrobbleService()
+        mockService.authState = .connected(username: "testuser")
+        let settings = MockScrobblingSettings()
+        settings.setServiceEnabled("Mock", true)
+
+        let playerService = PlayerService()
+        playerService.currentTrack = TestFixtures.makeSong(id: "mix1", title: "Growing Mix", duration: 0)
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 1,
+            duration: 240,
+            observedVideoId: "mix1"
+        )
+
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [mockService],
+            queue: ScrobbleQueue(directory: dir),
+            mixTracklistParser: parser,
+            unknownDurationParseDelay: .milliseconds(100)
+        )
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+
+        try await Task.sleep(for: .milliseconds(20))
+        #expect(mockService.nowPlayingTracks.isEmpty)
+
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 2,
+            duration: 3600,
+            observedVideoId: "mix1"
+        )
+        await self.waitUntil { mockYouTube.getWatchNextCompletionCount == 1 }
+        await self.waitUntil { mockService.nowPlayingTracks.contains { $0.title == "Track 0" } }
+        #expect(!mockService.nowPlayingTracks.contains { $0.title == "Growing Mix" })
+    }
+
+    @Test("Regular-track replays remain separate while mix parsing is pending")
+    func pendingRegularTrackReplaysStaySeparate() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let parseGate = AsyncGate()
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = .empty
+        mockYouTube.beforeWatchNextReturn = { _ in await parseGate.wait() }
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+        let mockService = MockScrobbleService()
+        mockService.authState = .connected(username: "testuser")
+        let settings = MockScrobblingSettings(scrobblePercentThreshold: 0.001)
+        settings.setServiceEnabled("Mock", true)
+
+        let playerService = PlayerService()
+        playerService.currentTrack = TestFixtures.makeSong(id: "regular", title: "Long Regular", duration: 700)
+        playerService.state = .playing
+        playerService.duration = 700
+        playerService.setPlaybackStateVideoId("regular")
+        let queue = ScrobbleQueue(directory: dir)
+
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [mockService],
+            queue: queue,
+            mixTracklistParser: parser
+        )
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+
+        await self.waitUntil { mockYouTube.getWatchNextCallCount == 1 }
+        playerService.progress = 1
+        try await Task.sleep(for: .milliseconds(20))
+        playerService.progress = 10
+        try await Task.sleep(for: .milliseconds(20))
+        playerService.progress = 0
+        try await Task.sleep(for: .milliseconds(20))
+        playerService.progress = 1
+        try await Task.sleep(for: .milliseconds(20))
+
+        await parseGate.open()
+        await self.waitUntil { queue.count == 2 }
+
+        #expect(queue.pendingTracks.allSatisfy { $0.title == "Long Regular" })
+        #expect(queue.pendingTracks[0].timestamp != queue.pendingTracks[1].timestamp)
+    }
+
+    @Test("Pending whole-track thresholds are revalidated when duration grows")
+    func pendingWholeTrackThresholdRevalidatesDuration() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let parseGate = AsyncGate()
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = .empty
+        mockYouTube.beforeWatchNextReturn = { _ in await parseGate.wait() }
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+        let mockService = MockScrobbleService()
+        mockService.authState = .connected(username: "testuser")
+        let settings = MockScrobblingSettings(scrobblePercentThreshold: 0.001)
+        settings.setServiceEnabled("Mock", true)
+
+        let playerService = PlayerService()
+        playerService.currentTrack = TestFixtures.makeSong(id: "regular", title: "Long Regular", duration: nil)
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 0,
+            duration: 700,
+            observedVideoId: "regular"
+        )
+        let queue = ScrobbleQueue(directory: dir)
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [mockService],
+            queue: queue,
+            mixTracklistParser: parser
+        )
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+
+        await self.waitUntil { mockYouTube.getWatchNextCallCount == 1 }
+        playerService.progress = 1
+        try await Task.sleep(for: .milliseconds(20))
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 1,
+            duration: 3600,
+            observedVideoId: "regular"
+        )
+        await parseGate.open()
+        await self.waitUntil { mockYouTube.getWatchNextCompletionCount == 1 }
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(queue.isEmpty)
+        #expect(coordinator.trackTracker?.hasScrobbled == false)
+    }
+
+    @Test("Duration growth clears a provisional latch before a rewind splits the play")
+    func durationGrowthRevalidatesLatchBeforeReplayDetection() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let parseGate = AsyncGate()
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = .empty
+        mockYouTube.beforeWatchNextReturn = { _ in await parseGate.wait() }
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+        let mockService = MockScrobbleService()
+        mockService.authState = .connected(username: "testuser")
+        let settings = MockScrobblingSettings(scrobblePercentThreshold: 0.01)
+        settings.setServiceEnabled("Mock", true)
+
+        let playerService = PlayerService()
+        playerService.currentTrack = TestFixtures.makeSong(
+            id: "regular",
+            title: "Growing Regular Track",
+            duration: nil
+        )
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 0,
+            duration: 40,
+            observedVideoId: "regular"
+        )
+        let queue = ScrobbleQueue(directory: dir)
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [mockService],
+            queue: queue,
+            mixTracklistParser: parser,
+            unknownDurationParseDelay: .milliseconds(20)
+        )
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+
+        await self.waitUntil { mockYouTube.getWatchNextCallCount == 1 }
+        for progress in 1 ... 6 {
+            playerService.progress = TimeInterval(progress)
+            try await Task.sleep(for: .milliseconds(10))
+        }
+        await self.waitUntil { coordinator.pendingWholeTrackPlays.count == 1 }
+
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 0,
+            duration: 700,
+            observedVideoId: "regular"
+        )
+        await self.waitUntil {
+            coordinator.pendingWholeTrackPlays.isEmpty
+                && coordinator.trackTracker?.hasScrobbled == false
+        }
+
+        playerService.progress = 1
+        try await Task.sleep(for: .milliseconds(10))
+        playerService.progress = 2
+        await self.waitUntil { coordinator.pendingWholeTrackPlays.count == 1 }
+
+        await parseGate.open()
+        await self.waitUntil { queue.count == 1 }
+
+        #expect(queue.pendingTracks.first?.title == "Growing Regular Track")
+    }
+
+    @Test("Termination uses a bounded fallback when mix parsing stalls")
+    func terminationTimeoutPersistsFallback() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let parseGate = AsyncGate()
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = .empty
+        mockYouTube.beforeWatchNextReturn = { _ in await parseGate.wait() }
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+        let mockService = MockScrobbleService()
+        mockService.authState = .connected(username: "testuser")
+        let settings = MockScrobblingSettings(scrobblePercentThreshold: 0.001)
+        settings.setServiceEnabled("Mock", true)
+
+        let playerService = PlayerService()
+        playerService.currentTrack = TestFixtures.makeSong(id: "regular", title: "Long Regular", duration: 700)
+        playerService.state = .playing
+        playerService.duration = 700
+        playerService.setPlaybackStateVideoId("regular")
+        let queue = ScrobbleQueue(directory: dir)
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [mockService],
+            queue: queue,
+            mixTracklistParser: parser
+        )
+        coordinator.startMonitoring()
+
+        await self.waitUntil { mockYouTube.getWatchNextCallCount == 1 }
+        playerService.progress = 1
+        try await Task.sleep(for: .milliseconds(20))
+        await coordinator.prepareForTermination(timeout: .milliseconds(20))
+
+        #expect(queue.count == 1)
+        #expect(queue.pendingTracks.first?.title == "Long Regular")
+        await parseGate.open()
+    }
+}

--- a/Tests/KasetTests/ScrobblingCoordinatorMixTests.swift
+++ b/Tests/KasetTests/ScrobblingCoordinatorMixTests.swift
@@ -1,0 +1,804 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+@Suite(.serialized, .tags(.service))
+@MainActor
+struct ScrobblingCoordinatorMixTests {
+    private func makeTemporaryDirectory() throws -> URL {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ScrobblingCoordinatorMixTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        return tempDir
+    }
+
+    private func cleanupDirectory(_ dir: URL) {
+        try? FileManager.default.removeItem(at: dir)
+    }
+
+    // MARK: - Mix-Mode Detection
+
+    private func makeWatchNextData(chapters: [YouTubeChapter]) -> WatchNextData {
+        WatchNextData(
+            videoTitle: "Long Mix",
+            viewCountText: nil,
+            publishedText: nil,
+            channel: nil,
+            related: [],
+            chapters: chapters
+        )
+    }
+
+    private func makeMixChapters(
+        videoId: String = "mix1",
+        count: Int = 3,
+        entryDuration: TimeInterval = 600
+    ) -> [YouTubeChapter] {
+        (0 ..< count).map { index in
+            YouTubeChapter(
+                videoId: videoId,
+                title: "Artist \(index) - Track \(index)",
+                startTime: TimeInterval(index) * entryDuration,
+                endTime: TimeInterval(index + 1) * entryDuration,
+                timeText: nil,
+                thumbnailURL: nil
+            )
+        }
+    }
+
+    private func waitUntil(
+        timeout: Duration = .seconds(2),
+        _ condition: @MainActor () -> Bool
+    ) async {
+        let deadline = ContinuousClock.now + timeout
+        while !condition(), ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+    }
+
+    /// Regression: duration often arrives after the fallback parse. When the parsed bounds cannot
+    /// prove a long video, classification must remain pending without refetching, then commit the
+    /// already-parsed mix as soon as the current playback duration becomes authoritative.
+    @Test("Mix parse stays pending until duration confirms it and fires exactly once")
+    func mixParseWaitsForConfirmingDuration() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = self.makeWatchNextData(
+            chapters: self.makeMixChapters(entryDuration: 100)
+        )
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+
+        let mockService = MockScrobbleService()
+        mockService.authState = .connected(username: "testuser")
+        let settings = MockScrobblingSettings()
+        settings.setServiceEnabled("Mock", true)
+        defer { settings.setServiceEnabled("Mock", false) }
+
+        let playerService = PlayerService()
+        // Track is playing, but duration hasn't loaded yet (the race the fix addresses).
+        playerService.currentTrack = TestFixtures.makeSong(id: "mix1", title: "Long Mix", duration: nil)
+        playerService.state = .playing
+        playerService.duration = 0
+        playerService.setPlaybackStateVideoId("mix1")
+
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [mockService],
+            queue: ScrobbleQueue(directory: dir),
+            mixTracklistParser: parser,
+            unknownDurationParseDelay: .milliseconds(20)
+        )
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+
+        // First poll ran synchronously in startMonitoring; duration unknown → no fetch attempted.
+        #expect(mockYouTube.getWatchNextCallCount == 0)
+        await self.waitUntil { mockService.nowPlayingTracks.first?.title == "Long Mix" }
+        #expect(mockService.nowPlayingTracks.first?.title == "Long Mix")
+
+        // Duration becomes known — the observed change must commit the existing parse result.
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 0,
+            duration: 3600,
+            observedVideoId: "mix1"
+        )
+        await self.waitUntil { mockYouTube.getWatchNextCallCount >= 1 }
+        #expect(mockYouTube.getWatchNextCallCount == 1)
+
+        await self.waitUntil { mockYouTube.getWatchNextCompletionCount == 1 }
+        playerService.progress = 0.1
+        await self.waitUntil { mockService.nowPlayingTracks.contains { $0.title == "Track 0" } }
+        #expect(mockService.nowPlayingTracks.contains { $0.title == "Track 0" })
+
+        // Further duration churn must not re-fetch (latched once per track).
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 0.2,
+            duration: 3601,
+            observedVideoId: "mix1"
+        )
+        await self.waitUntil(timeout: .milliseconds(200)) { mockYouTube.getWatchNextCallCount > 1 }
+        #expect(mockYouTube.getWatchNextCallCount == 1)
+    }
+
+    @Test("Mix fetch is not attempted for a track-scoped short duration")
+    func mixFetchSkippedForShortTracks() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = self.makeWatchNextData(
+            chapters: self.makeMixChapters(videoId: "short1", entryDuration: 100)
+        )
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+
+        let mockService = MockScrobbleService()
+        mockService.authState = .connected(username: "testuser")
+        let settings = MockScrobblingSettings()
+        settings.setServiceEnabled("Mock", true)
+        defer { settings.setServiceEnabled("Mock", false) }
+
+        let playerService = PlayerService()
+        playerService.currentTrack = TestFixtures.makeSong(id: "short1", title: "Regular Song", duration: 240)
+        playerService.state = .playing
+        playerService.duration = 3600 // May still be stale from the previous track.
+        playerService.setPlaybackStateVideoId("short1")
+
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [mockService],
+            queue: ScrobbleQueue(directory: dir),
+            mixTracklistParser: parser,
+            unknownDurationParseDelay: .milliseconds(20)
+        )
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+
+        // The Song's own 4-minute duration is tied to this video and wins over stale player state.
+        await self.waitUntil(timeout: .milliseconds(200)) { mockYouTube.getWatchNextCallCount >= 1 }
+        #expect(mockYouTube.getWatchNextCallCount == 0)
+        await self.waitUntil { mockService.nowPlayingTracks.count == 1 }
+        #expect(mockService.nowPlayingTracks.first?.title == "Regular Song")
+    }
+
+    @Test("A provisional short player duration does not latch a long mix as not-mix")
+    func provisionalShortDurationDoesNotLatchNotMix() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = self.makeWatchNextData(
+            chapters: self.makeMixChapters(videoId: "short1", entryDuration: 100)
+        )
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+
+        let mockService = MockScrobbleService()
+        mockService.authState = .connected(username: "testuser")
+        let settings = MockScrobblingSettings()
+        settings.setServiceEnabled("Mock", true)
+        defer { settings.setServiceEnabled("Mock", false) }
+
+        let playerService = PlayerService()
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 10,
+            duration: 240,
+            observedVideoId: "previous"
+        )
+        playerService.currentTrack = TestFixtures.makeSong(id: "mix1", title: "Long Mix", duration: nil)
+
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [mockService],
+            queue: ScrobbleQueue(directory: dir),
+            mixTracklistParser: parser
+        )
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(mockYouTube.getWatchNextCallCount == 0)
+        #expect(mockService.nowPlayingTracks.isEmpty)
+
+        // Even another stale progress update must not make that duration current-track scoped.
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 11,
+            duration: 240,
+            observedVideoId: "previous"
+        )
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(mockYouTube.getWatchNextCallCount == 0)
+        #expect(mockService.nowPlayingTracks.isEmpty)
+
+        // The current video's real duration arrives later. Detection must still be unresolved so
+        // it can parse the mix instead of remaining latched in whole-track mode.
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 1,
+            duration: 3600,
+            observedVideoId: "mix1"
+        )
+        await self.waitUntil { mockYouTube.getWatchNextCompletionCount == 1 }
+        playerService.progress = 0.1
+        await self.waitUntil { mockService.nowPlayingTracks.count == 1 }
+
+        #expect(mockService.nowPlayingTracks.first?.title == "Track 0")
+    }
+
+    @Test("A current playback update can resolve a player-only short duration")
+    func playerOnlyShortDurationResolvesAfterPlaybackUpdate() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = .empty
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+
+        let mockService = MockScrobbleService()
+        mockService.authState = .connected(username: "testuser")
+        let settings = MockScrobblingSettings()
+        settings.setServiceEnabled("Mock", true)
+        defer { settings.setServiceEnabled("Mock", false) }
+
+        let playerService = PlayerService()
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 100,
+            duration: 3600,
+            observedVideoId: "previous-long"
+        )
+        playerService.currentTrack = TestFixtures.makeSong(id: "short1", title: "Regular Song", duration: nil)
+
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [mockService],
+            queue: ScrobbleQueue(directory: dir),
+            mixTracklistParser: parser,
+            unknownDurationParseDelay: .milliseconds(100)
+        )
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(mockYouTube.getWatchNextCallCount == 0)
+        #expect(mockService.nowPlayingTracks.isEmpty)
+
+        // PlayerService publishes progress and duration together for the current playback update.
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 1,
+            duration: 240,
+            observedVideoId: "short1"
+        )
+        await self.waitUntil { mockService.nowPlayingTracks.count == 1 }
+
+        #expect(mockYouTube.getWatchNextCallCount == 1)
+        #expect(mockService.nowPlayingTracks.first?.title == "Regular Song")
+    }
+
+    @Test("A duration-less track falls back through parsing and resumes regular handling")
+    func durationlessTrackFallsBackAfterParse() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = .empty
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+
+        let mockService = MockScrobbleService()
+        mockService.authState = .connected(username: "testuser")
+        let settings = MockScrobblingSettings()
+        settings.setServiceEnabled("Mock", true)
+        defer { settings.setServiceEnabled("Mock", false) }
+
+        let playerService = PlayerService()
+        playerService.currentTrack = TestFixtures.makeSong(id: "unknown", title: "Unknown Duration", duration: nil)
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 1,
+            duration: 0,
+            observedVideoId: "unknown"
+        )
+
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [mockService],
+            queue: ScrobbleQueue(directory: dir),
+            mixTracklistParser: parser,
+            unknownDurationParseDelay: .milliseconds(20)
+        )
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+
+        await self.waitUntil { mockYouTube.getWatchNextCompletionCount == 1 }
+        await self.waitUntil { mockService.nowPlayingTracks.count == 1 }
+
+        #expect(mockService.nowPlayingTracks.first?.title == "Unknown Duration")
+    }
+
+    @Test("A late short duration overrides an in-flight unknown-duration fallback parse")
+    func lateShortDurationOverridesFallbackParse() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let parseGate = AsyncGate()
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = self.makeWatchNextData(chapters: self.makeMixChapters())
+        mockYouTube.beforeWatchNextReturn = { _ in await parseGate.wait() }
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+
+        let mockService = MockScrobbleService()
+        mockService.authState = .connected(username: "testuser")
+        let settings = MockScrobblingSettings()
+        settings.setServiceEnabled("Mock", true)
+        defer { settings.setServiceEnabled("Mock", false) }
+
+        let playerService = PlayerService()
+        playerService.currentTrack = TestFixtures.makeSong(id: "short1", title: "Regular Song", duration: nil)
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 1,
+            duration: 0,
+            observedVideoId: "short1"
+        )
+
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [mockService],
+            queue: ScrobbleQueue(directory: dir),
+            mixTracklistParser: parser,
+            unknownDurationParseDelay: .milliseconds(20)
+        )
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+
+        await self.waitUntil { mockYouTube.getWatchNextCallCount == 1 }
+        playerService.currentTrack = TestFixtures.makeSong(id: "short1", title: "Regular Song", duration: 240)
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 2,
+            duration: 240,
+            observedVideoId: "short1"
+        )
+        await self.waitUntil { mockService.nowPlayingTracks.count == 1 }
+
+        #expect(mockService.nowPlayingTracks.first?.title == "Regular Song")
+        #expect(mockYouTube.getWatchNextCompletionCount == 0)
+        await parseGate.open()
+    }
+
+    @Test("A late short duration rejects a completed fallback mix classification")
+    func lateShortDurationRejectsCompletedFallbackMix() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = self.makeWatchNextData(
+            chapters: self.makeMixChapters(videoId: "short1", entryDuration: 100)
+        )
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+        let mockService = MockScrobbleService()
+        mockService.authState = .connected(username: "testuser")
+        let settings = MockScrobblingSettings()
+        settings.setServiceEnabled("Mock", true)
+
+        let playerService = PlayerService()
+        playerService.currentTrack = TestFixtures.makeSong(id: "short1", title: "Regular Song", duration: nil)
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 1,
+            duration: 0,
+            observedVideoId: "short1"
+        )
+
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [mockService],
+            queue: ScrobbleQueue(directory: dir),
+            mixTracklistParser: parser,
+            unknownDurationParseDelay: .milliseconds(20)
+        )
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+
+        await self.waitUntil { mockYouTube.getWatchNextCompletionCount == 1 }
+        await self.waitUntil { mockService.nowPlayingTracks.first?.title == "Regular Song" }
+        #expect(mockService.nowPlayingTracks.first?.title == "Regular Song")
+
+        playerService.currentTrack = TestFixtures.makeSong(id: "short1", title: "Regular Song", duration: 240)
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 2,
+            duration: 240,
+            observedVideoId: "short1"
+        )
+        await self.waitUntil { mockService.nowPlayingTracks.count == 1 }
+
+        #expect(mockService.nowPlayingTracks.first?.title == "Regular Song")
+        #expect(mockService.nowPlayingTracks.count == 1)
+    }
+
+    @Test("Whole-track side effects wait while mix detection is pending")
+    func wholeTrackSideEffectsWaitForMixDetection() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let parseGate = AsyncGate()
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = self.makeWatchNextData(chapters: self.makeMixChapters())
+        mockYouTube.beforeWatchNextReturn = { _ in await parseGate.wait() }
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+
+        let mockService = MockScrobbleService()
+        mockService.authState = .connected(username: "testuser")
+        let settings = MockScrobblingSettings()
+        settings.setServiceEnabled("Mock", true)
+        defer { settings.setServiceEnabled("Mock", false) }
+
+        let playerService = PlayerService()
+        playerService.currentTrack = TestFixtures.makeSong(id: "mix1", title: "Whole Mix", duration: 3600)
+        playerService.state = .playing
+        playerService.duration = 3600
+        playerService.setPlaybackStateVideoId("mix1")
+        let queue = ScrobbleQueue(directory: dir)
+
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [mockService],
+            queue: queue,
+            mixTracklistParser: parser
+        )
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+
+        await self.waitUntil { mockYouTube.getWatchNextCallCount == 1 }
+        try await Task.sleep(for: .milliseconds(100))
+        #expect(mockService.nowPlayingTracks.isEmpty)
+        #expect(queue.isEmpty)
+
+        await parseGate.open()
+        await self.waitUntil { mockYouTube.getWatchNextCompletionCount == 1 }
+        playerService.progress = 0.1
+        await self.waitUntil { mockService.nowPlayingTracks.count == 1 }
+
+        #expect(mockService.nowPlayingTracks.first?.title == "Track 0")
+        #expect(!mockService.nowPlayingTracks.contains { $0.title == "Whole Mix" })
+    }
+
+    @Test("Stale playback samples are not credited to the new video's mix")
+    func stalePlaybackSamplesAreIgnored() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let parseGate = AsyncGate()
+        let chapters = [
+            YouTubeChapter(videoId: "mix1", title: "Artist 0 - Track 0", startTime: 0, endTime: 100, timeText: nil, thumbnailURL: nil),
+            YouTubeChapter(videoId: "mix1", title: "Artist 1 - Track 1", startTime: 100, endTime: 200, timeText: nil, thumbnailURL: nil),
+            YouTubeChapter(videoId: "mix1", title: "Artist 2 - Track 2", startTime: 200, endTime: 300, timeText: nil, thumbnailURL: nil),
+        ]
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = self.makeWatchNextData(chapters: chapters)
+        mockYouTube.beforeWatchNextReturn = { _ in await parseGate.wait() }
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+
+        let mockService = MockScrobbleService()
+        mockService.authState = .connected(username: "testuser")
+        let settings = MockScrobblingSettings()
+        let originalPercent = settings.scrobblePercentThreshold
+        settings.scrobblePercentThreshold = 0.001
+        settings.setServiceEnabled("Mock", true)
+        defer {
+            settings.scrobblePercentThreshold = originalPercent
+            settings.setServiceEnabled("Mock", false)
+        }
+
+        let playerService = PlayerService()
+        playerService.currentTrack = TestFixtures.makeSong(id: "mix1", title: "Whole Mix", duration: 700)
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 0,
+            duration: 700,
+            observedVideoId: "previous"
+        )
+        let queue = ScrobbleQueue(directory: dir)
+
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [mockService],
+            queue: queue,
+            mixTracklistParser: parser
+        )
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+
+        await self.waitUntil { mockYouTube.getWatchNextCallCount == 1 }
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 1,
+            duration: 700,
+            observedVideoId: "previous"
+        )
+        try await Task.sleep(for: .milliseconds(20))
+        await parseGate.open()
+        await self.waitUntil { mockYouTube.getWatchNextCompletionCount == 1 }
+
+        #expect(queue.isEmpty)
+
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 1,
+            duration: 700,
+            observedVideoId: "mix1"
+        )
+        await self.waitUntil { mockService.nowPlayingTracks.contains { $0.title == "Track 0" } }
+    }
+
+    @Test("An eligible regular video finalizes after a pending mix parse returns nil")
+    func pendingRegularVideoFinalizesAfterParse() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let parseGate = AsyncGate()
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = .empty
+        mockYouTube.beforeWatchNextReturn = { _ in await parseGate.wait() }
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+
+        let mockService = MockScrobbleService()
+        mockService.authState = .connected(username: "testuser")
+        let settings = MockScrobblingSettings()
+        let originalPercent = settings.scrobblePercentThreshold
+        let originalMinSeconds = settings.scrobbleMinSeconds
+        settings.scrobblePercentThreshold = 0.001
+        settings.scrobbleMinSeconds = 240
+        settings.setServiceEnabled("Mock", true)
+        defer {
+            settings.scrobblePercentThreshold = originalPercent
+            settings.scrobbleMinSeconds = originalMinSeconds
+            settings.setServiceEnabled("Mock", false)
+        }
+
+        let playerService = PlayerService()
+        playerService.currentTrack = TestFixtures.makeSong(id: "regular-long", title: "Long Regular Video", duration: nil)
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 0,
+            duration: 700,
+            observedVideoId: "regular-long"
+        )
+        let queue = ScrobbleQueue(directory: dir)
+
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [mockService],
+            queue: queue,
+            mixTracklistParser: parser
+        )
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+
+        await self.waitUntil { mockYouTube.getWatchNextCallCount == 1 }
+        playerService.progress = 1
+        try await Task.sleep(for: .milliseconds(20))
+
+        // Leave the track while its parse is still pending. The next track must start normally,
+        // while the qualifying previous listen waits for classification instead of being dropped.
+        playerService.currentTrack = TestFixtures.makeSong(id: "next", title: "Next Song", duration: 200)
+        playerService.duration = 200
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(queue.isEmpty)
+
+        coordinator.stopMonitoring()
+        await parseGate.open()
+        await self.waitUntil { queue.count == 1 }
+
+        #expect(queue.pendingTracks.first?.title == "Long Regular Video")
+    }
+
+    @Test("A real mix that ends before parsing completes finalizes its qualifying sub-tracks")
+    func pendingMixFinalizesSubTracksAfterExit() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let parseGate = AsyncGate()
+        let chapters = [
+            YouTubeChapter(videoId: "mix1", title: "Artist 0 - Track 0", startTime: 0, endTime: 100, timeText: nil, thumbnailURL: nil),
+            YouTubeChapter(videoId: "mix1", title: "Artist 1 - Track 1", startTime: 100, endTime: 200, timeText: nil, thumbnailURL: nil),
+            YouTubeChapter(videoId: "mix1", title: "Artist 2 - Track 2", startTime: 200, endTime: 300, timeText: nil, thumbnailURL: nil),
+        ]
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = self.makeWatchNextData(chapters: chapters)
+        mockYouTube.beforeWatchNextReturn = { _ in await parseGate.wait() }
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+
+        let mockService = MockScrobbleService()
+        mockService.authState = .connected(username: "testuser")
+        let settings = MockScrobblingSettings()
+        let originalPercent = settings.scrobblePercentThreshold
+        let originalMinSeconds = settings.scrobbleMinSeconds
+        settings.scrobblePercentThreshold = 0.001
+        settings.scrobbleMinSeconds = 240
+        settings.setServiceEnabled("Mock", true)
+        defer {
+            settings.scrobblePercentThreshold = originalPercent
+            settings.scrobbleMinSeconds = originalMinSeconds
+            settings.setServiceEnabled("Mock", false)
+        }
+
+        let playerService = PlayerService()
+        playerService.currentTrack = TestFixtures.makeSong(id: "mix1", title: "Whole Mix", duration: 700)
+        playerService.state = .playing
+        playerService.duration = 700
+        playerService.setPlaybackStateVideoId("mix1")
+        let queue = ScrobbleQueue(directory: dir)
+
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [mockService],
+            queue: queue,
+            mixTracklistParser: parser
+        )
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+
+        await self.waitUntil { mockYouTube.getWatchNextCallCount == 1 }
+        playerService.progress = 1
+        try await Task.sleep(for: .milliseconds(20))
+        playerService.currentTrack = TestFixtures.makeSong(id: "next", title: "Next Song", duration: 200)
+        playerService.duration = 200
+
+        await parseGate.open()
+        await self.waitUntil { queue.count == 1 }
+
+        #expect(queue.pendingTracks.first?.title == "Track 0")
+        #expect(!queue.pendingTracks.contains { $0.title == "Whole Mix" })
+    }
+
+    @Test("A duration-less mix keeps provisional playback when it exits during fallback parsing")
+    func durationlessPendingMixFinalizesAfterExit() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let parseGate = AsyncGate()
+        let chapters = [
+            YouTubeChapter(videoId: "mix1", title: "Artist 0 - Track 0", startTime: 0, endTime: 100, timeText: nil, thumbnailURL: nil),
+            YouTubeChapter(videoId: "mix1", title: "Artist 1 - Track 1", startTime: 100, endTime: 200, timeText: nil, thumbnailURL: nil),
+            YouTubeChapter(videoId: "mix1", title: "Artist 2 - Track 2", startTime: 200, endTime: 300, timeText: nil, thumbnailURL: nil),
+        ]
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = self.makeWatchNextData(chapters: chapters)
+        mockYouTube.beforeWatchNextReturn = { _ in await parseGate.wait() }
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+
+        let mockService = MockScrobbleService()
+        mockService.authState = .connected(username: "testuser")
+        let settings = MockScrobblingSettings()
+        let originalPercent = settings.scrobblePercentThreshold
+        settings.scrobblePercentThreshold = 0.001
+        settings.setServiceEnabled("Mock", true)
+        defer {
+            settings.scrobblePercentThreshold = originalPercent
+            settings.setServiceEnabled("Mock", false)
+        }
+
+        let playerService = PlayerService()
+        playerService.currentTrack = TestFixtures.makeSong(id: "mix1", title: "Whole Mix", duration: nil)
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 0,
+            duration: 0,
+            observedVideoId: "mix1"
+        )
+        let queue = ScrobbleQueue(directory: dir)
+
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [mockService],
+            queue: queue,
+            mixTracklistParser: parser,
+            unknownDurationParseDelay: .milliseconds(20)
+        )
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+
+        await self.waitUntil { mockYouTube.getWatchNextCallCount == 1 }
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 1,
+            duration: 0,
+            observedVideoId: "mix1"
+        )
+        try await Task.sleep(for: .milliseconds(20))
+        playerService.currentTrack = TestFixtures.makeSong(id: "next", title: "Next Song", duration: 200)
+        playerService.updatePlaybackState(
+            isPlaying: true,
+            progress: 0,
+            duration: 200,
+            observedVideoId: "next"
+        )
+
+        await parseGate.open()
+        await self.waitUntil { queue.count == 1 }
+
+        #expect(queue.pendingTracks.first?.title == "Track 0")
+    }
+
+    @Test("Playback captured during parsing seeds the active mix entry without duplicates")
+    func pendingPlaybackSeedsActiveMixEntry() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let parseGate = AsyncGate()
+        let chapters = [
+            YouTubeChapter(videoId: "mix1", title: "Artist 0 - Track 0", startTime: 0, endTime: 100, timeText: nil, thumbnailURL: nil),
+            YouTubeChapter(videoId: "mix1", title: "Artist 1 - Track 1", startTime: 100, endTime: 200, timeText: nil, thumbnailURL: nil),
+            YouTubeChapter(videoId: "mix1", title: "Artist 2 - Track 2", startTime: 200, endTime: 300, timeText: nil, thumbnailURL: nil),
+        ]
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = self.makeWatchNextData(chapters: chapters)
+        mockYouTube.beforeWatchNextReturn = { _ in await parseGate.wait() }
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+
+        let mockService = MockScrobbleService()
+        mockService.authState = .connected(username: "testuser")
+        let settings = MockScrobblingSettings()
+        let originalPercent = settings.scrobblePercentThreshold
+        let originalMinSeconds = settings.scrobbleMinSeconds
+        settings.scrobblePercentThreshold = 0.001
+        settings.scrobbleMinSeconds = 240
+        settings.setServiceEnabled("Mock", true)
+        defer {
+            settings.scrobblePercentThreshold = originalPercent
+            settings.scrobbleMinSeconds = originalMinSeconds
+            settings.setServiceEnabled("Mock", false)
+        }
+
+        let playerService = PlayerService()
+        playerService.currentTrack = TestFixtures.makeSong(id: "mix1", title: "Whole Mix", duration: 700)
+        playerService.state = .playing
+        playerService.duration = 700
+        playerService.setPlaybackStateVideoId("mix1")
+        let queue = ScrobbleQueue(directory: dir)
+
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [mockService],
+            queue: queue,
+            mixTracklistParser: parser
+        )
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+
+        await self.waitUntil { mockYouTube.getWatchNextCallCount == 1 }
+        playerService.progress = 1
+        try await Task.sleep(for: .milliseconds(20))
+        await parseGate.open()
+        await self.waitUntil { queue.count == 1 }
+
+        // Trigger live mix handling after the provisional listen already qualified Track 0.
+        playerService.progress = 1.1
+        await self.waitUntil { mockService.nowPlayingTracks.count == 1 }
+        playerService.progress = 2.1
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(queue.count == 1)
+        #expect(queue.pendingTracks.first?.title == "Track 0")
+    }
+}

--- a/Tests/KasetTests/ScrobblingCoordinatorTests.swift
+++ b/Tests/KasetTests/ScrobblingCoordinatorTests.swift
@@ -635,4 +635,52 @@ struct ScrobblingCoordinatorTests {
         await self.waitUntil(timeout: .milliseconds(200)) { mockYouTube.getWatchNextCallCount >= 1 }
         #expect(mockYouTube.getWatchNextCallCount == 0)
     }
+
+    @Test("A stale mix fetch does not block the next track's fetch")
+    func staleMixFetchDoesNotBlockNextTrack() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let firstRequestGate = AsyncGate()
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = self.makeWatchNextData(chapters: self.makeMixChapters())
+        mockYouTube.beforeWatchNextReturn = { videoId in
+            if videoId == "mix1" {
+                await firstRequestGate.wait()
+            }
+        }
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+
+        let mockService = MockScrobbleService()
+        mockService.authState = .connected(username: "testuser")
+        let settings = SettingsManager.shared
+        settings.setServiceEnabled("Mock", true)
+        defer { settings.setServiceEnabled("Mock", false) }
+
+        let playerService = PlayerService()
+        playerService.currentTrack = TestFixtures.makeSong(id: "mix1", title: "First Mix", duration: 3600)
+        playerService.state = .playing
+        playerService.duration = 3600
+
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [mockService],
+            queue: ScrobbleQueue(directory: dir),
+            mixTracklistParser: parser
+        )
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+
+        await self.waitUntil { mockYouTube.getWatchNextCallCount == 1 }
+        #expect(mockYouTube.requestedWatchNextVideoIds == ["mix1"])
+
+        // The first request remains suspended while playback moves to another long mix. The new
+        // track must start its own parse immediately rather than waiting for the stale request.
+        playerService.currentTrack = TestFixtures.makeSong(id: "mix2", title: "Second Mix", duration: 3600)
+        await self.waitUntil { mockYouTube.getWatchNextCallCount == 2 }
+
+        #expect(mockYouTube.requestedWatchNextVideoIds == ["mix1", "mix2"])
+        await firstRequestGate.open()
+    }
 }

--- a/Tests/KasetTests/ScrobblingCoordinatorTests.swift
+++ b/Tests/KasetTests/ScrobblingCoordinatorTests.swift
@@ -683,4 +683,138 @@ struct ScrobblingCoordinatorTests {
         #expect(mockYouTube.requestedWatchNextVideoIds == ["mix1", "mix2"])
         await firstRequestGate.open()
     }
+
+    /// Regression: a slow tracklist fetch must not let a real mix scrobble once as the whole
+    /// video and again per sub-track — the whole-track threshold is deferred until the parse
+    /// resolves, and resumes only when it resolves with no tracklist.
+    @Test("Whole-track scrobble is deferred while a mix parse is in flight")
+    func wholeTrackScrobbleDeferredDuringMixParse() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let parseGate = AsyncGate()
+        let mockYouTube = MockYouTubeClient()
+        // No chapters — the parse eventually resolves to "not a mix".
+        mockYouTube.watchNextData = self.makeWatchNextData(chapters: [])
+        mockYouTube.beforeWatchNextReturn = { _ in await parseGate.wait() }
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+
+        let mockService = MockScrobbleService()
+        mockService.authState = .connected(username: "testuser")
+        let settings = SettingsManager.shared
+        settings.setServiceEnabled("Mock", true)
+        let savedMinSeconds = settings.scrobbleMinSeconds
+        settings.scrobbleMinSeconds = 2
+        defer {
+            settings.setServiceEnabled("Mock", false)
+            settings.scrobbleMinSeconds = savedMinSeconds
+        }
+
+        let playerService = PlayerService()
+        playerService.currentTrack = TestFixtures.makeSong(id: "long1", title: "Long Video", duration: 3600)
+        playerService.state = .playing
+        playerService.duration = 3600
+
+        let queue = ScrobbleQueue(directory: dir)
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [mockService],
+            queue: queue,
+            mixTracklistParser: parser
+        )
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+
+        await self.waitUntil { mockYouTube.getWatchNextCallCount == 1 }
+
+        // Accumulate well past the (lowered) min-seconds threshold while the parse is suspended.
+        for tick in 1 ... 4 {
+            playerService.progress = TimeInterval(tick)
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+        #expect(queue.isEmpty, "whole-track scrobble must wait for the mix parse to resolve")
+
+        // Parse resolves with no tracklist — whole-track scrobbling may now proceed.
+        await parseGate.open()
+        var tick: TimeInterval = 5
+        await self.waitUntil {
+            playerService.progress = tick
+            tick += 1
+            return queue.count == 1
+        }
+        #expect(queue.count == 1)
+    }
+
+    /// Regression: seeking within a sub-track that already scrobbled must not clear its latch —
+    /// a re-scrobble with the same timestamp is a Last.fm duplicate. A backward jump is an
+    /// intentional replay and restarts the sub-track with a fresh timestamp instead.
+    @Test("Seek within a scrobbled sub-track does not duplicate; replay gets a fresh timestamp")
+    func mixSeekAfterScrobbleDoesNotDuplicate() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = self.makeWatchNextData(chapters: self.makeMixChapters())
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+
+        let mockService = MockScrobbleService()
+        mockService.authState = .connected(username: "testuser")
+        let settings = SettingsManager.shared
+        settings.setServiceEnabled("Mock", true)
+        let savedMinSeconds = settings.scrobbleMinSeconds
+        settings.scrobbleMinSeconds = 2
+        defer {
+            settings.setServiceEnabled("Mock", false)
+            settings.scrobbleMinSeconds = savedMinSeconds
+        }
+
+        let playerService = PlayerService()
+        playerService.currentTrack = TestFixtures.makeSong(id: "mix1", title: "Long Mix", duration: 1800)
+        playerService.state = .playing
+        playerService.duration = 1800
+
+        let queue = ScrobbleQueue(directory: dir)
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [mockService],
+            queue: queue,
+            mixTracklistParser: parser
+        )
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+
+        // Play within the first sub-track (0–600s) until it scrobbles.
+        var tick: TimeInterval = 1
+        await self.waitUntil {
+            playerService.progress = tick
+            tick += 1
+            return queue.count == 1
+        }
+        #expect(queue.count == 1)
+        let firstTimestamp = queue.pendingTracks.first?.timestamp
+
+        // Forward seek within the same sub-track, then keep playing — no duplicate scrobble.
+        playerService.progress = 100
+        try? await Task.sleep(for: .milliseconds(20))
+        for step in 1 ... 5 {
+            playerService.progress = 100 + TimeInterval(step)
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+        #expect(queue.count == 1, "forward seek after scrobbling must not re-arm the scrobble latch")
+
+        // Backward seek — intentional replay. A second scrobble with a fresh timestamp is allowed.
+        playerService.progress = 10
+        try? await Task.sleep(for: .milliseconds(20))
+        var replayTick: TimeInterval = 11
+        await self.waitUntil {
+            playerService.progress = replayTick
+            replayTick += 1
+            return queue.count == 2
+        }
+        #expect(queue.count == 2)
+        let timestamps = queue.pendingTracks.map(\.timestamp)
+        #expect(timestamps.last != firstTimestamp, "replay scrobble must carry a fresh timestamp")
+    }
 }

--- a/Tests/KasetTests/ScrobblingCoordinatorTests.swift
+++ b/Tests/KasetTests/ScrobblingCoordinatorTests.swift
@@ -514,4 +514,125 @@ struct ScrobblingCoordinatorTests {
         let thresholdMet = accumulated >= duration * percentThreshold || accumulated >= minSeconds
         #expect(thresholdMet, "Threshold should be met at exactly 50% of duration")
     }
+
+    // MARK: - Mix-Mode Detection
+
+    private func makeWatchNextData(chapters: [YouTubeChapter]) -> WatchNextData {
+        WatchNextData(
+            videoTitle: "Long Mix",
+            viewCountText: nil,
+            publishedText: nil,
+            channel: nil,
+            related: [],
+            chapters: chapters
+        )
+    }
+
+    private func makeMixChapters(videoId: String = "mix1", count: Int = 3) -> [YouTubeChapter] {
+        (0 ..< count).map { index in
+            YouTubeChapter(
+                videoId: videoId,
+                title: "Artist \(index) - Track \(index)",
+                startTime: TimeInterval(index) * 600,
+                endTime: TimeInterval(index + 1) * 600,
+                timeText: nil,
+                thumbnailURL: nil
+            )
+        }
+    }
+
+    private func waitUntil(
+        timeout: Duration = .seconds(2),
+        _ condition: @MainActor () -> Bool
+    ) async {
+        let deadline = ContinuousClock.now + timeout
+        while !condition(), ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+    }
+
+    /// Regression: the mix-tracklist fetch is gated on track duration, which YouTube reports a beat
+    /// after the track object appears. A one-shot check at track-start always missed, so every mix
+    /// silently fell back to whole-video scrobbling. The fetch must retry from the poll loop until
+    /// duration is known, then fire exactly once.
+    @Test("Mix fetch is deferred until duration is known, then fires exactly once")
+    func mixFetchDeferredUntilDurationKnown() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = self.makeWatchNextData(chapters: self.makeMixChapters())
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+
+        let mockService = MockScrobbleService()
+        mockService.authState = .connected(username: "testuser")
+        let settings = SettingsManager.shared
+        settings.setServiceEnabled("Mock", true)
+        defer { settings.setServiceEnabled("Mock", false) }
+
+        let playerService = PlayerService()
+        // Track is playing, but duration hasn't loaded yet (the race the fix addresses).
+        playerService.currentTrack = TestFixtures.makeSong(id: "mix1", title: "Long Mix", duration: nil)
+        playerService.state = .playing
+        playerService.duration = 0
+
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [mockService],
+            queue: ScrobbleQueue(directory: dir),
+            mixTracklistParser: parser
+        )
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+
+        // First poll ran synchronously in startMonitoring; duration unknown → no fetch attempted.
+        #expect(mockYouTube.getWatchNextCallCount == 0)
+
+        // Duration becomes known — the observed change must drive the deferred fetch.
+        playerService.duration = 3600
+        await self.waitUntil { mockYouTube.getWatchNextCallCount >= 1 }
+        #expect(mockYouTube.getWatchNextCallCount == 1)
+
+        // Further duration churn must not re-fetch (latched once per track).
+        playerService.duration = 3601
+        await self.waitUntil(timeout: .milliseconds(200)) { mockYouTube.getWatchNextCallCount > 1 }
+        #expect(mockYouTube.getWatchNextCallCount == 1)
+    }
+
+    @Test("Mix fetch is not attempted for short tracks even once duration is known")
+    func mixFetchSkippedForShortTracks() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let mockYouTube = MockYouTubeClient()
+        mockYouTube.watchNextData = self.makeWatchNextData(chapters: self.makeMixChapters())
+        let parser = MixTracklistParser(youTubeClient: mockYouTube)
+
+        let mockService = MockScrobbleService()
+        mockService.authState = .connected(username: "testuser")
+        let settings = SettingsManager.shared
+        settings.setServiceEnabled("Mock", true)
+        defer { settings.setServiceEnabled("Mock", false) }
+
+        let playerService = PlayerService()
+        playerService.currentTrack = TestFixtures.makeSong(id: "short1", title: "Regular Song", duration: nil)
+        playerService.state = .playing
+        playerService.duration = 0
+
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [mockService],
+            queue: ScrobbleQueue(directory: dir),
+            mixTracklistParser: parser
+        )
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+
+        // A 4-minute track never crosses the 10-minute mix threshold.
+        playerService.duration = 240
+        await self.waitUntil(timeout: .milliseconds(200)) { mockYouTube.getWatchNextCallCount >= 1 }
+        #expect(mockYouTube.getWatchNextCallCount == 0)
+    }
 }

--- a/Tests/KasetTests/ScrobblingCoordinatorTests.swift
+++ b/Tests/KasetTests/ScrobblingCoordinatorTests.swift
@@ -18,6 +18,16 @@ struct ScrobblingCoordinatorTests {
         try? FileManager.default.removeItem(at: dir)
     }
 
+    private func waitUntil(
+        timeout: Duration = .seconds(2),
+        _ condition: @MainActor () -> Bool
+    ) async {
+        let deadline = ContinuousClock.now + timeout
+        while !condition(), ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+    }
+
     private func makeTrack(
         title: String = "Test Song",
         artist: String = "Test Artist",
@@ -206,7 +216,7 @@ struct ScrobblingCoordinatorTests {
     @Test("Seek forward does not inflate play time")
     func seekForwardIgnored() {
         var accumulated: TimeInterval = 0
-        var lastProgress: TimeInterval = 10.0
+        let lastProgress: TimeInterval = 10.0
 
         // Seek from 10s to 100s (delta = 90s > 2s threshold → ignored)
         let newProgress: TimeInterval = 100.0
@@ -221,7 +231,7 @@ struct ScrobblingCoordinatorTests {
     @Test("Seek backward does not inflate play time")
     func seekBackwardIgnored() {
         var accumulated: TimeInterval = 0
-        var lastProgress: TimeInterval = 100.0
+        let lastProgress: TimeInterval = 100.0
 
         // Seek from 100s to 10s (negative delta → ignored)
         let newProgress: TimeInterval = 10.0
@@ -275,7 +285,7 @@ struct ScrobblingCoordinatorTests {
         mockService.authState = .disconnected
 
         let playerService = PlayerService()
-        let settings = SettingsManager.shared
+        let settings = MockScrobblingSettings()
         settings.setServiceEnabled("Mock", true)
         defer { settings.setServiceEnabled("Mock", false) }
 
@@ -304,7 +314,7 @@ struct ScrobblingCoordinatorTests {
         mockService.authState = .connected(username: "testuser")
 
         let playerService = PlayerService()
-        let settings = SettingsManager.shared
+        let settings = MockScrobblingSettings()
         settings.setServiceEnabled("Mock", true)
         defer { settings.setServiceEnabled("Mock", false) }
 
@@ -346,7 +356,7 @@ struct ScrobblingCoordinatorTests {
         ]
 
         let playerService = PlayerService()
-        let settings = SettingsManager.shared
+        let settings = MockScrobblingSettings()
         settings.setServiceEnabled("Mock", true)
 
         let coordinator = ScrobblingCoordinator(
@@ -382,7 +392,7 @@ struct ScrobblingCoordinatorTests {
         mockService.shouldThrowOnScrobble = CancellationError()
 
         let playerService = PlayerService()
-        let settings = SettingsManager.shared
+        let settings = MockScrobblingSettings()
         settings.setServiceEnabled("Mock", true)
 
         let coordinator = ScrobblingCoordinator(
@@ -460,6 +470,93 @@ struct ScrobblingCoordinatorTests {
         #expect(!isReplay, "Backward jump before scrobbling should not trigger replay (could be a seek)")
     }
 
+    @Test("A regular-track replay replaces the tracker and can scrobble again")
+    func regularTrackReplayStartsFresh() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let mockService = MockScrobbleService()
+        mockService.authState = .connected(username: "testuser")
+        let settings = MockScrobblingSettings()
+        let originalPercent = settings.scrobblePercentThreshold
+        let originalMinSeconds = settings.scrobbleMinSeconds
+        settings.scrobblePercentThreshold = 0.01
+        settings.scrobbleMinSeconds = 240
+        settings.setServiceEnabled("Mock", true)
+        defer {
+            settings.scrobblePercentThreshold = originalPercent
+            settings.scrobbleMinSeconds = originalMinSeconds
+            settings.setServiceEnabled("Mock", false)
+        }
+
+        let playerService = PlayerService()
+        playerService.currentTrack = TestFixtures.makeSong(id: "song1", title: "Regular Song", duration: 100)
+        playerService.state = .playing
+        playerService.duration = 100
+        playerService.setPlaybackStateVideoId("song1")
+        let queue = ScrobbleQueue(directory: dir)
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [mockService],
+            queue: queue
+        )
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+
+        playerService.progress = 0.1
+        await self.waitUntil { mockService.nowPlayingTracks.count == 1 }
+        playerService.progress = 1.1
+        await self.waitUntil { queue.count == 1 }
+        let firstTimestamp = queue.pendingTracks.first?.timestamp
+
+        playerService.progress = 50
+        try await Task.sleep(for: .milliseconds(20))
+        playerService.progress = 0.1
+        await self.waitUntil { mockService.nowPlayingTracks.count == 2 }
+        playerService.progress = 1.1
+        await self.waitUntil { queue.count == 2 }
+
+        #expect(queue.pendingTracks.last?.timestamp != firstTimestamp)
+    }
+
+    @Test("Stopping and restarting monitoring preserves the same regular play latch")
+    func monitoringRestartPreservesRegularPlay() async throws {
+        let dir = try self.makeTemporaryDirectory()
+        defer { self.cleanupDirectory(dir) }
+
+        let mockService = MockScrobbleService()
+        mockService.authState = .connected(username: "testuser")
+        let settings = MockScrobblingSettings(scrobblePercentThreshold: 0.01)
+        settings.setServiceEnabled("Mock", true)
+        let playerService = PlayerService()
+        playerService.currentTrack = TestFixtures.makeSong(id: "song1", title: "Regular Song", duration: 100)
+        playerService.state = .playing
+        playerService.duration = 100
+        playerService.setPlaybackStateVideoId("song1")
+        let queue = ScrobbleQueue(directory: dir)
+        let coordinator = ScrobblingCoordinator(
+            playerService: playerService,
+            settingsManager: settings,
+            services: [mockService],
+            queue: queue
+        )
+
+        coordinator.startMonitoring()
+        playerService.progress = 0.1
+        await self.waitUntil { mockService.nowPlayingTracks.count == 1 }
+        playerService.progress = 1.1
+        await self.waitUntil { queue.count == 1 }
+
+        coordinator.stopMonitoring(finalizeCurrentTrack: false)
+        coordinator.startMonitoring()
+        defer { coordinator.stopMonitoring() }
+        playerService.progress = 2.1
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(queue.count == 1)
+    }
+
     // MARK: - Fix: Title/artist-based track change detection
 
     @Test("Title change triggers track change detection even with same videoId")
@@ -513,308 +610,5 @@ struct ScrobblingCoordinatorTests {
 
         let thresholdMet = accumulated >= duration * percentThreshold || accumulated >= minSeconds
         #expect(thresholdMet, "Threshold should be met at exactly 50% of duration")
-    }
-
-    // MARK: - Mix-Mode Detection
-
-    private func makeWatchNextData(chapters: [YouTubeChapter]) -> WatchNextData {
-        WatchNextData(
-            videoTitle: "Long Mix",
-            viewCountText: nil,
-            publishedText: nil,
-            channel: nil,
-            related: [],
-            chapters: chapters
-        )
-    }
-
-    private func makeMixChapters(videoId: String = "mix1", count: Int = 3) -> [YouTubeChapter] {
-        (0 ..< count).map { index in
-            YouTubeChapter(
-                videoId: videoId,
-                title: "Artist \(index) - Track \(index)",
-                startTime: TimeInterval(index) * 600,
-                endTime: TimeInterval(index + 1) * 600,
-                timeText: nil,
-                thumbnailURL: nil
-            )
-        }
-    }
-
-    private func waitUntil(
-        timeout: Duration = .seconds(2),
-        _ condition: @MainActor () -> Bool
-    ) async {
-        let deadline = ContinuousClock.now + timeout
-        while !condition(), ContinuousClock.now < deadline {
-            try? await Task.sleep(for: .milliseconds(10))
-        }
-    }
-
-    /// Regression: the mix-tracklist fetch is gated on track duration, which YouTube reports a beat
-    /// after the track object appears. A one-shot check at track-start always missed, so every mix
-    /// silently fell back to whole-video scrobbling. The fetch must retry from the poll loop until
-    /// duration is known, then fire exactly once.
-    @Test("Mix fetch is deferred until duration is known, then fires exactly once")
-    func mixFetchDeferredUntilDurationKnown() async throws {
-        let dir = try self.makeTemporaryDirectory()
-        defer { self.cleanupDirectory(dir) }
-
-        let mockYouTube = MockYouTubeClient()
-        mockYouTube.watchNextData = self.makeWatchNextData(chapters: self.makeMixChapters())
-        let parser = MixTracklistParser(youTubeClient: mockYouTube)
-
-        let mockService = MockScrobbleService()
-        mockService.authState = .connected(username: "testuser")
-        let settings = SettingsManager.shared
-        settings.setServiceEnabled("Mock", true)
-        defer { settings.setServiceEnabled("Mock", false) }
-
-        let playerService = PlayerService()
-        // Track is playing, but duration hasn't loaded yet (the race the fix addresses).
-        playerService.currentTrack = TestFixtures.makeSong(id: "mix1", title: "Long Mix", duration: nil)
-        playerService.state = .playing
-        playerService.duration = 0
-
-        let coordinator = ScrobblingCoordinator(
-            playerService: playerService,
-            settingsManager: settings,
-            services: [mockService],
-            queue: ScrobbleQueue(directory: dir),
-            mixTracklistParser: parser
-        )
-        coordinator.startMonitoring()
-        defer { coordinator.stopMonitoring() }
-
-        // First poll ran synchronously in startMonitoring; duration unknown → no fetch attempted.
-        #expect(mockYouTube.getWatchNextCallCount == 0)
-
-        // Duration becomes known — the observed change must drive the deferred fetch.
-        playerService.duration = 3600
-        await self.waitUntil { mockYouTube.getWatchNextCallCount >= 1 }
-        #expect(mockYouTube.getWatchNextCallCount == 1)
-
-        // Further duration churn must not re-fetch (latched once per track).
-        playerService.duration = 3601
-        await self.waitUntil(timeout: .milliseconds(200)) { mockYouTube.getWatchNextCallCount > 1 }
-        #expect(mockYouTube.getWatchNextCallCount == 1)
-    }
-
-    @Test("Mix fetch is not attempted for short tracks even once duration is known")
-    func mixFetchSkippedForShortTracks() async throws {
-        let dir = try self.makeTemporaryDirectory()
-        defer { self.cleanupDirectory(dir) }
-
-        let mockYouTube = MockYouTubeClient()
-        mockYouTube.watchNextData = self.makeWatchNextData(chapters: self.makeMixChapters())
-        let parser = MixTracklistParser(youTubeClient: mockYouTube)
-
-        let mockService = MockScrobbleService()
-        mockService.authState = .connected(username: "testuser")
-        let settings = SettingsManager.shared
-        settings.setServiceEnabled("Mock", true)
-        defer { settings.setServiceEnabled("Mock", false) }
-
-        let playerService = PlayerService()
-        playerService.currentTrack = TestFixtures.makeSong(id: "short1", title: "Regular Song", duration: nil)
-        playerService.state = .playing
-        playerService.duration = 0
-
-        let coordinator = ScrobblingCoordinator(
-            playerService: playerService,
-            settingsManager: settings,
-            services: [mockService],
-            queue: ScrobbleQueue(directory: dir),
-            mixTracklistParser: parser
-        )
-        coordinator.startMonitoring()
-        defer { coordinator.stopMonitoring() }
-
-        // A 4-minute track never crosses the 10-minute mix threshold.
-        playerService.duration = 240
-        await self.waitUntil(timeout: .milliseconds(200)) { mockYouTube.getWatchNextCallCount >= 1 }
-        #expect(mockYouTube.getWatchNextCallCount == 0)
-    }
-
-    @Test("A stale mix fetch does not block the next track's fetch")
-    func staleMixFetchDoesNotBlockNextTrack() async throws {
-        let dir = try self.makeTemporaryDirectory()
-        defer { self.cleanupDirectory(dir) }
-
-        let firstRequestGate = AsyncGate()
-        let mockYouTube = MockYouTubeClient()
-        mockYouTube.watchNextData = self.makeWatchNextData(chapters: self.makeMixChapters())
-        mockYouTube.beforeWatchNextReturn = { videoId in
-            if videoId == "mix1" {
-                await firstRequestGate.wait()
-            }
-        }
-        let parser = MixTracklistParser(youTubeClient: mockYouTube)
-
-        let mockService = MockScrobbleService()
-        mockService.authState = .connected(username: "testuser")
-        let settings = SettingsManager.shared
-        settings.setServiceEnabled("Mock", true)
-        defer { settings.setServiceEnabled("Mock", false) }
-
-        let playerService = PlayerService()
-        playerService.currentTrack = TestFixtures.makeSong(id: "mix1", title: "First Mix", duration: 3600)
-        playerService.state = .playing
-        playerService.duration = 3600
-
-        let coordinator = ScrobblingCoordinator(
-            playerService: playerService,
-            settingsManager: settings,
-            services: [mockService],
-            queue: ScrobbleQueue(directory: dir),
-            mixTracklistParser: parser
-        )
-        coordinator.startMonitoring()
-        defer { coordinator.stopMonitoring() }
-
-        await self.waitUntil { mockYouTube.getWatchNextCallCount == 1 }
-        #expect(mockYouTube.requestedWatchNextVideoIds == ["mix1"])
-
-        // The first request remains suspended while playback moves to another long mix. The new
-        // track must start its own parse immediately rather than waiting for the stale request.
-        playerService.currentTrack = TestFixtures.makeSong(id: "mix2", title: "Second Mix", duration: 3600)
-        await self.waitUntil { mockYouTube.getWatchNextCallCount == 2 }
-
-        #expect(mockYouTube.requestedWatchNextVideoIds == ["mix1", "mix2"])
-        await firstRequestGate.open()
-    }
-
-    /// Regression: a slow tracklist fetch must not let a real mix scrobble once as the whole
-    /// video and again per sub-track — the whole-track threshold is deferred until the parse
-    /// resolves, and resumes only when it resolves with no tracklist.
-    @Test("Whole-track scrobble is deferred while a mix parse is in flight")
-    func wholeTrackScrobbleDeferredDuringMixParse() async throws {
-        let dir = try self.makeTemporaryDirectory()
-        defer { self.cleanupDirectory(dir) }
-
-        let parseGate = AsyncGate()
-        let mockYouTube = MockYouTubeClient()
-        // No chapters — the parse eventually resolves to "not a mix".
-        mockYouTube.watchNextData = self.makeWatchNextData(chapters: [])
-        mockYouTube.beforeWatchNextReturn = { _ in await parseGate.wait() }
-        let parser = MixTracklistParser(youTubeClient: mockYouTube)
-
-        let mockService = MockScrobbleService()
-        mockService.authState = .connected(username: "testuser")
-        let settings = SettingsManager.shared
-        settings.setServiceEnabled("Mock", true)
-        let savedMinSeconds = settings.scrobbleMinSeconds
-        settings.scrobbleMinSeconds = 2
-        defer {
-            settings.setServiceEnabled("Mock", false)
-            settings.scrobbleMinSeconds = savedMinSeconds
-        }
-
-        let playerService = PlayerService()
-        playerService.currentTrack = TestFixtures.makeSong(id: "long1", title: "Long Video", duration: 3600)
-        playerService.state = .playing
-        playerService.duration = 3600
-
-        let queue = ScrobbleQueue(directory: dir)
-        let coordinator = ScrobblingCoordinator(
-            playerService: playerService,
-            settingsManager: settings,
-            services: [mockService],
-            queue: queue,
-            mixTracklistParser: parser
-        )
-        coordinator.startMonitoring()
-        defer { coordinator.stopMonitoring() }
-
-        await self.waitUntil { mockYouTube.getWatchNextCallCount == 1 }
-
-        // Accumulate well past the (lowered) min-seconds threshold while the parse is suspended.
-        for tick in 1 ... 4 {
-            playerService.progress = TimeInterval(tick)
-            try? await Task.sleep(for: .milliseconds(20))
-        }
-        #expect(queue.isEmpty, "whole-track scrobble must wait for the mix parse to resolve")
-
-        // Parse resolves with no tracklist — whole-track scrobbling may now proceed.
-        await parseGate.open()
-        var tick: TimeInterval = 5
-        await self.waitUntil {
-            playerService.progress = tick
-            tick += 1
-            return queue.count == 1
-        }
-        #expect(queue.count == 1)
-    }
-
-    /// Regression: seeking within a sub-track that already scrobbled must not clear its latch —
-    /// a re-scrobble with the same timestamp is a Last.fm duplicate. A backward jump is an
-    /// intentional replay and restarts the sub-track with a fresh timestamp instead.
-    @Test("Seek within a scrobbled sub-track does not duplicate; replay gets a fresh timestamp")
-    func mixSeekAfterScrobbleDoesNotDuplicate() async throws {
-        let dir = try self.makeTemporaryDirectory()
-        defer { self.cleanupDirectory(dir) }
-
-        let mockYouTube = MockYouTubeClient()
-        mockYouTube.watchNextData = self.makeWatchNextData(chapters: self.makeMixChapters())
-        let parser = MixTracklistParser(youTubeClient: mockYouTube)
-
-        let mockService = MockScrobbleService()
-        mockService.authState = .connected(username: "testuser")
-        let settings = SettingsManager.shared
-        settings.setServiceEnabled("Mock", true)
-        let savedMinSeconds = settings.scrobbleMinSeconds
-        settings.scrobbleMinSeconds = 2
-        defer {
-            settings.setServiceEnabled("Mock", false)
-            settings.scrobbleMinSeconds = savedMinSeconds
-        }
-
-        let playerService = PlayerService()
-        playerService.currentTrack = TestFixtures.makeSong(id: "mix1", title: "Long Mix", duration: 1800)
-        playerService.state = .playing
-        playerService.duration = 1800
-
-        let queue = ScrobbleQueue(directory: dir)
-        let coordinator = ScrobblingCoordinator(
-            playerService: playerService,
-            settingsManager: settings,
-            services: [mockService],
-            queue: queue,
-            mixTracklistParser: parser
-        )
-        coordinator.startMonitoring()
-        defer { coordinator.stopMonitoring() }
-
-        // Play within the first sub-track (0–600s) until it scrobbles.
-        var tick: TimeInterval = 1
-        await self.waitUntil {
-            playerService.progress = tick
-            tick += 1
-            return queue.count == 1
-        }
-        #expect(queue.count == 1)
-        let firstTimestamp = queue.pendingTracks.first?.timestamp
-
-        // Forward seek within the same sub-track, then keep playing — no duplicate scrobble.
-        playerService.progress = 100
-        try? await Task.sleep(for: .milliseconds(20))
-        for step in 1 ... 5 {
-            playerService.progress = 100 + TimeInterval(step)
-            try? await Task.sleep(for: .milliseconds(20))
-        }
-        #expect(queue.count == 1, "forward seek after scrobbling must not re-arm the scrobble latch")
-
-        // Backward seek — intentional replay. A second scrobble with a fresh timestamp is allowed.
-        playerService.progress = 10
-        try? await Task.sleep(for: .milliseconds(20))
-        var replayTick: TimeInterval = 11
-        await self.waitUntil {
-            playerService.progress = replayTick
-            replayTick += 1
-            return queue.count == 2
-        }
-        #expect(queue.count == 2)
-        let timestamps = queue.pendingTracks.map(\.timestamp)
-        #expect(timestamps.last != firstTimestamp, "replay scrobble must carry a fresh timestamp")
     }
 }

--- a/Tests/KasetTests/YouTubeResponseParserTests.swift
+++ b/Tests/KasetTests/YouTubeResponseParserTests.swift
@@ -265,6 +265,52 @@ struct WatchNextParserTests {
         #expect(firstRelated.videoId == "pAMZjmDGFRQ")
         #expect(firstRelated.channelName == "Plingoro")
         #expect(firstRelated.lengthText == "17:10")
+
+        let description = try #require(watchNext.descriptionText)
+        #expect(description.hasPrefix("The official video for"))
+    }
+
+    @Test("Falls back to the engagement panel description when secondary info omits it")
+    func parsesEngagementPanelDescription() {
+        let watchNext = WatchNextParser.parse(Self.engagementPanelOnlyResponse())
+
+        #expect(watchNext.descriptionText == "Tracklist:\n00:00 A - One")
+    }
+
+    @Test("An empty secondary-info description still falls back to the engagement panel")
+    func emptySecondaryDescriptionFallsBackToPanel() {
+        var data = Self.engagementPanelOnlyResponse()
+        data["contents"] = ["twoColumnWatchNextResults": ["results": ["results": ["contents": [
+            ["videoSecondaryInfoRenderer": ["attributedDescription": ["content": ""]]],
+        ]]]]]
+
+        let watchNext = WatchNextParser.parse(data)
+
+        #expect(watchNext.descriptionText == "Tracklist:\n00:00 A - One")
+    }
+
+    private static func engagementPanelOnlyResponse() -> [String: Any] {
+        [
+            "engagementPanels": [
+                [
+                    "engagementPanelSectionListRenderer": [
+                        "content": [
+                            "structuredDescriptionContentRenderer": [
+                                "items": [
+                                    [
+                                        "expandableVideoDescriptionBodyRenderer": [
+                                            "attributedDescriptionBodyText": [
+                                                "content": "Tracklist:\n00:00 A - One",
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]
     }
 
     @Test("Parses canonical chapters and merges macro-marker end bounds")

--- a/Tests/KasetTests/YouTubeResponseParserTests.swift
+++ b/Tests/KasetTests/YouTubeResponseParserTests.swift
@@ -270,49 +270,6 @@ struct WatchNextParserTests {
         #expect(description.hasPrefix("The official video for"))
     }
 
-    @Test("Falls back to the engagement panel description when secondary info omits it")
-    func parsesEngagementPanelDescription() {
-        let watchNext = WatchNextParser.parse(Self.engagementPanelOnlyResponse())
-
-        #expect(watchNext.descriptionText == "Tracklist:\n00:00 A - One")
-    }
-
-    @Test("An empty secondary-info description still falls back to the engagement panel")
-    func emptySecondaryDescriptionFallsBackToPanel() {
-        var data = Self.engagementPanelOnlyResponse()
-        data["contents"] = ["twoColumnWatchNextResults": ["results": ["results": ["contents": [
-            ["videoSecondaryInfoRenderer": ["attributedDescription": ["content": ""]]],
-        ]]]]]
-
-        let watchNext = WatchNextParser.parse(data)
-
-        #expect(watchNext.descriptionText == "Tracklist:\n00:00 A - One")
-    }
-
-    private static func engagementPanelOnlyResponse() -> [String: Any] {
-        [
-            "engagementPanels": [
-                [
-                    "engagementPanelSectionListRenderer": [
-                        "content": [
-                            "structuredDescriptionContentRenderer": [
-                                "items": [
-                                    [
-                                        "expandableVideoDescriptionBodyRenderer": [
-                                            "attributedDescriptionBodyText": [
-                                                "content": "Tracklist:\n00:00 A - One",
-                                            ],
-                                        ],
-                                    ],
-                                ],
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-        ]
-    }
-
     @Test("Parses canonical chapters and merges macro-marker end bounds")
     func parsesPlayerOverlayChapters() throws {
         let watchNext = WatchNextParser.parse(Self.chapterRendererResponse())
@@ -358,6 +315,49 @@ struct WatchNextParserTests {
         let chapters = WatchNextParser.chapters(of: Self.heatmapOnlyResponse())
 
         #expect(chapters.isEmpty)
+    }
+
+    @Test("Parses the structured watch-page description")
+    func parsesDescriptionText() {
+        let description = "00:00 - Artist A - Track One\n03:15 - Artist B - Track Two"
+        let parsed = WatchNextParser.parse(Self.descriptionResponse(description))
+
+        #expect(parsed.descriptionText == description)
+    }
+
+    @Test("Falls back to the secondary-info description")
+    func parsesSecondaryInfoDescription() {
+        let parsed = WatchNextParser.parse(Self.secondaryInfoDescriptionResponse("Secondary description"))
+
+        #expect(parsed.descriptionText == "Secondary description")
+    }
+
+    @Test("Prefers the structured description over secondary info")
+    func structuredDescriptionTakesPriority() {
+        var response = Self.descriptionResponse("Structured description")
+        response["contents"] = Self.secondaryInfoDescriptionResponse("Secondary description")["contents"]
+
+        let parsed = WatchNextParser.parse(response)
+
+        #expect(parsed.descriptionText == "Structured description")
+    }
+
+    @Test("Parses the runs-based watch-page description")
+    func parsesRunsDescriptionText() {
+        let parsed = WatchNextParser.parse([
+            "engagementPanels": [
+                [
+                    "descriptionBodyText": [
+                        "runs": [
+                            ["text": "00:00 Artist A - Track One\n"],
+                            ["text": "03:00 Artist B - Track Two"],
+                        ],
+                    ],
+                ],
+            ],
+        ])
+
+        #expect(parsed.descriptionText == "00:00 Artist A - Track One\n03:00 Artist B - Track Two")
     }
 
     private static func chapterRendererResponse() -> [String: Any] {
@@ -443,6 +443,48 @@ struct WatchNextParserTests {
                                         "markerType": "MARKER_TYPE_HEATMAP",
                                         "markers": [
                                             ["startMillis": "0", "durationMillis": "1000", "intensityScoreNormalized": 1],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]
+    }
+
+    private static func secondaryInfoDescriptionResponse(_ description: String) -> [String: Any] {
+        [
+            "contents": [
+                "twoColumnWatchNextResults": [
+                    "results": [
+                        "results": [
+                            "contents": [
+                                [
+                                    "videoSecondaryInfoRenderer": [
+                                        "attributedDescription": ["content": description],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]
+    }
+
+    private static func descriptionResponse(_ description: String) -> [String: Any] {
+        [
+            "engagementPanels": [
+                [
+                    "engagementPanelSectionListRenderer": [
+                        "content": [
+                            "structuredDescriptionContentRenderer": [
+                                "items": [
+                                    [
+                                        "expandableVideoDescriptionBodyRenderer": [
+                                            "attributedDescriptionBodyText": ["content": description],
                                         ],
                                     ],
                                 ],

--- a/Tests/KasetTests/YouTubeResponseParserTests.swift
+++ b/Tests/KasetTests/YouTubeResponseParserTests.swift
@@ -267,7 +267,7 @@ struct WatchNextParserTests {
         #expect(firstRelated.lengthText == "17:10")
     }
 
-    @Test("Parses canonical player-overlay chapter renderers")
+    @Test("Parses canonical chapters and merges macro-marker end bounds")
     func parsesPlayerOverlayChapters() throws {
         let watchNext = WatchNextParser.parse(Self.chapterRendererResponse())
 
@@ -277,13 +277,14 @@ struct WatchNextParserTests {
         #expect(first.videoId == "video-1")
         #expect(first.title == "Introduction")
         #expect(first.startTime == 0)
-        #expect(first.endTime == nil)
+        #expect(first.endTime == 197)
         #expect(first.timeText == nil)
         #expect(first.thumbnailURL?.absoluteString == "https://example.com/intro-336.jpg")
 
         let second = watchNext.chapters[1]
         #expect(second.title == "Single-threaded code")
         #expect(second.startTime == 197)
+        #expect(second.endTime == 360)
     }
 
     @Test("Falls back to deduplicated macro marker chapter cards")
@@ -341,15 +342,16 @@ struct WatchNextParserTests {
                     ],
                 ],
             ],
-            // This duplicate fallback shape should be ignored when canonical
-            // chapterRenderer data exists.
+            // Matching macro markers provide end bounds that the canonical
+            // chapterRenderer timeline omits.
             "engagementPanels": [
                 [
                     "engagementPanelSectionListRenderer": [
                         "content": [
                             "macroMarkersListRenderer": [
                                 "contents": [
-                                    ["macroMarkersListItemRenderer": self.macroMarkerRenderer(title: "Introduction", startMs: 0, endMs: 197_000, imageName: "intro", includesExplicitStart: false)],
+                                    ["macroMarkersListItemRenderer": self.macroMarkerRenderer(title: "Introduction", startMs: 0, endMs: 197_000, imageName: "intro")],
+                                    ["macroMarkersListItemRenderer": self.macroMarkerRenderer(title: "Single-threaded code", startMs: 197_000, endMs: 360_000, imageName: "single")],
                                 ],
                             ],
                         ],


### PR DESCRIPTION
## Description

Extends scrobbling (ADR-0011) to long mix videos (DJ sets, compilations). Instead of scrobbling a 2-hour mix as one track, Kaset parses the mix's tracklist from YouTube chapters (with a description-timestamp fallback) and scrobbles each sub-track individually as it plays — matching how Last.fm expects listens to be reported.

## AI Prompt (Optional)

<details>
<summary>🤖 AI Prompt Used</summary>

The feature was developed interactively with Claude Code. The API-exploration prompt that grounded the design (per the AGENTS.md api-explorer rule):

```
Kaset mix scrobbling — API exploration tasks

I need you to run the Kaset API explorer (swift run api-explorer) against a
known YouTube Music mix video to answer these questions. Use video ID
dZ2NQ-xQINI (a known DJ mix) for all tests, or substitute any 1hr+ mix you
know has a tracklist.

Task 1: Regular YouTube next endpoint — chapters
[queries for chapter renderers, macro markers, description data, ...]
```

**AI Tool:** Claude Code

</details>

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Related Issues

Relates to #74 / #99 (the original Last.fm scrobbling feature requests) — this extends that scrobbling support to the sub-tracks of continuous mixes.

## Changes Made

- `MixTracklist` / `MixTrackEntry` model: sub-track entries with time ranges, artist/title parsed from chapter labels; `entry(at:)` lookup; a video only counts as a mix above a minimum duration with a plausible tracklist
- `MixTracklistParser`: builds the tracklist from YouTube chapters via `YouTubeClient`, falling back to description timestamps
- `ScrobblingCoordinator` mix mode: when the current video has a tracklist, per-sub-track play time is accumulated and each sub-track is scrobbled once its threshold is met; sub-track transitions finalize the previous entry
- `PlaybackScrobbleTracker` extracted to own accumulate/threshold/finalize state for both single-track and mix entries; fixes a mix-detection race where duration arrives after the track object
- Unit tests for the model, parser, and coordinator mix mode

## Testing

- [x] Unit tests pass (`swift test --skip KasetUITests`) — 1796 passed, 150 suites
- [x] Manual testing performed — played multi-hour DJ mixes and verified per-sub-track scrobbles on Last.fm (correct titles, artists, and timestamps; no whole-mix scrobble)
- [x] UI tested on macOS 26+

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `swiftlint --strict && swiftformat .`
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally
- [ ] I have updated documentation if needed
- [x] I have checked for any performance implications
- [x] My changes generate no new warnings

## Screenshots

<!-- TODO (optional): Last.fm profile showing individual sub-track scrobbles from one mix -->

## Additional Notes

- No behavior change for regular tracks: mix mode only activates when a tracklist is found for a long video.
- Follow-up PR planned on top of this: a YouTube-style segmented seek bar in the player driven by the same tracklist data.

