### PR TITLE
feat: create playlists from the sidebar

### DIFF
--- a/Sources/Kaset/KasetApp.swift
+++ b/Sources/Kaset/KasetApp.swift
@@ -21,6 +21,10 @@ extension EnvironmentValues {
     @Entry var usesLegacyMacOS15UI = false
 }
 
+extension EnvironmentValues {
+    @Entry var onPlaylistDeleted: (() -> Void)?
+}
+
 // MARK: - KasetApp
 
 /// Main entry point for the Kaset macOS application.

--- a/Sources/Kaset/Services/Library/LibraryMutationActions.swift
+++ b/Sources/Kaset/Services/Library/LibraryMutationActions.swift
@@ -83,18 +83,30 @@ enum LibraryMutationActions {
         client: any YTMusicClientProtocol,
         libraryViewModel: LibraryViewModel?
     ) async throws {
+        let pinnedIndex = SidebarPinnedItemsManager.shared.items.firstIndex { $0.contentId == playlist.id }
+        let pinnedItem = pinnedIndex.map { SidebarPinnedItemsManager.shared.items[$0] }
+        SidebarPinnedItemsManager.shared.remove(contentId: playlist.id)
+        LibraryMutationBroadcaster.shared.playlistRemoved(playlistId: playlist.id)
+
         do {
             try await client.deletePlaylist(playlistId: playlist.id)
             self.invalidateResponseCaches()
             libraryViewModel?.markNeedsReloadOnActivation()
-            LibraryMutationBroadcaster.shared.playlistRemoved(playlistId: playlist.id)
+            DiagnosticsLogger.api.info("Deleted playlist: \(playlist.title)")
 
             // Library browse responses can lag briefly behind a successful deletion.
             try? await Task.sleep(for: .milliseconds(500))
             await LibraryMutationBroadcaster.shared.reconcileRemovedPlaylist(playlistId: playlist.id)
             self.invalidateResponseCaches()
-            DiagnosticsLogger.api.info("Deleted playlist: \(playlist.title)")
         } catch {
+            if let pinnedItem, let pinnedIndex {
+                SidebarPinnedItemsManager.shared.insert(pinnedItem, at: pinnedIndex)
+            }
+            // Restore the caller's view directly (like the optimistic podcast mutations do) rather
+            // than broadcasting a creation: other Library instances self-heal on their next reload,
+            // and a global playlistCreated here would fabricate the playlist in views that never
+            // saw the optimistic removal.
+            libraryViewModel?.addToLibrary(playlist: playlist)
             DiagnosticsLogger.api.error("Failed to delete playlist: \(error.localizedDescription)")
             throw error
         }

--- a/Sources/Kaset/Services/Library/LibraryMutationActions.swift
+++ b/Sources/Kaset/Services/Library/LibraryMutationActions.swift
@@ -118,9 +118,8 @@ enum LibraryMutationActions {
         client: any YTMusicClientProtocol,
         libraryViewModel: LibraryViewModel?
     ) async throws {
-        let pinnedIndex = SidebarPinnedItemsManager.shared.items.firstIndex { $0.contentId == playlist.id }
-        let pinnedItem = pinnedIndex.map { SidebarPinnedItemsManager.shared.items[$0] }
-        SidebarPinnedItemsManager.shared.remove(contentId: playlist.id)
+        let pinnedItemsManager = SidebarPinnedItemsManager.shared
+        let removedPins = pinnedItemsManager.removePlaylistPins(matching: playlist.id)
         LibraryMutationBroadcaster.shared.playlistRemoved(playlistId: playlist.id)
 
         do {
@@ -134,9 +133,7 @@ enum LibraryMutationActions {
             await LibraryMutationBroadcaster.shared.reconcileRemovedPlaylist(playlistId: playlist.id)
             self.invalidateResponseCaches()
         } catch {
-            if let pinnedItem, let pinnedIndex {
-                SidebarPinnedItemsManager.shared.insert(pinnedItem, at: pinnedIndex)
-            }
+            pinnedItemsManager.restore(removedPins)
             // Restore the caller's view directly (like the optimistic podcast mutations do) rather
             // than broadcasting a creation: other Library instances self-heal on their next reload,
             // and a global playlistCreated here would fabricate the playlist in views that never

--- a/Sources/Kaset/Services/SidebarPinnedItemsManager.swift
+++ b/Sources/Kaset/Services/SidebarPinnedItemsManager.swift
@@ -69,6 +69,14 @@ final class SidebarPinnedItemsManager {
         DiagnosticsLogger.ui.info("Added to sidebar: \(item.title)")
     }
 
+    func insert(_ item: SidebarPinnedItem, at index: Int) {
+        guard !self.isPinned(contentId: item.contentId) else { return }
+
+        self.items.insert(item, at: min(index, self.items.endIndex))
+        self.save()
+        DiagnosticsLogger.ui.info("Restored to sidebar: \(item.title)")
+    }
+
     func remove(contentId: String) {
         guard let index = self.items.firstIndex(where: { $0.contentId == contentId }) else {
             DiagnosticsLogger.ui.debug("Item not pinned to sidebar: \(contentId)")

--- a/Sources/Kaset/Services/SidebarPinnedItemsManager.swift
+++ b/Sources/Kaset/Services/SidebarPinnedItemsManager.swift
@@ -7,6 +7,11 @@ import Observation
 @MainActor
 @Observable
 final class SidebarPinnedItemsManager {
+    struct RemovedPin {
+        let item: SidebarPinnedItem
+        let index: Int
+    }
+
     static let shared = SidebarPinnedItemsManager()
 
     private(set) var items: [SidebarPinnedItem] = []
@@ -59,7 +64,7 @@ final class SidebarPinnedItemsManager {
     }
 
     func add(_ item: SidebarPinnedItem) {
-        guard !self.isPinned(contentId: item.contentId) else {
+        guard !self.isPinned(item) else {
             DiagnosticsLogger.ui.debug("Item already pinned to sidebar: \(item.contentId)")
             return
         }
@@ -69,12 +74,35 @@ final class SidebarPinnedItemsManager {
         DiagnosticsLogger.ui.info("Added to sidebar: \(item.title)")
     }
 
-    func insert(_ item: SidebarPinnedItem, at index: Int) {
-        guard !self.isPinned(contentId: item.contentId) else { return }
+    @discardableResult
+    func removePlaylistPins(matching playlistId: String) -> [RemovedPin] {
+        let playlistKey = LibraryContentIdentity.playlistKey(for: playlistId)
+        let removedPins = self.items.enumerated().compactMap { index, item -> RemovedPin? in
+            guard self.matchesPlaylist(item, playlistKey: playlistKey) else { return nil }
+            return RemovedPin(item: item, index: index)
+        }
+        guard !removedPins.isEmpty else {
+            DiagnosticsLogger.ui.debug("Playlist not pinned to sidebar: \(playlistId)")
+            return []
+        }
 
-        self.items.insert(item, at: min(index, self.items.endIndex))
+        self.items.removeAll { self.matchesPlaylist($0, playlistKey: playlistKey) }
         self.save()
-        DiagnosticsLogger.ui.info("Restored to sidebar: \(item.title)")
+        DiagnosticsLogger.ui.info("Removed \(removedPins.count) playlist pin(s) from sidebar")
+        return removedPins
+    }
+
+    func restore(_ removedPins: [RemovedPin]) {
+        var restoredCount = 0
+        for removedPin in removedPins.sorted(by: { $0.index < $1.index }) {
+            guard !self.isPinned(contentId: removedPin.item.contentId) else { continue }
+            self.items.insert(removedPin.item, at: min(removedPin.index, self.items.endIndex))
+            restoredCount += 1
+        }
+        guard restoredCount > 0 else { return }
+
+        self.save()
+        DiagnosticsLogger.ui.info("Restored \(restoredCount) playlist pin(s) to sidebar")
     }
 
     func remove(contentId: String) {
@@ -89,10 +117,16 @@ final class SidebarPinnedItemsManager {
     }
 
     func toggle(_ item: SidebarPinnedItem) {
-        if self.isPinned(contentId: item.contentId) {
-            self.remove(contentId: item.contentId)
-        } else {
+        guard self.isPinned(item) else {
             self.add(item)
+            return
+        }
+
+        switch item.itemType {
+        case let .playlist(playlist):
+            self.removePlaylistPins(matching: playlist.id)
+        case .album:
+            self.remove(contentId: item.contentId)
         }
     }
 
@@ -138,12 +172,29 @@ final class SidebarPinnedItemsManager {
     }
 
     func isPinned(_ item: SidebarPinnedItem) -> Bool {
-        self.isPinned(contentId: item.contentId)
+        self.items.contains { self.matchesIdentity($0, item) }
     }
 
     func reset(with items: [SidebarPinnedItem]) {
         self.items = items
         self.save()
+    }
+
+    private func matchesIdentity(_ lhs: SidebarPinnedItem, _ rhs: SidebarPinnedItem) -> Bool {
+        switch (lhs.itemType, rhs.itemType) {
+        case let (.playlist(lhsPlaylist), .playlist(rhsPlaylist)):
+            LibraryContentIdentity.playlistKey(for: lhsPlaylist.id) ==
+                LibraryContentIdentity.playlistKey(for: rhsPlaylist.id)
+        case let (.album(lhsAlbum), .album(rhsAlbum)):
+            lhsAlbum.id == rhsAlbum.id
+        default:
+            false
+        }
+    }
+
+    private func matchesPlaylist(_ item: SidebarPinnedItem, playlistKey: String) -> Bool {
+        guard case let .playlist(playlist) = item.itemType else { return false }
+        return LibraryContentIdentity.playlistKey(for: playlist.id) == playlistKey
     }
 
     private func save() {

--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -400,7 +400,8 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
                 if self.settings.appSource == .music {
                     Sidebar(
                         selection: self.$navigationSelection,
-                        pinnedSelection: self.$selectedSidebarPinnedItem
+                        pinnedSelection: self.$selectedSidebarPinnedItem,
+                        client: self.client
                     )
                 } else {
                     YouTubeSidebar(selection: self.$youtubeNavigationSelection)

--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -659,6 +659,9 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
             .navigationDestinations(client: client)
         }
         .environment(self.libraryViewModel)
+        .environment(\.onPlaylistDeleted) {
+            self.navigationSelection = .home
+        }
     }
 
     /// View shown while checking initial login status.

--- a/Sources/Kaset/Views/PlaylistDetailView+HeaderActions.swift
+++ b/Sources/Kaset/Views/PlaylistDetailView+HeaderActions.swift
@@ -185,7 +185,11 @@ extension PlaylistDetailView {
                     client: self.viewModel.client,
                     libraryViewModel: self.libraryViewModel
                 ) {
-                    self.dismiss()
+                    if let onPlaylistDeleted = self.onPlaylistDeleted {
+                        onPlaylistDeleted()
+                    } else {
+                        self.dismiss()
+                    }
                 }
             } label: {
                 self.headerActionLabel(

--- a/Sources/Kaset/Views/PlaylistDetailView.swift
+++ b/Sources/Kaset/Views/PlaylistDetailView.swift
@@ -16,6 +16,7 @@ struct PlaylistDetailView: View {
     @Environment(SongLikeStatusManager.self) private var likeStatusManager
     @Environment(LibraryViewModel.self) var libraryViewModel: LibraryViewModel?
     @Environment(\.dismiss) var dismiss
+    @Environment(\.onPlaylistDeleted) var onPlaylistDeleted
     /// Tracks whether this playlist has been added to library in this session.
     @State var isAddedToLibrary: Bool = false
     /// Whether the refine playlist sheet is visible.

--- a/Sources/Kaset/Views/SharedViews/SongActionsHelper.swift
+++ b/Sources/Kaset/Views/SharedViews/SongActionsHelper.swift
@@ -121,11 +121,13 @@ enum SongActionsHelper {
     }
 
     /// Shows a confirmation dialog before permanently deleting a playlist owned by the user.
+    /// Deletion is optimistic: `onConfirm` fires immediately and the playlist is removed from
+    /// the sidebar and library up front, then restored with an error alert if the API call fails.
     static func confirmDeletePlaylist(
         _ playlist: Playlist,
         client: any YTMusicClientProtocol,
         libraryViewModel: LibraryViewModel?,
-        onSuccess: (() -> Void)? = nil
+        onConfirm: (() -> Void)? = nil
     ) {
         let alert = NSAlert()
         alert.messageText = "Delete “\(playlist.title)”?"
@@ -137,6 +139,7 @@ enum SongActionsHelper {
         let handleResponse: (NSApplication.ModalResponse) -> Void = { response in
             guard response == .alertFirstButtonReturn else { return }
 
+            onConfirm?()
             Task { @MainActor in
                 do {
                     try await self.deletePlaylist(
@@ -144,7 +147,6 @@ enum SongActionsHelper {
                         client: client,
                         libraryViewModel: libraryViewModel
                     )
-                    onSuccess?()
                 } catch {
                     self.presentPlaylistDeletionError(error)
                 }

--- a/Sources/Kaset/Views/SharedViews/SongActionsHelper.swift
+++ b/Sources/Kaset/Views/SharedViews/SongActionsHelper.swift
@@ -174,6 +174,7 @@ enum SongActionsHelper {
 
     struct PlaylistCreationFailure: Error {
         let message: String
+        let recoverySuggestion: String
     }
 
     static func presentCreatePlaylistDialog(
@@ -196,7 +197,10 @@ enum SongActionsHelper {
             guard response == .alertFirstButtonReturn else { return }
             let title = titleField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !title.isEmpty else {
-                completion(.failure(PlaylistCreationFailure(message: "Playlist Name Required")))
+                completion(.failure(PlaylistCreationFailure(
+                    message: "Playlist Name Required",
+                    recoverySuggestion: "Enter a name for the playlist and try again."
+                )))
                 return
             }
 
@@ -210,6 +214,20 @@ enum SongActionsHelper {
             alert.beginSheetModal(for: window, completionHandler: handleResponse)
         } else {
             handleResponse(alert.runModal())
+        }
+    }
+
+    static func presentPlaylistCreationError(_ failure: PlaylistCreationFailure) {
+        let alert = NSAlert()
+        alert.messageText = failure.message
+        alert.informativeText = failure.recoverySuggestion
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "OK")
+
+        if let window = NSApp.keyWindow ?? NSApp.mainWindow {
+            alert.beginSheetModal(for: window)
+        } else {
+            alert.runModal()
         }
     }
 
@@ -247,7 +265,10 @@ enum SongActionsHelper {
 
             completion(.success(playlist))
         } catch {
-            completion(.failure(PlaylistCreationFailure(message: "Unable to Create Playlist")))
+            completion(.failure(PlaylistCreationFailure(
+                message: "Unable to Create Playlist",
+                recoverySuggestion: "Check your connection and try again."
+            )))
             DiagnosticsLogger.ui.error("Failed to create playlist: \(error.localizedDescription)")
         }
     }

--- a/Sources/Kaset/Views/SharedViews/SongActionsHelper.swift
+++ b/Sources/Kaset/Views/SharedViews/SongActionsHelper.swift
@@ -158,6 +158,98 @@ enum SongActionsHelper {
         }
     }
 
+    struct PlaylistCreationRequest {
+        let client: any YTMusicClientProtocol
+        let videoIds: [String]
+        let thumbnailURL: URL?
+
+        init(client: any YTMusicClientProtocol, videoIds: [String], thumbnailURL: URL? = nil) {
+            self.client = client
+            self.videoIds = videoIds
+            self.thumbnailURL = thumbnailURL
+        }
+    }
+
+    struct PlaylistCreationFailure: Error {
+        let message: String
+    }
+
+    static func presentCreatePlaylistDialog(
+        informativeText: String,
+        request: PlaylistCreationRequest,
+        onWillCreate: @escaping () -> Void = {},
+        completion: @escaping (Result<Playlist, PlaylistCreationFailure>) -> Void
+    ) {
+        let alert = NSAlert()
+        alert.messageText = "Create Playlist"
+        alert.informativeText = informativeText
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "Create")
+        alert.addButton(withTitle: "Cancel")
+        let titleField = NSTextField(frame: NSRect(x: 0, y: 0, width: 280, height: 24))
+        titleField.placeholderString = "Playlist name"
+        alert.accessoryView = titleField
+
+        let handleResponse: (NSApplication.ModalResponse) -> Void = { response in
+            guard response == .alertFirstButtonReturn else { return }
+            let title = titleField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !title.isEmpty else {
+                completion(.failure(PlaylistCreationFailure(message: "Playlist Name Required")))
+                return
+            }
+
+            onWillCreate()
+            Task {
+                await Self.createPlaylist(title: title, request: request, completion: completion)
+            }
+        }
+
+        if let window = NSApp.keyWindow ?? NSApp.mainWindow {
+            alert.beginSheetModal(for: window, completionHandler: handleResponse)
+        } else {
+            handleResponse(alert.runModal())
+        }
+    }
+
+    private static func createPlaylist(
+        title: String,
+        request: PlaylistCreationRequest,
+        completion: @escaping (Result<Playlist, PlaylistCreationFailure>) -> Void
+    ) async {
+        do {
+            let playlistId = try await request.client.createPlaylist(
+                title: title,
+                description: nil,
+                privacyStatus: .private,
+                videoIds: request.videoIds
+            )
+            let playlist = Playlist(
+                id: playlistId,
+                title: title,
+                description: nil,
+                thumbnailURL: request.thumbnailURL,
+                trackCount: request.videoIds.count,
+                canDelete: true
+            )
+
+            Self.invalidateLibraryResponseCaches()
+            LibraryMutationBroadcaster.shared.playlistCreated(playlist)
+
+            // Library browse responses can lag briefly behind a successful playlist creation.
+            // Refresh in the background, but keep the optimistic playlist visible if the
+            // cache/backend still returns a stale snapshot.
+            try? await Task.sleep(for: .milliseconds(500))
+            Self.invalidateLibraryResponseCaches()
+            await LibraryMutationBroadcaster.shared.reconcileCreatedPlaylist(playlist)
+            Self.invalidateLibraryResponseCaches()
+
+            completion(.success(playlist))
+        } catch {
+            completion(.failure(PlaylistCreationFailure(message: "Unable to Create Playlist")))
+            DiagnosticsLogger.ui.error("Failed to create playlist: \(error.localizedDescription)")
+        }
+    }
+
     private static func presentPlaylistDeletionError(_ error: Error) {
         let alert = NSAlert()
         alert.messageText = "Unable to Delete Playlist"

--- a/Sources/Kaset/Views/SharedViews/SongContextMenus.swift
+++ b/Sources/Kaset/Views/SharedViews/SongContextMenus.swift
@@ -1,4 +1,3 @@
-import AppKit
 import Foundation
 import SwiftUI
 
@@ -233,66 +232,26 @@ struct AddToPlaylistContextMenu: View {
     private func presentCreatePlaylistDialog() {
         guard !self.isCreatingPlaylist else { return }
 
-        let alert = NSAlert()
-        alert.messageText = "Create Playlist"
-        alert.informativeText = "Create a private playlist and add \"\(self.song.title)\" to it."
-        alert.alertStyle = .informational
-        alert.addButton(withTitle: "Create")
-        alert.addButton(withTitle: "Cancel")
-        let titleField = NSTextField(frame: NSRect(x: 0, y: 0, width: 280, height: 24))
-        titleField.placeholderString = "Playlist name"
-        alert.accessoryView = titleField
-        let handleResponse: (NSApplication.ModalResponse) -> Void = { response in
-            guard response == .alertFirstButtonReturn else { return }
-            let title = titleField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !title.isEmpty else {
-                self.loadState = .failed("Playlist Name Required")
-                return
+        SongActionsHelper.presentCreatePlaylistDialog(
+            informativeText: "Create a private playlist and add \"\(self.song.title)\" to it.",
+            request: SongActionsHelper.PlaylistCreationRequest(
+                client: self.client,
+                videoIds: [self.song.videoId],
+                thumbnailURL: self.song.thumbnailURL
+            ),
+            onWillCreate: { self.isCreatingPlaylist = true },
+            completion: { result in
+                switch result {
+                case .success:
+                    Task {
+                        self.isCreatingPlaylist = false
+                        await self.loadPlaylists(forceRefresh: true)
+                    }
+                case let .failure(failure):
+                    self.isCreatingPlaylist = false
+                    self.loadState = .failed(failure.message)
+                }
             }
-            Task { await self.createPlaylist(title: title) }
-        }
-
-        if let window = NSApp.keyWindow ?? NSApp.mainWindow {
-            alert.beginSheetModal(for: window, completionHandler: handleResponse)
-        } else {
-            handleResponse(alert.runModal())
-        }
-    }
-
-    private func createPlaylist(title: String) async {
-        guard !title.isEmpty, !self.isCreatingPlaylist else { return }
-        self.isCreatingPlaylist = true
-        defer { self.isCreatingPlaylist = false }
-        do {
-            let playlistId = try await self.client.createPlaylist(
-                title: title,
-                description: nil,
-                privacyStatus: .private,
-                videoIds: [self.song.videoId]
-            )
-            let playlist = Playlist(
-                id: playlistId,
-                title: title,
-                description: nil,
-                thumbnailURL: self.song.thumbnailURL,
-                trackCount: 1
-            )
-
-            SongActionsHelper.invalidateLibraryResponseCaches()
-            LibraryMutationBroadcaster.shared.playlistCreated(playlist)
-
-            // Library browse responses can lag briefly behind a successful playlist creation.
-            // Refresh in the background, but keep the optimistic playlist visible if the
-            // cache/backend still returns a stale snapshot.
-            try? await Task.sleep(for: .milliseconds(500))
-            SongActionsHelper.invalidateLibraryResponseCaches()
-            await LibraryMutationBroadcaster.shared.reconcileCreatedPlaylist(playlist)
-            SongActionsHelper.invalidateLibraryResponseCaches()
-
-            await self.loadPlaylists(forceRefresh: true)
-        } catch {
-            self.loadState = .failed("Unable to Create Playlist")
-            DiagnosticsLogger.ui.error("Failed to create playlist: \(error.localizedDescription)")
-        }
+        )
     }
 }

--- a/Sources/Kaset/Views/Sidebar.swift
+++ b/Sources/Kaset/Views/Sidebar.swift
@@ -9,9 +9,12 @@ struct Sidebar: View {
 
     @Binding var selection: NavigationItem?
     @Binding var pinnedSelection: SidebarPinnedItem?
+    let client: any YTMusicClientProtocol
     @Environment(AuthService.self) private var authService
     @Environment(SidebarPinnedItemsManager.self) private var sidebarPinnedItemsManager
     @Environment(PodcastsAvailabilityService.self) private var podcastsAvailability
+    @State private var isCreatingPlaylist = false
+    @State private var isHoveringPlaylistsHeader = false
 
     var body: some View {
         List {
@@ -58,14 +61,16 @@ struct Sidebar: View {
                 }
             }
 
-            if self.hasPersonalAccount, self.sidebarPinnedItemsManager.isVisible {
-                Section(String(localized: "Playlists")) {
+            if self.hasPersonalAccount {
+                Section {
                     ForEach(self.sidebarPinnedItemsManager.items) { item in
                         self.sidebarPinnedRow(item)
                     }
                     .onMove { source, destination in
                         self.sidebarPinnedItemsManager.move(from: source, to: destination)
                     }
+                } header: {
+                    self.playlistsSectionHeader
                 }
             }
         }
@@ -121,6 +126,58 @@ struct Sidebar: View {
         HapticService.navigation()
     }
 
+    private var playlistsSectionHeader: some View {
+        HStack {
+            Text(String(localized: "Playlists"))
+
+            Spacer()
+
+            if self.isCreatingPlaylist {
+                ProgressView()
+                    .controlSize(.small)
+                    .padding(.trailing, 8)
+            } else {
+                Button {
+                    self.presentCreatePlaylistDialog()
+                } label: {
+                    Image(systemName: "plus")
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(.secondary)
+                .opacity(self.isHoveringPlaylistsHeader ? 1 : 0)
+                .padding(.trailing, 8)
+                .help(String(localized: "Create Playlist"))
+                .accessibilityLabel(String(localized: "Create Playlist"))
+            }
+        }
+        .onHover { hovering in
+            withAnimation(AppAnimation.quick) {
+                self.isHoveringPlaylistsHeader = hovering
+            }
+        }
+    }
+
+    private func presentCreatePlaylistDialog() {
+        guard !self.isCreatingPlaylist else { return }
+
+        SongActionsHelper.presentCreatePlaylistDialog(
+            informativeText: "Create a new playlist.",
+            request: SongActionsHelper.PlaylistCreationRequest(client: self.client, videoIds: []),
+            onWillCreate: { self.isCreatingPlaylist = true },
+            completion: { result in
+                self.isCreatingPlaylist = false
+                switch result {
+                case let .success(playlist):
+                    let pinnedItem = SidebarPinnedItem.from(playlist)
+                    self.sidebarPinnedItemsManager.add(pinnedItem)
+                    self.selectPinnedItem(pinnedItem)
+                case let .failure(failure):
+                    DiagnosticsLogger.ui.error("Failed to create playlist from sidebar: \(failure.message)")
+                }
+            }
+        )
+    }
+
     private func sidebarPinnedRow(_ item: SidebarPinnedItem) -> some View {
         KasetSidebarRow(
             title: item.title,
@@ -169,9 +226,11 @@ struct Sidebar: View {
 }
 
 #Preview {
-    Sidebar(selection: .constant(.home), pinnedSelection: .constant(nil))
+    let authService = AuthService()
+    let client = YTMusicClient(authService: authService, webKitManager: .shared)
+    Sidebar(selection: .constant(.home), pinnedSelection: .constant(nil), client: client)
         .frame(width: 220)
-        .environment(AuthService())
+        .environment(authService)
         .environment(SidebarPinnedItemsManager(skipLoad: true))
         .environment(PodcastsAvailabilityService())
 }

--- a/Sources/Kaset/Views/Sidebar.swift
+++ b/Sources/Kaset/Views/Sidebar.swift
@@ -172,7 +172,7 @@ struct Sidebar: View {
                     self.sidebarPinnedItemsManager.add(pinnedItem)
                     self.selectPinnedItem(pinnedItem)
                 case let .failure(failure):
-                    DiagnosticsLogger.ui.error("Failed to create playlist from sidebar: \(failure.message)")
+                    SongActionsHelper.presentPlaylistCreationError(failure)
                 }
             }
         )

--- a/Tests/KasetTests/LibraryMutationActionsTests.swift
+++ b/Tests/KasetTests/LibraryMutationActionsTests.swift
@@ -77,4 +77,38 @@ struct LibraryMutationActionsTests {
         #expect(self.mockClient.deletePlaylistIds == ["VL-owned"])
         #expect(!self.libraryViewModel.isInLibrary(playlistId: "VL-owned"))
     }
+
+    @Test("Delete playlist unpins it from the sidebar")
+    func deletePlaylistUnpinsFromSidebar() async throws {
+        let playlist = TestFixtures.makePlaylist(id: "VL-pinned-delete", title: "Pinned Playlist")
+        SidebarPinnedItemsManager.shared.add(.from(playlist))
+
+        try await LibraryMutationActions.deletePlaylist(
+            playlist,
+            client: self.mockClient,
+            libraryViewModel: self.libraryViewModel
+        )
+
+        #expect(!SidebarPinnedItemsManager.shared.isPinned(contentId: "VL-pinned-delete"))
+    }
+
+    @Test("Failed playlist deletion restores the sidebar pin and library entry")
+    func deletePlaylistRestoresStateOnFailure() async throws {
+        let playlist = TestFixtures.makePlaylist(id: "VL-delete-fails", title: "Sticky Playlist")
+        self.libraryViewModel.addToLibrary(playlist: playlist)
+        SidebarPinnedItemsManager.shared.add(.from(playlist))
+        self.mockClient.shouldThrowError = URLError(.notConnectedToInternet)
+
+        await #expect(throws: (any Error).self) {
+            try await LibraryMutationActions.deletePlaylist(
+                playlist,
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel
+            )
+        }
+
+        #expect(SidebarPinnedItemsManager.shared.isPinned(contentId: "VL-delete-fails"))
+        #expect(self.libraryViewModel.isInLibrary(playlistId: "VL-delete-fails"))
+        SidebarPinnedItemsManager.shared.remove(contentId: "VL-delete-fails")
+    }
 }

--- a/Tests/KasetTests/LibraryMutationActionsTests.swift
+++ b/Tests/KasetTests/LibraryMutationActionsTests.swift
@@ -267,8 +267,9 @@ struct LibraryMutationActionsTests {
 
     @Test("Delete playlist unpins it from the sidebar")
     func deletePlaylistUnpinsFromSidebar() async throws {
-        let playlist = TestFixtures.makePlaylist(id: "VL-pinned-delete", title: "Pinned Playlist")
-        SidebarPinnedItemsManager.shared.add(.from(playlist))
+        let pinnedPlaylist = TestFixtures.makePlaylist(id: "PL-pinned-delete", title: "Pinned Playlist")
+        let playlist = TestFixtures.makePlaylist(id: "VLPL-pinned-delete", title: "Pinned Playlist")
+        SidebarPinnedItemsManager.shared.add(.from(pinnedPlaylist))
 
         try await LibraryMutationActions.deletePlaylist(
             playlist,
@@ -276,14 +277,15 @@ struct LibraryMutationActionsTests {
             libraryViewModel: self.libraryViewModel
         )
 
-        #expect(!SidebarPinnedItemsManager.shared.isPinned(contentId: "VL-pinned-delete"))
+        #expect(!SidebarPinnedItemsManager.shared.isPinned(contentId: "PL-pinned-delete"))
     }
 
     @Test("Failed playlist deletion restores the sidebar pin and library entry")
     func deletePlaylistRestoresStateOnFailure() async throws {
-        let playlist = TestFixtures.makePlaylist(id: "VL-delete-fails", title: "Sticky Playlist")
+        let pinnedPlaylist = TestFixtures.makePlaylist(id: "PL-delete-fails", title: "Sticky Playlist")
+        let playlist = TestFixtures.makePlaylist(id: "VLPL-delete-fails", title: "Sticky Playlist")
         self.libraryViewModel.addToLibrary(playlist: playlist)
-        SidebarPinnedItemsManager.shared.add(.from(playlist))
+        SidebarPinnedItemsManager.shared.add(.from(pinnedPlaylist))
         self.mockClient.shouldThrowError = URLError(.notConnectedToInternet)
 
         await #expect(throws: (any Error).self) {
@@ -294,9 +296,9 @@ struct LibraryMutationActionsTests {
             )
         }
 
-        #expect(SidebarPinnedItemsManager.shared.isPinned(contentId: "VL-delete-fails"))
-        #expect(self.libraryViewModel.isInLibrary(playlistId: "VL-delete-fails"))
-        SidebarPinnedItemsManager.shared.remove(contentId: "VL-delete-fails")
+        #expect(SidebarPinnedItemsManager.shared.isPinned(contentId: "PL-delete-fails"))
+        #expect(self.libraryViewModel.isInLibrary(playlistId: "VLPL-delete-fails"))
+        SidebarPinnedItemsManager.shared.remove(contentId: "PL-delete-fails")
     }
 
     private func waitUntil(_ condition: @autoclosure () -> Bool, timeout: Duration = .seconds(1)) async -> Bool {

--- a/Tests/KasetTests/NotificationServiceTests.swift
+++ b/Tests/KasetTests/NotificationServiceTests.swift
@@ -23,6 +23,20 @@ struct NotificationServiceTests {
         try? await Task.sleep(for: .milliseconds(50))
     }
 
+    /// Polls until `condition` holds, bounded by a deadline that tolerates slow CI
+    /// runners — a fixed wait races with Observation delivery and the service's
+    /// loading-resolution poll loop.
+    private func waitForObservationDelivery(until condition: @autoclosure @MainActor () -> Bool) async {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(2))
+        while !condition(), clock.now < deadline {
+            for _ in 0 ..< 5 {
+                await Task.yield()
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+    }
+
     // MARK: - Observation Lifecycle
 
     @Test("observation is active after init")
@@ -43,7 +57,7 @@ struct NotificationServiceTests {
         self.playerService.currentTrack = TestFixtures.makeSong(id: "song-1", title: "First Song")
         self.playerService.state = .playing
 
-        await self.waitForObservationDelivery()
+        await self.waitForObservationDelivery(until: self.notificationService.lastNotifiedTrackId == "song-1")
 
         #expect(self.notificationService.lastNotifiedTrackId == "song-1")
     }
@@ -55,7 +69,7 @@ struct NotificationServiceTests {
         playerService.state = .playing
 
         let notificationService = NotificationService(playerService: playerService)
-        await self.waitForObservationDelivery()
+        await self.waitForObservationDelivery(until: notificationService.lastNotifiedTrackId == "initial-song")
 
         #expect(notificationService.lastNotifiedTrackId == "initial-song")
         notificationService.stopObserving()
@@ -65,11 +79,11 @@ struct NotificationServiceTests {
     func detectsMultipleTrackChanges() async {
         self.playerService.currentTrack = TestFixtures.makeSong(id: "song-1", title: "First Song")
         self.playerService.state = .playing
-        await self.waitForObservationDelivery()
+        await self.waitForObservationDelivery(until: self.notificationService.lastNotifiedTrackId == "song-1")
         #expect(self.notificationService.lastNotifiedTrackId == "song-1")
 
         self.playerService.currentTrack = TestFixtures.makeSong(id: "song-2", title: "Second Song")
-        await self.waitForObservationDelivery()
+        await self.waitForObservationDelivery(until: self.notificationService.lastNotifiedTrackId == "song-2")
         #expect(self.notificationService.lastNotifiedTrackId == "song-2")
     }
 
@@ -93,7 +107,7 @@ struct NotificationServiceTests {
 
         self.playerService.state = .playing
 
-        await self.waitForObservationDelivery()
+        await self.waitForObservationDelivery(until: self.notificationService.lastNotifiedTrackId == "song-1")
         #expect(self.notificationService.lastNotifiedTrackId == "song-1")
     }
 
@@ -101,12 +115,12 @@ struct NotificationServiceTests {
     func doesNotNotifyForSameTrackTwice() async {
         self.playerService.currentTrack = TestFixtures.makeSong(id: "song-1", title: "First Song")
         self.playerService.state = .playing
-        await self.waitForObservationDelivery()
+        await self.waitForObservationDelivery(until: self.notificationService.lastNotifiedTrackId == "song-1")
         #expect(self.notificationService.lastNotifiedTrackId == "song-1")
 
         // Set a different track, then back to the same one
         self.playerService.currentTrack = TestFixtures.makeSong(id: "song-2", title: "Second Song")
-        await self.waitForObservationDelivery()
+        await self.waitForObservationDelivery(until: self.notificationService.lastNotifiedTrackId == "song-2")
 
         // The lastNotifiedTrackId should now be song-2, meaning song-1 wasn't skipped
         #expect(self.notificationService.lastNotifiedTrackId == "song-2")
@@ -133,7 +147,7 @@ struct NotificationServiceTests {
         self.playerService.currentTrack = TestFixtures.makeSong(id: "song-1", title: "Real Song")
         self.playerService.state = .playing
 
-        await self.waitForObservationDelivery()
+        await self.waitForObservationDelivery(until: self.notificationService.lastNotifiedTrackId == "song-1")
         #expect(self.notificationService.lastNotifiedTrackId == "song-1")
     }
 
@@ -146,7 +160,7 @@ struct NotificationServiceTests {
 
         self.playerService.currentTrack = TestFixtures.makeSong(id: "song-1", title: "Real Song")
 
-        await self.waitForObservationDelivery()
+        await self.waitForObservationDelivery(until: self.notificationService.lastNotifiedTrackId == "song-1")
         #expect(self.notificationService.lastNotifiedTrackId == "song-1")
     }
 
@@ -162,7 +176,7 @@ struct NotificationServiceTests {
     func stopObservingPreventsFutureNotifications() async {
         self.playerService.currentTrack = TestFixtures.makeSong(id: "song-1", title: "First Song")
         self.playerService.state = .playing
-        await self.waitForObservationDelivery()
+        await self.waitForObservationDelivery(until: self.notificationService.lastNotifiedTrackId == "song-1")
         #expect(self.notificationService.lastNotifiedTrackId == "song-1")
 
         self.notificationService.stopObserving()
@@ -181,7 +195,7 @@ struct NotificationServiceTests {
         // And still detects changes without a polling delay.
         self.playerService.currentTrack = TestFixtures.makeSong(id: "late-song", title: "Late Song")
         self.playerService.state = .playing
-        await self.waitForObservationDelivery()
+        await self.waitForObservationDelivery(until: self.notificationService.lastNotifiedTrackId == "late-song")
         #expect(self.notificationService.lastNotifiedTrackId == "late-song")
     }
 }

--- a/Tests/KasetTests/SidebarPinnedItemsManagerTests.swift
+++ b/Tests/KasetTests/SidebarPinnedItemsManagerTests.swift
@@ -33,6 +33,18 @@ struct SidebarPinnedItemsManagerTests {
         #expect(self.manager.items.count == 1)
     }
 
+    @Test("Treats raw and browse playlist IDs as the same pin")
+    func ignoresEquivalentPlaylistAliases() {
+        let rawPlaylist = SidebarPinnedItem.from(TestFixtures.makePlaylist(id: "PL-playlist-1", title: "Road Mix"))
+        let browsePlaylist = SidebarPinnedItem.from(TestFixtures.makePlaylist(id: "VLPL-playlist-1", title: "Road Mix"))
+
+        self.manager.add(rawPlaylist)
+        self.manager.add(browsePlaylist)
+
+        #expect(self.manager.items.map(\.contentId) == ["PL-playlist-1"])
+        #expect(self.manager.isPinned(browsePlaylist))
+    }
+
     @Test("Toggles pins on and off")
     func togglesPins() {
         let album = SidebarPinnedItem.from(TestFixtures.makeAlbum(id: "MPRE-album-1", title: "Night Album"))
@@ -42,6 +54,34 @@ struct SidebarPinnedItemsManagerTests {
 
         self.manager.toggle(album)
         #expect(self.manager.isPinned(album) == false)
+    }
+
+    @Test("Toggling an equivalent playlist alias removes every persisted alias")
+    func togglesEquivalentPlaylistAlias() {
+        let rawPlaylist = SidebarPinnedItem.from(TestFixtures.makePlaylist(id: "PL-playlist-1", title: "Road Mix"))
+        let browsePlaylist = SidebarPinnedItem.from(TestFixtures.makePlaylist(id: "VLPL-playlist-1", title: "Road Mix"))
+        self.manager.reset(with: [rawPlaylist, browsePlaylist])
+
+        self.manager.toggle(browsePlaylist)
+
+        #expect(self.manager.items.isEmpty)
+    }
+
+    @Test("Removes and restores every persisted alias of a playlist")
+    func removesAndRestoresEveryPlaylistAlias() {
+        let rawPlaylist = SidebarPinnedItem.from(TestFixtures.makePlaylist(id: "PL-playlist-1", title: "Road Mix"))
+        let album = SidebarPinnedItem.from(TestFixtures.makeAlbum(id: "MPRE-album-1", title: "Night Album"))
+        let browsePlaylist = SidebarPinnedItem.from(TestFixtures.makePlaylist(id: "VLPL-playlist-1", title: "Road Mix"))
+        self.manager.reset(with: [rawPlaylist, album, browsePlaylist])
+
+        let removedPins = self.manager.removePlaylistPins(matching: "VLPL-playlist-1")
+
+        #expect(removedPins.map(\.item.contentId) == ["PL-playlist-1", "VLPL-playlist-1"])
+        #expect(self.manager.items.map(\.contentId) == ["MPRE-album-1"])
+
+        self.manager.restore(removedPins)
+
+        #expect(self.manager.items.map(\.contentId) == ["PL-playlist-1", "MPRE-album-1", "VLPL-playlist-1"])
     }
 
     @Test("Moves pins by drag source and destination")


### PR DESCRIPTION
## Description

Playlists can now be created from the sidebar: a "+" button reveals on hover over the **Playlists** section header, opens the existing create-playlist dialog, and on success pins the new playlist to the sidebar and navigates straight to it. Previously the only way to create a playlist was buried in a song's "Add to Playlist" context menu, so an empty account had no visible entry point at all. While creation is in flight the "+" is replaced by a small inline spinner.

The second commit fixes a bug this feature made prominent: deleting a playlist left its sidebar pin behind forever (`deletePlaylist` never touched `SidebarPinnedItemsManager`), and the deleted playlist's page stayed open when it had been opened from the sidebar (`dismiss()` is a no-op there). Deletion is now optimistic — the pin and library entry disappear and navigation happens immediately on confirm; on API failure the pin is restored at its original position, the library entry comes back, and the existing error alert is shown.

## AI Prompt (Optional)

<details>
<summary>🤖 AI Prompt Used</summary>

```
I'd like a little PLUS (+) next to the Playlists label in the left sidebar,
because how do I create a playlist in this app otherwise. Show it only on
hover, with a spinner while the playlist is created. Also deleting a playlist
does nothing visible for seconds and the playlist is stuck in the sidebar —
investigate and lean into optimistic updates.
```

**AI Tool:** Claude Code

</details>

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Related Issues

None found.

## Changes Made

- `Sidebar` — custom Playlists section header with a hover-revealed "+" (spinner while creating); the section now renders even with no pinned items so the entry point always exists
- `SongActionsHelper.presentCreatePlaylistDialog` — the NSAlert create dialog previously inlined in `AddToPlaylistContextMenu` is extracted so both call sites share one create/broadcast/reconcile path (`PlaylistCreationRequest` + `Result` completion)
- `LibraryMutationActions.deletePlaylist` — optimistic: unpins from the sidebar and broadcasts the library removal before the API call, rolls both back on failure; reconciliation unchanged
- `SidebarPinnedItemsManager.insert(_:at:)` — position-preserving restore for the rollback path
- `onPlaylistDeleted` `@Entry` environment key — the pinned-playlist detail page navigates home after deletion instead of calling `dismiss()` (a no-op outside a navigation stack); nav-stack contexts keep the `dismiss()` fallback

## Testing

- [x] Unit tests pass (`swift test --skip KasetUITests`)
- [x] Manual testing performed — created playlists from the sidebar (spinner, pin, navigation), deleted pinned and unpinned playlists, verified instant UI response and Library consistency after reload
- [x] UI tested on macOS 26+

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `swiftlint --strict && swiftformat .`
- [x] I have added tests that prove my fix/feature works (deletion unpins from sidebar; failed deletion restores pin + library entry)
- [x] New and existing unit tests pass locally
- [x] I have updated documentation if needed
- [x] I have checked for any performance implications
- [x] My changes generate no new warnings

## Screenshots

https://github.com/user-attachments/assets/72e60f0d-7115-4ba6-be51-c7aee3048a94

## Additional Notes

Includes the same `test:` deflake commit as #363/#364 (the `NotificationServiceTests` fixed-wait flake lives on `main` and hits fresh branches); it disappears on rebase once any of them merges.

<!-- agent-transcript:start -->
## Agent Transcript

<details>
<summary>Redacted agent session transcript (scoped to this PR)</summary>

````text
source: local Claude Code session, trimmed to this PR's scope
omitted: raw tool outputs, system prompts, local paths, unrelated session turns

[user]
i'd like a little PLUS (+) next to the playlists label in the left sidebar,
because how do I create a playlist in this app otherwise.

[assistant]
Scouted first: createPlaylist already exists in the API layer (posts
playlist/create) and an NSAlert create dialog already exists inside the song
context menu — the feature was just undiscoverable. The sidebar Playlists
section is driven by SidebarPinnedItemsManager, which does NOT observe
LibraryMutationBroadcaster, so a created playlist must be explicitly pinned.
Implemented: custom section header with a "+" button, extracted the dialog
into a shared SongActionsHelper.presentCreatePlaylistDialog so both call
sites share one create/broadcast path; on success the playlist is pinned and
opened. Section now renders even with zero pinned items.

[user]
Show the + only when hovering the Playlists header; align its right padding
with the header's left margin.

[user]
Delete playlist looks broken — I confirm the dialog and nothing happens.
...actually it IS deleted (gone from Library), but it's stuck in the sidebar.

[assistant]
Root cause: LibraryMutationActions.deletePlaylist broadcasts the removal to
the Library view models only; nothing ever removes the sidebar pin (pre-
existing bug — any pinned playlist deleted becomes a ghost pin). Also the
detail page stays open because dismiss() is a no-op when the page was opened
from a sidebar pin rather than a navigation stack. Fixed: deletePlaylist now
unpins; a new onPlaylistDeleted @Entry environment value lets the pinned
context navigate home (nav-stack contexts keep the dismiss() fallback).

[user]
Show a spinner (check the app for precedent) while the playlist is created.
Deletion takes seconds before anything happens — lean into optimistic updates.

[assistant]
Precedent check: inline ProgressView().controlSize(.small) is the app's busy
idiom (CommandBar, artist page); no skeleton pattern exists — spinner replaces
the "+" while creating. Deletion made optimistic: pin + library entry removed
and navigation fires immediately on confirm; API call runs after; on failure
the pin is restored at its original index (new SidebarPinnedItemsManager
.insert(_:at:)), the library entry is restored, and the existing error alert
shows.


[assistant]
Verification: swiftlint --strict clean, swiftformat clean, swift build OK,
swift test --skip KasetUITests → 1776/1776 pass incl. 2 new
LibraryMutationActionsTests (deletion unpins from sidebar; failed deletion
restores pin + library entry). Hover animation uses the shared
AppAnimation.quick constant (review-pass finding). Manual test: create from
sidebar (spinner → pin → navigate), delete (instant unpin + redirect home).

[user]
ok, yep, that is good.
````

</details>
<!-- agent-transcript:end -->

