### PR TITLE
fix(player): harden playback reliability and queue ownership

### DIFF
--- a/Sources/APIExplorer/main.swift
+++ b/Sources/APIExplorer/main.swift
@@ -13,6 +13,7 @@
 //    browse <browseId> [params]    - Explore a browse endpoint
 //    action <endpoint> <body>      - Explore an action endpoint (body as JSON)
 //    continuation <token> [ep]     - Explore a continuation (ep: browse or next)
+//    analyze-file <path>           - Safely summarize a saved JSON response
 //    list                          - List all known endpoints
 //    auth                          - Check authentication status
 //    help                          - Show this help message
@@ -815,6 +816,126 @@ private func chapterProbeSummary(_ data: [String: Any], limit: Int = 8) -> Strin
     return output
 }
 
+// MARK: - LibraryFeedbackProbeItem
+
+private struct LibraryFeedbackProbeItem: Hashable {
+    enum Kind: String {
+        case single
+        case toggle
+    }
+
+    let kind: Kind
+    let iconType: String
+    let hasPrimaryToken: Bool
+    let hasToggledToken: Bool
+    let tokensAreDistinct: Bool?
+}
+
+private func firstFeedbackToken(in value: Any) -> String? {
+    if let dictionary = value as? [String: Any] {
+        if let token = dictionary["feedbackToken"] as? String, !token.isEmpty {
+            return token
+        }
+        for nestedValue in dictionary.values {
+            if let token = firstFeedbackToken(in: nestedValue) {
+                return token
+            }
+        }
+    } else if let array = value as? [Any] {
+        for item in array {
+            if let token = firstFeedbackToken(in: item) {
+                return token
+            }
+        }
+    }
+    return nil
+}
+
+private func isLibraryFeedbackIcon(_ iconType: String) -> Bool {
+    iconType.contains("LIBRARY") || iconType.contains("BOOKMARK")
+}
+
+private func collectLibraryFeedbackProbeItems(
+    in value: Any,
+    items: inout [LibraryFeedbackProbeItem]
+) {
+    if let dictionary = value as? [String: Any] {
+        if let renderer = dictionary["menuServiceItemRenderer"] as? [String: Any] {
+            let token = firstFeedbackToken(in: renderer["serviceEndpoint"] as Any)
+            if token != nil {
+                let icon = renderer["icon"] as? [String: Any]
+                let iconType = icon?["iconType"] as? String ?? "unknown"
+                if isLibraryFeedbackIcon(iconType) {
+                    items.append(LibraryFeedbackProbeItem(
+                        kind: .single,
+                        iconType: iconType,
+                        hasPrimaryToken: true,
+                        hasToggledToken: false,
+                        tokensAreDistinct: nil
+                    ))
+                }
+            }
+        }
+
+        if let renderer = dictionary["toggleMenuServiceItemRenderer"] as? [String: Any] {
+            let defaultToken = firstFeedbackToken(in: renderer["defaultServiceEndpoint"] as Any)
+            let toggledToken = firstFeedbackToken(in: renderer["toggledServiceEndpoint"] as Any)
+            guard defaultToken != nil || toggledToken != nil else {
+                for nestedValue in dictionary.values {
+                    collectLibraryFeedbackProbeItems(in: nestedValue, items: &items)
+                }
+                return
+            }
+            let icon = renderer["defaultIcon"] as? [String: Any]
+            let iconType = icon?["iconType"] as? String ?? "unknown"
+            if isLibraryFeedbackIcon(iconType) {
+                let tokensAreDistinct: Bool? = if let defaultToken, let toggledToken {
+                    defaultToken != toggledToken
+                } else {
+                    nil
+                }
+                items.append(LibraryFeedbackProbeItem(
+                    kind: .toggle,
+                    iconType: iconType,
+                    hasPrimaryToken: defaultToken != nil,
+                    hasToggledToken: toggledToken != nil,
+                    tokensAreDistinct: tokensAreDistinct
+                ))
+            }
+        }
+
+        for nestedValue in dictionary.values {
+            collectLibraryFeedbackProbeItems(in: nestedValue, items: &items)
+        }
+    } else if let array = value as? [Any] {
+        for item in array {
+            collectLibraryFeedbackProbeItems(in: item, items: &items)
+        }
+    }
+}
+
+private func libraryFeedbackProbeSummary(_ data: [String: Any]) -> String {
+    var items: [LibraryFeedbackProbeItem] = []
+    collectLibraryFeedbackProbeItems(in: data, items: &items)
+    guard !items.isEmpty else { return "" }
+
+    let grouped = Dictionary(grouping: items, by: \.self)
+    var output = "\n📚 Library feedback actions (token values redacted):\n"
+    for item in grouped.keys.sorted(by: {
+        ($0.kind.rawValue, $0.iconType) < ($1.kind.rawValue, $1.iconType)
+    }) {
+        let count = grouped[item]?.count ?? 0
+        switch item.kind {
+        case .single:
+            output += "  • single icon=\(item.iconType) token=\(item.hasPrimaryToken ? "present" : "missing") count=\(count)\n"
+        case .toggle:
+            let distinct = item.tokensAreDistinct.map { $0 ? "yes" : "no" } ?? "unknown"
+            output += "  • toggle defaultIcon=\(item.iconType) defaultToken=\(item.hasPrimaryToken ? "present" : "missing") toggledToken=\(item.hasToggledToken ? "present" : "missing") distinct=\(distinct) count=\(count)\n"
+        }
+    }
+    return output
+}
+
 func analyzeResponse(_ data: [String: Any], verbose: Bool = false) -> String {
     var output = ""
 
@@ -902,6 +1023,8 @@ func analyzeResponse(_ data: [String: Any], verbose: Bool = false) -> String {
     output += playlistSetVideoIdSourceSummary(data)
 
     output += chapterProbeSummary(data)
+
+    output += libraryFeedbackProbeSummary(data)
 
     output += rendererHistogram(data)
 
@@ -2152,6 +2275,7 @@ func showHelp() {
           browse <browseId> [params]     Explore a browse endpoint
           action <endpoint> <body>       Explore an action endpoint (body as JSON)
           continuation <token> [ep]      Explore a continuation (ep: 'browse' or 'next')
+          analyze-file <path>            Safely summarize a saved JSON response
           list                           List all known endpoints
           auth                           Check authentication status
           accounts                       Discover available accounts (via authuser)
@@ -2209,6 +2333,9 @@ func showHelp() {
           swift run api-explorer continuation <token>           # browse endpoint (default)
           swift run api-explorer continuation <token> next      # next endpoint (for mix queues)
 
+          # Safely inspect a saved response without printing raw token values
+          swift run api-explorer analyze-file Tests/KasetTests/Fixtures/example.json
+
           # Check auth status
           swift run api-explorer auth
 
@@ -2221,6 +2348,25 @@ func showHelp() {
 
         """
     )
+}
+
+/// Analyzes a saved JSON response without printing raw values.
+/// Useful for parser/fixture validation when live authenticated cookies are unavailable.
+func analyzeSavedResponse(at path: String) {
+    let url = URL(fileURLWithPath: path)
+    do {
+        let data = try Data(contentsOf: url)
+        guard let response = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            print("❌ Saved response is not a JSON object")
+            return
+        }
+        print("📄 Analyzing saved response: \(url.lastPathComponent)")
+        print("   Raw JSON and token values remain hidden")
+        print()
+        print(analyzeResponse(response))
+    } catch {
+        print("❌ Failed to analyze saved response: \(error.localizedDescription)")
+    }
 }
 
 // MARK: - Main Entry Point
@@ -2327,6 +2473,13 @@ func runMain() async {
         await exploreContinuation(
             token, endpoint: endpoint, verbose: verbose, outputFile: outputFile
         )
+
+    case "analyze-file":
+        guard filteredArgs.count >= 2 else {
+            print("❌ Usage: analyze-file <path>")
+            return
+        }
+        analyzeSavedResponse(at: filteredArgs[1])
 
     case "list":
         listEndpoints()

--- a/Sources/Kaset/Services/AI/CommandExecutor.swift
+++ b/Sources/Kaset/Services/AI/CommandExecutor.swift
@@ -3,6 +3,11 @@ import Foundation
 @available(macOS 26.0, *)
 @MainActor
 struct CommandExecutor {
+    private struct QueueCommandOwnership {
+        let playbackIntent: MusicPlaybackIntent?
+        let queueGeneration: Int?
+    }
+
     enum Request: Equatable {
         case pause
         case resume
@@ -17,6 +22,45 @@ struct CommandExecutor {
         case queueSearch(query: String, description: String)
         case openSearch(query: String)
         case musicIntent(MusicIntent)
+
+        var requiresPlaybackClaim: Bool {
+            switch self {
+            case .pause, .resume, .skip, .previous, .clearQueue, .shuffleQueue,
+                 .toggleShuffle, .playSearch:
+                true
+            case let .musicIntent(intent):
+                switch intent.action {
+                case .play, .shuffle, .skip, .previous, .pause, .resume:
+                    true
+                case .queue, .like, .dislike, .search:
+                    false
+                }
+            case .queueSearch, .like, .dislike, .openSearch:
+                false
+            }
+        }
+
+        var isQueueRequest: Bool {
+            switch self {
+            case .queueSearch:
+                true
+            case let .musicIntent(intent):
+                intent.action == .queue
+            default:
+                false
+            }
+        }
+
+        var requiresPlaybackValidation: Bool {
+            switch self {
+            case .like, .dislike:
+                true
+            case let .musicIntent(intent):
+                intent.action == .like || intent.action == .dislike
+            default:
+                false
+            }
+        }
     }
 
     struct Outcome: Equatable {
@@ -51,6 +95,15 @@ struct CommandExecutor {
                 searchQueryToOpen: query
             )
         }
+
+        static var ignored: Self {
+            Self(
+                resultMessage: nil,
+                errorMessage: nil,
+                shouldDismiss: false,
+                searchQueryToOpen: nil
+            )
+        }
     }
 
     let client: any YTMusicClientProtocol
@@ -58,66 +111,138 @@ struct CommandExecutor {
 
     private let logger = DiagnosticsLogger.ai
 
-    func execute(_ request: Request) async -> Outcome {
+    func execute(
+        _ request: Request,
+        reservation: MusicPlaybackReservation? = nil
+    ) async -> Outcome {
+        guard !Task.isCancelled else { return .ignored }
+        let playbackIntent: MusicPlaybackIntent?
+        let queueGeneration: Int?
+        if request.isQueueRequest, !self.playerService.queue.isEmpty {
+            playbackIntent = nil
+            let submittedQueueGeneration = reservation?.queueMutationGeneration
+                ?? self.playerService.reserveQueueMutation()
+            guard self.playerService.acceptsQueueMutation(submittedQueueGeneration) else {
+                return .ignored
+            }
+            queueGeneration = submittedQueueGeneration
+        } else if request.requiresPlaybackClaim || request.isQueueRequest {
+            guard let claimedIntent = self.claimPlaybackIntent(reservation) else { return .ignored }
+            playbackIntent = claimedIntent
+            queueGeneration = nil
+        } else {
+            playbackIntent = nil
+            queueGeneration = nil
+            if request.requiresPlaybackValidation {
+                guard self.validatePlaybackReservation(reservation) else { return .ignored }
+            }
+        }
+
+        switch request {
+        case .pause, .resume, .skip, .previous:
+            return await self.executeTransportControl(request)
+        case .like, .dislike, .clearQueue, .shuffleQueue, .toggleShuffle:
+            return self.executeImmediateControl(request)
+        case let .playSearch(query, description):
+            guard let playbackIntent else { return .ignored }
+            return await self.playSearchResult(
+                query: query,
+                description: description,
+                playbackIntent: playbackIntent
+            )
+        case let .queueSearch(query, description):
+            return await self.queueSearchResult(
+                query: query,
+                description: description,
+                ownership: QueueCommandOwnership(
+                    playbackIntent: playbackIntent,
+                    queueGeneration: queueGeneration
+                )
+            )
+        case let .openSearch(query):
+            return .openSearch(query)
+        case let .musicIntent(intent):
+            return await self.executeMusicIntent(
+                intent,
+                ownership: QueueCommandOwnership(
+                    playbackIntent: playbackIntent,
+                    queueGeneration: queueGeneration
+                )
+            )
+        }
+    }
+
+    private func executeTransportControl(_ request: Request) async -> Outcome {
+        HapticService.playback()
         switch request {
         case .pause:
-            HapticService.playback()
             await self.playerService.pause()
             return .result("Paused")
-
         case .resume:
-            HapticService.playback()
             await self.playerService.resume()
             return .result("Playing")
-
         case .skip:
-            HapticService.playback()
             await self.playerService.next()
             return .result("Skipped")
-
         case .previous:
-            HapticService.playback()
             await self.playerService.previous()
             return .result("Playing previous track")
+        default:
+            return .ignored
+        }
+    }
 
+    private func executeImmediateControl(_ request: Request) -> Outcome {
+        HapticService.toggle()
+        switch request {
         case .like:
-            HapticService.toggle()
             self.playerService.likeCurrentTrack()
             return .result("Liked!")
-
         case .dislike:
-            HapticService.toggle()
             self.playerService.dislikeCurrentTrack()
             return .result("Disliked")
-
         case .clearQueue:
-            HapticService.toggle()
             self.playerService.clearQueue()
             return .result("Queue cleared")
-
         case .shuffleQueue:
-            HapticService.toggle()
             self.playerService.shuffleQueue()
             return .result("Queue shuffled")
-
         case .toggleShuffle:
-            HapticService.toggle()
             self.playerService.toggleShuffle()
             let status = self.playerService.shuffleEnabled ? "on" : "off"
             return .result("Shuffle is now \(status)")
-
-        case let .playSearch(query, description):
-            return await self.playSearchResult(query: query, description: description)
-
-        case let .queueSearch(query, description):
-            return await self.queueSearchResult(query: query, description: description)
-
-        case let .openSearch(query):
-            return .openSearch(query)
-
-        case let .musicIntent(intent):
-            return await self.executeMusicIntent(intent)
+        default:
+            return .ignored
         }
+    }
+
+    private func claimPlaybackIntent(
+        _ reservation: MusicPlaybackReservation?
+    ) -> MusicPlaybackIntent? {
+        let reservation = reservation ?? self.playerService.reserveMusicPlaybackIntent()
+        return self.playerService.claimMusicPlaybackIntent(reservation)
+    }
+
+    private func validatePlaybackReservation(
+        _ reservation: MusicPlaybackReservation?
+    ) -> Bool {
+        let reservation = reservation ?? self.playerService.reserveMusicPlaybackIntent()
+        return self.playerService.acceptsMusicPlaybackReservation(reservation)
+    }
+
+    private func commandStillOwnsPlayback(_ intent: MusicPlaybackIntent) -> Bool {
+        !Task.isCancelled && self.playerService.acceptsMusicPlaybackIntent(intent)
+    }
+
+    private func commandStillOwnsQueue(_ ownership: QueueCommandOwnership) -> Bool {
+        if let playbackIntent = ownership.playbackIntent {
+            return self.commandStillOwnsPlayback(playbackIntent)
+        }
+        if let queueGeneration = ownership.queueGeneration {
+            return !Task.isCancelled
+                && self.playerService.acceptsQueueMutation(queueGeneration)
+        }
+        return false
     }
 
     func describeQueueLocally(previewLimit: Int = 3) -> Outcome {
@@ -127,7 +252,19 @@ struct CommandExecutor {
             return .result("Your queue is empty.", shouldDismiss: false)
         }
 
-        let safeCurrentIndex = min(max(self.playerService.currentIndex, 0), queue.count - 1)
+        guard let activeIndex = self.playerService.activePlaybackQueueIndex else {
+            let preview = queue.prefix(previewLimit).map { song in
+                let artist = song.artistsDisplay.isEmpty ? "Unknown Artist" : song.artistsDisplay
+                return "\"\(song.title)\" by \(artist)"
+            }.joined(separator: ", ")
+            let remainingCount = max(0, queue.count - min(previewLimit, queue.count))
+            let suffix = remainingCount > 0 ? ", and \(remainingCount) more." : "."
+            return .result(
+                "Your queue has \(queue.count) tracks: \(preview)\(suffix)",
+                shouldDismiss: false
+            )
+        }
+        let safeCurrentIndex = min(max(activeIndex, 0), queue.count - 1)
         let currentTrack = queue[safe: safeCurrentIndex] ?? queue[0]
         let currentArtist = currentTrack.artistsDisplay.isEmpty ? "Unknown Artist" : currentTrack.artistsDisplay
         let intro = if self.playerService.isPlaying {
@@ -161,7 +298,10 @@ struct CommandExecutor {
         return .result(summary, shouldDismiss: false)
     }
 
-    private func executeMusicIntent(_ intent: MusicIntent) async -> Outcome {
+    private func executeMusicIntent(
+        _ intent: MusicIntent,
+        ownership: QueueCommandOwnership
+    ) async -> Outcome {
         let searchQuery = ContentSourceResolver.buildSearchQuery(from: intent)
         let description = ContentSourceResolver.queryDescription(for: intent)
         let contentSource = ContentSourceResolver.suggestedContentSource(for: intent)
@@ -180,12 +320,25 @@ struct CommandExecutor {
                 await self.playerService.resume()
                 return .result("Resuming playback")
             }
-            return await self.playContent(intent: intent, query: searchQuery, description: description, source: contentSource)
+            guard let playbackIntent = ownership.playbackIntent else { return .ignored }
+            return await self.playContent(
+                intent: intent,
+                query: searchQuery,
+                description: description,
+                source: contentSource,
+                playbackIntent: playbackIntent
+            )
 
         case .queue:
             HapticService.success()
             if !searchQuery.isEmpty {
-                return await self.queueContent(intent: intent, query: searchQuery, description: description, source: contentSource)
+                return await self.queueContent(
+                    intent: intent,
+                    query: searchQuery,
+                    description: description,
+                    source: contentSource,
+                    ownership: ownership
+                )
             }
             return .error(String(localized: "Couldn't search for music"))
 
@@ -235,14 +388,25 @@ struct CommandExecutor {
         }
     }
 
-    private func playSearchResult(query: String, description: String = "") async -> Outcome {
+    private func playSearchResult(
+        query: String,
+        description: String = "",
+        playbackIntent: MusicPlaybackIntent
+    ) async -> Outcome {
         do {
             let allSongs = try await self.client.searchSongs(query: query)
+            guard self.commandStillOwnsPlayback(playbackIntent) else { return .ignored }
             let songs = Array(allSongs.prefix(20))
 
             self.logger.info("Songs search returned \(allSongs.count), using top \(songs.count) for query: \(query)")
             if let firstSong = songs.first {
-                await self.playerService.playQueue(songs, startingAt: 0)
+                await self.playerService.playQueue(
+                    songs,
+                    startingAt: 0,
+                    deferringSmartShuffleFill: false,
+                    intent: playbackIntent
+                )
+                guard self.commandStillOwnsPlayback(playbackIntent) else { return .ignored }
                 self.logger.info("Started queue with \(songs.count) songs, first: \(firstSong.title)")
                 if !description.isEmpty {
                     return .result("Playing \(description)")
@@ -251,20 +415,33 @@ struct CommandExecutor {
             }
             return .error("No songs found for \"\(query)\"")
         } catch {
+            guard self.commandStillOwnsPlayback(playbackIntent) else { return .ignored }
             self.logger.error("Search failed: \(error.localizedDescription)")
             return .error(String(localized: "Couldn't search for music"))
         }
     }
 
-    private func queueSearchResult(query: String, description: String = "") async -> Outcome {
+    private func queueSearchResult(
+        query: String,
+        description: String = "",
+        ownership: QueueCommandOwnership
+    ) async -> Outcome {
         do {
             let allSongs = try await self.client.searchSongs(query: query)
+            guard self.commandStillOwnsQueue(ownership) else { return .ignored }
             let songs = Array(allSongs.prefix(10))
 
             self.logger.info("Queue songs search returned \(allSongs.count), using top \(songs.count) for query: \(query)")
             if let firstSong = songs.first {
                 if self.playerService.queue.isEmpty {
-                    await self.playerService.playQueue(songs, startingAt: 0)
+                    guard let playbackIntent = ownership.playbackIntent else { return .ignored }
+                    await self.playerService.playQueue(
+                        songs,
+                        startingAt: 0,
+                        deferringSmartShuffleFill: false,
+                        intent: playbackIntent
+                    )
+                    guard self.commandStillOwnsPlayback(playbackIntent) else { return .ignored }
                     if !description.isEmpty {
                         return .result("Playing \(description)")
                     }
@@ -279,6 +456,7 @@ struct CommandExecutor {
             }
             return .error("No songs found for \"\(query)\"")
         } catch {
+            guard self.commandStillOwnsQueue(ownership) else { return .ignored }
             self.logger.error("Search failed: \(error.localizedDescription)")
             return .error(String(localized: "Couldn't search for music"))
         }
@@ -288,27 +466,54 @@ struct CommandExecutor {
         intent: MusicIntent,
         query: String,
         description: String,
-        source: ContentSource
+        source: ContentSource,
+        playbackIntent: MusicPlaybackIntent
     ) async -> Outcome {
         switch source {
         case .moodsAndGenres:
             if let songs = await self.findSongsFromMoodsAndGenres(intent: intent) {
-                await self.playerService.playQueue(songs, startingAt: 0)
+                guard self.commandStillOwnsPlayback(playbackIntent) else { return .ignored }
+                await self.playerService.playQueue(
+                    songs,
+                    startingAt: 0,
+                    deferringSmartShuffleFill: false,
+                    intent: playbackIntent
+                )
+                guard self.commandStillOwnsPlayback(playbackIntent) else { return .ignored }
                 return .result("Playing \(description.isEmpty ? "curated playlist" : description)")
             }
 
             self.logger.info("No matching Moods & Genres playlist, falling back to search")
-            return await self.playSearchResult(query: query, description: description)
+            return await self.playSearchResult(
+                query: query,
+                description: description,
+                playbackIntent: playbackIntent
+            )
 
         case .charts:
             if let songs = await self.findSongsFromCharts() {
-                await self.playerService.playQueue(songs, startingAt: 0)
+                guard self.commandStillOwnsPlayback(playbackIntent) else { return .ignored }
+                await self.playerService.playQueue(
+                    songs,
+                    startingAt: 0,
+                    deferringSmartShuffleFill: false,
+                    intent: playbackIntent
+                )
+                guard self.commandStillOwnsPlayback(playbackIntent) else { return .ignored }
                 return .result("Playing top songs")
             }
-            return await self.playSearchResult(query: query, description: description)
+            return await self.playSearchResult(
+                query: query,
+                description: description,
+                playbackIntent: playbackIntent
+            )
 
         case .search:
-            return await self.playSearchResult(query: query, description: description)
+            return await self.playSearchResult(
+                query: query,
+                description: description,
+                playbackIntent: playbackIntent
+            )
         }
     }
 
@@ -316,13 +521,22 @@ struct CommandExecutor {
         intent: MusicIntent,
         query: String,
         description: String,
-        source: ContentSource
+        source: ContentSource,
+        ownership: QueueCommandOwnership
     ) async -> Outcome {
         switch source {
         case .moodsAndGenres:
             if let songs = await self.findSongsFromMoodsAndGenres(intent: intent) {
+                guard self.commandStillOwnsQueue(ownership) else { return .ignored }
                 if self.playerService.queue.isEmpty {
-                    await self.playerService.playQueue(songs, startingAt: 0)
+                    guard let playbackIntent = ownership.playbackIntent else { return .ignored }
+                    await self.playerService.playQueue(
+                        songs,
+                        startingAt: 0,
+                        deferringSmartShuffleFill: false,
+                        intent: playbackIntent
+                    )
+                    guard self.commandStillOwnsPlayback(playbackIntent) else { return .ignored }
                     return .result("Playing \(description.isEmpty ? "curated playlist" : description)")
                 }
 
@@ -330,12 +544,24 @@ struct CommandExecutor {
                 return .result("Added \(description.isEmpty ? "curated songs" : description) to queue")
             }
 
-            return await self.queueSearchResult(query: query, description: description)
+            return await self.queueSearchResult(
+                query: query,
+                description: description,
+                ownership: ownership
+            )
 
         case .charts:
             if let songs = await self.findSongsFromCharts() {
+                guard self.commandStillOwnsQueue(ownership) else { return .ignored }
                 if self.playerService.queue.isEmpty {
-                    await self.playerService.playQueue(songs, startingAt: 0)
+                    guard let playbackIntent = ownership.playbackIntent else { return .ignored }
+                    await self.playerService.playQueue(
+                        songs,
+                        startingAt: 0,
+                        deferringSmartShuffleFill: false,
+                        intent: playbackIntent
+                    )
+                    guard self.commandStillOwnsPlayback(playbackIntent) else { return .ignored }
                     return .result("Playing top songs")
                 }
 
@@ -343,10 +569,18 @@ struct CommandExecutor {
                 return .result("Added top songs to queue")
             }
 
-            return await self.queueSearchResult(query: query, description: description)
+            return await self.queueSearchResult(
+                query: query,
+                description: description,
+                ownership: ownership
+            )
 
         case .search:
-            return await self.queueSearchResult(query: query, description: description)
+            return await self.queueSearchResult(
+                query: query,
+                description: description,
+                ownership: ownership
+            )
         }
     }
 
@@ -365,7 +599,9 @@ struct CommandExecutor {
                     }
 
                     let songs = section.items.compactMap { item -> Song? in
-                        if case let .song(song) = item { return song }
+                        if case let .song(song) = item {
+                            return song
+                        }
                         return nil
                     }
                     if !songs.isEmpty {
@@ -394,7 +630,9 @@ struct CommandExecutor {
 
             for section in response.sections {
                 let songs = section.items.compactMap { item -> Song? in
-                    if case let .song(song) = item { return song }
+                    if case let .song(song) = item {
+                        return song
+                    }
                     return nil
                 }
                 if songs.count >= 5 {

--- a/Sources/Kaset/Services/AI/Tools/QueueTool.swift
+++ b/Sources/Kaset/Services/AI/Tools/QueueTool.swift
@@ -42,7 +42,7 @@ struct QueueTool: Tool {
     nonisolated func call(arguments: Arguments) async throws -> String {
         await MainActor.run {
             let queue = self.playerService.queue
-            let currentIndex = self.playerService.currentIndex
+            let currentIndex = self.playerService.activePlaybackQueueIndex
             let limit = arguments.limit > 0 ? arguments.limit : 20
 
             guard !queue.isEmpty else {

--- a/Sources/Kaset/Services/Library/LibraryContentReconciler.swift
+++ b/Sources/Kaset/Services/Library/LibraryContentReconciler.swift
@@ -114,6 +114,16 @@ struct LibraryContentReconciler {
         }
     }
 
+    /// Removes a locally-created playlist without recording a backend removal.
+    /// Used when the account that owned the optimistic creation is no longer active.
+    mutating func discardAddedPlaylist(_ playlistId: String, from snapshot: inout LibraryContentSnapshot) {
+        let playlistKey = LibraryContentIdentity.playlistKey(for: playlistId)
+        self.pendingAddedPlaylists.removeValue(forKey: playlistKey)
+        self.pendingAddedPlaylistMatchCounts.removeValue(forKey: playlistKey)
+        snapshot.playlistIds = LibraryContentIdentity.removingPlaylist(playlistId, from: snapshot.playlistIds)
+        snapshot.playlists.removeAll { LibraryContentIdentity.playlistKey(for: $0.id) == playlistKey }
+    }
+
     mutating func removePlaylistId(_ playlistId: String, from snapshot: inout LibraryContentSnapshot) {
         let playlistKey = LibraryContentIdentity.playlistKey(for: playlistId)
         self.pendingAddedPlaylists.removeValue(forKey: playlistKey)

--- a/Sources/Kaset/Services/Library/LibraryMutationActions.swift
+++ b/Sources/Kaset/Services/Library/LibraryMutationActions.swift
@@ -4,9 +4,20 @@ import Foundation
 /// and eventual-consistency reconciliation after YouTube Music accepts a change.
 @MainActor
 enum LibraryMutationActions {
+    private struct PlaylistDeletionKey: Hashable {
+        let playlistId: String
+        let owner: MusicAccountMutationOwner?
+    }
+
+    private struct PendingPlaylistDeletion {
+        let id: UUID
+        let task: Task<Void, Error>
+    }
+
     static var artistReconciliationRetryDelays: [Duration] = [.seconds(2), .seconds(3)]
 
     private static var artistReconciliationTasks: [String: Task<Void, Never>] = [:]
+    private static var pendingPlaylistDeletions: [PlaylistDeletionKey: PendingPlaylistDeletion] = [:]
 
     /// Adds a song to a playlist.
     static func addSongToPlaylist(
@@ -116,32 +127,67 @@ enum LibraryMutationActions {
     static func deletePlaylist(
         _ playlist: Playlist,
         client: any YTMusicClientProtocol,
-        libraryViewModel: LibraryViewModel?
+        libraryViewModel: LibraryViewModel?,
+        owner: MusicAccountMutationOwner? = nil,
+        whileValid isCurrent: @escaping () -> Bool = { true }
     ) async throws {
-        let pinnedItemsManager = SidebarPinnedItemsManager.shared
-        let removedPins = pinnedItemsManager.removePlaylistPins(matching: playlist.id)
-        LibraryMutationBroadcaster.shared.playlistRemoved(playlistId: playlist.id)
-
-        do {
-            try await client.deletePlaylist(playlistId: playlist.id)
-            self.invalidateResponseCaches()
-            libraryViewModel?.markNeedsReloadOnActivation()
-            DiagnosticsLogger.api.info("Deleted playlist: \(playlist.title)")
-
-            // Library browse responses can lag briefly behind a successful deletion.
-            try? await Task.sleep(for: .milliseconds(500))
-            await LibraryMutationBroadcaster.shared.reconcileRemovedPlaylist(playlistId: playlist.id)
-            self.invalidateResponseCaches()
-        } catch {
-            pinnedItemsManager.restore(removedPins)
-            // Restore the caller's view directly (like the optimistic podcast mutations do) rather
-            // than broadcasting a creation: other Library instances self-heal on their next reload,
-            // and a global playlistCreated here would fabricate the playlist in views that never
-            // saw the optimistic removal.
-            libraryViewModel?.addToLibrary(playlist: playlist)
-            DiagnosticsLogger.api.error("Failed to delete playlist: \(error.localizedDescription)")
-            throw error
+        guard isCurrent() else { throw CancellationError() }
+        let key = PlaylistDeletionKey(
+            playlistId: LibraryContentIdentity.playlistKey(for: playlist.id),
+            owner: owner
+        )
+        if let pendingDeletion = self.pendingPlaylistDeletions[key] {
+            try await pendingDeletion.task.value
+            return
         }
+
+        let operationID = UUID()
+        let removedPins = SidebarPinnedItemsManager.shared.removePlaylistPins(matching: playlist.id)
+        let removalReceipt = LibraryMutationBroadcaster.shared.playlistRemoved(
+            playlistId: playlist.id
+        )
+        let task = Task { @MainActor in
+            var didDeleteRemotely = false
+            do {
+                guard isCurrent() else { throw CancellationError() }
+                try await client.deletePlaylist(playlistId: playlist.id)
+                didDeleteRemotely = true
+                guard isCurrent() else { throw CancellationError() }
+                self.invalidateResponseCaches()
+                libraryViewModel?.markNeedsReloadOnActivation()
+                DiagnosticsLogger.api.info("Deleted playlist: \(playlist.title)")
+
+                // Library browse responses can lag briefly behind a successful deletion.
+                try? await Task.sleep(for: .milliseconds(500))
+                guard isCurrent() else { throw CancellationError() }
+                await LibraryMutationBroadcaster.shared.reconcileRemovedPlaylist(playlistId: playlist.id)
+                self.invalidateResponseCaches()
+            } catch {
+                guard isCurrent() else {
+                    if !didDeleteRemotely {
+                        SidebarPinnedItemsManager.shared.restore(removedPins)
+                    }
+                    throw CancellationError()
+                }
+                SidebarPinnedItemsManager.shared.restore(removedPins)
+                LibraryMutationBroadcaster.shared.rollbackPlaylistRemoval(
+                    playlist,
+                    receipt: removalReceipt
+                )
+                DiagnosticsLogger.api.error("Failed to delete playlist: \(error.localizedDescription)")
+                throw error
+            }
+        }
+        self.pendingPlaylistDeletions[key] = PendingPlaylistDeletion(
+            id: operationID,
+            task: task
+        )
+        defer {
+            if self.pendingPlaylistDeletions[key]?.id == operationID {
+                self.pendingPlaylistDeletions.removeValue(forKey: key)
+            }
+        }
+        try await task.value
     }
 
     /// Subscribes to a podcast show (adds to library).

--- a/Sources/Kaset/Services/Player/AlbumPlaybackActions.swift
+++ b/Sources/Kaset/Services/Player/AlbumPlaybackActions.swift
@@ -4,15 +4,19 @@ import Foundation
 @MainActor
 enum AlbumPlaybackActions {
     /// Adds an album's songs to play next (immediately after current track).
+    @discardableResult
     static func addAlbumToQueueNext(
         _ album: Album,
         client: any YTMusicClientProtocol,
         playerService: PlayerService
-    ) {
-        Task {
+    ) -> Task<Void, Never> {
+        let queueGeneration = playerService.queueLoadGeneration
+        return Task {
             do {
                 let songs = try await self.albumSongs(album, client: client, purpose: .queue)
-                guard !songs.isEmpty else { return }
+                guard !songs.isEmpty,
+                      playerService.isCurrentQueueLoad(queueGeneration)
+                else { return }
                 playerService.insertNextInQueue(songs)
                 DiagnosticsLogger.ui.info("Added album '\(album.title)' (\(songs.count) songs) to play next")
             } catch {
@@ -22,15 +26,19 @@ enum AlbumPlaybackActions {
     }
 
     /// Adds an album's songs to the end of the queue.
+    @discardableResult
     static func addAlbumToQueueLast(
         _ album: Album,
         client: any YTMusicClientProtocol,
         playerService: PlayerService
-    ) {
-        Task {
+    ) -> Task<Void, Never> {
+        let queueGeneration = playerService.queueLoadGeneration
+        return Task {
             do {
                 let songs = try await self.albumSongs(album, client: client, purpose: .queue)
-                guard !songs.isEmpty else { return }
+                guard !songs.isEmpty,
+                      playerService.isCurrentQueueLoad(queueGeneration)
+                else { return }
                 playerService.appendToQueue(songs)
                 DiagnosticsLogger.ui.info("Added album '\(album.title)' (\(songs.count) songs) to end of queue")
             } catch {
@@ -40,21 +48,30 @@ enum AlbumPlaybackActions {
     }
 
     /// Plays an album immediately, replacing the current queue.
+    @discardableResult
+    @MainActor
     static func playAlbum(
         _ album: Album,
         client: any YTMusicClientProtocol,
         playerService: PlayerService
-    ) {
-        Task {
+    ) -> Task<Void, Never> {
+        let intent = playerService.beginMusicPlaybackIntent()
+        return Task { @MainActor in
             do {
                 let response = try await client.getPlaylist(id: album.id)
+                guard playerService.acceptsMusicPlaybackIntent(intent) else { return }
                 let songs = QueueSongMetadata.albumSongs(
                     response.detail.tracks,
                     album: album,
                     purpose: .playback(trackCount: response.detail.tracks.count)
                 )
                 guard !songs.isEmpty else { return }
-                await playerService.playQueue(songs, startingAt: 0)
+                await playerService.playQueue(
+                    songs,
+                    startingAt: 0,
+                    deferringSmartShuffleFill: false,
+                    intent: intent
+                )
                 DiagnosticsLogger.ui.info("Playing album '\(album.title)' (\(songs.count) songs)")
             } catch {
                 DiagnosticsLogger.ui.error("Failed to play album: \(error.localizedDescription)")

--- a/Sources/Kaset/Services/Player/MusicPlaybackIntent.swift
+++ b/Sources/Kaset/Services/Player/MusicPlaybackIntent.swift
@@ -7,13 +7,13 @@ import Foundation
 /// Web document/media generations reject stale bridge traffic. This token is the
 /// complementary native fence: async API work and scheduled corrective actions
 /// may mutate playback only while the user intent that created them is current.
-struct MusicPlaybackIntent: Equatable, Sendable {
+struct MusicPlaybackIntent: Equatable {
     let generation: UInt64
 }
 
 // MARK: - MusicRemoteTransportCommand
 
-enum MusicRemoteTransportCommand: Equatable, Sendable {
+enum MusicRemoteTransportCommand: Equatable {
     case play
     case pause
     case togglePlayPause
@@ -27,7 +27,7 @@ enum MusicRemoteTransportCommand: Equatable, Sendable {
 
 /// A non-mutating snapshot reserved before parsing or API resolution. It can be
 /// claimed exactly while no newer native playback intent has been created.
-struct MusicPlaybackReservation: Equatable, Sendable {
+struct MusicPlaybackReservation: Equatable {
     let playbackGeneration: UInt64
     let reservationGeneration: UInt64
     let queueMutationGeneration: Int
@@ -37,7 +37,7 @@ struct MusicPlaybackReservation: Equatable, Sendable {
 
 // MARK: - MusicQueueMetadataOwner
 
-enum MusicQueueMetadataOwner: Equatable, Sendable {
+enum MusicQueueMetadataOwner: Equatable {
     case active
     case none
     case entry(UUID)
@@ -45,21 +45,21 @@ enum MusicQueueMetadataOwner: Equatable, Sendable {
 
 // MARK: - MusicAccountMutationOwner
 
-struct MusicAccountMutationOwner: Equatable, Sendable {
+struct MusicAccountMutationOwner: Equatable {
     let accountID: String
     let sessionGeneration: UInt64
 }
 
 // MARK: - MusicLibraryConfirmedState
 
-struct MusicLibraryConfirmedState: Equatable, Sendable {
+struct MusicLibraryConfirmedState: Equatable {
     let isInLibrary: Bool
     let feedbackTokens: FeedbackTokens?
 }
 
 // MARK: - MusicPlaybackRestoreClock
 
-struct MusicPlaybackRestoreClock: Equatable, Sendable {
+struct MusicPlaybackRestoreClock: Equatable {
     let progress: TimeInterval
     let duration: TimeInterval
 }

--- a/Sources/Kaset/Services/Player/MusicPlaybackIntent.swift
+++ b/Sources/Kaset/Services/Player/MusicPlaybackIntent.swift
@@ -45,7 +45,7 @@ enum MusicQueueMetadataOwner: Equatable {
 
 // MARK: - MusicAccountMutationOwner
 
-struct MusicAccountMutationOwner: Equatable {
+struct MusicAccountMutationOwner: Hashable {
     let accountID: String
     let sessionGeneration: UInt64
 }
@@ -80,9 +80,19 @@ extension PlayerService {
         allowsPriorTerminalEvent: Bool = false
     ) -> MusicPlaybackIntent {
         self.invalidateRemoteMusicTransportCommands()
+        let previousIntentGeneration = self.musicPlaybackIntentGeneration
         self.musicPlaybackIntentGeneration &+= 1
         self.musicPlaybackReservationGeneration &+= 1
         self.musicPlaybackIntentAcceptsPriorTerminalEvent = allowsPriorTerminalEvent
+        if allowsPriorTerminalEvent {
+            self.musicPlaybackMinimumAcceptedTerminalIntentGeneration = min(
+                self.musicPlaybackMinimumAcceptedTerminalIntentGeneration,
+                previousIntentGeneration
+            )
+        } else {
+            self.musicPlaybackMinimumAcceptedTerminalIntentGeneration =
+                self.musicPlaybackIntentGeneration
+        }
         self.musicPlaybackIntentIssuedAtMilliseconds = if let issuedAtMilliseconds,
                                                           issuedAtMilliseconds.isFinite
         {
@@ -118,12 +128,13 @@ extension PlayerService {
         ) {
             return true
         }
-        guard self.acceptsMusicPlaybackIntent(intent),
-              self.musicPlaybackIntentAcceptsPriorTerminalEvent,
+        guard self.musicPlaybackIntentAcceptsPriorTerminalEvent,
               let eventIssuedAtMilliseconds,
-              eventIssuedAtMilliseconds.isFinite
+              eventIssuedAtMilliseconds.isFinite,
+              eventIssuedAtMilliseconds <= self.musicPlaybackIntentIssuedAtMilliseconds
         else { return false }
-        return eventIssuedAtMilliseconds <= self.musicPlaybackIntentIssuedAtMilliseconds
+        return intent.generation >= self.musicPlaybackMinimumAcceptedTerminalIntentGeneration
+            && intent.generation <= self.musicPlaybackIntentGeneration
     }
 
     func acceptsMusicRemoteCommand(

--- a/Sources/Kaset/Services/Player/MusicPlaybackIntent.swift
+++ b/Sources/Kaset/Services/Player/MusicPlaybackIntent.swift
@@ -1,0 +1,505 @@
+import Foundation
+
+// MARK: - MusicPlaybackIntent
+
+/// Opaque ownership token for one native Music playback intent.
+///
+/// Web document/media generations reject stale bridge traffic. This token is the
+/// complementary native fence: async API work and scheduled corrective actions
+/// may mutate playback only while the user intent that created them is current.
+struct MusicPlaybackIntent: Equatable, Sendable {
+    let generation: UInt64
+}
+
+// MARK: - MusicRemoteTransportCommand
+
+enum MusicRemoteTransportCommand: Equatable, Sendable {
+    case play
+    case pause
+    case togglePlayPause
+    case next
+    case previous
+    case relativeSeek(delta: TimeInterval, admittedAt: ContinuousClock.Instant)
+    case absoluteSeek(position: TimeInterval)
+}
+
+// MARK: - MusicPlaybackReservation
+
+/// A non-mutating snapshot reserved before parsing or API resolution. It can be
+/// claimed exactly while no newer native playback intent has been created.
+struct MusicPlaybackReservation: Equatable, Sendable {
+    let playbackGeneration: UInt64
+    let reservationGeneration: UInt64
+    let queueMutationGeneration: Int
+    let queueEntryID: UUID?
+    let videoID: String?
+}
+
+// MARK: - MusicQueueMetadataOwner
+
+enum MusicQueueMetadataOwner: Equatable, Sendable {
+    case active
+    case none
+    case entry(UUID)
+}
+
+// MARK: - MusicAccountMutationOwner
+
+struct MusicAccountMutationOwner: Equatable, Sendable {
+    let accountID: String
+    let sessionGeneration: UInt64
+}
+
+// MARK: - MusicLibraryConfirmedState
+
+struct MusicLibraryConfirmedState: Equatable, Sendable {
+    let isInLibrary: Bool
+    let feedbackTokens: FeedbackTokens?
+}
+
+// MARK: - MusicPlaybackRestoreClock
+
+struct MusicPlaybackRestoreClock: Equatable, Sendable {
+    let progress: TimeInterval
+    let duration: TimeInterval
+}
+
+@MainActor
+extension PlayerService {
+    var currentMusicPlaybackIntent: MusicPlaybackIntent {
+        MusicPlaybackIntent(generation: self.musicPlaybackIntentGeneration)
+    }
+
+    var playbackRequestGeneration: UInt64 {
+        self.musicPlaybackIntentGeneration
+    }
+
+    @discardableResult
+    func beginMusicPlaybackIntent(
+        issuedAtMilliseconds: Double? = nil,
+        allowsPriorTerminalEvent: Bool = false
+    ) -> MusicPlaybackIntent {
+        self.invalidateRemoteMusicTransportCommands()
+        self.musicPlaybackIntentGeneration &+= 1
+        self.musicPlaybackReservationGeneration &+= 1
+        self.musicPlaybackIntentAcceptsPriorTerminalEvent = allowsPriorTerminalEvent
+        self.musicPlaybackIntentIssuedAtMilliseconds = if let issuedAtMilliseconds,
+                                                          issuedAtMilliseconds.isFinite
+        {
+            issuedAtMilliseconds
+        } else {
+            Date().timeIntervalSince1970 * 1000
+        }
+        return self.currentMusicPlaybackIntent
+    }
+
+    func acceptsMusicPlaybackIntent(_ intent: MusicPlaybackIntent) -> Bool {
+        intent == self.currentMusicPlaybackIntent
+    }
+
+    func acceptsMusicBridgeEvent(
+        intent: MusicPlaybackIntent,
+        eventIssuedAtMilliseconds: Double?
+    ) -> Bool {
+        guard self.acceptsMusicPlaybackIntent(intent),
+              let eventIssuedAtMilliseconds,
+              eventIssuedAtMilliseconds.isFinite
+        else { return false }
+        return eventIssuedAtMilliseconds > self.musicPlaybackIntentIssuedAtMilliseconds
+    }
+
+    func acceptsMusicTerminalBridgeEvent(
+        intent: MusicPlaybackIntent,
+        eventIssuedAtMilliseconds: Double?
+    ) -> Bool {
+        if self.acceptsMusicBridgeEvent(
+            intent: intent,
+            eventIssuedAtMilliseconds: eventIssuedAtMilliseconds
+        ) {
+            return true
+        }
+        guard self.acceptsMusicPlaybackIntent(intent),
+              self.musicPlaybackIntentAcceptsPriorTerminalEvent,
+              let eventIssuedAtMilliseconds,
+              eventIssuedAtMilliseconds.isFinite
+        else { return false }
+        return eventIssuedAtMilliseconds <= self.musicPlaybackIntentIssuedAtMilliseconds
+    }
+
+    func acceptsMusicRemoteCommand(
+        intent: MusicPlaybackIntent,
+        commandIssuedAtMilliseconds: Double?
+    ) -> Bool {
+        guard self.acceptsMusicPlaybackIntent(intent),
+              let commandIssuedAtMilliseconds,
+              commandIssuedAtMilliseconds.isFinite
+        else { return false }
+        if self.remoteMusicTransportIntent == intent {
+            return commandIssuedAtMilliseconds >= self.musicPlaybackIntentIssuedAtMilliseconds
+        }
+        return commandIssuedAtMilliseconds > self.musicPlaybackIntentIssuedAtMilliseconds
+    }
+
+    func enqueueRemoteMusicTransportCommand(
+        _ command: MusicRemoteTransportCommand,
+        issuedAtMilliseconds: Double
+    ) {
+        guard issuedAtMilliseconds.isFinite else { return }
+
+        if let intent = self.remoteMusicTransportIntent,
+           self.acceptsMusicRemoteCommand(
+               intent: intent,
+               commandIssuedAtMilliseconds: issuedAtMilliseconds
+           )
+        {
+            self.musicPlaybackIntentIssuedAtMilliseconds = max(
+                self.musicPlaybackIntentIssuedAtMilliseconds,
+                issuedAtMilliseconds
+            )
+            let pendingCount = self.remoteMusicTransportCommands.count
+                - self.remoteMusicTransportCommandReadIndex
+            guard pendingCount < 64 else { return }
+            self.remoteMusicTransportCommands.append(command)
+            return
+        }
+
+        let currentIntent = self.currentMusicPlaybackIntent
+        guard self.acceptsMusicRemoteCommand(
+            intent: currentIntent,
+            commandIssuedAtMilliseconds: issuedAtMilliseconds
+        ) else { return }
+        let intent = self.beginMusicPlaybackIntent(issuedAtMilliseconds: issuedAtMilliseconds)
+        let batchGeneration = self.remoteMusicTransportBatchGeneration
+        self.remoteMusicTransportIntent = intent
+        self.remoteMusicTransportCommands = [command]
+        self.remoteMusicTransportCommandReadIndex = 0
+        self.remoteMusicTransportTask = Task { @MainActor [weak self] in
+            await self?.drainRemoteMusicTransportCommands(
+                batchGeneration: batchGeneration,
+                intent: intent
+            )
+        }
+    }
+
+    private func drainRemoteMusicTransportCommands(
+        batchGeneration: UInt64,
+        intent: MusicPlaybackIntent
+    ) async {
+        defer {
+            if self.remoteMusicTransportBatchGeneration == batchGeneration {
+                self.remoteMusicTransportCommands.removeAll()
+                self.remoteMusicTransportCommandReadIndex = 0
+                self.remoteMusicTransportIntent = nil
+                self.remoteMusicTransportTask = nil
+            }
+        }
+
+        while !Task.isCancelled,
+              self.remoteMusicTransportBatchGeneration == batchGeneration,
+              self.acceptsMusicPlaybackIntent(intent),
+              self.remoteMusicTransportCommandReadIndex < self.remoteMusicTransportCommands.count
+        {
+            let command = self.remoteMusicTransportCommands[self.remoteMusicTransportCommandReadIndex]
+            self.remoteMusicTransportCommandReadIndex += 1
+            switch command {
+            case .play:
+                self.clearRemoteMusicSkipCoalescingTarget()
+                await self.resume(intent: intent)
+            case .pause:
+                self.clearRemoteMusicSkipCoalescingTarget()
+                await self.pause(intent: intent)
+            case .togglePlayPause:
+                self.clearRemoteMusicSkipCoalescingTarget()
+                await self.playPause(intent: intent)
+            case .next:
+                self.clearRemoteMusicSkipCoalescingTarget()
+                await self.next(intent: intent, defersNetworkFollowUp: true)
+            case .previous:
+                self.clearRemoteMusicSkipCoalescingTarget()
+                await self.previous(intent: intent, defersNetworkFollowUp: true)
+            case let .relativeSeek(delta, admittedAt):
+                await self.applyRemoteMusicRelativeSeek(
+                    delta: delta,
+                    admittedAt: admittedAt,
+                    batchGeneration: batchGeneration,
+                    intent: intent
+                )
+            case let .absoluteSeek(position):
+                self.clearRemoteMusicSkipCoalescingTarget()
+                guard position.isFinite else { continue }
+                await self.seek(to: position, intent: intent)
+            }
+        }
+
+        let completedBatch = !Task.isCancelled
+            && self.remoteMusicTransportBatchGeneration == batchGeneration
+            && self.acceptsMusicPlaybackIntent(intent)
+            && self.remoteMusicTransportCommandReadIndex >= self.remoteMusicTransportCommands.count
+        if completedBatch {
+            self.scheduleRemoteMusicTransportFollowUp()
+        }
+    }
+
+    func clearRemoteMusicSkipCoalescingTarget() {
+        self.remoteMusicSkipTarget = nil
+        self.remoteMusicSkipVideoID = nil
+        self.remoteMusicSkipQueueEntryID = nil
+        self.remoteMusicSkipAdmittedAt = nil
+    }
+
+    func cancelRemoteMusicTransportFollowUp() {
+        self.remoteMusicMetadataFollowUpGeneration &+= 1
+        self.remoteMusicMetadataFollowUpTask?.cancel()
+        self.remoteMusicMetadataFollowUpTask = nil
+        self.remoteMusicQueueFollowUpGeneration &+= 1
+        self.remoteMusicQueueFollowUpTask?.cancel()
+        self.remoteMusicQueueFollowUpTask = nil
+    }
+
+    private func scheduleRemoteMusicTransportFollowUp() {
+        self.scheduleRemoteMusicMetadataFollowUp()
+        self.scheduleRemoteMusicQueueFollowUp()
+    }
+
+    private func scheduleRemoteMusicMetadataFollowUp() {
+        self.remoteMusicMetadataFollowUpGeneration &+= 1
+        let generation = self.remoteMusicMetadataFollowUpGeneration
+        self.remoteMusicMetadataFollowUpTask?.cancel()
+        self.remoteMusicMetadataFollowUpTask = nil
+
+        guard let currentTrack = self.currentTrack else { return }
+        let queueEntryID = self.queueEntryIDOwningCurrentPlayback
+        let queueEntryNeedsMetadata = queueEntryID.flatMap { entryID in
+            self.queueEntries.first(where: { $0.id == entryID })?.song.feedbackTokens == nil
+        } ?? false
+        guard currentTrack.feedbackTokens == nil || queueEntryNeedsMetadata else { return }
+        let videoID = currentTrack.videoId
+
+        self.remoteMusicMetadataFollowUpTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer {
+                if self.remoteMusicMetadataFollowUpGeneration == generation {
+                    self.remoteMusicMetadataFollowUpTask = nil
+                }
+            }
+            guard self.remoteMusicMetadataFollowUpGeneration == generation,
+                  self.queueEntryIDOwningCurrentPlayback == queueEntryID,
+                  self.currentTrack?.videoId == videoID
+            else { return }
+            await self.fetchSongMetadata(
+                videoId: videoID,
+                queueOwner: queueEntryID.map(MusicQueueMetadataOwner.entry) ?? .none
+            )
+        }
+    }
+
+    private func scheduleRemoteMusicQueueFollowUp() {
+        guard self.remoteMusicQueueFollowUpTask == nil else { return }
+        self.remoteMusicQueueFollowUpGeneration &+= 1
+        let generation = self.remoteMusicQueueFollowUpGeneration
+        let queueGeneration = self.queueLoadGeneration
+        self.remoteMusicQueueFollowUpTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer {
+                if self.remoteMusicQueueFollowUpGeneration == generation {
+                    self.remoteMusicQueueFollowUpTask = nil
+                }
+            }
+            guard self.remoteMusicQueueFollowUpGeneration == generation,
+                  self.isCurrentQueueLoad(queueGeneration)
+            else { return }
+            await self.fetchMoreMixSongsIfNeeded(queueGeneration: queueGeneration)
+            guard self.remoteMusicQueueFollowUpGeneration == generation,
+                  self.isCurrentQueueLoad(queueGeneration)
+            else { return }
+            await self.fillSmartShuffleWindow()
+            guard self.remoteMusicQueueFollowUpGeneration == generation,
+                  self.isCurrentQueueLoad(queueGeneration)
+            else { return }
+            self.saveQueueForPersistence()
+        }
+    }
+
+    private func applyRemoteMusicRelativeSeek(
+        delta: TimeInterval,
+        admittedAt: ContinuousClock.Instant,
+        batchGeneration: UInt64,
+        intent: MusicPlaybackIntent
+    ) async {
+        guard delta.isFinite,
+              self.remoteMusicTransportBatchGeneration == batchGeneration,
+              self.acceptsMusicPlaybackIntent(intent)
+        else { return }
+
+        let currentVideoID = self.currentTrack?.videoId ?? self.pendingPlayVideoId
+        let currentQueueEntryID = self.queueEntryIDOwningCurrentPlayback
+        let playbackSnapshot = await self.currentMusicPlaybackSnapshot()
+        guard self.remoteMusicTransportBatchGeneration == batchGeneration,
+              self.acceptsMusicPlaybackIntent(intent)
+        else { return }
+        guard self.queueEntryIDOwningCurrentPlayback == currentQueueEntryID,
+              (self.currentTrack?.videoId ?? self.pendingPlayVideoId) == currentVideoID,
+              let playbackSnapshot,
+              self.remoteMusicPlaybackSnapshot(playbackSnapshot, matches: currentVideoID)
+        else {
+            self.clearRemoteMusicSkipCoalescingTarget()
+            return
+        }
+
+        let canCoalesce = self.remoteMusicSkipVideoID == currentVideoID
+            && self.remoteMusicSkipQueueEntryID == currentQueueEntryID
+            && self.remoteMusicSkipAdmittedAt.map {
+                admittedAt >= $0 && admittedAt - $0 <= .seconds(1)
+            } == true
+        let baseProgress = if canCoalesce, let remoteMusicSkipTarget = self.remoteMusicSkipTarget {
+            remoteMusicSkipTarget
+        } else {
+            playbackSnapshot.progress
+        }
+        let rawTarget = baseProgress + delta
+        let target = if playbackSnapshot.duration > 0 {
+            min(max(0, rawTarget), playbackSnapshot.duration)
+        } else {
+            max(0, rawTarget)
+        }
+
+        self.remoteMusicSkipTarget = target
+        self.remoteMusicSkipVideoID = currentVideoID
+        self.remoteMusicSkipQueueEntryID = currentQueueEntryID
+        self.remoteMusicSkipAdmittedAt = admittedAt
+        self.progress = target
+        await self.seek(to: target, intent: intent)
+    }
+
+    private func remoteMusicPlaybackSnapshot(
+        _ snapshot: SingletonPlayerWebView.PlaybackSnapshot,
+        matches currentVideoID: String?
+    ) -> Bool {
+        guard let snapshotVideoID = snapshot.videoId, let currentVideoID else { return true }
+        return snapshotVideoID == currentVideoID
+    }
+
+    private func invalidateRemoteMusicTransportCommands() {
+        self.remoteMusicTransportBatchGeneration &+= 1
+        self.remoteMusicTransportTask?.cancel()
+        self.remoteMusicTransportTask = nil
+        self.remoteMusicTransportCommands.removeAll()
+        self.remoteMusicTransportCommandReadIndex = 0
+        self.remoteMusicTransportIntent = nil
+    }
+
+    func reserveMusicPlaybackIntent() -> MusicPlaybackReservation {
+        self.musicPlaybackReservationGeneration &+= 1
+        return MusicPlaybackReservation(
+            playbackGeneration: self.musicPlaybackIntentGeneration,
+            reservationGeneration: self.musicPlaybackReservationGeneration,
+            queueMutationGeneration: self.reserveQueueMutation(),
+            queueEntryID: self.queueEntryIDOwningCurrentPlayback,
+            videoID: self.currentTrack?.videoId ?? self.pendingPlayVideoId
+        )
+    }
+
+    func acceptsMusicPlaybackReservation(_ reservation: MusicPlaybackReservation) -> Bool {
+        reservation.playbackGeneration == self.musicPlaybackIntentGeneration
+            && reservation.reservationGeneration == self.musicPlaybackReservationGeneration
+            && reservation.queueEntryID == self.queueEntryIDOwningCurrentPlayback
+            && reservation.videoID == (self.currentTrack?.videoId ?? self.pendingPlayVideoId)
+    }
+
+    func claimMusicPlaybackIntent(_ reservation: MusicPlaybackReservation) -> MusicPlaybackIntent? {
+        guard reservation.playbackGeneration == self.musicPlaybackIntentGeneration,
+              reservation.reservationGeneration == self.musicPlaybackReservationGeneration
+        else { return nil }
+        return self.beginMusicPlaybackIntent()
+    }
+
+    func claimMusicPlaybackIntent(
+        _ reservation: MusicPlaybackReservation,
+        queueEntryID: UUID
+    ) -> MusicPlaybackIntent? {
+        guard self.queueEntries.contains(where: { $0.id == queueEntryID }) else { return nil }
+        return self.claimMusicPlaybackIntent(reservation)
+    }
+
+    func currentQueueEntryID(matching song: Song) -> UUID? {
+        guard let entry = self.queueEntries[safe: self.currentIndex],
+              entry.song.id == song.id,
+              entry.song.videoId == song.videoId
+        else { return nil }
+        return entry.id
+    }
+
+    var queueEntryIDOwningCurrentPlayback: UUID? {
+        guard let currentTrack = self.currentTrack,
+              let activePlaybackQueueEntryID,
+              let entry = self.queueEntries.first(where: { $0.id == activePlaybackQueueEntryID }),
+              entry.song.videoId == currentTrack.videoId
+        else { return nil }
+        return entry.id
+    }
+
+    var activePlaybackQueueIndex: Int? {
+        guard let entryID = self.queueEntryIDOwningCurrentPlayback else { return nil }
+        return self.queueEntries.firstIndex(where: { $0.id == entryID })
+    }
+
+    var activePlaybackOwnsCurrentQueueEntry: Bool {
+        self.activePlaybackQueueEntryID != nil
+            && self.activePlaybackQueueEntryID == self.currentQueueEntryID
+    }
+
+    var shouldUseNativeQueueForTrackNavigation: Bool {
+        self.activePlaybackOwnsCurrentQueueEntry
+            || (
+                self.currentTrack == nil
+                    && self.pendingPlayVideoId == nil
+                    && self.currentEpisode == nil
+            )
+    }
+
+    func invalidateMixContinuationRequest() {
+        self.activeMixContinuationRequestID = nil
+        self.isFetchingMoreMixSongs = false
+        let waiters = self.mixContinuationWaiters
+        self.mixContinuationWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
+
+    func waitForActiveMixContinuationRequest() async {
+        guard self.isFetchingMoreMixSongs else { return }
+        await withCheckedContinuation { continuation in
+            self.mixContinuationWaiters.append(continuation)
+        }
+    }
+
+    func finishMixContinuationRequest(_ requestID: UUID) {
+        guard self.activeMixContinuationRequestID == requestID else { return }
+        self.activeMixContinuationRequestID = nil
+        self.isFetchingMoreMixSongs = false
+        let waiters = self.mixContinuationWaiters
+        self.mixContinuationWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
+
+    func scheduleMusicPlaybackIntentTask(
+        expectedQueueEntryID: UUID? = nil,
+        operation: @escaping @MainActor (PlayerService, MusicPlaybackIntent) async -> Void
+    ) {
+        let intent = self.currentMusicPlaybackIntent
+        Task { @MainActor [weak self] in
+            guard let self,
+                  self.acceptsMusicPlaybackIntent(intent)
+            else { return }
+            if let expectedQueueEntryID,
+               self.currentQueueEntryID != expectedQueueEntryID
+            {
+                return
+            }
+            await operation(self, intent)
+        }
+    }
+}

--- a/Sources/Kaset/Services/Player/MusicPlaybackOccurrence.swift
+++ b/Sources/Kaset/Services/Player/MusicPlaybackOccurrence.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+// MARK: - MusicPlaybackOccurrence
+
+/// Identifies one playback of one Music media element.
+///
+/// Web occurrences are scoped to a committed document generation. Native
+/// occurrences cover the interval before the observer binds a Web occurrence,
+/// including deterministic unit-test playback.
+struct MusicPlaybackOccurrence: Hashable, Sendable {
+    let documentGeneration: UInt64?
+    let mediaGeneration: UInt64
+    let nativeGeneration: UInt64
+    let videoId: String?
+
+    static func web(
+        documentGeneration: UInt64,
+        mediaGeneration: UInt64,
+        nativeGeneration: UInt64 = 0,
+        videoId: String? = nil
+    ) -> Self {
+        Self(
+            documentGeneration: documentGeneration,
+            mediaGeneration: mediaGeneration,
+            nativeGeneration: nativeGeneration,
+            videoId: videoId
+        )
+    }
+
+    static func native(generation: UInt64, videoId: String? = nil) -> Self {
+        Self(
+            documentGeneration: nil,
+            mediaGeneration: generation,
+            nativeGeneration: generation,
+            videoId: videoId
+        )
+    }
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.documentGeneration == rhs.documentGeneration
+            && lhs.mediaGeneration == rhs.mediaGeneration
+            && lhs.nativeGeneration == rhs.nativeGeneration
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(self.documentGeneration)
+        hasher.combine(self.mediaGeneration)
+        hasher.combine(self.nativeGeneration)
+    }
+}

--- a/Sources/Kaset/Services/Player/MusicPlaybackOccurrence.swift
+++ b/Sources/Kaset/Services/Player/MusicPlaybackOccurrence.swift
@@ -7,7 +7,7 @@ import Foundation
 /// Web occurrences are scoped to a committed document generation. Native
 /// occurrences cover the interval before the observer binds a Web occurrence,
 /// including deterministic unit-test playback.
-struct MusicPlaybackOccurrence: Hashable, Sendable {
+struct MusicPlaybackOccurrence: Hashable {
     let documentGeneration: UInt64?
     let mediaGeneration: UInt64
     let nativeGeneration: UInt64

--- a/Sources/Kaset/Services/Player/NowPlayingManager.swift
+++ b/Sources/Kaset/Services/Player/NowPlayingManager.swift
@@ -6,14 +6,14 @@ import os
 
 // MARK: - RemoteMusicCommandDirection
 
-enum RemoteMusicCommandDirection: Equatable, Sendable {
+enum RemoteMusicCommandDirection: Equatable {
     case forward
     case backward
 }
 
 // MARK: - RemoteMusicCommandPayload
 
-enum RemoteMusicCommandPayload: Equatable, Sendable {
+enum RemoteMusicCommandPayload: Equatable {
     case play
     case pause
     case togglePlayPause
@@ -24,7 +24,7 @@ enum RemoteMusicCommandPayload: Equatable, Sendable {
 
 // MARK: - CapturedRemoteMusicCommand
 
-struct CapturedRemoteMusicCommand: Equatable, Sendable {
+struct CapturedRemoteMusicCommand: Equatable {
     let sequence: UInt64
     let issuedAtMilliseconds: Double
     let admittedAt: ContinuousClock.Instant

--- a/Sources/Kaset/Services/Player/NowPlayingManager.swift
+++ b/Sources/Kaset/Services/Player/NowPlayingManager.swift
@@ -4,6 +4,115 @@ import MediaPlayer
 import Observation
 import os
 
+// MARK: - RemoteMusicCommandDirection
+
+enum RemoteMusicCommandDirection: Equatable, Sendable {
+    case forward
+    case backward
+}
+
+// MARK: - RemoteMusicCommandPayload
+
+enum RemoteMusicCommandPayload: Equatable, Sendable {
+    case play
+    case pause
+    case togglePlayPause
+    case nextPrevious(direction: RemoteMusicCommandDirection)
+    case skip(interval: TimeInterval, direction: RemoteMusicCommandDirection)
+    case absoluteSeek(position: TimeInterval)
+}
+
+// MARK: - CapturedRemoteMusicCommand
+
+struct CapturedRemoteMusicCommand: Equatable, Sendable {
+    let sequence: UInt64
+    let issuedAtMilliseconds: Double
+    let admittedAt: ContinuousClock.Instant
+    let payload: RemoteMusicCommandPayload
+}
+
+// MARK: - RemoteMusicCommandIngress
+
+/// Thread-safe callback inbox for native media commands. Callback order and clocks
+/// are captured synchronously before any MainActor scheduling can reorder delivery.
+final class RemoteMusicCommandIngress: @unchecked Sendable {
+    private struct State {
+        var nextSequence: UInt64 = 0
+        var pendingCommands: [CapturedRemoteMusicCommand] = []
+        var isDrainScheduled = false
+    }
+
+    private let lock = NSLock()
+    private var state = State()
+
+    /// Returns `true` only when the caller must schedule the single MainActor drain.
+    @discardableResult
+    func capture(_ payload: RemoteMusicCommandPayload) -> Bool {
+        self.lock.withLock {
+            self.captureLocked(
+                payload,
+                issuedAtMilliseconds: Date().timeIntervalSince1970 * 1000,
+                admittedAt: ContinuousClock.now
+            )
+        }
+    }
+
+    /// Deterministic clock injection for ingress ordering and stale-admission tests.
+    @discardableResult
+    func capture(
+        _ payload: RemoteMusicCommandPayload,
+        issuedAtMilliseconds: Double,
+        admittedAt: ContinuousClock.Instant
+    ) -> Bool {
+        self.lock.withLock {
+            self.captureLocked(
+                payload,
+                issuedAtMilliseconds: issuedAtMilliseconds,
+                admittedAt: admittedAt
+            )
+        }
+    }
+
+    func takePendingCommands() -> [CapturedRemoteMusicCommand] {
+        self.lock.withLock {
+            let commands = self.state.pendingCommands
+            self.state.pendingCommands.removeAll(keepingCapacity: true)
+            return commands
+        }
+    }
+
+    /// Returns `true` when callbacks arrived during the last batch and the existing
+    /// drain must loop. Otherwise, it atomically rearms scheduling for the next callback.
+    func finishDrainBatch() -> Bool {
+        self.lock.withLock {
+            guard self.state.pendingCommands.isEmpty else { return true }
+            self.state.isDrainScheduled = false
+            return false
+        }
+    }
+
+    private func captureLocked(
+        _ payload: RemoteMusicCommandPayload,
+        issuedAtMilliseconds: Double,
+        admittedAt: ContinuousClock.Instant
+    ) -> Bool {
+        let command = CapturedRemoteMusicCommand(
+            sequence: self.state.nextSequence,
+            issuedAtMilliseconds: issuedAtMilliseconds,
+            admittedAt: admittedAt,
+            payload: payload
+        )
+        self.state.nextSequence &+= 1
+        self.state.pendingCommands.append(command)
+
+        guard !self.state.isDrainScheduled else { return false }
+        self.state.isDrainScheduled = true
+        return true
+    }
+}
+
+// MARK: - NowPlayingManager
+
 /// Manages remote command center integration for media key support.
 /// Note: Now Playing info display is handled natively by WKWebView's media session.
 /// This class only sets up remote command handlers to route media keys to our PlayerService.
@@ -24,11 +133,8 @@ final class NowPlayingManager {
     private weak var youtubePlayerService: YouTubePlayerService?
     private weak var playbackArbiter: PlaybackArbiter?
     private let settings = SettingsManager.shared
+    private let remoteMusicCommandIngress = RemoteMusicCommandIngress()
     private static let defaultSkipInterval: TimeInterval = 15
-    private static let skipTargetCoalescingWindow: Duration = .seconds(1)
-    private var lastSkipTarget: TimeInterval?
-    private var lastSkipVideoId: String?
-    private var lastSkipIssuedAt: ContinuousClock.Instant?
 
     private init() {}
 
@@ -100,8 +206,16 @@ final class NowPlayingManager {
     // MARK: - Remote Commands
 
     private func setupRemoteCommands() {
-        guard let player = playerService else { return }
+        guard self.playerService != nil else { return }
         let commandCenter = MPRemoteCommandCenter.shared()
+        let ingress = self.remoteMusicCommandIngress
+        let captureCommand: @Sendable (RemoteMusicCommandPayload) -> Void = { [weak self] payload in
+            guard ingress.capture(payload) else { return }
+            Task { @MainActor [weak self] in
+                self?.drainRemoteMusicCommandIngress()
+            }
+        }
+
         // Remove any existing targets to prevent duplicates
         commandCenter.playCommand.removeTarget(nil)
         commandCenter.pauseCommand.removeTarget(nil)
@@ -114,202 +228,196 @@ final class NowPlayingManager {
 
         // Play command
         commandCenter.playCommand.isEnabled = true
-        commandCenter.playCommand.addTarget { [weak self] _ in
-            Task { @MainActor in
-                if let self, self.routesToYouTubeVideo, let youtube = self.youtubePlayerService {
-                    youtube.resume()
-                } else {
-                    await player.resume()
-                }
-            }
+        commandCenter.playCommand.addTarget { _ in
+            captureCommand(.play)
             return .success
         }
 
         // Pause command
         commandCenter.pauseCommand.isEnabled = true
-        commandCenter.pauseCommand.addTarget { [weak self] _ in
-            Task { @MainActor in
-                if let self, self.routesToYouTubeVideo, let youtube = self.youtubePlayerService {
-                    youtube.pause()
-                } else {
-                    await player.pause()
-                }
-            }
+        commandCenter.pauseCommand.addTarget { _ in
+            captureCommand(.pause)
             return .success
         }
 
         // Toggle play/pause command
         commandCenter.togglePlayPauseCommand.isEnabled = true
-        commandCenter.togglePlayPauseCommand.addTarget { [weak self] _ in
-            Task { @MainActor in
-                if let self, self.routesToYouTubeVideo, let youtube = self.youtubePlayerService {
-                    youtube.playPause()
-                } else {
-                    await player.playPause()
-                }
-            }
+        commandCenter.togglePlayPauseCommand.addTarget { _ in
+            captureCommand(.togglePlayPause)
             return .success
         }
 
         // Next track command
         commandCenter.nextTrackCommand.isEnabled = true
-        commandCenter.nextTrackCommand.addTarget { [weak self] _ in
-            guard let self else { return .commandFailed }
-            Task { @MainActor in
-                await self.handleNextPreviousMediaKey(direction: .forward, player: player)
-            }
+        commandCenter.nextTrackCommand.addTarget { _ in
+            captureCommand(.nextPrevious(direction: .forward))
             return .success
         }
 
         // Previous track command
         commandCenter.previousTrackCommand.isEnabled = true
-        commandCenter.previousTrackCommand.addTarget { [weak self] _ in
-            guard let self else { return .commandFailed }
-            Task { @MainActor in
-                await self.handleNextPreviousMediaKey(direction: .backward, player: player)
-            }
+        commandCenter.previousTrackCommand.addTarget { _ in
+            captureCommand(.nextPrevious(direction: .backward))
             return .success
         }
 
         // Skip forward command (Control Center skip buttons or media keys)
         commandCenter.skipForwardCommand.isEnabled = self.settings.mediaControlStyle == .skipForwardBackward
         commandCenter.skipForwardCommand.preferredIntervals = [NSNumber(value: Self.defaultSkipInterval)]
-        commandCenter.skipForwardCommand.addTarget { [weak self] event in
-            guard let self else { return .commandFailed }
+        commandCenter.skipForwardCommand.addTarget { event in
             let interval = (event as? MPSkipIntervalCommandEvent)?.interval ?? Self.defaultSkipInterval
-            Task { @MainActor in
-                await self.handleSkipCommand(interval: interval, direction: .forward, player: player)
-            }
+            captureCommand(.skip(interval: interval, direction: .forward))
             return .success
         }
 
         // Skip backward command (Control Center skip buttons or media keys)
         commandCenter.skipBackwardCommand.isEnabled = self.settings.mediaControlStyle == .skipForwardBackward
         commandCenter.skipBackwardCommand.preferredIntervals = [NSNumber(value: Self.defaultSkipInterval)]
-        commandCenter.skipBackwardCommand.addTarget { [weak self] event in
-            guard let self else { return .commandFailed }
+        commandCenter.skipBackwardCommand.addTarget { event in
             let interval = (event as? MPSkipIntervalCommandEvent)?.interval ?? Self.defaultSkipInterval
-            Task { @MainActor in
-                await self.handleSkipCommand(interval: interval, direction: .backward, player: player)
-            }
+            captureCommand(.skip(interval: interval, direction: .backward))
             return .success
         }
 
         // Change playback position command
         commandCenter.changePlaybackPositionCommand.isEnabled = true
-        commandCenter.changePlaybackPositionCommand.addTarget { [weak self] event in
-            guard let self else { return .commandFailed }
+        commandCenter.changePlaybackPositionCommand.addTarget { event in
             guard let positionEvent = event as? MPChangePlaybackPositionCommandEvent else {
                 return .commandFailed
             }
-            let position = positionEvent.positionTime
-            Task { @MainActor in
-                self.clearSkipCoalescingTarget()
-                await player.seek(to: position)
-            }
+            captureCommand(.absoluteSeek(position: positionEvent.positionTime))
             return .success
         }
 
         self.logger.info("Remote commands configured")
     }
 
-    private enum SkipDirection {
-        case forward
-        case backward
+    private func drainRemoteMusicCommandIngress() {
+        while true {
+            let commands = self.remoteMusicCommandIngress.takePendingCommands()
+            if let player = self.playerService {
+                for command in commands {
+                    self.handleCapturedRemoteMusicCommand(command, player: player)
+                }
+            }
+            guard self.remoteMusicCommandIngress.finishDrainBatch() else { return }
+        }
     }
 
-    private func handleNextPreviousMediaKey(direction: SkipDirection, player: PlayerService) async {
+    private func handleCapturedRemoteMusicCommand(
+        _ capturedCommand: CapturedRemoteMusicCommand,
+        player: PlayerService
+    ) {
+        switch capturedCommand.payload {
+        case .play:
+            if self.routesToYouTubeVideo, let youtube = self.youtubePlayerService {
+                youtube.resume()
+            } else {
+                self.enqueueMusicRemoteCommand(.play, capturedCommand: capturedCommand, player: player)
+            }
+        case .pause:
+            if self.routesToYouTubeVideo, let youtube = self.youtubePlayerService {
+                youtube.pause()
+            } else {
+                self.enqueueMusicRemoteCommand(.pause, capturedCommand: capturedCommand, player: player)
+            }
+        case .togglePlayPause:
+            if self.routesToYouTubeVideo, let youtube = self.youtubePlayerService {
+                youtube.playPause()
+            } else {
+                self.enqueueMusicRemoteCommand(.togglePlayPause, capturedCommand: capturedCommand, player: player)
+            }
+        case let .nextPrevious(direction):
+            self.handleNextPreviousMediaKey(
+                direction: direction,
+                capturedCommand: capturedCommand,
+                player: player
+            )
+        case let .skip(interval, direction):
+            self.handleSkipCommand(
+                interval: interval,
+                direction: direction,
+                capturedCommand: capturedCommand,
+                player: player
+            )
+        case let .absoluteSeek(position):
+            guard position.isFinite else { return }
+            self.enqueueMusicRemoteCommand(
+                .absoluteSeek(position: position),
+                capturedCommand: capturedCommand,
+                player: player
+            )
+        }
+    }
+
+    private func handleNextPreviousMediaKey(
+        direction: RemoteMusicCommandDirection,
+        capturedCommand: CapturedRemoteMusicCommand,
+        player: PlayerService
+    ) {
         if self.settings.mediaControlStyle == .skipForwardBackward {
-            await self.handleSkipCommand(interval: Self.defaultSkipInterval, direction: direction, player: player)
+            self.handleSkipCommand(
+                interval: Self.defaultSkipInterval,
+                direction: direction,
+                capturedCommand: capturedCommand,
+                player: player
+            )
         } else {
-            await self.handleTrackNavigation(direction: direction, player: player)
+            self.handleTrackNavigation(
+                direction: direction,
+                capturedCommand: capturedCommand,
+                player: player
+            )
         }
     }
 
     private func handleSkipCommand(
         interval: TimeInterval,
-        direction: SkipDirection,
+        direction: RemoteMusicCommandDirection,
+        capturedCommand: CapturedRemoteMusicCommand,
         player: PlayerService
-    ) async {
-        guard player.currentTrack != nil || player.pendingPlayVideoId != nil || !player.queue.isEmpty else {
-            return
-        }
+    ) {
+        guard interval.isFinite,
+              player.currentTrack != nil || player.pendingPlayVideoId != nil || !player.queue.isEmpty
+        else { return }
 
         if self.settings.mediaControlStyle == .nextPreviousTrack {
-            await self.handleTrackNavigation(direction: direction, player: player)
+            self.handleTrackNavigation(
+                direction: direction,
+                capturedCommand: capturedCommand,
+                player: player
+            )
             return
         }
 
-        let now = ContinuousClock.now
-        let currentVideoId = player.currentTrack?.videoId ?? player.pendingPlayVideoId
-        if let currentVideoId {
-            if self.lastSkipVideoId != currentVideoId {
-                self.clearSkipCoalescingTarget()
-            }
-            self.lastSkipVideoId = currentVideoId
-        }
-
-        guard let playbackSnapshot = await SingletonPlayerWebView.shared.currentPlaybackSnapshot(),
-              self.playbackSnapshot(playbackSnapshot, matches: currentVideoId)
-        else {
-            self.clearSkipCoalescingTarget()
-            return
-        }
-
-        let reportedProgress = playbackSnapshot.progress
-        let reportedDuration = playbackSnapshot.duration
-
-        // WebView progress can lag behind rapid media-key repeats. Briefly use the cached
-        // target so repeated or reversed skips accumulate before stale observer updates land.
-        let baseProgress = if self.canCoalesceSkipTarget(at: now), let lastSkipTarget = self.lastSkipTarget {
-            lastSkipTarget
-        } else {
-            reportedProgress
-        }
-
-        let rawTarget = switch direction {
-        case .forward:
-            baseProgress + interval
-        case .backward:
-            baseProgress - interval
-        }
-        let target = if reportedDuration > 0 {
-            min(max(0, rawTarget), reportedDuration)
-        } else {
-            max(0, rawTarget)
-        }
-
-        self.lastSkipTarget = target
-        self.lastSkipIssuedAt = now
-        player.progress = target
-        await player.seek(to: target)
+        let delta = direction == .forward ? interval : -interval
+        self.enqueueMusicRemoteCommand(
+            .relativeSeek(delta: delta, admittedAt: capturedCommand.admittedAt),
+            capturedCommand: capturedCommand,
+            player: player
+        )
     }
 
-    private func playbackSnapshot(
-        _ snapshot: SingletonPlayerWebView.PlaybackSnapshot?,
-        matches currentVideoId: String?
-    ) -> Bool {
-        guard let snapshotVideoId = snapshot?.videoId, let currentVideoId else { return true }
-        return snapshotVideoId == currentVideoId
+    private func handleTrackNavigation(
+        direction: RemoteMusicCommandDirection,
+        capturedCommand: CapturedRemoteMusicCommand,
+        player: PlayerService
+    ) {
+        self.enqueueMusicRemoteCommand(
+            direction == .forward ? .next : .previous,
+            capturedCommand: capturedCommand,
+            player: player
+        )
     }
 
-    private func handleTrackNavigation(direction: SkipDirection, player: PlayerService) async {
-        self.clearSkipCoalescingTarget()
-        switch direction {
-        case .forward:
-            await player.next()
-        case .backward:
-            await player.previous()
-        }
-    }
-
-    private func canCoalesceSkipTarget(at now: ContinuousClock.Instant) -> Bool {
-        guard let lastSkipIssuedAt = self.lastSkipIssuedAt else { return false }
-        return now - lastSkipIssuedAt <= Self.skipTargetCoalescingWindow
-    }
-
-    private func clearSkipCoalescingTarget() {
-        self.lastSkipTarget = nil
-        self.lastSkipIssuedAt = nil
+    private func enqueueMusicRemoteCommand(
+        _ command: MusicRemoteTransportCommand,
+        capturedCommand: CapturedRemoteMusicCommand,
+        player: PlayerService
+    ) {
+        player.enqueueRemoteMusicTransportCommand(
+            command,
+            issuedAtMilliseconds: capturedCommand.issuedAtMilliseconds
+        )
     }
 }

--- a/Sources/Kaset/Services/Player/NowPlayingManager.swift
+++ b/Sources/Kaset/Services/Player/NowPlayingManager.swift
@@ -318,19 +318,25 @@ final class NowPlayingManager {
         switch capturedCommand.payload {
         case .play:
             if self.routesToYouTubeVideo, let youtube = self.youtubePlayerService {
-                youtube.resume()
+                youtube.handleRemoteResume(
+                    issuedAtMilliseconds: capturedCommand.issuedAtMilliseconds
+                )
             } else {
                 self.enqueueMusicRemoteCommand(.play, capturedCommand: capturedCommand, player: player)
             }
         case .pause:
             if self.routesToYouTubeVideo, let youtube = self.youtubePlayerService {
-                youtube.pause()
+                youtube.handleRemotePause(
+                    issuedAtMilliseconds: capturedCommand.issuedAtMilliseconds
+                )
             } else {
                 self.enqueueMusicRemoteCommand(.pause, capturedCommand: capturedCommand, player: player)
             }
         case .togglePlayPause:
             if self.routesToYouTubeVideo, let youtube = self.youtubePlayerService {
-                youtube.playPause()
+                youtube.handleRemoteTogglePlayPause(
+                    issuedAtMilliseconds: capturedCommand.issuedAtMilliseconds
+                )
             } else {
                 self.enqueueMusicRemoteCommand(.togglePlayPause, capturedCommand: capturedCommand, player: player)
             }
@@ -341,6 +347,15 @@ final class NowPlayingManager {
                 player: player
             )
         case let .skip(interval, direction):
+            if self.routesToYouTubeVideo, let youtube = self.youtubePlayerService {
+                guard interval.isFinite else { return }
+                let delta = direction == .forward ? interval : -interval
+                youtube.handleRemoteSeek(
+                    to: max(0, youtube.progress + delta),
+                    issuedAtMilliseconds: capturedCommand.issuedAtMilliseconds
+                )
+                return
+            }
             self.handleSkipCommand(
                 interval: interval,
                 direction: direction,
@@ -353,7 +368,10 @@ final class NowPlayingManager {
                 routesToYouTubeVideo: self.routesToYouTubeVideo,
                 hasYouTubePlayer: self.youtubePlayerService != nil
             ), let youtube = self.youtubePlayerService {
-                youtube.seek(to: position)
+                youtube.handleRemoteSeek(
+                    to: position,
+                    issuedAtMilliseconds: capturedCommand.issuedAtMilliseconds
+                )
             } else {
                 self.enqueueMusicRemoteCommand(
                     .absoluteSeek(position: position),
@@ -369,6 +387,27 @@ final class NowPlayingManager {
         capturedCommand: CapturedRemoteMusicCommand,
         player: PlayerService
     ) {
+        if self.routesToYouTubeVideo, let youtube = self.youtubePlayerService {
+            if self.settings.mediaControlStyle == .skipForwardBackward {
+                let delta = direction == .forward ? Self.defaultSkipInterval : -Self.defaultSkipInterval
+                youtube.handleRemoteSeek(
+                    to: max(0, youtube.progress + delta),
+                    issuedAtMilliseconds: capturedCommand.issuedAtMilliseconds
+                )
+            } else if direction == .forward {
+                Task { @MainActor in
+                    await youtube.handleRemoteSkipForward(
+                        issuedAtMilliseconds: capturedCommand.issuedAtMilliseconds
+                    )
+                }
+            } else {
+                youtube.handleRemoteSkipBackward(
+                    issuedAtMilliseconds: capturedCommand.issuedAtMilliseconds
+                )
+            }
+            return
+        }
+
         if self.settings.mediaControlStyle == .skipForwardBackward {
             self.handleSkipCommand(
                 interval: Self.defaultSkipInterval,

--- a/Sources/Kaset/Services/Player/NowPlayingManager.swift
+++ b/Sources/Kaset/Services/Player/NowPlayingManager.swift
@@ -171,6 +171,13 @@ final class NowPlayingManager {
         self.playbackArbiter?.routesMediaKeysToVideo == true
     }
 
+    nonisolated static func routesAbsoluteSeekToVideo(
+        routesToYouTubeVideo: Bool,
+        hasYouTubePlayer: Bool
+    ) -> Bool {
+        routesToYouTubeVideo && hasYouTubePlayer
+    }
+
     private func observeSettingsChanges() {
         withObservationTracking {
             _ = self.settings.mediaControlStyle
@@ -342,11 +349,18 @@ final class NowPlayingManager {
             )
         case let .absoluteSeek(position):
             guard position.isFinite else { return }
-            self.enqueueMusicRemoteCommand(
-                .absoluteSeek(position: position),
-                capturedCommand: capturedCommand,
-                player: player
-            )
+            if Self.routesAbsoluteSeekToVideo(
+                routesToYouTubeVideo: self.routesToYouTubeVideo,
+                hasYouTubePlayer: self.youtubePlayerService != nil
+            ), let youtube = self.youtubePlayerService {
+                youtube.seek(to: position)
+            } else {
+                self.enqueueMusicRemoteCommand(
+                    .absoluteSeek(position: position),
+                    capturedCommand: capturedCommand,
+                    player: player
+                )
+            }
         }
     }
 

--- a/Sources/Kaset/Services/Player/PlaybackArbiter.swift
+++ b/Sources/Kaset/Services/Player/PlaybackArbiter.swift
@@ -32,11 +32,16 @@ final class PlaybackArbiter {
     /// Video playback is about to start — pause music.
     func videoWillStartPlaying() {
         self.activeSource = .video
+        let intent = self.playerService.beginMusicPlaybackIntent()
 
-        guard self.playerService.isPlaying else { return }
+        let hasActiveOrPendingMusic = self.playerService.isPlaying
+            || self.playerService.state == .loading
+            || self.playerService.isAwaitingPlaybackConfirmation
+            || self.playerService.pendingPlayVideoId != nil
+        guard hasActiveOrPendingMusic else { return }
         self.logger.info("Arbiter: pausing music for video playback")
         Task {
-            await self.playerService.pause()
+            await self.playerService.pause(intent: intent)
         }
     }
 

--- a/Sources/Kaset/Services/Player/PlayerQueueModels.swift
+++ b/Sources/Kaset/Services/Player/PlayerQueueModels.swift
@@ -18,6 +18,41 @@ struct QueueEntry: Identifiable, Hashable {
 // MARK: - QueueState
 
 struct QueueState {
+    enum PlaybackOwner: Equatable {
+        case none
+        case queueEntry(id: UUID, progress: TimeInterval, duration: TimeInterval)
+        case detached(song: Song, episode: ArtistEpisode?, progress: TimeInterval, duration: TimeInterval)
+    }
+
     let entries: [QueueEntry]
     let currentIndex: Int
+    let shouldResumePlayback: Bool
+    let wasPlaybackEnded: Bool
+    let shuffleMode: PlayerService.ShuffleMode
+    let mixContinuation: String?
+    let mixContinuationRequiresAuth: Bool
+    let queueOrderBeforeShuffle: [QueueEntry]?
+    let playbackOwner: PlaybackOwner
+
+    init(
+        entries: [QueueEntry],
+        currentIndex: Int,
+        shouldResumePlayback: Bool = false,
+        wasPlaybackEnded: Bool = false,
+        shuffleMode: PlayerService.ShuffleMode = .off,
+        mixContinuation: String? = nil,
+        mixContinuationRequiresAuth: Bool = false,
+        queueOrderBeforeShuffle: [QueueEntry]? = nil,
+        playbackOwner: PlaybackOwner = .none
+    ) {
+        self.entries = entries
+        self.currentIndex = currentIndex
+        self.shouldResumePlayback = shouldResumePlayback
+        self.wasPlaybackEnded = wasPlaybackEnded
+        self.shuffleMode = shuffleMode
+        self.mixContinuation = mixContinuation
+        self.mixContinuationRequiresAuth = mixContinuationRequiresAuth
+        self.queueOrderBeforeShuffle = queueOrderBeforeShuffle
+        self.playbackOwner = playbackOwner
+    }
 }

--- a/Sources/Kaset/Services/Player/PlayerService+Episodes.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+Episodes.swift
@@ -18,6 +18,12 @@ extension PlayerService {
     /// thumbnail, then installs `currentEpisode` through the player so the UI
     /// can gate live behavior before metadata loading suspends.
     func playEpisode(_ episode: ArtistEpisode) async {
+        let intent = self.beginMusicPlaybackIntent()
+        await self.playEpisode(episode, intent: intent)
+    }
+
+    func playEpisode(_ episode: ArtistEpisode, intent: MusicPlaybackIntent) async {
+        guard self.acceptsMusicPlaybackIntent(intent) else { return }
         self.logger.info("Playing artist episode: \(episode.title) (live=\(episode.isLive))")
 
         // A standalone episode is a new playback context that replaces the queue: supersede any
@@ -43,6 +49,12 @@ extension PlayerService {
         // Pass the episode into `play` so episode state is installed before
         // any async metadata fetch can suspend. This prevents a stale episode
         // task from marking a later normal track as episode playback.
-        await self.play(song: representative, webLoadStrategy: .standard, episode: episode)
+        await self.play(
+            song: representative,
+            webLoadStrategy: .standard,
+            episode: episode,
+            queueEntryID: nil,
+            intent: intent
+        )
     }
 }

--- a/Sources/Kaset/Services/Player/PlayerService+Library.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+Library.swift
@@ -8,6 +8,7 @@ private struct LibraryMutationRequest {
     let accountID: String
     let mutationRevision: UInt64
     let accountSessionGeneration: UInt64
+    let expectedState: MusicLibraryConfirmedState
 }
 
 @MainActor
@@ -24,33 +25,20 @@ extension PlayerService {
         let activeAccountID = self.songLikeStatusManager.activeAccountID
         let client = self.ytMusicClient
         let previousStatus = self.currentTrackLikeStatus
-        self.songLikeStatusManager.setStatus(
-            previousStatus,
-            for: [track.videoId],
-            accountID: activeAccountID
-        )
-
         // Toggle: if already liked, remove the like
         let newStatus: LikeStatus = previousStatus == .like ? .indifferent : .like
+        let request = self.songLikeStatusManager.enqueueRating(
+            track,
+            status: newStatus,
+            accountID: activeAccountID,
+            client: client,
+            visibleBaseline: previousStatus
+        )
         // Optimistic UI update for PlayerBar
         self.currentTrackLikeStatus = newStatus
 
-        // Delegate to SongLikeStatusManager for API call + cache sync + event emission
         Task {
-            let finalStatus: LikeStatus = if newStatus == .like {
-                await self.songLikeStatusManager.like(
-                    track,
-                    accountID: activeAccountID,
-                    client: client
-                )
-            } else {
-                await self.songLikeStatusManager.unlike(
-                    track,
-                    accountID: activeAccountID,
-                    client: client
-                )
-            }
-
+            let finalStatus = await request.value
             self.reconcileCurrentTrackLikeStatusAfterRating(
                 track: track,
                 requestedAccountID: activeAccountID,
@@ -71,33 +59,20 @@ extension PlayerService {
         let activeAccountID = self.songLikeStatusManager.activeAccountID
         let client = self.ytMusicClient
         let previousStatus = self.currentTrackLikeStatus
-        self.songLikeStatusManager.setStatus(
-            previousStatus,
-            for: [track.videoId],
-            accountID: activeAccountID
-        )
-
         // Toggle: if already disliked, remove the dislike
         let newStatus: LikeStatus = previousStatus == .dislike ? .indifferent : .dislike
+        let request = self.songLikeStatusManager.enqueueRating(
+            track,
+            status: newStatus,
+            accountID: activeAccountID,
+            client: client,
+            visibleBaseline: previousStatus
+        )
         // Optimistic UI update for PlayerBar
         self.currentTrackLikeStatus = newStatus
 
-        // Delegate to SongLikeStatusManager for API call + cache sync + event emission
         Task {
-            let finalStatus: LikeStatus = if newStatus == .dislike {
-                await self.songLikeStatusManager.dislike(
-                    track,
-                    accountID: activeAccountID,
-                    client: client
-                )
-            } else {
-                await self.songLikeStatusManager.undislike(
-                    track,
-                    accountID: activeAccountID,
-                    client: client
-                )
-            }
-
+            let finalStatus = await request.value
             self.reconcileCurrentTrackLikeStatusAfterRating(
                 track: track,
                 requestedAccountID: activeAccountID,
@@ -167,10 +142,9 @@ extension PlayerService {
         // Optimistic update
         let currentTokens = self.currentTrackFeedbackTokens
         let expectedInLibrary = !isCurrentlyInLibrary
-        let expectedFeedbackTokens = FeedbackTokens(
-            add: currentTokens?.remove,
-            remove: currentTokens?.add
-        )
+        // Feedback tokens are action-specific. Keep the known add/remove pair
+        // stable until an authoritative metadata refresh rotates it.
+        let expectedFeedbackTokens = currentTokens
         self.applyLibraryState(
             videoId: track.videoId,
             isInLibrary: expectedInLibrary,
@@ -182,7 +156,11 @@ extension PlayerService {
             videoId: track.videoId,
             accountID: activeAccountID,
             mutationRevision: mutationRevision,
-            accountSessionGeneration: accountSessionGeneration
+            accountSessionGeneration: accountSessionGeneration,
+            expectedState: MusicLibraryConfirmedState(
+                isInLibrary: expectedInLibrary,
+                feedbackTokens: expectedFeedbackTokens
+            )
         )
         let request = self.enqueueSerializedLibraryMutation(mutation)
 
@@ -191,15 +169,10 @@ extension PlayerService {
             do {
                 try await request.value.get()
                 guard self.accountSessionGeneration == accountSessionGeneration else { return }
-                self.confirmedLibraryStateByKey[mutationKey] = MusicLibraryConfirmedState(
-                    isInLibrary: expectedInLibrary,
-                    feedbackTokens: expectedFeedbackTokens
-                )
                 guard self.isCurrentLibraryMutation(key: mutationKey, revision: mutationRevision) else { return }
                 let action = isCurrentlyInLibrary ? "removed from" : "added to"
                 self.logger.info("Successfully \(action) library")
 
-                // After successful toggle, we need to swap the tokens
                 // The browse metadata can lag briefly, so delay the refresh and keep
                 // the optimistic library state if the response is still stale.
                 try? await Task.sleep(for: .milliseconds(500))
@@ -282,6 +255,10 @@ extension PlayerService {
             }
             do {
                 try await client.editSongLibraryStatus(feedbackTokens: [mutation.token])
+                guard self.accountSessionGeneration == mutation.accountSessionGeneration else {
+                    return .failure(CancellationError())
+                }
+                self.confirmedLibraryStateByKey[key] = mutation.expectedState
                 return .success(())
             } catch {
                 return .failure(error)

--- a/Sources/Kaset/Services/Player/PlayerService+Library.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+Library.swift
@@ -2,7 +2,7 @@ import Foundation
 
 // MARK: - LibraryMutationRequest
 
-private struct LibraryMutationRequest: Sendable {
+private struct LibraryMutationRequest {
     let token: String
     let videoId: String
     let accountID: String

--- a/Sources/Kaset/Services/Player/PlayerService+Library.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+Library.swift
@@ -1,6 +1,14 @@
 import Foundation
 
-// MARK: - Like/Dislike/Library Actions
+// MARK: - LibraryMutationRequest
+
+private struct LibraryMutationRequest: Sendable {
+    let token: String
+    let videoId: String
+    let accountID: String
+    let mutationRevision: UInt64
+    let accountSessionGeneration: UInt64
+}
 
 @MainActor
 extension PlayerService {
@@ -13,7 +21,7 @@ extension PlayerService {
         }
         guard let track = currentTrack else { return }
         self.logger.info("Liking current track: \(track.videoId)")
-        let activeAccountID = SongLikeStatusManager.shared.activeAccountID
+        let activeAccountID = self.songLikeStatusManager.activeAccountID
         let client = self.ytMusicClient
 
         // Toggle: if already liked, remove the like
@@ -24,20 +32,20 @@ extension PlayerService {
         // Delegate to SongLikeStatusManager for API call + cache sync + event emission
         Task {
             let finalStatus: LikeStatus = if newStatus == .like {
-                await SongLikeStatusManager.shared.like(
+                await self.songLikeStatusManager.like(
                     track,
                     accountID: activeAccountID,
                     client: client
                 )
             } else {
-                await SongLikeStatusManager.shared.unlike(
+                await self.songLikeStatusManager.unlike(
                     track,
                     accountID: activeAccountID,
                     client: client
                 )
             }
 
-            guard SongLikeStatusManager.shared.activeAccountID == activeAccountID,
+            guard self.songLikeStatusManager.activeAccountID == activeAccountID,
                   self.currentTrack?.videoId == track.videoId
             else {
                 return
@@ -56,7 +64,7 @@ extension PlayerService {
         }
         guard let track = currentTrack else { return }
         self.logger.info("Disliking current track: \(track.videoId)")
-        let activeAccountID = SongLikeStatusManager.shared.activeAccountID
+        let activeAccountID = self.songLikeStatusManager.activeAccountID
         let client = self.ytMusicClient
 
         // Toggle: if already disliked, remove the dislike
@@ -67,20 +75,20 @@ extension PlayerService {
         // Delegate to SongLikeStatusManager for API call + cache sync + event emission
         Task {
             let finalStatus: LikeStatus = if newStatus == .dislike {
-                await SongLikeStatusManager.shared.dislike(
+                await self.songLikeStatusManager.dislike(
                     track,
                     accountID: activeAccountID,
                     client: client
                 )
             } else {
-                await SongLikeStatusManager.shared.undislike(
+                await self.songLikeStatusManager.undislike(
                     track,
                     accountID: activeAccountID,
                     client: client
                 )
             }
 
-            guard SongLikeStatusManager.shared.activeAccountID == activeAccountID,
+            guard self.songLikeStatusManager.activeAccountID == activeAccountID,
                   self.currentTrack?.videoId == track.videoId
             else {
                 return
@@ -90,6 +98,7 @@ extension PlayerService {
         }
     }
 
+    // swiftlint:disable function_body_length
     /// Toggles the library status of the current track.
     func toggleLibraryStatus() {
         guard self.canPerformAccountMutation else {
@@ -98,7 +107,7 @@ extension PlayerService {
         }
         guard let track = currentTrack else { return }
         self.logger.info("Toggling library status for current track: \(track.videoId)")
-        let activeAccountID = SongLikeStatusManager.shared.activeAccountID
+        let activeAccountID = self.songLikeStatusManager.activeAccountID
 
         // Determine which token to use based on current state
         let isCurrentlyInLibrary = self.currentTrackInLibrary
@@ -110,24 +119,57 @@ extension PlayerService {
             self.logger.warning("No feedback token available for library toggle")
             return
         }
+        self.libraryMutationGeneration &+= 1
+        self.libraryMutationRevisionCounter &+= 1
+        let mutationKey = activeAccountID + "\u{0}" + track.videoId
+        let mutationRevision = self.libraryMutationRevisionCounter
+        self.libraryMutationRevisions[mutationKey] = mutationRevision
+        if self.confirmedLibraryStateByKey[mutationKey] == nil {
+            self.confirmedLibraryStateByKey[mutationKey] = MusicLibraryConfirmedState(
+                isInLibrary: self.currentTrackInLibrary,
+                feedbackTokens: self.currentTrackFeedbackTokens
+            )
+        }
+        let accountSessionGeneration = self.accountSessionGeneration
+        let pendingMutationKey = self.pendingLibraryMutationKey(
+            accountID: activeAccountID,
+            videoId: track.videoId,
+            sessionGeneration: accountSessionGeneration
+        )
+        self.pendingLibraryMutationCountsByKey[pendingMutationKey, default: 0] += 1
 
         // Optimistic update
-        let previousState = self.currentTrackInLibrary
-        let previousTokens = self.currentTrackFeedbackTokens
+        let currentTokens = self.currentTrackFeedbackTokens
         let expectedInLibrary = !isCurrentlyInLibrary
         let expectedFeedbackTokens = FeedbackTokens(
-            add: previousTokens?.remove,
-            remove: previousTokens?.add
+            add: currentTokens?.remove,
+            remove: currentTokens?.add
         )
-        self.updateCurrentTrackLibraryState(
+        self.applyLibraryState(
+            videoId: track.videoId,
             isInLibrary: expectedInLibrary,
             feedbackTokens: expectedFeedbackTokens
         )
 
+        let mutation = LibraryMutationRequest(
+            token: token,
+            videoId: track.videoId,
+            accountID: activeAccountID,
+            mutationRevision: mutationRevision,
+            accountSessionGeneration: accountSessionGeneration
+        )
+        let request = self.enqueueSerializedLibraryMutation(mutation)
+
         // Use API call for reliable library management
         Task {
             do {
-                try await self.ytMusicClient?.editSongLibraryStatus(feedbackTokens: [token])
+                try await request.value.get()
+                guard self.accountSessionGeneration == accountSessionGeneration else { return }
+                self.confirmedLibraryStateByKey[mutationKey] = MusicLibraryConfirmedState(
+                    isInLibrary: expectedInLibrary,
+                    feedbackTokens: expectedFeedbackTokens
+                )
+                guard self.isCurrentLibraryMutation(key: mutationKey, revision: mutationRevision) else { return }
                 let action = isCurrentlyInLibrary ? "removed from" : "added to"
                 self.logger.info("Successfully \(action) library")
 
@@ -136,37 +178,125 @@ extension PlayerService {
                 // the optimistic library state if the response is still stale.
                 try? await Task.sleep(for: .milliseconds(500))
 
-                guard SongLikeStatusManager.shared.activeAccountID == activeAccountID else { return }
+                guard self.songLikeStatusManager.activeAccountID == activeAccountID,
+                      self.accountSessionGeneration == accountSessionGeneration,
+                      self.isCurrentLibraryMutation(key: mutationKey, revision: mutationRevision)
+                else { return }
 
-                await self.fetchSongMetadata(videoId: track.videoId)
+                await self.fetchSongMetadata(
+                    videoId: track.videoId,
+                    updatesConfirmedLibraryState: false
+                )
 
-                guard SongLikeStatusManager.shared.activeAccountID == activeAccountID,
+                guard self.songLikeStatusManager.activeAccountID == activeAccountID,
+                      self.accountSessionGeneration == accountSessionGeneration,
+                      self.isCurrentLibraryMutation(key: mutationKey, revision: mutationRevision),
                       self.currentTrack?.videoId == track.videoId
                 else {
                     return
                 }
 
-                if self.currentTrackInLibrary != expectedInLibrary {
-                    self.updateCurrentTrackLibraryState(
+                if self.currentTrack?.isInLibrary != expectedInLibrary {
+                    self.applyLibraryState(
+                        videoId: track.videoId,
                         isInLibrary: expectedInLibrary,
                         feedbackTokens: expectedFeedbackTokens
+                    )
+                } else {
+                    self.confirmedLibraryStateByKey[mutationKey] = MusicLibraryConfirmedState(
+                        isInLibrary: expectedInLibrary,
+                        feedbackTokens: self.currentTrackFeedbackTokens
                     )
                 }
             } catch {
                 self.logger.error("Failed to toggle library status: \(error.localizedDescription)")
-                // Revert on failure
-                guard SongLikeStatusManager.shared.activeAccountID == activeAccountID,
-                      self.currentTrack?.videoId == track.videoId
-                else {
-                    return
-                }
-
-                self.updateCurrentTrackLibraryState(
-                    isInLibrary: previousState,
-                    feedbackTokens: previousTokens
+                // Revert the exact optimistic queue entry when this mutation is still latest.
+                guard self.accountSessionGeneration == accountSessionGeneration,
+                      self.isCurrentLibraryMutation(key: mutationKey, revision: mutationRevision)
+                else { return }
+                guard let confirmedState = self.confirmedLibraryStateByKey[mutationKey] else { return }
+                self.applyLibraryState(
+                    videoId: track.videoId,
+                    isInLibrary: confirmedState.isInLibrary,
+                    feedbackTokens: confirmedState.feedbackTokens
                 )
             }
         }
+    }
+
+    // swiftlint:enable function_body_length
+
+    private func enqueueSerializedLibraryMutation(
+        _ mutation: LibraryMutationRequest
+    ) -> Task<Result<Void, any Error>, Never> {
+        let key = mutation.accountID + "\u{0}" + mutation.videoId
+        let pendingMutationKey = self.pendingLibraryMutationKey(
+            accountID: mutation.accountID,
+            videoId: mutation.videoId,
+            sessionGeneration: mutation.accountSessionGeneration
+        )
+        let client = self.ytMusicClient
+        let predecessor = self.libraryMutationTails[key]
+        let request = Task { () -> Result<Void, any Error> in
+            defer {
+                self.finishSerializedLibraryMutation(
+                    key: key,
+                    pendingMutationKey: pendingMutationKey,
+                    mutationRevision: mutation.mutationRevision
+                )
+            }
+            if let predecessor {
+                _ = await predecessor.value
+            }
+            guard self.songLikeStatusManager.activeAccountID == mutation.accountID,
+                  self.accountSessionGeneration == mutation.accountSessionGeneration,
+                  let client
+            else {
+                return .failure(CancellationError())
+            }
+            do {
+                try await client.editSongLibraryStatus(feedbackTokens: [mutation.token])
+                return .success(())
+            } catch {
+                return .failure(error)
+            }
+        }
+        self.libraryMutationTails[key] = request
+        self.libraryMutationTailGenerations[key] = mutation.mutationRevision
+        return request
+    }
+
+    private func finishSerializedLibraryMutation(
+        key: String,
+        pendingMutationKey: String,
+        mutationRevision: UInt64
+    ) {
+        self.finishPendingLibraryMutation(key: pendingMutationKey)
+        if self.libraryMutationTailGenerations[key] == mutationRevision {
+            self.libraryMutationTails.removeValue(forKey: key)
+            self.libraryMutationTailGenerations.removeValue(forKey: key)
+        }
+    }
+
+    private func pendingLibraryMutationKey(
+        accountID: String,
+        videoId: String,
+        sessionGeneration: UInt64
+    ) -> String {
+        accountID + "\u{0}" + videoId + "\u{0}" + String(sessionGeneration)
+    }
+
+    private func finishPendingLibraryMutation(key: String) {
+        guard let count = self.pendingLibraryMutationCountsByKey[key] else { return }
+        if count <= 1 {
+            self.pendingLibraryMutationCountsByKey.removeValue(forKey: key)
+        } else {
+            self.pendingLibraryMutationCountsByKey[key] = count - 1
+        }
+    }
+
+    private func isCurrentLibraryMutation(key: String, revision: UInt64) -> Bool {
+        self.libraryMutationRevisions[key] == revision
     }
 
     /// Updates the like status from WebView observation.
@@ -176,7 +306,7 @@ extension PlayerService {
         // Only accept WebView status if SongLikeStatusManager has no cached value
         // (cache is more authoritative than WebView's observation)
         if let videoId = self.currentTrack?.videoId,
-           let cachedStatus = SongLikeStatusManager.shared.status(for: videoId)
+           let cachedStatus = self.songLikeStatusManager.status(for: videoId)
         {
             self.currentTrackLikeStatus = cachedStatus
         } else {
@@ -191,34 +321,92 @@ extension PlayerService {
         self.currentTrackFeedbackTokens = nil
     }
 
-    private func updateCurrentTrackLibraryState(
+    private func applyLibraryState(
+        videoId: String,
         isInLibrary: Bool,
         feedbackTokens: FeedbackTokens?
     ) {
-        self.currentTrackInLibrary = isInLibrary
-        self.currentTrackFeedbackTokens = feedbackTokens
+        var didChange = false
+        if var currentTrack = self.currentTrack, currentTrack.videoId == videoId {
+            self.currentTrackInLibrary = isInLibrary
+            self.currentTrackFeedbackTokens = feedbackTokens
+            currentTrack.isInLibrary = isInLibrary
+            currentTrack.feedbackTokens = feedbackTokens
+            self.currentTrack = currentTrack
+            didChange = true
+        }
 
-        guard var currentTrack = self.currentTrack else { return }
-        currentTrack.isInLibrary = isInLibrary
-        currentTrack.feedbackTokens = feedbackTokens
-        self.currentTrack = currentTrack
+        var updatedEntries = self.queueEntries
+        var didChangeQueue = false
+        for index in updatedEntries.indices where updatedEntries[index].song.videoId == videoId {
+            var song = updatedEntries[index].song
+            song.isInLibrary = isInLibrary
+            song.feedbackTokens = feedbackTokens
+            updatedEntries[index] = QueueEntry(
+                id: updatedEntries[index].id,
+                song: song,
+                source: updatedEntries[index].source
+            )
+            didChange = true
+            didChangeQueue = true
+        }
+        if didChangeQueue {
+            self.setQueue(entries: updatedEntries)
+        }
+        if didChange {
+            self.saveQueueForPersistence()
+        }
     }
 
     /// Fetches full song metadata including feedbackTokens from the API.
-    func fetchSongMetadata(videoId: String) async {
+    func fetchSongMetadata(
+        videoId: String,
+        queueOwner: MusicQueueMetadataOwner = .active,
+        updatesConfirmedLibraryState: Bool = true
+    ) async {
         guard let client = ytMusicClient else {
             self.logger.warning("No YTMusicClient available for fetching song metadata")
             return
         }
 
-        let activeAccountID = SongLikeStatusManager.shared.activeAccountID
+        let activeAccountID = self.songLikeStatusManager.activeAccountID
+        let ratingRevision = self.songLikeStatusManager.ratingRevision(
+            for: videoId,
+            accountID: activeAccountID
+        )
+        let libraryMutationGeneration = self.libraryMutationGeneration
+        let accountSessionGeneration = self.accountSessionGeneration
+        let pendingMutationKey = self.pendingLibraryMutationKey(
+            accountID: activeAccountID,
+            videoId: videoId,
+            sessionGeneration: accountSessionGeneration
+        )
+        let libraryMutationWasPending = self.pendingLibraryMutationCountsByKey[pendingMutationKey, default: 0] > 0
+        let queueEntryID: UUID? = switch queueOwner {
+        case .active: self.activePlaybackQueueEntryID
+        case .none: nil
+        case let .entry(entryID): entryID
+        }
 
         do {
             let songData = try await client.getSong(videoId: videoId)
-            guard SongLikeStatusManager.shared.activeAccountID == activeAccountID else { return }
+            guard self.songLikeStatusManager.activeAccountID == activeAccountID,
+                  self.currentTrack?.videoId == videoId,
+                  self.activePlaybackQueueEntryID == queueEntryID
+            else { return }
 
-            let cachedLikeStatus = SongLikeStatusManager.shared.status(for: videoId)
-            let resolvedLikeStatus = songData.likeStatus ?? cachedLikeStatus
+            let cachedLikeStatus = self.songLikeStatusManager.status(for: videoId)
+            let ratingRevisionIsCurrent = self.songLikeStatusManager.ratingRevision(
+                for: videoId,
+                accountID: activeAccountID
+            ) == ratingRevision
+            let libraryMutationIsCurrent = self.libraryMutationGeneration == libraryMutationGeneration
+                && self.accountSessionGeneration == accountSessionGeneration
+                && !libraryMutationWasPending
+                && self.pendingLibraryMutationCountsByKey[pendingMutationKey, default: 0] == 0
+            let resolvedLikeStatus = ratingRevisionIsCurrent
+                ? (songData.likeStatus ?? cachedLikeStatus)
+                : (cachedLikeStatus ?? self.currentTrackLikeStatus)
 
             // Update current track with full metadata if it's still the same song
             if self.currentTrack?.videoId == videoId {
@@ -227,30 +415,49 @@ extension PlayerService {
                 let artists = self.currentTrack?.artists.isEmpty == true ? songData.artists : (self.currentTrack?.artists ?? songData.artists)
 
                 self.currentTrack = Song(
-                    id: videoId,
+                    id: self.currentTrack?.id ?? videoId,
                     title: title,
                     artists: artists,
                     album: songData.album ?? self.currentTrack?.album,
                     duration: songData.duration ?? self.currentTrack?.duration,
                     thumbnailURL: songData.thumbnailURL ?? self.currentTrack?.thumbnailURL,
                     videoId: videoId,
-                    musicVideoType: songData.musicVideoType,
+                    isPlayable: songData.isPlayable,
+                    hasVideo: songData.hasVideo ?? self.currentTrack?.hasVideo,
+                    musicVideoType: songData.musicVideoType ?? self.currentTrack?.musicVideoType,
                     likeStatus: resolvedLikeStatus,
-                    isInLibrary: songData.isInLibrary,
-                    feedbackTokens: songData.feedbackTokens
+                    isInLibrary: libraryMutationIsCurrent
+                        ? songData.isInLibrary
+                        : self.currentTrack?.isInLibrary,
+                    feedbackTokens: libraryMutationIsCurrent
+                        ? songData.feedbackTokens
+                        : self.currentTrack?.feedbackTokens,
+                    isExplicit: songData.isExplicit ?? self.currentTrack?.isExplicit
                 )
 
                 // Update service state and sync with SongLikeStatusManager.
                 // Unknown like status stays out of the cache so it cannot override
                 // a known rating from the WebView or a prior user action.
-                if let likeStatus = songData.likeStatus {
+                if ratingRevisionIsCurrent, let likeStatus = songData.likeStatus {
                     self.currentTrackLikeStatus = likeStatus
-                    SongLikeStatusManager.shared.setStatus(likeStatus, for: videoId)
+                    self.songLikeStatusManager.setStatus(likeStatus, for: videoId)
                 } else if let cachedLikeStatus {
                     self.currentTrackLikeStatus = cachedLikeStatus
                 }
-                self.currentTrackInLibrary = songData.isInLibrary ?? false
-                self.currentTrackFeedbackTokens = songData.feedbackTokens
+                if libraryMutationIsCurrent {
+                    self.applyLibraryState(
+                        videoId: videoId,
+                        isInLibrary: songData.isInLibrary ?? false,
+                        feedbackTokens: songData.feedbackTokens
+                    )
+                    if updatesConfirmedLibraryState {
+                        let key = activeAccountID + "\u{0}" + videoId
+                        self.confirmedLibraryStateByKey[key] = MusicLibraryConfirmedState(
+                            isInLibrary: self.currentTrackInLibrary,
+                            feedbackTokens: self.currentTrackFeedbackTokens
+                        )
+                    }
+                }
 
                 // Update video availability based on API-detected musicVideoType
                 // This is more reliable than DOM inspection since it comes directly from the API
@@ -261,37 +468,50 @@ extension PlayerService {
 
                 self.logger.info("Updated track metadata - inLibrary: \(self.currentTrackInLibrary), hasTokens: \(self.currentTrackFeedbackTokens != nil)")
 
-                // Also update the corresponding song in the queue with enriched metadata
-                // This ensures the queue displays complete info without separate API calls
-                if let queueIndex = self.queueEntries.firstIndex(where: { $0.song.videoId == videoId }) {
-                    // Only update if the queue entry is missing metadata
-                    let currentQueueSong = self.queueEntries[queueIndex].song
-                    let needsUpdate = currentQueueSong.artists.isEmpty ||
-                        currentQueueSong.artists.allSatisfy { $0.name.isEmpty || $0.name == "Unknown Artist" } ||
-                        currentQueueSong.title.isEmpty ||
-                        currentQueueSong.title == "Loading..." ||
-                        currentQueueSong.thumbnailURL == nil
-
-                    if needsUpdate {
-                        var enrichedQueueSong = songData
-                        enrichedQueueSong.likeStatus = resolvedLikeStatus
-                        var updatedEntries = self.queueEntries
-                        // Preserve `source` so enriching a playing Smart Shuffle suggestion does
-                        // not demote it to `.queued` (which would lose its marker and persist it).
-                        updatedEntries[queueIndex] = QueueEntry(
-                            id: updatedEntries[queueIndex].id,
-                            song: enrichedQueueSong,
-                            source: updatedEntries[queueIndex].source
-                        )
-                        self.setQueue(entries: updatedEntries)
-                        self.logger.debug("Enriched queue entry at index \(queueIndex): '\(enrichedQueueSong.title)' with artists: \(enrichedQueueSong.artistsDisplay)")
-                        // Save the enriched queue to persistence
-                        self.saveQueueForPersistence()
-                    }
-                }
+                self.applyFetchedMetadataToQueue(
+                    entryID: queueEntryID,
+                    response: songData,
+                    resolvedLikeStatus: resolvedLikeStatus,
+                    libraryMutationIsCurrent: libraryMutationIsCurrent
+                )
             }
         } catch {
             self.logger.warning("Failed to fetch song metadata: \(error.localizedDescription)")
         }
+    }
+
+    private func applyFetchedMetadataToQueue(
+        entryID: UUID?,
+        response: Song,
+        resolvedLikeStatus: LikeStatus?,
+        libraryMutationIsCurrent: Bool
+    ) {
+        guard let entryID,
+              let queueIndex = self.queueEntries.firstIndex(where: { $0.id == entryID })
+        else { return }
+
+        let currentQueueSong = self.queueEntries[queueIndex].song
+        var enrichedQueueSong = Self.songNeedsQueueEnrichment(currentQueueSong)
+            ? Self.mergingQueueMetadata(current: currentQueueSong, response: response)
+            : currentQueueSong
+        enrichedQueueSong.likeStatus = resolvedLikeStatus
+        if entryID == self.activePlaybackQueueEntryID {
+            enrichedQueueSong.isInLibrary = self.currentTrackInLibrary
+            enrichedQueueSong.feedbackTokens = self.currentTrackFeedbackTokens
+        } else if libraryMutationIsCurrent {
+            enrichedQueueSong.isInLibrary = response.isInLibrary
+            enrichedQueueSong.feedbackTokens = response.feedbackTokens
+        }
+        var updatedEntries = self.queueEntries
+        updatedEntries[queueIndex] = QueueEntry(
+            id: updatedEntries[queueIndex].id,
+            song: enrichedQueueSong,
+            source: updatedEntries[queueIndex].source
+        )
+        self.setQueue(entries: updatedEntries)
+        self.logger.debug(
+            "Enriched queue entry at index \(queueIndex): '\(enrichedQueueSong.title)' with artists: \(enrichedQueueSong.artistsDisplay)"
+        )
+        self.saveQueueForPersistence()
     }
 }

--- a/Sources/Kaset/Services/Player/PlayerService+PlaybackBoundaries.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+PlaybackBoundaries.swift
@@ -1,0 +1,145 @@
+import Foundation
+
+@MainActor
+extension PlayerService {
+    /// Clears active playback UI/WebView state when startup resolves to guest mode.
+    ///
+    /// Unlike explicit sign-out, this preserves only persisted sessions that are
+    /// known to have been created in guest mode. Legacy/unknown sessions are
+    /// cleared because they may contain account-owned listening metadata.
+    func clearPlaybackForGuestStartup() {
+        self.logger.info("Clearing active playback state for guest startup")
+        guard self.restoredPlaybackSessionOwnerScope == Self.playbackSessionScopeGuest else {
+            self.clearSavedQueue()
+            self.clearPlaybackForPrivacyBoundary(persistEmptyQueue: true)
+            return
+        }
+        self.logger.info("Preserving restored guest-owned playback session")
+    }
+
+    /// Clears guest-owned restored playback when startup resolves to a signed-in
+    /// account. Guest Mode itself is not persisted, so a guest-owned restore must
+    /// not silently move onto the authenticated playback store.
+    func clearGuestPlaybackForAuthenticatedStartup() {
+        guard self.restoredPlaybackSessionOwnerScope == Self.playbackSessionScopeGuest else { return }
+        self.logger.info("Clearing guest-owned playback state for authenticated startup")
+        self.clearSavedQueue()
+        self.clearPlaybackForPrivacyBoundary(persistEmptyQueue: true)
+    }
+
+    /// Synchronously clears playback, queue, and WebView state at the sign-out privacy boundary.
+    func clearPlaybackForSignOut() {
+        self.logger.info("Clearing playback state for sign-out")
+        self.clearPlaybackForPrivacyBoundary(persistEmptyQueue: true)
+    }
+
+    private func clearPlaybackForPrivacyBoundary(persistEmptyQueue: Bool) {
+        self.accountSessionGeneration &+= 1
+        self.songLikeStatusManager.invalidateSession()
+        self.confirmedLibraryStateByKey.removeAll()
+        self.invalidatePendingPlaybackRequests()
+        self.cancelDeferredQueueWork()
+        self.clearRestoredPlaybackSessionState()
+        SingletonPlayerWebView.shared.tearDown()
+        self.state = .idle
+        self.shouldResumeAfterInterruption = false
+        self.isAwaitingPlaybackConfirmation = false
+        self.isExplicitPauseIntentActive = true
+        self.songNearingEnd = false
+        self.isKasetInitiatedPlayback = false
+        self.shouldSuppressAutoplayAfterQueueEnd = false
+        self.currentEpisode = nil
+        self.currentTrack = nil
+        self.activePlaybackQueueEntryID = nil
+        self.resetMusicPlaybackOccurrenceState()
+        self.pendingPlayVideoId = nil
+        self.progress = 0
+        self.currentTimeMs = 0
+        self.duration = 0
+        self.showMiniPlayer = false
+        self.isMiniPlayerVisible = false
+        self.showLyrics = false
+        self.showQueue = false
+        self.showVideo = false
+        self.currentTrackHasVideo = false
+        self.mixContinuationToken = nil
+        self.mixContinuationRequiresAuth = false
+        self.queueOrderBeforeShuffle = nil
+        self.clearQueueUndoRedoHistory()
+        self.currentIndex = 0
+        if !persistEmptyQueue {
+            self.suppressNextEmptyQueuePersistence = true
+        }
+        self.setQueue([])
+        self.resetTrackStatus()
+        if persistEmptyQueue {
+            self.saveQueueForPersistence()
+        }
+    }
+
+    /// Stops playback and clears state.
+    func stop() async {
+        let intent = self.beginMusicPlaybackIntent()
+        await self.stop(intent: intent)
+    }
+
+    func stop(
+        intent: MusicPlaybackIntent,
+        preservesQueueContext: Bool = false
+    ) async {
+        guard self.acceptsMusicPlaybackIntent(intent) else { return }
+        if !preservesQueueContext {
+            self.cancelDeferredQueueWork()
+        }
+        self.logger.debug("Stopping playback")
+        self.isStoppingPlayback = true
+        self.shouldResumeAfterInterruption = false
+        self.isAwaitingPlaybackConfirmation = false
+        self.isExplicitPauseIntentActive = true
+        self.clearRestoredPlaybackSessionState()
+        self.state = .idle
+        self.songNearingEnd = false
+        self.isKasetInitiatedPlayback = false
+        self.shouldSuppressAutoplayAfterQueueEnd = false
+        self.currentEpisode = nil
+        self.currentTrack = nil
+        self.activePlaybackQueueEntryID = nil
+        self.resetMusicPlaybackOccurrenceState()
+        self.pendingPlayVideoId = nil
+        self.progress = 0
+        self.currentTimeMs = 0
+        self.duration = 0
+        self.resetAdPlaybackState()
+        await SingletonPlayerWebView.shared.cancelPendingPlayback()
+        guard self.acceptsMusicPlaybackIntent(intent) else {
+            self.isStoppingPlayback = false
+            return
+        }
+        self.state = .idle
+        self.shouldResumeAfterInterruption = false
+        self.isAwaitingPlaybackConfirmation = false
+        self.isExplicitPauseIntentActive = true
+        self.currentTrack = nil
+        self.activePlaybackQueueEntryID = nil
+        self.pendingPlayVideoId = nil
+        self.progress = 0
+        self.currentTimeMs = 0
+        self.duration = 0
+        self.isStoppingPlayback = false
+    }
+
+    /// Stops current or pending playback and clears the queue under one intent.
+    /// A newer playback that starts while Web cancellation suspends wins.
+    func stopAndClearQueue() async {
+        let intent = self.beginMusicPlaybackIntent()
+        await self.stopAndClearQueue(intent: intent)
+    }
+
+    func stopAndClearQueue(intent: MusicPlaybackIntent) async {
+        guard self.acceptsMusicPlaybackIntent(intent) else { return }
+        let undoState = self.makeQueueStateSnapshot()
+        await self.stop(intent: intent)
+        guard self.acceptsMusicPlaybackIntent(intent) else { return }
+        self.clearQueueEntriesAfterStop(intent: intent, undoState: undoState)
+    }
+}

--- a/Sources/Kaset/Services/Player/PlayerService+PlaybackControls.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+PlaybackControls.swift
@@ -82,10 +82,29 @@ extension PlayerService {
     /// Plays a track by video ID.
     func play(videoId: String) async {
         self.logger.debug("play() called with videoId: \(videoId)")
+        let acceptsPlaybackRequest = SingletonPlayerWebView.shared.acceptsPlaybackRequest(
+            videoId: videoId,
+            strategy: .standard
+        )
+        guard acceptsPlaybackRequest else {
+            self.logger.debug("Video \(videoId) already loaded; resuming existing playback")
+            await self.resume()
+            return
+        }
+        self.beginNativeMusicPlaybackOccurrence(videoId: videoId)
+        self.activePlaybackQueueEntryID = nil
+        self.isStoppingPlayback = false
         self.logger.info("Playing video: \(videoId)")
         self.clearRestoredPlaybackSessionState()
         self.currentEpisode = nil
         self.state = .loading
+        self.shouldResumeAfterInterruption = true
+        self.isAwaitingPlaybackConfirmation = true
+        self.isExplicitPauseIntentActive = false
+        self.resetAdPlaybackState()
+        self.progress = 0
+        self.currentTimeMs = 0
+        self.duration = 0
         self.songNearingEnd = false
         self.shouldSuppressAutoplayAfterQueueEnd = false
 
@@ -130,11 +149,41 @@ extension PlayerService {
         episode: ArtistEpisode? = nil
     ) async {
         self.logger.info("Playing song: \(song.title)")
-        self.logger.debug("Web load strategy: \(String(describing: webLoadStrategy))")
+        let acceptsPlaybackRequest = SingletonPlayerWebView.shared.acceptsPlaybackRequest(
+            videoId: song.videoId,
+            strategy: webLoadStrategy
+        )
+        let targetQueueEntryID = self.queueEntries[safe: self.currentIndex].flatMap { entry in
+            entry.song.id == song.id && entry.song.videoId == song.videoId ? entry.id : nil
+        }
+        let isSameLogicalPlayback = targetQueueEntryID == self.activePlaybackQueueEntryID
+            && self.currentTrack?.id == song.id
+            && self.currentEpisode?.id == episode?.id
+        guard acceptsPlaybackRequest || !isSameLogicalPlayback else {
+            self.logger.debug("Song \(song.videoId) already loaded; resuming existing playback")
+            await self.resume()
+            return
+        }
+        let effectiveLoadStrategy: SingletonPlayerWebView.VideoLoadStrategy = acceptsPlaybackRequest
+            ? webLoadStrategy
+            : SingletonPlayerWebView.freshSameIDPlaybackStrategy(
+                isShowingAd: self.isShowingAd
+            )
+        self.beginNativeMusicPlaybackOccurrence(videoId: song.videoId)
+        self.activePlaybackQueueEntryID = targetQueueEntryID
+        self.isStoppingPlayback = false
+        self.logger.debug("Web load strategy: \(String(describing: effectiveLoadStrategy))")
         self.clearRestoredPlaybackSessionState()
         self.currentEpisode = episode
         // Brief `.loading` until the observer reports playback; in-place restarts may flash loading briefly.
         self.state = .loading
+        self.shouldResumeAfterInterruption = true
+        self.isAwaitingPlaybackConfirmation = true
+        self.isExplicitPauseIntentActive = false
+        self.resetAdPlaybackState()
+        self.progress = 0
+        self.currentTimeMs = 0
+        self.duration = song.duration ?? 0
         self.songNearingEnd = false
         self.shouldSuppressAutoplayAfterQueueEnd = false
         self.currentTrack = song
@@ -165,7 +214,10 @@ extension PlayerService {
         // create it from `pendingPlayVideoId` and autoload in `PersistentPlayerView`.
         self.showMiniPlayer = false
         if SingletonPlayerWebView.shared.webView != nil {
-            SingletonPlayerWebView.shared.loadVideo(videoId: song.videoId, strategy: webLoadStrategy)
+            SingletonPlayerWebView.shared.loadVideo(
+                videoId: song.videoId,
+                strategy: effectiveLoadStrategy
+            )
         }
 
         // Fetch full song metadata if we don't have feedbackTokens
@@ -205,6 +257,9 @@ extension PlayerService {
 
     func markPlaybackEnded() {
         self.state = .ended
+        self.shouldResumeAfterInterruption = false
+        self.isAwaitingPlaybackConfirmation = false
+        self.isExplicitPauseIntentActive = true
     }
 
     /// Updates whether the current track has video available.
@@ -248,16 +303,36 @@ extension PlayerService {
     func playPause() async {
         self.logger.debug("Toggle play/pause")
 
-        if self.isPendingRestoredLoadDeferred || self.pendingPlayVideoId != nil && self.shouldLoadPendingVideoBeforePlayback {
+        // `resume()` owns restored-session transitions. Never clear these flags
+        // here: a failed navigation may have deferred a still-authoritative seek.
+        if self.isRestoringPlaybackSession {
+            if self.shouldAutoResumeAfterRestoredLoad {
+                await self.pause()
+            } else {
+                await self.resume()
+            }
+            return
+        }
+
+        if self.isPendingRestoredLoadDeferred || self.pendingRestoredSeek != nil {
             await self.resume()
+            return
+        }
+
+        if self.pendingPlayVideoId != nil, self.shouldLoadPendingVideoBeforePlayback {
+            if self.shouldResumeAfterInterruption {
+                await self.pause()
+            } else {
+                await self.resume()
+            }
             return
         }
 
         self.clearRestoredPlaybackSessionState()
 
-        if self.pendingPlayVideoId != nil {
-            SingletonPlayerWebView.shared.playPause()
-        } else if self.isPlaying {
+        if self.state == .paused, !self.isAwaitingPlaybackConfirmation {
+            await self.resume()
+        } else if self.shouldResumeAfterInterruption || self.isAwaitingPlaybackConfirmation {
             await self.pause()
         } else {
             await self.resume()
@@ -267,6 +342,9 @@ extension PlayerService {
     /// Pauses playback.
     func pause() async {
         self.logger.debug("Pausing playback")
+        self.shouldResumeAfterInterruption = false
+        self.isAwaitingPlaybackConfirmation = false
+        self.isExplicitPauseIntentActive = true
 
         if self.isPendingRestoredLoadDeferred {
             self.state = .paused
@@ -300,6 +378,20 @@ extension PlayerService {
     /// Resumes playback.
     func resume() async {
         self.logger.debug("Resuming playback")
+        self.isStoppingPlayback = false
+        self.shouldResumeAfterInterruption = true
+        self.isAwaitingPlaybackConfirmation = true
+        self.isExplicitPauseIntentActive = false
+        if self.currentTrack != nil || self.pendingPlayVideoId != nil,
+           self.beginNativeMusicPlaybackReplayIfNeeded() != nil
+        {
+            self.state = .loading
+            self.progress = 0
+            self.currentTimeMs = 0
+            self.songNearingEnd = false
+            self.shouldSuppressAutoplayAfterQueueEnd = false
+            self.resetAdPlaybackState()
+        }
 
         guard let pendingPlayVideoId = self.pendingPlayVideoId else {
             self.clearRestoredPlaybackSessionState()
@@ -310,6 +402,13 @@ extension PlayerService {
         let shouldLoadPendingVideo = self.shouldLoadPendingVideoBeforePlayback
         if self.isPendingRestoredLoadDeferred {
             self.beginRestoredPlaybackLoad(autoResumeAfterSeek: true)
+        } else if self.isRestoringPlaybackSession {
+            self.shouldAutoResumeAfterRestoredLoad = true
+            self.state = .loading
+            if !shouldLoadPendingVideo {
+                SingletonPlayerWebView.shared.resumeReadyAdvertisementIfPresent()
+                return
+            }
         } else {
             self.clearRestoredPlaybackSessionState()
         }
@@ -588,11 +687,16 @@ extension PlayerService {
         self.clearRestoredPlaybackSessionState()
         SingletonPlayerWebView.shared.tearDown()
         self.state = .idle
+        self.shouldResumeAfterInterruption = false
+        self.isAwaitingPlaybackConfirmation = false
+        self.isExplicitPauseIntentActive = true
         self.songNearingEnd = false
         self.isKasetInitiatedPlayback = false
         self.shouldSuppressAutoplayAfterQueueEnd = false
         self.currentEpisode = nil
         self.currentTrack = nil
+        self.activePlaybackQueueEntryID = nil
+        self.resetMusicPlaybackOccurrenceState()
         self.pendingPlayVideoId = nil
         self.progress = 0
         self.currentTimeMs = 0
@@ -621,16 +725,26 @@ extension PlayerService {
     /// Stops playback and clears state.
     func stop() async {
         self.logger.debug("Stopping playback")
+        self.isStoppingPlayback = true
+        self.shouldResumeAfterInterruption = false
+        self.isAwaitingPlaybackConfirmation = false
+        self.isExplicitPauseIntentActive = true
         self.clearRestoredPlaybackSessionState()
-        await self.evaluatePlayerCommand("pauseVideo()")
         self.state = .idle
         self.songNearingEnd = false
         self.isKasetInitiatedPlayback = false
         self.shouldSuppressAutoplayAfterQueueEnd = false
         self.currentEpisode = nil
         self.currentTrack = nil
+        self.activePlaybackQueueEntryID = nil
+        self.resetMusicPlaybackOccurrenceState()
+        self.pendingPlayVideoId = nil
         self.progress = 0
+        self.currentTimeMs = 0
         self.duration = 0
+        self.resetAdPlaybackState()
+        await SingletonPlayerWebView.shared.cancelPendingPlayback()
+        self.isStoppingPlayback = false
     }
 
     /// Show the AirPlay picker for selecting audio output devices.

--- a/Sources/Kaset/Services/Player/PlayerService+PlaybackControls.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+PlaybackControls.swift
@@ -1,3 +1,5 @@
+// swiftlint:disable file_length
+
 import Foundation
 
 @MainActor
@@ -81,14 +83,41 @@ extension PlayerService {
 
     /// Plays a track by video ID.
     func play(videoId: String) async {
+        let intent = self.beginMusicPlaybackIntent()
+        await self.play(videoId: videoId, intent: intent)
+    }
+
+    func play(videoId: String, intent: MusicPlaybackIntent) async {
+        guard self.acceptsMusicPlaybackIntent(intent) else { return }
         self.logger.debug("play() called with videoId: \(videoId)")
         let acceptsPlaybackRequest = SingletonPlayerWebView.shared.acceptsPlaybackRequest(
             videoId: videoId,
             strategy: .standard
         )
         guard acceptsPlaybackRequest else {
+            self.beginNativeMusicPlaybackOccurrence(
+                videoId: videoId,
+                synchronizeCurrentDocument: true
+            )
+            self.clearRestoredPlaybackSessionState()
+            self.pendingPlayVideoId = videoId
+            self.activePlaybackQueueEntryID = nil
+            self.currentEpisode = nil
+            if self.currentTrack?.videoId != videoId {
+                self.resetTrackStatus()
+                self.currentTrack = Song(
+                    id: videoId,
+                    title: "Loading...",
+                    artists: [],
+                    videoId: videoId
+                )
+            }
             self.logger.debug("Video \(videoId) already loaded; resuming existing playback")
-            await self.resume()
+            await self.resume(intent: intent)
+            guard self.acceptsMusicPlaybackIntent(intent) else { return }
+            if self.currentTrack?.feedbackTokens == nil {
+                await self.fetchSongMetadata(videoId: videoId, queueOwner: .none)
+            }
             return
         }
         self.beginNativeMusicPlaybackOccurrence(videoId: videoId)
@@ -121,22 +150,26 @@ extension PlayerService {
 
         self.pendingPlayVideoId = videoId
 
-        // Hidden-first playback: keep the persistent WebView anchored at 1×1 and
-        // let its observer confirm playback once YouTube actually starts. If the
-        // singleton already exists, navigate immediately; otherwise SwiftUI will
-        // create it from `pendingPlayVideoId` and autoload in `PersistentPlayerView`.
         self.showMiniPlayer = false
         if SingletonPlayerWebView.shared.webView != nil {
             SingletonPlayerWebView.shared.loadVideo(videoId: videoId)
         }
 
-        // Fetch full song metadata in the background to get feedbackTokens
-        await self.fetchSongMetadata(videoId: videoId)
+        await self.fetchSongMetadata(
+            videoId: videoId,
+            queueOwner: .none
+        )
     }
 
     /// Plays a song.
     func play(song: Song) async {
-        await self.play(song: song, webLoadStrategy: .standard)
+        let intent = self.beginMusicPlaybackIntent()
+        await self.play(
+            song: song,
+            webLoadStrategy: .standard,
+            queueEntryID: self.currentQueueEntryID(matching: song),
+            intent: intent
+        )
     }
 
     /// Plays a song.
@@ -148,20 +181,74 @@ extension PlayerService {
         webLoadStrategy: SingletonPlayerWebView.VideoLoadStrategy,
         episode: ArtistEpisode? = nil
     ) async {
+        let intent = self.beginMusicPlaybackIntent()
+        await self.play(
+            song: song,
+            webLoadStrategy: webLoadStrategy,
+            episode: episode,
+            queueEntryID: self.currentQueueEntryID(matching: song),
+            intent: intent
+        )
+    }
+
+    // swiftlint:disable function_body_length
+    func play(
+        song: Song,
+        webLoadStrategy: SingletonPlayerWebView.VideoLoadStrategy,
+        episode: ArtistEpisode? = nil,
+        queueEntryID: UUID?,
+        startsPaused: Bool = false,
+        restoreClock: MusicPlaybackRestoreClock? = nil,
+        fetchesMetadata: Bool = true,
+        intent: MusicPlaybackIntent
+    ) async {
+        guard self.acceptsMusicPlaybackIntent(intent) else { return }
         self.logger.info("Playing song: \(song.title)")
         let acceptsPlaybackRequest = SingletonPlayerWebView.shared.acceptsPlaybackRequest(
             videoId: song.videoId,
             strategy: webLoadStrategy
         )
-        let targetQueueEntryID = self.queueEntries[safe: self.currentIndex].flatMap { entry in
-            entry.song.id == song.id && entry.song.videoId == song.videoId ? entry.id : nil
+        let hasSameLogicalOwner = if let queueEntryID {
+            queueEntryID == self.activePlaybackQueueEntryID
+        } else {
+            self.activePlaybackQueueEntryID == nil && self.currentTrack?.id == song.id
         }
-        let isSameLogicalPlayback = targetQueueEntryID == self.activePlaybackQueueEntryID
-            && self.currentTrack?.id == song.id
+        let isSameLogicalPlayback = hasSameLogicalOwner
+            && self.currentTrack?.videoId == song.videoId
             && self.currentEpisode?.id == episode?.id
-        guard acceptsPlaybackRequest || !isSameLogicalPlayback else {
-            self.logger.debug("Song \(song.videoId) already loaded; resuming existing playback")
-            await self.resume()
+        let hasPendingSameLogicalLoad = self.pendingPlayVideoId == song.videoId
+            && (self.state == .loading || self.isAwaitingPlaybackConfirmation)
+        guard !isSameLogicalPlayback
+            || (acceptsPlaybackRequest && !hasPendingSameLogicalLoad)
+        else {
+            if let restoreClock {
+                self.logger.debug("Song \(song.videoId) already loaded; restoring playback clock")
+                let targetProgress = self.beginPlaybackClockRestoration(
+                    restoreClock,
+                    songDuration: song.duration,
+                    startsPaused: startsPaused
+                )
+                SingletonPlayerWebView.shared.seekAndPause(to: targetProgress)
+                self.saveQueueForPersistence()
+                if fetchesMetadata, song.feedbackTokens == nil {
+                    await self.fetchSongMetadata(
+                        videoId: song.videoId,
+                        queueOwner: queueEntryID.map(MusicQueueMetadataOwner.entry) ?? .none
+                    )
+                }
+                return
+            }
+            if startsPaused {
+                self.logger.debug("Song \(song.videoId) already loaded; preserving paused playback")
+                self.shouldResumeAfterInterruption = false
+                self.isAwaitingPlaybackConfirmation = false
+                self.isExplicitPauseIntentActive = true
+                self.state = .paused
+                SingletonPlayerWebView.shared.pause()
+            } else {
+                self.logger.debug("Song \(song.videoId) already loaded; resuming existing playback")
+                await self.resume(intent: intent)
+            }
             return
         }
         let effectiveLoadStrategy: SingletonPlayerWebView.VideoLoadStrategy = acceptsPlaybackRequest
@@ -170,28 +257,94 @@ extension PlayerService {
                 isShowingAd: self.isShowingAd
             )
         self.beginNativeMusicPlaybackOccurrence(videoId: song.videoId)
-        self.activePlaybackQueueEntryID = targetQueueEntryID
+        self.activePlaybackQueueEntryID = queueEntryID
         self.isStoppingPlayback = false
         self.logger.debug("Web load strategy: \(String(describing: effectiveLoadStrategy))")
         self.clearRestoredPlaybackSessionState()
         self.currentEpisode = episode
-        // Brief `.loading` until the observer reports playback; in-place restarts may flash loading briefly.
         self.state = .loading
         self.shouldResumeAfterInterruption = true
         self.isAwaitingPlaybackConfirmation = true
         self.isExplicitPauseIntentActive = false
         self.resetAdPlaybackState()
-        self.progress = 0
-        self.currentTimeMs = 0
-        self.duration = song.duration ?? 0
+        self.progress = restoreClock?.progress ?? 0
+        self.currentTimeMs = Int((restoreClock?.progress ?? 0) * 1000)
+        self.duration = max(restoreClock?.duration ?? 0, song.duration ?? 0)
         self.songNearingEnd = false
         self.shouldSuppressAutoplayAfterQueueEnd = false
         self.currentTrack = song
-
-        // Mark that we initiated this playback (to detect and correct YouTube's autoplay override)
+        let restoredTargetProgress = restoreClock.map {
+            self.beginPlaybackClockRestoration(
+                $0,
+                songDuration: song.duration,
+                startsPaused: startsPaused
+            )
+        }
+        if startsPaused, restoredTargetProgress == nil {
+            self.shouldResumeAfterInterruption = false
+            self.isAwaitingPlaybackConfirmation = false
+            self.isExplicitPauseIntentActive = true
+            self.state = .paused
+        }
         self.isKasetInitiatedPlayback = true
+        self.applyInitialTrackStatus(from: song)
+        self.pendingPlayVideoId = song.videoId
+        self.routePlaybackToWeb(
+            song: song,
+            strategy: effectiveLoadStrategy,
+            acceptsPlaybackRequest: acceptsPlaybackRequest,
+            restoredTargetProgress: restoredTargetProgress,
+            startsPaused: startsPaused
+        )
 
-        // Use existing feedbackTokens if the song already has them
+        if queueEntryID != nil || restoreClock != nil {
+            self.saveQueueForPersistence()
+        }
+        if fetchesMetadata, song.feedbackTokens == nil {
+            await self.fetchSongMetadata(
+                videoId: song.videoId,
+                queueOwner: queueEntryID.map(MusicQueueMetadataOwner.entry) ?? .none
+            )
+        }
+    }
+
+    // swiftlint:enable function_body_length
+
+    private func routePlaybackToWeb(
+        song: Song,
+        strategy: SingletonPlayerWebView.VideoLoadStrategy,
+        acceptsPlaybackRequest: Bool,
+        restoredTargetProgress: TimeInterval?,
+        startsPaused: Bool
+    ) {
+        self.showMiniPlayer = false
+        let restoresLoadedSameVideo = restoredTargetProgress != nil
+            && !acceptsPlaybackRequest
+            && !self.isShowingAd
+            && SingletonPlayerWebView.shared.webView != nil
+        if let restoredTargetProgress, restoresLoadedSameVideo {
+            if let nativeGeneration = self.currentMusicPlaybackOccurrence?.nativeGeneration {
+                SingletonPlayerWebView.shared.setNativePlaybackGeneration(nativeGeneration)
+            }
+            SingletonPlayerWebView.shared.seekAndPause(to: restoredTargetProgress)
+        } else if SingletonPlayerWebView.shared.webView != nil {
+            self.onMusicPlaybackNavigationRequested?(
+                song.videoId,
+                self.shouldAutoplayPlaybackDocument
+            )
+            SingletonPlayerWebView.shared.loadVideo(
+                videoId: song.videoId,
+                strategy: strategy
+            )
+        }
+
+        if startsPaused, restoredTargetProgress == nil {
+            SingletonPlayerWebView.shared.pause()
+        }
+    }
+
+    func applyInitialTrackStatus(from song: Song) {
+        self.resetTrackStatus()
         if let tokens = song.feedbackTokens {
             self.currentTrackFeedbackTokens = tokens
             self.currentTrackInLibrary = song.isInLibrary ?? false
@@ -200,29 +353,8 @@ extension PlayerService {
             }
         }
 
-        // SongLikeStatusManager cache is the most up-to-date source for like status;
-        // use it to correct stale/missing song.likeStatus immediately.
-        if let cachedStatus = SongLikeStatusManager.shared.status(for: song.videoId) {
+        if let cachedStatus = self.songLikeStatusManager.status(for: song.videoId) {
             self.currentTrackLikeStatus = cachedStatus
-        }
-
-        self.pendingPlayVideoId = song.videoId
-
-        // Hidden-first playback: keep the persistent WebView anchored at 1×1 and
-        // let its observer confirm playback once YouTube actually starts. If the
-        // singleton already exists, navigate immediately; otherwise SwiftUI will
-        // create it from `pendingPlayVideoId` and autoload in `PersistentPlayerView`.
-        self.showMiniPlayer = false
-        if SingletonPlayerWebView.shared.webView != nil {
-            SingletonPlayerWebView.shared.loadVideo(
-                videoId: song.videoId,
-                strategy: effectiveLoadStrategy
-            )
-        }
-
-        // Fetch full song metadata if we don't have feedbackTokens
-        if song.feedbackTokens == nil {
-            await self.fetchSongMetadata(videoId: song.videoId)
         }
     }
 
@@ -301,29 +433,35 @@ extension PlayerService {
 
     /// Toggles play/pause.
     func playPause() async {
+        let intent = self.beginMusicPlaybackIntent()
+        await self.playPause(intent: intent)
+    }
+
+    func playPause(intent: MusicPlaybackIntent) async {
+        guard self.acceptsMusicPlaybackIntent(intent) else { return }
         self.logger.debug("Toggle play/pause")
 
         // `resume()` owns restored-session transitions. Never clear these flags
         // here: a failed navigation may have deferred a still-authoritative seek.
         if self.isRestoringPlaybackSession {
             if self.shouldAutoResumeAfterRestoredLoad {
-                await self.pause()
+                await self.pause(intent: intent)
             } else {
-                await self.resume()
+                await self.resume(intent: intent)
             }
             return
         }
 
         if self.isPendingRestoredLoadDeferred || self.pendingRestoredSeek != nil {
-            await self.resume()
+            await self.resume(intent: intent)
             return
         }
 
         if self.pendingPlayVideoId != nil, self.shouldLoadPendingVideoBeforePlayback {
             if self.shouldResumeAfterInterruption {
-                await self.pause()
+                await self.pause(intent: intent)
             } else {
-                await self.resume()
+                await self.resume(intent: intent)
             }
             return
         }
@@ -331,16 +469,22 @@ extension PlayerService {
         self.clearRestoredPlaybackSessionState()
 
         if self.state == .paused, !self.isAwaitingPlaybackConfirmation {
-            await self.resume()
+            await self.resume(intent: intent)
         } else if self.shouldResumeAfterInterruption || self.isAwaitingPlaybackConfirmation {
-            await self.pause()
+            await self.pause(intent: intent)
         } else {
-            await self.resume()
+            await self.resume(intent: intent)
         }
     }
 
     /// Pauses playback.
     func pause() async {
+        let intent = self.beginMusicPlaybackIntent()
+        await self.pause(intent: intent)
+    }
+
+    func pause(intent: MusicPlaybackIntent) async {
+        guard self.acceptsMusicPlaybackIntent(intent) else { return }
         self.logger.debug("Pausing playback")
         self.shouldResumeAfterInterruption = false
         self.isAwaitingPlaybackConfirmation = false
@@ -377,6 +521,12 @@ extension PlayerService {
 
     /// Resumes playback.
     func resume() async {
+        let intent = self.beginMusicPlaybackIntent()
+        await self.resume(intent: intent)
+    }
+
+    func resume(intent: MusicPlaybackIntent) async {
+        guard self.acceptsMusicPlaybackIntent(intent) else { return }
         self.logger.debug("Resuming playback")
         self.isStoppingPlayback = false
         self.shouldResumeAfterInterruption = true
@@ -433,40 +583,25 @@ extension PlayerService {
 
     /// Skips to next track.
     func next() async {
+        let intent = self.beginMusicPlaybackIntent()
+        await self.next(intent: intent)
+    }
+
+    func next(
+        intent: MusicPlaybackIntent,
+        defersNetworkFollowUp: Bool = false
+    ) async {
+        guard self.acceptsMusicPlaybackIntent(intent) else { return }
         self.logger.debug("Skipping to next track")
         self.clearRestoredPlaybackSessionState()
 
-        if !self.queue.isEmpty {
-            if self.currentIndex < self.queue.count - 1 {
-                self.pushForwardSkipStackIfLeavingIndex(for: self.currentIndex + 1)
-                self.currentIndex += 1
-                if let nextSong = self.queue[safe: self.currentIndex] {
-                    await self.play(song: nextSong)
-                }
-                await self.fetchMoreMixSongsIfNeeded()
-                await self.fillSmartShuffleWindow()
-                self.saveQueueForPersistence()
-            } else if self.repeatMode == .all {
-                self.pushForwardSkipStackIfLeavingIndex(for: 0)
-                self.currentIndex = 0
-                if let firstSong = self.queue.first {
-                    await self.play(song: firstSong)
-                }
-                await self.fillSmartShuffleWindow()
-                self.saveQueueForPersistence()
-            } else if self.mixContinuationToken != nil {
-                let previousCount = self.queue.count
-                await self.fetchMoreMixSongsIfNeeded()
-                if self.queue.count > previousCount {
-                    self.pushForwardSkipStackIfLeavingIndex(for: self.currentIndex + 1)
-                    self.currentIndex += 1
-                    if let nextSong = self.queue[safe: self.currentIndex] {
-                        await self.play(song: nextSong)
-                    }
-                    await self.fillSmartShuffleWindow()
-                    self.saveQueueForPersistence()
-                }
-            }
+        if self.shouldUseNativeQueueForTrackNavigation,
+           !self.queueEntries.isEmpty
+        {
+            await self.advanceNativeQueue(
+                intent: intent,
+                defersNetworkFollowUp: defersNetworkFollowUp
+            )
             return
         }
 
@@ -482,34 +617,130 @@ extension PlayerService {
         }
     }
 
+    private func advanceNativeQueue(
+        intent: MusicPlaybackIntent,
+        defersNetworkFollowUp: Bool
+    ) async {
+        if self.currentIndex < self.queueEntries.count - 1 {
+            await self.advanceToQueueIndex(
+                self.currentIndex + 1,
+                intent: intent,
+                fetchesMixContinuation: true,
+                defersNetworkFollowUp: defersNetworkFollowUp
+            )
+            return
+        }
+        if self.repeatMode == .all {
+            await self.advanceToQueueIndex(
+                0,
+                intent: intent,
+                fetchesMixContinuation: false,
+                defersNetworkFollowUp: defersNetworkFollowUp
+            )
+            return
+        }
+        guard self.mixContinuationToken != nil else { return }
+        let previousCount = self.queueEntries.count
+        let queueGeneration = self.queueLoadGeneration
+        await self.fetchMoreMixSongsIfNeeded(queueGeneration: queueGeneration)
+        guard self.acceptsMusicPlaybackIntent(intent),
+              self.queueEntries.count > previousCount
+        else { return }
+        await self.advanceToQueueIndex(
+            self.currentIndex + 1,
+            intent: intent,
+            fetchesMixContinuation: false,
+            defersNetworkFollowUp: defersNetworkFollowUp
+        )
+    }
+
+    private func advanceToQueueIndex(
+        _ index: Int,
+        intent: MusicPlaybackIntent,
+        fetchesMixContinuation: Bool,
+        defersNetworkFollowUp: Bool
+    ) async {
+        guard self.acceptsMusicPlaybackIntent(intent),
+              let entry = self.queueEntries[safe: index]
+        else { return }
+        let queueGeneration = self.queueLoadGeneration
+        self.pushForwardSkipStackIfLeavingIndex(for: index)
+        self.currentIndex = index
+        await self.play(
+            song: entry.song,
+            webLoadStrategy: .standard,
+            queueEntryID: entry.id,
+            fetchesMetadata: !defersNetworkFollowUp,
+            intent: intent
+        )
+        guard self.isCurrentQueueLoad(queueGeneration) else { return }
+        if defersNetworkFollowUp {
+            self.saveQueueForPersistence()
+            return
+        }
+        if fetchesMixContinuation {
+            await self.fetchMoreMixSongsIfNeeded(queueGeneration: queueGeneration)
+            guard self.isCurrentQueueLoad(queueGeneration) else { return }
+        }
+        await self.fillSmartShuffleWindow()
+        guard self.isCurrentQueueLoad(queueGeneration) else { return }
+        self.saveQueueForPersistence()
+    }
+
     /// Goes to previous track.
     func previous() async {
+        let intent = self.beginMusicPlaybackIntent()
+        await self.previous(intent: intent)
+    }
+
+    func previous(
+        intent: MusicPlaybackIntent,
+        defersNetworkFollowUp: Bool = false
+    ) async {
+        guard self.acceptsMusicPlaybackIntent(intent) else { return }
         self.logger.debug("Going to previous track")
         self.clearRestoredPlaybackSessionState()
 
-        if !self.queue.isEmpty {
+        if self.shouldUseNativeQueueForTrackNavigation,
+           !self.queueEntries.isEmpty
+        {
+            let queueGeneration = self.queueLoadGeneration
             if self.progress > 3 {
-                await self.seek(to: 0)
+                await self.seek(to: 0, intent: intent)
                 return
             }
 
-            if let priorIndex = self.popForwardSkipIndex(), self.queue.indices.contains(priorIndex) {
+            if let priorIndex = self.popForwardSkipIndex(), self.queueEntries.indices.contains(priorIndex) {
                 self.currentIndex = priorIndex
-                if let prevSong = self.queue[safe: priorIndex] {
-                    await self.play(song: prevSong)
+                if let previousEntry = self.queueEntries[safe: priorIndex] {
+                    await self.play(
+                        song: previousEntry.song,
+                        webLoadStrategy: .standard,
+                        queueEntryID: previousEntry.id,
+                        fetchesMetadata: !defersNetworkFollowUp,
+                        intent: intent
+                    )
                 }
+                guard self.isCurrentQueueLoad(queueGeneration) else { return }
                 self.saveQueueForPersistence()
                 return
             }
 
             if self.currentIndex > 0 {
                 self.currentIndex -= 1
-                if let prevSong = self.queue[safe: self.currentIndex] {
-                    await self.play(song: prevSong)
+                if let previousEntry = self.queueEntries[safe: self.currentIndex] {
+                    await self.play(
+                        song: previousEntry.song,
+                        webLoadStrategy: .standard,
+                        queueEntryID: previousEntry.id,
+                        fetchesMetadata: !defersNetworkFollowUp,
+                        intent: intent
+                    )
                 }
+                guard self.isCurrentQueueLoad(queueGeneration) else { return }
                 self.saveQueueForPersistence()
             } else {
-                await self.seek(to: 0)
+                await self.seek(to: 0, intent: intent)
             }
             return
         }
@@ -522,7 +753,7 @@ extension PlayerService {
         }
 
         if self.progress > 3 {
-            await self.seek(to: 0)
+            await self.seek(to: 0, intent: intent)
         } else {
             SingletonPlayerWebView.shared.previous()
         }
@@ -530,6 +761,12 @@ extension PlayerService {
 
     /// Seeks to a specific time.
     func seek(to time: TimeInterval) async {
+        let intent = self.beginMusicPlaybackIntent()
+        await self.seek(to: time, intent: intent)
+    }
+
+    func seek(to time: TimeInterval, intent: MusicPlaybackIntent) async {
+        guard self.acceptsMusicPlaybackIntent(intent) else { return }
         let clampedTime = self.duration > 0 ? min(max(time, 0), self.duration) : max(time, 0)
         self.logger.debug("Seeking to \(clampedTime)")
 
@@ -583,6 +820,8 @@ extension PlayerService {
     func setShuffleMode(_ newMode: ShuffleMode) {
         let oldMode = self.shuffleMode
         guard newMode != oldMode else { return }
+        let undoState = self.makeQueueStateSnapshot()
+        self.recordQueueStateForUndo(undoState)
         self.shuffleMode = newMode
 
         // Leaving smart: cancel any in-flight fill (so it can't re-add suggestions after the strip),
@@ -597,12 +836,12 @@ extension PlayerService {
         case .off:
             // If the current track is a Smart Shuffle suggestion, `stripSuggestedEntries()` keeps it
             // above and restore appends non-snapshot entries so playback stays anchored to it.
-            self.restoreQueueOrderBeforeShuffle(recordUndo: true)
+            self.restoreQueueOrderBeforeShuffle(recordUndo: false)
         case .on:
             // From .off: shuffle and snapshot original order.
             // From .smart (suggestions already stripped): reshuffle the originals in place.
             self.materializeShuffleQueueForCurrentTrack(
-                recordUndo: true,
+                recordUndo: false,
                 storesOriginalOrder: oldMode == .off
             )
         case .smart:
@@ -610,11 +849,11 @@ extension PlayerService {
             // From .on, preserve the existing original-order snapshot so turning shuffle off restores
             // playlist order rather than the already-shuffled order.
             self.materializeShuffleQueueForCurrentTrack(
-                recordUndo: true,
+                recordUndo: false,
                 storesOriginalOrder: oldMode == .off
             )
             // Phase 2 (async): fetch radio seeds and fill the suggestion window.
-            Task { await self.fillSmartShuffleWindow() }
+            self.scheduleSmartShuffleFillForCurrentQueue()
         }
 
         self.persistShuffleMode()
@@ -624,7 +863,8 @@ extension PlayerService {
     /// Cycles the player-bar shuffle control: off -> on -> smart -> off.
     /// When Smart Shuffle is disabled in settings, the smart state is skipped (off -> on -> off).
     func cycleShuffleMode() {
-        let smartAvailable = SettingsManager.shared.smartShuffleEnabled
+        self.beginMusicPlaybackIntent(allowsPriorTerminalEvent: true)
+        let smartAvailable = self.smartShuffleFeatureEnabled()
         switch self.shuffleMode {
         case .off: self.setShuffleMode(.on)
         case .on: self.setShuffleMode(smartAvailable ? .smart : .off)
@@ -635,6 +875,7 @@ extension PlayerService {
     /// Binary shuffle toggle, preserved for menu (⌘S), mini player, AppleScript, and AI callers.
     /// Turning shuffle "on" enables plain shuffle; turning "off" also exits smart mode.
     func toggleShuffle() {
+        self.beginMusicPlaybackIntent(allowsPriorTerminalEvent: true)
         self.setShuffleMode(self.shuffleEnabled ? .off : .on)
     }
 
@@ -649,102 +890,6 @@ extension PlayerService {
     func cycleRepeatMode() {
         self.advanceRepeatMode()
         self.logger.info("Repeat mode: \(String(describing: self.repeatMode))")
-    }
-
-    /// Clears active playback UI/WebView state when startup resolves to guest mode.
-    ///
-    /// Unlike explicit sign-out, this preserves only persisted sessions that are
-    /// known to have been created in guest mode. Legacy/unknown sessions are
-    /// cleared because they may contain account-owned listening metadata.
-    func clearPlaybackForGuestStartup() {
-        self.logger.info("Clearing active playback state for guest startup")
-        guard self.restoredPlaybackSessionOwnerScope == Self.playbackSessionScopeGuest else {
-            self.clearSavedQueue()
-            self.clearPlaybackForPrivacyBoundary(persistEmptyQueue: true)
-            return
-        }
-        self.logger.info("Preserving restored guest-owned playback session")
-    }
-
-    /// Clears guest-owned restored playback when startup resolves to a signed-in
-    /// account. Guest Mode itself is not persisted, so a guest-owned restore must
-    /// not silently move onto the authenticated playback store.
-    func clearGuestPlaybackForAuthenticatedStartup() {
-        guard self.restoredPlaybackSessionOwnerScope == Self.playbackSessionScopeGuest else { return }
-        self.logger.info("Clearing guest-owned playback state for authenticated startup")
-        self.clearSavedQueue()
-        self.clearPlaybackForPrivacyBoundary(persistEmptyQueue: true)
-    }
-
-    /// Synchronously clears playback, queue, and WebView state at the sign-out privacy boundary.
-    func clearPlaybackForSignOut() {
-        self.logger.info("Clearing playback state for sign-out")
-        self.clearPlaybackForPrivacyBoundary(persistEmptyQueue: true)
-    }
-
-    private func clearPlaybackForPrivacyBoundary(persistEmptyQueue: Bool) {
-        self.invalidatePendingPlaybackRequests()
-        self.clearRestoredPlaybackSessionState()
-        SingletonPlayerWebView.shared.tearDown()
-        self.state = .idle
-        self.shouldResumeAfterInterruption = false
-        self.isAwaitingPlaybackConfirmation = false
-        self.isExplicitPauseIntentActive = true
-        self.songNearingEnd = false
-        self.isKasetInitiatedPlayback = false
-        self.shouldSuppressAutoplayAfterQueueEnd = false
-        self.currentEpisode = nil
-        self.currentTrack = nil
-        self.activePlaybackQueueEntryID = nil
-        self.resetMusicPlaybackOccurrenceState()
-        self.pendingPlayVideoId = nil
-        self.progress = 0
-        self.currentTimeMs = 0
-        self.duration = 0
-        self.showMiniPlayer = false
-        self.isMiniPlayerVisible = false
-        self.showLyrics = false
-        self.showQueue = false
-        self.showVideo = false
-        self.currentTrackHasVideo = false
-        self.mixContinuationToken = nil
-        self.mixContinuationRequiresAuth = false
-        self.queueOrderBeforeShuffle = nil
-        self.clearQueueUndoRedoHistory()
-        self.currentIndex = 0
-        if !persistEmptyQueue {
-            self.suppressNextEmptyQueuePersistence = true
-        }
-        self.setQueue([])
-        self.resetTrackStatus()
-        if persistEmptyQueue {
-            self.saveQueueForPersistence()
-        }
-    }
-
-    /// Stops playback and clears state.
-    func stop() async {
-        self.logger.debug("Stopping playback")
-        self.isStoppingPlayback = true
-        self.shouldResumeAfterInterruption = false
-        self.isAwaitingPlaybackConfirmation = false
-        self.isExplicitPauseIntentActive = true
-        self.clearRestoredPlaybackSessionState()
-        self.state = .idle
-        self.songNearingEnd = false
-        self.isKasetInitiatedPlayback = false
-        self.shouldSuppressAutoplayAfterQueueEnd = false
-        self.currentEpisode = nil
-        self.currentTrack = nil
-        self.activePlaybackQueueEntryID = nil
-        self.resetMusicPlaybackOccurrenceState()
-        self.pendingPlayVideoId = nil
-        self.progress = 0
-        self.currentTimeMs = 0
-        self.duration = 0
-        self.resetAdPlaybackState()
-        await SingletonPlayerWebView.shared.cancelPendingPlayback()
-        self.isStoppingPlayback = false
     }
 
     /// Show the AirPlay picker for selecting audio output devices.

--- a/Sources/Kaset/Services/Player/PlayerService+PlaybackRestoration.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+PlaybackRestoration.swift
@@ -106,6 +106,9 @@ extension PlayerService {
         duration: TimeInterval
     ) {
         guard let currentSong = queue[safe: currentIndex] else { return }
+        self.beginMusicPlaybackIntent()
+        self.cancelDeferredQueueWork()
+        self.clearQueueUndoRedoHistory()
 
         self.clearRestoredPlaybackSessionState()
         self.clearForwardSkipNavigationStack()
@@ -145,19 +148,23 @@ extension PlayerService {
         // Seed the SongLikeStatusManager cache from the persisted song's likeStatus
         // so that fetchSongMetadata won't overwrite it with a parsed .indifferent default.
         if let persistedLikeStatus = currentSong.likeStatus, persistedLikeStatus != .indifferent {
-            SongLikeStatusManager.shared.setStatus(persistedLikeStatus, for: currentSong.videoId)
+            self.songLikeStatusManager.setStatus(persistedLikeStatus, for: currentSong.videoId)
             self.currentTrackLikeStatus = persistedLikeStatus
         }
 
         // SongLikeStatusManager cache is the most up-to-date source for like status
-        if let cachedStatus = SongLikeStatusManager.shared.status(for: currentSong.videoId) {
+        if let cachedStatus = self.songLikeStatusManager.status(for: currentSong.videoId) {
             self.currentTrackLikeStatus = cachedStatus
         }
 
         // At app launch the cache may be empty and the persisted song may lack likeStatus.
         // Fetch metadata from the API to get the correct like status.
+        let queueEntryID = self.currentQueueEntryID
         Task { [videoId = currentSong.videoId] in
-            await self.fetchSongMetadata(videoId: videoId)
+            await self.fetchSongMetadata(
+                videoId: videoId,
+                queueOwner: queueEntryID.map(MusicQueueMetadataOwner.entry) ?? .none
+            )
         }
     }
 
@@ -168,6 +175,34 @@ extension PlayerService {
         self.shouldForcePendingRestoredLoad = false
         self.isRestoringPlaybackSession = false
         self.shouldAutoResumeAfterRestoredLoad = false
+    }
+
+    /// Reconciles an undo/redo clock against physical media before resuming playback.
+    /// The observer owns retries until it sees the target, so a navigation or a
+    /// same-document restore cannot be overwritten by the outgoing media clock.
+    @discardableResult
+    func beginPlaybackClockRestoration(
+        _ restoreClock: MusicPlaybackRestoreClock,
+        songDuration: TimeInterval?,
+        startsPaused: Bool
+    ) -> TimeInterval {
+        self.clearRestoredPlaybackSessionState()
+        let resolvedDuration = max(restoreClock.duration, songDuration ?? 0)
+        let targetProgress = self.clampedRestoredProgress(
+            restoreClock.progress,
+            duration: resolvedDuration
+        )
+        self.progress = targetProgress
+        self.currentTimeMs = Int(targetProgress * 1000)
+        self.duration = resolvedDuration
+        self.pendingRestoredSeek = targetProgress
+        self.isRestoringPlaybackSession = true
+        self.shouldAutoResumeAfterRestoredLoad = !startsPaused
+        self.shouldResumeAfterInterruption = !startsPaused
+        self.isAwaitingPlaybackConfirmation = !startsPaused
+        self.isExplicitPauseIntentActive = startsPaused
+        self.state = startsPaused ? .paused : .loading
+        return targetProgress
     }
 
     /// Starts loading a restored session into the WebView without discarding the saved seek target.
@@ -229,6 +264,29 @@ extension PlayerService {
         self.reloadCurrentTrackForIdentitySwitch()
     }
 
+    private func clearAccountScopedPlaybackMetadata() {
+        func sanitized(_ entry: QueueEntry) -> QueueEntry {
+            var song = entry.song
+            song.likeStatus = nil
+            song.isInLibrary = nil
+            song.feedbackTokens = nil
+            return QueueEntry(id: entry.id, song: song, source: entry.source)
+        }
+
+        self.setQueue(entries: self.queueEntries.map(sanitized))
+        self.queueOrderBeforeShuffle = self.queueOrderBeforeShuffle?.map(sanitized)
+        if var currentTrack = self.currentTrack {
+            currentTrack.likeStatus = nil
+            currentTrack.isInLibrary = nil
+            currentTrack.feedbackTokens = nil
+            self.currentTrack = currentTrack
+        }
+        self.resetTrackStatus()
+        self.saveQueueForPersistence(
+            ownerScopeOverride: self.restoredPlaybackSessionOwnerScope
+        )
+    }
+
     /// Re-loads the currently playing track so it is served under the WebView
     /// session's current (just-switched) delegated identity.
     ///
@@ -239,6 +297,17 @@ extension PlayerService {
     /// Playback position and play/pause intent are preserved across the reload
     /// via the existing restored-session machinery.
     func reloadCurrentTrackForIdentitySwitch() {
+        self.accountSessionGeneration &+= 1
+        self.songLikeStatusManager.invalidateSession()
+        self.beginMusicPlaybackIntent()
+        self.cancelDeferredQueueWork()
+        self.clearQueueUndoRedoHistory()
+        self.libraryMutationGeneration &+= 1
+        self.confirmedLibraryStateByKey.removeAll()
+        self.mixContinuationToken = nil
+        self.mixContinuationRequiresAuth = false
+        self.clearAccountScopedPlaybackMetadata()
+
         guard let currentTrack = self.currentTrack else {
             self.logger.debug("Identity switch: no current track to re-point")
             return

--- a/Sources/Kaset/Services/Player/PlayerService+PlaybackRestoration.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+PlaybackRestoration.swift
@@ -4,6 +4,53 @@ import Foundation
 
 @MainActor
 extension PlayerService {
+    func updateAdPlaybackState(
+        isShowingAd: Bool,
+        observedProgress: TimeInterval,
+        observedVideoId: String?,
+        isAuthoritativeContent: Bool
+    ) {
+        if isShowingAd {
+            self.isShowingAd = true
+            return
+        }
+        guard isAuthoritativeContent else { return }
+        self.isShowingAd = false
+        self.lastNonAdContentProgress = observedProgress
+        self.lastNonAdContentVideoId = observedVideoId ?? self.currentTrack?.videoId
+    }
+
+    func resetAdPlaybackState() {
+        self.isShowingAd = false
+        self.lastNonAdContentProgress = 0
+        self.lastNonAdContentVideoId = nil
+    }
+
+    func lastNonAdContentProgress(for videoId: String) -> TimeInterval {
+        self.lastNonAdContentVideoId == videoId ? self.lastNonAdContentProgress : 0
+    }
+
+    func pendingRestoredSeekForWebRecovery(videoId: String) -> TimeInterval? {
+        guard self.pendingPlayVideoId == videoId,
+              self.isRestoringPlaybackSession || self.isPendingRestoredLoadDeferred
+        else { return nil }
+        return self.pendingRestoredSeek
+    }
+
+    /// Whether a newly committed ordinary playback document should retain an
+    /// autoplay request. Restored/repoint loads deliberately stay paused until
+    /// native seek reconciliation completes.
+    var shouldAutoplayPlaybackDocument: Bool {
+        guard !self.isRestoringPlaybackSession,
+              !self.isPendingRestoredLoadDeferred
+        else { return false }
+        return self.shouldResumeAfterInterruption
+    }
+
+    var shouldResumeReadyAdDuringRestoration: Bool {
+        self.isRestoringPlaybackSession && self.shouldAutoResumeAfterRestoredLoad
+    }
+
     /// Updates playback state from the persistent WebView observer.
     func updatePlaybackState(isPlaying: Bool, progress: Double, duration: Double) {
         let previousProgress = self.progress
@@ -26,6 +73,30 @@ extension PlayerService {
         )
     }
 
+    /// Updates only play/pause transport while deliberately preserving the
+    /// canonical content clock (used for ready advertisement media).
+    func updatePlaybackTransportState(isPlaying: Bool) {
+        if isPlaying {
+            guard self.shouldResumeAfterInterruption
+                || self.shouldResumeReadyAdDuringRestoration
+            else { return }
+            switch self.state {
+            case .loading, .paused, .playing, .buffering:
+                self.state = .playing
+            case .idle, .ended, .error:
+                break
+            }
+        } else {
+            self.isAwaitingPlaybackConfirmation = false
+            switch self.state {
+            case .loading, .playing, .buffering:
+                self.state = .paused
+            case .idle, .paused, .ended, .error:
+                break
+            }
+        }
+    }
+
     /// Applies a previously persisted playback session in a paused, resume-ready state.
     func applyRestoredPlaybackSession(
         queue: [Song],
@@ -46,6 +117,7 @@ extension PlayerService {
             self.setQueue(queue)
         }
         self.currentIndex = currentIndex
+        self.activePlaybackQueueEntryID = self.currentQueueEntryID
         self.currentTrack = currentSong
         self.pendingPlayVideoId = currentSong.videoId
         self.currentTrackHasVideo = currentSong.musicVideoType?.hasVideoContent ?? currentSong.hasVideo ?? false
@@ -109,10 +181,39 @@ extension PlayerService {
         }
     }
 
+    /// Converts an interrupted restored/repoint load into a retryable paused
+    /// state without discarding its saved seek. A later explicit resume starts a
+    /// fresh full-page navigation and reuses the same restoration target.
+    func deferRestoredPlaybackAfterNavigationFailure() {
+        if self.pendingPlayVideoId == nil {
+            self.pendingPlayVideoId = self.currentTrack?.videoId
+        }
+
+        if self.pendingRestoredSeek == nil, self.state != .ended {
+            let contentProgress: TimeInterval = if self.isShowingAd,
+                                                   let targetVideoId = self.pendingPlayVideoId
+            {
+                self.lastNonAdContentProgress(for: targetVideoId)
+            } else {
+                self.progress
+            }
+            self.pendingRestoredSeek = contentProgress > 0 ? contentProgress : nil
+        }
+        self.isRestoringPlaybackSession = false
+        self.isPendingRestoredLoadDeferred = true
+        self.shouldForcePendingRestoredLoad = true
+        self.shouldAutoResumeAfterRestoredLoad = false
+        self.shouldResumeAfterInterruption = false
+
+        if self.state != .ended {
+            self.state = .paused
+        }
+    }
+
     /// Whether the pending track must be loaded into the WebView before playback can resume.
     var shouldLoadPendingVideoBeforePlayback: Bool {
         guard let pendingPlayVideoId = self.pendingPlayVideoId else { return false }
-        return self.shouldForcePendingRestoredLoad || SingletonPlayerWebView.shared.currentVideoId != pendingPlayVideoId
+        return self.shouldForcePendingRestoredLoad || self.currentWebPlaybackVideoId() != pendingPlayVideoId
     }
 
     func reloadCurrentTrackForAuthDataStoreChange(usesCookieFreeDataStore: Bool) {
@@ -155,7 +256,7 @@ extension PlayerService {
         }
         // If the current track was never actually loaded into the WebView, there
         // is likewise nothing to re-point under the old identity.
-        if SingletonPlayerWebView.shared.currentVideoId != currentTrack.videoId {
+        if self.currentWebPlaybackVideoId() != currentTrack.videoId {
             self.logger.debug("Identity switch: current track not loaded in WebView; skipping re-point")
             return
         }
@@ -202,9 +303,20 @@ private extension PlayerService {
         }
 
         if isPlaying {
+            guard !self.isExplicitPauseIntentActive else {
+                SingletonPlayerWebView.shared.pause()
+                return
+            }
+            self.isAwaitingPlaybackConfirmation = false
             self.confirmPlaybackStarted()
-        } else if self.state == .playing {
-            self.state = .paused
+        } else {
+            self.isAwaitingPlaybackConfirmation = false
+            switch self.state {
+            case .loading, .playing, .buffering:
+                self.state = .paused
+            case .idle, .paused, .ended, .error:
+                break
+            }
         }
 
         // Detect when song is about to end (within last 2 seconds)

--- a/Sources/Kaset/Services/Player/PlayerService+Queue.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+Queue.swift
@@ -7,6 +7,7 @@ import Foundation
 extension PlayerService {
     /// Plays a queue of songs starting at the specified index.
     func playQueue(_ songs: [Song], startingAt index: Int = 0) async {
+        guard !songs.isEmpty else { return }
         await self.playQueue(songs, startingAt: index, deferringSmartShuffleFill: false)
     }
 
@@ -15,15 +16,28 @@ extension PlayerService {
     /// - Parameter deferringSmartShuffleFill: When true, the trailing Smart Shuffle fill is skipped
     ///   and a deferred-load generation is returned so the caller can grow the queue to the full playlist
     ///   before suggestions are generated (via ``appendOriginalTracks(_:)`` + ``endQueueLoading(_:)``).
-    ///   The loading flag is set synchronously before playback's first suspension point, so the
-    ///   premature fill cannot slip through. When false the queue is treated as complete: any stale
-    ///   deferred load is superseded and suggestions fill immediately for smart mode.
     /// - Returns: The deferred-load generation when deferring, otherwise nil.
     @discardableResult
     func playQueue(_ songs: [Song], startingAt index: Int = 0, deferringSmartShuffleFill: Bool) async -> Int? {
         guard !songs.isEmpty else { return nil }
-        // A new playback replaces the queue: reset smart-shuffle bookkeeping and cancel any
-        // in-flight fill so the prior queue's state cannot starve or pollute this one.
+        let intent = self.beginMusicPlaybackIntent()
+        return await self.playQueue(
+            songs,
+            startingAt: index,
+            deferringSmartShuffleFill: deferringSmartShuffleFill,
+            intent: intent
+        )
+    }
+
+    @discardableResult
+    func playQueue(
+        _ songs: [Song],
+        startingAt index: Int,
+        deferringSmartShuffleFill: Bool,
+        intent: MusicPlaybackIntent
+    ) async -> Int? {
+        guard self.acceptsMusicPlaybackIntent(intent), !songs.isEmpty else { return nil }
+        self.invalidateMixContinuationRequest()
         self.resetSmartShuffleForNewQueue()
         let loadGeneration: Int?
         if deferringSmartShuffleFill {
@@ -32,6 +46,7 @@ extension PlayerService {
             self.invalidateStaleQueueLoad()
             loadGeneration = nil
         }
+        let queueGeneration = loadGeneration ?? self.queueLoadGeneration
         self.clearForwardSkipNavigationStack()
         self.recordQueueStateForUndo()
         let safeIndex = max(0, min(index, songs.count - 1))
@@ -49,16 +64,20 @@ extension PlayerService {
             self.setQueue(entries: entries)
             self.currentIndex = safeIndex
         }
-        // Clear mix continuation since this is not a mix queue
         self.mixContinuationToken = nil
-        if let song = self.queue[safe: self.currentIndex] {
-            await self.play(song: song)
+        if let entry = self.queueEntries[safe: self.currentIndex] {
+            await self.play(
+                song: entry.song,
+                webLoadStrategy: .standard,
+                queueEntryID: entry.id,
+                intent: intent
+            )
         }
+        guard self.isCurrentQueueLoad(queueGeneration) else { return loadGeneration }
         self.saveQueueForPersistence()
-        // While a deferred load is pending, `endQueueLoading` performs the single authoritative fill
-        // against the complete playlist (the `isQueueLoading` guard already no-ops a call here).
         if self.shuffleMode == .smart, loadGeneration == nil {
             await self.fillSmartShuffleWindow()
+            guard self.isCurrentQueueLoad(queueGeneration) else { return nil }
         }
         return loadGeneration
     }
@@ -66,22 +85,40 @@ extension PlayerService {
     /// Plays a song and fetches similar songs (radio queue) in the background.
     /// The queue will be populated with similar songs from YouTube Music's radio feature.
     func playWithRadio(song: Song) async {
+        let intent = self.beginMusicPlaybackIntent()
+        await self.playWithRadio(song: song, intent: intent)
+    }
+
+    func playWithRadio(song: Song, intent: MusicPlaybackIntent) async {
+        guard self.acceptsMusicPlaybackIntent(intent) else { return }
         self.logger.info("Playing with radio: \(song.title)")
         self.clearForwardSkipNavigationStack()
         self.recordQueueStateForUndo()
         self.prepareForNewPlaybackContext()
-
-        // Clear mix continuation since this is a song radio, not a mix
+        self.invalidateMixContinuationRequest()
         self.mixContinuationToken = nil
+        let queueGeneration = self.queueLoadGeneration
 
-        // Start with just this song in the queue
-        self.setQueue([song])
+        let seedEntry = QueueEntry(id: UUID(), song: song)
+        self.setQueue(entries: [seedEntry])
         self.queueOrderBeforeShuffle = nil
         self.currentIndex = 0
-        await self.play(song: song)
+        await self.play(
+            song: song,
+            webLoadStrategy: .standard,
+            queueEntryID: seedEntry.id,
+            intent: intent
+        )
+        guard self.isCurrentQueueLoad(queueGeneration),
+              self.activePlaybackQueueEntryID == seedEntry.id
+        else { return }
 
-        // Fetch radio queue in background
-        await self.fetchAndApplyRadioQueue(for: song.videoId)
+        await self.fetchAndApplyRadioQueue(
+            for: song.videoId,
+            seedEntryID: seedEntry.id,
+            queueGeneration: queueGeneration
+        )
+        guard self.isCurrentQueueLoad(queueGeneration) else { return }
         self.saveQueueForPersistence()
     }
 
@@ -91,12 +128,16 @@ extension PlayerService {
     /// - Parameters:
     ///   - playlistId: The mix playlist ID (e.g., "RDEM..." for artist mix)
     ///   - startVideoId: Optional video ID to start with. If nil, API picks a random starting point.
-    func playWithMix(playlistId: String, startVideoId: String?) async {
+    func playWithMix(
+        playlistId: String,
+        startVideoId: String?,
+        intent suppliedIntent: MusicPlaybackIntent? = nil
+    ) async {
+        let intent = suppliedIntent ?? self.beginMusicPlaybackIntent()
+        guard self.acceptsMusicPlaybackIntent(intent) else { return }
         self.logger.info("Playing mix playlist: \(playlistId), startVideoId: \(startVideoId ?? "nil (random)")")
-        let requestGeneration = self.playbackRequestGeneration
         let continuationRequiresAuth = self.authService?.hasPersonalAccount == true
         self.clearForwardSkipNavigationStack()
-        self.recordQueueStateForUndo()
 
         guard let client = self.ytMusicClient else {
             self.logger.warning("No YTMusicClient available for playing mix")
@@ -111,10 +152,12 @@ extension PlayerService {
                 return
             }
 
-            guard requestGeneration == self.playbackRequestGeneration else {
-                self.logger.info("Discarding stale mix playback request after privacy boundary")
+            guard self.acceptsMusicPlaybackIntent(intent) else {
+                self.logger.info("Discarding stale mix playback request after playback boundary")
                 return
             }
+
+            let priorQueueState = self.makeQueueStateSnapshot()
 
             // Store continuation token for infinite mix
             self.mixContinuationToken = result.continuationToken
@@ -124,31 +167,49 @@ extension PlayerService {
             // YouTube's API returns a personalized but consistent order per session,
             // so we shuffle to give the user variety on each Mix button click
             let shuffledSongs = result.songs.shuffled()
+            let shuffledEntries = shuffledSongs.map { QueueEntry(id: UUID(), song: $0) }
+            self.recordQueueStateForUndo(priorQueueState)
 
             // The mix is confirmed non-empty: now supersede any in-flight deferred load and reset
             // smart-shuffle (done here, not before the await, so a failed/empty mix that returns
             // without replacing the queue does not prematurely stand down an active playlist load).
             self.prepareForNewPlaybackContext()
+            let queueGeneration = self.queueLoadGeneration
 
             // Set up the queue and play the first song
-            self.setQueue(shuffledSongs)
+            self.setQueue(entries: shuffledEntries)
             self.queueOrderBeforeShuffle = nil
             self.currentIndex = 0
-            self.currentTrack = shuffledSongs[0]
 
-            // Start playback
-            await self.play(videoId: shuffledSongs[0].videoId)
-
-            self.logger.info("Mix queue loaded with \(shuffledSongs.count) songs, hasContinuation: \(result.continuationToken != nil)")
+            if let firstEntry = self.queueEntries.first {
+                await self.play(
+                    song: firstEntry.song,
+                    webLoadStrategy: .standard,
+                    queueEntryID: firstEntry.id,
+                    intent: intent
+                )
+            }
+            guard self.isCurrentQueueLoad(queueGeneration) else { return }
+            self.logger.info(
+                "Mix queue loaded with \(shuffledEntries.count) songs, hasContinuation: \(result.continuationToken != nil)"
+            )
             self.saveQueueForPersistence()
         } catch {
+            guard self.acceptsMusicPlaybackIntent(intent) else { return }
             self.logger.warning("Failed to fetch mix queue: \(error.localizedDescription)")
         }
     }
 
     /// Fetches more songs for the current mix when approaching the end of the queue.
     /// This enables "infinite mix" behavior like YouTube Music web.
-    func fetchMoreMixSongsIfNeeded() async {
+    func fetchMoreMixSongsIfNeeded(
+        queueGeneration suppliedQueueGeneration: Int? = nil
+    ) async {
+        if self.isFetchingMoreMixSongs {
+            await self.waitForActiveMixContinuationRequest()
+            return
+        }
+
         let songsRemaining = self.queue.count - self.currentIndex - 1
         self.logger.debug("Infinite mix check: \(songsRemaining) songs remaining, hasContinuation: \(self.mixContinuationToken != nil)")
 
@@ -166,17 +227,23 @@ extension PlayerService {
             return
         }
 
+        let queueGeneration = suppliedQueueGeneration ?? self.queueLoadGeneration
+        guard self.isCurrentQueueLoad(queueGeneration) else { return }
         self.logger.info("Fetching more mix songs, \(songsRemaining) remaining in queue")
         self.isFetchingMoreMixSongs = true
-        let requestGeneration = self.playbackRequestGeneration
+        let requestID = UUID()
+        self.activeMixContinuationRequestID = requestID
+        defer {
+            self.finishMixContinuationRequest(requestID)
+        }
 
         do {
             let result = try await client.getMixQueueContinuation(continuationToken: token)
-            guard requestGeneration == self.playbackRequestGeneration else {
-                self.logger.info("Discarding stale mix continuation after privacy boundary")
-                self.isFetchingMoreMixSongs = false
+            guard self.isCurrentQueueLoad(queueGeneration) else {
+                self.logger.info("Discarding stale mix continuation after queue replacement")
                 return
             }
+            guard self.activeMixContinuationRequestID == requestID else { return }
             self.logger.debug("Continuation returned \(result.songs.count) songs, hasNextToken: \(result.continuationToken != nil)")
 
             // Filter out songs already in queue to avoid duplicates
@@ -195,96 +262,116 @@ extension PlayerService {
         } catch {
             self.logger.warning("Failed to fetch more mix songs: \(error.localizedDescription)")
         }
-
-        self.isFetchingMoreMixSongs = false
     }
 
-    /// Fetches radio queue and applies it, keeping the current song at the front.
+    /// Fetches radio queue and applies it to the queue context that owns the seed.
     func fetchAndApplyRadioQueue(for videoId: String) async {
-        let requestGeneration = self.playbackRequestGeneration
-        guard let client = ytMusicClient else {
-            self.logger.warning("No YTMusicClient available for fetching radio queue")
-            return
-        }
+        await self.fetchAndApplyRadioQueue(
+            for: videoId,
+            seedEntryID: self.activePlaybackQueueEntryID,
+            queueGeneration: self.queueLoadGeneration
+        )
+    }
+
+    func fetchAndApplyRadioQueue(
+        for videoId: String,
+        seedEntryID: UUID?,
+        queueGeneration: Int
+    ) async {
+        guard self.isCurrentQueueLoad(queueGeneration),
+              let client = self.ytMusicClient
+        else { return }
 
         do {
             let radioSongs = try await client.getRadioQueue(videoId: videoId)
-            guard requestGeneration == self.playbackRequestGeneration else {
-                self.logger.info("Discarding stale radio queue after privacy boundary")
+            guard self.isCurrentQueueLoad(queueGeneration) else {
+                self.logger.info("Discarding stale radio queue after queue replacement")
                 return
             }
             guard !radioSongs.isEmpty else {
                 self.logger.info("No radio songs returned")
                 return
             }
-
-            // Only update if we're still playing the same song
-            guard let currentSong = self.currentTrack, currentSong.videoId == videoId else {
-                self.logger.info("Track changed, discarding radio queue")
+            guard let seedEntryID,
+                  let seedEntry = self.queueEntries.first(where: { $0.id == seedEntryID }),
+                  seedEntry.song.videoId == videoId,
+                  self.currentTrack?.videoId == videoId,
+                  self.activePlaybackQueueEntryID == seedEntryID
+            else {
+                self.logger.info("Logical seed changed, discarding radio queue")
                 return
             }
 
-            // Ensure the current song is at the front of the queue
-            // The radio queue may or may not include the seed song
-            var newQueue: [Song] = []
-
-            // Check if the current song is already in the radio queue
-            let radioContainsCurrentSong = radioSongs.contains { $0.videoId == videoId }
-
-            if radioContainsCurrentSong {
-                // Find the index of current song and reorder queue to start from it
-                if let currentSongIndex = radioSongs.firstIndex(where: { $0.videoId == videoId }) {
-                    // Put current song first, then the rest
-                    newQueue.append(currentSong)
-                    for (index, song) in radioSongs.enumerated() where index != currentSongIndex {
-                        newQueue.append(song)
-                    }
-                } else {
-                    newQueue = radioSongs
-                }
-            } else {
-                // Current song not in radio queue - prepend it
-                newQueue.append(currentSong)
-                newQueue.append(contentsOf: radioSongs)
+            let existingVideoIDs = Set(self.queue.map(\.videoId))
+            let relatedEntries = radioSongs.compactMap { song -> QueueEntry? in
+                guard song.videoId != videoId,
+                      !existingVideoIDs.contains(song.videoId)
+                else { return nil }
+                return QueueEntry(id: UUID(), song: song)
             }
+            guard !relatedEntries.isEmpty else { return }
 
             self.clearForwardSkipNavigationStack()
             self.recordQueueStateForUndo()
-            let entries = newQueue.map { QueueEntry(id: UUID(), song: $0) }
             if self.shuffleEnabled {
+                let liveEntryIDs = Set(self.queueEntries.map(\.id))
+                var originalEntries = (self.queueOrderBeforeShuffle ?? []).filter {
+                    liveEntryIDs.contains($0.id)
+                }
+                let originalIDs = Set(originalEntries.map(\.id))
+                originalEntries.append(contentsOf: self.queueEntries.filter {
+                    !originalIDs.contains($0.id)
+                })
+                originalEntries.append(contentsOf: relatedEntries)
+                let seedOriginalIndex = originalEntries.firstIndex(where: { $0.id == seedEntryID }) ?? 0
                 self.materializeShuffleQueue(
-                    entries: entries,
-                    startingAt: 0,
+                    entries: originalEntries,
+                    startingAt: seedOriginalIndex,
                     recordUndo: false,
                     storesOriginalOrder: true
                 )
             } else {
-                self.setQueue(entries: entries)
+                self.setQueue(entries: self.queueEntries + relatedEntries)
                 self.queueOrderBeforeShuffle = nil
-                self.currentIndex = 0
             }
-            self.logger.info("Radio queue updated with \(newQueue.count) songs (current song at front)")
+            if let seedIndex = self.queueEntries.firstIndex(where: { $0.id == seedEntryID }) {
+                self.currentIndex = seedIndex
+            }
+            self.activePlaybackQueueEntryID = seedEntryID
+            self.logger.info("Radio queue merged with \(relatedEntries.count) related songs")
             self.saveQueueForPersistence()
         } catch {
+            guard self.isCurrentQueueLoad(queueGeneration) else { return }
             self.logger.warning("Failed to fetch radio queue: \(error.localizedDescription)")
         }
     }
 
-    /// Clears the entire queue and current track (for "Clear" in side panel). Records state for undo.
-    func clearQueueEntirely() {
+    /// Stops playback and clears the entire queue. Records state for undo.
+    func clearQueueEntirely() async {
+        await self.stopAndClearQueue()
+    }
+
+    func clearQueueEntriesAfterStop(
+        intent: MusicPlaybackIntent,
+        undoState: QueueState? = nil
+    ) {
+        guard self.acceptsMusicPlaybackIntent(intent) else { return }
+        self.cancelDeferredQueueWork()
         self.clearForwardSkipNavigationStack()
-        self.recordQueueStateForUndo()
+        self.recordQueueStateForUndo(undoState ?? self.makeQueueStateSnapshot())
         self.mixContinuationToken = nil
         self.prepareForNewPlaybackContext()
         self.setQueue([])
         self.queueOrderBeforeShuffle = nil
         self.currentIndex = 0
         self.logger.info("Queue cleared entirely")
-        self.saveQueueForPersistence()
+        self.clearSavedQueue()
     }
 
     /// Clears the playback queue except for the currently playing track.
     func clearQueue() {
+        self.beginMusicPlaybackIntent(allowsPriorTerminalEvent: true)
+        self.cancelDeferredQueueWork()
         self.clearForwardSkipNavigationStack()
         self.recordQueueStateForUndo()
         // Clear mix continuation since queue is being manually cleared
@@ -299,7 +386,7 @@ extension PlayerService {
             return
         }
         // Keep only the current track
-        let currentEntryID = self.queueEntryIDs[safe: self.currentIndex]
+        let currentEntryID = self.queueEntryIDOwningCurrentPlayback
         self.setQueue([currentTrack], entryIDs: currentEntryID.map { [$0] })
         self.queueOrderBeforeShuffle = nil
         self.currentIndex = 0
@@ -309,16 +396,44 @@ extension PlayerService {
 
     /// Plays a song from the queue at the specified index.
     func playFromQueue(at index: Int) async {
-        guard index >= 0, index < self.queue.count else { return }
+        guard self.queueEntries.indices.contains(index) else { return }
+        let intent = self.beginMusicPlaybackIntent()
+        await self.playFromQueue(at: index, intent: intent)
+    }
+
+    func playFromQueue(at index: Int, intent: MusicPlaybackIntent) async {
+        guard self.acceptsMusicPlaybackIntent(intent) else { return }
+        guard index >= 0, index < self.queueEntries.count else { return }
+        let queueGeneration = self.queueLoadGeneration
         self.clearForwardSkipNavigationStack()
         self.currentIndex = index
-        if let song = queue[safe: index] {
-            await self.play(song: song)
+        if let entry = self.queueEntries[safe: index] {
+            await self.play(
+                song: entry.song,
+                webLoadStrategy: .standard,
+                queueEntryID: entry.id,
+                intent: intent
+            )
         }
-        // Check if we need to fetch more songs for infinite mix
-        await self.fetchMoreMixSongsIfNeeded()
+        guard self.isCurrentQueueLoad(queueGeneration) else { return }
+        await self.fetchMoreMixSongsIfNeeded(queueGeneration: queueGeneration)
+        guard self.isCurrentQueueLoad(queueGeneration) else { return }
         await self.fillSmartShuffleWindow()
+        guard self.isCurrentQueueLoad(queueGeneration) else { return }
         self.saveQueueForPersistence()
+    }
+
+    func playFromQueue(entryID: UUID) async {
+        guard self.queueEntries.contains(where: { $0.id == entryID }) else { return }
+        let intent = self.beginMusicPlaybackIntent()
+        await self.playFromQueue(entryID: entryID, intent: intent)
+    }
+
+    func playFromQueue(entryID: UUID, intent: MusicPlaybackIntent) async {
+        guard self.acceptsMusicPlaybackIntent(intent),
+              let index = self.queueEntries.firstIndex(where: { $0.id == entryID })
+        else { return }
+        await self.playFromQueue(at: index, intent: intent)
     }
 
     /// Inserts songs immediately after the current track.
@@ -410,6 +525,11 @@ extension PlayerService {
         self.recordQueueStateForUndo()
 
         let currentEntryID = self.currentQueueEntryID
+        let activePlaybackEntryID = self.activePlaybackQueueEntryID
+        let preferredRetainedEntryID = activePlaybackEntryID ?? currentEntryID
+        let preferredRetainedEntry = preferredRetainedEntryID.flatMap { preferredRetainedEntryID in
+            self.queueEntries.first(where: { $0.id == preferredRetainedEntryID })
+        }
         var seenVideoIds = Set<String>()
         var deduplicatedEntries: [QueueEntry] = []
         var removedCount = 0
@@ -420,7 +540,13 @@ extension PlayerService {
                 continue
             }
             seenVideoIds.insert(entry.song.videoId)
-            deduplicatedEntries.append(entry)
+            if preferredRetainedEntry?.song.videoId == entry.song.videoId,
+               let preferredRetainedEntry
+            {
+                deduplicatedEntries.append(preferredRetainedEntry)
+            } else {
+                deduplicatedEntries.append(entry)
+            }
         }
 
         guard removedCount > 0 else { return }
@@ -429,6 +555,7 @@ extension PlayerService {
         self.setQueue(entries: deduplicatedEntries)
         self.realignCurrentIndexAfterDuplicateRemoval(
             currentEntryID: currentEntryID,
+            activePlaybackEntryID: activePlaybackEntryID,
             priorEntries: priorEntries
         )
         self.logger.info("Removed \(removedCount) duplicate queue entries")
@@ -467,8 +594,18 @@ extension PlayerService {
 
     private func realignCurrentIndexAfterDuplicateRemoval(
         currentEntryID: UUID?,
+        activePlaybackEntryID: UUID?,
         priorEntries: [QueueEntry]
     ) {
+        if let activePlaybackEntryID,
+           !self.queueEntries.contains(where: { $0.id == activePlaybackEntryID }),
+           let removedActiveEntry = priorEntries.first(where: { $0.id == activePlaybackEntryID }),
+           let retainedActiveEntry = self.queueEntries.first(where: {
+               $0.song.videoId == removedActiveEntry.song.videoId
+           })
+        {
+            self.activePlaybackQueueEntryID = retainedActiveEntry.id
+        }
         if let currentEntryID,
            let keptIndex = self.queueEntries.firstIndex(where: { $0.id == currentEntryID })
         {
@@ -510,6 +647,43 @@ extension PlayerService {
         self.saveQueueForPersistence()
     }
 
+    /// Reorders one logical queue entry before another entry, or to the end when `beforeEntryID` is nil.
+    /// Entry IDs keep drag/drop stable when the queue changes between gesture start and drop.
+    func reorderQueue(entryID: UUID, before beforeEntryID: UUID?) {
+        guard entryID != self.queueEntryIDOwningCurrentPlayback,
+              let sourceIndex = self.queueEntries.firstIndex(where: { $0.id == entryID })
+        else {
+            self.logger.warning("Cannot reorder: cannot move current or missing track")
+            return
+        }
+        guard beforeEntryID != entryID else { return }
+        if let beforeEntryID,
+           !self.queueEntries.contains(where: { $0.id == beforeEntryID })
+        {
+            return
+        }
+
+        var updatedEntries = self.queueEntries
+        let movedEntry = updatedEntries.remove(at: sourceIndex)
+        let destination = beforeEntryID.flatMap { targetID in
+            updatedEntries.firstIndex(where: { $0.id == targetID })
+        } ?? updatedEntries.endIndex
+        updatedEntries.insert(movedEntry, at: destination)
+        guard updatedEntries != self.queueEntries else { return }
+
+        let currentEntryID = self.currentQueueEntryID
+        self.clearForwardSkipNavigationStack()
+        self.recordQueueStateForUndo()
+        self.setQueue(entries: updatedEntries)
+        if let currentEntryID,
+           let newCurrentIndex = updatedEntries.firstIndex(where: { $0.id == currentEntryID })
+        {
+            self.currentIndex = newCurrentIndex
+        }
+        self.logger.info("Queue reordered by entry identity")
+        self.saveQueueForPersistence()
+    }
+
     /// Reorders the queue by moving items from source indices to destination offset.
     /// Used for drag-and-drop reordering; does not allow moving the current track.
     /// - Parameters:
@@ -518,10 +692,6 @@ extension PlayerService {
     func reorderQueue(from source: IndexSet, to destination: Int) {
         guard !source.contains(self.currentIndex) else {
             self.logger.warning("Cannot reorder: cannot move current track")
-            return
-        }
-        guard destination != self.currentIndex else {
-            self.logger.warning("Cannot reorder: destination is current track")
             return
         }
         self.clearForwardSkipNavigationStack()
@@ -569,6 +739,8 @@ extension PlayerService {
            let newIndex = reorderedEntries.firstIndex(where: { $0.id == currentEntryID })
         {
             self.currentIndex = newIndex
+        } else {
+            self.currentIndex = min(self.currentIndex, max(0, reorderedEntries.count - 1))
         }
 
         self.logger.info("Queue reordered with \(reorderedEntries.count) songs")
@@ -577,6 +749,7 @@ extension PlayerService {
 
     /// Shuffles the queue, keeping the current track in place at the front.
     func shuffleQueue() {
+        self.beginMusicPlaybackIntent(allowsPriorTerminalEvent: true)
         self.materializeShuffleQueueForCurrentTrack(recordUndo: true, storesOriginalOrder: false)
     }
 
@@ -713,6 +886,11 @@ extension PlayerService {
         let progress: TimeInterval
         let duration: TimeInterval
         let ownerScope: String?
+        let shuffleMode: ShuffleMode?
+        let preShuffleQueue: [Song]?
+        let preShuffleEntrySources: [QueueEntry.Source]?
+        let preShuffleActiveIndex: Int?
+        let preShuffleEntryIndices: [Int]?
     }
 
     /// UserDefaults keys for queue persistence (no expiry; saved queue is kept until overwritten or cleared).
@@ -721,9 +899,9 @@ extension PlayerService {
     private static let savedPlaybackSessionKey = "kaset.saved.playbackSession"
 
     /// Saves the current queue to UserDefaults for restoration on next launch.
-    func saveQueueForPersistence() {
+    func saveQueueForPersistence(ownerScopeOverride: String? = nil) {
         let queue = self.queue
-        guard !queue.isEmpty else {
+        guard !queue.isEmpty || self.currentTrack != nil else {
             if self.suppressNextEmptyQueuePersistence {
                 self.suppressNextEmptyQueuePersistence = false
                 self.logger.info("Skipped clearing saved playback session after guest-startup cleanup")
@@ -738,9 +916,31 @@ extension PlayerService {
 
         // Smart Shuffle suggestions are ephemeral (regenerated from live context), so never
         // persist them. Strip before saving, keeping the currently-playing track if it is one.
-        let currentID = self.currentQueueEntryID
-        let persistedEntries = Self.stripSuggested(from: self.queueEntries, keepingCurrentID: currentID)
+        let activeQueueEntryID = self.queueEntryIDOwningCurrentPlayback
+        let persistedEntries: [QueueEntry]
+        let currentID: UUID?
+        if let activeQueueEntryID {
+            currentID = activeQueueEntryID
+            persistedEntries = Self.stripSuggested(
+                from: self.queueEntries,
+                keepingCurrentID: activeQueueEntryID
+            )
+        } else if let currentTrack = self.currentTrack {
+            let standaloneEntry = QueueEntry(id: UUID(), song: currentTrack)
+            currentID = standaloneEntry.id
+            persistedEntries = [standaloneEntry]
+        } else {
+            currentID = nil
+            persistedEntries = Self.stripSuggested(
+                from: self.queueEntries,
+                keepingCurrentID: nil
+            )
+        }
         let persistableQueue = persistedEntries.map(\.song)
+        let persistedEntryIDs = Set(persistedEntries.map(\.id))
+        let preShuffleEntries = self.queueOrderBeforeShuffle?.filter {
+            persistedEntryIDs.contains($0.id)
+        }
         guard !persistableQueue.isEmpty else {
             self.removeSavedPlaybackSession()
             return
@@ -761,10 +961,14 @@ extension PlayerService {
                 : max(self.progress, 0)
 
             let isKnownGuestSession = self.authService?.shouldPersistGuestPlaybackState == true
-            let ownerScope = isKnownGuestSession
+            let ownerScope = ownerScopeOverride ?? (isKnownGuestSession
                 ? Self.playbackSessionScopeGuest
-                : Self.playbackSessionScopeAuthenticated
+                : Self.playbackSessionScopeAuthenticated)
             let persistedQueue = isKnownGuestSession ? Self.queueWithoutAccountMetadata(persistableQueue) : persistableQueue
+            let persistedEntryIndexByID = Dictionary(
+                uniqueKeysWithValues: persistedEntries.enumerated().map { ($0.element.id, $0.offset) }
+            )
+            let preShuffleEntryIndices = preShuffleEntries?.compactMap { persistedEntryIndexByID[$0.id] }
             let queueData = try encoder.encode(persistedQueue)
             let sessionData = try encoder.encode(
                 PersistedPlaybackSession(
@@ -774,13 +978,23 @@ extension PlayerService {
                     currentVideoId: currentVideoId,
                     progress: clampedProgress,
                     duration: resolvedDuration,
-                    ownerScope: ownerScope
+                    ownerScope: ownerScope,
+                    shuffleMode: self.shuffleMode,
+                    preShuffleQueue: preShuffleEntries.map { entries in
+                        let songs = entries.map(\.song)
+                        return isKnownGuestSession ? Self.queueWithoutAccountMetadata(songs) : songs
+                    },
+                    preShuffleEntrySources: preShuffleEntries?.map(\.source),
+                    preShuffleActiveIndex: activeQueueEntryID.flatMap { activeID in
+                        preShuffleEntries?.firstIndex(where: { $0.id == activeID })
+                    },
+                    preShuffleEntryIndices: preShuffleEntryIndices
                 )
             )
 
-            UserDefaults.standard.set(queueData, forKey: Self.savedQueueKey)
-            UserDefaults.standard.set(safeIndex, forKey: Self.savedQueueIndexKey)
-            UserDefaults.standard.set(sessionData, forKey: Self.savedPlaybackSessionKey)
+            self.queuePersistenceDefaults.set(queueData, forKey: Self.savedQueueKey)
+            self.queuePersistenceDefaults.set(safeIndex, forKey: Self.savedQueueIndexKey)
+            self.queuePersistenceDefaults.set(sessionData, forKey: Self.savedPlaybackSessionKey)
             self.restoredPlaybackSessionOwnerScope = ownerScope
             self.logger.info("Saved playback session with \(persistedQueue.count) songs at index \(safeIndex)")
         } catch {
@@ -788,18 +1002,21 @@ extension PlayerService {
         }
     }
 
+    static func songWithoutAccountMetadata(_ song: Song) -> Song {
+        var sanitized = song
+        sanitized.likeStatus = nil
+        sanitized.isInLibrary = nil
+        sanitized.feedbackTokens = nil
+        return sanitized
+    }
+
     private static func queueWithoutAccountMetadata(_ queue: [Song]) -> [Song] {
-        queue.map { song in
-            var sanitized = song
-            sanitized.likeStatus = nil
-            sanitized.isInLibrary = nil
-            sanitized.feedbackTokens = nil
-            return sanitized
-        }
+        queue.map(self.songWithoutAccountMetadata)
     }
 
     func invalidatePendingPlaybackRequests() {
-        self.playbackRequestGeneration &+= 1
+        self.beginMusicPlaybackIntent()
+        self.invalidateMixContinuationRequest()
     }
 
     /// Re-tags a restored/persisted playback session after crossing a playback
@@ -807,7 +1024,7 @@ extension PlayerService {
     func updateRestoredPlaybackSessionOwnerScope(_ ownerScope: String?) {
         self.restoredPlaybackSessionOwnerScope = ownerScope
 
-        guard let sessionData = UserDefaults.standard.data(forKey: Self.savedPlaybackSessionKey) else { return }
+        guard let sessionData = self.queuePersistenceDefaults.data(forKey: Self.savedPlaybackSessionKey) else { return }
 
         do {
             let decoder = JSONDecoder()
@@ -819,10 +1036,15 @@ extension PlayerService {
                 currentVideoId: savedSession.currentVideoId,
                 progress: savedSession.progress,
                 duration: savedSession.duration,
-                ownerScope: ownerScope
+                ownerScope: ownerScope,
+                shuffleMode: savedSession.shuffleMode,
+                preShuffleQueue: savedSession.preShuffleQueue,
+                preShuffleEntrySources: savedSession.preShuffleEntrySources,
+                preShuffleActiveIndex: savedSession.preShuffleActiveIndex,
+                preShuffleEntryIndices: savedSession.preShuffleEntryIndices
             )
             let sessionData = try JSONEncoder().encode(updatedSession)
-            UserDefaults.standard.set(sessionData, forKey: Self.savedPlaybackSessionKey)
+            self.queuePersistenceDefaults.set(sessionData, forKey: Self.savedPlaybackSessionKey)
         } catch {
             self.logger.error("Failed to update playback session owner scope: \(error.localizedDescription)")
         }
@@ -834,7 +1056,7 @@ extension PlayerService {
     func restoreQueueFromPersistence() -> Bool {
         let decoder = JSONDecoder()
 
-        if let sessionData = UserDefaults.standard.data(forKey: Self.savedPlaybackSessionKey) {
+        if let sessionData = self.queuePersistenceDefaults.data(forKey: Self.savedPlaybackSessionKey) {
             do {
                 let savedSession = try decoder.decode(PersistedPlaybackSession.self, from: sessionData)
                 let restoredQueue = savedSession.ownerScope == Self.playbackSessionScopeGuest
@@ -842,7 +1064,7 @@ extension PlayerService {
                     : savedSession.queue
                 guard !restoredQueue.isEmpty else {
                     self.logger.info("Saved playback session is empty")
-                    UserDefaults.standard.removeObject(forKey: Self.savedPlaybackSessionKey)
+                    self.queuePersistenceDefaults.removeObject(forKey: Self.savedPlaybackSessionKey)
                     return self.restoreLegacyQueueFromPersistence(using: decoder)
                 }
 
@@ -859,6 +1081,17 @@ extension PlayerService {
                     progress: savedSession.progress,
                     duration: savedSession.duration
                 )
+                let savedShuffleMode = savedSession.shuffleMode ?? self.shuffleMode
+                self.shuffleMode = Self.resolvedShuffleMode(
+                    savedShuffleMode,
+                    smartShuffleEnabled: self.smartShuffleFeatureEnabled()
+                )
+                self.queueOrderBeforeShuffle = self.reconstructedPreShuffleEntries(
+                    songs: savedSession.preShuffleQueue,
+                    sources: savedSession.preShuffleEntrySources,
+                    activeIndex: savedSession.preShuffleActiveIndex,
+                    entryIndices: savedSession.preShuffleEntryIndices
+                )
                 self.restoredPlaybackSessionOwnerScope = savedSession.ownerScope
                 self.logger.info(
                     "Restored playback session with \(restoredQueue.count) songs at index \(resolvedIndex)"
@@ -867,11 +1100,68 @@ extension PlayerService {
                 return true
             } catch {
                 self.logger.error("Failed to restore playback session: \(error.localizedDescription)")
-                UserDefaults.standard.removeObject(forKey: Self.savedPlaybackSessionKey)
+                self.queuePersistenceDefaults.removeObject(forKey: Self.savedPlaybackSessionKey)
             }
         }
 
         return self.restoreLegacyQueueFromPersistence(using: decoder)
+    }
+
+    private func reconstructedPreShuffleEntries(
+        songs: [Song]?,
+        sources: [QueueEntry.Source]?,
+        activeIndex: Int?,
+        entryIndices: [Int]?
+    ) -> [QueueEntry]? {
+        guard let songs, !songs.isEmpty else { return nil }
+        if let entryIndices,
+           entryIndices.count == songs.count,
+           Set(entryIndices).count == entryIndices.count,
+           entryIndices.indices.allSatisfy({ index in
+               self.queueEntries.indices.contains(entryIndices[index])
+                   && self.queueEntries[entryIndices[index]].song.videoId == songs[index].videoId
+           })
+        {
+            return entryIndices.enumerated().map { index, queueIndex in
+                let entry = self.queueEntries[queueIndex]
+                return QueueEntry(
+                    id: entry.id,
+                    song: entry.song,
+                    source: sources?[safe: index] ?? entry.source
+                )
+            }
+        }
+
+        var availableEntries = self.queueEntries
+        var restoredEntries: [QueueEntry] = []
+        restoredEntries.reserveCapacity(songs.count)
+
+        for (index, song) in songs.enumerated() {
+            let activeEntryID = self.activePlaybackQueueEntryID
+            let activeMatchIndex = index == activeIndex ? availableEntries.firstIndex(where: {
+                $0.id == activeEntryID
+                    && $0.song.id == song.id
+                    && $0.song.videoId == song.videoId
+            }) : nil
+            let reservesActiveEntry = activeIndex != nil && index != activeIndex
+            let matchIndex = activeMatchIndex
+                ?? availableEntries.firstIndex(where: {
+                    (!reservesActiveEntry || $0.id != activeEntryID)
+                        && $0.song.id == song.id
+                        && $0.song.videoId == song.videoId
+                })
+                ?? availableEntries.firstIndex(where: {
+                    (!reservesActiveEntry || $0.id != activeEntryID)
+                        && $0.song.videoId == song.videoId
+                })
+            guard let matchIndex else { continue }
+            var entry = availableEntries.remove(at: matchIndex)
+            if let source = sources?[safe: index] {
+                entry = QueueEntry(id: entry.id, song: entry.song, source: source)
+            }
+            restoredEntries.append(entry)
+        }
+        return restoredEntries.isEmpty ? nil : restoredEntries
     }
 
     /// After restoring a saved session in smart mode, regenerates the (ephemeral, never-persisted)
@@ -879,7 +1169,7 @@ extension PlayerService {
     /// no-op until a client is attached and while the queue is still loading.
     private func fillSmartShuffleWindowAfterRestoreIfNeeded() {
         guard self.shuffleMode == .smart else { return }
-        Task { @MainActor in await self.fillSmartShuffleWindow() }
+        self.scheduleSmartShuffleFillForCurrentQueue()
     }
 
     /// Clears the saved queue from UserDefaults.
@@ -890,8 +1180,8 @@ extension PlayerService {
 
     /// Restores the legacy queue/index payload when no playback session is available.
     private func restoreLegacyQueueFromPersistence(using decoder: JSONDecoder) -> Bool {
-        guard let queueData = UserDefaults.standard.data(forKey: Self.savedQueueKey),
-              let savedIndex = UserDefaults.standard.object(forKey: Self.savedQueueIndexKey) as? Int
+        guard let queueData = self.queuePersistenceDefaults.data(forKey: Self.savedQueueKey),
+              let savedIndex = self.queuePersistenceDefaults.object(forKey: Self.savedQueueIndexKey) as? Int
         else {
             self.logger.info("No saved queue found")
             return false
@@ -931,9 +1221,9 @@ extension PlayerService {
 
     /// Removes all persisted queue/session payloads.
     private func removeSavedPlaybackSession() {
-        UserDefaults.standard.removeObject(forKey: Self.savedQueueKey)
-        UserDefaults.standard.removeObject(forKey: Self.savedQueueIndexKey)
-        UserDefaults.standard.removeObject(forKey: Self.savedPlaybackSessionKey)
+        self.queuePersistenceDefaults.removeObject(forKey: Self.savedQueueKey)
+        self.queuePersistenceDefaults.removeObject(forKey: Self.savedQueueIndexKey)
+        self.queuePersistenceDefaults.removeObject(forKey: Self.savedPlaybackSessionKey)
         self.restoredPlaybackSessionOwnerScope = nil
     }
 

--- a/Sources/Kaset/Services/Player/PlayerService+QueueEnrichment.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+QueueEnrichment.swift
@@ -32,23 +32,14 @@ extension PlayerService {
     }
 
     /// Identifies songs in the queue that need metadata enrichment.
-    /// - Returns: Array of tuples containing index and videoId for songs needing enrichment.
-    func identifySongsNeedingEnrichment() -> [(index: Int, videoId: String)] {
-        var songsNeedingEnrichment: [(index: Int, videoId: String)] = []
+    /// - Returns: Stable queue-entry IDs and video IDs for songs needing enrichment.
+    func identifySongsNeedingEnrichment() -> [(entryID: UUID, videoId: String)] {
+        var songsNeedingEnrichment: [(entryID: UUID, videoId: String)] = []
 
-        for (index, song) in queue.enumerated() {
-            // Check if song needs enrichment:
-            // 1. No artists or all artists are empty/unknown
-            // 2. Title is placeholder ("Loading..." or empty)
-            // 3. No thumbnail
-            let needsEnrichment = song.artists.isEmpty ||
-                song.artists.allSatisfy { $0.name.isEmpty || $0.name == "Unknown Artist" } ||
-                song.title.isEmpty ||
-                song.title == "Loading..." ||
-                song.thumbnailURL == nil
-
-            if needsEnrichment {
-                songsNeedingEnrichment.append((index: index, videoId: song.videoId))
+        for entry in self.queueEntries {
+            let song = entry.song
+            if Self.songNeedsQueueEnrichment(song) {
+                songsNeedingEnrichment.append((entryID: entry.id, videoId: song.videoId))
             }
         }
 
@@ -68,24 +59,31 @@ extension PlayerService {
 
         // Process in small batches to avoid overwhelming the API
         // Process one song at a time to be gentle on the API
-        for (index, videoId) in songsToEnrich {
-            // Check if still needed (song might have been removed)
-            guard index < queue.count, queue[index].videoId == videoId else { continue }
+        for (entryID, videoId) in songsToEnrich {
+            guard self.queueEntries.contains(where: { $0.id == entryID && $0.song.videoId == videoId }) else {
+                continue
+            }
 
             do {
                 let enrichedSong = try await client.getSong(videoId: videoId)
 
-                // Update the queue in-place
-                if index < queue.count, queue[index].videoId == videoId {
+                if let index = self.queueEntries.firstIndex(where: {
+                    $0.id == entryID && $0.song.videoId == videoId
+                }), Self.songNeedsQueueEnrichment(self.queueEntries[index].song) {
                     var updatedEntries = self.queueEntries
+                    let mergedSong = Self.mergingQueueMetadata(
+                        current: updatedEntries[index].song,
+                        response: enrichedSong,
+                        includesAccountMetadata: false
+                    )
                     // Preserve `source` so a Smart Shuffle `.suggested` entry is not demoted to `.queued`.
                     updatedEntries[index] = QueueEntry(
                         id: updatedEntries[index].id,
-                        song: enrichedSong,
+                        song: mergedSong,
                         source: updatedEntries[index].source
                     )
                     self.setQueue(entries: updatedEntries)
-                    self.logger.debug("Enriched song \(index): '\(enrichedSong.title)' - artists: \(enrichedSong.artistsDisplay)")
+                    self.logger.debug("Enriched song \(index): '\(mergedSong.title)' - artists: \(mergedSong.artistsDisplay)")
                 }
 
                 // Small delay between requests to be API-friendly
@@ -100,5 +98,44 @@ extension PlayerService {
         // Save the enriched queue to persistence
         self.saveQueueForPersistence()
         self.logger.info("Queue metadata enrichment complete, saved to persistence")
+    }
+
+    static func songNeedsQueueEnrichment(_ song: Song) -> Bool {
+        song.artists.isEmpty
+            || song.artists.allSatisfy { $0.name.isEmpty || $0.name == "Unknown Artist" }
+            || song.title.isEmpty
+            || song.title == "Loading..."
+            || song.thumbnailURL == nil
+    }
+
+    static func mergingQueueMetadata(
+        current: Song,
+        response: Song,
+        includesAccountMetadata: Bool = true
+    ) -> Song {
+        let keepsCurrentArtists = !current.artists.isEmpty
+            && !current.artists.allSatisfy { $0.name.isEmpty || $0.name == "Unknown Artist" }
+        let keepsCurrentTitle = !current.title.isEmpty && current.title != "Loading..."
+        return Song(
+            id: current.id,
+            title: keepsCurrentTitle ? current.title : response.title,
+            artists: keepsCurrentArtists ? current.artists : response.artists,
+            album: current.album ?? response.album,
+            duration: current.duration ?? response.duration,
+            thumbnailURL: current.thumbnailURL ?? response.thumbnailURL,
+            videoId: current.videoId,
+            // `getSong` uses the `next` parser, which defaults playability to true.
+            // Preserve the browse renderer's authoritative grey-out state during
+            // background enrichment alongside the account-scoped fields below.
+            isPlayable: includesAccountMetadata ? response.isPlayable : current.isPlayable,
+            hasVideo: current.hasVideo ?? response.hasVideo,
+            musicVideoType: current.musicVideoType ?? response.musicVideoType,
+            likeStatus: includesAccountMetadata ? (current.likeStatus ?? response.likeStatus) : current.likeStatus,
+            isInLibrary: includesAccountMetadata ? (current.isInLibrary ?? response.isInLibrary) : current.isInLibrary,
+            feedbackTokens: includesAccountMetadata
+                ? (current.feedbackTokens ?? response.feedbackTokens)
+                : current.feedbackTokens,
+            isExplicit: current.isExplicit ?? response.isExplicit
+        )
     }
 }

--- a/Sources/Kaset/Services/Player/PlayerService+QueueHistory.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+QueueHistory.swift
@@ -1,0 +1,268 @@
+import Foundation
+
+@MainActor
+extension PlayerService {
+    // MARK: - Queue Undo / Redo
+
+    /// Whether queue undo is available.
+    var canUndoQueue: Bool {
+        !self.queueUndoHistory.isEmpty
+    }
+
+    /// Whether queue redo is available.
+    var canRedoQueue: Bool {
+        !self.queueRedoHistory.isEmpty
+    }
+
+    /// Clears queue undo/redo history at account/privacy boundaries.
+    func clearQueueUndoRedoHistory() {
+        self.queueUndoHistory.removeAll()
+        self.queueRedoHistory.removeAll()
+    }
+
+    /// Records current queue state for undo (call before mutating queue). Clears redo. Keeps up to 10 states.
+    func recordQueueStateForUndo() {
+        self.recordQueueStateForUndo(self.makeQueueStateSnapshot())
+    }
+
+    func makeQueueStateSnapshot() -> QueueState {
+        QueueState(
+            entries: self.queueEntries.map(Self.queueHistoryEntryWithoutAccountMetadata),
+            currentIndex: self.currentIndex,
+            shouldResumePlayback: self.shouldResumeAfterInterruption
+                && !self.isExplicitPauseIntentActive,
+            wasPlaybackEnded: self.state == .ended,
+            shuffleMode: self.shuffleMode,
+            mixContinuation: self.mixContinuationToken,
+            mixContinuationRequiresAuth: self.mixContinuationRequiresAuth,
+            queueOrderBeforeShuffle: self.queueOrderBeforeShuffle?.map(Self.queueHistoryEntryWithoutAccountMetadata),
+            playbackOwner: self.currentQueueHistoryPlaybackOwner
+        )
+    }
+
+    func recordQueueStateForUndo(_ state: QueueState) {
+        self.queueUndoHistory.append(state)
+        if self.queueUndoHistory.count > Self.queueUndoMaxCount {
+            self.queueUndoHistory.removeFirst()
+        }
+        self.queueRedoHistory.removeAll()
+        self.logger.debug("Recorded queue state for undo, undo count: \(self.queueUndoHistory.count)")
+    }
+
+    /// Restores the previous queue state and aligns playback to its exact current entry.
+    func undoQueue() async {
+        let intent = self.beginMusicPlaybackIntent()
+        await self.undoQueue(intent: intent)
+    }
+
+    func undoQueue(intent: MusicPlaybackIntent) async {
+        guard self.acceptsMusicPlaybackIntent(intent),
+              let state = self.queueUndoHistory.popLast()
+        else { return }
+        let redoState = self.makeQueueStateSnapshot()
+        self.cancelDeferredQueueWork()
+        self.prepareForNewPlaybackContext()
+        let restoreQueueGeneration = self.reserveQueueMutation()
+        self.queueRedoHistory.append(redoState)
+        self.clearForwardSkipNavigationStack()
+        await self.restoreQueueState(
+            state,
+            intent: intent,
+            queueGeneration: restoreQueueGeneration
+        )
+        guard self.acceptsQueueMutation(restoreQueueGeneration) else { return }
+        self.logger.info("Undid queue to \(state.entries.count) songs at index \(self.currentIndex)")
+    }
+
+    /// Restores the next queue state after an undo and aligns playback to its exact current entry.
+    func redoQueue() async {
+        let intent = self.beginMusicPlaybackIntent()
+        await self.redoQueue(intent: intent)
+    }
+
+    func redoQueue(intent: MusicPlaybackIntent) async {
+        guard self.acceptsMusicPlaybackIntent(intent),
+              let state = self.queueRedoHistory.popLast()
+        else { return }
+        let undoState = self.makeQueueStateSnapshot()
+        self.cancelDeferredQueueWork()
+        self.prepareForNewPlaybackContext()
+        let restoreQueueGeneration = self.reserveQueueMutation()
+        self.queueUndoHistory.append(undoState)
+        self.clearForwardSkipNavigationStack()
+        await self.restoreQueueState(
+            state,
+            intent: intent,
+            queueGeneration: restoreQueueGeneration
+        )
+        guard self.acceptsQueueMutation(restoreQueueGeneration) else { return }
+        self.logger.info("Redid queue to \(state.entries.count) songs at index \(self.currentIndex)")
+    }
+
+    private func restoreQueueState(
+        _ state: QueueState,
+        intent: MusicPlaybackIntent,
+        queueGeneration: Int
+    ) async {
+        let downgradesSmartShuffle = state.shuffleMode == .smart
+            && !self.smartShuffleFeatureEnabled()
+        let playbackOwnerEntryID: UUID? = if case let .queueEntry(entryID, _, _) = state.playbackOwner {
+            entryID
+        } else {
+            nil
+        }
+        let restoredEntries = downgradesSmartShuffle
+            ? Self.stripSuggested(from: state.entries, keepingCurrentID: playbackOwnerEntryID)
+            : state.entries
+        self.setQueue(entries: restoredEntries)
+        self.currentIndex = min(state.currentIndex, max(0, restoredEntries.count - 1))
+        self[keyPath: \.mixContinuationToken] = state.mixContinuation
+        self.mixContinuationRequiresAuth = state.mixContinuationRequiresAuth
+        self.shuffleMode = downgradesSmartShuffle ? .on : state.shuffleMode
+        self.queueOrderBeforeShuffle = if downgradesSmartShuffle {
+            state.queueOrderBeforeShuffle.map {
+                Self.stripSuggested(from: $0, keepingCurrentID: playbackOwnerEntryID)
+            }
+        } else {
+            state.queueOrderBeforeShuffle
+        }
+        self.persistShuffleMode()
+
+        if state.wasPlaybackEnded, self.restoreEndedQueueState(state) {
+            await self.refreshRestoredQueueHistoryMetadata(intent: intent)
+            self.completeQueueStateRestore(queueGeneration: queueGeneration)
+            return
+        }
+
+        if case let .detached(song, episode, progress, duration) = state.playbackOwner {
+            self.activePlaybackQueueEntryID = nil
+            let restoreClock = episode?.isLive == true
+                ? nil
+                : MusicPlaybackRestoreClock(
+                    progress: progress,
+                    duration: duration
+                )
+            await self.play(
+                song: song,
+                webLoadStrategy: .standard,
+                episode: episode,
+                queueEntryID: nil,
+                startsPaused: !state.shouldResumePlayback,
+                restoreClock: restoreClock,
+                intent: intent
+            )
+            self.completeQueueStateRestore(queueGeneration: queueGeneration)
+            return
+        }
+
+        guard case let .queueEntry(ownerEntryID, progress, duration) = state.playbackOwner,
+              let ownerIndex = self.queueEntries.firstIndex(where: { $0.id == ownerEntryID }),
+              let entry = self.queueEntries[safe: ownerIndex]
+        else {
+            await self.stop(intent: intent, preservesQueueContext: true)
+            self.completeQueueStateRestore(queueGeneration: queueGeneration)
+            return
+        }
+        self.currentIndex = ownerIndex
+        await self.play(
+            song: entry.song,
+            webLoadStrategy: .standard,
+            queueEntryID: entry.id,
+            startsPaused: !state.shouldResumePlayback,
+            restoreClock: MusicPlaybackRestoreClock(
+                progress: progress,
+                duration: duration
+            ),
+            intent: intent
+        )
+        self.completeQueueStateRestore(queueGeneration: queueGeneration)
+    }
+
+    private func refreshRestoredQueueHistoryMetadata(intent: MusicPlaybackIntent) async {
+        guard self.acceptsMusicPlaybackIntent(intent), let currentTrack = self.currentTrack else { return }
+        await self.fetchSongMetadata(videoId: currentTrack.videoId)
+    }
+
+    private func completeQueueStateRestore(queueGeneration: Int) {
+        guard self.acceptsQueueMutation(queueGeneration) else { return }
+        self.saveQueueForPersistence()
+        if self.shuffleMode == .smart {
+            self.scheduleSmartShuffleFillForCurrentQueue()
+        }
+    }
+
+    private func restoreEndedQueueState(_ state: QueueState) -> Bool {
+        let song: Song
+        let episode: ArtistEpisode?
+        let queueEntryID: UUID?
+        let progress: TimeInterval
+        let duration: TimeInterval
+
+        switch state.playbackOwner {
+        case let .detached(detachedSong, detachedEpisode, savedProgress, savedDuration):
+            song = detachedSong
+            episode = detachedEpisode
+            queueEntryID = nil
+            progress = savedProgress
+            duration = savedDuration
+        case let .queueEntry(entryID, savedProgress, savedDuration):
+            guard let ownerIndex = self.queueEntries.firstIndex(where: { $0.id == entryID }),
+                  let entry = self.queueEntries[safe: ownerIndex]
+            else { return false }
+            self.currentIndex = ownerIndex
+            song = entry.song
+            episode = nil
+            queueEntryID = entry.id
+            progress = savedProgress
+            duration = savedDuration
+        case .none:
+            return false
+        }
+
+        self.clearRestoredPlaybackSessionState()
+        self.activePlaybackQueueEntryID = queueEntryID
+        self.currentTrack = song
+        self.currentTrackHasVideo = song.musicVideoType?.hasVideoContent ?? song.hasVideo ?? false
+        self.applyInitialTrackStatus(from: song)
+        self.currentEpisode = episode
+        self.pendingPlayVideoId = song.videoId
+        self.progress = progress
+        self.currentTimeMs = Int(progress * 1000)
+        self.duration = max(duration, song.duration ?? 0)
+        self.songNearingEnd = false
+        self.isKasetInitiatedPlayback = false
+        self.resetAdPlaybackState()
+        let occurrence = self.beginNativeMusicPlaybackOccurrence(videoId: song.videoId)
+        _ = self.claimTerminalMusicPlaybackOccurrence(occurrence)
+        self.shouldSuppressAutoplayAfterQueueEnd = queueEntryID != nil
+            && !self.canAdvanceNativeQueueAfterTrackEnd
+        self.markPlaybackEnded()
+        SingletonPlayerWebView.shared.pause()
+        return true
+    }
+
+    private static func queueHistoryEntryWithoutAccountMetadata(_ entry: QueueEntry) -> QueueEntry {
+        QueueEntry(
+            id: entry.id,
+            song: songWithoutAccountMetadata(entry.song),
+            source: entry.source
+        )
+    }
+
+    private var currentQueueHistoryPlaybackOwner: QueueState.PlaybackOwner {
+        guard let currentTrack = self.currentTrack else { return .none }
+        if let entryID = self.queueEntryIDOwningCurrentPlayback {
+            return .queueEntry(
+                id: entryID,
+                progress: self.progress,
+                duration: self.duration
+            )
+        }
+        return .detached(
+            song: Self.songWithoutAccountMetadata(currentTrack),
+            episode: self.currentEpisode,
+            progress: self.progress,
+            duration: self.duration
+        )
+    }
+}

--- a/Sources/Kaset/Services/Player/PlayerService+QueuePlaylist.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+QueuePlaylist.swift
@@ -4,8 +4,32 @@ import Foundation
 
 @MainActor
 extension PlayerService {
+    var currentAccountMutationOwner: MusicAccountMutationOwner {
+        MusicAccountMutationOwner(
+            accountID: self.songLikeStatusManager.activeAccountID,
+            sessionGeneration: self.accountSessionGeneration
+        )
+    }
+
+    func acceptsAccountMutationOwner(_ owner: MusicAccountMutationOwner) -> Bool {
+        owner == self.currentAccountMutationOwner
+    }
+
     /// Creates a private playlist from the current queue and notifies library views.
     func saveQueueAsPlaylist(title: String) async throws -> Playlist {
+        let owner = self.currentAccountMutationOwner
+        return try await self.saveQueueAsPlaylist(
+            title: title,
+            songs: self.queue,
+            owner: owner
+        )
+    }
+
+    func saveQueueAsPlaylist(
+        title: String,
+        songs: [Song],
+        owner: MusicAccountMutationOwner
+    ) async throws -> Playlist {
         guard let client = self.ytMusicClient else {
             throw YTMusicError.parseError(message: "YouTube Music client is unavailable")
         }
@@ -14,8 +38,10 @@ extension PlayerService {
         guard !trimmedTitle.isEmpty else {
             throw YTMusicError.parseError(message: "Playlist name is required")
         }
+        guard self.acceptsAccountMutationOwner(owner) else {
+            throw CancellationError()
+        }
 
-        let songs = self.queue
         let videoIds = songs.map(\.videoId)
         let playlistId = try await client.createPlaylist(
             title: trimmedTitle,
@@ -23,6 +49,9 @@ extension PlayerService {
             privacyStatus: .private,
             videoIds: videoIds
         )
+        guard self.acceptsAccountMutationOwner(owner) else {
+            throw CancellationError()
+        }
 
         let playlist = Playlist(
             id: playlistId,
@@ -36,8 +65,19 @@ extension PlayerService {
         LibraryMutationBroadcaster.shared.playlistCreated(playlist)
 
         try? await Task.sleep(for: .milliseconds(500))
+        guard self.acceptsAccountMutationOwner(owner) else {
+            LibraryMutationBroadcaster.shared.discardCreatedPlaylist(playlist)
+            throw CancellationError()
+        }
         SongActionsHelper.invalidateLibraryResponseCaches()
-        await LibraryMutationBroadcaster.shared.reconcileCreatedPlaylist(playlist)
+        let didReconcile = await LibraryMutationBroadcaster.shared.reconcileCreatedPlaylist(
+            playlist,
+            whileValid: { self.acceptsAccountMutationOwner(owner) }
+        )
+        guard didReconcile, self.acceptsAccountMutationOwner(owner) else {
+            LibraryMutationBroadcaster.shared.discardCreatedPlaylist(playlist)
+            throw CancellationError()
+        }
         SongActionsHelper.invalidateLibraryResponseCaches()
 
         self.logger.info("Saved queue as playlist '\(trimmedTitle)' with \(songs.count) songs")

--- a/Sources/Kaset/Services/Player/PlayerService+SmartShuffle.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+SmartShuffle.swift
@@ -4,6 +4,13 @@ import Foundation
 
 @MainActor
 extension PlayerService {
+    static func resolvedShuffleMode(
+        _ mode: ShuffleMode,
+        smartShuffleEnabled: Bool
+    ) -> ShuffleMode {
+        mode == .smart && !smartShuffleEnabled ? .on : mode
+    }
+
     /// Filters candidates to playable songs not already present (matched by `videoId`), and drops
     /// duplicates within the candidate list. Order is preserved.
     static func dedupeSuggestions(
@@ -94,7 +101,7 @@ extension PlayerService {
         guard !self.isQueueLoading else { return }
         // If the feature was disabled in settings while still in smart mode, stop topping up.
         // Already-queued suggestions remain until the user cycles shuffle off (which strips them).
-        guard SettingsManager.shared.smartShuffleEnabled else { return }
+        guard self.smartShuffleFeatureEnabled() else { return }
 
         // Coalesce onto any fill already running rather than starting a second interleaved loop.
         if let existing = self.smartShuffleFillTask {
@@ -136,14 +143,16 @@ extension PlayerService {
         var safety = self.queueEntries.count + (target + 2) * (everyN + burst) + 10
         while safety > 0,
               self.shuffleMode == .smart,
-              SettingsManager.shared.smartShuffleEnabled,
+              self.smartShuffleFeatureEnabled(),
               !Task.isCancelled
         {
             safety -= 1
             let entries = self.queueEntries
             let upcomingStart = min(self.currentIndex + 1, entries.count)
             let suggestionsAhead = entries[upcomingStart...].count(where: { $0.source == .suggested })
-            if suggestionsAhead >= target { break }
+            if suggestionsAhead >= target {
+                break
+            }
             guard let slot = Self.nextSuggestionSlot(
                 in: entries,
                 afterIndex: self.currentIndex,
@@ -164,14 +173,16 @@ extension PlayerService {
                 // aborting the whole fill on the nearest gap.
                 transientlyFailedSeeds.insert(seedEntry.song.videoId)
                 radioErrorBudget -= 1
-                if radioErrorBudget <= 0 { break }
+                if radioErrorBudget <= 0 {
+                    break
+                }
                 continue
             }
 
             // The queue, mode, or feature setting may have changed while awaiting — re-validate
             // against current state before inserting any recommendations.
             guard self.shuffleMode == .smart,
-                  SettingsManager.shared.smartShuffleEnabled,
+                  self.smartShuffleFeatureEnabled(),
                   !Task.isCancelled
             else { break }
             let entriesNow = self.queueEntries
@@ -214,7 +225,7 @@ extension PlayerService {
 
     /// Removes upcoming `.suggested` entries, keeping the currently-playing track, and realigns the index.
     func stripSuggestedEntries() {
-        let currentID = self.currentQueueEntryID
+        let currentID = self.queueEntryIDOwningCurrentPlayback
         let kept = Self.stripSuggested(from: self.queueEntries, keepingCurrentID: currentID)
         guard kept.count != self.queueEntries.count else { return }
         self.setQueue(entries: kept)
@@ -254,8 +265,29 @@ extension PlayerService {
     /// supersedes any in-flight deferred load so a stale pager cannot suppress or pollute the new
     /// playback's suggestions.
     func prepareForNewPlaybackContext() {
+        self.cancelRemoteMusicTransportFollowUp()
         self.resetSmartShuffleForNewQueue()
         self.invalidateStaleQueueLoad()
+        self.invalidateMixContinuationRequest()
+    }
+
+    /// Cancels async work owned by the current queue without otherwise changing
+    /// the queue. Used by terminal/privacy/restoration boundaries.
+    func cancelDeferredQueueWork() {
+        self.cancelRemoteMusicTransportFollowUp()
+        self.invalidateStaleQueueLoad()
+        self.cancelSmartShuffleFill()
+        self.invalidateMixContinuationRequest()
+    }
+
+    func scheduleSmartShuffleFillForCurrentQueue() {
+        let queueGeneration = self.queueLoadGeneration
+        Task { @MainActor [weak self] in
+            guard let self,
+                  self.isCurrentQueueLoad(queueGeneration)
+            else { return }
+            await self.fillSmartShuffleWindow()
+        }
     }
 
     // MARK: - Progressive queue loading
@@ -274,6 +306,14 @@ extension PlayerService {
     /// clobbering the new playback's loading state.
     func isCurrentQueueLoad(_ generation: Int) -> Bool {
         generation == self.queueLoadGeneration
+    }
+
+    func reserveQueueMutation() -> Int {
+        self.queueLoadGeneration
+    }
+
+    func acceptsQueueMutation(_ generation: Int) -> Bool {
+        self.isCurrentQueueLoad(generation)
     }
 
     /// Supersedes any in-flight deferred load without starting a new one: bumps the generation (so

--- a/Sources/Kaset/Services/Player/PlayerService+WebQueueSync.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+WebQueueSync.swift
@@ -24,7 +24,10 @@ extension PlayerService {
             SingletonPlayerWebView.shared.seekAndPause(to: self.duration)
         }
 
-        await self.finishTrackEnded(observedVideoId: self.currentTrack?.videoId)
+        await self.finishTrackEnded(
+            observedVideoId: self.currentTrack?.videoId,
+            intent: self.currentMusicPlaybackIntent
+        )
     }
 
     private var shouldSynchronizeWebViewForTerminalManualSeekToEnd: Bool {
@@ -64,7 +67,7 @@ extension PlayerService {
         title.isEmpty || artist.isEmpty || !self.metadataMatchesSong(title: title, artist: artist, song: song)
     }
 
-    private var canAdvanceNativeQueueAfterTrackEnd: Bool {
+    var canAdvanceNativeQueueAfterTrackEnd: Bool {
         self.shuffleEnabled
             || self.repeatMode == .one
             || self.currentIndex < self.queue.count - 1
@@ -116,11 +119,13 @@ extension PlayerService {
             duration: song.duration,
             thumbnailURL: intendedThumbnailURL,
             videoId: song.videoId,
+            isPlayable: song.isPlayable,
             hasVideo: song.hasVideo,
             musicVideoType: song.musicVideoType,
             likeStatus: song.likeStatus,
             isInLibrary: song.isInLibrary,
-            feedbackTokens: song.feedbackTokens
+            feedbackTokens: song.feedbackTokens,
+            isExplicit: song.isExplicit
         )
     }
 
@@ -133,6 +138,7 @@ extension PlayerService {
     ) -> Bool {
         guard trackChanged,
               self.shouldSuppressAutoplayAfterQueueEnd,
+              self.activePlaybackOwnsCurrentQueueEntry,
               let currentQueueSong = self.queue[safe: self.currentIndex],
               !self.observedTrackMatchesSong(
                   observedVideoId: observedVideoId,
@@ -147,8 +153,8 @@ extension PlayerService {
         self.markPlaybackEnded()
         self.logger.info("Suppressing unexpected autoplay after native queue ended")
         self.keepQueueSongVisible(currentQueueSong, thumbnailUrl: thumbnailUrl)
-        Task {
-            await self.pause()
+        self.scheduleMusicPlaybackIntentTask(expectedQueueEntryID: self.currentQueueEntryID) { service, intent in
+            await service.pause(intent: intent)
         }
         return true
     }
@@ -160,14 +166,18 @@ extension PlayerService {
         thumbnailUrl: String,
         trackChanged: Bool
     ) -> Bool {
-        guard self.isKasetInitiatedPlayback, !self.queue.isEmpty else {
+        guard self.isKasetInitiatedPlayback,
+              !self.queue.isEmpty,
+              self.activePlaybackOwnsCurrentQueueEntry
+        else {
             return false
         }
 
-        guard let intendedSong = self.queue[safe: self.currentIndex] else {
+        guard let intendedEntry = self.queueEntries[safe: self.currentIndex] else {
             self.isKasetInitiatedPlayback = false
             return false
         }
+        let intendedSong = intendedEntry.song
 
         let matchesObservedVideo = self.normalizedObservedVideoId(observedVideoId) == intendedSong.videoId
         if matchesObservedVideo, self.shouldKeepQueueMetadata(title: title, artist: artist, song: intendedSong) {
@@ -199,8 +209,13 @@ extension PlayerService {
             "YouTube loaded different track '\(title)' (\(resolvedVideoId)), re-playing intended track '\(intendedSong.title)'"
         )
         self.isKasetInitiatedPlayback = false
-        Task {
-            await self.play(song: intendedSong, webLoadStrategy: .forceFullPageWhenSameVideoId)
+        self.scheduleMusicPlaybackIntentTask(expectedQueueEntryID: intendedEntry.id) { service, intent in
+            await service.play(
+                song: intendedSong,
+                webLoadStrategy: .forceFullPageWhenSameVideoId,
+                queueEntryID: intendedEntry.id,
+                intent: intent
+            )
         }
         return true
     }
@@ -216,8 +231,30 @@ extension PlayerService {
         trackChanged: Bool,
         playbackOccurrence: MusicPlaybackOccurrence?
     ) -> Bool {
-        guard trackChanged, !self.queue.isEmpty, self.songNearingEnd else {
+        guard trackChanged,
+              !self.queue.isEmpty,
+              self.songNearingEnd,
+              self.activePlaybackOwnsCurrentQueueEntry
+        else {
             return false
+        }
+        if let expectedNextIndex = self.expectedQueueIndexAfterCurrentTrack(),
+           let expectedNextEntry = self.queueEntries[safe: expectedNextIndex],
+           let currentEntry = self.queueEntries[safe: self.currentIndex],
+           expectedNextEntry.song.videoId == currentEntry.song.videoId,
+           self.queueEntries.count(where: { $0.song.videoId == expectedNextEntry.song.videoId }) > 1,
+           self.observedTrackMatchesSong(
+               observedVideoId: observedVideoId,
+               title: title,
+               artist: artist,
+               song: expectedNextEntry.song
+           )
+        {
+            self.logger.debug(
+                "Deferring ambiguous same-video near-end handoff until a terminal/media transition"
+            )
+            self.keepQueueSongVisible(currentEntry.song, thumbnailUrl: thumbnailUrl)
+            return true
         }
         // Claim before scheduling either corrective branch below. Those branches
         // deliberately own this terminal transition even when YouTube's observed
@@ -243,14 +280,14 @@ extension PlayerService {
                     self.logger.info(
                         "YouTube autoplay near end during repeat one; re-asserting current queue track (not advancing)"
                     )
-                    Task {
-                        await self.replayCurrentQueueSongForRepeatOneAfterTrackEnd()
+                    self.scheduleMusicPlaybackIntentTask(expectedQueueEntryID: self.currentQueueEntryID) { service, intent in
+                        await service.replayCurrentQueueSongForRepeatOneAfterTrackEnd(intent: intent)
                     }
                     return true
                 }
                 self.logger.info("YouTube autoplay detected, overriding with queue track")
-                Task {
-                    await self.next()
+                self.scheduleMusicPlaybackIntentTask(expectedQueueEntryID: self.currentQueueEntryID) { service, intent in
+                    await service.next(intent: intent)
                 }
                 return true
             }
@@ -277,22 +314,22 @@ extension PlayerService {
         if self.canAdvanceNativeQueueAfterTrackEnd {
             if self.repeatMode == .one {
                 self.logger.info("Near-end track change with repeat one; re-asserting current queue track")
-                Task {
-                    await self.replayCurrentQueueSongForRepeatOneAfterTrackEnd()
+                self.scheduleMusicPlaybackIntentTask(expectedQueueEntryID: self.currentQueueEntryID) { service, intent in
+                    await service.replayCurrentQueueSongForRepeatOneAfterTrackEnd(intent: intent)
                 }
                 return true
             }
             self.logger.info("Near-end track change detected, advancing native queue to enforce playback order")
-            Task {
-                await self.next()
+            self.scheduleMusicPlaybackIntentTask(expectedQueueEntryID: self.currentQueueEntryID) { service, intent in
+                await service.next(intent: intent)
             }
             return true
         }
 
         self.markPlaybackEnded()
         self.logger.info("Unexpected autoplay detected at end of native queue; pausing playback")
-        Task {
-            await self.pause()
+        self.scheduleMusicPlaybackIntentTask(expectedQueueEntryID: self.currentQueueEntryID) { service, intent in
+            await service.pause(intent: intent)
         }
         return true
     }
@@ -308,10 +345,12 @@ extension PlayerService {
     ) -> Bool {
         guard self.repeatMode == .one,
               self.hasUserInteractedThisSession,
-              let queued = self.queue[safe: self.currentIndex]
+              self.activePlaybackOwnsCurrentQueueEntry,
+              let queuedEntry = self.queueEntries[safe: self.currentIndex]
         else {
             return false
         }
+        let queued = queuedEntry.song
 
         let observedNorm = self.normalizedObservedVideoId(observedVideoId)
         let videoMismatch = observedNorm.map { $0 != queued.videoId } ?? false
@@ -337,8 +376,13 @@ extension PlayerService {
         self.lastRepeatOneRecoveryInstant = now
 
         self.logger.info("Repeat one: safety net re-asserting queue track (observed=\(observedNorm ?? "nil"))")
-        Task {
-            await self.play(song: queued, webLoadStrategy: .forceFullPageWhenSameVideoId)
+        self.scheduleMusicPlaybackIntentTask(expectedQueueEntryID: queuedEntry.id) { service, intent in
+            await service.play(
+                song: queued,
+                webLoadStrategy: .forceFullPageWhenSameVideoId,
+                queueEntryID: queuedEntry.id,
+                intent: intent
+            )
         }
         return true
     }
@@ -351,12 +395,14 @@ extension PlayerService {
         trackChanged: Bool
     ) -> Bool {
         guard !self.queue.isEmpty,
+              self.activePlaybackOwnsCurrentQueueEntry,
               let observedVideoId = self.normalizedObservedVideoId(observedVideoId),
-              let currentQueueSong = self.queue[safe: self.currentIndex],
-              currentQueueSong.videoId != observedVideoId
+              let currentQueueEntry = self.queueEntries[safe: self.currentIndex],
+              currentQueueEntry.song.videoId != observedVideoId
         else {
             return false
         }
+        let currentQueueSong = currentQueueEntry.song
 
         // Repeat one: autoplay can swap the video before title/artist update, so `trackChanged` may still be false.
         // Without this branch we fall through and assign `currentTrack` from YouTube, breaking UI sync.
@@ -370,32 +416,40 @@ extension PlayerService {
             self.logger.info(
                 "Repeat one: observed \(observedVideoId) diverged from queue; re-playing without advancing queue index"
             )
-            Task {
-                await self.play(song: currentQueueSong, webLoadStrategy: .forceFullPageWhenSameVideoId)
+            self.scheduleMusicPlaybackIntentTask(expectedQueueEntryID: currentQueueEntry.id) { service, intent in
+                await service.play(
+                    song: currentQueueSong,
+                    webLoadStrategy: .forceFullPageWhenSameVideoId,
+                    queueEntryID: currentQueueEntry.id,
+                    intent: intent
+                )
             }
             return true
         }
 
-        if let matchingIndex = self.queue.firstIndex(where: { $0.videoId == observedVideoId }),
-           let matchingSong = self.queue[safe: matchingIndex]
-        {
+        let matchingEntries = self.queueEntries.enumerated().filter { $0.element.song.videoId == observedVideoId }
+        if matchingEntries.count == 1, let match = matchingEntries.first {
+            let matchingIndex = match.offset
+            let matchingSong = match.element.song
             let queueIndexChanged = matchingIndex != self.currentIndex
             if queueIndexChanged {
                 self.currentIndex = matchingIndex
                 self.activePlaybackQueueEntryID = self.currentQueueEntryID
                 self.logger.info("Observed playback moved to queue index \(matchingIndex), realigning native queue")
-                self.saveQueueForPersistence()
             }
 
             if queueIndexChanged || self.shouldKeepQueueMetadata(title: title, artist: artist, song: matchingSong) {
                 if self.currentTrack?.videoId != matchingSong.videoId {
                     self.resetTrackStatus()
                     // Immediately restore like status from SongLikeStatusManager cache
-                    if let cachedStatus = SongLikeStatusManager.shared.status(for: matchingSong.videoId) {
+                    if let cachedStatus = self.songLikeStatusManager.status(for: matchingSong.videoId) {
                         self.currentTrackLikeStatus = cachedStatus
                     }
                 }
                 self.keepQueueSongVisible(matchingSong, thumbnailUrl: thumbnailUrl)
+                if queueIndexChanged {
+                    self.saveQueueForPersistence()
+                }
                 return true
             }
             return false
@@ -404,15 +458,23 @@ extension PlayerService {
         self.logger.info(
             "Observed track \(observedVideoId) diverged from native queue track \(currentQueueSong.videoId); re-playing intended queue track"
         )
-        Task {
-            await self.play(song: currentQueueSong, webLoadStrategy: .forceFullPageWhenSameVideoId)
+        self.scheduleMusicPlaybackIntentTask(expectedQueueEntryID: currentQueueEntry.id) { service, intent in
+            await service.play(
+                song: currentQueueSong,
+                webLoadStrategy: .forceFullPageWhenSameVideoId,
+                queueEntryID: currentQueueEntry.id,
+                intent: intent
+            )
         }
         return true
     }
 
     /// Replays the current queue song after a natural `ended` event. User-initiated **Next** uses ``PlayerService/next()`` instead.
-    private func replayCurrentQueueSongForRepeatOneAfterTrackEnd() async {
-        guard let currentSong = self.queue[safe: self.currentIndex] else { return }
+    private func replayCurrentQueueSongForRepeatOneAfterTrackEnd(intent: MusicPlaybackIntent) async {
+        guard self.acceptsMusicPlaybackIntent(intent),
+              let currentEntry = self.queueEntries[safe: self.currentIndex]
+        else { return }
+        let currentSong = currentEntry.song
         self.songNearingEnd = false
         let kasetAlignedWithQueue = self.pendingPlayVideoId == currentSong.videoId
             && self.currentWebPlaybackVideoId() == currentSong.videoId
@@ -433,22 +495,35 @@ extension PlayerService {
                 self.state = .playing
             }
         } else {
-            await self.play(song: currentSong, webLoadStrategy: .preferInPlaceWhenSameVideoId)
+            await self.play(
+                song: currentSong,
+                webLoadStrategy: .preferInPlaceWhenSameVideoId,
+                queueEntryID: currentEntry.id,
+                intent: intent
+            )
         }
     }
 
     /// Replays the currently playing song for repeat-one when no native queue is active.
-    private func replayCurrentSongForRepeatOneWithoutQueueAfterTrackEnd() async {
+    private func replayCurrentSongForRepeatOneWithoutQueueAfterTrackEnd(
+        intent: MusicPlaybackIntent
+    ) async {
+        guard self.acceptsMusicPlaybackIntent(intent) else { return }
         self.songNearingEnd = false
         if let currentTrack = self.currentTrack {
             self.logger.info("Track ended with repeat one and no queue; replaying current track")
-            await self.play(song: currentTrack, webLoadStrategy: .preferInPlaceWhenSameVideoId)
+            await self.play(
+                song: currentTrack,
+                webLoadStrategy: .preferInPlaceWhenSameVideoId,
+                queueEntryID: nil,
+                intent: intent
+            )
             return
         }
 
         if let pendingVideoId = self.pendingPlayVideoId {
             self.logger.info("Track ended with repeat one and no queue metadata; replaying pending video")
-            await self.play(videoId: pendingVideoId)
+            await self.play(videoId: pendingVideoId, intent: intent)
             return
         }
     }
@@ -456,21 +531,35 @@ extension PlayerService {
     /// Handles a natural track completion reported directly by the WebView.
     func handleTrackEnded(
         observedVideoId: String?,
-        playbackOccurrence: MusicPlaybackOccurrence? = nil
+        playbackOccurrence: MusicPlaybackOccurrence? = nil,
+        intent suppliedIntent: MusicPlaybackIntent? = nil
     ) async {
+        let intent = suppliedIntent ?? self.currentMusicPlaybackIntent
+        guard self.acceptsMusicPlaybackIntent(intent) else { return }
         self.logger.debug("Track ended reported by WebView: \(observedVideoId ?? "unknown")")
         guard self.claimTerminalMusicPlaybackOccurrence(playbackOccurrence) else {
             self.logger.debug("Ignoring duplicate track-ended transition for consumed playback occurrence")
             return
         }
-        await self.finishTrackEnded(observedVideoId: observedVideoId)
+        guard !self.isExplicitPauseIntentActive else {
+            self.songNearingEnd = false
+            self.logger.debug("Consumed track-ended transition without advancing because pause intent is active")
+            return
+        }
+        await self.finishTrackEnded(observedVideoId: observedVideoId, intent: intent)
     }
 
-    private func finishTrackEnded(observedVideoId: String?) async {
+    private func finishTrackEnded(
+        observedVideoId: String?,
+        intent: MusicPlaybackIntent
+    ) async {
+        guard self.acceptsMusicPlaybackIntent(intent) else { return }
         self.songNearingEnd = false
-        guard !self.queue.isEmpty else {
+        guard self.activePlaybackOwnsCurrentQueueEntry,
+              !self.queue.isEmpty
+        else {
             if self.repeatMode == .one, self.currentTrack != nil || self.pendingPlayVideoId != nil {
-                await self.replayCurrentSongForRepeatOneWithoutQueueAfterTrackEnd()
+                await self.replayCurrentSongForRepeatOneWithoutQueueAfterTrackEnd(intent: intent)
                 return
             }
             self.markPlaybackEnded()
@@ -506,17 +595,17 @@ extension PlayerService {
             self.shouldSuppressAutoplayAfterQueueEnd = true
             self.markPlaybackEnded()
             self.logger.info("Reached end of native queue; not yielding to YouTube autoplay")
-            await self.pause()
+            await self.pause(intent: intent)
             return
         }
         self.shouldSuppressAutoplayAfterQueueEnd = false
         if self.repeatMode == .one {
             self.logger.info("Track ended with repeat one; replaying current queue song")
-            await self.replayCurrentQueueSongForRepeatOneAfterTrackEnd()
+            await self.replayCurrentQueueSongForRepeatOneAfterTrackEnd(intent: intent)
             return
         }
         self.logger.info("Track ended in WebView, advancing native queue immediately")
-        await self.next()
+        await self.next(intent: intent)
     }
 
     /// Updates track metadata and enforces Kaset's queue when YouTube tries to diverge.
@@ -615,7 +704,7 @@ extension PlayerService {
         if trackChanged {
             self.resetTrackStatus()
             // Immediately restore like status from SongLikeStatusManager cache
-            if let cachedStatus = SongLikeStatusManager.shared.status(for: resolvedVideoId) {
+            if let cachedStatus = self.songLikeStatusManager.status(for: resolvedVideoId) {
                 self.currentTrackLikeStatus = cachedStatus
             }
         }

--- a/Sources/Kaset/Services/Player/PlayerService+WebQueueSync.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+WebQueueSync.swift
@@ -13,6 +13,10 @@ extension PlayerService {
     /// repeat / queue / autoplay-suppression rules apply consistently with a natural end.
     func handleManualSeekToEnd() async {
         self.logger.info("Manual seek reached end of track; routing through track-ended path")
+        guard self.claimTerminalMusicPlaybackOccurrence(self.currentMusicPlaybackOccurrence) else {
+            self.logger.debug("Ignoring duplicate manual track-end transition for consumed playback occurrence")
+            return
+        }
         self.clearRestoredPlaybackSessionState()
         self.progress = self.duration
 
@@ -20,7 +24,7 @@ extension PlayerService {
             SingletonPlayerWebView.shared.seekAndPause(to: self.duration)
         }
 
-        await self.handleTrackEnded(observedVideoId: self.currentTrack?.videoId)
+        await self.finishTrackEnded(observedVideoId: self.currentTrack?.videoId)
     }
 
     private var shouldSynchronizeWebViewForTerminalManualSeekToEnd: Bool {
@@ -201,15 +205,27 @@ extension PlayerService {
         return true
     }
 
+    // The occurrence token joins the existing observed metadata so the near-end
+    // transition can be claimed atomically instead of advancing twice.
+    // swiftlint:disable:next function_parameter_count
     private func handleNearEndTrackChangeIfNeeded(
         observedVideoId: String?,
         title: String,
         artist: String,
         thumbnailUrl: String,
-        trackChanged: Bool
+        trackChanged: Bool,
+        playbackOccurrence: MusicPlaybackOccurrence?
     ) -> Bool {
         guard trackChanged, !self.queue.isEmpty, self.songNearingEnd else {
             return false
+        }
+        // Claim before scheduling either corrective branch below. Those branches
+        // deliberately own this terminal transition even when YouTube's observed
+        // successor is not the queue's expected song; otherwise a queued `ended`
+        // callback can race the unstructured corrective task and advance twice.
+        guard self.claimTerminalMusicPlaybackOccurrence(playbackOccurrence) else {
+            self.logger.debug("Ignoring duplicate near-end transition for consumed playback occurrence")
+            return true
         }
 
         self.songNearingEnd = false
@@ -240,6 +256,11 @@ extension PlayerService {
             }
 
             self.currentIndex = expectedNextIndex
+            self.beginNativeMusicPlaybackOccurrence(
+                videoId: expectedNextTrack.videoId,
+                synchronizeCurrentDocument: true
+            )
+            self.activePlaybackQueueEntryID = self.currentQueueEntryID
             self.logger.info("Track advanced to queue index \(expectedNextIndex)")
             self.saveQueueForPersistence()
 
@@ -361,6 +382,7 @@ extension PlayerService {
             let queueIndexChanged = matchingIndex != self.currentIndex
             if queueIndexChanged {
                 self.currentIndex = matchingIndex
+                self.activePlaybackQueueEntryID = self.currentQueueEntryID
                 self.logger.info("Observed playback moved to queue index \(matchingIndex), realigning native queue")
                 self.saveQueueForPersistence()
             }
@@ -393,8 +415,19 @@ extension PlayerService {
         guard let currentSong = self.queue[safe: self.currentIndex] else { return }
         self.songNearingEnd = false
         let kasetAlignedWithQueue = self.pendingPlayVideoId == currentSong.videoId
-            && SingletonPlayerWebView.shared.currentVideoId == currentSong.videoId
+            && self.currentWebPlaybackVideoId() == currentSong.videoId
         if self.hasUserInteractedThisSession, kasetAlignedWithQueue {
+            self.beginNativeMusicPlaybackOccurrence(
+                videoId: currentSong.videoId,
+                synchronizeCurrentDocument: true
+            )
+            self.activePlaybackQueueEntryID = self.currentQueueEntryID
+            self.resetAdPlaybackState()
+            self.progress = 0
+            self.currentTimeMs = 0
+            self.shouldResumeAfterInterruption = true
+            self.isAwaitingPlaybackConfirmation = true
+            self.isExplicitPauseIntentActive = false
             SingletonPlayerWebView.shared.restartInPlaceFromBeginning()
             if self.state == .ended || self.state == .loading {
                 self.state = .playing
@@ -421,8 +454,19 @@ extension PlayerService {
     }
 
     /// Handles a natural track completion reported directly by the WebView.
-    func handleTrackEnded(observedVideoId: String?) async {
+    func handleTrackEnded(
+        observedVideoId: String?,
+        playbackOccurrence: MusicPlaybackOccurrence? = nil
+    ) async {
         self.logger.debug("Track ended reported by WebView: \(observedVideoId ?? "unknown")")
+        guard self.claimTerminalMusicPlaybackOccurrence(playbackOccurrence) else {
+            self.logger.debug("Ignoring duplicate track-ended transition for consumed playback occurrence")
+            return
+        }
+        await self.finishTrackEnded(observedVideoId: observedVideoId)
+    }
+
+    private func finishTrackEnded(observedVideoId: String?) async {
         self.songNearingEnd = false
         guard !self.queue.isEmpty else {
             if self.repeatMode == .one, self.currentTrack != nil || self.pendingPlayVideoId != nil {
@@ -477,6 +521,22 @@ extension PlayerService {
 
     /// Updates track metadata and enforces Kaset's queue when YouTube tries to diverge.
     func updateTrackMetadata(title: String, artist: String, thumbnailUrl: String, videoId observedVideoId: String?) {
+        self.updateTrackMetadata(
+            title: title,
+            artist: artist,
+            thumbnailUrl: thumbnailUrl,
+            videoId: observedVideoId,
+            playbackOccurrence: self.currentMusicPlaybackOccurrence
+        )
+    }
+
+    func updateTrackMetadata(
+        title: String,
+        artist: String,
+        thumbnailUrl: String,
+        videoId observedVideoId: String?,
+        playbackOccurrence: MusicPlaybackOccurrence?
+    ) {
         self.logger.debug("Track metadata updated: \(title) - \(artist)")
         let thumbnailURL = URL(string: thumbnailUrl)
         let artistObj = Artist(id: "unknown", name: artist)
@@ -510,7 +570,8 @@ extension PlayerService {
             title: title,
             artist: artist,
             thumbnailUrl: thumbnailUrl,
-            trackChanged: trackChanged
+            trackChanged: trackChanged,
+            playbackOccurrence: playbackOccurrence
         ) {
             return
         }

--- a/Sources/Kaset/Services/Player/PlayerService.swift
+++ b/Sources/Kaset/Services/Player/PlayerService.swift
@@ -8,6 +8,21 @@ import os
 @MainActor
 @Observable
 final class PlayerService: NSObject, PlayerServiceProtocol {
+    @ObservationIgnored var currentWebPlaybackVideoId: @MainActor () -> String? = {
+        SingletonPlayerWebView.shared.currentVideoId
+    }
+
+    /// Latest media occurrence observed or initiated for Music playback.
+    @ObservationIgnored private(set) var currentMusicPlaybackOccurrence: MusicPlaybackOccurrence?
+
+    @ObservationIgnored private var nativeMusicPlaybackGeneration: UInt64 = 0
+    @ObservationIgnored private var lastClaimedNativeMusicPlaybackGeneration: UInt64 = 0
+    @ObservationIgnored private var lastClaimedWebMusicPlaybackOccurrence: MusicPlaybackOccurrence?
+
+    var currentNativeMusicPlaybackGeneration: UInt64 {
+        self.currentMusicPlaybackOccurrence?.nativeGeneration ?? self.nativeMusicPlaybackGeneration
+    }
+
     /// Shared instance for AppleScript access.
     ///
     /// **Safety Invariant:** This property is set exactly once during app initialization
@@ -67,6 +82,14 @@ final class PlayerService: NSObject, PlayerServiceProtocol {
     /// Current playback state.
     var state: PlaybackState = .idle
 
+    /// Native play/pause intent survives transient ad buffering/pauses where
+    /// observable transport state is not authoritative for recovery.
+    var shouldResumeAfterInterruption = false
+    var isStoppingPlayback = false
+
+    var isAwaitingPlaybackConfirmation = false
+    var isExplicitPauseIntentActive = false
+
     /// Currently playing track.
     var currentTrack: Song?
 
@@ -86,6 +109,15 @@ final class PlayerService: NSObject, PlayerServiceProtocol {
 
     /// Total duration of current track in seconds.
     var duration: TimeInterval = 0
+
+    /// Whether the music playback WebView currently reports an advertisement.
+    var isShowingAd = false
+
+    /// Last clock sample known to belong to the requested music content.
+    var lastNonAdContentProgress: TimeInterval = 0
+
+    /// Video identity owning `lastNonAdContentProgress`.
+    var lastNonAdContentVideoId: String?
 
     /// Current volume (0.0 - 1.0).
     var volume: Double = 1.0
@@ -154,6 +186,9 @@ final class PlayerService: NSObject, PlayerServiceProtocol {
     }
 
     private(set) var currentQueueEntryID: UUID?
+
+    /// Queue occurrence currently represented by active Web media.
+    var activePlaybackQueueEntryID: UUID?
 
     /// Whether the mini player should be shown (user needs to interact to start playback).
     var showMiniPlayer: Bool = false
@@ -576,4 +611,246 @@ final class PlayerService: NSObject, PlayerServiceProtocol {
     /// Debounces repeat-one recovery `play()` when YouTube sends bursty metadata (safety net in `PlayerService+WebQueueSync`).
     /// Internal so the WebQueueSync extension can throttle; not part of the public API.
     var lastRepeatOneRecoveryInstant: ContinuousClock.Instant?
+
+    /// Starts a native fallback occurrence until the Web observer binds the
+    /// corresponding document/media occurrence.
+    @discardableResult
+    func beginNativeMusicPlaybackOccurrence(
+        videoId: String? = nil,
+        synchronizeCurrentDocument: Bool = false
+    ) -> MusicPlaybackOccurrence {
+        self.nativeMusicPlaybackGeneration = max(
+            self.nativeMusicPlaybackGeneration,
+            self.currentMusicPlaybackOccurrence?.nativeGeneration ?? 0
+        )
+        self.nativeMusicPlaybackGeneration &+= 1
+        let occurrence = MusicPlaybackOccurrence.native(
+            generation: self.nativeMusicPlaybackGeneration,
+            videoId: videoId
+        )
+        self.currentMusicPlaybackOccurrence = occurrence
+        if synchronizeCurrentDocument {
+            SingletonPlayerWebView.shared.setNativePlaybackGeneration(
+                occurrence.nativeGeneration
+            )
+        }
+        return occurrence
+    }
+
+    /// A terminal transition can be claimed before the Web observer binds its
+    /// document/media occurrence. Resuming that media is a new playback, so it
+    /// needs a fresh native generation and the active document must publish it.
+    @discardableResult
+    func beginNativeMusicPlaybackReplayIfNeeded() -> MusicPlaybackOccurrence? {
+        guard let currentMusicPlaybackOccurrence else { return nil }
+        let wasConsumed = if currentMusicPlaybackOccurrence.documentGeneration == nil {
+            currentMusicPlaybackOccurrence.mediaGeneration
+                <= self.lastClaimedNativeMusicPlaybackGeneration
+        } else if let lastClaimedWebMusicPlaybackOccurrence {
+            !Self.isWebMusicPlaybackOccurrence(
+                currentMusicPlaybackOccurrence,
+                newerThan: lastClaimedWebMusicPlaybackOccurrence
+            )
+        } else {
+            false
+        }
+        guard wasConsumed else { return nil }
+
+        return self.beginNativeMusicPlaybackOccurrence(
+            videoId: self.currentTrack?.videoId
+                ?? self.pendingPlayVideoId
+                ?? currentMusicPlaybackOccurrence.videoId,
+            synchronizeCurrentDocument: true
+        )
+    }
+
+    func resetMusicPlaybackOccurrenceState() {
+        self.currentMusicPlaybackOccurrence = nil
+        self.lastClaimedWebMusicPlaybackOccurrence = nil
+    }
+
+    /// Binds the active native playback state to an observer-issued occurrence.
+    /// Older or already-terminal Web occurrences cannot replace a newer replay.
+    @discardableResult
+    func bindWebMusicPlaybackOccurrence(
+        documentGeneration: UInt64,
+        mediaGeneration: UInt64,
+        nativeGeneration: UInt64 = 0,
+        videoId: String? = nil
+    ) -> MusicPlaybackOccurrence? {
+        guard mediaGeneration > 0 else { return self.currentMusicPlaybackOccurrence }
+        let occurrence = MusicPlaybackOccurrence.web(
+            documentGeneration: documentGeneration,
+            mediaGeneration: mediaGeneration,
+            nativeGeneration: nativeGeneration,
+            videoId: videoId
+        )
+        let nativeOccurrence = self.currentMusicPlaybackOccurrence.flatMap {
+            $0.documentGeneration == nil ? $0 : nil
+        }
+        if self.songNearingEnd,
+           let currentMusicPlaybackOccurrence,
+           currentMusicPlaybackOccurrence.documentGeneration != nil,
+           Self.isWebMusicPlaybackOccurrence(
+               occurrence,
+               newerThan: currentMusicPlaybackOccurrence
+           )
+        {
+            return nil
+        }
+        if let nativeOccurrence,
+           occurrence.nativeGeneration < nativeOccurrence.nativeGeneration
+        {
+            return nil
+        }
+        let hasConfirmedVideoMismatch = if let nativeVideoId = nativeOccurrence?.videoId,
+                                           let videoId
+        {
+            nativeVideoId != videoId
+        } else {
+            false
+        }
+        let inheritsConsumedNativeOccurrence = if let nativeOccurrence {
+            occurrence.nativeGeneration == nativeOccurrence.nativeGeneration
+                && !hasConfirmedVideoMismatch
+                && nativeOccurrence.mediaGeneration
+                <= self.lastClaimedNativeMusicPlaybackGeneration
+        } else {
+            false
+        }
+
+        if let lastClaimedWebMusicPlaybackOccurrence,
+           !Self.isWebMusicPlaybackOccurrence(
+               occurrence,
+               newerThan: lastClaimedWebMusicPlaybackOccurrence
+           )
+        {
+            return nil
+        }
+
+        if let currentMusicPlaybackOccurrence,
+           currentMusicPlaybackOccurrence.documentGeneration != nil,
+           !Self.isWebMusicPlaybackOccurrence(
+               occurrence,
+               newerThanOrEqualTo: currentMusicPlaybackOccurrence
+           )
+        {
+            return nil
+        }
+
+        self.currentMusicPlaybackOccurrence = occurrence
+        if inheritsConsumedNativeOccurrence {
+            self.lastClaimedWebMusicPlaybackOccurrence = occurrence
+        }
+        return occurrence
+    }
+
+    func acceptsWebMusicPlaybackOccurrence(_ occurrence: MusicPlaybackOccurrence) -> Bool {
+        if let currentMusicPlaybackOccurrence {
+            if currentMusicPlaybackOccurrence.documentGeneration == nil {
+                guard occurrence.nativeGeneration >= currentMusicPlaybackOccurrence.nativeGeneration else {
+                    return false
+                }
+                if occurrence.nativeGeneration == currentMusicPlaybackOccurrence.nativeGeneration,
+                   currentMusicPlaybackOccurrence.mediaGeneration
+                   <= self.lastClaimedNativeMusicPlaybackGeneration
+                {
+                    return false
+                }
+            } else if !Self.isWebMusicPlaybackOccurrence(
+                occurrence,
+                newerThanOrEqualTo: currentMusicPlaybackOccurrence
+            ) {
+                return false
+            }
+        }
+
+        if let lastClaimedWebMusicPlaybackOccurrence,
+           !Self.isWebMusicPlaybackOccurrence(
+               occurrence,
+               newerThan: lastClaimedWebMusicPlaybackOccurrence
+           )
+        {
+            return false
+        }
+        return true
+    }
+
+    /// Atomically consumes one terminal transition for one playback occurrence.
+    /// Main-actor isolation makes the check-and-record indivisible with respect
+    /// to near-end, natural-ended, and manual-ended callers.
+    func claimTerminalMusicPlaybackOccurrence(_ occurrence: MusicPlaybackOccurrence?) -> Bool {
+        let resolvedOccurrence = occurrence
+            ?? self.currentMusicPlaybackOccurrence
+            ?? self.beginNativeMusicPlaybackOccurrence(
+                videoId: self.currentTrack?.videoId ?? self.pendingPlayVideoId
+            )
+
+        if resolvedOccurrence.documentGeneration == nil {
+            guard resolvedOccurrence.mediaGeneration > self.lastClaimedNativeMusicPlaybackGeneration else {
+                return false
+            }
+            self.lastClaimedNativeMusicPlaybackGeneration = resolvedOccurrence.mediaGeneration
+            return true
+        }
+
+        if let currentNativeOccurrence = self.currentMusicPlaybackOccurrence,
+           currentNativeOccurrence.documentGeneration == nil
+        {
+            guard resolvedOccurrence.nativeGeneration >= currentNativeOccurrence.nativeGeneration else {
+                return false
+            }
+            if resolvedOccurrence.nativeGeneration == currentNativeOccurrence.nativeGeneration,
+               currentNativeOccurrence.mediaGeneration <= self.lastClaimedNativeMusicPlaybackGeneration
+            {
+                return false
+            }
+        }
+
+        if let currentWebOccurrence = self.currentMusicPlaybackOccurrence,
+           currentWebOccurrence.documentGeneration != nil,
+           !Self.isWebMusicPlaybackOccurrence(
+               resolvedOccurrence,
+               newerThanOrEqualTo: currentWebOccurrence
+           )
+        {
+            return false
+        }
+
+        if let lastClaimedWebMusicPlaybackOccurrence,
+           !Self.isWebMusicPlaybackOccurrence(
+               resolvedOccurrence,
+               newerThan: lastClaimedWebMusicPlaybackOccurrence
+           )
+        {
+            return false
+        }
+        self.lastClaimedWebMusicPlaybackOccurrence = resolvedOccurrence
+        return true
+    }
+
+    private static func isWebMusicPlaybackOccurrence(
+        _ occurrence: MusicPlaybackOccurrence,
+        newerThan other: MusicPlaybackOccurrence
+    ) -> Bool {
+        guard let documentGeneration = occurrence.documentGeneration,
+              let otherDocumentGeneration = other.documentGeneration
+        else {
+            return false
+        }
+        if documentGeneration != otherDocumentGeneration {
+            return documentGeneration > otherDocumentGeneration
+        }
+        if occurrence.mediaGeneration != other.mediaGeneration {
+            return occurrence.mediaGeneration > other.mediaGeneration
+        }
+        return occurrence.nativeGeneration > other.nativeGeneration
+    }
+
+    private static func isWebMusicPlaybackOccurrence(
+        _ occurrence: MusicPlaybackOccurrence,
+        newerThanOrEqualTo other: MusicPlaybackOccurrence
+    ) -> Bool {
+        occurrence == other || self.isWebMusicPlaybackOccurrence(occurrence, newerThan: other)
+    }
 }

--- a/Sources/Kaset/Services/Player/PlayerService.swift
+++ b/Sources/Kaset/Services/Player/PlayerService.swift
@@ -811,7 +811,15 @@ final class PlayerService: NSObject, PlayerServiceProtocol {
                 guard occurrence.nativeGeneration >= currentMusicPlaybackOccurrence.nativeGeneration else {
                     return false
                 }
+                let hasConfirmedVideoMismatch = if let nativeVideoId = currentMusicPlaybackOccurrence.videoId,
+                                                   let webVideoId = occurrence.videoId
+                {
+                    nativeVideoId != webVideoId
+                } else {
+                    false
+                }
                 if occurrence.nativeGeneration == currentMusicPlaybackOccurrence.nativeGeneration,
+                   !hasConfirmedVideoMismatch,
                    currentMusicPlaybackOccurrence.mediaGeneration
                    <= self.lastClaimedNativeMusicPlaybackGeneration
                 {

--- a/Sources/Kaset/Services/Player/PlayerService.swift
+++ b/Sources/Kaset/Services/Player/PlayerService.swift
@@ -12,6 +12,18 @@ final class PlayerService: NSObject, PlayerServiceProtocol {
         SingletonPlayerWebView.shared.currentVideoId
     }
 
+    @ObservationIgnored var currentMusicPlaybackSnapshot: @MainActor () async -> SingletonPlayerWebView.PlaybackSnapshot? = {
+        await SingletonPlayerWebView.shared.currentPlaybackSnapshot()
+    }
+
+    @ObservationIgnored var smartShuffleFeatureEnabled: @MainActor () -> Bool = {
+        SettingsManager.shared.smartShuffleEnabled
+    }
+
+    @ObservationIgnored var queuePersistenceDefaults: UserDefaults = .standard
+
+    @ObservationIgnored var onMusicPlaybackNavigationRequested: ((String, Bool) -> Void)?
+
     /// Latest media occurrence observed or initiated for Music playback.
     @ObservationIgnored private(set) var currentMusicPlaybackOccurrence: MusicPlaybackOccurrence?
 
@@ -56,7 +68,7 @@ final class PlayerService: NSObject, PlayerServiceProtocol {
     }
 
     /// Shuffle mode for playback. `smart` interleaves recommended tracks.
-    enum ShuffleMode: String, CaseIterable {
+    enum ShuffleMode: String, CaseIterable, Codable {
         case off
         case on
         case smart
@@ -282,14 +294,41 @@ final class PlayerService: NSObject, PlayerServiceProtocol {
     let logger = DiagnosticsLogger.player
     var ytMusicClient: (any YTMusicClientProtocol)?
     var authService: AuthService?
+    var songLikeStatusManager = SongLikeStatusManager.shared
 
     /// Continuation token for loading more songs in infinite mix/radio.
     var mixContinuationToken: String?
     var mixContinuationRequiresAuth = false
-    var playbackRequestGeneration = 0
+    var musicPlaybackIntentGeneration: UInt64 = 0
+    var musicPlaybackReservationGeneration: UInt64 = 0
+    var musicPlaybackIntentIssuedAtMilliseconds: Double = 0
+    var musicPlaybackIntentAcceptsPriorTerminalEvent = false
+    var libraryMutationGeneration: UInt64 = 0
+    var libraryMutationRevisionCounter: UInt64 = 0
+    var libraryMutationRevisions: [String: UInt64] = [:]
+    var confirmedLibraryStateByKey: [String: MusicLibraryConfirmedState] = [:]
+    var pendingLibraryMutationCountsByKey: [String: Int] = [:]
+    var accountSessionGeneration: UInt64 = 0
+    @ObservationIgnored var libraryMutationTails: [String: Task<Result<Void, any Error>, Never>] = [:]
+    @ObservationIgnored var libraryMutationTailGenerations: [String: UInt64] = [:]
+    @ObservationIgnored var remoteMusicTransportCommands: [MusicRemoteTransportCommand] = []
+    @ObservationIgnored var remoteMusicTransportCommandReadIndex = 0
+    @ObservationIgnored var remoteMusicTransportTask: Task<Void, Never>?
+    @ObservationIgnored var remoteMusicTransportBatchGeneration: UInt64 = 0
+    @ObservationIgnored var remoteMusicTransportIntent: MusicPlaybackIntent?
+    @ObservationIgnored var remoteMusicSkipTarget: TimeInterval?
+    @ObservationIgnored var remoteMusicSkipVideoID: String?
+    @ObservationIgnored var remoteMusicSkipQueueEntryID: UUID?
+    @ObservationIgnored var remoteMusicSkipAdmittedAt: ContinuousClock.Instant?
+    @ObservationIgnored var remoteMusicMetadataFollowUpTask: Task<Void, Never>?
+    @ObservationIgnored var remoteMusicMetadataFollowUpGeneration: UInt64 = 0
+    @ObservationIgnored var remoteMusicQueueFollowUpTask: Task<Void, Never>?
+    @ObservationIgnored var remoteMusicQueueFollowUpGeneration: UInt64 = 0
 
     /// Whether we're currently fetching more mix songs.
     var isFetchingMoreMixSongs: Bool = false
+    var activeMixContinuationRequestID: UUID?
+    var mixContinuationWaiters: [CheckedContinuation<Void, Never>] = []
 
     /// Smart Shuffle: videoIds suggested this session, for dedup across fills.
     var smartShuffleSeenSuggestionIds: Set<String> = []
@@ -314,9 +353,9 @@ final class PlayerService: NSObject, PlayerServiceProtocol {
     static let queueDisplayModeKey = "kaset.queue.displayMode"
 
     /// Undo/redo history for queue (up to 10 states). In-memory only.
-    private var queueUndoHistory: [QueueState] = []
-    private var queueRedoHistory: [QueueState] = []
-    private static let queueUndoMaxCount = 10
+    var queueUndoHistory: [QueueState] = []
+    var queueRedoHistory: [QueueState] = []
+    static let queueUndoMaxCount = 10
 
     /// Queue index before each `next()`; `previous()` pops so Back returns to the track you skipped from (shuffle- and seek-safe).
     private var forwardSkipIndexStack: [Int] = []
@@ -372,9 +411,10 @@ final class PlayerService: NSObject, PlayerServiceProtocol {
 
             // Don't resurrect smart mode if the feature has since been disabled in settings;
             // fall back to plain shuffle (the user still wanted shuffle, just not suggestions).
-            if self.shuffleMode == .smart, !SettingsManager.shared.smartShuffleEnabled {
-                self.shuffleMode = .on
-            }
+            self.shuffleMode = Self.resolvedShuffleMode(
+                self.shuffleMode,
+                smartShuffleEnabled: self.smartShuffleFeatureEnabled()
+            )
 
             if let savedRepeatMode = UserDefaults.standard.string(forKey: Self.repeatModeKey) {
                 switch savedRepeatMode {
@@ -447,62 +487,6 @@ final class PlayerService: NSObject, PlayerServiceProtocol {
         self.airPlayWasRequested = true
     }
 
-    // MARK: - Queue Undo / Redo
-
-    /// Whether queue undo is available.
-    var canUndoQueue: Bool {
-        !self.queueUndoHistory.isEmpty
-    }
-
-    /// Whether queue redo is available.
-    var canRedoQueue: Bool {
-        !self.queueRedoHistory.isEmpty
-    }
-
-    /// Clears queue undo/redo history at account/privacy boundaries.
-    func clearQueueUndoRedoHistory() {
-        self.queueUndoHistory.removeAll()
-        self.queueRedoHistory.removeAll()
-    }
-
-    /// Records current queue state for undo (call before mutating queue). Clears redo. Keeps up to 3 states.
-    func recordQueueStateForUndo() {
-        let state = QueueState(entries: self.queueEntries, currentIndex: self.currentIndex)
-        self.queueUndoHistory.append(state)
-        if self.queueUndoHistory.count > Self.queueUndoMaxCount {
-            self.queueUndoHistory.removeFirst()
-        }
-        self.queueRedoHistory.removeAll()
-        self.logger.debug("Recorded queue state for undo, undo count: \(self.queueUndoHistory.count)")
-    }
-
-    /// Restores the previous queue state. Does nothing if undo history is empty.
-    func undoQueue() {
-        guard let state = self.queueUndoHistory.popLast() else { return }
-        // Undo replaces the queue, so cancel Smart Shuffle fills and supersede any in-flight
-        // deferred load: otherwise stale async work can splice tracks into the restored queue.
-        self.prepareForNewPlaybackContext()
-        self.queueRedoHistory.append(QueueState(entries: self.queueEntries, currentIndex: self.currentIndex))
-        self.setQueue(entries: state.entries)
-        self.currentIndex = min(state.currentIndex, max(0, state.entries.count - 1))
-        self.saveQueueForPersistence()
-        self.logger.info("Undid queue to \(state.entries.count) songs at index \(self.currentIndex)")
-        self.clearForwardSkipNavigationStack()
-    }
-
-    /// Restores the next queue state after an undo. Does nothing if redo history is empty.
-    func redoQueue() {
-        guard let state = self.queueRedoHistory.popLast() else { return }
-        // Redo replaces the queue, so cancel/supersede stale async queue work (see undoQueue).
-        self.prepareForNewPlaybackContext()
-        self.queueUndoHistory.append(QueueState(entries: self.queueEntries, currentIndex: self.currentIndex))
-        self.setQueue(entries: state.entries)
-        self.currentIndex = min(state.currentIndex, max(0, state.entries.count - 1))
-        self.saveQueueForPersistence()
-        self.logger.info("Redid queue to \(state.entries.count) songs at index \(self.currentIndex)")
-        self.clearForwardSkipNavigationStack()
-    }
-
     /// Clears forward-skip undo when the queue is replaced or reordered so indices are not stale.
     func clearForwardSkipNavigationStack() {
         self.forwardSkipIndexStack.removeAll()
@@ -515,6 +499,11 @@ final class PlayerService: NSObject, PlayerServiceProtocol {
 
     func setQueue(entries: [QueueEntry]) {
         self.queueStorage = entries
+        if let activePlaybackQueueEntryID,
+           !entries.contains(where: { $0.id == activePlaybackQueueEntryID })
+        {
+            self.activePlaybackQueueEntryID = nil
+        }
         self.synchronizeCurrentQueueEntryID()
     }
 
@@ -578,6 +567,11 @@ final class PlayerService: NSObject, PlayerServiceProtocol {
             self.currentTrackHasVideo = hasVideo
             self.logger.debug("Loaded mock video availability: \(hasVideo)")
         }
+    }
+
+    /// Sets the like-status cache used by playback metadata and rating actions.
+    func setSongLikeStatusManager(_ manager: SongLikeStatusManager) {
+        self.songLikeStatusManager = manager
     }
 
     /// Sets the YTMusicClient for API calls (dependency injection).
@@ -787,6 +781,13 @@ final class PlayerService: NSObject, PlayerServiceProtocol {
             )
 
         if resolvedOccurrence.documentGeneration == nil {
+            if let currentMusicPlaybackOccurrence {
+                guard currentMusicPlaybackOccurrence.documentGeneration == nil,
+                      resolvedOccurrence.nativeGeneration >= currentMusicPlaybackOccurrence.nativeGeneration
+                else {
+                    return false
+                }
+            }
             guard resolvedOccurrence.mediaGeneration > self.lastClaimedNativeMusicPlaybackGeneration else {
                 return false
             }

--- a/Sources/Kaset/Services/Player/PlayerService.swift
+++ b/Sources/Kaset/Services/Player/PlayerService.swift
@@ -330,6 +330,7 @@ final class PlayerService: NSObject, PlayerServiceProtocol {
     var musicPlaybackReservationGeneration: UInt64 = 0
     var musicPlaybackIntentIssuedAtMilliseconds: Double = 0
     var musicPlaybackIntentAcceptsPriorTerminalEvent = false
+    var musicPlaybackMinimumAcceptedTerminalIntentGeneration: UInt64 = 0
     var libraryMutationGeneration: UInt64 = 0
     var libraryMutationRevisionCounter: UInt64 = 0
     var libraryMutationRevisions: [String: UInt64] = [:]

--- a/Sources/Kaset/Services/Player/PlaylistPlaybackActions.swift
+++ b/Sources/Kaset/Services/Player/PlaylistPlaybackActions.swift
@@ -12,17 +12,19 @@ enum PlaylistPlaybackActions {
     }
 
     /// Plays a playlist immediately, replacing the current queue.
+    @discardableResult
+    @MainActor
     static func playPlaylist(
         _ playlist: Playlist,
         client: any YTMusicClientProtocol,
         playerService: PlayerService
-    ) {
-        Task { @MainActor in
-            let requestGeneration = playerService.playbackRequestGeneration
+    ) -> Task<Void, Never> {
+        let intent = playerService.beginMusicPlaybackIntent()
+        return Task { @MainActor in
             do {
                 let response = try await client.getPlaylist(id: playlist.id)
-                guard requestGeneration == playerService.playbackRequestGeneration else {
-                    DiagnosticsLogger.ui.info("Discarding stale playlist playback request after privacy boundary")
+                guard playerService.acceptsMusicPlaybackIntent(intent) else {
+                    DiagnosticsLogger.ui.info("Discarding stale playlist playback request after newer playback intent")
                     return
                 }
                 var songs = response.detail.tracks
@@ -30,8 +32,8 @@ enum PlaylistPlaybackActions {
                 if self.isRadioPlaylist(playlist.id) {
                     do {
                         let allTracks = try await client.getPlaylistAllTracks(playlistId: playlist.id)
-                        guard requestGeneration == playerService.playbackRequestGeneration else {
-                            DiagnosticsLogger.ui.info("Discarding stale playlist all-tracks request after privacy boundary")
+                        guard playerService.acceptsMusicPlaybackIntent(intent) else {
+                            DiagnosticsLogger.ui.info("Discarding stale playlist all-tracks request after newer playback intent")
                             return
                         }
                         if allTracks.count >= songs.count, !allTracks.isEmpty {
@@ -53,7 +55,10 @@ enum PlaylistPlaybackActions {
                     // fill cannot slip through.
                     let willDeferLoad = response.continuationToken != nil
                     let loadGeneration = await playerService.playQueue(
-                        playableSongs, startingAt: 0, deferringSmartShuffleFill: willDeferLoad
+                        playableSongs,
+                        startingAt: 0,
+                        deferringSmartShuffleFill: willDeferLoad,
+                        intent: intent
                     )
                     DiagnosticsLogger.ui.info("Playing playlist '\(playlist.title)' (\(playableSongs.count) initial songs)")
 
@@ -78,7 +83,12 @@ enum PlaylistPlaybackActions {
                 let playableSongs = self.playableSongsWithPlaylistArtwork(songs, playlist: playlist)
                 guard !playableSongs.isEmpty else { return }
 
-                await playerService.playQueue(playableSongs, startingAt: 0)
+                await playerService.playQueue(
+                    playableSongs,
+                    startingAt: 0,
+                    deferringSmartShuffleFill: false,
+                    intent: intent
+                )
                 DiagnosticsLogger.ui.info("Playing playlist '\(playlist.title)' (\(playableSongs.count) songs)")
             } catch {
                 DiagnosticsLogger.ui.error("Failed to play playlist: \(error.localizedDescription)")

--- a/Sources/Kaset/Services/Player/WebPlaybackDocumentGeneration.swift
+++ b/Sources/Kaset/Services/Player/WebPlaybackDocumentGeneration.swift
@@ -430,8 +430,13 @@ struct WebPlaybackDocumentGeneration: Equatable {
         guard let components = url.flatMap({
             URLComponents(url: $0, resolvingAgainstBaseURL: false)
         }) else { return true }
-        return (components.scheme?.lowercased() == "about" && components.path == "blank")
-            || components.scheme?.lowercased() == "data"
+        if components.scheme?.lowercased() == "data" {
+            return true
+        }
+        guard components.scheme?.lowercased() == "about",
+              let decodedURL = url?.absoluteString.removingPercentEncoding?.lowercased()
+        else { return false }
+        return decodedURL == "about:blank" || decodedURL.hasPrefix("about:blank#")
     }
 
     static func blankURL(generation: UInt64) -> URL? {
@@ -459,13 +464,23 @@ struct WebPlaybackDocumentGeneration: Equatable {
 
     static func blankGeneration(from url: URL?) -> UInt64? {
         guard self.isInternalBlankNavigation(url),
-              let fragment = url.flatMap({
-                  URLComponents(url: $0, resolvingAgainstBaseURL: false)
-              })?.fragment,
+              let fragment = self.internalBlankFragment(from: url),
               let rawGeneration = URLComponents(string: "?\(fragment)")?.queryItems?
               .first(where: { $0.name == Self.blankURLFragmentKey })?.value
         else { return nil }
         return UInt64(rawGeneration)
+    }
+
+    private static func internalBlankFragment(from url: URL?) -> String? {
+        if let fragment = url.flatMap({
+            URLComponents(url: $0, resolvingAgainstBaseURL: false)
+        })?.fragment {
+            return fragment
+        }
+        guard let decodedURL = url?.absoluteString.removingPercentEncoding,
+              let fragmentStart = decodedURL.firstIndex(of: "#")
+        else { return nil }
+        return String(decodedURL[decodedURL.index(after: fragmentStart)...])
     }
 
     static func acceptsMainFrameResponse(_ url: URL?, expectedHost: String) -> Bool {

--- a/Sources/Kaset/Services/Player/WebPlaybackDocumentGeneration.swift
+++ b/Sources/Kaset/Services/Player/WebPlaybackDocumentGeneration.swift
@@ -1,0 +1,486 @@
+import CoreFoundation
+import Foundation
+
+// MARK: - WebPlaybackTrackedNavigation
+
+struct WebPlaybackTrackedNavigation: Equatable, Sendable {
+    let generation: UInt64
+    var pendingSeek: Double?
+    var didCommit = false
+    var didActivatePlaybackOrigin = false
+
+    init(generation: UInt64, pendingSeek: Double? = nil) {
+        self.generation = generation
+        self.pendingSeek = pendingSeek
+    }
+}
+
+// MARK: - WebPlaybackNavigationFailure
+
+enum WebPlaybackNavigationFailure {
+    private static let webKitErrorDomain = "WebKitErrorDomain"
+    private static let frameLoadInterruptedByPolicyChange = 102
+
+    static func isRetryableCancellation(_ error: Error) -> Bool {
+        let error = error as NSError
+        if error.domain == NSURLErrorDomain, error.code == URLError.cancelled.rawValue {
+            return true
+        }
+        return error.domain == Self.webKitErrorDomain
+            && error.code == Self.frameLoadInterruptedByPolicyChange
+    }
+}
+
+// MARK: - WebPlaybackDocumentGeneration
+
+/// Tracks which WebView document is allowed to mutate native playback state.
+///
+/// Reserving or starting a navigation suppresses bridge events from the outgoing
+/// document. The new generation becomes current only after WebKit commits that
+/// document. Cancelling or failing before commit restores the last committed
+/// document. Teardown invalidates every previously issued generation.
+struct WebPlaybackDocumentGeneration: Equatable, Sendable {
+    static let urlQueryKey = "kasetDocumentGeneration"
+    static let blankURLFragmentKey = "kasetBlankGeneration"
+    private static let trustedRedirectHosts: Set<String> = [
+        "accounts.google.com",
+        "consent.google.com",
+        "consent.youtube.com",
+    ]
+
+    static let mediaSuppressionScript = """
+    (function() {
+        window.__kasetPlaybackSuppressed = true;
+        if (!window.__kasetPlaybackSuppressionInstalled) {
+            window.__kasetPlaybackSuppressionInstalled = true;
+            document.addEventListener('play', function(event) {
+                if (!window.__kasetPlaybackSuppressed) return;
+                const media = event.target;
+                if (media && typeof media.pause === 'function') media.pause();
+            }, true);
+        }
+        document.querySelectorAll('video, audio').forEach(function(media) {
+            try { media.pause(); } catch (e) {}
+        });
+    })();
+    """
+
+    private(set) var currentGeneration: UInt64 = 0
+    private(set) var pendingGeneration: UInt64?
+    private(set) var inFlightGeneration: UInt64?
+    private(set) var committedIntermediaryGeneration: UInt64?
+    private(set) var blankNavigationGeneration: UInt64?
+    private var nextGeneration: UInt64 = 0
+    private var startedGenerations: Set<UInt64> = []
+    private var validatedPlaybackResponse: ValidatedPlaybackResponse?
+
+    private struct ValidatedPlaybackResponse: Equatable, Sendable {
+        let generation: UInt64
+        let videoID: String
+    }
+
+    /// Generation that should be injected into the next document-start scripts.
+    var userScriptGeneration: UInt64 {
+        self.pendingGeneration ?? self.inFlightGeneration ?? self.currentGeneration
+    }
+
+    /// Reserves a generation for the next document and suppresses the currently
+    /// committed document until this request commits, fails, or is cancelled.
+    mutating func beginNavigation() -> UInt64 {
+        self.nextGeneration &+= 1
+        self.pendingGeneration = self.nextGeneration
+        self.committedIntermediaryGeneration = nil
+        self.blankNavigationGeneration = nil
+        self.validatedPlaybackResponse = nil
+        return self.nextGeneration
+    }
+
+    /// Marks a still-current reserved generation as provisionally loading.
+    /// This intentionally does not replace `currentGeneration`; WebKit may keep
+    /// the previous document alive if the provisional navigation is cancelled.
+    @discardableResult
+    mutating func startNavigation(_ generation: UInt64) -> Bool {
+        guard self.pendingGeneration == generation else { return false }
+        self.startedGenerations.insert(generation)
+        self.inFlightGeneration = generation
+        self.pendingGeneration = nil
+        return true
+    }
+
+    /// Promotes a provisionally loading generation after WebKit commits it.
+    @discardableResult
+    mutating func commitNavigation(
+        _ generation: UInt64,
+        expectedVideoID: String? = nil
+    ) -> Bool {
+        if let expectedVideoID {
+            guard self.validatedPlaybackResponse == ValidatedPlaybackResponse(
+                generation: generation,
+                videoID: expectedVideoID
+            ) else { return false }
+        }
+        guard self.startedGenerations.remove(generation) != nil else { return false }
+        let didAdvance = generation > self.currentGeneration
+        let didCommitCurrentProvisional = self.inFlightGeneration == generation
+        if didAdvance {
+            self.currentGeneration = generation
+        }
+        if didCommitCurrentProvisional {
+            self.inFlightGeneration = nil
+        }
+        self.committedIntermediaryGeneration = nil
+        self.blankNavigationGeneration = nil
+        self.validatedPlaybackResponse = nil
+        return didAdvance || didCommitCurrentProvisional
+    }
+
+    /// Records a committed trusted auth/consent document as the explicit owner
+    /// of subsequent tokenless continuations for this one in-flight generation.
+    @discardableResult
+    mutating func commitIntermediaryNavigation(_ generation: UInt64) -> Bool {
+        guard self.startedGenerations.contains(generation),
+              self.inFlightGeneration == generation,
+              self.pendingGeneration == nil
+        else { return false }
+        self.committedIntermediaryGeneration = generation
+        self.validatedPlaybackResponse = nil
+        return true
+    }
+
+    /// Records the successful expected playback response observed before commit.
+    @discardableResult
+    mutating func recordSuccessfulPlaybackResponse(
+        url: URL?,
+        host expectedHost: String,
+        videoID: String
+    ) -> Bool {
+        guard let generation = self.inFlightGeneration,
+              Self.generation(from: url) == generation,
+              Self.isExpectedPlaybackURL(
+                  url,
+                  host: expectedHost,
+                  videoID: videoID
+              )
+        else { return false }
+        self.validatedPlaybackResponse = ValidatedPlaybackResponse(
+            generation: generation,
+            videoID: videoID
+        )
+        return true
+    }
+
+    /// Cancels a request before `WKWebView.load` starts, allowing the existing
+    /// committed document to publish bridge events again.
+    mutating func cancelPendingNavigation() {
+        self.pendingGeneration = nil
+        self.committedIntermediaryGeneration = nil
+        self.validatedPlaybackResponse = nil
+    }
+
+    /// Cancels or fails a tracked provisional navigation before commit. Returns
+    /// `true` only when it was the newest provisional navigation whose failure
+    /// changes which generation should be installed for the next document.
+    @discardableResult
+    mutating func cancelInFlightNavigation(_ generation: UInt64) -> Bool {
+        guard self.startedGenerations.remove(generation) != nil else { return false }
+        let didCancelCurrentProvisional = self.inFlightGeneration == generation
+        if didCancelCurrentProvisional {
+            self.inFlightGeneration = nil
+            self.committedIntermediaryGeneration = nil
+            self.validatedPlaybackResponse = nil
+        }
+        return didCancelCurrentProvisional
+    }
+
+    /// Invalidates all documents issued before teardown or WebView replacement.
+    mutating func invalidate() {
+        self.nextGeneration &+= 1
+        self.currentGeneration = self.nextGeneration
+        self.pendingGeneration = nil
+        self.inFlightGeneration = nil
+        self.committedIntermediaryGeneration = nil
+        self.blankNavigationGeneration = nil
+        self.startedGenerations.removeAll()
+        self.validatedPlaybackResponse = nil
+    }
+
+    /// Invalidates playback documents and grants one exact internal blank URL
+    /// permission for explicit teardown/recovery blanking.
+    mutating func beginBlankNavigation() -> UInt64 {
+        self.invalidate()
+        self.blankNavigationGeneration = self.currentGeneration
+        return self.currentGeneration
+    }
+
+    func ownsBlankNavigation(_ url: URL?) -> Bool {
+        guard let blankNavigationGeneration else { return false }
+        return Self.blankGeneration(from: url) == blankNavigationGeneration
+    }
+
+    /// Returns whether a bridge payload belongs to the one committed document.
+    /// While a newer navigation is reserved or provisionally loading, all
+    /// outgoing-document messages are suppressed.
+    func accepts(generation: UInt64) -> Bool {
+        self.pendingGeneration == nil
+            && self.inFlightGeneration == nil
+            && generation == self.currentGeneration
+    }
+
+    /// Media-key commands may arrive from the still-current committed document
+    /// while its replacement is pending/provisional. Accept only commands issued
+    /// after that replacement began; a delayed older event must not overwrite the
+    /// newer native selection intent.
+    func acceptsUserCommand(
+        generation: UInt64,
+        issuedAtMilliseconds: Double?,
+        navigationStartedAtMilliseconds: Double?
+    ) -> Bool {
+        guard generation == self.currentGeneration else { return false }
+        guard self.pendingGeneration != nil || self.inFlightGeneration != nil else {
+            return true
+        }
+        guard let issuedAtMilliseconds,
+              issuedAtMilliseconds.isFinite,
+              let navigationStartedAtMilliseconds,
+              navigationStartedAtMilliseconds.isFinite
+        else { return false }
+        return issuedAtMilliseconds >= navigationStartedAtMilliseconds
+    }
+
+    /// Returns whether post-load work still belongs to the active document.
+    /// A committed navigation may finish after a newer selection has already
+    /// reserved, started, or committed another generation.
+    func canFinishNavigation(_ generation: UInt64) -> Bool {
+        self.pendingGeneration == nil
+            && self.inFlightGeneration == nil
+            && generation == self.currentGeneration
+    }
+
+    func accepts(rawGeneration: Any?) -> Bool {
+        guard let generation = Self.decode(rawGeneration) else { return false }
+        return self.accepts(generation: generation)
+    }
+
+    static func decode(_ rawGeneration: Any?) -> UInt64? {
+        guard let rawGeneration else { return nil }
+
+        if let generation = rawGeneration as? NSNumber {
+            guard CFGetTypeID(generation) != CFBooleanGetTypeID() else { return nil }
+            return Self.decodeFloatingPoint(generation.doubleValue)
+        }
+        if let generation = rawGeneration as? UInt64 {
+            return generation
+        }
+        if let generation = rawGeneration as? UInt {
+            return UInt64(generation)
+        }
+        if let generation = rawGeneration as? Int {
+            return generation >= 0 ? UInt64(generation) : nil
+        }
+        if let generation = rawGeneration as? Double {
+            return Self.decodeFloatingPoint(generation)
+        }
+        if let generation = rawGeneration as? Float {
+            return Self.decodeFloatingPoint(Double(generation))
+        }
+        return nil
+    }
+
+    static func generation(from url: URL?) -> UInt64? {
+        let components = url.flatMap {
+            URLComponents(url: $0, resolvingAgainstBaseURL: false)
+        }
+        let queryGeneration = components?.queryItems?
+            .first { $0.name == Self.urlQueryKey }?.value
+        let fragmentGeneration = components?.fragment.flatMap {
+            URLComponents(string: "?\($0)")?.queryItems?
+                .first { $0.name == Self.urlQueryKey }?.value
+        }
+        let rawGeneration = queryGeneration ?? fragmentGeneration
+        guard let rawGeneration else { return nil }
+        return UInt64(rawGeneration)
+    }
+
+    static func request(_ request: URLRequest, belongsTo generation: UInt64) -> Bool {
+        let requestGeneration = Self.generation(from: request.url)
+        let mainDocumentGeneration = Self.generation(from: request.mainDocumentURL)
+        guard requestGeneration == nil
+            || mainDocumentGeneration == nil
+            || requestGeneration == mainDocumentGeneration
+        else { return false }
+        return (requestGeneration ?? mainDocumentGeneration) == generation
+    }
+
+    /// Returns whether a main-frame navigation can host the expected playback
+    /// bridge. Generation association alone is insufficient: redirects to
+    /// consent, captive-portal, or error origins cannot run Kaset's trusted
+    /// bridge and would otherwise leave native playback stuck in loading.
+    static func isExpectedPlaybackURL(_ url: URL?, host expectedHost: String) -> Bool {
+        guard let components = url.flatMap({
+            URLComponents(url: $0, resolvingAgainstBaseURL: false)
+        }) else { return false }
+        return components.scheme?.lowercased() == "https"
+            && components.host?.lowercased() == expectedHost.lowercased()
+    }
+
+    static func isExpectedPlaybackURL(
+        _ url: URL?,
+        host expectedHost: String,
+        videoID: String
+    ) -> Bool {
+        guard self.isExpectedPlaybackURL(url, host: expectedHost),
+              let components = url.flatMap({
+                  URLComponents(url: $0, resolvingAgainstBaseURL: false)
+              }),
+              components.path == "/watch"
+        else { return false }
+        return components.queryItems?.first { $0.name == "v" }?.value == videoID
+    }
+
+    static func isAllowedPlaybackNavigationURL(_ url: URL?, playbackHost: String) -> Bool {
+        guard let url,
+              url.scheme?.lowercased() == "https",
+              let host = url.host?.lowercased()
+        else { return false }
+        return host == playbackHost.lowercased() || Self.trustedRedirectHosts.contains(host)
+    }
+
+    static func isTrustedIntermediaryURL(_ url: URL?) -> Bool {
+        guard let url,
+              url.scheme?.lowercased() == "https",
+              let host = url.host?.lowercased()
+        else { return false }
+        return Self.trustedRedirectHosts.contains(host)
+    }
+
+    static func requestBelongsToNavigationChain(
+        _ request: URLRequest,
+        currentURL: URL?,
+        generation: UInt64,
+        playbackHost: String,
+        committedIntermediaryGeneration: UInt64? = nil
+    ) -> Bool {
+        let requestGeneration = Self.generation(from: request.url)
+        let mainDocumentGeneration = Self.generation(from: request.mainDocumentURL)
+        guard requestGeneration == nil
+            || mainDocumentGeneration == nil
+            || requestGeneration == mainDocumentGeneration
+        else { return false }
+        guard Self.isAllowedPlaybackNavigationURL(
+            request.url,
+            playbackHost: playbackHost
+        ) else { return false }
+        if let explicitGeneration = requestGeneration ?? mainDocumentGeneration {
+            return explicitGeneration == generation
+        }
+        return committedIntermediaryGeneration == generation
+            && Self.isAllowedPlaybackNavigationURL(currentURL, playbackHost: playbackHost)
+    }
+
+    static func requestByBindingGeneration(
+        _ request: URLRequest,
+        generation: UInt64
+    ) -> URLRequest? {
+        guard let url = request.url,
+              var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        else { return nil }
+        var queryItems = components.queryItems ?? []
+        queryItems.removeAll { $0.name == Self.urlQueryKey }
+        queryItems.append(URLQueryItem(name: Self.urlQueryKey, value: String(generation)))
+        components.queryItems = queryItems
+        components.fragment = "\(Self.urlQueryKey)=\(generation)"
+        guard let boundURL = components.url else { return nil }
+        var boundRequest = request
+        boundRequest.url = boundURL
+        boundRequest.mainDocumentURL = boundURL
+        return boundRequest
+    }
+
+    static func javaScriptStringLiteral(_ value: String?) -> String {
+        guard let value,
+              let data = try? JSONSerialization.data(withJSONObject: value, options: .fragmentsAllowed),
+              let literal = String(data: data, encoding: .utf8)
+        else { return "null" }
+        return literal
+    }
+
+    static func isFragmentOnlyNavigation(from currentURL: URL?, to proposedURL: URL?) -> Bool {
+        guard var current = currentURL.flatMap({
+            URLComponents(url: $0, resolvingAgainstBaseURL: false)
+        }),
+            var proposed = proposedURL.flatMap({
+                URLComponents(url: $0, resolvingAgainstBaseURL: false)
+            })
+        else { return false }
+        let currentFragment = current.fragment
+        let proposedFragment = proposed.fragment
+        current.fragment = nil
+        proposed.fragment = nil
+        return current == proposed && currentFragment != proposedFragment
+    }
+
+    static func isInternalBlankNavigation(_ url: URL?) -> Bool {
+        guard let components = url.flatMap({
+            URLComponents(url: $0, resolvingAgainstBaseURL: false)
+        }) else { return true }
+        return (components.scheme?.lowercased() == "about" && components.path == "blank")
+            || components.scheme?.lowercased() == "data"
+    }
+
+    static func blankURL(generation: UInt64) -> URL? {
+        URL(string: "about:blank#\(self.blankURLFragmentKey)=\(generation)")
+    }
+
+    static func blankGeneration(from url: URL?) -> UInt64? {
+        guard self.isInternalBlankNavigation(url),
+              let fragment = url.flatMap({
+                  URLComponents(url: $0, resolvingAgainstBaseURL: false)
+              })?.fragment,
+              let rawGeneration = URLComponents(string: "?\(fragment)")?.queryItems?
+              .first(where: { $0.name == Self.blankURLFragmentKey })?.value
+        else { return nil }
+        return UInt64(rawGeneration)
+    }
+
+    static func acceptsMainFrameResponse(_ url: URL?, expectedHost: String) -> Bool {
+        guard !self.isInternalBlankNavigation(url) else { return false }
+        return self.isAllowedPlaybackNavigationURL(url, playbackHost: expectedHost)
+    }
+
+    static func acceptsMainFrameResponse(
+        _ response: URLResponse,
+        expectedHost: String,
+        expectedVideoID: String?,
+        allowsInternalBlank: Bool
+    ) -> Bool {
+        if self.isInternalBlankNavigation(response.url) {
+            return allowsInternalBlank
+        }
+        guard self.isAllowedPlaybackNavigationURL(
+            response.url,
+            playbackHost: expectedHost
+        ),
+            let httpResponse = response as? HTTPURLResponse,
+            (200 ..< 300).contains(httpResponse.statusCode),
+            let responseHost = response.url?.host?.lowercased()
+        else { return false }
+        if responseHost == expectedHost.lowercased() {
+            guard let expectedVideoID else { return false }
+            return Self.isExpectedPlaybackURL(
+                response.url,
+                host: expectedHost,
+                videoID: expectedVideoID
+            )
+        }
+        return true
+    }
+
+    private static func decodeFloatingPoint(_ value: Double) -> UInt64? {
+        guard value.isFinite,
+              value >= 0,
+              value.rounded(.towardZero) == value,
+              value < Double(UInt64.max)
+        else { return nil }
+        return UInt64(value)
+    }
+}

--- a/Sources/Kaset/Services/Player/WebPlaybackDocumentGeneration.swift
+++ b/Sources/Kaset/Services/Player/WebPlaybackDocumentGeneration.swift
@@ -3,7 +3,7 @@ import Foundation
 
 // MARK: - WebPlaybackTrackedNavigation
 
-struct WebPlaybackTrackedNavigation: Equatable, Sendable {
+struct WebPlaybackTrackedNavigation: Equatable {
     let generation: UInt64
     var pendingSeek: Double?
     var didCommit = false
@@ -17,7 +17,7 @@ struct WebPlaybackTrackedNavigation: Equatable, Sendable {
 
 // MARK: - WebPlaybackCancelledNavigation
 
-struct WebPlaybackCancelledNavigation: Sendable {
+struct WebPlaybackCancelledNavigation {
     let generation: UInt64
     let shouldReportFailure: Bool
 }
@@ -46,7 +46,7 @@ enum WebPlaybackNavigationFailure {
 /// document. The new generation becomes current only after WebKit commits that
 /// document. Cancelling or failing before commit restores the last committed
 /// document. Teardown invalidates every previously issued generation.
-struct WebPlaybackDocumentGeneration: Equatable, Sendable {
+struct WebPlaybackDocumentGeneration: Equatable {
     static let urlQueryKey = "kasetDocumentGeneration"
     static let blankURLFragmentKey = "kasetBlankGeneration"
     private static let trustedRedirectHosts: Set<String> = [
@@ -81,7 +81,7 @@ struct WebPlaybackDocumentGeneration: Equatable, Sendable {
     private var startedGenerations: Set<UInt64> = []
     private var validatedPlaybackResponse: ValidatedPlaybackResponse?
 
-    private struct ValidatedPlaybackResponse: Equatable, Sendable {
+    private struct ValidatedPlaybackResponse: Equatable {
         let generation: UInt64
         let videoID: String
     }

--- a/Sources/Kaset/Services/Player/YouTubePlayerService+RemoteCommands.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService+RemoteCommands.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+@MainActor
+extension YouTubePlayerService {
+    private static let maximumFutureCommandSkewMilliseconds = 5000.0
+
+    @discardableResult
+    func beginYouTubePlaybackIntent(
+        issuedAtMilliseconds: Double? = nil
+    ) -> UInt64 {
+        let now = Date().timeIntervalSince1970 * 1000
+        let candidate = issuedAtMilliseconds ?? now
+        guard candidate.isFinite else { return self.youtubePlaybackIntentGeneration }
+        let previousBoundary = self.youtubePlaybackIntentIssuedAtMilliseconds
+        if issuedAtMilliseconds != nil {
+            guard candidate <= now + Self.maximumFutureCommandSkewMilliseconds,
+                  candidate >= previousBoundary
+            else { return self.youtubePlaybackIntentGeneration }
+        }
+        self.youtubePlaybackIntentGeneration &+= 1
+        let generation = self.youtubePlaybackIntentGeneration
+        if issuedAtMilliseconds == nil {
+            self.youtubePlaybackIntentIssuedAtMilliseconds = previousBoundary > now + Self.maximumFutureCommandSkewMilliseconds
+                ? now
+                : max(previousBoundary, now)
+            self.youtubeRemoteCommandIntentIssuedAtMilliseconds = nil
+        } else {
+            self.youtubePlaybackIntentIssuedAtMilliseconds = max(previousBoundary, candidate)
+            self.youtubeRemoteCommandIntentIssuedAtMilliseconds = nil
+        }
+        return generation
+    }
+
+    func acceptsYouTubeRemoteCommand(issuedAtMilliseconds: Double) -> Bool {
+        let now = Date().timeIntervalSince1970 * 1000
+        guard issuedAtMilliseconds.isFinite,
+              issuedAtMilliseconds <= now + Self.maximumFutureCommandSkewMilliseconds
+        else { return false }
+        if issuedAtMilliseconds > self.youtubePlaybackIntentIssuedAtMilliseconds {
+            return true
+        }
+        return issuedAtMilliseconds == self.youtubePlaybackIntentIssuedAtMilliseconds
+            && self.youtubeRemoteCommandIntentIssuedAtMilliseconds == issuedAtMilliseconds
+    }
+
+    @discardableResult
+    func admitYouTubeRemoteCommand(issuedAtMilliseconds: Double) -> Bool {
+        guard self.acceptsYouTubeRemoteCommand(
+            issuedAtMilliseconds: issuedAtMilliseconds
+        ) else { return false }
+        self.youtubePlaybackIntentIssuedAtMilliseconds = max(
+            self.youtubePlaybackIntentIssuedAtMilliseconds,
+            issuedAtMilliseconds
+        )
+        self.youtubeRemoteCommandIntentIssuedAtMilliseconds = issuedAtMilliseconds
+        self.youtubePlaybackIntentGeneration &+= 1
+        return true
+    }
+
+    func handleRemoteTogglePlayPause(issuedAtMilliseconds: Double) {
+        guard self.admitYouTubeRemoteCommand(
+            issuedAtMilliseconds: issuedAtMilliseconds
+        ) else { return }
+        self.performPlayPause(resumeIssuedAtMilliseconds: issuedAtMilliseconds)
+    }
+
+    func handleRemoteResume(issuedAtMilliseconds: Double) {
+        guard self.admitYouTubeRemoteCommand(
+            issuedAtMilliseconds: issuedAtMilliseconds
+        ) else { return }
+        self.performResume(issuedAtMilliseconds: issuedAtMilliseconds)
+    }
+
+    func handleRemotePause(issuedAtMilliseconds: Double) {
+        guard self.admitYouTubeRemoteCommand(
+            issuedAtMilliseconds: issuedAtMilliseconds
+        ) else { return }
+        self.performPause()
+    }
+
+    func handleRemoteSkipForward(issuedAtMilliseconds: Double) async {
+        guard self.admitYouTubeRemoteCommand(
+            issuedAtMilliseconds: issuedAtMilliseconds
+        ) else { return }
+        await self.skipForward(ownedBy: self.youtubePlaybackIntentGeneration)
+    }
+
+    func handleRemoteSkipBackward(issuedAtMilliseconds: Double) {
+        guard self.admitYouTubeRemoteCommand(
+            issuedAtMilliseconds: issuedAtMilliseconds
+        ) else { return }
+        self.skipBackwardWithoutBeginningIntent()
+    }
+}

--- a/Sources/Kaset/Services/Player/YouTubePlayerService+Seeking.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService+Seeking.swift
@@ -16,6 +16,18 @@ extension YouTubePlayerService {
 
     /// Seeks to a position in seconds.
     func seek(to time: Double) {
+        self.beginYouTubePlaybackIntent()
+        self.clearRelativeSeekCoalescingTarget()
+        self.performSeek(to: time)
+    }
+
+    func handleRemoteSeek(
+        to time: Double,
+        issuedAtMilliseconds: Double
+    ) {
+        guard self.admitYouTubeRemoteCommand(
+            issuedAtMilliseconds: issuedAtMilliseconds
+        ) else { return }
         self.clearRelativeSeekCoalescingTarget()
         self.performSeek(to: time)
     }
@@ -80,12 +92,14 @@ extension YouTubePlayerService {
     /// Seeks backward by a fixed interval, clamping to the beginning.
     func seekBackward(by seconds: Double = 30) {
         guard seconds.isFinite, seconds > 0 else { return }
+        self.beginYouTubePlaybackIntent()
         self.seekRelative(by: -seconds)
     }
 
     /// Seeks forward by a fixed interval, clamping to the known duration.
     func seekForward(by seconds: Double = 30) {
         guard seconds.isFinite, seconds > 0 else { return }
+        self.beginYouTubePlaybackIntent()
         self.seekRelative(by: seconds)
     }
 

--- a/Sources/Kaset/Services/Player/YouTubePlayerService+Seeking.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService+Seeking.swift
@@ -22,18 +22,20 @@ extension YouTubePlayerService {
 
     private func performSeek(to time: Double) {
         guard time.isFinite else { return }
+        self.invalidateExplicitStartTargetForUserSeek()
         let target = self.clampedSeekTarget(time)
         if self.duration > 0, target >= self.duration - Self.seekToEndThreshold {
             self.handleManualSeekToEnd()
             return
         }
 
+        self.recordPendingUserSeek(to: target)
         self.progress = target
         if self.pendingPausedIdentityReloadVideoId == self.currentVideo?.videoId {
             self.pendingPausedIdentityReloadResumeAt = target > 0 ? target : nil
             self.userUpdatedPendingPausedIdentityReloadSeek = true
         }
-        self.playbackController.seek(to: target)
+        self.playbackController.seekWithRecovery(to: target)
     }
 
     private func clampedSeekTarget(_ time: Double) -> Double {
@@ -48,18 +50,31 @@ extension YouTubePlayerService {
         let terminalSeekTime = max(0, self.duration - Self.seekToEndThreshold)
         self.progress = self.duration
         self.lastNonAdContentProgress = self.duration
+        self.clearPendingUserSeek()
         self.clearRelativeSeekCoalescingTarget()
         if self.pendingPausedIdentityReloadVideoId == self.currentVideo?.videoId {
             self.pendingPausedIdentityReloadResumeAt = nil
             self.userUpdatedPendingPausedIdentityReloadSeek = true
         }
 
+        // Fence native pause intent before any WebView command can synchronously
+        // publish a late playing sample, then cancel every older deferred seek so
+        // it cannot overwrite this terminal position after the command returns.
+        self.activateExplicitPauseIntent()
+        self.pendingPausedIdentityReloadVideoId = nil
+        self.pendingPausedIdentityReloadResumeAt = nil
+        self.userUpdatedPendingPausedIdentityReloadSeek = true
+        self.playbackController.cancelPendingRecoverySeek()
+        self.playbackController.markCurrentPlaybackOccurrenceEnded()
         // Keep the WebView away from exact-duration seeks and pause it so a
         // follow-up state update cannot look like a fresh replay of the just-
         // concluded watch.
         self.playbackController.seek(to: terminalSeekTime)
         self.playbackController.pause()
-        self.handleVideoEnded(videoId: self.currentVideo?.videoId)
+        self.handleVideoEnded(
+            videoId: self.currentVideo?.videoId,
+            isNativeTerminal: true
+        )
     }
 
     /// Seeks backward by a fixed interval, clamping to the beginning.

--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -130,6 +130,11 @@ final class YouTubePlayerService {
     /// actions clear this; an accepted playing update restores it for autoplay.
     @ObservationIgnored private var desiredPlaybackIntent: DesiredPlaybackIntent = .paused
 
+    /// Rejects remote-command callbacks captured before a newer native video action.
+    @ObservationIgnored var youtubePlaybackIntentIssuedAtMilliseconds: Double = 0
+    @ObservationIgnored var youtubeRemoteCommandIntentIssuedAtMilliseconds: Double?
+    @ObservationIgnored var youtubePlaybackIntentGeneration: UInt64 = 0
+
     /// Explicit native pause dominates late playing samples until the next native
     /// resume/new-watch intent. Natural end is intentionally separate so genuine
     /// same-document autoplay can still become authoritative.
@@ -309,6 +314,7 @@ final class YouTubePlayerService {
 
     /// Starts playback of a video, docked inline.
     func play(video: YouTubeVideo, usesCookieFreeDataStore: Bool = false, startAt: Double? = nil) {
+        self.beginYouTubePlaybackIntent()
         self.autoplayRecoveryRequestGeneration &+= 1
         self.shouldRecoverAutoplayTransitionOnResume = false
         let normalizedStartAt = Self.normalizedExplicitStartAt(startAt)
@@ -370,6 +376,7 @@ final class YouTubePlayerService {
     }
 
     func reloadCurrentVideoForIdentitySwitch() {
+        self.beginYouTubePlaybackIntent()
         guard let currentVideo = self.currentVideo else {
             self.logger.debug("Identity switch: no current video to re-point")
             return
@@ -543,20 +550,31 @@ final class YouTubePlayerService {
 
     /// Toggles play/pause.
     func playPause() {
+        self.beginYouTubePlaybackIntent()
+        self.performPlayPause()
+    }
+
+    func performPlayPause(resumeIssuedAtMilliseconds: Double? = nil) {
         if self.isPlaying
             || self.isAwaitingResumeConfirmation
             || (self.desiredPlaybackIntent == .playing
                 && !(self.hasObservedPausedMedia && !self.isPlaying))
         {
-            self.pause()
+            self.performPause()
         } else {
-            self.resume()
+            self.performResume(issuedAtMilliseconds: resumeIssuedAtMilliseconds)
         }
     }
 
     /// Resumes playback.
     func resume() {
-        self.lastResumeIssuedAtMilliseconds = Date().timeIntervalSince1970 * 1000
+        self.beginYouTubePlaybackIntent()
+        self.performResume()
+    }
+
+    func performResume(issuedAtMilliseconds: Double? = nil) {
+        self.lastResumeIssuedAtMilliseconds = issuedAtMilliseconds
+            ?? Date().timeIntervalSince1970 * 1000
         self.desiredPlaybackIntent = .playing
         self.isExplicitPauseIntentActive = false
         self.isAwaitingResumeConfirmation = true
@@ -616,6 +634,11 @@ final class YouTubePlayerService {
 
     /// Pauses playback.
     func pause() {
+        self.beginYouTubePlaybackIntent()
+        self.performPause()
+    }
+
+    func performPause() {
         self.autoplayRecoveryRequestGeneration &+= 1
         self.activateExplicitPauseIntent()
         let didCancelPendingLoad = self.playbackController.cancelPendingLoad()
@@ -649,6 +672,7 @@ final class YouTubePlayerService {
 
     /// Stops playback entirely and releases the surface.
     func stop() {
+        self.beginYouTubePlaybackIntent()
         self.autoplayRecoveryRequestGeneration &+= 1
         self.shouldRecoverAutoplayTransitionOnResume = false
         self.logger.info("YouTubePlayer: stop")
@@ -736,20 +760,35 @@ final class YouTubePlayerService {
     /// Skips to the next video (first up-next candidate; fetched lazily
     /// when none are known, e.g. when playing in the floating window).
     func skipForward() async {
+        let playbackIntentGeneration = self.beginYouTubePlaybackIntent()
+        await self.skipForward(ownedBy: playbackIntentGeneration)
+    }
+
+    func skipForward(ownedBy playbackIntentGeneration: UInt64) async {
         guard let current = self.currentVideo else { return }
 
         var target = self.upNext.first
         if target == nil, let client = self.youtubeClient {
             target = await (try? client.getWatchNext(videoId: current.videoId))?
                 .related.first { !$0.isShort }
+            guard self.youtubePlaybackIntentGeneration == playbackIntentGeneration,
+                  self.currentVideo?.videoId == current.videoId
+            else { return }
         }
         guard let next = target else { return }
+        // `advance` deliberately preserves the already-admitted intent generation and
+        // timestamp; it must not restamp an async remote-next completion.
         self.advance(to: next)
     }
 
     /// Skips back to the previously played video, or restarts the current
     /// one when there is no history.
     func skipBackward() {
+        self.beginYouTubePlaybackIntent()
+        self.skipBackwardWithoutBeginningIntent()
+    }
+
+    func skipBackwardWithoutBeginningIntent() {
         if let previous = self.history.popLast() {
             self.advance(to: previous, recordingHistory: false)
         } else {
@@ -1307,6 +1346,9 @@ extension YouTubePlayerService {
               || (update.hasReadyMedia && update.boundVideoId == videoId)
         else { return }
 
+        self.beginYouTubePlaybackIntent(
+            issuedAtMilliseconds: update.eventIssuedAtMilliseconds
+        )
         self.logger.info("YouTubePlayer: page drifted to a different video, following")
         let shouldRepointDriftedVideo = self.pendingPausedIdentityReloadVideoId != nil
         let driftedContentProgress: Double? = if !update.isAd,
@@ -1434,15 +1476,21 @@ extension YouTubePlayerService {
             self.logger.debug("YouTubePlayer: ignoring ended event (stale id or ad)")
             return false
         }
-        if !isNativeTerminal,
-           let eventIssuedAtMilliseconds,
-           let lastResumeIssuedAtMilliseconds = self.lastResumeIssuedAtMilliseconds,
-           Self.isEndEventStale(
-               eventIssuedAtMilliseconds: eventIssuedAtMilliseconds,
-               lastResumeIssuedAtMilliseconds: lastResumeIssuedAtMilliseconds
-           )
-        {
-            return false
+        if !isNativeTerminal, let eventIssuedAtMilliseconds {
+            if Self.isEndEventStale(
+                eventIssuedAtMilliseconds: eventIssuedAtMilliseconds,
+                lastResumeIssuedAtMilliseconds: self.youtubePlaybackIntentIssuedAtMilliseconds
+            ) {
+                return false
+            }
+            if let lastResumeIssuedAtMilliseconds = self.lastResumeIssuedAtMilliseconds,
+               Self.isEndEventStale(
+                   eventIssuedAtMilliseconds: eventIssuedAtMilliseconds,
+                   lastResumeIssuedAtMilliseconds: lastResumeIssuedAtMilliseconds
+               )
+            {
+                return false
+            }
         }
         guard self.claimEndedPlaybackOccurrence(
             playbackOccurrence,
@@ -1450,6 +1498,11 @@ extension YouTubePlayerService {
         ) else {
             self.logger.debug("YouTubePlayer: ignoring ended event for stale playback occurrence")
             return false
+        }
+        if !isNativeTerminal, let eventIssuedAtMilliseconds {
+            self.beginYouTubePlaybackIntent(
+                issuedAtMilliseconds: eventIssuedAtMilliseconds
+            )
         }
         self.isPlaying = false
         self.desiredPlaybackIntent = .paused
@@ -1473,6 +1526,8 @@ extension YouTubePlayerService {
         eventIssuedAtMilliseconds: Double,
         lastResumeIssuedAtMilliseconds: Double
     ) -> Bool {
+        // Bridge timestamps are whole milliseconds while native intent timestamps can be
+        // fractional. Equality is ambiguous, so occurrence/generation ownership handles it.
         floor(eventIssuedAtMilliseconds) < floor(lastResumeIssuedAtMilliseconds)
     }
 

--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -5,7 +5,7 @@ import Observation
 
 // MARK: - YouTubePlaybackOccurrence
 
-struct YouTubePlaybackOccurrence: Hashable, Sendable {
+struct YouTubePlaybackOccurrence: Hashable {
     let documentGeneration: UInt64
     let mediaGeneration: UInt64
 }

--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -2,6 +2,13 @@
 import Foundation
 import Observation
 
+// MARK: - YouTubePlaybackOccurrence
+
+struct YouTubePlaybackOccurrence: Hashable, Sendable {
+    let documentGeneration: UInt64
+    let mediaGeneration: UInt64
+}
+
 // MARK: - YouTubeWatchPlaybackControlling
 
 /// Playback command surface backing `YouTubePlayerService`.
@@ -11,11 +18,15 @@ protocol YouTubeWatchPlaybackControlling: AnyObject {
     func prepare(webKitManager: WebKitManager, playerService: YouTubePlayerService, usesCookieFreeDataStore: Bool)
     func loadVideo(videoId: String)
     func reloadVideo(videoId: String, resumeAt seconds: Double?)
-    func cancelPendingLoad()
+    @discardableResult
+    func cancelPendingLoad() -> Bool
     func playPause()
     func play()
     func pause()
     func seek(to time: Double)
+    func seekWithRecovery(to seconds: Double)
+    func cancelPendingRecoverySeek()
+    func markCurrentPlaybackOccurrenceEnded()
     func setVolume(_ volume: Double)
     func showAirPlayPicker()
     func availableCaptionTracks() async -> [YouTubeCaptionTrack]
@@ -91,13 +102,56 @@ final class YouTubePlayerService {
     /// just scheduled). Reset whenever a new video becomes current.
     private var currentWatchConcluded = false
 
+    /// Document/media occurrence currently represented by bridge state. This is
+    /// finer-grained than `currentWatchConcluded`: same-document replay can start
+    /// a new occurrence for the same video before an older ended task executes.
+    @ObservationIgnored private(set) var currentPlaybackOccurrence: YouTubePlaybackOccurrence?
+    @ObservationIgnored private var lastEndedPlaybackOccurrence: YouTubePlaybackOccurrence?
+    @ObservationIgnored private var lastResumeIssuedAtMilliseconds: Double?
+    @ObservationIgnored private var isAutoplayTransitionPending = false
+    @ObservationIgnored private var shouldRecoverAutoplayTransitionOnResume = false
+    @ObservationIgnored private var autoplayRecoveryRequestGeneration: UInt64 = 0
+
     /// Whether the video is currently playing.
     private(set) var isPlaying = false
 
-    /// Whether the current watch page has reported at least one playback state.
-    /// Before this flips true, `isPlaying == false` means loading/unknown rather
-    /// than a deliberate paused state.
-    private var hasObservedPlaybackState = false
+    /// The page has reported ready media in a paused state. This distinguishes a
+    /// settled autoplay failure from the pre-media loading gap.
+    @ObservationIgnored private var hasObservedPausedMedia = false
+
+    private enum DesiredPlaybackIntent: Equatable {
+        case playing
+        case paused
+    }
+
+    /// The single authoritative play/pause intent. Observer pauses can be
+    /// transient while a requested document loads, so only explicit terminal
+    /// actions clear this; an accepted playing update restores it for autoplay.
+    @ObservationIgnored private var desiredPlaybackIntent: DesiredPlaybackIntent = .paused
+
+    /// Explicit native pause dominates late playing samples until the next native
+    /// resume/new-watch intent. Natural end is intentionally separate so genuine
+    /// same-document autoplay can still become authoritative.
+    @ObservationIgnored private var isExplicitPauseIntentActive = false
+    @ObservationIgnored private var isAwaitingResumeConfirmation = false
+
+    private struct ExplicitStartTarget {
+        let videoId: String
+        let seconds: Double
+    }
+
+    private struct PendingUserSeekTarget {
+        let videoId: String
+        let seconds: Double
+    }
+
+    /// An explicit `play(startAt:)` target remains available to native recovery
+    /// until real content reports an authoritative position.
+    @ObservationIgnored private var pendingExplicitStartTarget: ExplicitStartTarget?
+
+    /// A direct user seek stays authoritative until the bridge acknowledges the
+    /// exact target, including across identity or process reloads.
+    @ObservationIgnored private var pendingUserSeekTarget: PendingUserSeekTarget?
 
     /// A paused video does not need an immediate identity-switch reload, because
     /// there is no active playback to re-attribute. Defer the reload until the
@@ -107,6 +161,7 @@ final class YouTubePlayerService {
     var pendingPausedIdentityReloadResumeAt: Double?
     var userUpdatedPendingPausedIdentityReloadSeek = false
     private var isIdentityReloadInFlight = false
+    private var pausedIdentityReloadAwaitingFirstUpdate = false
 
     /// Current position in seconds.
     var progress: Double = 0
@@ -116,6 +171,7 @@ final class YouTubePlayerService {
     /// preroll/midroll ad doesn't resume the content near 0 (the ad element's
     /// time).
     var lastNonAdContentProgress: Double = 0
+    private var lastNonAdContentVideoId: String?
 
     /// Video length in seconds.
     private(set) var duration: Double = 0
@@ -252,6 +308,9 @@ final class YouTubePlayerService {
 
     /// Starts playback of a video, docked inline.
     func play(video: YouTubeVideo, usesCookieFreeDataStore: Bool = false, startAt: Double? = nil) {
+        self.autoplayRecoveryRequestGeneration &+= 1
+        self.shouldRecoverAutoplayTransitionOnResume = false
+        let normalizedStartAt = Self.normalizedExplicitStartAt(startAt)
         self.logger.info("YouTubePlayer: play video")
         self.usesCookieFreePlaybackDataStore = usesCookieFreeDataStore
         self.playbackWillStart?()
@@ -261,11 +320,20 @@ final class YouTubePlayerService {
         }
         self.upNext = []
         self.currentVideo = video
+        self.resetPlaybackOccurrenceState()
+        self.desiredPlaybackIntent = .playing
+        self.isExplicitPauseIntentActive = false
+        self.isAwaitingResumeConfirmation = false
         self.watchActivityGeneration += 1 // a new watch began
         self.currentWatchConcluded = false
-        self.hasObservedPlaybackState = false
         self.isIdentityReloadInFlight = false
         self.resetPerVideoState()
+        if let normalizedStartAt {
+            self.pendingExplicitStartTarget = ExplicitStartTarget(
+                videoId: video.videoId,
+                seconds: normalizedStartAt
+            )
+        }
         self.isPlaybackLoading = true
         self.surfaceLocation = .inline
 
@@ -275,11 +343,16 @@ final class YouTubePlayerService {
             playerService: self,
             usesCookieFreeDataStore: self.usesCookieFreePlaybackDataStore
         )
-        if let startAt, startAt >= 0 {
-            self.playbackController.reloadVideo(videoId: video.videoId, resumeAt: startAt)
+        if let normalizedStartAt {
+            self.playbackController.reloadVideo(videoId: video.videoId, resumeAt: normalizedStartAt)
         } else {
             self.playbackController.loadVideo(videoId: video.videoId)
         }
+    }
+
+    nonisolated static func normalizedExplicitStartAt(_ seconds: Double?) -> Double? {
+        guard let seconds, seconds.isFinite, seconds >= 0 else { return nil }
+        return seconds
     }
 
     /// Re-points the current video under the WebView session's current
@@ -303,20 +376,16 @@ final class YouTubePlayerService {
         // Resume at the last real CONTENT position. During an ad, self.progress
         // tracks the ad element's time, so prefer the remembered content progress
         // to avoid resuming the content near 0 after a switch mid-ad.
-        let resumeProgress = if self.currentWatchConcluded {
-            0.0
-        } else {
-            self.isShowingAd ? self.lastNonAdContentProgress : self.progress
-        }
-        let wasPlaying = self.isPlaying
-        self.logger.info("Identity switch: re-pointing current video under new session identity (resume at \(Int(resumeProgress))s, wasPlaying=\(wasPlaying))")
+        let resumeAt = self.interruptionResumeAt(for: currentVideo.videoId)
+        let intendsToPlay = self.desiredPlaybackIntent == .playing
+        self.logger.info("Identity switch: re-pointing current video under new session identity (resume at \(resumeAt ?? 0)s, intendsToPlay=\(intendsToPlay))")
 
-        if !wasPlaying, self.hasObservedPlaybackState {
+        if !intendsToPlay {
             // Do not load an autoplaying watch page while the user is paused. The
             // current paused document is inert; reload under the new identity only
             // when the user explicitly resumes.
             self.pendingPausedIdentityReloadVideoId = currentVideo.videoId
-            self.pendingPausedIdentityReloadResumeAt = self.currentWatchConcluded ? nil : (resumeProgress > 0 ? resumeProgress : nil)
+            self.pendingPausedIdentityReloadResumeAt = resumeAt
             self.userUpdatedPendingPausedIdentityReloadSeek = false
             return
         }
@@ -331,28 +400,186 @@ final class YouTubePlayerService {
         // no-op against the old/torn-down page.
         self.playbackController.reloadVideo(
             videoId: currentVideo.videoId,
-            resumeAt: resumeProgress > 0 ? resumeProgress : nil
+            resumeAt: resumeAt
         )
         self.isIdentityReloadInFlight = true
         self.isPlaybackLoading = true
     }
 
+    /// Returns the best native resume target for an interrupted document.
+    /// Native seek intent wins until the observer proves it was applied;
+    /// otherwise use the last genuine content clock.
+    private func interruptionResumeAt(for videoId: String) -> Double? {
+        if let pendingUserSeekTarget = self.pendingUserSeekTarget,
+           pendingUserSeekTarget.videoId == videoId
+        {
+            return pendingUserSeekTarget.seconds
+        }
+        guard !self.currentWatchConcluded else { return nil }
+        if let explicitStartTarget = self.explicitStartTarget(for: videoId) {
+            return explicitStartTarget
+        }
+        guard self.lastNonAdContentVideoId == videoId,
+              self.lastNonAdContentProgress > 0
+        else { return nil }
+        return self.lastNonAdContentProgress
+    }
+
+    private func explicitStartTarget(for videoId: String) -> Double? {
+        guard self.pendingExplicitStartTarget?.videoId == videoId else { return nil }
+        return self.pendingExplicitStartTarget?.seconds
+    }
+
+    func invalidateExplicitStartTargetForUserSeek() {
+        self.pendingExplicitStartTarget = nil
+    }
+
+    func recordPendingUserSeek(to seconds: Double) {
+        guard let videoId = self.currentVideo?.videoId else { return }
+        if self.currentWatchConcluded
+            || self.isAutoplayTransitionPending
+            || self.shouldRecoverAutoplayTransitionOnResume
+        {
+            self.autoplayRecoveryRequestGeneration &+= 1
+            self.isAutoplayTransitionPending = false
+            self.shouldRecoverAutoplayTransitionOnResume = false
+        }
+        self.pendingUserSeekTarget = PendingUserSeekTarget(
+            videoId: videoId,
+            seconds: seconds
+        )
+    }
+
+    func clearPendingUserSeek() {
+        self.pendingUserSeekTarget = nil
+    }
+
+    func handlePendingSeekExhausted(videoId: String, target: Double) {
+        if let explicitStartTarget = self.pendingExplicitStartTarget,
+           explicitStartTarget.videoId == videoId,
+           abs(explicitStartTarget.seconds - target) < 0.001
+        {
+            self.pendingExplicitStartTarget = nil
+        }
+        if let pendingUserSeekTarget = self.pendingUserSeekTarget,
+           pendingUserSeekTarget.videoId == videoId,
+           abs(pendingUserSeekTarget.seconds - target) < 0.001
+        {
+            self.pendingUserSeekTarget = nil
+        }
+        if self.pendingPausedIdentityReloadVideoId == videoId,
+           let pendingResumeAt = self.pendingPausedIdentityReloadResumeAt,
+           abs(pendingResumeAt - target) < 0.001
+        {
+            self.pendingPausedIdentityReloadResumeAt = self.interruptionResumeAt(for: videoId)
+            self.userUpdatedPendingPausedIdentityReloadSeek = false
+        }
+    }
+
+    /// Rebuilds a terminated watch-page process while preserving content
+    /// position and the user's playing-versus-paused intent.
+    func recoverAfterWebContentProcessTermination(resumeAtOverride: Double? = nil) {
+        guard let currentVideo = self.currentVideo else { return }
+
+        let hasPendingUserSeek = self.pendingUserSeekTarget?.videoId == currentVideo.videoId
+        if self.isAutoplayTransitionPending, !hasPendingUserSeek {
+            self.isAutoplayTransitionPending = false
+            self.shouldRecoverAutoplayTransitionOnResume = true
+            self.desiredPlaybackIntent = .paused
+            self.isAwaitingResumeConfirmation = false
+            self.autoplayRecoveryRequestGeneration &+= 1
+            self.isPlaying = false
+            self.isIdentityReloadInFlight = false
+            self.isPlaybackLoading = false
+            self.hasObservedPausedMedia = true
+            return
+        }
+
+        let resumeAt = resumeAtOverride ?? self.interruptionResumeAt(for: currentVideo.videoId)
+
+        if self.desiredPlaybackIntent == .paused {
+            self.pendingPausedIdentityReloadVideoId = currentVideo.videoId
+            self.pendingPausedIdentityReloadResumeAt = resumeAt
+            self.userUpdatedPendingPausedIdentityReloadSeek = false
+            self.isIdentityReloadInFlight = false
+            self.isPlaying = false
+            self.isPlaybackLoading = false
+            return
+        }
+
+        self.playbackController.reloadVideo(videoId: currentVideo.videoId, resumeAt: resumeAt)
+        self.isPlaying = false
+        self.isIdentityReloadInFlight = true
+        self.isPlaybackLoading = true
+    }
+
+    /// Leaves a failed watch-page navigation in an explicitly retryable paused
+    /// state instead of trusting the outgoing document as the requested video.
+    func handleWebNavigationFailure(resumeAtOverride: Double? = nil) {
+        self.deferCurrentVideoReload(resumeAtOverride: resumeAtOverride)
+    }
+
+    /// Preserves the newly selected native video when its provisional WebView
+    /// load is intentionally cancelled (for example, switching sources mid-load).
+    /// The outgoing page belongs to the previous video and must not be restored
+    /// as authoritative; resume reloads the selected video instead.
+    func handleWebNavigationCancellation(resumeAtOverride: Double? = nil) {
+        self.deferCurrentVideoReload(resumeAtOverride: resumeAtOverride)
+    }
+
+    private func deferCurrentVideoReload(resumeAtOverride: Double? = nil) {
+        guard let currentVideo = self.currentVideo else { return }
+        self.pendingPausedIdentityReloadVideoId = currentVideo.videoId
+        self.pendingPausedIdentityReloadResumeAt = resumeAtOverride
+            ?? self.interruptionResumeAt(for: currentVideo.videoId)
+        self.userUpdatedPendingPausedIdentityReloadSeek = false
+        self.isIdentityReloadInFlight = false
+        self.desiredPlaybackIntent = .paused
+        self.isAwaitingResumeConfirmation = false
+        self.isPlaying = false
+        self.isPlaybackLoading = false
+    }
+
     /// Toggles play/pause.
     func playPause() {
-        if !self.isPlaying {
-            if self.reloadPendingPausedIdentitySwitchForUserResume() {
-                return
-            }
-            self.playbackWillStart?()
+        if self.isPlaying
+            || self.isAwaitingResumeConfirmation
+            || (self.desiredPlaybackIntent == .playing
+                && !(self.hasObservedPausedMedia && !self.isPlaying))
+        {
+            self.pause()
         } else {
-            self.deferInFlightIdentityReloadIfNeeded()
-            self.playbackController.cancelPendingLoad()
+            self.resume()
         }
-        self.playbackController.playPause()
     }
 
     /// Resumes playback.
     func resume() {
+        self.lastResumeIssuedAtMilliseconds = Date().timeIntervalSince1970 * 1000
+        self.desiredPlaybackIntent = .playing
+        self.isExplicitPauseIntentActive = false
+        self.isAwaitingResumeConfirmation = true
+        self.hasObservedPausedMedia = false
+        if self.shouldRecoverAutoplayTransitionOnResume {
+            if let nextVideo = self.upNext.first {
+                self.advance(to: nextVideo)
+            } else {
+                // Keep the deferred marker armed while lookup is in flight. A
+                // pause may cancel this request generation, but the next resume
+                // must retry rather than play the invalidated concluded page.
+                self.autoplayRecoveryRequestGeneration &+= 1
+                let recoveryGeneration = self.autoplayRecoveryRequestGeneration
+                let expectedVideoId = self.currentVideo?.videoId
+                Task { @MainActor in
+                    await self.recoverAutoplayTransition(
+                        expectedVideoId: expectedVideoId,
+                        generation: recoveryGeneration
+                    )
+                }
+            }
+            return
+        }
+        self.autoplayRecoveryRequestGeneration &+= 1
         if self.reloadPendingPausedIdentitySwitchForUserResume() {
             return
         }
@@ -379,6 +606,8 @@ final class YouTubePlayerService {
             usesCookieFreeDataStore: self.usesCookieFreePlaybackDataStore
         )
         self.playbackController.reloadVideo(videoId: currentVideo.videoId, resumeAt: resumeAt)
+        self.desiredPlaybackIntent = .playing
+        self.isExplicitPauseIntentActive = false
         self.isIdentityReloadInFlight = true
         self.isPlaybackLoading = true
         return true
@@ -386,17 +615,31 @@ final class YouTubePlayerService {
 
     /// Pauses playback.
     func pause() {
-        self.deferInFlightIdentityReloadIfNeeded()
-        self.playbackController.cancelPendingLoad()
+        self.autoplayRecoveryRequestGeneration &+= 1
+        self.activateExplicitPauseIntent()
+        let didCancelPendingLoad = self.playbackController.cancelPendingLoad()
+        if didCancelPendingLoad {
+            // Cancellation synchronously re-enters the service's retry path.
+            // Reassert the terminal user intent before issuing the raw pause.
+            self.activateExplicitPauseIntent()
+        }
         self.playbackController.pause()
+    }
+
+    func activateExplicitPauseIntent() {
+        self.desiredPlaybackIntent = .paused
+        self.isExplicitPauseIntentActive = true
+        self.isAwaitingResumeConfirmation = false
+        self.hasObservedPausedMedia = true
+        self.deferInFlightIdentityReloadIfNeeded()
     }
 
     private func deferInFlightIdentityReloadIfNeeded() {
         if self.isIdentityReloadInFlight, let currentVideo = self.currentVideo {
             self.pendingPausedIdentityReloadVideoId = currentVideo.videoId
-            let resumeProgress = self.isShowingAd ? self.lastNonAdContentProgress : self.progress
-            self.pendingPausedIdentityReloadResumeAt = self.currentWatchConcluded ? nil : (resumeProgress > 0 ? resumeProgress : nil)
+            self.pendingPausedIdentityReloadResumeAt = self.interruptionResumeAt(for: currentVideo.videoId)
             self.userUpdatedPendingPausedIdentityReloadSeek = false
+            self.pausedIdentityReloadAwaitingFirstUpdate = true
             self.isIdentityReloadInFlight = false
         }
         self.isPlaying = false
@@ -405,6 +648,8 @@ final class YouTubePlayerService {
 
     /// Stops playback entirely and releases the surface.
     func stop() {
+        self.autoplayRecoveryRequestGeneration &+= 1
+        self.shouldRecoverAutoplayTransitionOnResume = false
         self.logger.info("YouTubePlayer: stop")
         // Closing/stopping a video that accrued progress changes its resume
         // state in history, so signal the conclusion before clearing — this
@@ -419,9 +664,15 @@ final class YouTubePlayerService {
             }
         }
         self.currentVideo = nil
+        self.resetPlaybackOccurrenceState()
+        self.desiredPlaybackIntent = .paused
+        // Teardown invalidates the document generation, but retain the native
+        // pause fence until the next play/resume in case a callback was already
+        // admitted to main-actor work before teardown began.
+        self.isExplicitPauseIntentActive = true
+        self.isAwaitingResumeConfirmation = false
         self.isPlaying = false
         self.isPlaybackLoading = false
-        self.hasObservedPlaybackState = false
         self.isIdentityReloadInFlight = false
         self.progress = 0
         self.duration = 0
@@ -511,6 +762,8 @@ final class YouTubePlayerService {
     }
 
     private func advance(to video: YouTubeVideo, recordingHistory: Bool = true) {
+        self.autoplayRecoveryRequestGeneration &+= 1
+        self.shouldRecoverAutoplayTransitionOnResume = false
         self.logger.info("YouTubePlayer: advancing to another video")
         if recordingHistory, let current = self.currentVideo {
             self.rememberInHistory(current)
@@ -519,11 +772,13 @@ final class YouTubePlayerService {
 
         self.playbackWillStart?()
         self.currentVideo = video
+        self.resetPlaybackOccurrenceState()
+        self.desiredPlaybackIntent = .playing
+        self.isExplicitPauseIntentActive = false
         // A skip concludes the prior watch (deduped) and begins a new one.
         self.signalWatchConclusion()
         self.watchActivityGeneration += 1
         self.currentWatchConcluded = false
-        self.hasObservedPlaybackState = false
         self.isIdentityReloadInFlight = false
         self.resetPerVideoState()
         self.isPlaybackLoading = true
@@ -539,6 +794,37 @@ final class YouTubePlayerService {
         if self.surfaceLocation == .inline {
             self.skipNavigationRequest = video
         }
+    }
+
+    private func recoverAutoplayTransition(
+        expectedVideoId: String?,
+        generation: UInt64
+    ) async {
+        guard let expectedVideoId,
+              let client = self.youtubeClient
+        else {
+            self.finishFailedAutoplayRecovery(generation: generation)
+            return
+        }
+        let nextVideo = await (try? client.getWatchNext(videoId: expectedVideoId))?
+            .related.first { !$0.isShort }
+        guard generation == self.autoplayRecoveryRequestGeneration,
+              self.currentVideo?.videoId == expectedVideoId,
+              self.desiredPlaybackIntent == .playing
+        else { return }
+        guard let nextVideo else {
+            self.finishFailedAutoplayRecovery(generation: generation)
+            return
+        }
+        self.advance(to: nextVideo)
+    }
+
+    private func finishFailedAutoplayRecovery(generation: UInt64) {
+        guard generation == self.autoplayRecoveryRequestGeneration else { return }
+        self.shouldRecoverAutoplayTransitionOnResume = true
+        self.desiredPlaybackIntent = .paused
+        self.isAwaitingResumeConfirmation = false
+        self.hasObservedPausedMedia = true
     }
 
     private func rememberInHistory(_ video: YouTubeVideo) {
@@ -568,7 +854,15 @@ final class YouTubePlayerService {
         self.pendingPausedIdentityReloadVideoId = nil
         self.pendingPausedIdentityReloadResumeAt = nil
         self.userUpdatedPendingPausedIdentityReloadSeek = false
+        self.pausedIdentityReloadAwaitingFirstUpdate = false
+        self.pendingExplicitStartTarget = nil
+        self.pendingUserSeekTarget = nil
+        self.isAutoplayTransitionPending = false
+        self.shouldRecoverAutoplayTransitionOnResume = false
         self.lastNonAdContentProgress = 0
+        self.lastNonAdContentVideoId = nil
+        self.hasObservedPausedMedia = false
+        self.isAwaitingResumeConfirmation = false
         self.clearRelativeSeekCoalescingTarget()
     }
 
@@ -717,7 +1011,7 @@ final class YouTubePlayerService {
     /// pause in place, keep everything loaded for restore.
     func prepareForSourceSwitch() {
         guard self.surfaceLocation == .inline, self.currentVideo != nil else { return }
-        if self.isPlaying {
+        if self.desiredPlaybackIntent == .playing {
             self.pause()
         }
         self.pauseInPlaceOnDisappear = true
@@ -750,7 +1044,9 @@ final class YouTubePlayerService {
             self.stop()
         }
     }
+}
 
+extension YouTubePlayerService {
     // MARK: - Bridge Callbacks
 
     /// A `STATE_UPDATE` payload from the watch page observer script.
@@ -758,53 +1054,169 @@ final class YouTubePlayerService {
         let isPlaying: Bool
         let progress: Double
         let duration: Double
+        var hasReadyMedia = false
         var videoId: String?
+        var boundVideoId: String?
         var title: String?
         var isAd = false
+        var didApplyPendingSeek = false
+        var didFailPendingSeek = false
+        var pendingSeekTarget: Double?
+        var pendingSeekVideoId: String?
+        var pendingSeekAttempt: UInt64?
+        var nativePausePending = false
+        var eventIssuedAtMilliseconds: Double?
+        var playbackOccurrence: YouTubePlaybackOccurrence?
     }
 
     /// Applies a `STATE_UPDATE` from the watch page observer script.
     func updatePlaybackState(_ update: PlaybackUpdate) {
-        self.hasObservedPlaybackState = true
-        if let pendingId = self.pendingPausedIdentityReloadVideoId,
-           pendingId == (update.videoId ?? self.currentVideo?.videoId),
-           update.isPlaying
-        {
-            if self.pendingPausedIdentityReloadResumeAt == nil,
-               let resumeProgress = self.deferredIdentityReloadResumeProgress(for: update)
-            {
-                self.pendingPausedIdentityReloadResumeAt = resumeProgress
+        self.recordPostConclusionAutoplayTransitionIfNeeded(update)
+        guard self.acceptsPlaybackOccurrence(update.playbackOccurrence) else { return }
+        let reconciledPlayingState = self.reconciledPlayingState(for: update)
+        guard self.currentVideo != nil else {
+            if reconciledPlayingState.wasSuppressed {
+                self.playbackController.pause()
             }
-            _ = self.reloadPendingPausedIdentitySwitchForUserResume()
             return
         }
-        if let pendingId = self.pendingPausedIdentityReloadVideoId,
-           pendingId == (update.videoId ?? self.currentVideo?.videoId),
-           !update.isPlaying
-        {
-            if !self.userUpdatedPendingPausedIdentityReloadSeek {
-                self.pendingPausedIdentityReloadResumeAt = self.deferredIdentityReloadResumeProgress(for: update)
-            }
-        }
+        self.bindPlaybackOccurrence(update.playbackOccurrence)
+        let effectiveIsPlaying = reconciledPlayingState.isPlaying
+        let shouldPreserveTerminalIntent = self.currentWatchConcluded
+            && self.desiredPlaybackIntent == .paused
+            && !update.hasReadyMedia
+        self.reconcileObservedPauseIntent(update)
+        self.reconcileDesiredPlaybackIntent(
+            for: update,
+            effectiveIsPlaying: effectiveIsPlaying,
+            shouldPreserveTerminalIntent: shouldPreserveTerminalIntent
+        )
 
+        let completedIdentityReload = self.isIdentityReloadInFlight
+            || self.pausedIdentityReloadAwaitingFirstUpdate
+        guard !self.reconcilePendingPausedIdentityReload(
+            for: update,
+            effectiveIsPlaying: effectiveIsPlaying,
+            completedIdentityReload: completedIdentityReload
+        ) else { return }
+        self.completeIdentityReloadIfNeeded(completedIdentityReload)
+
+        // A bridge update from the newly accepted document proves a successful
+        // reload. Later pause/resume must control that document directly rather
+        // than scheduling another identity reload.
+        self.isIdentityReloadInFlight = false
+        self.acknowledgeExplicitStartTarget(with: update)
+        self.acknowledgePendingUserSeek(with: update)
+        self.applyPlaybackSnapshot(update, effectiveIsPlaying: effectiveIsPlaying)
+        self.reopenConcludedWatchIfNeeded(update, effectiveIsPlaying: effectiveIsPlaying)
+        self.refreshPlaybackMetadataIfNeeded(update, effectiveIsPlaying: effectiveIsPlaying)
+        self.followPageDriftIfNeeded(update)
+        self.completeAutoplayTransitionIfNeeded(update)
+        self.recordReadyContentProgressIfPossible(update)
+
+        if reconciledPlayingState.wasSuppressed {
+            self.playbackController.pause()
+        }
+    }
+
+    /// A concluded media occurrence can keep emitting loading/ad snapshots while
+    /// YouTube prepares autoplay. Record only the recovery marker before stale
+    /// occurrence filtering; the rejected snapshot must not mutate normal state.
+    func recordPostConclusionAutoplayTransitionIfNeeded(_ update: PlaybackUpdate) {
+        guard self.currentVideo != nil,
+              self.currentWatchConcluded,
+              self.desiredPlaybackIntent == .paused,
+              self.pendingUserSeekTarget == nil,
+              update.isAd || !update.hasReadyMedia
+        else { return }
+        self.isAutoplayTransitionPending = true
+    }
+
+    private func reconcileDesiredPlaybackIntent(
+        for update: PlaybackUpdate,
+        effectiveIsPlaying: Bool,
+        shouldPreserveTerminalIntent: Bool
+    ) {
+        if effectiveIsPlaying {
+            // Accepted playback (including YouTube autoplay/SPA drift) becomes
+            // the authoritative requested-play intent for future recovery.
+            let isCurrentResumeSample = if self.isAwaitingResumeConfirmation,
+                                           let lastResumeIssuedAtMilliseconds,
+                                           let eventIssuedAtMilliseconds = update.eventIssuedAtMilliseconds
+            {
+                eventIssuedAtMilliseconds >= lastResumeIssuedAtMilliseconds
+            } else {
+                true
+            }
+            if !shouldPreserveTerminalIntent,
+               !update.nativePausePending,
+               isCurrentResumeSample
+            {
+                self.desiredPlaybackIntent = .playing
+                self.isAwaitingResumeConfirmation = false
+            }
+            self.hasObservedPausedMedia = false
+        } else if update.hasReadyMedia {
+            self.hasObservedPausedMedia = true
+        }
+    }
+
+    @discardableResult
+    private func reconcilePendingPausedIdentityReload(
+        for update: PlaybackUpdate,
+        effectiveIsPlaying: Bool,
+        completedIdentityReload: Bool
+    ) -> Bool {
+        guard let pendingId = self.pendingPausedIdentityReloadVideoId,
+              pendingId == (update.videoId ?? self.currentVideo?.videoId)
+        else { return false }
+
+        if effectiveIsPlaying, !completedIdentityReload {
+            if self.pendingPausedIdentityReloadResumeAt == nil {
+                self.pendingPausedIdentityReloadResumeAt =
+                    self.explicitStartTarget(for: pendingId)
+                        ?? self.deferredIdentityReloadResumeProgress(for: update)
+            }
+            _ = self.reloadPendingPausedIdentitySwitchForUserResume()
+            return true
+        }
+        if !effectiveIsPlaying, !self.userUpdatedPendingPausedIdentityReloadSeek {
+            self.pendingPausedIdentityReloadResumeAt =
+                self.explicitStartTarget(for: pendingId)
+                    ?? self.deferredIdentityReloadResumeProgress(for: update)
+        }
+        return false
+    }
+
+    private func completeIdentityReloadIfNeeded(_ completedIdentityReload: Bool) {
+        guard completedIdentityReload else { return }
+        self.pendingPausedIdentityReloadVideoId = nil
+        self.pendingPausedIdentityReloadResumeAt = nil
+        self.userUpdatedPendingPausedIdentityReloadSeek = false
+        self.pausedIdentityReloadAwaitingFirstUpdate = false
+    }
+
+    private func applyPlaybackSnapshot(
+        _ update: PlaybackUpdate,
+        effectiveIsPlaying: Bool
+    ) {
         // YouTube can start the next video on its own (SPA navigation);
         // make sure music yields whenever video audio actually starts.
-        if update.isPlaying, !self.isPlaying {
+        if effectiveIsPlaying, !self.isPlaying {
             self.playbackWillStart?()
         }
 
-        self.isPlaying = update.isPlaying
+        self.isPlaying = effectiveIsPlaying
         self.progress = update.progress
         self.duration = update.duration
         self.isShowingAd = update.isAd
         self.isPlaybackLoading = false
+    }
 
-        // Remember the last real content position (ignoring ad playback) so an
-        // identity-switch reload during an ad resumes the content, not the ad.
-        if !update.isAd {
-            self.lastNonAdContentProgress = update.progress
-        }
-
+    private func reopenConcludedWatchIfNeeded(
+        _ update: PlaybackUpdate,
+        effectiveIsPlaying: Bool
+    ) {
         // A concluded video that is playing again (replayed via the player bar or
         // a seek back after it finished) begins a fresh watch — clear the
         // conclusion flag so its later stop/finish signals the new partial
@@ -812,17 +1224,33 @@ final class YouTubePlayerService {
         // still playing real content (drift to a different id is handled below
         // and starts its own unconcluded watch).
         if self.currentWatchConcluded,
-           update.isPlaying,
+           effectiveIsPlaying,
            !update.isAd,
            let videoId = update.videoId,
            videoId == self.currentVideo?.videoId
         {
             self.currentWatchConcluded = false
         }
+    }
 
+    private func completeAutoplayTransitionIfNeeded(_ update: PlaybackUpdate) {
+        guard self.isAutoplayTransitionPending,
+              !self.currentWatchConcluded,
+              !update.isAd,
+              update.hasReadyMedia,
+              let boundVideoId = update.boundVideoId,
+              boundVideoId == self.currentVideo?.videoId
+        else { return }
+        self.isAutoplayTransitionPending = false
+    }
+
+    private func refreshPlaybackMetadataIfNeeded(
+        _ update: PlaybackUpdate,
+        effectiveIsPlaying: Bool
+    ) {
         // Fetch captions/quality options once per video, after playback starts
         // (the player APIs aren't ready before that).
-        if update.isPlaying,
+        if effectiveIsPlaying,
            let videoId = self.currentVideo?.videoId,
            self.playbackOptionsVideoId != videoId
         {
@@ -838,7 +1266,7 @@ final class YouTubePlayerService {
         // fires when the user enables ambient mid-playback or when content
         // starts after an ad. `refreshStoryboardSpec` is self-guarding, so
         // calling it on each qualifying update is cheap.
-        if update.isPlaying,
+        if effectiveIsPlaying,
            !update.isAd,
            self.currentVideo != nil,
            SettingsManager.shared.ambientBackdropEnabled
@@ -847,45 +1275,133 @@ final class YouTubePlayerService {
                 await self.refreshStoryboardSpec()
             }
         }
+    }
 
+    private func followPageDriftIfNeeded(_ update: PlaybackUpdate) {
         // Track SPA drift: if the page moved to a different video, follow it
         // so the controls stay truthful.
-        if let videoId = update.videoId, let current = self.currentVideo,
-           videoId != current.videoId
+        guard !update.isAd,
+              let videoId = update.videoId,
+              let current = self.currentVideo,
+              videoId != current.videoId,
+              !self.isAutoplayTransitionPending
+              || (update.hasReadyMedia && update.boundVideoId == videoId)
+        else { return }
+
+        self.logger.info("YouTubePlayer: page drifted to a different video, following")
+        let shouldRepointDriftedVideo = self.pendingPausedIdentityReloadVideoId != nil
+        let driftedContentProgress: Double? = if !update.isAd,
+                                                 update.hasReadyMedia,
+                                                 update.boundVideoId == videoId
         {
-            self.logger.info("YouTubePlayer: page drifted to a different video, following")
-            let shouldRepointDriftedVideo = self.pendingPausedIdentityReloadVideoId != nil
-            self.resetPerVideoState()
-            self.currentVideo = YouTubeVideo(
-                videoId: videoId,
-                title: update.title ?? current.title,
-                channelName: current.channelName,
-                channelId: current.channelId
-            )
-            // The page autoplayed/navigated to a new video (e.g. in the floating
-            // window) — the prior video concluded and a new watch began. Signal
-            // the conclusion (unless it already finished, to avoid double-bumping
-            // a natural end that auto-advances), then mark the new video as a
-            // fresh, unconcluded watch.
-            self.signalWatchConclusion()
-            self.watchActivityGeneration += 1
-            self.currentWatchConcluded = false
-            YouTubeWatchWebView.shared.currentVideoId = videoId
-            if shouldRepointDriftedVideo {
-                self.reloadCurrentVideoForIdentitySwitch()
-            }
+            update.progress
+        } else {
+            nil
         }
+        self.resetPerVideoState()
+        self.currentVideo = YouTubeVideo(
+            videoId: videoId,
+            title: update.title ?? current.title,
+            channelName: current.channelName,
+            channelId: current.channelId
+        )
+        if let driftedContentProgress {
+            self.lastNonAdContentProgress = driftedContentProgress
+            self.lastNonAdContentVideoId = videoId
+        }
+        // The page autoplayed/navigated to a new video (e.g. in the floating
+        // window) — the prior video concluded and a new watch began. Signal
+        // the conclusion (unless it already finished, to avoid double-bumping
+        // a natural end that auto-advances), then mark the new video as a
+        // fresh, unconcluded watch.
+        self.signalWatchConclusion()
+        self.watchActivityGeneration += 1
+        self.currentWatchConcluded = false
+        YouTubeWatchWebView.shared.currentVideoId = videoId
+        if shouldRepointDriftedVideo {
+            self.reloadCurrentVideoForIdentitySwitch()
+        }
+    }
+
+    private func recordReadyContentProgressIfPossible(_ update: PlaybackUpdate) {
+        // Record only a ready physical-media clock owned by the now-current
+        // video. Page metadata can lead the actual element during SPA drift.
+        if !update.isAd,
+           update.hasReadyMedia,
+           let boundVideoId = update.boundVideoId,
+           boundVideoId == self.currentVideo?.videoId
+        {
+            self.lastNonAdContentProgress = update.progress
+            self.lastNonAdContentVideoId = boundVideoId
+        }
+    }
+
+    private func reconciledPlayingState(for update: PlaybackUpdate) -> (
+        isPlaying: Bool,
+        wasSuppressed: Bool
+    ) {
+        // Kaset's native controls own explicit pause/resume intent. Web playback
+        // samples may acknowledge the pause, but cannot revoke it; only a native
+        // resume/new-watch action clears `isExplicitPauseIntentActive`.
+        let isSuppressed = update.isPlaying
+            && self.isExplicitPauseIntentActive
+        return (update.isPlaying && !isSuppressed, isSuppressed)
+    }
+
+    private func reconcileObservedPauseIntent(_ update: PlaybackUpdate) {
+        guard !update.isPlaying,
+              !self.isExplicitPauseIntentActive,
+              !self.isAwaitingResumeConfirmation,
+              !self.isPlaybackLoading,
+              update.hasReadyMedia,
+              !update.isAd,
+              self.isPlaying
+        else { return }
+        self.desiredPlaybackIntent = .paused
     }
 
     private func deferredIdentityReloadResumeProgress(for update: PlaybackUpdate) -> Double? {
-        if update.isAd {
-            return self.lastNonAdContentProgress > 0 ? self.lastNonAdContentProgress : nil
+        let currentVideoId = self.currentVideo?.videoId
+        if !update.isAd,
+           update.hasReadyMedia,
+           update.boundVideoId == currentVideoId,
+           update.progress > 0
+        {
+            return update.progress
         }
-        return update.progress > 0 ? update.progress : nil
+        guard self.lastNonAdContentVideoId == currentVideoId,
+              self.lastNonAdContentProgress > 0
+        else { return nil }
+        return self.lastNonAdContentProgress
+    }
+
+    private func acknowledgeExplicitStartTarget(with update: PlaybackUpdate) {
+        guard !update.isAd,
+              let target = self.pendingExplicitStartTarget,
+              (update.pendingSeekVideoId ?? update.videoId) == target.videoId
+        else { return }
+        guard update.didApplyPendingSeek else { return }
+        self.pendingExplicitStartTarget = nil
+    }
+
+    private func acknowledgePendingUserSeek(with update: PlaybackUpdate) {
+        guard update.didApplyPendingSeek,
+              let pendingUserSeekTarget = self.pendingUserSeekTarget,
+              update.pendingSeekVideoId == pendingUserSeekTarget.videoId,
+              let appliedTarget = update.pendingSeekTarget,
+              abs(appliedTarget - pendingUserSeekTarget.seconds) < 0.001
+        else { return }
+        self.pendingUserSeekTarget = nil
     }
 
     /// Handles natural video completion.
-    func handleVideoEnded(videoId: String?) {
+    @discardableResult
+    func handleVideoEnded(
+        videoId: String?,
+        playbackOccurrence: YouTubePlaybackOccurrence? = nil,
+        eventIssuedAtMilliseconds: Double? = nil,
+        isNativeTerminal: Bool = false
+    ) -> Bool {
         self.logger.info("YouTubePlayer: video ended")
         // Ignore an ended event that is not for the CURRENT content watch:
         //   - a late `VIDEO_ENDED` for the previous video arriving after a skip
@@ -897,9 +1413,31 @@ final class YouTubePlayerService {
         let isStaleId = videoId != nil && videoId != self.currentVideo?.videoId
         guard !isStaleId, !self.isShowingAd else {
             self.logger.debug("YouTubePlayer: ignoring ended event (stale id or ad)")
-            return
+            return false
+        }
+        if !isNativeTerminal,
+           let eventIssuedAtMilliseconds,
+           let lastResumeIssuedAtMilliseconds = self.lastResumeIssuedAtMilliseconds,
+           Self.isEndEventStale(
+               eventIssuedAtMilliseconds: eventIssuedAtMilliseconds,
+               lastResumeIssuedAtMilliseconds: lastResumeIssuedAtMilliseconds
+           )
+        {
+            return false
+        }
+        guard self.claimEndedPlaybackOccurrence(
+            playbackOccurrence,
+            isNativeTerminal: isNativeTerminal
+        ) else {
+            self.logger.debug("YouTubePlayer: ignoring ended event for stale playback occurrence")
+            return false
         }
         self.isPlaying = false
+        self.desiredPlaybackIntent = .paused
+        self.isAwaitingResumeConfirmation = false
+        self.lastResumeIssuedAtMilliseconds = nil
+        self.pendingExplicitStartTarget = nil
+        self.pendingUserSeekTarget = nil
         self.isPlaybackLoading = false
         // A finish changes watch history (the video crosses into "finished"), so
         // signal it — this lets Home drop a just-finished video from Continue
@@ -907,8 +1445,16 @@ final class YouTubePlayerService {
         // user was already sitting on Home (no navigation fires).
         if self.signalWatchConclusion() {
             self.watchActivityGeneration += 1
+            self.onVideoEnded?(videoId)
         }
-        self.onVideoEnded?(videoId)
+        return true
+    }
+
+    nonisolated static func isEndEventStale(
+        eventIssuedAtMilliseconds: Double,
+        lastResumeIssuedAtMilliseconds: Double
+    ) -> Bool {
+        floor(eventIssuedAtMilliseconds) < floor(lastResumeIssuedAtMilliseconds)
     }
 
     /// Marks the CURRENT watch as concluded with resume state to reflect and
@@ -927,5 +1473,92 @@ final class YouTubePlayerService {
         self.watchConclusionGeneration += 1
         self.currentWatchConcluded = true
         return true
+    }
+
+    func acceptsPlaybackOccurrence(_ occurrence: YouTubePlaybackOccurrence?) -> Bool {
+        guard let occurrence else { return true }
+        if let lastEndedPlaybackOccurrence,
+           !Self.isPlaybackOccurrence(occurrence, newerThan: lastEndedPlaybackOccurrence)
+        {
+            return false
+        }
+        guard let currentPlaybackOccurrence else { return true }
+        return Self.isPlaybackOccurrence(
+            occurrence,
+            newerThanOrEqualTo: currentPlaybackOccurrence
+        )
+    }
+
+    private func bindPlaybackOccurrence(_ occurrence: YouTubePlaybackOccurrence?) {
+        guard let occurrence else { return }
+        self.currentPlaybackOccurrence = occurrence
+    }
+
+    private func claimEndedPlaybackOccurrence(
+        _ occurrence: YouTubePlaybackOccurrence?,
+        isNativeTerminal: Bool
+    ) -> Bool {
+        let isResumedNativeTerminal = isNativeTerminal
+            && self.currentWatchConcluded
+            && self.lastResumeIssuedAtMilliseconds != nil
+        guard let occurrence = occurrence ?? self.currentPlaybackOccurrence else {
+            // Legacy/test callers without a bridge occurrence remain protected by
+            // the watch-level conclusion latch.
+            if isResumedNativeTerminal {
+                self.currentWatchConcluded = false
+                return true
+            }
+            return !self.currentWatchConcluded
+        }
+        if let lastEndedPlaybackOccurrence,
+           !Self.isPlaybackOccurrence(occurrence, newerThan: lastEndedPlaybackOccurrence)
+        {
+            guard isResumedNativeTerminal,
+                  occurrence == self.currentPlaybackOccurrence
+            else { return false }
+            self.currentWatchConcluded = false
+            return true
+        }
+        let isNewerThanCurrent = self.currentPlaybackOccurrence.map {
+            Self.isPlaybackOccurrence(occurrence, newerThan: $0)
+        } ?? true
+        if let currentPlaybackOccurrence {
+            guard Self.isPlaybackOccurrence(
+                occurrence,
+                newerThanOrEqualTo: currentPlaybackOccurrence
+            ) else { return false }
+        }
+        if isResumedNativeTerminal || (isNewerThanCurrent && self.currentWatchConcluded) {
+            self.currentWatchConcluded = false
+        }
+        self.currentPlaybackOccurrence = occurrence
+        self.lastEndedPlaybackOccurrence = occurrence
+        return true
+    }
+
+    private func resetPlaybackOccurrenceState() {
+        self.currentPlaybackOccurrence = nil
+        self.lastEndedPlaybackOccurrence = nil
+        self.lastResumeIssuedAtMilliseconds = nil
+    }
+
+    private static func isPlaybackOccurrence(
+        _ occurrence: YouTubePlaybackOccurrence,
+        newerThanOrEqualTo other: YouTubePlaybackOccurrence
+    ) -> Bool {
+        if occurrence.documentGeneration != other.documentGeneration {
+            return occurrence.documentGeneration > other.documentGeneration
+        }
+        return occurrence.mediaGeneration >= other.mediaGeneration
+    }
+
+    private static func isPlaybackOccurrence(
+        _ occurrence: YouTubePlaybackOccurrence,
+        newerThan other: YouTubePlaybackOccurrence
+    ) -> Bool {
+        if occurrence.documentGeneration != other.documentGeneration {
+            return occurrence.documentGeneration > other.documentGeneration
+        }
+        return occurrence.mediaGeneration > other.mediaGeneration
     }
 }

--- a/Sources/Kaset/Services/Protocols.swift
+++ b/Sources/Kaset/Services/Protocols.swift
@@ -359,8 +359,11 @@ protocol PlayerServiceProtocol: AnyObject, Sendable {
     /// Playback queue.
     var queue: [Song] { get }
 
-    /// Index of current track in queue.
+    /// Queue cursor used for next/previous navigation.
     var currentIndex: Int { get }
+
+    /// Index of the queue entry that actually owns playback, or nil for detached playback.
+    var activePlaybackQueueIndex: Int? { get }
 
     /// Whether the mini player should be shown.
     var showMiniPlayer: Bool { get set }
@@ -441,8 +444,35 @@ protocol PlayerServiceProtocol: AnyObject, Sendable {
     /// Stops playback and clears state.
     func stop() async
 
+    /// Reserves native playback ownership without changing the current intent.
+    func reserveMusicPlaybackIntent() -> MusicPlaybackReservation
+
+    /// Claims a reservation only if no newer playback intent has superseded it.
+    func claimMusicPlaybackIntent(_ reservation: MusicPlaybackReservation) -> MusicPlaybackIntent?
+
+    /// Whether an unclaimed reservation still names the current playback context.
+    func acceptsMusicPlaybackReservation(_ reservation: MusicPlaybackReservation) -> Bool
+
+    /// Captures the queue context for queue-only deferred mutations.
+    func reserveQueueMutation() -> Int
+
+    /// Whether a queue-only mutation still targets the same queue context.
+    func acceptsQueueMutation(_ generation: Int) -> Bool
+
+    /// Whether the supplied native playback intent still owns mutations.
+    func acceptsMusicPlaybackIntent(_ intent: MusicPlaybackIntent) -> Bool
+
     /// Plays a queue of songs starting at the specified index.
     func playQueue(_ songs: [Song], startingAt index: Int) async
+
+    /// Conditionally plays a queue under a previously claimed native intent.
+    @discardableResult
+    func playQueue(
+        _ songs: [Song],
+        startingAt index: Int,
+        deferringSmartShuffleFill: Bool,
+        intent: MusicPlaybackIntent
+    ) async -> Int?
 
     /// Plays a song and fetches similar songs (radio queue) in the background.
     /// The queue will be populated with similar songs from YouTube Music's radio feature.
@@ -453,7 +483,11 @@ protocol PlayerServiceProtocol: AnyObject, Sendable {
     /// - Parameters:
     ///   - playlistId: The mix playlist ID (e.g., "RDEM...")
     ///   - startVideoId: Optional starting video ID
-    func playWithMix(playlistId: String, startVideoId: String?) async
+    func playWithMix(
+        playlistId: String,
+        startVideoId: String?,
+        intent: MusicPlaybackIntent?
+    ) async
 
     /// Clears the queue while preserving the current track when possible.
     func clearQueue()
@@ -491,4 +525,14 @@ protocol PlayerServiceProtocol: AnyObject, Sendable {
 
     /// Updates the like status from WebView observation.
     func updateLikeStatus(_ status: LikeStatus)
+}
+
+extension PlayerServiceProtocol {
+    func playWithMix(playlistId: String, startVideoId: String?) async {
+        await self.playWithMix(
+            playlistId: playlistId,
+            startVideoId: startVideoId,
+            intent: nil
+        )
+    }
 }

--- a/Sources/Kaset/Services/Scripting/ScriptCommands.swift
+++ b/Sources/Kaset/Services/Scripting/ScriptCommands.swift
@@ -387,7 +387,7 @@ final class GetPlayQueueCommand: NSScriptCommand {
             }
 
             let info: [String: Any] = [
-                "currentIndex": tracks.isEmpty ? 0 : playerService.currentIndex + 1,
+                "currentIndex": playerService.activePlaybackQueueIndex.map { $0 + 1 } ?? 0,
                 "tracks": tracks,
             ]
 
@@ -430,7 +430,7 @@ final class PlayTrackAtIndexCommand: NSScriptCommand {
             return nil
         }
 
-        let queueCount = MainActor.assumeIsolated { playerService.queue.count }
+        let queueCount = MainActor.assumeIsolated { playerService.queueEntries.count }
 
         // Convert 1-based AppleScript index to 0-based Swift index
         let zeroBasedIndex = indexValue - 1
@@ -442,9 +442,18 @@ final class PlayTrackAtIndexCommand: NSScriptCommand {
             return nil
         }
 
+        let selection = MainActor.assumeIsolated { () -> (UUID, MusicPlaybackReservation)? in
+            guard let entryID = playerService.queueEntries[safe: zeroBasedIndex]?.id else { return nil }
+            return (entryID, playerService.reserveMusicPlaybackIntent())
+        }
+        guard let (entryID, reservation) = selection else { return nil }
         logger.info("Executing playTrackAtIndex command with index: \(indexValue)")
         Task { @MainActor in
-            await playerService.playFromQueue(at: zeroBasedIndex)
+            guard let intent = playerService.claimMusicPlaybackIntent(
+                reservation,
+                queueEntryID: entryID
+            ) else { return }
+            await playerService.playFromQueue(entryID: entryID, intent: intent)
         }
         return nil
     }

--- a/Sources/Kaset/Services/Scrobbling/ScrobblingCoordinator.swift
+++ b/Sources/Kaset/Services/Scrobbling/ScrobblingCoordinator.swift
@@ -1,9 +1,7 @@
 import Foundation
 import Observation
 
-/// Bridges PlayerService to scrobbling backends.
-/// Observes PlayerService playback mutations, tracks accumulated play time,
-/// and triggers scrobbles when thresholds are met.
+/// Bridges PlayerService playback mutations to scrobbling backends.
 @MainActor
 @Observable
 final class ScrobblingCoordinator {
@@ -25,6 +23,7 @@ final class ScrobblingCoordinator {
     let mixTracklistParser: MixTracklistParser?
     let unknownDurationParseDelay: Duration
     let mixParseTimeout: Duration
+    private let now: () -> Date
 
     // MARK: - Tracking State
 
@@ -111,7 +110,8 @@ final class ScrobblingCoordinator {
         queue: ScrobbleQueue = ScrobbleQueue(),
         mixTracklistParser: MixTracklistParser? = nil,
         unknownDurationParseDelay: Duration = .seconds(2),
-        mixParseTimeout: Duration = .seconds(10)
+        mixParseTimeout: Duration = .seconds(10),
+        now: @escaping () -> Date = Date.init
     ) {
         self.playerService = playerService
         self.settingsManager = settingsManager
@@ -120,6 +120,7 @@ final class ScrobblingCoordinator {
         self.mixTracklistParser = mixTracklistParser
         self.unknownDurationParseDelay = unknownDurationParseDelay
         self.mixParseTimeout = mixParseTimeout
+        self.now = now
     }
 
     /// Permanent teardown must call stopMonitoring(finalizeCurrentTrack: true) first.
@@ -273,7 +274,7 @@ final class ScrobblingCoordinator {
                     self.startTrackingNewTrack(track)
                 case .unresolved, .parsing, .awaitingDuration:
                     self.refreshPendingWholeTrackPlay(with: tracker)
-                    self.trackTracker = PlaybackScrobbleTracker(startTime: Date(), initialProgress: progress)
+                    self.trackTracker = PlaybackScrobbleTracker(startTime: self.now(), initialProgress: progress)
                 case .mix:
                     break
                 }
@@ -342,7 +343,7 @@ final class ScrobblingCoordinator {
         self.currentTrackArtist = track.artistsDisplay
         self.trackedSong = track
         self.trackTracker = PlaybackScrobbleTracker(
-            startTime: Date(),
+            startTime: self.now(),
             initialProgress: self.playerService.progress
         )
         self.requiredPlaybackStateSequence = requiredPlaybackStateSequence
@@ -540,7 +541,7 @@ final class ScrobblingCoordinator {
     ) {
         guard var tracker = self.trackTracker else { return }
         let segmentStart = tracker.lastProgress
-        let now = Date()
+        let now = self.now()
         let credited = tracker.accumulate(progress: progress, isPlaying: isPlaying, now: now)
         self.trackTracker = tracker
 
@@ -686,7 +687,7 @@ final class ScrobblingCoordinator {
                         self.mixEntryTracker?.accumulate(
                             progress: endTime,
                             isPlaying: isPlaying,
-                            now: Date()
+                            now: self.now()
                         )
                     }
                 }
@@ -712,7 +713,7 @@ final class ScrobblingCoordinator {
                restartedNearEntryStart
             {
                 self.mixEntryScrobbledIds.remove(entry.id)
-                self.mixEntryTracker = PlaybackScrobbleTracker(startTime: Date(), initialProgress: progress)
+                self.mixEntryTracker = PlaybackScrobbleTracker(startTime: self.now(), initialProgress: progress)
                 self.logger.debug("Mix replay detected at \(String(format: "%.1f", progress))s for sub-track '\(entry.title)'")
             } else {
                 self.mixEntryTracker?.resetForSeek()
@@ -721,7 +722,7 @@ final class ScrobblingCoordinator {
         }
 
         // Accumulate play time (the tracker ignores seeks and paused spans internally)
-        self.mixEntryTracker?.accumulate(progress: progress, isPlaying: isPlaying, now: Date())
+        self.mixEntryTracker?.accumulate(progress: progress, isPlaying: isPlaying, now: self.now())
 
         // Send "now playing" once per sub-track
         if self.mixEntryTracker?.hasSentNowPlaying == false, isPlaying {
@@ -748,7 +749,7 @@ final class ScrobblingCoordinator {
             self.mixEntryScrobbledIds.remove(entry.id)
         }
         var tracker = PlaybackScrobbleTracker(
-            startTime: provisionalCredit?.startTime ?? Date(),
+            startTime: provisionalCredit?.startTime ?? self.now(),
             initialProgress: progress
         )
         if let provisionalCredit {

--- a/Sources/Kaset/Services/SongLikeStatusManager.swift
+++ b/Sources/Kaset/Services/SongLikeStatusManager.swift
@@ -129,7 +129,7 @@ final class SongLikeStatusManager {
         accountID: String? = nil,
         client: (any YTMusicClientProtocol)? = nil
     ) async -> LikeStatus {
-        await self.rate(song, status: .like, accountID: accountID, client: client)
+        await self.enqueueRating(song, status: .like, accountID: accountID, client: client).value
     }
 
     /// Unlikes a song (removes rating).
@@ -144,7 +144,7 @@ final class SongLikeStatusManager {
         accountID: String? = nil,
         client: (any YTMusicClientProtocol)? = nil
     ) async -> LikeStatus {
-        await self.rate(song, status: .indifferent, accountID: accountID, client: client)
+        await self.enqueueRating(song, status: .indifferent, accountID: accountID, client: client).value
     }
 
     /// Dislikes a song.
@@ -159,7 +159,7 @@ final class SongLikeStatusManager {
         accountID: String? = nil,
         client: (any YTMusicClientProtocol)? = nil
     ) async -> LikeStatus {
-        await self.rate(song, status: .dislike, accountID: accountID, client: client)
+        await self.enqueueRating(song, status: .dislike, accountID: accountID, client: client).value
     }
 
     /// Undislikes a song (removes rating).
@@ -174,27 +174,43 @@ final class SongLikeStatusManager {
         accountID: String? = nil,
         client: (any YTMusicClientProtocol)? = nil
     ) async -> LikeStatus {
-        await self.rate(song, status: .indifferent, accountID: accountID, client: client)
+        await self.enqueueRating(song, status: .indifferent, accountID: accountID, client: client).value
     }
 
-    /// Rates a song with the given status.
-    /// - Parameters:
-    ///   - song: The song to rate.
-    ///   - status: The rating to apply.
-    ///   - accountID: Optional account scope override.
-    ///   - client: Optional client override.
-    /// - Returns: The final status after the request settles.
-    private func rate(
+    /// Registers a rating mutation synchronously, then returns its completion task.
+    /// Submission-time registration preserves user action order even when callers
+    /// await the result from unstructured tasks.
+    func enqueueRating(
         _ song: Song,
         status: LikeStatus,
-        accountID: String?,
-        client overrideClient: (any YTMusicClientProtocol)?
-    ) async -> LikeStatus {
+        accountID: String? = nil,
+        client overrideClient: (any YTMusicClientProtocol)? = nil,
+        visibleBaseline: LikeStatus? = nil
+    ) -> Task<LikeStatus, Never> {
         let resolvedAccountID = accountID.map(Self.resolvedAccountID) ?? self.activeAccountID
+        let key = Self.ratingMutationKey(
+            accountID: resolvedAccountID,
+            videoId: song.videoId
+        )
+        if let visibleBaseline {
+            if self.ratingMutationTails[key] == nil,
+               self.confirmedStatusByAccount[resolvedAccountID]?[song.videoId] == nil
+            {
+                self.setConfirmedStatus(
+                    visibleBaseline,
+                    for: song.videoId,
+                    accountID: resolvedAccountID
+                )
+            }
+            self.setStatus(visibleBaseline, for: song.videoId, accountID: resolvedAccountID)
+        }
 
         guard let client = overrideClient ?? self.client else {
             DiagnosticsLogger.api.warning("SongLikeStatusManager: No client set, cannot rate song")
-            return self.status(for: song.videoId, accountID: resolvedAccountID) ?? song.likeStatus ?? .indifferent
+            let fallback = self.status(for: song.videoId, accountID: resolvedAccountID)
+                ?? song.likeStatus
+                ?? .indifferent
+            return Task { @MainActor in fallback }
         }
 
         let sessionGeneration = self.sessionGeneration
@@ -202,8 +218,6 @@ final class SongLikeStatusManager {
             videoId: song.videoId,
             accountID: resolvedAccountID
         )
-
-        // Optimistically update cache and notify observers
         let previousStatus = self.status(for: song.videoId, accountID: resolvedAccountID)
         if self.confirmedStatusByAccount[resolvedAccountID]?[song.videoId] == nil {
             self.setConfirmedStatus(previousStatus, for: song.videoId, accountID: resolvedAccountID)
@@ -214,81 +228,107 @@ final class SongLikeStatusManager {
             for: resolvedAccountID
         )
 
-        do {
-            try await self.performSerializedRatingMutation(
-                client: client,
-                mutation: RatingMutationRequest(
-                    videoId: song.videoId,
-                    status: status,
-                    accountID: resolvedAccountID,
-                    revision: revision,
-                    sessionGeneration: sessionGeneration
-                )
+        let mutation = RatingMutationRequest(
+            videoId: song.videoId,
+            status: status,
+            accountID: resolvedAccountID,
+            revision: revision,
+            sessionGeneration: sessionGeneration
+        )
+        let request = self.enqueueSerializedRatingMutation(
+            client: client,
+            mutation: mutation
+        )
+        return Task { @MainActor in
+            await self.settleRatingMutation(
+                song: song,
+                status: status,
+                mutation: mutation,
+                request: request
             )
-            guard self.sessionGeneration == sessionGeneration else {
-                return self.status(for: song.videoId, accountID: resolvedAccountID) ?? status
+        }
+    }
+
+    private func settleRatingMutation(
+        song: Song,
+        status: LikeStatus,
+        mutation: RatingMutationRequest,
+        request: Task<Result<Void, any Error>, Never>
+    ) async -> LikeStatus {
+        defer {
+            self.finishRatingMutation(
+                accountID: mutation.accountID,
+                videoId: mutation.videoId,
+                revision: mutation.revision
+            )
+        }
+        do {
+            try await request.value.get()
+            guard self.sessionGeneration == mutation.sessionGeneration else {
+                return self.status(for: song.videoId, accountID: mutation.accountID) ?? status
             }
-            self.setConfirmedStatus(status, for: song.videoId, accountID: resolvedAccountID)
             guard self.isCurrentRatingOperation(
-                revision,
+                mutation.revision,
                 videoId: song.videoId,
-                accountID: resolvedAccountID
+                accountID: mutation.accountID
             ) else {
-                return self.status(for: song.videoId, accountID: resolvedAccountID) ?? status
+                return self.status(for: song.videoId, accountID: mutation.accountID) ?? status
             }
             DiagnosticsLogger.api.info("Rated song \(song.videoId) as \(status.rawValue)")
             return status
         } catch is CancellationError {
-            guard self.isCurrentRatingOperation(
-                revision,
-                videoId: song.videoId,
-                accountID: resolvedAccountID
-            ) else {
-                return self.status(for: song.videoId, accountID: resolvedAccountID) ?? status
-            }
-            let confirmedStatus = self.confirmedStatus(for: song.videoId, accountID: resolvedAccountID)
-            let rollbackStatus = confirmedStatus ?? .indifferent
-            let sessionIsCurrent = self.sessionGeneration == sessionGeneration
-            let shouldRestoreOldAccount = sessionIsCurrent || self.activeAccountID != resolvedAccountID
-            if shouldRestoreOldAccount {
-                self.restoreStatus(confirmedStatus, for: song.videoId, accountID: resolvedAccountID)
-            }
-            if sessionIsCurrent {
-                self.publishEvent(
-                    LikeStatusEvent(videoId: song.videoId, status: rollbackStatus, song: song),
-                    for: resolvedAccountID
-                )
-            }
-            DiagnosticsLogger.api.debug("Rating cancelled for song \(song.videoId)")
-            return shouldRestoreOldAccount
-                ? rollbackStatus
-                : (self.status(for: song.videoId, accountID: resolvedAccountID) ?? .indifferent)
+            return self.rollbackRatingMutation(
+                song: song,
+                status: status,
+                mutation: mutation,
+                logsCancellation: true
+            )
         } catch {
-            guard self.isCurrentRatingOperation(
-                revision,
-                videoId: song.videoId,
-                accountID: resolvedAccountID
-            ) else {
-                return self.status(for: song.videoId, accountID: resolvedAccountID) ?? status
-            }
-            let confirmedStatus = self.confirmedStatus(for: song.videoId, accountID: resolvedAccountID)
-            let rollbackStatus = confirmedStatus ?? .indifferent
-            let sessionIsCurrent = self.sessionGeneration == sessionGeneration
-            let shouldRestoreOldAccount = sessionIsCurrent || self.activeAccountID != resolvedAccountID
-            if shouldRestoreOldAccount {
-                self.restoreStatus(confirmedStatus, for: song.videoId, accountID: resolvedAccountID)
-            }
-            if sessionIsCurrent {
-                self.publishEvent(
-                    LikeStatusEvent(videoId: song.videoId, status: rollbackStatus, song: song),
-                    for: resolvedAccountID
-                )
-            }
             DiagnosticsLogger.api.error("Failed to rate song: \(error.localizedDescription)")
-            return shouldRestoreOldAccount
-                ? rollbackStatus
-                : (self.status(for: song.videoId, accountID: resolvedAccountID) ?? .indifferent)
+            return self.rollbackRatingMutation(
+                song: song,
+                status: status,
+                mutation: mutation,
+                logsCancellation: false
+            )
         }
+    }
+
+    private func rollbackRatingMutation(
+        song: Song,
+        status: LikeStatus,
+        mutation: RatingMutationRequest,
+        logsCancellation: Bool
+    ) -> LikeStatus {
+        guard self.isCurrentRatingOperation(
+            mutation.revision,
+            videoId: song.videoId,
+            accountID: mutation.accountID
+        ) else {
+            return self.status(for: song.videoId, accountID: mutation.accountID) ?? status
+        }
+        let confirmedStatus = self.confirmedStatus(
+            for: song.videoId,
+            accountID: mutation.accountID
+        )
+        let rollbackStatus = confirmedStatus ?? .indifferent
+        let sessionIsCurrent = self.sessionGeneration == mutation.sessionGeneration
+        let shouldRestoreOldAccount = sessionIsCurrent || self.activeAccountID != mutation.accountID
+        if shouldRestoreOldAccount {
+            self.restoreStatus(confirmedStatus, for: song.videoId, accountID: mutation.accountID)
+        }
+        if sessionIsCurrent {
+            self.publishEvent(
+                LikeStatusEvent(videoId: song.videoId, status: rollbackStatus, song: song),
+                for: mutation.accountID
+            )
+        }
+        if logsCancellation {
+            DiagnosticsLogger.api.debug("Rating cancelled for song \(song.videoId)")
+        }
+        return shouldRestoreOldAccount
+            ? rollbackStatus
+            : (self.status(for: song.videoId, accountID: mutation.accountID) ?? .indifferent)
     }
 
     // MARK: - Cache Management
@@ -369,28 +409,34 @@ final class SongLikeStatusManager {
         self.ratingRevisionByAccount[accountID]?[videoId] == revision
     }
 
-    private func performSerializedRatingMutation(
+    private func enqueueSerializedRatingMutation(
         client: any YTMusicClientProtocol,
         mutation: RatingMutationRequest
-    ) async throws {
-        let key = mutation.accountID + "\u{0}" + mutation.videoId
+    ) -> Task<Result<Void, any Error>, Never> {
+        let key = Self.ratingMutationKey(
+            accountID: mutation.accountID,
+            videoId: mutation.videoId
+        )
         let predecessor = self.ratingMutationTails[key]
-        let requestTask = Task { () -> Result<Void, any Error> in
+        let requestTask = Task { @MainActor () -> Result<Void, any Error> in
             if let predecessor {
                 _ = await predecessor.value
             }
             guard self.sessionGeneration == mutation.sessionGeneration,
-                  self.activeAccountID == mutation.accountID,
-                  self.isCurrentRatingOperation(
-                      mutation.revision,
-                      videoId: mutation.videoId,
-                      accountID: mutation.accountID
-                  )
+                  self.activeAccountID == mutation.accountID
             else {
                 return .failure(CancellationError())
             }
             do {
                 try await client.rateSong(videoId: mutation.videoId, rating: mutation.status)
+                guard self.sessionGeneration == mutation.sessionGeneration else {
+                    return .failure(CancellationError())
+                }
+                self.setConfirmedStatus(
+                    mutation.status,
+                    for: mutation.videoId,
+                    accountID: mutation.accountID
+                )
                 return .success(())
             } catch {
                 return .failure(error)
@@ -398,12 +444,22 @@ final class SongLikeStatusManager {
         }
         self.ratingMutationTails[key] = requestTask
         self.ratingMutationTailRevisions[key] = mutation.revision
-        let result = await requestTask.value
-        if self.ratingMutationTailRevisions[key] == mutation.revision {
-            self.ratingMutationTails.removeValue(forKey: key)
-            self.ratingMutationTailRevisions.removeValue(forKey: key)
-        }
-        try result.get()
+        return requestTask
+    }
+
+    private func finishRatingMutation(
+        accountID: String,
+        videoId: String,
+        revision: UInt64
+    ) {
+        let key = Self.ratingMutationKey(accountID: accountID, videoId: videoId)
+        guard self.ratingMutationTailRevisions[key] == revision else { return }
+        self.ratingMutationTails.removeValue(forKey: key)
+        self.ratingMutationTailRevisions.removeValue(forKey: key)
+    }
+
+    private static func ratingMutationKey(accountID: String, videoId: String) -> String {
+        accountID + "\u{0}" + videoId
     }
 
     private static func resolvedAccountID(_ accountID: String?) -> String {

--- a/Sources/Kaset/Services/SongLikeStatusManager.swift
+++ b/Sources/Kaset/Services/SongLikeStatusManager.swift
@@ -21,11 +21,11 @@ struct LikeStatusEvent: Equatable {
 @MainActor
 @Observable
 final class SongLikeStatusManager {
-    private struct ConfirmedRatingStatus: Sendable {
+    private struct ConfirmedRatingStatus {
         let value: LikeStatus?
     }
 
-    private struct RatingMutationRequest: Sendable {
+    private struct RatingMutationRequest {
         let videoId: String
         let status: LikeStatus
         let accountID: String

--- a/Sources/Kaset/Services/SongLikeStatusManager.swift
+++ b/Sources/Kaset/Services/SongLikeStatusManager.swift
@@ -21,6 +21,18 @@ struct LikeStatusEvent: Equatable {
 @MainActor
 @Observable
 final class SongLikeStatusManager {
+    private struct ConfirmedRatingStatus: Sendable {
+        let value: LikeStatus?
+    }
+
+    private struct RatingMutationRequest: Sendable {
+        let videoId: String
+        let status: LikeStatus
+        let accountID: String
+        let revision: UInt64
+        let sessionGeneration: UInt64
+    }
+
     /// Shared singleton instance.
     static let shared = SongLikeStatusManager()
 
@@ -29,6 +41,14 @@ final class SongLikeStatusManager {
 
     /// Cache of account ID to (video ID to like status).
     private var statusCacheByAccount: [String: [String: LikeStatus]] = [:]
+
+    /// Monotonic latest-operation revisions scoped by account and video ID.
+    private var sessionGeneration: UInt64 = 0
+    private var ratingRevisionCounter: UInt64 = 0
+    private var ratingRevisionByAccount: [String: [String: UInt64]] = [:]
+    private var confirmedStatusByAccount: [String: [String: ConfirmedRatingStatus]] = [:]
+    @ObservationIgnored private var ratingMutationTails: [String: Task<Result<Void, any Error>, Never>] = [:]
+    @ObservationIgnored private var ratingMutationTailRevisions: [String: UInt64] = [:]
 
     /// Currently active account scope for cache lookups.
     private(set) var activeAccountID = SongLikeStatusManager.primaryAccountID
@@ -39,7 +59,7 @@ final class SongLikeStatusManager {
     /// Reference to the YTMusic client for API calls.
     private var client: (any YTMusicClientProtocol)?
 
-    private init() {}
+    init() {}
 
     // MARK: - Configuration
 
@@ -60,6 +80,7 @@ final class SongLikeStatusManager {
         let resolvedAccountID = Self.resolvedAccountID(accountID)
         guard self.activeAccountID != resolvedAccountID else { return }
 
+        self.invalidateSession(clearsActiveCache: false)
         self.activeAccountID = resolvedAccountID
         DiagnosticsLogger.api.debug("SongLikeStatusManager: Switched cache scope to account \(resolvedAccountID)")
     }
@@ -176,8 +197,17 @@ final class SongLikeStatusManager {
             return self.status(for: song.videoId, accountID: resolvedAccountID) ?? song.likeStatus ?? .indifferent
         }
 
+        let sessionGeneration = self.sessionGeneration
+        let revision = self.beginRatingOperation(
+            videoId: song.videoId,
+            accountID: resolvedAccountID
+        )
+
         // Optimistically update cache and notify observers
         let previousStatus = self.status(for: song.videoId, accountID: resolvedAccountID)
+        if self.confirmedStatusByAccount[resolvedAccountID]?[song.videoId] == nil {
+            self.setConfirmedStatus(previousStatus, for: song.videoId, accountID: resolvedAccountID)
+        }
         self.setStatus(status, for: song.videoId, accountID: resolvedAccountID)
         self.publishEvent(
             LikeStatusEvent(videoId: song.videoId, status: status, song: song),
@@ -185,29 +215,79 @@ final class SongLikeStatusManager {
         )
 
         do {
-            try await client.rateSong(videoId: song.videoId, rating: status)
+            try await self.performSerializedRatingMutation(
+                client: client,
+                mutation: RatingMutationRequest(
+                    videoId: song.videoId,
+                    status: status,
+                    accountID: resolvedAccountID,
+                    revision: revision,
+                    sessionGeneration: sessionGeneration
+                )
+            )
+            guard self.sessionGeneration == sessionGeneration else {
+                return self.status(for: song.videoId, accountID: resolvedAccountID) ?? status
+            }
+            self.setConfirmedStatus(status, for: song.videoId, accountID: resolvedAccountID)
+            guard self.isCurrentRatingOperation(
+                revision,
+                videoId: song.videoId,
+                accountID: resolvedAccountID
+            ) else {
+                return self.status(for: song.videoId, accountID: resolvedAccountID) ?? status
+            }
             DiagnosticsLogger.api.info("Rated song \(song.videoId) as \(status.rawValue)")
             return status
         } catch is CancellationError {
-            // Task was cancelled - rollback optimistic update and notify
-            let rollbackStatus = previousStatus ?? .indifferent
-            self.restoreStatus(previousStatus, for: song.videoId, accountID: resolvedAccountID)
-            self.publishEvent(
-                LikeStatusEvent(videoId: song.videoId, status: rollbackStatus, song: song),
-                for: resolvedAccountID
-            )
-            DiagnosticsLogger.api.debug("Rating cancelled for song \(song.videoId), rolled back")
-            return rollbackStatus
+            guard self.isCurrentRatingOperation(
+                revision,
+                videoId: song.videoId,
+                accountID: resolvedAccountID
+            ) else {
+                return self.status(for: song.videoId, accountID: resolvedAccountID) ?? status
+            }
+            let confirmedStatus = self.confirmedStatus(for: song.videoId, accountID: resolvedAccountID)
+            let rollbackStatus = confirmedStatus ?? .indifferent
+            let sessionIsCurrent = self.sessionGeneration == sessionGeneration
+            let shouldRestoreOldAccount = sessionIsCurrent || self.activeAccountID != resolvedAccountID
+            if shouldRestoreOldAccount {
+                self.restoreStatus(confirmedStatus, for: song.videoId, accountID: resolvedAccountID)
+            }
+            if sessionIsCurrent {
+                self.publishEvent(
+                    LikeStatusEvent(videoId: song.videoId, status: rollbackStatus, song: song),
+                    for: resolvedAccountID
+                )
+            }
+            DiagnosticsLogger.api.debug("Rating cancelled for song \(song.videoId)")
+            return shouldRestoreOldAccount
+                ? rollbackStatus
+                : (self.status(for: song.videoId, accountID: resolvedAccountID) ?? .indifferent)
         } catch {
-            // Revert on failure and notify
-            let rollbackStatus = previousStatus ?? .indifferent
-            self.restoreStatus(previousStatus, for: song.videoId, accountID: resolvedAccountID)
-            self.publishEvent(
-                LikeStatusEvent(videoId: song.videoId, status: rollbackStatus, song: song),
-                for: resolvedAccountID
-            )
+            guard self.isCurrentRatingOperation(
+                revision,
+                videoId: song.videoId,
+                accountID: resolvedAccountID
+            ) else {
+                return self.status(for: song.videoId, accountID: resolvedAccountID) ?? status
+            }
+            let confirmedStatus = self.confirmedStatus(for: song.videoId, accountID: resolvedAccountID)
+            let rollbackStatus = confirmedStatus ?? .indifferent
+            let sessionIsCurrent = self.sessionGeneration == sessionGeneration
+            let shouldRestoreOldAccount = sessionIsCurrent || self.activeAccountID != resolvedAccountID
+            if shouldRestoreOldAccount {
+                self.restoreStatus(confirmedStatus, for: song.videoId, accountID: resolvedAccountID)
+            }
+            if sessionIsCurrent {
+                self.publishEvent(
+                    LikeStatusEvent(videoId: song.videoId, status: rollbackStatus, song: song),
+                    for: resolvedAccountID
+                )
+            }
             DiagnosticsLogger.api.error("Failed to rate song: \(error.localizedDescription)")
-            return rollbackStatus
+            return shouldRestoreOldAccount
+                ? rollbackStatus
+                : (self.status(for: song.videoId, accountID: resolvedAccountID) ?? .indifferent)
         }
     }
 
@@ -219,6 +299,7 @@ final class SongLikeStatusManager {
     ///   - status: The like status.
     func setStatus(_ status: LikeStatus, for videoId: String) {
         self.setStatus(status, for: videoId, accountID: self.activeAccountID)
+        self.setConfirmedStatus(status, for: videoId, accountID: self.activeAccountID)
     }
 
     /// Updates the cache with the same known status for multiple songs.
@@ -236,6 +317,7 @@ final class SongLikeStatusManager {
 
         for videoId in videoIds {
             cache[videoId] = status
+            self.setConfirmedStatus(status, for: videoId, accountID: resolvedAccountID)
         }
 
         self.statusCacheByAccount[resolvedAccountID] = cache
@@ -244,7 +326,77 @@ final class SongLikeStatusManager {
     /// Clears all cached statuses.
     func clearCache() {
         self.statusCacheByAccount.removeAll()
+        self.ratingRevisionByAccount.removeAll()
+        self.confirmedStatusByAccount.removeAll()
         self.lastLikeEvent = nil
+    }
+
+    func invalidateSession(clearsActiveCache: Bool = true) {
+        self.sessionGeneration &+= 1
+        for task in self.ratingMutationTails.values {
+            task.cancel()
+        }
+        if clearsActiveCache {
+            self.statusCacheByAccount.removeValue(forKey: self.activeAccountID)
+            self.confirmedStatusByAccount.removeValue(forKey: self.activeAccountID)
+            self.lastLikeEvent = nil
+        }
+    }
+
+    func ratingRevision(for videoId: String, accountID: String? = nil) -> UInt64 {
+        let resolvedAccountID = accountID.map(Self.resolvedAccountID) ?? self.activeAccountID
+        return self.ratingRevisionByAccount[resolvedAccountID]?[videoId] ?? 0
+    }
+
+    private func beginRatingOperation(videoId: String, accountID: String) -> UInt64 {
+        self.ratingRevisionCounter &+= 1
+        self.ratingRevisionByAccount[accountID, default: [:]][videoId] = self.ratingRevisionCounter
+        return self.ratingRevisionCounter
+    }
+
+    private func isCurrentRatingOperation(
+        _ revision: UInt64,
+        videoId: String,
+        accountID: String
+    ) -> Bool {
+        self.ratingRevisionByAccount[accountID]?[videoId] == revision
+    }
+
+    private func performSerializedRatingMutation(
+        client: any YTMusicClientProtocol,
+        mutation: RatingMutationRequest
+    ) async throws {
+        let key = mutation.accountID + "\u{0}" + mutation.videoId
+        let predecessor = self.ratingMutationTails[key]
+        let requestTask = Task { () -> Result<Void, any Error> in
+            if let predecessor {
+                _ = await predecessor.value
+            }
+            guard self.sessionGeneration == mutation.sessionGeneration,
+                  self.activeAccountID == mutation.accountID,
+                  self.isCurrentRatingOperation(
+                      mutation.revision,
+                      videoId: mutation.videoId,
+                      accountID: mutation.accountID
+                  )
+            else {
+                return .failure(CancellationError())
+            }
+            do {
+                try await client.rateSong(videoId: mutation.videoId, rating: mutation.status)
+                return .success(())
+            } catch {
+                return .failure(error)
+            }
+        }
+        self.ratingMutationTails[key] = requestTask
+        self.ratingMutationTailRevisions[key] = mutation.revision
+        let result = await requestTask.value
+        if self.ratingMutationTailRevisions[key] == mutation.revision {
+            self.ratingMutationTails.removeValue(forKey: key)
+            self.ratingMutationTailRevisions.removeValue(forKey: key)
+        }
+        try result.get()
     }
 
     private static func resolvedAccountID(_ accountID: String?) -> String {
@@ -257,6 +409,18 @@ final class SongLikeStatusManager {
 
     private func setStatus(_ status: LikeStatus, for videoId: String, accountID: String) {
         self.statusCacheByAccount[accountID, default: [:]][videoId] = status
+    }
+
+    private func confirmedStatus(for videoId: String, accountID: String) -> LikeStatus? {
+        self.confirmedStatusByAccount[accountID]?[videoId]?.value
+    }
+
+    private func setConfirmedStatus(
+        _ status: LikeStatus?,
+        for videoId: String,
+        accountID: String
+    ) {
+        self.confirmedStatusByAccount[accountID, default: [:]][videoId] = ConfirmedRatingStatus(value: status)
     }
 
     private func restoreStatus(_ status: LikeStatus?, for videoId: String, accountID: String) {

--- a/Sources/Kaset/ViewModels/CommandBarViewModel.swift
+++ b/Sources/Kaset/ViewModels/CommandBarViewModel.swift
@@ -1,6 +1,39 @@
 import Foundation
 import Observation
 
+// MARK: - CommandBarTimeoutRace
+
+@available(macOS 26.0, *)
+@MainActor
+private final class CommandBarTimeoutRace<Value: Sendable> {
+    private var continuation: CheckedContinuation<Value, any Error>?
+    private var pendingResult: Result<Value, any Error>?
+    private var isResolved = false
+
+    func install(_ continuation: CheckedContinuation<Value, any Error>) {
+        if let pendingResult {
+            self.isResolved = true
+            continuation.resume(with: pendingResult)
+            self.pendingResult = nil
+        } else {
+            self.continuation = continuation
+        }
+    }
+
+    func resolve(_ result: Result<Value, any Error>) {
+        guard !self.isResolved else { return }
+        guard let continuation else {
+            self.pendingResult = result
+            return
+        }
+        self.isResolved = true
+        self.continuation = nil
+        continuation.resume(with: result)
+    }
+}
+
+// MARK: - CommandBarViewModel
+
 @available(macOS 26.0, *)
 @MainActor
 @Observable
@@ -102,6 +135,7 @@ final class CommandBarViewModel {
     private(set) var lastFallbackReason: FallbackReason?
 
     @ObservationIgnored private var requestTask: Task<Void, Never>?
+    @ObservationIgnored private var activeRequestID: UUID?
     @ObservationIgnored private let parser = CommandIntentParser()
     @ObservationIgnored private let executor: CommandExecutor
     @ObservationIgnored private let playerService: any PlayerServiceProtocol
@@ -165,11 +199,17 @@ final class CommandBarViewModel {
             return
         }
 
-        self.startRequest()
+        let requestID = UUID()
+        self.startRequest(id: requestID)
+        let playbackReservation = self.playerService.reserveMusicPlaybackIntent()
 
         self.requestTask = Task { [weak self] in
             guard let self else { return }
-            await self.process(query: query)
+            await self.process(
+                query: query,
+                playbackReservation: playbackReservation,
+                requestID: requestID
+            )
         }
     }
 
@@ -186,45 +226,65 @@ final class CommandBarViewModel {
 
     func cancelActiveRequest() {
         self.requestTask?.cancel()
-        self.finishRequest()
+        guard let activeRequestID else { return }
+        self.finishRequest(id: activeRequestID)
     }
 
-    private func process(query: String) async {
+    private func process(
+        query: String,
+        playbackReservation: MusicPlaybackReservation,
+        requestID: UUID
+    ) async {
         self.logger.info("Processing command: \(query)")
         self.logger.debug("Using Foundation Models command prompt version \(self.aiPromptVersion.logDescription)")
 
         defer {
-            self.finishRequest()
+            self.finishRequest(id: requestID)
         }
 
         if let localRequest = self.parser.deterministicRequest(for: query) {
             self.phase = .localCommand
-            await self.applyOutcome(self.executor.execute(localRequest))
+            await self.applyOutcome(self.executor.execute(
+                localRequest,
+                reservation: playbackReservation
+            ))
             return
         }
 
         if self.parser.isQueueInspectionQuery(query) {
             self.phase = .localCommand
-            await self.describeQueue()
+            await self.describeQueue(requestID: requestID)
             return
         }
 
         self.aiClient.refreshAvailability()
 
         guard self.aiClient.isAvailable() else {
-            await self.handleFallback(query: query, reason: .aiUnavailable)
+            await self.handleFallback(
+                query: query,
+                reason: .aiUnavailable,
+                playbackReservation: playbackReservation
+            )
             return
         }
 
         guard self.aiClient.supportsCurrentLocale() else {
-            await self.handleFallback(query: query, reason: .unsupportedLocale)
+            await self.handleFallback(
+                query: query,
+                reason: .unsupportedLocale,
+                playbackReservation: playbackReservation
+            )
             return
         }
 
         do {
             self.phase = .aiParsing
             let parsedCommand = try await self.resolveCommand(query: query)
-            await self.executeParsedCommand(parsedCommand)
+            await self.executeParsedCommand(
+                parsedCommand,
+                playbackReservation: playbackReservation,
+                requestID: requestID
+            )
         } catch {
             let handledError = AIErrorHandler.handle(error)
 
@@ -232,17 +292,17 @@ final class CommandBarViewModel {
             case .cancelled:
                 self.logger.info("Command processing cancelled")
             case .timedOut:
-                await self.handleFallback(query: query, reason: .timedOut)
+                await self.handleFallback(query: query, reason: .timedOut, playbackReservation: playbackReservation)
             case .decodingFailure:
-                await self.handleFallback(query: query, reason: .decodingFailure)
+                await self.handleFallback(query: query, reason: .decodingFailure, playbackReservation: playbackReservation)
             case .sessionBusy:
-                await self.handleFallback(query: query, reason: .sessionBusy)
+                await self.handleFallback(query: query, reason: .sessionBusy, playbackReservation: playbackReservation)
             case .contextWindowExceeded:
-                await self.handleFallback(query: query, reason: .contextWindowExceeded)
+                await self.handleFallback(query: query, reason: .contextWindowExceeded, playbackReservation: playbackReservation)
             case .modelNotReady:
-                await self.handleFallback(query: query, reason: .modelNotReady)
+                await self.handleFallback(query: query, reason: .modelNotReady, playbackReservation: playbackReservation)
             case .notAvailable:
-                await self.handleFallback(query: query, reason: .aiUnavailable)
+                await self.handleFallback(query: query, reason: .aiUnavailable, playbackReservation: playbackReservation)
             case .contentBlocked, .unknown:
                 if let message = AIErrorHandler.handleAndMessage(error, context: "command processing") {
                     self.errorMessage = message
@@ -254,38 +314,27 @@ final class CommandBarViewModel {
     private func resolveCommand(query: String) async throws -> CommandBarParseResult {
         let resolveCommand = self.aiClient.resolveCommand
         let instructions = self.aiSystemInstructions
-        let requestTimeout = self.requestTimeout
-
-        return try await withThrowingTaskGroup(of: CommandBarParseResult.self) { group in
-            group.addTask {
-                try await resolveCommand(query, instructions)
-            }
-            group.addTask {
-                try await Task.sleep(for: requestTimeout)
-                throw AIError.timedOut
-            }
-
-            defer {
-                group.cancelAll()
-            }
-
-            guard let parsedCommand = try await group.next() else {
-                throw CancellationError()
-            }
-
-            return parsedCommand
+        return try await self.withHardTimeout(self.requestTimeout) {
+            try await resolveCommand(query, instructions)
         }
     }
 
-    private func executeParsedCommand(_ parsedCommand: CommandBarParseResult) async {
+    private func executeParsedCommand(
+        _ parsedCommand: CommandBarParseResult,
+        playbackReservation: MusicPlaybackReservation,
+        requestID: UUID
+    ) async {
         if parsedCommand.isQueueInspection {
-            await self.describeQueue()
+            await self.describeQueue(requestID: requestID)
             return
         }
 
         if let directRequest = parsedCommand.directRequest {
             self.phase = .executing
-            await self.applyOutcome(self.executor.execute(directRequest))
+            await self.applyOutcome(self.executor.execute(
+                directRequest,
+                reservation: playbackReservation
+            ))
             return
         }
 
@@ -295,10 +344,13 @@ final class CommandBarViewModel {
         }
 
         self.phase = .executing
-        await self.applyOutcome(self.executor.execute(.musicIntent(intent)))
+        await self.applyOutcome(self.executor.execute(
+            .musicIntent(intent),
+            reservation: playbackReservation
+        ))
     }
 
-    private func describeQueue() async {
+    private func describeQueue(requestID: UUID) async {
         guard !self.playerService.queue.isEmpty else {
             await self.applyOutcome(self.executor.describeQueueLocally())
             return
@@ -318,8 +370,19 @@ final class CommandBarViewModel {
 
         do {
             self.phase = .aiParsing
-            let queueSnapshot = await self.queueSnapshot(maxLimit: 20)
-            let summary = try await self.resolveQueueDescription(queueSnapshot: queueSnapshot)
+            let summary = try await self.withHardTimeout(self.queueDescriptionTimeout) { [weak self] in
+                guard let self, self.activeRequestID == requestID else {
+                    throw CancellationError()
+                }
+                let queueSnapshot = await self.queueSnapshot(maxLimit: 20)
+                guard self.activeRequestID == requestID else {
+                    throw CancellationError()
+                }
+                return try await self.resolveQueueDescription(
+                    queueSnapshot: queueSnapshot,
+                    requestID: requestID
+                )
+            }
             self.phase = .executing
             await self.applyOutcome(.result(summary.displayText, shouldDismiss: false))
         } catch {
@@ -346,7 +409,10 @@ final class CommandBarViewModel {
         }
     }
 
-    private func resolveQueueDescription(queueSnapshot: QueueSnapshot) async throws -> QueueAnalysisSummary {
+    private func resolveQueueDescription(
+        queueSnapshot: QueueSnapshot,
+        requestID: UUID
+    ) async throws -> QueueAnalysisSummary {
         let describeQueue = self.aiClient.describeQueue
         let instructions = self.queueDescriptionInstructions
         let prompt = FoundationModelsPromptLibrary.queueDescriptionPrompt(
@@ -355,37 +421,28 @@ final class CommandBarViewModel {
             shownTracks: queueSnapshot.shownTracks,
             version: self.aiPromptVersion
         )
-        let requestTimeout = self.queueDescriptionTimeout
 
-        return try await withThrowingTaskGroup(of: QueueAnalysisSummary.self) { group in
-            group.addTask {
-                try await describeQueue(prompt, instructions) { [weak self] partial in
-                    guard let self, let displayText = partial.displayText else { return }
-                    self.resultMessage = displayText
-                }
-            }
-            group.addTask {
-                try await Task.sleep(for: requestTimeout)
-                throw AIError.timedOut
-            }
-
-            defer {
-                group.cancelAll()
-            }
-
-            guard let summary = try await group.next() else {
-                throw CancellationError()
-            }
-
-            return summary
+        return try await describeQueue(prompt, instructions) { [weak self] partial in
+            guard let self,
+                  self.activeRequestID == requestID,
+                  let displayText = partial.displayText
+            else { return }
+            self.resultMessage = displayText
         }
     }
 
-    private func handleFallback(query: String, reason: FallbackReason) async {
+    private func handleFallback(
+        query: String,
+        reason: FallbackReason,
+        playbackReservation: MusicPlaybackReservation
+    ) async {
         self.phase = .fallback
         self.lastFallbackReason = reason
         self.logger.info("Falling back from AI for command '\(query)' due to \(reason.rawValue)")
-        await self.applyOutcome(self.executor.execute(self.parser.fallbackRequest(for: query)))
+        await self.applyOutcome(self.executor.execute(
+            self.parser.fallbackRequest(for: query),
+            reservation: playbackReservation
+        ))
     }
 
     private func applyLocalQueueDescription(reason: FallbackReason) async {
@@ -410,7 +467,7 @@ final class CommandBarViewModel {
     private func queueSnapshot(maxLimit: Int) async -> QueueSnapshot {
         let candidateLines = FoundationModelsPromptLibrary.queueTrackLines(
             from: self.playerService.queue,
-            currentIndex: self.playerService.currentIndex,
+            currentIndex: self.playerService.activePlaybackQueueIndex ?? -1,
             isPlaying: self.playerService.isPlaying,
             limit: maxLimit
         )
@@ -427,7 +484,7 @@ final class CommandBarViewModel {
         )
         let lines = FoundationModelsPromptLibrary.queueTrackLines(
             from: self.playerService.queue,
-            currentIndex: self.playerService.currentIndex,
+            currentIndex: self.playerService.activePlaybackQueueIndex ?? -1,
             isPlaying: self.playerService.isPlaying,
             limit: finalLineCount
         )
@@ -474,7 +531,42 @@ final class CommandBarViewModel {
         self.dismissAction()
     }
 
-    private func startRequest() {
+    private func withHardTimeout<Value: Sendable>(
+        _ timeout: Duration,
+        operation: @escaping @MainActor @Sendable () async throws -> Value
+    ) async throws -> Value {
+        let race = CommandBarTimeoutRace<Value>()
+        let operationTask = Task<Value, any Error> {
+            try await operation()
+        }
+        let timeoutTask = Task<Value, any Error> {
+            try await Task.sleep(for: timeout)
+            throw AIError.timedOut
+        }
+
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                race.install(continuation)
+                Task { @MainActor in
+                    await race.resolve(operationTask.result)
+                    timeoutTask.cancel()
+                }
+                Task { @MainActor in
+                    await race.resolve(timeoutTask.result)
+                    operationTask.cancel()
+                }
+            }
+        } onCancel: {
+            operationTask.cancel()
+            timeoutTask.cancel()
+            Task { @MainActor in
+                race.resolve(.failure(CancellationError()))
+            }
+        }
+    }
+
+    private func startRequest(id: UUID) {
+        self.activeRequestID = id
         self.isProcessing = true
         self.isInteractionDisabled = true
         self.errorMessage = nil
@@ -483,7 +575,9 @@ final class CommandBarViewModel {
         self.phase = .idle
     }
 
-    private func finishRequest() {
+    private func finishRequest(id: UUID) {
+        guard self.activeRequestID == id else { return }
+        self.activeRequestID = nil
         self.requestTask = nil
         self.isProcessing = false
         self.isInteractionDisabled = false

--- a/Sources/Kaset/ViewModels/LibraryViewModel.swift
+++ b/Sources/Kaset/ViewModels/LibraryViewModel.swift
@@ -13,6 +13,15 @@ import os
 final class LibraryMutationBroadcaster {
     static let shared = LibraryMutationBroadcaster()
 
+    struct PlaylistRemovalReceipt {
+        fileprivate struct Target {
+            let viewModel: LibraryViewModel
+            let playlistRevision: UInt64
+        }
+
+        fileprivate let targets: [Target]
+    }
+
     private final class WeakLibraryViewModelBox {
         weak var value: LibraryViewModel?
 
@@ -80,10 +89,31 @@ final class LibraryMutationBroadcaster {
         }
     }
 
-    func playlistRemoved(playlistId: String) {
-        for libraryViewModel in self.activeLibraryViewModels {
+    @discardableResult
+    func playlistRemoved(playlistId: String) -> PlaylistRemovalReceipt {
+        let activeViewModels = self.activeLibraryViewModels
+        var targets: [PlaylistRemovalReceipt.Target] = []
+        for libraryViewModel in activeViewModels {
+            let wasInLibrary = libraryViewModel.isInLibrary(playlistId: playlistId)
             libraryViewModel.markNeedsReloadOnActivation()
             libraryViewModel.removeFromLibrary(playlistId: playlistId)
+            if wasInLibrary {
+                targets.append(PlaylistRemovalReceipt.Target(
+                    viewModel: libraryViewModel,
+                    playlistRevision: libraryViewModel.playlistMutationRevision(for: playlistId)
+                ))
+            }
+        }
+        return PlaylistRemovalReceipt(targets: targets)
+    }
+
+    func rollbackPlaylistRemoval(_ playlist: Playlist, receipt: PlaylistRemovalReceipt) {
+        for target in receipt.targets {
+            guard target.viewModel.rollbackPlaylistRemoval(
+                playlist,
+                expectedPlaylistRevision: target.playlistRevision
+            ) else { continue }
+            target.viewModel.markNeedsReloadOnActivation()
         }
     }
 
@@ -136,6 +166,11 @@ final class LibraryViewModel {
 
     /// Monotonic revision for local library state mutations.
     private var libraryStateRevision: UInt64 = 0
+    private var playlistMutationRevisionByID: [String: UInt64] = [:]
+
+    func playlistMutationRevision(for playlistId: String) -> UInt64 {
+        self.playlistMutationRevisionByID[LibraryContentIdentity.playlistKey(for: playlistId)] ?? 0
+    }
 
     /// Whether a fresh load should run again after the current in-flight load completes.
     private var needsReloadAfterCurrentLoad = false
@@ -192,6 +227,24 @@ final class LibraryViewModel {
         self.libraryStateRevision &+= 1
     }
 
+    private func markPlaylistStateChanged(_ playlistId: String) {
+        self.markLibraryStateChanged()
+        let playlistKey = LibraryContentIdentity.playlistKey(for: playlistId)
+        self.playlistMutationRevisionByID[playlistKey, default: 0] &+= 1
+    }
+
+    @discardableResult
+    func rollbackPlaylistRemoval(
+        _ playlist: Playlist,
+        expectedPlaylistRevision: UInt64
+    ) -> Bool {
+        guard self.playlistMutationRevision(for: playlist.id) == expectedPlaylistRevision,
+              !self.isInLibrary(playlistId: playlist.id)
+        else { return false }
+        self.addToLibrary(playlist: playlist)
+        return true
+    }
+
     private func applyLibraryContent(_ content: PlaylistParser.LibraryContent) {
         let result = self.contentReconciler.apply(content, currentSnapshot: self.librarySnapshot)
         if result.preservedExistingArtists {
@@ -244,7 +297,7 @@ final class LibraryViewModel {
 
     /// Adds a playlist ID to the library set (called after successful add to library).
     func addToLibrarySet(playlistId: String) {
-        self.markLibraryStateChanged()
+        self.markPlaylistStateChanged(playlistId)
         var snapshot = self.librarySnapshot
         self.contentReconciler.addPlaylistId(playlistId, to: &snapshot)
         self.librarySnapshot = snapshot
@@ -253,14 +306,14 @@ final class LibraryViewModel {
     /// Adds a playlist to the library (called after successful add to library).
     /// Updates both the ID set and the playlists array for immediate UI update.
     func addToLibrary(playlist: Playlist) {
-        self.markLibraryStateChanged()
+        self.markPlaylistStateChanged(playlist.id)
         var snapshot = self.librarySnapshot
         self.contentReconciler.addPlaylist(playlist, to: &snapshot)
         self.librarySnapshot = snapshot
     }
 
     func discardOptimisticPlaylist(playlistId: String) {
-        self.markLibraryStateChanged()
+        self.markPlaylistStateChanged(playlistId)
         var snapshot = self.librarySnapshot
         self.contentReconciler.discardAddedPlaylist(playlistId, from: &snapshot)
         self.librarySnapshot = snapshot
@@ -302,7 +355,7 @@ final class LibraryViewModel {
 
     /// Removes a playlist ID from the library set (called after successful remove from library).
     func removeFromLibrarySet(playlistId: String) {
-        self.markLibraryStateChanged()
+        self.markPlaylistStateChanged(playlistId)
         var snapshot = self.librarySnapshot
         self.contentReconciler.removePlaylistId(playlistId, from: &snapshot)
         self.librarySnapshot = snapshot
@@ -311,7 +364,7 @@ final class LibraryViewModel {
     /// Removes a playlist from the library (called after successful remove from library).
     /// Updates both the ID set and the playlists array for immediate UI update.
     func removeFromLibrary(playlistId: String) {
-        self.markLibraryStateChanged()
+        self.markPlaylistStateChanged(playlistId)
         var snapshot = self.librarySnapshot
         self.contentReconciler.removePlaylist(playlistId, from: &snapshot)
         self.librarySnapshot = snapshot

--- a/Sources/Kaset/ViewModels/LibraryViewModel.swift
+++ b/Sources/Kaset/ViewModels/LibraryViewModel.swift
@@ -46,12 +46,36 @@ final class LibraryMutationBroadcaster {
         }
     }
 
-    func reconcileCreatedPlaylist(_ playlist: Playlist) async {
+    @discardableResult
+    func reconcileCreatedPlaylist(
+        _ playlist: Playlist,
+        whileValid isCurrent: () -> Bool = { true }
+    ) async -> Bool {
         for libraryViewModel in self.activeLibraryViewModels {
+            guard isCurrent() else {
+                self.discardCreatedPlaylist(playlist)
+                return false
+            }
             await libraryViewModel.refresh()
+            guard isCurrent() else {
+                self.discardCreatedPlaylist(playlist)
+                return false
+            }
             if !libraryViewModel.isInLibrary(playlistId: playlist.id) {
                 libraryViewModel.addToLibrary(playlist: playlist)
             }
+            libraryViewModel.markNeedsReloadOnActivation()
+        }
+        guard isCurrent() else {
+            self.discardCreatedPlaylist(playlist)
+            return false
+        }
+        return true
+    }
+
+    func discardCreatedPlaylist(_ playlist: Playlist) {
+        for libraryViewModel in self.activeLibraryViewModels {
+            libraryViewModel.discardOptimisticPlaylist(playlistId: playlist.id)
             libraryViewModel.markNeedsReloadOnActivation()
         }
     }
@@ -232,6 +256,13 @@ final class LibraryViewModel {
         self.markLibraryStateChanged()
         var snapshot = self.librarySnapshot
         self.contentReconciler.addPlaylist(playlist, to: &snapshot)
+        self.librarySnapshot = snapshot
+    }
+
+    func discardOptimisticPlaylist(playlistId: String) {
+        self.markLibraryStateChanged()
+        var snapshot = self.librarySnapshot
+        self.contentReconciler.discardAddedPlaylist(playlistId, from: &snapshot)
         self.librarySnapshot = snapshot
     }
 

--- a/Sources/Kaset/Views/ArtistDetailView.swift
+++ b/Sources/Kaset/Views/ArtistDetailView.swift
@@ -186,8 +186,9 @@ struct ArtistDetailView: View { // swiftlint:disable:this type_body_length
                     if detail.profileKind == .artist {
                         // Shuffle button - shuffles all artist's songs (fetches if needed)
                         Button {
+                            let intent = self.playerService.beginMusicPlaybackIntent()
                             Task {
-                                await self.shuffleAllSongs()
+                                await self.shuffleAllSongs(intent: intent)
                             }
                         } label: {
                             Label("Shuffle", systemImage: "shuffle")
@@ -330,13 +331,7 @@ struct ArtistDetailView: View { // swiftlint:disable:this type_body_length
     private func topSongRow(_ song: Song, index: Int) -> some View {
         HoverObservingRow { isHovered in
             Button {
-                // Fetch all songs and play as queue starting from the selected song
-                Task {
-                    let allSongs = await self.viewModel.getAllSongs()
-                    // Find the index of the selected song in the full list
-                    let startIndex = allSongs.firstIndex(where: { $0.videoId == song.videoId }) ?? index
-                    await self.playerService.playQueue(allSongs, startingAt: startIndex)
-                }
+                self.playTopSong(song, displayedIndex: index)
             } label: {
                 HStack(spacing: 12) {
                     // Thumbnail
@@ -390,11 +385,7 @@ struct ArtistDetailView: View { // swiftlint:disable:this type_body_length
         }
         .contextMenu {
             Button {
-                Task {
-                    let allSongs = await self.viewModel.getAllSongs()
-                    let startIndex = allSongs.firstIndex(where: { $0.videoId == song.videoId }) ?? index
-                    await self.playerService.playQueue(allSongs, startingAt: startIndex)
-                }
+                self.playTopSong(song, displayedIndex: index)
             } label: {
                 Label("Play", systemImage: "play.fill")
             }
@@ -451,6 +442,33 @@ struct ArtistDetailView: View { // swiftlint:disable:this type_body_length
                     Label("Go to Album", systemImage: "square.stack")
                 }
             }
+        }
+    }
+
+    private func playTopSong(_ song: Song, displayedIndex: Int) {
+        let intent = self.playerService.beginMusicPlaybackIntent()
+        let exactOrdinal = self.viewModel.displayedSongs
+            .prefix(displayedIndex)
+            .count(where: { $0.id == song.id && $0.videoId == song.videoId })
+        let videoOrdinal = self.viewModel.displayedSongs
+            .prefix(displayedIndex)
+            .count(where: { $0.videoId == song.videoId })
+        Task {
+            let allSongs = await self.viewModel.getAllSongs()
+            guard self.playerService.acceptsMusicPlaybackIntent(intent) else { return }
+            let exactMatches = allSongs.indices.filter {
+                allSongs[$0].id == song.id && allSongs[$0].videoId == song.videoId
+            }
+            let videoMatches = allSongs.indices.filter { allSongs[$0].videoId == song.videoId }
+            let startIndex = exactMatches[safe: exactOrdinal]
+                ?? videoMatches[safe: videoOrdinal]
+                ?? (allSongs.indices.contains(displayedIndex) ? displayedIndex : 0)
+            await self.playerService.playQueue(
+                allSongs,
+                startingAt: startIndex,
+                deferringSmartShuffleFill: false,
+                intent: intent
+            )
         }
     }
 
@@ -627,24 +645,42 @@ struct ArtistDetailView: View { // swiftlint:disable:this type_body_length
     // MARK: - Actions
 
     private func playMix(playlistId: String, startVideoId: String?) {
+        let intent = self.playerService.beginMusicPlaybackIntent()
         Task {
-            await self.playerService.playWithMix(playlistId: playlistId, startVideoId: startVideoId)
+            await self.playerService.playWithMix(
+                playlistId: playlistId,
+                startVideoId: startVideoId,
+                intent: intent
+            )
         }
     }
 
     private func playAll(_ songs: [Song]) {
         guard !songs.isEmpty else { return }
+        let intent = self.playerService.beginMusicPlaybackIntent()
         Task {
-            await self.playerService.playQueue(songs, startingAt: 0)
+            await self.playerService.playQueue(
+                songs,
+                startingAt: 0,
+                deferringSmartShuffleFill: false,
+                intent: intent
+            )
         }
     }
 
     /// Fetches all artist songs and plays them shuffled.
-    private func shuffleAllSongs() async {
+    private func shuffleAllSongs(intent: MusicPlaybackIntent) async {
         let allSongs = await self.viewModel.getAllSongs()
-        guard !allSongs.isEmpty else { return }
+        guard !allSongs.isEmpty,
+              self.playerService.acceptsMusicPlaybackIntent(intent)
+        else { return }
         let shuffledSongs = allSongs.shuffled()
-        await self.playerService.playQueue(shuffledSongs, startingAt: 0)
+        await self.playerService.playQueue(
+            shuffledSongs,
+            startingAt: 0,
+            deferringSmartShuffleFill: false,
+            intent: intent
+        )
     }
 
     // MARK: - Episodes Section (Latest episodes / live radios)
@@ -658,8 +694,9 @@ struct ArtistDetailView: View { // swiftlint:disable:this type_body_length
             self.sectionHeader(title: "Latest episodes", shelfKind: .episodes)
         } itemContent: { episode in
             Button {
+                let intent = self.playerService.beginMusicPlaybackIntent()
                 Task {
-                    await self.playerService.playEpisode(episode)
+                    await self.playerService.playEpisode(episode, intent: intent)
                 }
             } label: {
                 self.episodeCard(episode)

--- a/Sources/Kaset/Views/LibraryView.swift
+++ b/Sources/Kaset/Views/LibraryView.swift
@@ -353,7 +353,8 @@ struct LibraryView: View {
                     SongActionsHelper.confirmDeletePlaylist(
                         playlist,
                         client: self.viewModel.client,
-                        libraryViewModel: self.viewModel
+                        libraryViewModel: self.viewModel,
+                        playerService: self.playerService
                     )
                 } label: {
                     Label(String(localized: "Delete Playlist…"), systemImage: "trash")

--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -658,6 +658,7 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
         }
         .environment(self.libraryViewModel)
         .environment(\.onPlaylistDeleted) {
+            self.selectedSidebarPinnedItem = nil
             self.navigationSelection = .home
         }
     }

--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -5,7 +5,7 @@ import SwiftUI
 // MARK: - MainWindow
 
 /// Main application window with sidebar navigation and player bar.
-struct MainWindow: View {
+struct MainWindow: View { // swiftlint:disable:this type_body_length
     private struct PresentedWhatsNew: Identifiable {
         let whatsNew: WhatsNew
         let requestedVersion: WhatsNew.Version
@@ -316,9 +316,7 @@ struct MainWindow: View {
             // track/video still loaded under the previous identity must reload to
             // record to the new account. The shared cookie session covers both.
             guard self.accountService.verifiedAccountId != nil else { return }
-            if self.playerService.currentTrack != nil {
-                self.playerService.reloadCurrentTrackForIdentitySwitch()
-            }
+            self.playerService.reloadCurrentTrackForIdentitySwitch()
             if self.youtubePlayerService.currentVideo != nil {
                 self.youtubePlayerService.reloadCurrentVideoForIdentitySwitch()
             }
@@ -537,21 +535,33 @@ struct MainWindow: View {
         Group {
             switch item {
             case .home:
-                if let vm = homeViewModel { HomeView(viewModel: vm) }
+                if let vm = homeViewModel {
+                    HomeView(viewModel: vm)
+                }
             case .explore:
-                if let vm = exploreViewModel { ExploreView(viewModel: vm) }
+                if let vm = exploreViewModel {
+                    ExploreView(viewModel: vm)
+                }
             case .search:
                 if let vm = searchViewModel {
                     SearchView(viewModel: vm, focusTrigger: self.searchFocusTrigger)
                 }
             case .charts:
-                if let vm = chartsViewModel { ChartsView(viewModel: vm) }
+                if let vm = chartsViewModel {
+                    ChartsView(viewModel: vm)
+                }
             case .moodsAndGenres:
-                if let vm = moodsAndGenresViewModel { MoodsAndGenresView(viewModel: vm) }
+                if let vm = moodsAndGenresViewModel {
+                    MoodsAndGenresView(viewModel: vm)
+                }
             case .newReleases:
-                if let vm = newReleasesViewModel { NewReleasesView(viewModel: vm) }
+                if let vm = newReleasesViewModel {
+                    NewReleasesView(viewModel: vm)
+                }
             case .podcasts:
-                if let vm = podcastsViewModel { PodcastsView(viewModel: vm) }
+                if let vm = podcastsViewModel {
+                    PodcastsView(viewModel: vm)
+                }
             case .likedMusic:
                 if self.requiresSignIn(item) {
                     self.signInRequiredView(for: item)

--- a/Sources/Kaset/Views/MiniPlayerViews.swift
+++ b/Sources/Kaset/Views/MiniPlayerViews.swift
@@ -777,7 +777,7 @@ struct MiniPlayerWindow: View { // swiftlint:disable:this type_body_length
                             VStack(alignment: .leading, spacing: 2) {
                                 HStack(spacing: 4) {
                                     Text(song.title)
-                                        .font(.system(size: 9, weight: index == self.playerService.currentIndex ? .semibold : .regular))
+                                        .font(.system(size: 9, weight: index == self.playerService.activePlaybackQueueIndex ? .semibold : .regular))
                                         .lineLimit(1)
                                     if entry.source == .suggested {
                                         Image(systemName: "sparkles")
@@ -796,7 +796,7 @@ struct MiniPlayerWindow: View { // swiftlint:disable:this type_body_length
                         .foregroundStyle(.white.opacity(0.88))
                         .padding(.horizontal, 8)
                         .padding(.vertical, 5)
-                        .background(index == self.playerService.currentIndex ? Color.white.opacity(0.12) : Color.clear, in: .rect(cornerRadius: 10))
+                        .background(index == self.playerService.activePlaybackQueueIndex ? Color.white.opacity(0.12) : Color.clear, in: .rect(cornerRadius: 10))
                     }
                 }
             }

--- a/Sources/Kaset/Views/MiniPlayerWebView+Coordinator.swift
+++ b/Sources/Kaset/Views/MiniPlayerWebView+Coordinator.swift
@@ -635,7 +635,8 @@ private extension SingletonPlayerWebView.Coordinator {
                 self.playerService.updatePlaybackState(
                     isPlaying: isPlaying,
                     progress: Double(progress),
-                    duration: Double(duration)
+                    duration: Double(duration),
+                    observedVideoId: observedVideoId
                 )
             } else if hasReadyMedia, isAd {
                 self.playerService.updatePlaybackTransportState(isPlaying: isPlaying)

--- a/Sources/Kaset/Views/MiniPlayerWebView+Coordinator.swift
+++ b/Sources/Kaset/Views/MiniPlayerWebView+Coordinator.swift
@@ -69,6 +69,10 @@ extension SingletonPlayerWebView {
                 from: body,
                 documentGeneration: messageDocumentGeneration
             )
+            let musicPlaybackIntent = self.playerService.currentMusicPlaybackIntent
+            let eventIssuedAtMilliseconds = SingletonPlayerWebView.finitePlaybackBridgeDouble(
+                from: body["eventIssuedAtMilliseconds"]
+            )
 
             switch type {
             case "TRACK_ENDED":
@@ -76,32 +80,25 @@ extension SingletonPlayerWebView {
                 Task { @MainActor in
                     guard SingletonPlayerWebView.shared.documentGeneration.accepts(
                         generation: messageDocumentGeneration
-                    ), !endedDuringAd else { return }
+                    ), self.playerService.acceptsMusicTerminalBridgeEvent(
+                        intent: musicPlaybackIntent,
+                        eventIssuedAtMilliseconds: eventIssuedAtMilliseconds
+                    ),
+                        !endedDuringAd
+                    else { return }
                     await self.playerService.handleTrackEnded(
                         observedVideoId: observedVideoId,
-                        playbackOccurrence: playbackOccurrence
+                        playbackOccurrence: playbackOccurrence,
+                        intent: musicPlaybackIntent
                     )
                 }
-            case "REMOTE_NEXT":
-                Task { @MainActor in
-                    guard SingletonPlayerWebView.shared.documentGeneration.acceptsUserCommand(
-                        generation: messageDocumentGeneration,
-                        issuedAtMilliseconds: commandIssuedAtMilliseconds,
-                        navigationStartedAtMilliseconds: SingletonPlayerWebView.shared
-                            .documentNavigationStartedAtMilliseconds
-                    ) else { return }
-                    await self.playerService.next()
-                }
-            case "REMOTE_PREVIOUS":
-                Task { @MainActor in
-                    guard SingletonPlayerWebView.shared.documentGeneration.acceptsUserCommand(
-                        generation: messageDocumentGeneration,
-                        issuedAtMilliseconds: commandIssuedAtMilliseconds,
-                        navigationStartedAtMilliseconds: SingletonPlayerWebView.shared
-                            .documentNavigationStartedAtMilliseconds
-                    ) else { return }
-                    await self.playerService.previous()
-                }
+            case "REMOTE_NEXT", "REMOTE_PREVIOUS":
+                self.handleRemoteCommand(
+                    type: type,
+                    documentGeneration: messageDocumentGeneration,
+                    commandIssuedAtMilliseconds: commandIssuedAtMilliseconds,
+                    musicPlaybackIntent: musicPlaybackIntent
+                )
             case "AIRPLAY_STATUS":
                 self.handleAirPlayStatusUpdate(
                     body: body,
@@ -118,11 +115,35 @@ extension SingletonPlayerWebView {
                 self.handleStateUpdate(
                     body: body,
                     observedVideoId: observedVideoId,
-                    documentGeneration: messageDocumentGeneration
+                    documentGeneration: messageDocumentGeneration,
+                    musicPlaybackIntent: musicPlaybackIntent,
+                    eventIssuedAtMilliseconds: eventIssuedAtMilliseconds
                 )
             default:
                 return
             }
+        }
+
+        private func handleRemoteCommand(
+            type: String,
+            documentGeneration: UInt64,
+            commandIssuedAtMilliseconds: Double?,
+            musicPlaybackIntent: MusicPlaybackIntent
+        ) {
+            guard SingletonPlayerWebView.shared.documentGeneration.acceptsUserCommand(
+                generation: documentGeneration,
+                issuedAtMilliseconds: commandIssuedAtMilliseconds,
+                navigationStartedAtMilliseconds: SingletonPlayerWebView.shared
+                    .documentNavigationStartedAtMilliseconds
+            ), self.playerService.acceptsMusicRemoteCommand(
+                intent: musicPlaybackIntent,
+                commandIssuedAtMilliseconds: commandIssuedAtMilliseconds
+            ), let commandIssuedAtMilliseconds
+            else { return }
+            self.playerService.enqueueRemoteMusicTransportCommand(
+                type == "REMOTE_NEXT" ? .next : .previous,
+                issuedAtMilliseconds: commandIssuedAtMilliseconds
+            )
         }
 
         private static func observedVideoId(from body: [String: Any]) -> String? {
@@ -522,7 +543,9 @@ private extension SingletonPlayerWebView.Coordinator {
     private func handleStateUpdate(
         body: [String: Any],
         observedVideoId: String?,
-        documentGeneration: UInt64
+        documentGeneration: UInt64,
+        musicPlaybackIntent: MusicPlaybackIntent,
+        eventIssuedAtMilliseconds: Double?
     ) {
         let isPlaying = body["isPlaying"] as? Bool ?? false
         let progress = SingletonPlayerWebView.finitePlaybackBridgeDouble(from: body["progress"]) ?? 0
@@ -543,7 +566,11 @@ private extension SingletonPlayerWebView.Coordinator {
         Task { @MainActor in
             guard SingletonPlayerWebView.shared.documentGeneration.accepts(
                 generation: documentGeneration
-            ) else { return }
+            ), self.playerService.acceptsMusicBridgeEvent(
+                intent: musicPlaybackIntent,
+                eventIssuedAtMilliseconds: eventIssuedAtMilliseconds
+            ), self.playerService.currentTrack != nil || self.playerService.pendingPlayVideoId != nil
+            else { return }
             if let playbackOccurrence,
                !self.playerService.acceptsWebMusicPlaybackOccurrence(playbackOccurrence)
             {

--- a/Sources/Kaset/Views/MiniPlayerWebView+Coordinator.swift
+++ b/Sources/Kaset/Views/MiniPlayerWebView+Coordinator.swift
@@ -1,0 +1,628 @@
+import Foundation
+import os
+import WebKit
+
+// MARK: - SingletonPlayerWebView.Coordinator
+
+extension SingletonPlayerWebView {
+    nonisolated static func finitePlaybackBridgeDouble(from value: Any?) -> Double? {
+        guard !(value is Bool) else { return nil }
+
+        let decoded: Double? = switch value {
+        case let number as NSNumber:
+            number.doubleValue
+        case let double as Double:
+            double
+        case let float as Float:
+            Double(float)
+        case let integer as Int:
+            Double(integer)
+        default:
+            nil
+        }
+        guard let decoded, decoded.isFinite else { return nil }
+        return decoded
+    }
+
+    // MARK: - Coordinator
+
+    final class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler {
+        let playerService: PlayerService
+
+        init(playerService: PlayerService) {
+            self.playerService = playerService
+        }
+
+        func userContentController(_: WKUserContentController, didReceive message: WKScriptMessage) {
+            let singleton = SingletonPlayerWebView.shared
+            guard let body = message.body as? [String: Any],
+                  let messageDocumentGeneration = WebPlaybackDocumentGeneration.decode(
+                      body["documentGeneration"]
+                  ),
+                  SingletonPlayerWebView.acceptsBridgeSource(
+                      isMainFrame: message.frameInfo.isMainFrame,
+                      sourceScheme: message.frameInfo.securityOrigin.protocol,
+                      sourceHost: message.frameInfo.securityOrigin.host
+                  ),
+                  SingletonPlayerWebView.isCurrentBridgeWebView(
+                      sourceWebView: message.webView,
+                      currentWebView: singleton.webView
+                  ),
+                  let type = body["type"] as? String
+            else { return }
+
+            let isUserCommand = type == "REMOTE_NEXT" || type == "REMOTE_PREVIOUS"
+            let commandIssuedAtMilliseconds = SingletonPlayerWebView.finitePlaybackBridgeDouble(
+                from: body["commandIssuedAtMilliseconds"]
+            )
+            let acceptsGeneration = isUserCommand
+                ? singleton.documentGeneration.acceptsUserCommand(
+                    generation: messageDocumentGeneration,
+                    issuedAtMilliseconds: commandIssuedAtMilliseconds,
+                    navigationStartedAtMilliseconds: singleton.documentNavigationStartedAtMilliseconds
+                )
+                : singleton.documentGeneration.accepts(generation: messageDocumentGeneration)
+            guard acceptsGeneration else { return }
+
+            let observedVideoId = Self.observedVideoId(from: body)
+            let playbackOccurrence = Self.musicPlaybackOccurrence(
+                from: body,
+                documentGeneration: messageDocumentGeneration
+            )
+
+            switch type {
+            case "TRACK_ENDED":
+                let endedDuringAd = body["isAd"] as? Bool ?? false
+                Task { @MainActor in
+                    guard SingletonPlayerWebView.shared.documentGeneration.accepts(
+                        generation: messageDocumentGeneration
+                    ), !endedDuringAd else { return }
+                    await self.playerService.handleTrackEnded(
+                        observedVideoId: observedVideoId,
+                        playbackOccurrence: playbackOccurrence
+                    )
+                }
+            case "REMOTE_NEXT":
+                Task { @MainActor in
+                    guard SingletonPlayerWebView.shared.documentGeneration.acceptsUserCommand(
+                        generation: messageDocumentGeneration,
+                        issuedAtMilliseconds: commandIssuedAtMilliseconds,
+                        navigationStartedAtMilliseconds: SingletonPlayerWebView.shared
+                            .documentNavigationStartedAtMilliseconds
+                    ) else { return }
+                    await self.playerService.next()
+                }
+            case "REMOTE_PREVIOUS":
+                Task { @MainActor in
+                    guard SingletonPlayerWebView.shared.documentGeneration.acceptsUserCommand(
+                        generation: messageDocumentGeneration,
+                        issuedAtMilliseconds: commandIssuedAtMilliseconds,
+                        navigationStartedAtMilliseconds: SingletonPlayerWebView.shared
+                            .documentNavigationStartedAtMilliseconds
+                    ) else { return }
+                    await self.playerService.previous()
+                }
+            case "AIRPLAY_STATUS":
+                self.handleAirPlayStatusUpdate(
+                    body: body,
+                    documentGeneration: messageDocumentGeneration
+                )
+            case "LYRICS_TIME":
+                self.handleLyricsTimeUpdate(
+                    body: body,
+                    documentGeneration: messageDocumentGeneration
+                )
+            case "PLAYBACK_AUDIO_QUALITY_STATS":
+                Self.logAudioQualityStats(body: body, observedVideoId: observedVideoId)
+            case "STATE_UPDATE":
+                self.handleStateUpdate(
+                    body: body,
+                    observedVideoId: observedVideoId,
+                    documentGeneration: messageDocumentGeneration
+                )
+            default:
+                return
+            }
+        }
+
+        private static func observedVideoId(from body: [String: Any]) -> String? {
+            guard let videoId = body["videoId"] as? String, !videoId.isEmpty else { return nil }
+            return videoId
+        }
+
+        private static func musicPlaybackOccurrence(
+            from body: [String: Any],
+            documentGeneration: UInt64
+        ) -> MusicPlaybackOccurrence? {
+            guard let mediaGeneration = WebPlaybackDocumentGeneration.decode(body["mediaGeneration"]),
+                  mediaGeneration > 0
+            else {
+                return nil
+            }
+            return .web(
+                documentGeneration: documentGeneration,
+                mediaGeneration: mediaGeneration,
+                nativeGeneration: WebPlaybackDocumentGeneration.decode(
+                    body["nativePlaybackGeneration"]
+                ) ?? 0,
+                videoId: Self.observedVideoId(from: body)
+            )
+        }
+
+        private func handleAirPlayStatusUpdate(
+            body: [String: Any],
+            documentGeneration: UInt64
+        ) {
+            let isConnected = body["isConnected"] as? Bool ?? false
+            let wasRequested = body["wasRequested"] as? Bool ?? false
+
+            Task { @MainActor in
+                guard SingletonPlayerWebView.shared.documentGeneration.accepts(
+                    generation: documentGeneration
+                ) else { return }
+                self.playerService.updateAirPlayStatus(
+                    isConnected: isConnected,
+                    wasRequested: wasRequested
+                )
+            }
+        }
+
+        private func handleLyricsTimeUpdate(
+            body: [String: Any],
+            documentGeneration: UInt64
+        ) {
+            guard let time = body["time"] as? Double,
+                  body["isAd"] as? Bool != true
+            else { return }
+
+            Task { @MainActor in
+                guard SingletonPlayerWebView.shared.documentGeneration.accepts(
+                    generation: documentGeneration
+                ) else { return }
+                self.playerService.currentTimeMs = Int(time * 1000)
+            }
+        }
+
+        private static func likeStatus(from rawValue: String?) -> LikeStatus {
+            switch rawValue {
+            case "LIKE":
+                .like
+            case "DISLIKE":
+                .dislike
+            default:
+                .indifferent
+            }
+        }
+
+        private static let allowedAudioQualityStatsKeys: Set<String> = [
+            "afmt",
+            "audioBitrate",
+            "audioCodec",
+            "audioCodecs",
+            "audioFormat",
+            "audioItag",
+            "audioMimeType",
+            "audioQuality",
+            "audio_format",
+            "bitrate",
+            "codec",
+            "codecs",
+            "debug_audioFormat",
+            "debug_audioQuality",
+            "debug_playbackQuality",
+            "itag",
+            "mimeType",
+            "quality",
+        ]
+
+        private static let allowedAudioQualityStatsFragments: Set<String> = [
+            "bitrate",
+            "codec",
+            "format",
+            "itag",
+            "mime",
+            "quality",
+        ]
+
+        private static func logAudioQualityStats(body: [String: Any], observedVideoId: String?) {
+            let message = Self.audioQualityStatsLogMessage(body: body, observedVideoId: observedVideoId)
+            DiagnosticsLogger.player.info("Audio quality stats: \(message, privacy: .private)")
+        }
+
+        static func audioQualityStatsLogMessage(body: [String: Any], observedVideoId: String?) -> String {
+            let preferred = Self.sanitizedLogString(body["preferred"])
+            let desired = Self.sanitizedLogString(body["desired"])
+            let applied = (body["applied"] as? Bool) == true ? "true" : "false"
+            let observed = Self.sanitizedLogString(body["observed"])
+            let source = Self.sanitizedLogString(body["source"])
+            let videoId = Self.sanitizedLogString(observedVideoId, fallback: "unknown")
+            let available = Self.compactJSONText(
+                Self.sanitizedPrimitiveArray(body["available"]) ?? [],
+                fallback: "[]"
+            )
+            let stats = Self.compactJSONText(Self.sanitizedStatsForNerds(body["stats"]), fallback: "{}")
+
+            return """
+            preferred=\(preferred) desired=\(desired) applied=\(applied) observed=\(observed) \
+            source=\(source) videoId=\(videoId) available=\(available) stats=\(stats)
+            """
+        }
+
+        private static func sanitizedLogString(_ value: Any?, fallback: String = "unknown") -> String {
+            guard let value else { return fallback }
+
+            let string: String = if let stringValue = value as? String {
+                stringValue
+            } else {
+                String(describing: value)
+            }
+
+            let flattened = string
+                .replacingOccurrences(of: "\n", with: " ")
+                .replacingOccurrences(of: "\r", with: " ")
+                .replacingOccurrences(of: "\t", with: " ")
+
+            guard !flattened.isEmpty else { return fallback }
+            return String(flattened.prefix(200))
+        }
+
+        private static func compactJSONText(_ value: Any, fallback: String) -> String {
+            guard JSONSerialization.isValidJSONObject(value),
+                  let data = try? JSONSerialization.data(withJSONObject: value, options: [.sortedKeys]),
+                  let text = String(data: data, encoding: .utf8)
+            else {
+                return fallback
+            }
+
+            return text
+        }
+
+        private static func sanitizedStatsForNerds(_ value: Any?) -> [String: Any] {
+            guard let value = value as? [String: Any] else { return [:] }
+
+            var sanitized: [String: Any] = [:]
+            for key in value.keys.sorted() where sanitized.count < 12 {
+                guard Self.isAllowedAudioQualityStatsKey(key) else { continue }
+
+                let sanitizedKey = String(key.prefix(80))
+                if let primitive = Self.sanitizedPrimitive(value[key]) {
+                    sanitized[sanitizedKey] = primitive
+                    continue
+                }
+
+                if let primitiveArray = Self.sanitizedPrimitiveArray(value[key]) {
+                    sanitized[sanitizedKey] = primitiveArray
+                }
+            }
+
+            return sanitized
+        }
+
+        private static func isAllowedAudioQualityStatsKey(_ key: String) -> Bool {
+            if self.allowedAudioQualityStatsKeys.contains(key) {
+                return true
+            }
+
+            let lowercasedKey = key.lowercased()
+            return lowercasedKey.contains("audio")
+                && Self.allowedAudioQualityStatsFragments.contains { lowercasedKey.contains($0) }
+        }
+
+        private static func sanitizedPrimitiveArray(_ value: Any?) -> [Any]? {
+            guard let values = value as? [Any] else { return nil }
+
+            let sanitized = values.prefix(12).compactMap { Self.sanitizedPrimitive($0) }
+            return sanitized.isEmpty ? nil : sanitized
+        }
+
+        private static func sanitizedPrimitive(_ value: Any?) -> Any? {
+            guard let value else { return nil }
+
+            if let value = value as? String {
+                return String(value.prefix(160))
+            }
+
+            if let value = value as? Bool {
+                return value
+            }
+
+            return Self.sanitizedNumericPrimitive(value)
+        }
+
+        private static func sanitizedNumericPrimitive(_ value: Any) -> Any? {
+            if let value = value as? Int {
+                return value
+            }
+
+            if let value = value as? Int8 {
+                return value
+            }
+
+            if let value = value as? Int16 {
+                return value
+            }
+
+            if let value = value as? Int32 {
+                return value
+            }
+
+            if let value = value as? Int64 {
+                return value
+            }
+
+            if let value = value as? UInt {
+                return value
+            }
+
+            if let value = value as? UInt8 {
+                return value
+            }
+
+            if let value = value as? UInt16 {
+                return value
+            }
+
+            if let value = value as? UInt32 {
+                return value
+            }
+
+            if let value = value as? UInt64 {
+                return value
+            }
+
+            if let value = value as? Double {
+                return value.isFinite ? value : nil
+            }
+
+            if let value = value as? Float {
+                return value.isFinite ? Double(value) : nil
+            }
+
+            if let value = value as? NSNumber {
+                return value.doubleValue.isFinite ? value : nil
+            }
+
+            return nil
+        }
+
+        func webView(
+            _ webView: WKWebView,
+            decidePolicyFor navigationAction: WKNavigationAction,
+            decisionHandler: @escaping @MainActor (WKNavigationActionPolicy) -> Void
+        ) {
+            SingletonPlayerWebView.shared.decideNavigationPolicy(
+                webView: webView,
+                navigationAction: navigationAction,
+                decisionHandler: decisionHandler
+            )
+        }
+
+        func webView(
+            _: WKWebView,
+            decidePolicyFor navigationResponse: WKNavigationResponse,
+            decisionHandler: @escaping @MainActor (WKNavigationResponsePolicy) -> Void
+        ) {
+            guard navigationResponse.isForMainFrame else {
+                decisionHandler(.allow)
+                return
+            }
+            let singleton = SingletonPlayerWebView.shared
+            let isAllowed = SingletonPlayerWebView.acceptsMainFrameResponse(
+                navigationResponse.response,
+                expectedVideoID: singleton.currentVideoId,
+                documentGeneration: singleton.documentGeneration
+            )
+            if isAllowed {
+                singleton.recordAcceptedMainFrameResponse(navigationResponse.response)
+            }
+            decisionHandler(isAllowed ? .allow : .cancel)
+        }
+
+        func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+            SingletonPlayerWebView.shared.handleDocumentNavigationStart(navigation, webView: webView)
+        }
+
+        func webView(_ webView: WKWebView, didReceiveServerRedirectForProvisionalNavigation navigation: WKNavigation!) {
+            SingletonPlayerWebView.shared.handleDocumentNavigationRedirect(navigation, webView: webView)
+        }
+
+        func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
+            SingletonPlayerWebView.shared.commitDocumentNavigation(navigation, webView: webView)
+        }
+
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            guard SingletonPlayerWebView.shared.handleDocumentNavigationFinish(
+                navigation,
+                webView: webView
+            ) else {
+                SingletonPlayerWebView.shared.webKitManager?.extensionHostWebViewDidFailNavigation(webView)
+                return
+            }
+            guard WebPlaybackDocumentGeneration.isExpectedPlaybackURL(
+                webView.url,
+                host: "music.youtube.com"
+            ) else { return }
+            SingletonPlayerWebView.shared.syncAutoplayIntent(on: webView)
+            DiagnosticsLogger.player.info(
+                "Singleton WebView finished loading: \(webView.url?.absoluteString ?? "nil")"
+            )
+
+            // Apply the current volume when page finishes loading
+            // This is critical because YouTube may set its own default volume
+            let savedVolume = self.playerService.volume
+            let applyVolumeScript = """
+                (function() {
+                    try {
+                        const volume = \(savedVolume);
+                        window.__kasetTargetVolume = volume;
+                        window.__kasetIsSettingVolume = true;
+
+                        const video = document.querySelector('video');
+                        if (video) {
+                            video.volume = volume;
+                        }
+
+                        // Sync YouTube's internal player APIs if ready
+                        const ytVolume = Math.round(volume * 100);
+                        const player = document.querySelector('ytmusic-player');
+                        if (player && player.playerApi && typeof player.playerApi.setVolume === 'function') {
+                            player.playerApi.setVolume(ytVolume);
+                        }
+                        const moviePlayer = document.getElementById('movie_player');
+                        if (moviePlayer && typeof moviePlayer.setVolume === 'function') {
+                            moviePlayer.setVolume(ytVolume);
+                        }
+
+                        setTimeout(() => { window.__kasetIsSettingVolume = false; }, 100);
+                        return video ? 'applied' : 'no-video-yet';
+                    } catch (e) {
+                         return 'error: ' + e;
+                    }
+                })();
+            """
+            webView.evaluateJavaScript(applyVolumeScript) { result, error in
+                if let error {
+                    DiagnosticsLogger.player.error(
+                        "Failed to apply saved volume \(savedVolume): \(error.localizedDescription)"
+                    )
+                } else if let resultString = result as? String {
+                    DiagnosticsLogger.player.debug("Volume apply result: \(resultString)")
+                }
+
+                // Restore lyrics high-frequency polling if it was active
+                if SingletonPlayerWebView.shared.isLyricsPollActive {
+                    SingletonPlayerWebView.shared.startLyricsPoll()
+                }
+
+                // Re-inject video mode CSS if it was active
+                if SingletonPlayerWebView.shared.displayMode == .video {
+                    SingletonPlayerWebView.shared.refreshVideoModeCSS()
+                    // If refresh fails to find the container (because it's a new page),
+                    // it will log a debug message. We should also call the full injection.
+                    SingletonPlayerWebView.shared.injectVideoModeCSS()
+                }
+            }
+        }
+
+        func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+            SingletonPlayerWebView.shared.handleDocumentNavigationFailure(navigation, webView: webView, error: error)
+        }
+
+        func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+            SingletonPlayerWebView.shared.handleDocumentNavigationFailure(navigation, webView: webView, error: error)
+        }
+
+        func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+            SingletonPlayerWebView.shared.recoverFromContentProcessTermination(webView: webView)
+        }
+    }
+}
+
+private extension SingletonPlayerWebView.Coordinator {
+    private func handleStateUpdate(
+        body: [String: Any],
+        observedVideoId: String?,
+        documentGeneration: UInt64
+    ) {
+        let isPlaying = body["isPlaying"] as? Bool ?? false
+        let progress = SingletonPlayerWebView.finitePlaybackBridgeDouble(from: body["progress"]) ?? 0
+        let duration = SingletonPlayerWebView.finitePlaybackBridgeDouble(from: body["duration"]) ?? 0
+        let isAd = body["isAd"] as? Bool ?? false
+        let hasReadyMedia = body["hasReadyMedia"] as? Bool ?? false
+        let title = body["title"] as? String ?? ""
+        let artist = body["artist"] as? String ?? ""
+        let thumbnailUrl = body["thumbnailUrl"] as? String ?? ""
+        let trackChanged = body["trackChanged"] as? Bool ?? false
+        let likeStatus = Self.likeStatus(from: body["likeStatus"] as? String)
+        let hasVideo = body["hasVideo"] as? Bool ?? false
+        let playbackOccurrence = Self.musicPlaybackOccurrence(
+            from: body,
+            documentGeneration: documentGeneration
+        )
+
+        Task { @MainActor in
+            guard SingletonPlayerWebView.shared.documentGeneration.accepts(
+                generation: documentGeneration
+            ) else { return }
+            if let playbackOccurrence,
+               !self.playerService.acceptsWebMusicPlaybackOccurrence(playbackOccurrence)
+            {
+                return
+            }
+            let currentPlaybackOccurrence = self.playerService.currentMusicPlaybackOccurrence
+            let terminalPlaybackOccurrence = currentPlaybackOccurrence ?? playbackOccurrence
+            defer {
+                if let playbackOccurrence {
+                    self.playerService.bindWebMusicPlaybackOccurrence(
+                        documentGeneration: documentGeneration,
+                        mediaGeneration: playbackOccurrence.mediaGeneration,
+                        nativeGeneration: playbackOccurrence.nativeGeneration,
+                        videoId: observedVideoId
+                    )
+                }
+            }
+            let isAuthoritativeContent = SingletonPlayerWebView.isAuthoritativePlaybackSample(
+                hasReadyMedia: hasReadyMedia,
+                isShowingAd: isAd
+            )
+            self.playerService.updateAdPlaybackState(
+                isShowingAd: isAd,
+                observedProgress: Double(progress),
+                observedVideoId: observedVideoId,
+                isAuthoritativeContent: isAuthoritativeContent
+            )
+            if isAuthoritativeContent {
+                self.playerService.updatePlaybackState(
+                    isPlaying: isPlaying,
+                    progress: Double(progress),
+                    duration: Double(duration)
+                )
+            } else if hasReadyMedia, isAd {
+                self.playerService.updatePlaybackTransportState(isPlaying: isPlaying)
+                if !isPlaying, self.playerService.shouldResumeReadyAdDuringRestoration {
+                    SingletonPlayerWebView.shared.resumeReadyAdvertisementIfPresent()
+                }
+            }
+
+            // Update video availability
+            self.playerService.updateVideoAvailability(hasVideo: hasVideo)
+
+            // Update like status only when track changes (initial state)
+            if trackChanged {
+                self.playerService.updateLikeStatus(likeStatus)
+            }
+
+            let hasObservedMetadata = observedVideoId != nil || !title.isEmpty
+            // Repeat-one still needs drift recovery, but the normal same-song polling path
+            // should not rewrite `currentTrack` on every observer tick.
+            let repeatOneNeedsReconcile = self.playerService.repeatMode == .one
+                && hasObservedMetadata
+                && (trackChanged
+                    || (observedVideoId != nil && observedVideoId != self.playerService.currentTrack?.videoId)
+                    || (observedVideoId == nil && !title.isEmpty && title != self.playerService.currentTrack?.title))
+            let shouldReconcileMetadata = hasObservedMetadata && (trackChanged || repeatOneNeedsReconcile)
+
+            if shouldReconcileMetadata {
+                self.playerService.updateTrackMetadata(
+                    title: title,
+                    artist: artist,
+                    thumbnailUrl: thumbnailUrl,
+                    videoId: observedVideoId,
+                    playbackOccurrence: terminalPlaybackOccurrence
+                )
+
+                // Close video window on track change, but skip during grace period.
+                // We only close if the videoId actually changed to prevent closing
+                // due to spurious metadata (title/artist) glitches during resize.
+                let videoIdChanged = observedVideoId != nil && observedVideoId != self.playerService.currentTrack?.videoId
+
+                if self.playerService.showVideo, videoIdChanged, !self.playerService.isVideoGracePeriodActive {
+                    DiagnosticsLogger.player.info(
+                        "trackChanged to videoId '\(observedVideoId ?? "unknown")' while video shown - closing video window"
+                    )
+                    self.playerService.showVideo = false
+                }
+            }
+        }
+    }
+}

--- a/Sources/Kaset/Views/MiniPlayerWebView.swift
+++ b/Sources/Kaset/Views/MiniPlayerWebView.swift
@@ -232,6 +232,11 @@ final class SingletonPlayerWebView {
     var coordinator: Coordinator?
     let logger = DiagnosticsLogger.player
     private var loadGeneration = 0
+    private(set) var documentGeneration = WebPlaybackDocumentGeneration()
+    private(set) var documentNavigationStartedAtMilliseconds: Double?
+    private var documentNavigations: [ObjectIdentifier: WebPlaybackTrackedNavigation] = [:]
+    private var cancelledDocumentNavigations: [ObjectIdentifier: UInt64] = [:]
+    private var continuationGenerationsAwaitingStart: Set<UInt64> = []
 
     /// Current display mode for the WebView.
     enum DisplayMode {
@@ -248,6 +253,34 @@ final class SingletonPlayerWebView {
         case preferInPlaceWhenSameVideoId
         /// Same `videoId` as tracked: full `webView.load` (DOM out of sync with Swift). Different id: full load.
         case forceFullPageWhenSameVideoId
+    }
+
+    nonisolated static func acceptsPlaybackRequest(
+        videoId: String,
+        currentVideoId: String?,
+        hasWebView: Bool,
+        strategy: VideoLoadStrategy
+    ) -> Bool {
+        guard hasWebView, videoId == currentVideoId else { return true }
+        return strategy != .standard
+    }
+
+    func acceptsPlaybackRequest(
+        videoId: String,
+        strategy: VideoLoadStrategy
+    ) -> Bool {
+        Self.acceptsPlaybackRequest(
+            videoId: videoId,
+            currentVideoId: self.currentVideoId,
+            hasWebView: self.webView != nil,
+            strategy: strategy
+        )
+    }
+
+    nonisolated static func freshSameIDPlaybackStrategy(
+        isShowingAd: Bool
+    ) -> VideoLoadStrategy {
+        isShowingAd ? .forceFullPageWhenSameVideoId : .preferInPlaceWhenSameVideoId
     }
 
     var displayMode: DisplayMode = .hidden
@@ -300,8 +333,10 @@ final class SingletonPlayerWebView {
 
         self.installUserScripts(
             on: configuration.userContentController,
-            isRestoringPlaybackSession: playerService.isRestoringPlaybackSession,
-            targetVolume: playerService.volume
+            shouldAutoplay: playerService.shouldAutoplayPlaybackDocument,
+            targetVolume: playerService.volume,
+            documentGeneration: Self.userScriptDocumentGeneration(from: self.documentGeneration),
+            nativePlaybackGeneration: playerService.currentNativeMusicPlaybackGeneration
         )
 
         let newWebView = WKWebView(frame: .zero, configuration: configuration)
@@ -355,16 +390,20 @@ final class SingletonPlayerWebView {
 
     /// Stops playback, blanks the page, and detaches the persistent music WebView.
     func tearDown() {
+        let blankURL = self.beginBlankDocumentNavigation()
         guard let webView else { return }
         self.logger.info("Tearing down singleton music WebView")
         self.loadGeneration += 1
         self.currentVideoId = nil
         webView.evaluateJavaScript("document.querySelector('video')?.pause()", completionHandler: nil)
-        webView.loadHTMLString("", baseURL: nil)
+        if let blankURL {
+            webView.load(URLRequest(url: blankURL))
+        }
         webView.removeFromSuperview()
         self.webKitManager?.extensionHostWebViewDidDeactivate(role: .musicPlayer)
         self.webView = nil
         self.coordinator = nil
+        self.cancelledDocumentNavigations.removeAll()
         self.currentContainer = nil
         self.usesCookieFreeDataStore = nil
     }
@@ -426,20 +465,26 @@ final class SingletonPlayerWebView {
             self.logger.info("Loading video: \(videoId) (was: \(previousVideoId ?? "none"))")
         }
 
+        self.cancelActiveDocumentNavigation(on: webView)
+
         // Update currentVideoId immediately to prevent duplicate loads
         self.currentVideoId = videoId
         self.loadGeneration &+= 1
-        let generation = self.loadGeneration
+        self.documentNavigationStartedAtMilliseconds = Date().timeIntervalSince1970 * 1000
+        let reservedDocumentGeneration = self.documentGeneration.beginNavigation()
 
         // Get current volume from PlayerService via coordinator
         let currentVolume = self.coordinator?.playerService.volume ?? 1.0
-        let isRestoringPlaybackSession = self.coordinator?.playerService.isRestoringPlaybackSession ?? false
+        let shouldAutoplay = self.coordinator?.playerService.shouldAutoplayPlaybackDocument ?? false
         self.logger.info("Will apply volume \(currentVolume) after page load")
 
         self.installUserScripts(
             on: webView.configuration.userContentController,
-            isRestoringPlaybackSession: isRestoringPlaybackSession,
-            targetVolume: currentVolume
+            shouldAutoplay: shouldAutoplay,
+            targetVolume: currentVolume,
+            documentGeneration: reservedDocumentGeneration,
+            nativePlaybackGeneration: self.coordinator?.playerService
+                .currentNativeMusicPlaybackGeneration ?? 0
         )
 
         // Stop current playback first, then load new video. For a forced
@@ -447,37 +492,69 @@ final class SingletonPlayerWebView {
         // OLD <video>: the navigation tears it down anyway, and the pause event
         // would emit a stale STATE_UPDATE from the outgoing page that can be
         // mis-reconciled against a restored session before the new document loads.
-        let urlToLoad = URL(string: "https://music.youtube.com/watch?v=\(videoId)")!
-        let skipPrenavPause = (strategy == .forceFullPageWhenSameVideoId && videoId == previousVideoId)
-        if skipPrenavPause {
-            webView.evaluateJavaScript("window.__kasetTargetVolume = \(currentVolume);", completionHandler: nil)
-            webView.load(URLRequest(url: urlToLoad))
+        guard let urlToLoad = Self.playbackURL(
+            videoId: videoId,
+            documentGeneration: reservedDocumentGeneration
+        ) else {
+            self.handlePendingDocumentNavigationFailure(webView: webView)
             return
         }
-        let prenavScript = "document.querySelector('video')?.pause();"
-        webView.evaluateJavaScript("\(prenavScript)void 0;") { [weak self] _, _ in
-            guard let self, let webView = self.webView else { return }
-            guard self.loadGeneration == generation, self.currentVideoId == videoId else { return }
+        let prenavScript = """
+            window.__kasetAutoplayPending = false;
+            window.__kasetAutoplayAttempts = 0;
+            window.__kasetAutoplayRetryScheduled = false;
+            \(WebPlaybackDocumentGeneration.mediaSuppressionScript)
+        """
+        // Submit suppression best-effort, but never wait for its callback. During
+        // rapid replacements a provisional WebContent process can defer an eval
+        // completion for seconds; the generation gate already rejects every
+        // outgoing observation, while starting the new navigation tears down its
+        // media promptly.
+        webView.evaluateJavaScript("\(prenavScript)void 0;", completionHandler: nil)
 
-            // Keep the current page's target volume fresh until the new document
-            // finishes loading and gets the same value from didFinish.
-            let prepareScript = "window.__kasetTargetVolume = \(currentVolume);"
-            webView.evaluateJavaScript(prepareScript, completionHandler: nil)
-
-            webView.load(URLRequest(url: urlToLoad))
-        }
+        // Keep the current page's target volume fresh until the new document
+        // gets the same value from its document-start bootstrap.
+        webView.evaluateJavaScript(
+            "window.__kasetTargetVolume = \(currentVolume);",
+            completionHandler: nil
+        )
+        self.startDocumentNavigation(
+            on: webView,
+            request: URLRequest(url: urlToLoad),
+            generation: reservedDocumentGeneration
+        )
     }
 
     /// Returns the JS snippet that hands the autoplay intent to the freshly loaded
     /// page's window. Restored sessions suppress autoplay so the reconcile path
     /// resumes at the saved seek rather than at 0s.
     nonisolated static func autoplayIntentScript(isRestoringPlaybackSession: Bool) -> String {
-        "window.__kasetAutoplayPending = \(isRestoringPlaybackSession ? "false" : "true");"
+        self.autoplayIntentScript(shouldAutoplay: !isRestoringPlaybackSession)
+    }
+
+    nonisolated static func autoplayIntentScript(shouldAutoplay: Bool) -> String {
+        "window.__kasetAutoplayPending = \(shouldAutoplay ? "true" : "false");"
     }
 
     nonisolated static func pageBootstrapScript(
         isRestoringPlaybackSession: Bool,
-        targetVolume: Double
+        targetVolume: Double,
+        documentGeneration: UInt64,
+        nativePlaybackGeneration: UInt64 = 0
+    ) -> String {
+        self.pageBootstrapScript(
+            shouldAutoplay: !isRestoringPlaybackSession,
+            targetVolume: targetVolume,
+            documentGeneration: documentGeneration,
+            nativePlaybackGeneration: nativePlaybackGeneration
+        )
+    }
+
+    nonisolated static func pageBootstrapScript(
+        shouldAutoplay: Bool,
+        targetVolume: Double,
+        documentGeneration _: UInt64,
+        nativePlaybackGeneration: UInt64 = 0
     ) -> String {
         let clampedVolume = if targetVolume.isFinite {
             min(max(targetVolume, 0), 1)
@@ -486,15 +563,62 @@ final class SingletonPlayerWebView {
         }
 
         return """
-            \(Self.autoplayIntentScript(isRestoringPlaybackSession: isRestoringPlaybackSession))
+            (function() {
+                try {
+                    const queryGeneration = new URLSearchParams(window.location.search)
+                        .get('\(WebPlaybackDocumentGeneration.urlQueryKey)');
+                    const fragmentGeneration = new URLSearchParams(
+                        window.location.hash.replace(/^#/, '')
+                    ).get('\(WebPlaybackDocumentGeneration.urlQueryKey)');
+                    const rawGeneration = queryGeneration || fragmentGeneration;
+                    const parsedGeneration = rawGeneration === null || rawGeneration === ''
+                        ? Number.NaN
+                        : Number(rawGeneration);
+                    window.__kasetDocumentGeneration =
+                        Number.isSafeInteger(parsedGeneration) && parsedGeneration >= 0
+                            ? parsedGeneration
+                            : -1;
+                } catch (e) {
+                    window.__kasetDocumentGeneration = -1;
+                }
+            })();
+            window.__kasetNativePlaybackGeneration = \(nativePlaybackGeneration);
+            \(Self.autoplayIntentScript(shouldAutoplay: shouldAutoplay))
+            window.__kasetPlaybackSuppressed = \(shouldAutoplay ? "false" : "true");
+            window.__kasetResumeAdOnly = false;
+            if (!window.__kasetPlaybackSuppressionInstalled) {
+                window.__kasetPlaybackSuppressionInstalled = true;
+                document.addEventListener('play', function(event) {
+                    if (!window.__kasetPlaybackSuppressed) return;
+                    const media = event.target;
+                    if (media && typeof media.pause === 'function') media.pause();
+                }, true);
+            }
+            window.__kasetAutoplayAttempts = 0;
+            window.__kasetAutoplayRetryScheduled = false;
             window.__kasetTargetVolume = \(clampedVolume);
         """
     }
 
+    nonisolated static func playbackURL(videoId: String, documentGeneration: UInt64) -> URL? {
+        var components = URLComponents(string: "https://music.youtube.com/watch")
+        components?.queryItems = [
+            URLQueryItem(name: "v", value: videoId),
+            URLQueryItem(
+                name: WebPlaybackDocumentGeneration.urlQueryKey,
+                value: String(documentGeneration)
+            ),
+        ]
+        components?.fragment = "\(WebPlaybackDocumentGeneration.urlQueryKey)=\(documentGeneration)"
+        return components?.url
+    }
+
     private func installUserScripts(
         on contentController: WKUserContentController,
-        isRestoringPlaybackSession: Bool,
-        targetVolume: Double
+        shouldAutoplay: Bool,
+        targetVolume: Double,
+        documentGeneration: UInt64,
+        nativePlaybackGeneration: UInt64
     ) {
         contentController.removeAllUserScripts()
 
@@ -502,8 +626,10 @@ final class SingletonPlayerWebView {
         // `didFinish` is too late on fast or cached player loads.
         let pageBootstrapScript = WKUserScript(
             source: Self.pageBootstrapScript(
-                isRestoringPlaybackSession: isRestoringPlaybackSession,
-                targetVolume: targetVolume
+                shouldAutoplay: shouldAutoplay,
+                targetVolume: targetVolume,
+                documentGeneration: documentGeneration,
+                nativePlaybackGeneration: nativePlaybackGeneration
             ),
             injectionTime: .atDocumentStart,
             forMainFrameOnly: true
@@ -554,453 +680,677 @@ final class SingletonPlayerWebView {
         guard let webView else { return }
 
         let currentVolume = self.coordinator?.playerService.volume ?? 1.0
-        let isRestoringPlaybackSession = self.coordinator?.playerService.isRestoringPlaybackSession ?? false
+        let shouldAutoplay = self.coordinator?.playerService.shouldAutoplayPlaybackDocument ?? false
         self.installUserScripts(
             on: webView.configuration.userContentController,
-            isRestoringPlaybackSession: isRestoringPlaybackSession,
-            targetVolume: currentVolume
+            shouldAutoplay: shouldAutoplay,
+            targetVolume: currentVolume,
+            documentGeneration: Self.userScriptDocumentGeneration(from: self.documentGeneration),
+            nativePlaybackGeneration: self.coordinator?.playerService
+                .currentNativeMusicPlaybackGeneration ?? 0
         )
     }
 
-    // MARK: - Coordinator
+    func setNativePlaybackGeneration(_ generation: UInt64) {
+        self.webView?.evaluateJavaScript(
+            "window.__kasetNativePlaybackGeneration = \(generation);",
+            completionHandler: nil
+        )
+    }
+}
 
-    final class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler {
-        let playerService: PlayerService
+extension SingletonPlayerWebView {
+    struct ContentProcessRecoveryPlan: Equatable {
+        let shouldReload: Bool
+        let pendingSeek: TimeInterval?
+        let shouldAutoResume: Bool
+    }
 
-        init(playerService: PlayerService) {
-            self.playerService = playerService
-        }
+    /// Cancels every outstanding music navigation and makes any surviving
+    /// document inert. Used by explicit stop so a late commit/canplay callback
+    /// cannot resurrect playback after native state has been cleared.
+    func cancelPendingPlayback() async {
+        self.loadGeneration &+= 1
+        self.invalidateDocumentNavigationState()
+        self.currentVideoId = nil
+        guard let webView else { return }
+        webView.stopLoading()
+        _ = try? await webView.evaluateJavaScript("""
+            window.__kasetAutoplayPending = false;
+            window.__kasetAutoplayAttempts = 0;
+            window.__kasetAutoplayRetryScheduled = false;
+            \(WebPlaybackDocumentGeneration.mediaSuppressionScript)
+        """)
+    }
 
-        func userContentController(_: WKUserContentController, didReceive message: WKScriptMessage) {
-            guard let body = message.body as? [String: Any],
-                  let type = body["type"] as? String
-            else { return }
+    nonisolated static func userScriptDocumentGeneration(
+        from documentGeneration: WebPlaybackDocumentGeneration
+    ) -> UInt64 {
+        documentGeneration.userScriptGeneration
+    }
 
-            let observedVideoId = Self.observedVideoId(from: body)
+    nonisolated static func acceptsBridgeMessage(
+        sourceWebView: AnyObject?,
+        currentWebView: AnyObject?,
+        documentGeneration: WebPlaybackDocumentGeneration,
+        rawDocumentGeneration: Any?
+    ) -> Bool {
+        guard let sourceWebView,
+              let currentWebView,
+              sourceWebView === currentWebView
+        else { return false }
+        return documentGeneration.accepts(rawGeneration: rawDocumentGeneration)
+    }
 
-            switch type {
-            case "TRACK_ENDED":
-                Task { @MainActor in
-                    await self.playerService.handleTrackEnded(observedVideoId: observedVideoId)
-                }
-            case "REMOTE_NEXT":
-                Task { @MainActor in
-                    await self.playerService.next()
-                }
-            case "REMOTE_PREVIOUS":
-                Task { @MainActor in
-                    await self.playerService.previous()
-                }
-            case "AIRPLAY_STATUS":
-                self.handleAirPlayStatusUpdate(body: body)
-            case "LYRICS_TIME":
-                self.handleLyricsTimeUpdate(body: body)
-            case "PLAYBACK_AUDIO_QUALITY_STATS":
-                Self.logAudioQualityStats(body: body, observedVideoId: observedVideoId)
-            case "STATE_UPDATE":
-                self.handleStateUpdate(body: body, observedVideoId: observedVideoId)
-            default:
-                return
-            }
-        }
+    nonisolated static func isCurrentBridgeWebView(
+        sourceWebView: AnyObject?,
+        currentWebView: AnyObject?
+    ) -> Bool {
+        guard let sourceWebView, let currentWebView else { return false }
+        return sourceWebView === currentWebView
+    }
 
-        private static func observedVideoId(from body: [String: Any]) -> String? {
-            guard let videoId = body["videoId"] as? String, !videoId.isEmpty else { return nil }
-            return videoId
-        }
+    nonisolated static func acceptsBridgeSource(
+        isMainFrame: Bool,
+        sourceScheme: String,
+        sourceHost: String
+    ) -> Bool {
+        isMainFrame && sourceScheme == "https" && sourceHost == "music.youtube.com"
+    }
 
-        private func handleAirPlayStatusUpdate(body: [String: Any]) {
-            let isConnected = body["isConnected"] as? Bool ?? false
-            let wasRequested = body["wasRequested"] as? Bool ?? false
+    nonisolated static func acceptsMainFrameResponse(
+        _ response: URLResponse,
+        expectedVideoID: String?,
+        documentGeneration: WebPlaybackDocumentGeneration
+    ) -> Bool {
+        WebPlaybackDocumentGeneration.acceptsMainFrameResponse(
+            response,
+            expectedHost: "music.youtube.com",
+            expectedVideoID: expectedVideoID,
+            allowsInternalBlank: documentGeneration.ownsBlankNavigation(response.url)
+        )
+    }
 
-            Task { @MainActor in
-                self.playerService.updateAirPlayStatus(
-                    isConnected: isConnected,
-                    wasRequested: wasRequested
-                )
-            }
-        }
+    nonisolated static func isAuthoritativePlaybackSample(
+        hasReadyMedia: Bool,
+        isShowingAd: Bool
+    ) -> Bool {
+        hasReadyMedia && !isShowingAd
+    }
 
-        private func handleLyricsTimeUpdate(body: [String: Any]) {
-            guard let time = body["time"] as? Double else { return }
-
-            Task { @MainActor in
-                self.playerService.currentTimeMs = Int(time * 1000)
-            }
-        }
-
-        private func handleStateUpdate(body: [String: Any], observedVideoId: String?) {
-            let isPlaying = body["isPlaying"] as? Bool ?? false
-            let progress = body["progress"] as? Int ?? 0
-            let duration = body["duration"] as? Int ?? 0
-            let title = body["title"] as? String ?? ""
-            let artist = body["artist"] as? String ?? ""
-            let thumbnailUrl = body["thumbnailUrl"] as? String ?? ""
-            let trackChanged = body["trackChanged"] as? Bool ?? false
-            let likeStatus = Self.likeStatus(from: body["likeStatus"] as? String)
-            let hasVideo = body["hasVideo"] as? Bool ?? false
-
-            Task { @MainActor in
-                self.playerService.updatePlaybackState(
-                    isPlaying: isPlaying,
-                    progress: Double(progress),
-                    duration: Double(duration)
-                )
-
-                // Update video availability
-                self.playerService.updateVideoAvailability(hasVideo: hasVideo)
-
-                // Update like status only when track changes (initial state)
-                if trackChanged {
-                    self.playerService.updateLikeStatus(likeStatus)
-                }
-
-                let hasObservedMetadata = observedVideoId != nil || !title.isEmpty
-                // Repeat-one still needs drift recovery, but the normal same-song polling path
-                // should not rewrite `currentTrack` on every observer tick.
-                let repeatOneNeedsReconcile = self.playerService.repeatMode == .one
-                    && hasObservedMetadata
-                    && (trackChanged
-                        || (observedVideoId != nil && observedVideoId != self.playerService.currentTrack?.videoId)
-                        || (observedVideoId == nil && !title.isEmpty && title != self.playerService.currentTrack?.title))
-                let shouldReconcileMetadata = hasObservedMetadata && (trackChanged || repeatOneNeedsReconcile)
-
-                if shouldReconcileMetadata {
-                    self.playerService.updateTrackMetadata(
-                        title: title,
-                        artist: artist,
-                        thumbnailUrl: thumbnailUrl,
-                        videoId: observedVideoId
-                    )
-
-                    // Close video window on track change, but skip during grace period.
-                    // We only close if the videoId actually changed to prevent closing
-                    // due to spurious metadata (title/artist) glitches during resize.
-                    let videoIdChanged = observedVideoId != nil && observedVideoId != self.playerService.currentTrack?.videoId
-
-                    if self.playerService.showVideo, videoIdChanged, !self.playerService.isVideoGracePeriodActive {
-                        DiagnosticsLogger.player.info(
-                            "trackChanged to videoId '\(observedVideoId ?? "unknown")' while video shown - closing video window"
-                        )
-                        self.playerService.showVideo = false
-                    }
-                }
-            }
-        }
-
-        private static func likeStatus(from rawValue: String?) -> LikeStatus {
-            switch rawValue {
-            case "LIKE":
-                .like
-            case "DISLIKE":
-                .dislike
-            default:
-                .indifferent
-            }
-        }
-
-        private static let allowedAudioQualityStatsKeys: Set<String> = [
-            "afmt",
-            "audioBitrate",
-            "audioCodec",
-            "audioCodecs",
-            "audioFormat",
-            "audioItag",
-            "audioMimeType",
-            "audioQuality",
-            "audio_format",
-            "bitrate",
-            "codec",
-            "codecs",
-            "debug_audioFormat",
-            "debug_audioQuality",
-            "debug_playbackQuality",
-            "itag",
-            "mimeType",
-            "quality",
-        ]
-
-        private static let allowedAudioQualityStatsFragments: Set<String> = [
-            "bitrate",
-            "codec",
-            "format",
-            "itag",
-            "mime",
-            "quality",
-        ]
-
-        private static func logAudioQualityStats(body: [String: Any], observedVideoId: String?) {
-            let message = Self.audioQualityStatsLogMessage(body: body, observedVideoId: observedVideoId)
-            DiagnosticsLogger.player.info("Audio quality stats: \(message, privacy: .private)")
-        }
-
-        static func audioQualityStatsLogMessage(body: [String: Any], observedVideoId: String?) -> String {
-            let preferred = Self.sanitizedLogString(body["preferred"])
-            let desired = Self.sanitizedLogString(body["desired"])
-            let applied = (body["applied"] as? Bool) == true ? "true" : "false"
-            let observed = Self.sanitizedLogString(body["observed"])
-            let source = Self.sanitizedLogString(body["source"])
-            let videoId = Self.sanitizedLogString(observedVideoId, fallback: "unknown")
-            let available = Self.compactJSONText(
-                Self.sanitizedPrimitiveArray(body["available"]) ?? [],
-                fallback: "[]"
+    nonisolated static func contentProcessRecoveryPlan(
+        state: PlayerService.PlaybackState,
+        progress: TimeInterval,
+        isShowingAd: Bool,
+        lastNonAdContentProgress: TimeInterval,
+        isPendingRestoredLoadDeferred: Bool = false
+    ) -> ContentProcessRecoveryPlan {
+        guard !isPendingRestoredLoadDeferred else {
+            return ContentProcessRecoveryPlan(
+                shouldReload: false,
+                pendingSeek: nil,
+                shouldAutoResume: false
             )
-            let stats = Self.compactJSONText(Self.sanitizedStatsForNerds(body["stats"]), fallback: "{}")
+        }
+        let shouldReload = switch state {
+        case .loading, .playing, .buffering, .paused:
+            true
+        case .idle, .ended, .error:
+            false
+        }
+        let shouldAutoResume = switch state {
+        case .loading, .playing, .buffering:
+            true
+        case .idle, .paused, .ended, .error:
+            false
+        }
+        let pendingSeek: TimeInterval? = if !shouldReload || state == .loading {
+            nil
+        } else if isShowingAd {
+            lastNonAdContentProgress > 0 ? lastNonAdContentProgress : nil
+        } else {
+            progress
+        }
+        return ContentProcessRecoveryPlan(
+            shouldReload: shouldReload,
+            pendingSeek: pendingSeek,
+            shouldAutoResume: shouldAutoResume
+        )
+    }
+}
 
-            return """
-            preferred=\(preferred) desired=\(desired) applied=\(applied) observed=\(observed) \
-            source=\(source) videoId=\(videoId) available=\(available) stats=\(stats)
-            """
+extension SingletonPlayerWebView {
+    func invalidateDocumentNavigationState() {
+        for (identifier, navigation) in self.documentNavigations {
+            self.cancelledDocumentNavigations[identifier] = navigation.generation
+        }
+        self.documentGeneration.invalidate()
+        self.documentNavigationStartedAtMilliseconds = nil
+        self.documentNavigations.removeAll()
+        self.continuationGenerationsAwaitingStart.removeAll()
+    }
+
+    func beginBlankDocumentNavigation() -> URL? {
+        self.documentNavigations.removeAll()
+        self.continuationGenerationsAwaitingStart.removeAll()
+        let generation = self.documentGeneration.beginBlankNavigation()
+        return WebPlaybackDocumentGeneration.blankURL(generation: generation)
+    }
+
+    func recordAcceptedMainFrameResponse(_ response: URLResponse) {
+        guard let currentVideoId = self.currentVideoId else { return }
+        _ = self.documentGeneration.recordSuccessfulPlaybackResponse(
+            url: response.url,
+            host: "music.youtube.com",
+            videoID: currentVideoId
+        )
+    }
+
+    func decideNavigationPolicy(
+        webView: WKWebView,
+        navigationAction: WKNavigationAction,
+        decisionHandler: @escaping @MainActor (WKNavigationActionPolicy) -> Void
+    ) {
+        guard navigationAction.targetFrame?.isMainFrame == true else {
+            decisionHandler(.allow)
+            return
         }
 
-        private static func sanitizedLogString(_ value: Any?, fallback: String = "unknown") -> String {
-            guard let value else { return fallback }
-
-            let string: String = if let stringValue = value as? String {
-                stringValue
-            } else {
-                String(describing: value)
-            }
-
-            let flattened = string
-                .replacingOccurrences(of: "\n", with: " ")
-                .replacingOccurrences(of: "\r", with: " ")
-                .replacingOccurrences(of: "\t", with: " ")
-
-            guard !flattened.isEmpty else { return fallback }
-            return String(flattened.prefix(200))
+        if WebPlaybackDocumentGeneration.isInternalBlankNavigation(navigationAction.request.url) {
+            decisionHandler(
+                self.documentGeneration.ownsBlankNavigation(navigationAction.request.url)
+                    ? .allow
+                    : .cancel
+            )
+            return
         }
 
-        private static func compactJSONText(_ value: Any, fallback: String) -> String {
-            guard JSONSerialization.isValidJSONObject(value),
-                  let data = try? JSONSerialization.data(withJSONObject: value, options: [.sortedKeys]),
-                  let text = String(data: data, encoding: .utf8)
-            else {
-                return fallback
-            }
-
-            return text
-        }
-
-        private static func sanitizedStatsForNerds(_ value: Any?) -> [String: Any] {
-            guard let value = value as? [String: Any] else { return [:] }
-
-            var sanitized: [String: Any] = [:]
-            for key in value.keys.sorted() where sanitized.count < 12 {
-                guard Self.isAllowedAudioQualityStatsKey(key) else { continue }
-
-                let sanitizedKey = String(key.prefix(80))
-                if let primitive = Self.sanitizedPrimitive(value[key]) {
-                    sanitized[sanitizedKey] = primitive
-                    continue
-                }
-
-                if let primitiveArray = Self.sanitizedPrimitiveArray(value[key]) {
-                    sanitized[sanitizedKey] = primitiveArray
-                }
-            }
-
-            return sanitized
-        }
-
-        private static func isAllowedAudioQualityStatsKey(_ key: String) -> Bool {
-            if self.allowedAudioQualityStatsKeys.contains(key) {
-                return true
-            }
-
-            let lowercasedKey = key.lowercased()
-            return lowercasedKey.contains("audio")
-                && Self.allowedAudioQualityStatsFragments.contains { lowercasedKey.contains($0) }
-        }
-
-        private static func sanitizedPrimitiveArray(_ value: Any?) -> [Any]? {
-            guard let values = value as? [Any] else { return nil }
-
-            let sanitized = values.prefix(12).compactMap { Self.sanitizedPrimitive($0) }
-            return sanitized.isEmpty ? nil : sanitized
-        }
-
-        private static func sanitizedPrimitive(_ value: Any?) -> Any? {
-            guard let value else { return nil }
-
-            if let value = value as? String {
-                return String(value.prefix(160))
-            }
-
-            if let value = value as? Bool {
-                return value
-            }
-
-            return Self.sanitizedNumericPrimitive(value)
-        }
-
-        private static func sanitizedNumericPrimitive(_ value: Any) -> Any? {
-            if let value = value as? Int {
-                return value
-            }
-
-            if let value = value as? Int8 {
-                return value
-            }
-
-            if let value = value as? Int16 {
-                return value
-            }
-
-            if let value = value as? Int32 {
-                return value
-            }
-
-            if let value = value as? Int64 {
-                return value
-            }
-
-            if let value = value as? UInt {
-                return value
-            }
-
-            if let value = value as? UInt8 {
-                return value
-            }
-
-            if let value = value as? UInt16 {
-                return value
-            }
-
-            if let value = value as? UInt32 {
-                return value
-            }
-
-            if let value = value as? UInt64 {
-                return value
-            }
-
-            if let value = value as? Double {
-                return value.isFinite ? value : nil
-            }
-
-            if let value = value as? Float {
-                return value.isFinite ? Double(value) : nil
-            }
-
-            if let value = value as? NSNumber {
-                return value.doubleValue.isFinite ? value : nil
-            }
-
-            return nil
-        }
-
-        func webView(
-            _ webView: WKWebView,
-            decidePolicyFor navigationAction: WKNavigationAction,
-            decisionHandler: @escaping @MainActor (WKNavigationActionPolicy) -> Void
+        if WebPlaybackDocumentGeneration.isFragmentOnlyNavigation(
+            from: webView.url,
+            to: navigationAction.request.url
         ) {
-            guard navigationAction.targetFrame?.isMainFrame == true else {
-                decisionHandler(.allow)
-                return
-            }
-
-            SingletonPlayerWebView.shared.webKitManager?.extensionHostWebViewWillNavigate(
+            self.webKitManager?.extensionHostWebViewWillNavigate(
                 webView,
                 to: navigationAction.request.url
             )
             decisionHandler(.allow)
+            return
         }
 
-        func webView(_ webView: WKWebView, didStartProvisionalNavigation _: WKNavigation!) {
-            SingletonPlayerWebView.shared.webKitManager?.extensionHostWebViewDidStartNavigation(webView)
+        if self.documentGeneration.pendingGeneration != nil {
+            decisionHandler(.cancel)
+            return
         }
 
-        func webView(_ webView: WKWebView, didFinish _: WKNavigation!) {
-            SingletonPlayerWebView.shared.webKitManager?.extensionHostWebViewDidFinishNavigation(webView)
-            DiagnosticsLogger.player.info(
-                "Singleton WebView finished loading: \(webView.url?.absoluteString ?? "nil")"
-            )
-
-            // Apply the current volume when page finishes loading
-            // This is critical because YouTube may set its own default volume
-            let savedVolume = self.playerService.volume
-            let applyVolumeScript = """
-                (function() {
-                    try {
-                        const volume = \(savedVolume);
-                        window.__kasetTargetVolume = volume;
-                        window.__kasetIsSettingVolume = true;
-
-                        const video = document.querySelector('video');
-                        if (video) {
-                            video.volume = volume;
-                        }
-
-                        // Sync YouTube's internal player APIs if ready
-                        const ytVolume = Math.round(volume * 100);
-                        const player = document.querySelector('ytmusic-player');
-                        if (player && player.playerApi && typeof player.playerApi.setVolume === 'function') {
-                            player.playerApi.setVolume(ytVolume);
-                        }
-                        const moviePlayer = document.getElementById('movie_player');
-                        if (moviePlayer && typeof moviePlayer.setVolume === 'function') {
-                            moviePlayer.setVolume(ytVolume);
-                        }
-
-                        setTimeout(() => { window.__kasetIsSettingVolume = false; }, 100);
-                        return video ? 'applied' : 'no-video-yet';
-                    } catch (e) {
-                         return 'error: ' + e;
+        if let inFlightGeneration = self.documentGeneration.inFlightGeneration {
+            guard WebPlaybackDocumentGeneration.requestBelongsToNavigationChain(
+                navigationAction.request,
+                currentURL: webView.url,
+                generation: inFlightGeneration,
+                playbackHost: "music.youtube.com",
+                committedIntermediaryGeneration: self.documentGeneration.committedIntermediaryGeneration
+            ) else {
+                decisionHandler(.cancel)
+                return
+            }
+            if WebPlaybackDocumentGeneration.generation(from: navigationAction.request.url)
+                != inFlightGeneration
+            {
+                decisionHandler(.cancel)
+                self.continuationGenerationsAwaitingStart.insert(inFlightGeneration)
+                if let boundRequest = WebPlaybackDocumentGeneration.requestByBindingGeneration(
+                    navigationAction.request,
+                    generation: inFlightGeneration
+                ) {
+                    Task { @MainActor in
+                        self.startBoundNavigationContinuation(
+                            on: webView,
+                            request: boundRequest,
+                            generation: inFlightGeneration
+                        )
                     }
-                })();
-            """
-            webView.evaluateJavaScript(applyVolumeScript) { result, error in
-                if let error {
-                    DiagnosticsLogger.player.error(
-                        "Failed to apply saved volume \(savedVolume): \(error.localizedDescription)"
+                }
+                return
+            }
+            self.webKitManager?.extensionHostWebViewWillNavigate(
+                webView,
+                to: navigationAction.request.url
+            )
+            decisionHandler(.allow)
+            return
+        }
+
+        decisionHandler(.cancel)
+    }
+
+    func startDocumentNavigation(
+        on webView: WKWebView,
+        request: URLRequest,
+        generation: UInt64
+    ) {
+        guard webView === self.webView else {
+            if self.documentGeneration.pendingGeneration == generation {
+                self.handlePendingDocumentNavigationFailure(webView: self.webView)
+            }
+            return
+        }
+        guard self.documentGeneration.startNavigation(generation) else { return }
+        guard let navigation = webView.load(request) else {
+            self.handleCurrentDocumentNavigationFailure(generation, webView: webView)
+            return
+        }
+        self.documentNavigations[ObjectIdentifier(navigation)] = WebPlaybackTrackedNavigation(
+            generation: generation
+        )
+    }
+
+    func startBoundNavigationContinuation(
+        on webView: WKWebView,
+        request: URLRequest,
+        generation: UInt64
+    ) {
+        guard webView === self.webView,
+              self.documentGeneration.inFlightGeneration == generation,
+              self.documentGeneration.pendingGeneration == nil
+        else {
+            self.continuationGenerationsAwaitingStart.remove(generation)
+            return
+        }
+        guard let navigation = webView.load(request) else {
+            self.continuationGenerationsAwaitingStart.remove(generation)
+            self.handleCurrentDocumentNavigationFailure(generation, webView: webView)
+            return
+        }
+        self.documentNavigations[ObjectIdentifier(navigation)] = WebPlaybackTrackedNavigation(
+            generation: generation
+        )
+        self.continuationGenerationsAwaitingStart.remove(generation)
+    }
+
+    func cancelActiveDocumentNavigation(on webView: WKWebView) {
+        guard let generation = self.documentGeneration.inFlightGeneration else { return }
+        for (identifier, navigation) in self.documentNavigations
+            where navigation.generation == generation
+        {
+            self.cancelledDocumentNavigations[identifier] = generation
+        }
+        self.documentNavigations = self.documentNavigations.filter {
+            $0.value.generation != generation
+        }
+        _ = self.documentGeneration.cancelInFlightNavigation(generation)
+        self.continuationGenerationsAwaitingStart.remove(generation)
+        webView.stopLoading()
+    }
+
+    func trackDocumentNavigationStart(_ navigation: WKNavigation?, webView: WKWebView) {
+        guard webView === self.webView,
+              let navigation,
+              self.documentNavigations[ObjectIdentifier(navigation)] == nil,
+              let generation = WebPlaybackDocumentGeneration.generation(from: webView.url)
+              ?? (self.documentGeneration.committedIntermediaryGeneration
+                  == self.documentGeneration.inFlightGeneration
+                  && WebPlaybackDocumentGeneration.isAllowedPlaybackNavigationURL(
+                      webView.url,
+                      playbackHost: "music.youtube.com"
+                  ) ? self.documentGeneration.inFlightGeneration : nil),
+              generation == self.documentGeneration.inFlightGeneration
+        else { return }
+        self.documentNavigations[ObjectIdentifier(navigation)] = WebPlaybackTrackedNavigation(
+            generation: generation
+        )
+    }
+
+    func handleDocumentNavigationStart(_ navigation: WKNavigation?, webView: WKWebView) {
+        self.trackDocumentNavigationStart(navigation, webView: webView)
+        self.webKitManager?.extensionHostWebViewDidStartNavigation(webView)
+    }
+
+    func handleDocumentNavigationRedirect(_ navigation: WKNavigation?, webView: WKWebView) {
+        guard webView === self.webView,
+              let navigation,
+              let trackedNavigation = self.documentNavigations[ObjectIdentifier(navigation)],
+              trackedNavigation.generation == self.documentGeneration.inFlightGeneration,
+              self.documentGeneration.pendingGeneration == nil
+        else { return }
+        self.refreshInstalledUserScripts()
+    }
+
+    func commitDocumentNavigation(_ navigation: WKNavigation?, webView: WKWebView) {
+        guard webView === self.webView else { return }
+        if let navigation,
+           let cancelledGeneration = self.cancelledDocumentNavigations.removeValue(
+               forKey: ObjectIdentifier(navigation)
+           )
+        {
+            if Self.shouldSuppressCancelledNavigationCommit(
+                cancelledGeneration: cancelledGeneration,
+                committedURL: webView.url,
+                pendingGeneration: self.documentGeneration.pendingGeneration,
+                inFlightGeneration: self.documentGeneration.inFlightGeneration,
+                currentGeneration: self.documentGeneration.currentGeneration
+            ) {
+                let replacementGeneration = self.documentGeneration.pendingGeneration
+                    ?? self.documentGeneration.inFlightGeneration
+                if let replacementGeneration,
+                   replacementGeneration != cancelledGeneration
+                {
+                    self.suppressSurvivingDocumentMedia(webView)
+                } else {
+                    self.pauseSurvivingDocument(webView)
+                }
+            }
+            return
+        }
+        if WebPlaybackDocumentGeneration.isInternalBlankNavigation(webView.url) {
+            guard self.documentGeneration.ownsBlankNavigation(webView.url) else {
+                self.handleUnexpectedBlankDocumentCommit(navigation, webView: webView)
+                return
+            }
+            return
+        }
+        guard let navigation,
+              var trackedNavigation = self.documentNavigations[ObjectIdentifier(navigation)]
+        else { return }
+        trackedNavigation.didCommit = true
+        if let currentVideoId = self.currentVideoId,
+           WebPlaybackDocumentGeneration.isExpectedPlaybackURL(
+               webView.url,
+               host: "music.youtube.com",
+               videoID: currentVideoId
+           )
+        {
+            guard self.documentGeneration.commitNavigation(
+                trackedNavigation.generation,
+                expectedVideoID: currentVideoId
+            ) else { return }
+            self.documentNavigationStartedAtMilliseconds = nil
+            trackedNavigation.didActivatePlaybackOrigin = true
+        } else if WebPlaybackDocumentGeneration.isTrustedIntermediaryURL(webView.url) {
+            guard self.documentGeneration.commitIntermediaryNavigation(
+                trackedNavigation.generation
+            ) else { return }
+        }
+        self.documentNavigations[ObjectIdentifier(navigation)] = trackedNavigation
+        if trackedNavigation.didActivatePlaybackOrigin {
+            self.syncAutoplayIntent(on: webView)
+        }
+    }
+
+    func syncAutoplayIntent(on webView: WKWebView) {
+        let generation = self.documentGeneration.currentGeneration
+        guard self.documentGeneration.accepts(generation: generation) else { return }
+        let shouldAutoplay = self.coordinator?.playerService.shouldAutoplayPlaybackDocument ?? false
+        let nativePlaybackGeneration = self.coordinator?.playerService
+            .currentNativeMusicPlaybackGeneration ?? 0
+        let script = Self.autoplayIntentSynchronizationScript(
+            shouldAutoplay: shouldAutoplay,
+            nativePlaybackGeneration: nativePlaybackGeneration,
+            documentGeneration: generation
+        )
+        webView.evaluateJavaScript(script) { [weak self] _, error in
+            if let error {
+                self?.logger.debug("Autoplay intent synchronization deferred: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    nonisolated static func autoplayIntentSynchronizationScript(
+        shouldAutoplay: Bool,
+        nativePlaybackGeneration: UInt64,
+        documentGeneration: UInt64
+    ) -> String {
+        """
+        (function() {
+            if (window.__kasetDocumentGeneration !== \(documentGeneration)) return 'stale';
+            window.__kasetNativePlaybackGeneration = \(nativePlaybackGeneration);
+            window.__kasetAutoplayPending = \(shouldAutoplay ? "true" : "false");
+            window.__kasetPlaybackSuppressed = \(shouldAutoplay ? "false" : "true");
+            if (window.__kasetAutoplayPending) {
+                window.__kasetAutoplayAttempts = 0;
+                window.__kasetAutoplayRetryScheduled = false;
+            }
+            if (!window.__kasetAutoplayPending) { document.querySelector('video')?.pause(); }
+            return 'synced';
+        })();
+        """
+    }
+
+    func finishDocumentNavigation(_ navigation: WKNavigation?, webView: WKWebView) -> Bool {
+        guard webView === self.webView else { return false }
+        if WebPlaybackDocumentGeneration.isInternalBlankNavigation(webView.url) {
+            guard self.documentGeneration.ownsBlankNavigation(webView.url) else {
+                self.handleUnexpectedBlankDocumentCommit(navigation, webView: webView)
+                return false
+            }
+            return true
+        }
+        guard let navigation,
+              let trackedNavigation = self.documentNavigations.removeValue(
+                  forKey: ObjectIdentifier(navigation)
+              )
+        else { return false }
+        guard trackedNavigation.didCommit else {
+            self.handleCurrentDocumentNavigationFailure(
+                trackedNavigation.generation,
+                webView: webView
+            )
+            return false
+        }
+        if !trackedNavigation.didActivatePlaybackOrigin {
+            return WebPlaybackDocumentGeneration.isAllowedPlaybackNavigationURL(
+                webView.url,
+                playbackHost: "music.youtube.com"
+            ) && trackedNavigation.generation == self.documentGeneration.inFlightGeneration
+        }
+        guard self.documentGeneration.canFinishNavigation(
+            trackedNavigation.generation
+        ) else { return false }
+        return true
+    }
+
+    func handleUnexpectedBlankDocumentCommit(
+        _ navigation: WKNavigation?,
+        webView: WKWebView
+    ) {
+        guard webView === self.webView else { return }
+        if let navigation,
+           self.documentNavigations[ObjectIdentifier(navigation)] != nil
+        {
+            self.failDocumentNavigation(navigation, webView: webView)
+            return
+        }
+        if let generation = self.documentGeneration.inFlightGeneration {
+            self.documentNavigations = self.documentNavigations.filter {
+                $0.value.generation != generation
+            }
+            self.continuationGenerationsAwaitingStart.remove(generation)
+            self.handleCurrentDocumentNavigationFailure(generation, webView: webView)
+        } else if self.documentGeneration.pendingGeneration != nil {
+            self.handlePendingDocumentNavigationFailure(webView: webView)
+        } else if self.currentVideoId != nil {
+            self.handleCommittedDocumentNavigationFailure(
+                self.documentGeneration.currentGeneration,
+                webView: webView
+            )
+        }
+    }
+
+    func handleDocumentNavigationFinish(_ navigation: WKNavigation?, webView: WKWebView) -> Bool {
+        guard self.finishDocumentNavigation(navigation, webView: webView) else { return false }
+        self.webKitManager?.extensionHostWebViewDidFinishNavigation(webView)
+        return true
+    }
+
+    func failDocumentNavigation(_ navigation: WKNavigation?, webView: WKWebView) {
+        if let navigation {
+            self.cancelledDocumentNavigations.removeValue(forKey: ObjectIdentifier(navigation))
+        }
+        guard webView === self.webView,
+              let navigation,
+              let trackedNavigation = self.documentNavigations.removeValue(
+                  forKey: ObjectIdentifier(navigation)
+              )
+        else { return }
+        if trackedNavigation.didActivatePlaybackOrigin {
+            self.handleCommittedDocumentNavigationFailure(
+                trackedNavigation.generation,
+                webView: webView
+            )
+        } else {
+            self.handleCurrentDocumentNavigationFailure(
+                trackedNavigation.generation,
+                webView: webView
+            )
+        }
+    }
+
+    nonisolated static func shouldSuppressCancelledNavigationCommit(
+        cancelledGeneration: UInt64,
+        committedURL: URL?,
+        pendingGeneration: UInt64?,
+        inFlightGeneration: UInt64?,
+        currentGeneration: UInt64
+    ) -> Bool {
+        if WebPlaybackDocumentGeneration.generation(from: committedURL) == cancelledGeneration {
+            return true
+        }
+        let replacementGeneration = pendingGeneration
+            ?? inFlightGeneration
+            ?? currentGeneration
+        if WebPlaybackDocumentGeneration.generation(from: committedURL) == replacementGeneration {
+            return false
+        }
+        return true
+    }
+
+    func handleCurrentDocumentNavigationFailure(_ generation: UInt64, webView: WKWebView?) {
+        guard self.documentGeneration.cancelInFlightNavigation(generation) else { return }
+        self.pauseSurvivingDocument(webView)
+        self.currentVideoId = nil
+        self.documentGeneration.invalidate()
+        self.coordinator?.playerService.deferRestoredPlaybackAfterNavigationFailure()
+        self.refreshInstalledUserScripts()
+    }
+
+    func handlePendingDocumentNavigationFailure(webView: WKWebView?) {
+        self.documentGeneration.cancelPendingNavigation()
+        self.pauseSurvivingDocument(webView)
+        self.currentVideoId = nil
+        self.documentGeneration.invalidate()
+        self.coordinator?.playerService.deferRestoredPlaybackAfterNavigationFailure()
+        self.refreshInstalledUserScripts()
+    }
+
+    func handleCommittedDocumentNavigationFailure(_ generation: UInt64, webView: WKWebView?) {
+        guard self.documentGeneration.currentGeneration == generation,
+              self.documentGeneration.pendingGeneration == nil,
+              self.documentGeneration.inFlightGeneration == nil
+        else { return }
+        self.pauseSurvivingDocument(webView)
+        self.currentVideoId = nil
+        self.documentGeneration.invalidate()
+        self.coordinator?.playerService.deferRestoredPlaybackAfterNavigationFailure()
+        self.refreshInstalledUserScripts()
+    }
+
+    func pauseSurvivingDocument(_ webView: WKWebView?) {
+        webView?.stopLoading()
+        self.suppressSurvivingDocumentMedia(webView)
+    }
+
+    func suppressSurvivingDocumentMedia(_ webView: WKWebView?) {
+        webView?.evaluateJavaScript("""
+            window.__kasetAutoplayPending = false;
+            window.__kasetAutoplayAttempts = 0;
+            window.__kasetAutoplayRetryScheduled = false;
+            \(WebPlaybackDocumentGeneration.mediaSuppressionScript)
+        """, completionHandler: nil)
+    }
+
+    func handleDocumentNavigationFailure(
+        _ navigation: WKNavigation?,
+        webView: WKWebView,
+        error: Error
+    ) {
+        if WebPlaybackNavigationFailure.isRetryableCancellation(error) {
+            guard let navigation,
+                  let trackedNavigation = self.documentNavigations[ObjectIdentifier(navigation)]
+            else {
+                if let navigation {
+                    self.cancelledDocumentNavigations.removeValue(
+                        forKey: ObjectIdentifier(navigation)
                     )
-                } else if let resultString = result as? String {
-                    DiagnosticsLogger.player.debug("Volume apply result: \(resultString)")
                 }
-
-                // Restore lyrics high-frequency polling if it was active
-                if SingletonPlayerWebView.shared.isLyricsPollActive {
-                    SingletonPlayerWebView.shared.startLyricsPoll()
-                }
-
-                // Re-inject video mode CSS if it was active
-                if SingletonPlayerWebView.shared.displayMode == .video {
-                    SingletonPlayerWebView.shared.refreshVideoModeCSS()
-                    // If refresh fails to find the container (because it's a new page),
-                    // it will log a debug message. We should also call the full injection.
-                    SingletonPlayerWebView.shared.injectVideoModeCSS()
-                }
+                self.webKitManager?.extensionHostWebViewDidFailNavigation(webView)
+                return
+            }
+            let hasSameGenerationSuccessor = self.documentNavigations.contains { key, candidate in
+                key != ObjectIdentifier(navigation)
+                    && candidate.generation == trackedNavigation.generation
+            }
+            if !trackedNavigation.didActivatePlaybackOrigin,
+               hasSameGenerationSuccessor
+               || self.continuationGenerationsAwaitingStart.contains(trackedNavigation.generation)
+            {
+                self.documentNavigations.removeValue(forKey: ObjectIdentifier(navigation))
+                self.webKitManager?.extensionHostWebViewDidFailNavigation(webView)
+                return
             }
         }
+        self.failDocumentNavigation(navigation, webView: webView)
+        self.webKitManager?.extensionHostWebViewDidFailNavigation(webView)
+    }
 
-        func webView(_ webView: WKWebView, didFail _: WKNavigation!, withError _: Error) {
-            SingletonPlayerWebView.shared.webKitManager?.extensionHostWebViewDidFailNavigation(webView)
-        }
+    func recoverFromContentProcessTermination(webView: WKWebView) {
+        guard webView === self.webView else { return }
+        DiagnosticsLogger.player.error("Singleton WebView content process terminated, attempting recovery")
+        self.invalidateDocumentNavigationState()
+        self.cancelledDocumentNavigations.removeAll()
 
-        func webView(_ webView: WKWebView, didFailProvisionalNavigation _: WKNavigation!, withError _: Error) {
-            SingletonPlayerWebView.shared.webKitManager?.extensionHostWebViewDidFailNavigation(webView)
-        }
-
-        func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
-            // WebView content process crashed - attempt recovery
-            DiagnosticsLogger.player.error("Singleton WebView content process terminated, attempting recovery")
-
-            // Get the current video ID before reloading
-            let currentVideoId = SingletonPlayerWebView.shared.currentVideoId
-
-            // Reload the WebView
-            webView.reload()
-
-            // If we had a video playing, reload it after a brief delay
-            if let videoId = currentVideoId {
-                Task { @MainActor in
-                    try? await Task.sleep(for: .seconds(1))
-                    // Reset currentVideoId to force reload
-                    SingletonPlayerWebView.shared.currentVideoId = nil
-                    SingletonPlayerWebView.shared.loadVideo(videoId: videoId)
-                }
+        guard let playerService = self.coordinator?.playerService else {
+            if let blankURL = self.beginBlankDocumentNavigation() {
+                webView.load(URLRequest(url: blankURL))
             }
+            return
         }
+        guard !playerService.isStoppingPlayback else {
+            self.currentVideoId = nil
+            return
+        }
+        let videoId = playerService.pendingPlayVideoId
+            ?? playerService.currentTrack?.videoId
+            ?? self.currentVideoId
+        guard let videoId else {
+            if let blankURL = self.beginBlankDocumentNavigation() {
+                webView.load(URLRequest(url: blankURL))
+            }
+            return
+        }
+
+        let recoveryPlan = Self.contentProcessRecoveryPlan(
+            state: playerService.state,
+            progress: playerService.progress,
+            isShowingAd: playerService.isShowingAd,
+            lastNonAdContentProgress: playerService.lastNonAdContentProgress(for: videoId),
+            isPendingRestoredLoadDeferred: playerService.isPendingRestoredLoadDeferred
+        )
+        guard recoveryPlan.shouldReload else {
+            self.currentVideoId = nil
+            return
+        }
+
+        let preservedRestoredSeek = playerService.pendingRestoredSeekForWebRecovery(
+            videoId: videoId
+        )
+        let shouldAutoResume = if playerService.isRestoringPlaybackSession
+            || playerService.isPendingRestoredLoadDeferred
+        {
+            playerService.shouldAutoResumeAfterRestoredLoad
+        } else {
+            recoveryPlan.shouldReload && playerService.shouldResumeAfterInterruption
+        }
+        playerService.pendingRestoredSeek = preservedRestoredSeek ?? recoveryPlan.pendingSeek
+        playerService.beginRestoredPlaybackLoad(autoResumeAfterSeek: shouldAutoResume)
+        self.loadVideo(videoId: videoId, strategy: .forceFullPageWhenSameVideoId)
     }
 }

--- a/Sources/Kaset/Views/PlaylistDetailView+HeaderActions.swift
+++ b/Sources/Kaset/Views/PlaylistDetailView+HeaderActions.swift
@@ -183,7 +183,8 @@ extension PlaylistDetailView {
                         canDelete: detail.canDelete
                     ),
                     client: self.viewModel.client,
-                    libraryViewModel: self.libraryViewModel
+                    libraryViewModel: self.libraryViewModel,
+                    playerService: self.playerService
                 ) {
                     if let onPlaylistDeleted = self.onPlaylistDeleted {
                         onPlaylistDeleted()

--- a/Sources/Kaset/Views/PlaylistDetailView.swift
+++ b/Sources/Kaset/Views/PlaylistDetailView.swift
@@ -491,10 +491,14 @@ struct PlaylistDetailView: View {
         fallbackArtist: String?, fallbackAlbum: Album?
     ) {
         let initiallyLoadedCount = cleanedTracks.count
+        let intent = self.playerService.beginMusicPlaybackIntent()
         Task { @MainActor in
             let willDeferLoad = self.viewModel.hasMore
             let loadGeneration = await self.playerService.playQueue(
-                cleanedTracks, startingAt: index, deferringSmartShuffleFill: willDeferLoad
+                cleanedTracks,
+                startingAt: index,
+                deferringSmartShuffleFill: willDeferLoad,
+                intent: intent
             )
             // Not deferring (playlist already fully loaded): playQueue filled suggestions itself.
             guard let loadGeneration else { return }
@@ -530,7 +534,9 @@ struct PlaylistDetailView: View {
     {
         tracks.map { song in
             var cleanedArtists = song.artists.compactMap { artist -> Artist? in
-                if artist.name == "Album" { return nil }
+                if artist.name == "Album" {
+                    return nil
+                }
                 var cleanName = artist.name
                 if cleanName.hasPrefix("Album, ") {
                     cleanName = String(cleanName.dropFirst(7))

--- a/Sources/Kaset/Views/QueueSidePanelFooterActions.swift
+++ b/Sources/Kaset/Views/QueueSidePanelFooterActions.swift
@@ -1,0 +1,201 @@
+import AppKit
+import SwiftUI
+
+// MARK: - QueueFooterIconButton
+
+struct QueueFooterIconButton: View {
+    let systemImage: String
+    let helpText: String
+    let accessibilityLabel: String
+    var isEnabled: Bool = true
+    var tint: Color = .secondary
+    let action: () -> Void
+
+    var body: some View {
+        Button {
+            guard self.isEnabled else { return }
+            self.action()
+        } label: {
+            Image(systemName: self.systemImage)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(self.tint)
+                .frame(width: 20, height: 20)
+        }
+        .buttonStyle(.plain)
+        .disabled(!self.isEnabled)
+        .opacity(self.isEnabled ? 1 : 0.45)
+        .help(self.helpText)
+        .accessibilityLabel(self.accessibilityLabel)
+    }
+}
+
+// MARK: - QueueFooterActions
+
+struct QueueFooterActions: View {
+    @Environment(PlayerService.self) private var playerService
+    @Environment(AuthService.self) private var authService
+
+    @State private var isSavingPlaylist = false
+
+    private var canSaveQueueAsPlaylist: Bool {
+        self.authService.hasPersonalAccount
+            && !self.playerService.queue.isEmpty
+            && !self.isSavingPlaylist
+            && self.playerService.ytMusicClient != nil
+    }
+
+    var body: some View {
+        HStack(spacing: 0) {
+            HStack(spacing: 8) {
+                QueueFooterIconButton(
+                    systemImage: "arrow.uturn.backward",
+                    helpText: String(localized: "Undo the last queue change."),
+                    accessibilityLabel: String(localized: "Undo"),
+                    isEnabled: self.playerService.canUndoQueue
+                ) {
+                    let intent = self.playerService.beginMusicPlaybackIntent()
+                    Task { await self.playerService.undoQueue(intent: intent) }
+                }
+
+                QueueFooterIconButton(
+                    systemImage: "arrow.uturn.forward",
+                    helpText: String(localized: "Redo the last undone queue change."),
+                    accessibilityLabel: String(localized: "Redo"),
+                    isEnabled: self.playerService.canRedoQueue
+                ) {
+                    let intent = self.playerService.beginMusicPlaybackIntent()
+                    Task { await self.playerService.redoQueue(intent: intent) }
+                }
+            }
+
+            HStack(spacing: 0) {
+                Spacer(minLength: 16)
+
+                QueueFooterIconButton(
+                    systemImage: "shuffle",
+                    helpText: String(localized: "Shuffle the queue, keeping the current song first."),
+                    accessibilityLabel: String(localized: "Shuffle"),
+                    isEnabled: !self.playerService.queue.isEmpty
+                ) {
+                    self.playerService.shuffleQueue()
+                }
+
+                Spacer()
+
+                Group {
+                    QueueFooterIconButton(
+                        systemImage: "text.badge.plus",
+                        helpText: self.isSavingPlaylist
+                            ? String(localized: "Saving queue as playlist…")
+                            : String(localized: "Save the current queue as a new private playlist."),
+                        accessibilityLabel: String(localized: "Save to Playlist"),
+                        isEnabled: self.canSaveQueueAsPlaylist
+                    ) {
+                        self.presentSaveQueueAsPlaylistDialog()
+                    }
+                }
+                .accessibilityIdentifier(AccessibilityID.Queue.saveToPlaylistButton)
+
+                Spacer()
+
+                QueueFooterIconButton(
+                    systemImage: "trash",
+                    helpText: String(localized: "Clear the entire queue and stop playback."),
+                    accessibilityLabel: String(localized: "Clear Queue"),
+                    isEnabled: !self.playerService.queue.isEmpty,
+                    tint: .red
+                ) {
+                    let intent = self.playerService.beginMusicPlaybackIntent()
+                    Task {
+                        await self.playerService.stopAndClearQueue(intent: intent)
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+
+    private func presentSaveQueueAsPlaylistDialog() {
+        guard self.authService.hasPersonalAccount, !self.isSavingPlaylist else { return }
+        let songs = self.playerService.queue
+        guard !songs.isEmpty else { return }
+        let owner = self.playerService.currentAccountMutationOwner
+
+        let alert = NSAlert()
+        alert.messageText = "Save Queue to Playlist"
+        alert.informativeText = "Create a private playlist with all \(songs.count) songs from your queue."
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "Save")
+        alert.addButton(withTitle: "Cancel")
+
+        let titleField = NSTextField(frame: NSRect(x: 0, y: 0, width: 280, height: 24))
+        titleField.placeholderString = "Playlist name"
+        alert.accessoryView = titleField
+
+        let handleResponse: (NSApplication.ModalResponse) -> Void = { response in
+            guard response == .alertFirstButtonReturn else { return }
+            let title = titleField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !title.isEmpty else {
+                self.presentSaveQueueErrorAlert(message: "Playlist name is required.")
+                return
+            }
+            Task {
+                await self.saveQueueAsPlaylist(
+                    title: title,
+                    songs: songs,
+                    owner: owner
+                )
+            }
+        }
+
+        if let window = NSApp.keyWindow ?? NSApp.mainWindow {
+            alert.beginSheetModal(for: window, completionHandler: handleResponse)
+        } else {
+            handleResponse(alert.runModal())
+        }
+    }
+
+    private func saveQueueAsPlaylist(
+        title: String,
+        songs: [Song],
+        owner: MusicAccountMutationOwner
+    ) async {
+        guard self.authService.hasPersonalAccount,
+              self.playerService.acceptsAccountMutationOwner(owner),
+              !self.isSavingPlaylist
+        else { return }
+        self.isSavingPlaylist = true
+        defer { self.isSavingPlaylist = false }
+
+        do {
+            _ = try await self.playerService.saveQueueAsPlaylist(
+                title: title,
+                songs: songs,
+                owner: owner
+            )
+            self.presentSaveQueueSuccessAlert(title: title, songCount: songs.count)
+        } catch {
+            DiagnosticsLogger.ui.error("Failed to save queue as playlist: \(error.localizedDescription)")
+            self.presentSaveQueueErrorAlert(message: "Unable to save queue as playlist. Please try again.")
+        }
+    }
+
+    private func presentSaveQueueSuccessAlert(title: String, songCount: Int) {
+        let alert = NSAlert()
+        alert.messageText = "Playlist Saved"
+        alert.informativeText = "\"\(title)\" was created with \(songCount) songs."
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
+    }
+
+    private func presentSaveQueueErrorAlert(message: String) {
+        let alert = NSAlert()
+        alert.messageText = "Save Failed"
+        alert.informativeText = message
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
+    }
+}

--- a/Sources/Kaset/Views/QueueSidePanelView.swift
+++ b/Sources/Kaset/Views/QueueSidePanelView.swift
@@ -23,26 +23,32 @@ struct QueueSidePanelView: View {
             } else {
                 QueueListControllerRepresentable(
                     entries: self.playerService.queueEntries,
-                    currentIndex: self.playerService.currentIndex,
+                    currentIndex: self.playerService.activePlaybackQueueIndex ?? -1,
                     isPlaying: self.playerService.isPlaying,
                     favoritesManager: self.favoritesManager,
                     likeStatusManager: self.likeStatusManager,
                     allowsLikeActions: self.authService.hasPersonalAccount,
                     likeStatusEvent: self.likeStatusManager.lastLikeEvent,
-                    onSelect: { index in
-                        Task {
-                            await self.playerService.playFromQueue(at: index)
+                    onSelect: { entryID in
+                        let reservation = self.playerService.reserveMusicPlaybackIntent()
+                        Task { @MainActor in
+                            guard let intent = self.playerService.claimMusicPlaybackIntent(
+                                reservation,
+                                queueEntryID: entryID
+                            ) else { return }
+                            await self.playerService.playFromQueue(entryID: entryID, intent: intent)
                         }
                     },
-                    onReorder: { source, destination in
-                        self.playerService.reorderQueue(from: IndexSet(integer: source), to: destination)
+                    onReorder: { entryID, beforeEntryID in
+                        self.playerService.reorderQueue(entryID: entryID, before: beforeEntryID)
                     },
-                    onRemove: { index in
-                        self.playerService.removeFromQueue(at: index)
+                    onRemove: { entryID in
+                        self.playerService.removeFromQueue(entryIDs: [entryID])
                     },
                     onStartRadio: { song in
+                        let intent = self.playerService.beginMusicPlaybackIntent()
                         Task {
-                            await self.playerService.playWithRadio(song: song)
+                            await self.playerService.playWithRadio(song: song, intent: intent)
                         }
                     }
                 )
@@ -92,9 +98,9 @@ struct QueueListControllerRepresentable: NSViewControllerRepresentable {
     let allowsLikeActions: Bool
     /// Observed to refresh visible AppKit rows after optimistic like updates and rollbacks.
     let likeStatusEvent: LikeStatusEvent?
-    let onSelect: (Int) -> Void
-    let onReorder: (Int, Int) -> Void
-    let onRemove: (Int) -> Void
+    let onSelect: (UUID) -> Void
+    let onReorder: (UUID, UUID?) -> Void
+    let onRemove: (UUID) -> Void
     let onStartRadio: (Song) -> Void
 
     func makeNSViewController(context: Context) -> QueueListViewController {
@@ -105,15 +111,20 @@ struct QueueListControllerRepresentable: NSViewControllerRepresentable {
     }
 
     func updateNSViewController(_ viewController: QueueListViewController, context: Context) {
-        context.coordinator.entries = self.entries
-        context.coordinator.currentIndex = self.currentIndex
-        context.coordinator.isPlaying = self.isPlaying
         context.coordinator.favoritesManager = self.favoritesManager
         context.coordinator.likeStatusManager = self.likeStatusManager
         context.coordinator.allowsLikeActions = self.allowsLikeActions
         context.coordinator.lastLikeEvent = self.likeStatusEvent
 
-        if !context.coordinator.isDragging {
+        if context.coordinator.isDragging {
+            context.coordinator.pendingEntries = self.entries
+            context.coordinator.pendingCurrentIndex = self.currentIndex
+            context.coordinator.pendingIsPlaying = self.isPlaying
+            return
+        } else {
+            context.coordinator.entries = self.entries
+            context.coordinator.currentIndex = self.currentIndex
+            context.coordinator.isPlaying = self.isPlaying
             viewController.tableView?.reloadData()
             viewController.tableView?.normalizeVisibleRowFrames()
         }
@@ -215,18 +226,21 @@ struct QueueListControllerRepresentable: NSViewControllerRepresentable {
         var likeStatusManager: SongLikeStatusManager
         var allowsLikeActions: Bool
         var lastLikeEvent: LikeStatusEvent?
-        let onSelect: (Int) -> Void
-        let onReorder: (Int, Int) -> Void
-        let onRemove: (Int) -> Void
+        let onSelect: (UUID) -> Void
+        let onReorder: (UUID, UUID?) -> Void
+        let onRemove: (UUID) -> Void
         let onStartRadio: (Song) -> Void
         weak var viewController: QueueListViewController?
         var isDragging = false
+        var pendingEntries: [QueueEntry]?
+        var pendingCurrentIndex: Int?
+        var pendingIsPlaying: Bool?
         private let dragType = NSPasteboard.PasteboardType("com.kaset.queueitem")
 
         init(entries: [QueueEntry], currentIndex: Int, isPlaying: Bool, favoritesManager: FavoritesManager,
              likeStatusManager: SongLikeStatusManager,
              allowsLikeActions: Bool,
-             onSelect: @escaping (Int) -> Void, onReorder: @escaping (Int, Int) -> Void, onRemove: @escaping (Int) -> Void, onStartRadio: @escaping (Song) -> Void)
+             onSelect: @escaping (UUID) -> Void, onReorder: @escaping (UUID, UUID?) -> Void, onRemove: @escaping (UUID) -> Void, onStartRadio: @escaping (Song) -> Void)
         {
             self.entries = entries
             self.currentIndex = currentIndex
@@ -241,15 +255,16 @@ struct QueueListControllerRepresentable: NSViewControllerRepresentable {
             super.init()
         }
 
-        /// Removes the row with slide-out animation, then calls onRemove.
+        /// Removes the displayed entry with slide-out animation, then calls onRemove.
         /// - Parameter slideDirection: -1 = slide left, +1 = slide right (matches swipe direction).
         func removeRowWithAnimation(row: Int, slideDirection: CGFloat) {
-            guard let tableView = viewController?.tableView else {
-                self.onRemove(row)
+            guard let entryID = self.entries[safe: row]?.id else { return }
+            guard let tableView = self.viewController?.tableView else {
+                self.onRemove(entryID)
                 return
             }
             guard let rowView = tableView.rowView(atRow: row, makeIfNecessary: false) else {
-                self.onRemove(row)
+                self.onRemove(entryID)
                 return
             }
             let offsetX = slideDirection * rowView.bounds.width
@@ -261,12 +276,11 @@ struct QueueListControllerRepresentable: NSViewControllerRepresentable {
                 rowView.animator().frame.origin.x += offsetX
             } completionHandler: { [weak self] in
                 MainActor.assumeIsolated {
-                    // Reset row view so it can be reused without a stuck frame/alpha (fixes misaligned rows).
                     rowView.alphaValue = 1
                     var resetFrame = originalFrame
                     resetFrame.origin.x = 0
                     rowView.frame = resetFrame
-                    self?.onRemove(row)
+                    self?.onRemove(entryID)
                 }
             }
         }
@@ -291,8 +305,8 @@ struct QueueListControllerRepresentable: NSViewControllerRepresentable {
                 isPlaying: self.isPlaying,
                 isSuggested: entry.source == .suggested,
                 actions: QueueCellActions(
-                    onPlay: { [weak self] in self?.onSelect(row) },
-                    onRemove: { [weak self] in self?.onRemove(row) },
+                    onPlay: { [weak self] in self?.onSelect(entry.id) },
+                    onRemove: { [weak self] in self?.onRemove(entry.id) },
                     onToggleLike: { [weak self] in
                         guard let self else { return }
                         guard self.allowsLikeActions else { return }
@@ -316,17 +330,17 @@ struct QueueListControllerRepresentable: NSViewControllerRepresentable {
         func tableViewSelectionDidChange(_ notification: Notification) {
             guard let tableView = notification.object as? NSTableView else { return }
             let selectedRow = tableView.selectedRow
-            if selectedRow >= 0 {
-                self.onSelect(selectedRow)
+            if selectedRow >= 0, let entry = self.entries[safe: selectedRow] {
+                self.onSelect(entry.id)
                 tableView.deselectAll(nil)
             }
         }
 
         /// Drag Source
         func tableView(_: NSTableView, pasteboardWriterForRow row: Int) -> NSPasteboardWriting? {
-            guard row != self.currentIndex else { return nil }
+            guard let entry = self.entries[safe: row], entry.id != self.currentEntryID else { return nil }
             let item = NSPasteboardItem()
-            item.setString(String(row), forType: self.dragType)
+            item.setString(entry.id.uuidString, forType: self.dragType)
             self.isDragging = true
             return item
         }
@@ -337,27 +351,60 @@ struct QueueListControllerRepresentable: NSViewControllerRepresentable {
 
         func tableView(_ tableView: NSTableView, draggingSession _: NSDraggingSession, endedAt _: NSPoint, operation _: NSDragOperation) {
             self.isDragging = false
+            self.applyPendingSnapshot()
+            tableView.reloadData()
             (tableView as? DraggableTableView)?.normalizeVisibleRowFrames()
         }
 
         /// Drop Destination
         func tableView(_: NSTableView, validateDrop info: NSDraggingInfo, proposedRow row: Int, proposedDropOperation dropOperation: NSTableView.DropOperation) -> NSDragOperation {
-            guard dropOperation == .above else { return [] }
-            guard let str = info.draggingPasteboard.string(forType: dragType),
-                  let srcRow = Int(str) else { return [] }
-            let destRow = row
-            guard destRow != self.currentIndex, srcRow != destRow else { return [] }
+            guard dropOperation == .above,
+                  let sourceEntryID = self.draggedEntryID(from: info),
+                  sourceEntryID != self.currentEntryID
+            else { return [] }
+            let beforeEntryID = self.entries[safe: row]?.id
+            guard beforeEntryID != sourceEntryID,
+                  !self.dropWouldKeepEntryInPlace(sourceEntryID: sourceEntryID, proposedRow: row)
+            else { return [] }
             return .move
         }
 
         func tableView(_: NSTableView, acceptDrop info: NSDraggingInfo, row: Int, dropOperation _: NSTableView.DropOperation) -> Bool {
-            guard let str = info.draggingPasteboard.string(forType: dragType),
-                  let srcRow = Int(str) else { return false }
-            let destRow = row
-            guard srcRow != self.currentIndex, destRow != self.currentIndex, srcRow != destRow else { return false }
-            self.onReorder(srcRow, destRow)
-            self.isDragging = false
+            guard let sourceEntryID = self.draggedEntryID(from: info),
+                  sourceEntryID != self.currentEntryID,
+                  !self.dropWouldKeepEntryInPlace(sourceEntryID: sourceEntryID, proposedRow: row)
+            else { return false }
+            self.onReorder(sourceEntryID, self.entries[safe: row]?.id)
             return true
+        }
+
+        private func applyPendingSnapshot() {
+            if let pendingEntries {
+                self.entries = pendingEntries
+            }
+            if let pendingCurrentIndex {
+                self.currentIndex = pendingCurrentIndex
+            }
+            if let pendingIsPlaying {
+                self.isPlaying = pendingIsPlaying
+            }
+            self.pendingEntries = nil
+            self.pendingCurrentIndex = nil
+            self.pendingIsPlaying = nil
+        }
+
+        var currentEntryID: UUID? {
+            self.entries[safe: self.currentIndex]?.id
+        }
+
+        private func draggedEntryID(from info: NSDraggingInfo) -> UUID? {
+            guard let value = info.draggingPasteboard.string(forType: self.dragType) else { return nil }
+            return UUID(uuidString: value)
+        }
+
+        private func dropWouldKeepEntryInPlace(sourceEntryID: UUID, proposedRow: Int) -> Bool {
+            guard let sourceRow = self.entries.firstIndex(where: { $0.id == sourceEntryID }) else { return true }
+            return proposedRow == sourceRow || proposedRow == sourceRow + 1
         }
 
         // MARK: - Context Menu
@@ -400,10 +447,10 @@ struct QueueListControllerRepresentable: NSViewControllerRepresentable {
                 menu.addItem(NSMenuItem.separator())
             }
 
-            if row != self.currentIndex {
+            if entry.id != self.currentEntryID {
                 let removeItem = NSMenuItem(title: "Remove from Queue", action: #selector(Coordinator.contextMenuRemove(_:)), keyEquivalent: "")
                 removeItem.target = self
-                removeItem.representedObject = NSNumber(value: row)
+                removeItem.representedObject = entry.id.uuidString
                 removeItem.image = NSImage(systemSymbolName: "minus.circle", accessibilityDescription: nil)
                 menu.addItem(removeItem)
             }
@@ -430,8 +477,10 @@ struct QueueListControllerRepresentable: NSViewControllerRepresentable {
         }
 
         @objc private func contextMenuRemove(_ sender: NSMenuItem) {
-            guard let rowNumber = sender.representedObject as? NSNumber else { return }
-            self.onRemove(rowNumber.intValue)
+            guard let entryIDString = sender.representedObject as? String,
+                  let entryID = UUID(uuidString: entryIDString)
+            else { return }
+            self.onRemove(entryID)
         }
     }
 }
@@ -447,6 +496,7 @@ class DraggableTableView: NSTableView {
     private var verticalSwipeAccumulator: CGFloat = 0
     /// Row index under the cursor when the gesture *started* (.began), so we remove that row even if content scrolls by .ended.
     private var swipeRemoveTargetRow: Int = -1
+    private var swipeRemoveTargetEntryID: UUID?
     /// When non-nil, we're showing real-time slide feedback; value is the row view's initial origin.x to restore on cancel.
     private var swipeTrackedInitialOriginX: CGFloat?
     /// Cooldown after a remove so we don't trigger again from leftover events.
@@ -517,12 +567,15 @@ class DraggableTableView: NSTableView {
         case .changed:
             self.handleSwipeChanged(dx: dx, dy: dy)
         case .ended, .cancelled:
-            if self.handleSwipeEnded(event: event) { return }
+            if self.handleSwipeEnded(event: event) {
+                return
+            }
         default:
             if event.momentumPhase == .ended || event.momentumPhase == .cancelled {
                 self.horizontalSwipeAccumulator = 0
                 self.verticalSwipeAccumulator = 0
                 self.swipeRemoveTargetRow = -1
+                self.swipeRemoveTargetEntryID = nil
                 self.swipeTrackedInitialOriginX = nil
             }
         }
@@ -535,12 +588,14 @@ class DraggableTableView: NSTableView {
         self.horizontalSwipeAccumulator = dx
         self.verticalSwipeAccumulator = dy
         self.swipeRemoveTargetRow = -1
+        self.swipeRemoveTargetEntryID = nil
         self.swipeTrackedInitialOriginX = nil
-        if self.coordinator != nil {
+        if let coordinator = self.coordinator {
             let point = event.locationInWindow
             let localPoint = self.convert(point, from: nil)
             let rowAtStart = self.row(at: localPoint)
             self.swipeRemoveTargetRow = rowAtStart
+            self.swipeRemoveTargetEntryID = coordinator.entries[safe: rowAtStart]?.id
             if rowAtStart >= 0 {
                 Self.normalizeRowView(self.rowView(atRow: rowAtStart, makeIfNecessary: false))
             }
@@ -554,9 +609,10 @@ class DraggableTableView: NSTableView {
         self.verticalSwipeAccumulator += dy
         // Real-time row slide: once horizontal movement passes commit threshold, move the row with the finger.
         if let coord = coordinator,
+           let swipeRemoveTargetEntryID,
            swipeRemoveTargetRow >= 0,
-           swipeRemoveTargetRow != coord.currentIndex,
-           coord.entries[safe: swipeRemoveTargetRow] != nil,
+           swipeRemoveTargetEntryID != coord.currentEntryID,
+           coord.entries.contains(where: { $0.id == swipeRemoveTargetEntryID }),
            abs(horizontalSwipeAccumulator) > Self.swipeCommitThreshold,
            abs(horizontalSwipeAccumulator) > abs(verticalSwipeAccumulator)
         {
@@ -588,13 +644,15 @@ class DraggableTableView: NSTableView {
             self.swipeTrackedInitialOriginX = nil
             guard let coord = coordinator,
                   swipeRemoveTargetRow >= 0,
-                  coord.entries[safe: swipeRemoveTargetRow] != nil
+                  let entryID = swipeRemoveTargetEntryID
             else {
                 self.swipeRemoveTargetRow = -1
+                self.swipeRemoveTargetEntryID = nil
                 return false
             }
             let row = self.swipeRemoveTargetRow
             self.swipeRemoveTargetRow = -1
+            self.swipeRemoveTargetEntryID = nil
             guard let rowView = self.rowView(atRow: row, makeIfNecessary: false) else {
                 return false
             }
@@ -602,7 +660,7 @@ class DraggableTableView: NSTableView {
             let passed = CFAbsoluteTimeGetCurrent() >= self.swipeRemoveCooldownUntil
                 && abs(accH) >= Self.swipeRemoveDeltaThreshold
                 && abs(accH) > abs(accV)
-                && row != coord.currentIndex
+                && entryID != coord.entries[safe: coord.currentIndex]?.id
 
             if passed {
                 let slideDirection: CGFloat = accH > 0 ? 1 : -1
@@ -618,7 +676,7 @@ class DraggableTableView: NSTableView {
                 } completionHandler: {
                     MainActor.assumeIsolated {
                         Self.normalizeRowView(rowView)
-                        coord.onRemove(row)
+                        coord.onRemove(entryID)
                     }
                 }
                 return true
@@ -639,15 +697,21 @@ class DraggableTableView: NSTableView {
             }
         }
 
-        if CFAbsoluteTimeGetCurrent() < self.swipeRemoveCooldownUntil { return false }
+        if CFAbsoluteTimeGetCurrent() < self.swipeRemoveCooldownUntil {
+            return false
+        }
         guard abs(accH) >= Self.swipeRemoveDeltaThreshold,
               abs(accH) > abs(accV)
         else { return false }
         guard let coord = coordinator else { return false }
         let row = self.swipeRemoveTargetRow >= 0 ? self.swipeRemoveTargetRow : rowAtEnd
         self.swipeRemoveTargetRow = -1
-        if row < 0 { return false }
-        if row == coord.currentIndex { return false }
+        if row < 0 {
+            return false
+        }
+        if row == coord.currentIndex {
+            return false
+        }
         guard coord.entries[safe: row] != nil else { return false }
         let slideDirection: CGFloat = accH > 0 ? 1 : -1
         self.swipeRemoveCooldownUntil = CFAbsoluteTimeGetCurrent() + Self.swipeRemoveCooldown
@@ -704,188 +768,6 @@ private struct QueueSidePanelHeader: View {
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 14)
-    }
-}
-
-// MARK: - QueueFooterIconButton
-
-private struct QueueFooterIconButton: View {
-    let systemImage: String
-    let helpText: String
-    let accessibilityLabel: String
-    var isEnabled: Bool = true
-    var tint: Color = .secondary
-    let action: () -> Void
-
-    var body: some View {
-        Group {
-            Button {
-                guard self.isEnabled else { return }
-                self.action()
-            } label: {
-                Image(systemName: self.systemImage)
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundStyle(self.tint)
-                    .frame(width: 20, height: 20)
-            }
-            .buttonStyle(.plain)
-            .opacity(self.isEnabled ? 1 : 0.45)
-        }
-        .help(self.helpText)
-        .accessibilityLabel(self.accessibilityLabel)
-    }
-}
-
-// MARK: - QueueFooterActions
-
-private struct QueueFooterActions: View {
-    @Environment(PlayerService.self) private var playerService
-    @Environment(AuthService.self) private var authService
-
-    @State private var isSavingPlaylist = false
-
-    private var canSaveQueueAsPlaylist: Bool {
-        self.authService.hasPersonalAccount
-            && !self.playerService.queue.isEmpty
-            && !self.isSavingPlaylist
-            && self.playerService.ytMusicClient != nil
-    }
-
-    var body: some View {
-        HStack(spacing: 0) {
-            HStack(spacing: 8) {
-                QueueFooterIconButton(
-                    systemImage: "arrow.uturn.backward",
-                    helpText: String(localized: "Undo the last queue change."),
-                    accessibilityLabel: String(localized: "Undo"),
-                    isEnabled: self.playerService.canUndoQueue
-                ) {
-                    self.playerService.undoQueue()
-                }
-
-                QueueFooterIconButton(
-                    systemImage: "arrow.uturn.forward",
-                    helpText: String(localized: "Redo the last undone queue change."),
-                    accessibilityLabel: String(localized: "Redo"),
-                    isEnabled: self.playerService.canRedoQueue
-                ) {
-                    self.playerService.redoQueue()
-                }
-            }
-
-            HStack(spacing: 0) {
-                Spacer(minLength: 16)
-
-                QueueFooterIconButton(
-                    systemImage: "shuffle",
-                    helpText: String(localized: "Shuffle the queue, keeping the current song first."),
-                    accessibilityLabel: String(localized: "Shuffle"),
-                    isEnabled: !self.playerService.queue.isEmpty
-                ) {
-                    self.playerService.shuffleQueue()
-                }
-
-                Spacer()
-
-                Group {
-                    QueueFooterIconButton(
-                        systemImage: "text.badge.plus",
-                        helpText: self.isSavingPlaylist
-                            ? String(localized: "Saving queue as playlist…")
-                            : String(localized: "Save the current queue as a new private playlist."),
-                        accessibilityLabel: String(localized: "Save to Playlist"),
-                        isEnabled: self.canSaveQueueAsPlaylist
-                    ) {
-                        self.presentSaveQueueAsPlaylistDialog()
-                    }
-                }
-                .accessibilityIdentifier(AccessibilityID.Queue.saveToPlaylistButton)
-
-                Spacer()
-
-                QueueFooterIconButton(
-                    systemImage: "trash",
-                    helpText: String(localized: "Clear the entire queue and stop playback."),
-                    accessibilityLabel: String(localized: "Clear Queue"),
-                    isEnabled: !self.playerService.queue.isEmpty,
-                    tint: .red
-                ) {
-                    Task {
-                        if self.playerService.isPlaying {
-                            await self.playerService.stop()
-                        }
-                        self.playerService.clearQueueEntirely()
-                    }
-                }
-            }
-        }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 12)
-    }
-
-    private func presentSaveQueueAsPlaylistDialog() {
-        guard self.authService.hasPersonalAccount, !self.isSavingPlaylist else { return }
-        let songs = self.playerService.queue
-        guard !songs.isEmpty else { return }
-
-        let alert = NSAlert()
-        alert.messageText = "Save Queue to Playlist"
-        alert.informativeText = "Create a private playlist with all \(songs.count) songs from your queue."
-        alert.alertStyle = .informational
-        alert.addButton(withTitle: "Save")
-        alert.addButton(withTitle: "Cancel")
-
-        let titleField = NSTextField(frame: NSRect(x: 0, y: 0, width: 280, height: 24))
-        titleField.placeholderString = "Playlist name"
-        alert.accessoryView = titleField
-
-        let handleResponse: (NSApplication.ModalResponse) -> Void = { response in
-            guard response == .alertFirstButtonReturn else { return }
-            let title = titleField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !title.isEmpty else {
-                self.presentSaveQueueErrorAlert(message: "Playlist name is required.")
-                return
-            }
-            Task { await self.saveQueueAsPlaylist(title: title, songCount: songs.count) }
-        }
-
-        if let window = NSApp.keyWindow ?? NSApp.mainWindow {
-            alert.beginSheetModal(for: window, completionHandler: handleResponse)
-        } else {
-            handleResponse(alert.runModal())
-        }
-    }
-
-    private func saveQueueAsPlaylist(title: String, songCount: Int) async {
-        guard self.authService.hasPersonalAccount, !self.isSavingPlaylist else { return }
-        self.isSavingPlaylist = true
-        defer { self.isSavingPlaylist = false }
-
-        do {
-            _ = try await self.playerService.saveQueueAsPlaylist(title: title)
-            self.presentSaveQueueSuccessAlert(title: title, songCount: songCount)
-        } catch {
-            DiagnosticsLogger.ui.error("Failed to save queue as playlist: \(error.localizedDescription)")
-            self.presentSaveQueueErrorAlert(message: "Unable to save queue as playlist. Please try again.")
-        }
-    }
-
-    private func presentSaveQueueSuccessAlert(title: String, songCount: Int) {
-        let alert = NSAlert()
-        alert.messageText = "Playlist Saved"
-        alert.informativeText = "\"\(title)\" was created with \(songCount) songs."
-        alert.alertStyle = .informational
-        alert.addButton(withTitle: "OK")
-        alert.runModal()
-    }
-
-    private func presentSaveQueueErrorAlert(message: String) {
-        let alert = NSAlert()
-        alert.messageText = "Save Failed"
-        alert.informativeText = message
-        alert.alertStyle = .warning
-        alert.addButton(withTitle: "OK")
-        alert.runModal()
     }
 }
 

--- a/Sources/Kaset/Views/QueueView.swift
+++ b/Sources/Kaset/Views/QueueView.swift
@@ -107,18 +107,23 @@ struct QueueView: View {
                 ForEach(Array(self.playerService.queueEntries.enumerated()), id: \.element.id) { index, entry in
                     QueueRowView(
                         song: entry.song,
-                        isCurrentTrack: index == self.playerService.currentIndex,
+                        isCurrentTrack: index == self.playerService.activePlaybackQueueIndex,
                         index: index,
                         isSuggested: entry.source == .suggested,
                         allowsLikeActions: self.authService.hasPersonalAccount,
                         favoritesManager: self.favoritesManager,
                         playerService: self.playerService,
                         onRemove: {
-                            self.playerService.removeFromQueue(at: index)
+                            self.playerService.removeFromQueue(entryIDs: [entry.id])
                         },
                         onTap: {
-                            Task {
-                                await self.playerService.playFromQueue(at: index)
+                            let reservation = self.playerService.reserveMusicPlaybackIntent()
+                            Task { @MainActor in
+                                guard let intent = self.playerService.claimMusicPlaybackIntent(
+                                    reservation,
+                                    queueEntryID: entry.id
+                                ) else { return }
+                                await self.playerService.playFromQueue(entryID: entry.id, intent: intent)
                             }
                         }
                     )

--- a/Sources/Kaset/Views/SharedViews/SongActionsHelper.swift
+++ b/Sources/Kaset/Views/SharedViews/SongActionsHelper.swift
@@ -51,10 +51,32 @@ enum SongActionsHelper {
 
     /// Adds a song to the library by playing it and toggling library status.
     /// Note: This still requires playing because library toggle works on current track.
-    static func addToLibrary(_ song: Song, playerService: PlayerService) {
-        Task {
-            await playerService.play(song: song)
-            try? await Task.sleep(for: .milliseconds(100))
+    @discardableResult
+    static func addToLibrary(_ song: Song, playerService: PlayerService) -> Task<Void, Never> {
+        let intent = playerService.beginMusicPlaybackIntent()
+        let queueEntryID = playerService.currentQueueEntryID(matching: song)
+        return Task {
+            await playerService.play(
+                song: song,
+                webLoadStrategy: .standard,
+                queueEntryID: queueEntryID,
+                intent: intent
+            )
+            guard playerService.acceptsMusicPlaybackIntent(intent),
+                  playerService.currentTrack?.videoId == song.videoId
+            else { return }
+            guard !playerService.currentTrackInLibrary else { return }
+            if playerService.currentTrackFeedbackTokens?.add == nil {
+                await playerService.fetchSongMetadata(
+                    videoId: song.videoId,
+                    queueOwner: queueEntryID.map(MusicQueueMetadataOwner.entry) ?? .none
+                )
+            }
+            guard playerService.acceptsMusicPlaybackIntent(intent),
+                  playerService.currentTrack?.videoId == song.videoId,
+                  !playerService.currentTrackInLibrary,
+                  playerService.currentTrackFeedbackTokens?.add != nil
+            else { return }
             playerService.toggleLibraryStatus()
         }
     }

--- a/Sources/Kaset/Views/SharedViews/SongActionsHelper.swift
+++ b/Sources/Kaset/Views/SharedViews/SongActionsHelper.swift
@@ -133,12 +133,16 @@ enum SongActionsHelper {
     static func deletePlaylist(
         _ playlist: Playlist,
         client: any YTMusicClientProtocol,
-        libraryViewModel: LibraryViewModel?
+        libraryViewModel: LibraryViewModel?,
+        owner: MusicAccountMutationOwner,
+        playerService: PlayerService
     ) async throws {
         try await LibraryMutationActions.deletePlaylist(
             playlist,
             client: client,
-            libraryViewModel: libraryViewModel
+            libraryViewModel: libraryViewModel,
+            owner: owner,
+            whileValid: { playerService.acceptsAccountMutationOwner(owner) }
         )
     }
 
@@ -149,8 +153,10 @@ enum SongActionsHelper {
         _ playlist: Playlist,
         client: any YTMusicClientProtocol,
         libraryViewModel: LibraryViewModel?,
+        playerService: PlayerService,
         onConfirm: (() -> Void)? = nil
     ) {
+        let owner = playerService.currentAccountMutationOwner
         let alert = NSAlert()
         alert.messageText = "Delete “\(playlist.title)”?"
         alert.informativeText = "This permanently deletes the playlist from YouTube Music. You can only delete playlists you created."
@@ -159,7 +165,9 @@ enum SongActionsHelper {
         alert.addButton(withTitle: "Cancel")
 
         let handleResponse: (NSApplication.ModalResponse) -> Void = { response in
-            guard response == .alertFirstButtonReturn else { return }
+            guard response == .alertFirstButtonReturn,
+                  playerService.acceptsAccountMutationOwner(owner)
+            else { return }
 
             onConfirm?()
             Task { @MainActor in
@@ -167,8 +175,12 @@ enum SongActionsHelper {
                     try await self.deletePlaylist(
                         playlist,
                         client: client,
-                        libraryViewModel: libraryViewModel
+                        libraryViewModel: libraryViewModel,
+                        owner: owner,
+                        playerService: playerService
                     )
+                } catch is CancellationError {
+                    return
                 } catch {
                     self.presentPlaylistDeletionError(error)
                 }
@@ -209,7 +221,7 @@ enum SongActionsHelper {
     static func presentCreatePlaylistDialog(
         informativeText: String,
         request: PlaylistCreationRequest,
-        onWillCreate: @escaping () -> Void = {},
+        onWillCreate: @escaping () -> Bool = { true },
         completion: @escaping (Result<Playlist, PlaylistCreationFailure>) -> Void
     ) {
         let alert = NSAlert()
@@ -233,7 +245,7 @@ enum SongActionsHelper {
                 return
             }
 
-            onWillCreate()
+            guard onWillCreate() else { return }
             Task {
                 await Self.createPlaylist(title: title, request: request, completion: completion)
             }

--- a/Sources/Kaset/Views/SharedViews/SongContextMenus.swift
+++ b/Sources/Kaset/Views/SharedViews/SongContextMenus.swift
@@ -242,7 +242,11 @@ struct AddToPlaylistContextMenu: View {
                 thumbnailURL: self.song.thumbnailURL,
                 whileValid: { self.playerService.acceptsAccountMutationOwner(owner) }
             ),
-            onWillCreate: { self.isCreatingPlaylist = true },
+            onWillCreate: {
+                guard !self.isCreatingPlaylist else { return false }
+                self.isCreatingPlaylist = true
+                return true
+            },
             completion: { result in
                 self.isCreatingPlaylist = false
                 guard self.playerService.acceptsAccountMutationOwner(owner) else { return }

--- a/Sources/Kaset/Views/SharedViews/SongContextMenus.swift
+++ b/Sources/Kaset/Views/SharedViews/SongContextMenus.swift
@@ -81,6 +81,7 @@ struct AddToPlaylistContextMenu: View {
     let client: any YTMusicClientProtocol
 
     @Environment(AuthService.self) private var authService
+    @Environment(PlayerService.self) private var playerService
 
     @State private var loadState: PlaylistLoadState = .idle
     @State private var isCreatingPlaylist = false
@@ -232,6 +233,7 @@ struct AddToPlaylistContextMenu: View {
 
     private func presentCreatePlaylistDialog() {
         guard !self.isCreatingPlaylist else { return }
+        let owner = self.playerService.currentAccountMutationOwner
 
         let alert = NSAlert()
         alert.messageText = "Create Playlist"
@@ -249,7 +251,7 @@ struct AddToPlaylistContextMenu: View {
                 self.loadState = .failed("Playlist Name Required")
                 return
             }
-            Task { await self.createPlaylist(title: title) }
+            Task { await self.createPlaylist(title: title, owner: owner) }
         }
 
         if let window = NSApp.keyWindow ?? NSApp.mainWindow {
@@ -259,8 +261,14 @@ struct AddToPlaylistContextMenu: View {
         }
     }
 
-    private func createPlaylist(title: String) async {
-        guard !title.isEmpty, !self.isCreatingPlaylist else { return }
+    private func createPlaylist(
+        title: String,
+        owner: MusicAccountMutationOwner
+    ) async {
+        guard !title.isEmpty,
+              self.playerService.acceptsAccountMutationOwner(owner),
+              !self.isCreatingPlaylist
+        else { return }
         self.isCreatingPlaylist = true
         defer { self.isCreatingPlaylist = false }
         do {
@@ -270,6 +278,9 @@ struct AddToPlaylistContextMenu: View {
                 privacyStatus: .private,
                 videoIds: [self.song.videoId]
             )
+            guard self.playerService.acceptsAccountMutationOwner(owner) else {
+                throw CancellationError()
+            }
             let playlist = Playlist(
                 id: playlistId,
                 title: title,
@@ -285,8 +296,19 @@ struct AddToPlaylistContextMenu: View {
             // Refresh in the background, but keep the optimistic playlist visible if the
             // cache/backend still returns a stale snapshot.
             try? await Task.sleep(for: .milliseconds(500))
+            guard self.playerService.acceptsAccountMutationOwner(owner) else {
+                LibraryMutationBroadcaster.shared.discardCreatedPlaylist(playlist)
+                throw CancellationError()
+            }
             SongActionsHelper.invalidateLibraryResponseCaches()
-            await LibraryMutationBroadcaster.shared.reconcileCreatedPlaylist(playlist)
+            let didReconcile = await LibraryMutationBroadcaster.shared.reconcileCreatedPlaylist(
+                playlist,
+                whileValid: { self.playerService.acceptsAccountMutationOwner(owner) }
+            )
+            guard didReconcile, self.playerService.acceptsAccountMutationOwner(owner) else {
+                LibraryMutationBroadcaster.shared.discardCreatedPlaylist(playlist)
+                throw CancellationError()
+            }
             SongActionsHelper.invalidateLibraryResponseCaches()
 
             await self.loadPlaylists(forceRefresh: true)

--- a/Sources/Kaset/Views/SharedViews/StartRadioContextMenu.swift
+++ b/Sources/Kaset/Views/SharedViews/StartRadioContextMenu.swift
@@ -9,8 +9,9 @@ enum StartRadioContextMenu {
     /// Starts playing the song immediately and loads similar songs in the background.
     static func menuItem(for song: Song, playerService: PlayerService) -> some View {
         Button {
+            let intent = playerService.beginMusicPlaybackIntent()
             Task {
-                await playerService.playWithRadio(song: song)
+                await playerService.playWithRadio(song: song, intent: intent)
             }
         } label: {
             Label("Start Radio", systemImage: "dot.radiowaves.left.and.right")

--- a/Sources/Kaset/Views/Sidebar.swift
+++ b/Sources/Kaset/Views/Sidebar.swift
@@ -169,7 +169,11 @@ struct Sidebar: View {
                 videoIds: [],
                 whileValid: { self.playerService.acceptsAccountMutationOwner(owner) }
             ),
-            onWillCreate: { self.isCreatingPlaylist = true },
+            onWillCreate: {
+                guard !self.isCreatingPlaylist else { return false }
+                self.isCreatingPlaylist = true
+                return true
+            },
             completion: { result in
                 self.isCreatingPlaylist = false
                 guard self.playerService.acceptsAccountMutationOwner(owner) else { return }

--- a/Sources/Kaset/Views/SingletonPlayerWebView+ObserverScript.swift
+++ b/Sources/Kaset/Views/SingletonPlayerWebView+ObserverScript.swift
@@ -1,6 +1,21 @@
 // MARK: - SingletonPlayerWebView Observer Script Extension
 
 extension SingletonPlayerWebView {
+    /// Returns a wall-clock timestamp with sub-millisecond precision when WebKit exposes it.
+    /// Native intent fences use the same epoch, while `Date.now()` remains a safe fallback.
+    nonisolated static var eventTimestampFunctionJS: String {
+        """
+        function __kasetEventTimestampMilliseconds() {
+            const highResolutionTimestamp = typeof performance !== 'undefined'
+                ? Number(performance.timeOrigin) + Number(performance.now())
+                : Number.NaN;
+            return Number.isFinite(highResolutionTimestamp)
+                ? highResolutionTimestamp
+                : Date.now();
+        }
+        """
+    }
+
     /// Selects the authoritative playback clock for bridge state updates.
     /// The hidden player bar can lag or stop updating while its media element
     /// continues playing, so a ready media element wins over DOM attributes.
@@ -112,6 +127,7 @@ extension SingletonPlayerWebView {
         (function() {
             'use strict';
             const bridge = window.webkit.messageHandlers.singletonPlayer;
+            \(eventTimestampFunctionJS)
             \(autoplayRecoveryFunctionJS)
             window.__kasetAttemptAutoplayRecovery = __kasetAttemptAutoplayRecovery;
             \(playbackClockFunctionJS)
@@ -262,7 +278,11 @@ extension SingletonPlayerWebView {
                         const occurrenceGeneration = video.__kasetMediaGeneration || mediaGeneration;
                         endedMediaGeneration = occurrenceGeneration;
                         video.__kasetEndedOccurrenceGeneration = occurrenceGeneration;
-                        sendTrackEnded(video);
+                        const endedPayload = trackEndedPayload(video);
+                        if (!endedPayload) return;
+                        sendTrackEnded(endedPayload);
+                        setTimeout(() => retryTrackEnded(video, endedPayload), 16);
+                        setTimeout(() => retryTrackEnded(video, endedPayload), 100);
                         stopPolling();
                     });
                     video.addEventListener('waiting', () => sendUpdate(true)); // Buffer state
@@ -470,27 +490,37 @@ extension SingletonPlayerWebView {
                 return !!(moviePlayer && moviePlayer.classList.contains('ad-showing'));
             }
 
-            function sendTrackEnded(video) {
-                if (!video || video !== document.querySelector('video')) return;
+            function trackEndedPayload(video) {
+                if (!video || video !== document.querySelector('video') || !video.ended) return null;
                 const occurrenceGeneration = video.__kasetEndedOccurrenceGeneration
                     || video.__kasetMediaGeneration
                     || mediaGeneration;
                 const endedVideoId = video.__kasetBoundVideoId || lastVideoId || currentVideoId();
-                bridge.postMessage({
+                return {
                     type: 'TRACK_ENDED',
                     documentGeneration: window.__kasetDocumentGeneration,
                     nativePlaybackGeneration: window.__kasetNativePlaybackGeneration || 0,
+                    eventIssuedAtMilliseconds: __kasetEventTimestampMilliseconds(),
                     videoId: endedVideoId,
                     mediaGeneration: occurrenceGeneration,
                     isAd: isAdShowing()
-                });
+                };
+            }
+
+            function sendTrackEnded(payload) {
+                bridge.postMessage(payload);
+            }
+
+            function retryTrackEnded(video, payload) {
+                if (!video || video !== document.querySelector('video') || !video.ended) return;
+                sendTrackEnded(payload);
             }
 
             function sendUpdate(force = false) {
                 // Throttle non-forced updates across polling and mutation paths.
                 // If an update is skipped, keep one trailing send so paused/setup
                 // mutations that are not followed by a polling tick still reach Swift.
-                const now = Date.now();
+                const now = __kasetEventTimestampMilliseconds();
                 if (!force) {
                     const elapsed = now - lastUpdateTime;
                     if (elapsed < UPDATE_THROTTLE_MS) {
@@ -610,6 +640,7 @@ extension SingletonPlayerWebView {
                         type: 'STATE_UPDATE',
                         documentGeneration: window.__kasetDocumentGeneration,
                         nativePlaybackGeneration: window.__kasetNativePlaybackGeneration || 0,
+                        eventIssuedAtMilliseconds: now,
                         isPlaying: isPlaying,
                         progress: playbackClock.progress,
                         duration: playbackClock.duration,

--- a/Sources/Kaset/Views/SingletonPlayerWebView+ObserverScript.swift
+++ b/Sources/Kaset/Views/SingletonPlayerWebView+ObserverScript.swift
@@ -1,6 +1,60 @@
 // MARK: - SingletonPlayerWebView Observer Script Extension
 
 extension SingletonPlayerWebView {
+    /// Selects the authoritative playback clock for bridge state updates.
+    /// The hidden player bar can lag or stop updating while its media element
+    /// continues playing, so a ready media element wins over DOM attributes.
+    nonisolated static var playbackClockFunctionJS: String {
+        """
+        function __kasetPlaybackClock(mediaElement, progressBar, hasReadyMedia) {
+            const barProgress = progressBar
+                ? Number(progressBar.getAttribute('value'))
+                : Number.NaN;
+            const barDuration = progressBar
+                ? Number(progressBar.getAttribute('aria-valuemax'))
+                : Number.NaN;
+            const mediaProgress = mediaElement
+                ? Number(mediaElement.currentTime)
+                : Number.NaN;
+            const mediaDuration = mediaElement
+                ? Number(mediaElement.duration)
+                : Number.NaN;
+
+            return {
+                progress: hasReadyMedia && Number.isFinite(mediaProgress)
+                    ? mediaProgress
+                    : (Number.isFinite(barProgress) ? barProgress : 0),
+                duration: hasReadyMedia && Number.isFinite(mediaDuration) && mediaDuration > 0
+                    ? mediaDuration
+                    : (Number.isFinite(barDuration) && barDuration > 0 ? barDuration : 0)
+            };
+        }
+        """
+    }
+
+    /// Pure occurrence-binding decisions shared by the observer and JS tests.
+    nonisolated static var playbackOccurrenceFunctionJS: String {
+        """
+        function __kasetShouldBindMediaOccurrence(
+            hasBoundOccurrence,
+            sourceChanged,
+            mediaTimeReset,
+            identityChanged,
+            transitionEvidence
+        ) {
+            return !hasBoundOccurrence
+                || sourceChanged
+                || (mediaTimeReset && !identityChanged)
+                || (identityChanged && transitionEvidence);
+        }
+
+        function __kasetShouldAdvanceEndedOccurrence(endedMediaGeneration, mediaGeneration) {
+            return endedMediaGeneration !== null
+                && endedMediaGeneration === mediaGeneration;
+        }
+        """
+    }
+
     /// Pure JS function used by the observer script's `canplay` handler.
     /// Exposed as a named function so unit tests can exercise the branching
     /// inside a `JSContext` without standing up a real `WKWebView`.
@@ -8,10 +62,46 @@ extension SingletonPlayerWebView {
         """
         function __kasetAttemptAutoplayRecovery(video, playBtn) {
             if (!window.__kasetAutoplayPending) return 'noop';
-            if (!video.paused) { window.__kasetAutoplayPending = false; return 'noop'; }
-            window.__kasetAutoplayPending = false;
-            if (playBtn) { playBtn.click(); return 'clicked'; }
-            try { video.play(); return 'played'; } catch (e) { return 'error'; }
+            if (window.__kasetPlaybackSuppressed) return 'suppressed';
+            if (!video.paused) {
+                window.__kasetAutoplayPending = false;
+                window.__kasetAutoplayAttempts = 0;
+                return 'noop';
+            }
+
+            const attempts = window.__kasetAutoplayAttempts || 0;
+            if (attempts >= 5) {
+                return 'exhausted';
+            }
+            window.__kasetAutoplayAttempts = attempts + 1;
+
+            function scheduleRetry() {
+                if (typeof setTimeout !== 'function' || window.__kasetAutoplayRetryScheduled) return;
+                window.__kasetAutoplayRetryScheduled = true;
+                setTimeout(() => {
+                    window.__kasetAutoplayRetryScheduled = false;
+                    const currentVideo = document.querySelector('video');
+                    if (!window.__kasetAutoplayPending || !currentVideo || !currentVideo.paused) return;
+                    __kasetAttemptAutoplayRecovery(currentVideo, null);
+                }, 250);
+            }
+
+            if (playBtn) {
+                playBtn.click();
+                scheduleRetry();
+                return 'clicked';
+            }
+            try {
+                const playResult = video.play();
+                if (playResult && typeof playResult.catch === 'function') {
+                    playResult.catch(() => scheduleRetry());
+                }
+                scheduleRetry();
+                return 'played';
+            } catch (e) {
+                scheduleRetry();
+                return 'error';
+            }
         }
         """
     }
@@ -23,9 +113,18 @@ extension SingletonPlayerWebView {
             'use strict';
             const bridge = window.webkit.messageHandlers.singletonPlayer;
             \(autoplayRecoveryFunctionJS)
+            window.__kasetAttemptAutoplayRecovery = __kasetAttemptAutoplayRecovery;
+            \(playbackClockFunctionJS)
+            \(playbackOccurrenceFunctionJS)
             let lastTitle = '';
             let lastArtist = '';
             let lastVideoId = '';
+            let mediaVideoId = '';
+            let mediaSource = '';
+            let mediaGeneration = 0;
+            let lastMediaCurrentTime = 0;
+            let mediaIdentityNeedsRefresh = false;
+            let endedMediaGeneration = null;
             let isPollingActive = false;
             let pollIntervalId = null;
             let lastUpdateTime = 0;
@@ -63,6 +162,57 @@ extension SingletonPlayerWebView {
                 setTimeout(waitForPlayerBar, 500);
             }
 
+            function bindVideoIdentity(video, transitionEvidence) {
+                if (!video || video !== document.querySelector('video')) return false;
+                const videoId = currentVideoId();
+                const source = video.currentSrc || video.src || '';
+                const currentTime = Number.isFinite(video.currentTime) ? video.currentTime : 0;
+                const hasBoundOccurrence = mediaGeneration > 0;
+                const isReplacementElement = hasBoundOccurrence && !video.__kasetMediaGeneration;
+                const previousMediaVideoId = mediaVideoId;
+                const sourceChanged = hasBoundOccurrence
+                    && (isReplacementElement || source !== mediaSource);
+                const mediaTimeReset = hasBoundOccurrence && currentTime + 2 < lastMediaCurrentTime;
+                const identityChanged = !!videoId && videoId !== mediaVideoId;
+
+                if (!__kasetShouldBindMediaOccurrence(
+                    hasBoundOccurrence,
+                    sourceChanged,
+                    mediaTimeReset,
+                    identityChanged,
+                    transitionEvidence === true
+                )) {
+                    if (videoId && (!mediaVideoId || (identityChanged && mediaIdentityNeedsRefresh))) {
+                        mediaVideoId = videoId;
+                        video.__kasetBoundVideoId = videoId;
+                        mediaIdentityNeedsRefresh = false;
+                    }
+                    if (!identityChanged) {
+                        lastMediaCurrentTime = currentTime;
+                    }
+                    return false;
+                }
+
+                mediaGeneration += 1;
+                mediaVideoId = videoId;
+                mediaSource = source;
+                lastMediaCurrentTime = currentTime;
+                const shouldPreserveIdentityRefresh = mediaTimeReset
+                    && !isReplacementElement
+                    && !sourceChanged;
+                mediaIdentityNeedsRefresh = (
+                    shouldPreserveIdentityRefresh && mediaIdentityNeedsRefresh
+                ) || (
+                    (isReplacementElement || sourceChanged)
+                    && (!videoId || videoId === previousMediaVideoId)
+                );
+                video.__kasetBoundVideoId = videoId;
+                video.__kasetMediaGeneration = mediaGeneration;
+                video.__kasetEndedOccurrenceGeneration = null;
+                video.__kasetEndedReported = false;
+                return true;
+            }
+
             function setupVideoListeners() {
                 // Watch for video element to attach play/pause listeners
                 function attachVideoListeners() {
@@ -73,22 +223,54 @@ extension SingletonPlayerWebView {
                     }
                     if (video.__kasetListenersAttached) return;
                     video.__kasetListenersAttached = true;
+                    bindVideoIdentity(video, video.readyState >= 1);
 
-                    video.addEventListener('play', startPolling);
-                    video.addEventListener('playing', startPolling);
+                    function handlePlaybackStarted() {
+                        if (__kasetShouldAdvanceEndedOccurrence(
+                            endedMediaGeneration,
+                            mediaGeneration
+                        )) {
+                            mediaGeneration += 1;
+                            video.__kasetMediaGeneration = mediaGeneration;
+                            video.__kasetEndedOccurrenceGeneration = null;
+                            video.__kasetEndedReported = false;
+                        }
+                        endedMediaGeneration = null;
+                        bindVideoIdentity(video, !mediaVideoId);
+                        startPolling();
+                    }
+                    video.addEventListener('play', handlePlaybackStarted);
+                    video.addEventListener('playing', handlePlaybackStarted);
                     // Enforce volume on playing event to catch all track changes
                     // (auto-advance, SPA navigation, button clicks)
                     video.addEventListener('playing', () => {
                         window.__kasetAutoplayPending = false;
+                        window.__kasetAutoplayAttempts = 0;
+                        window.__kasetAutoplayRetryScheduled = false;
+                        bindVideoIdentity(video, !mediaVideoId);
                         enforceVolumeNow();
                     });
                     video.addEventListener('pause', stopPolling);
+                    video.addEventListener('play', () => {
+                        if (window.__kasetPlaybackSuppressed) video.pause();
+                    });
                     video.addEventListener('ended', () => {
-                        sendTrackEnded();
+                        if (video !== document.querySelector('video')) return;
+                        if (!video.ended) return;
+                        if (video.__kasetEndedReported) return;
+                        video.__kasetEndedReported = true;
+                        const occurrenceGeneration = video.__kasetMediaGeneration || mediaGeneration;
+                        endedMediaGeneration = occurrenceGeneration;
+                        video.__kasetEndedOccurrenceGeneration = occurrenceGeneration;
+                        sendTrackEnded(video);
                         stopPolling();
                     });
                     video.addEventListener('waiting', () => sendUpdate(true)); // Buffer state
                     video.addEventListener('seeked', () => sendUpdate(true)); // Seek completed
+                    // Media events keep advancing when hidden-page JavaScript
+                    // timers are throttled, so use them as the primary progress
+                    // heartbeat and retain the interval only as a fallback.
+                    video.addEventListener('timeupdate', () => sendUpdate());
 
                     // AirPlay state tracking
                     video.addEventListener('webkitcurrentplaybacktargetiswirelesschanged', () => {
@@ -98,6 +280,7 @@ extension SingletonPlayerWebView {
 
                         bridge.postMessage({
                             type: 'AIRPLAY_STATUS',
+                            documentGeneration: window.__kasetDocumentGeneration,
                             isConnected: isWireless,
                             wasConnected: wasConnected,
                             wasRequested: window.__kasetAirPlayRequested || false
@@ -110,6 +293,7 @@ extension SingletonPlayerWebView {
                         window.__kasetAirPlayConnected = true;
                         bridge.postMessage({
                             type: 'AIRPLAY_STATUS',
+                            documentGeneration: window.__kasetDocumentGeneration,
                             isConnected: true,
                             wasConnected: false,
                             wasRequested: window.__kasetAirPlayRequested || false
@@ -118,6 +302,7 @@ extension SingletonPlayerWebView {
                         window.__kasetAirPlayConnected = false;
                         bridge.postMessage({
                             type: 'AIRPLAY_STATUS',
+                            documentGeneration: window.__kasetDocumentGeneration,
                             isConnected: false,
                             wasConnected: true,
                             wasRequested: true
@@ -136,7 +321,10 @@ extension SingletonPlayerWebView {
 
                     // Enforce volume at media lifecycle events where YouTube resets volume.
                     // YouTube's player often restores its stored volume at these points.
-                    video.addEventListener('loadedmetadata', () => enforceVolumeNow());
+                    video.addEventListener('loadedmetadata', () => {
+                        bindVideoIdentity(video, true);
+                        enforceVolumeNow();
+                    });
                     video.addEventListener('loadeddata', () => enforceVolumeNow());
                     function recoverAutoplayIfNeeded() {
                         enforceVolumeNow();
@@ -221,8 +409,11 @@ extension SingletonPlayerWebView {
                     const v = document.querySelector('video');
                     if (v) {
                         bridge.postMessage({
-                            type: 'LYRICS_TIME',
-                            time: v.currentTime
+                        type: 'LYRICS_TIME',
+                        documentGeneration: window.__kasetDocumentGeneration,
+                        nativePlaybackGeneration: window.__kasetNativePlaybackGeneration || 0,
+                            time: v.currentTime,
+                            isAd: isAdShowing()
                         });
                     }
                 }, 100);
@@ -274,11 +465,24 @@ extension SingletonPlayerWebView {
                 sendUpdate(true);
             }
 
-            function sendTrackEnded() {
-                const endedVideoId = lastVideoId || currentVideoId();
+            function isAdShowing() {
+                const moviePlayer = document.getElementById('movie_player');
+                return !!(moviePlayer && moviePlayer.classList.contains('ad-showing'));
+            }
+
+            function sendTrackEnded(video) {
+                if (!video || video !== document.querySelector('video')) return;
+                const occurrenceGeneration = video.__kasetEndedOccurrenceGeneration
+                    || video.__kasetMediaGeneration
+                    || mediaGeneration;
+                const endedVideoId = video.__kasetBoundVideoId || lastVideoId || currentVideoId();
                 bridge.postMessage({
                     type: 'TRACK_ENDED',
-                    videoId: endedVideoId
+                    documentGeneration: window.__kasetDocumentGeneration,
+                    nativePlaybackGeneration: window.__kasetNativePlaybackGeneration || 0,
+                    videoId: endedVideoId,
+                    mediaGeneration: occurrenceGeneration,
+                    isAd: isAdShowing()
                 });
             }
 
@@ -308,7 +512,7 @@ extension SingletonPlayerWebView {
                     // Use video element's paused property for language-agnostic detection
                     // Previously checked button title/aria-label which fails for non-English locales
                     const video = document.querySelector('video');
-                    const isPlaying = video ? !video.paused : false;
+                    let isPlaying = video ? !video.paused : false;
 
                     const progressBar = document.querySelector('#progress-bar');
 
@@ -318,6 +522,17 @@ extension SingletonPlayerWebView {
                     const thumbEl = document.querySelector('.ytmusic-player-bar .thumbnail img, ytmusic-player-bar .image');
 
                     const playerData = currentPlayerData();
+                    const mediaElement = document.querySelector('video');
+                    const hasReadyMedia = !!(
+                        mediaElement
+                        && mediaElement.currentSrc
+                        && mediaElement.readyState >= 1
+                    );
+                    const playbackClock = __kasetPlaybackClock(
+                        mediaElement,
+                        progressBar,
+                        hasReadyMedia
+                    );
                     const playerTitle = playerData && typeof playerData.title === 'string'
                         ? playerData.title.trim()
                         : '';
@@ -328,6 +543,14 @@ extension SingletonPlayerWebView {
                     let title = titleEl ? titleEl.textContent.trim() : '';
                     let artist = artistEl ? artistEl.textContent.trim() : '';
                     const videoId = currentVideoId();
+                    if (video) bindVideoIdentity(video, false);
+                    const isAd = isAdShowing();
+                    if (video && window.__kasetResumeAdOnly && !isAd) {
+                        window.__kasetResumeAdOnly = false;
+                        window.__kasetPlaybackSuppressed = true;
+                        video.pause();
+                        isPlaying = false;
+                    }
                     let thumbnailUrl = '';
 
                     // Prefer player API metadata when the DOM appears to be lagging behind the actual video.
@@ -385,12 +608,18 @@ extension SingletonPlayerWebView {
 
                     bridge.postMessage({
                         type: 'STATE_UPDATE',
+                        documentGeneration: window.__kasetDocumentGeneration,
+                        nativePlaybackGeneration: window.__kasetNativePlaybackGeneration || 0,
                         isPlaying: isPlaying,
-                        progress: progressBar ? parseInt(progressBar.getAttribute('value') || '0') : 0,
-                        duration: progressBar ? parseInt(progressBar.getAttribute('aria-valuemax') || '0') : 0,
+                        progress: playbackClock.progress,
+                        duration: playbackClock.duration,
+                        isAd: isAd,
+                        hasReadyMedia: hasReadyMedia,
                         title: title,
                         artist: artist,
                         videoId: videoId,
+                        mediaVideoId: mediaVideoId,
+                        mediaGeneration: mediaGeneration,
                         thumbnailUrl: thumbnailUrl,
                         trackChanged: trackChanged,
                         likeStatus: likeStatus,

--- a/Sources/Kaset/Views/SingletonPlayerWebView+PlaybackAudioQuality.swift
+++ b/Sources/Kaset/Views/SingletonPlayerWebView+PlaybackAudioQuality.swift
@@ -403,6 +403,7 @@ extension SingletonPlayerWebView {
             function collectAudioQualitySnapshot(quality, desired, applied, players) {
                 var snapshot = {
                     type: 'PLAYBACK_AUDIO_QUALITY_STATS',
+                    documentGeneration: window.__kasetDocumentGeneration,
                     preferred: quality,
                     desired: desired,
                     applied: !!applied,

--- a/Sources/Kaset/Views/SingletonPlayerWebView+PlaybackControls.swift
+++ b/Sources/Kaset/Views/SingletonPlayerWebView+PlaybackControls.swift
@@ -283,12 +283,10 @@ extension SingletonPlayerWebView {
         webView.evaluateJavaScript(script, completionHandler: nil)
     }
 
-    /// Atomically pause and seek the underlying video.
-    func seekAndPause(to time: Double) {
-        guard let webView else { return }
-
+    /// Pure script for atomically pausing and seeking the underlying video.
+    nonisolated static func seekAndPauseScript(to time: Double) -> String {
         let safeTime = time.isFinite ? max(time, 0) : 0
-        let script = """
+        return """
             (function() {
                 const video = document.querySelector('video');
                 if (!video) { return 'no-video'; }
@@ -298,7 +296,12 @@ extension SingletonPlayerWebView {
                 return 'seeked-paused';
             })();
         """
-        webView.evaluateJavaScript(script, completionHandler: nil)
+    }
+
+    /// Atomically pause and seek the underlying video.
+    func seekAndPause(to time: Double) {
+        guard let webView else { return }
+        webView.evaluateJavaScript(Self.seekAndPauseScript(to: time), completionHandler: nil)
     }
 
     /// Seeks to the start and resumes playback without a full page load (repeat-one, same-URL recovery).

--- a/Sources/Kaset/Views/SingletonPlayerWebView+PlaybackControls.swift
+++ b/Sources/Kaset/Views/SingletonPlayerWebView+PlaybackControls.swift
@@ -95,21 +95,59 @@ extension SingletonPlayerWebView {
         }
     }
 
+    nonisolated static var playPauseCommandScript: String {
+        """
+        (function() {
+            const playBtn = document.querySelector('.play-pause-button.ytmusic-player-bar');
+            if (playBtn) {
+                const video = document.querySelector('video');
+                const wantsPlay = !video || video.paused;
+                window.__kasetAutoplayPending = wantsPlay;
+                window.__kasetPlaybackSuppressed = !wantsPlay;
+                if (wantsPlay) {
+                    window.__kasetAutoplayAttempts = 0;
+                    window.__kasetAutoplayRetryScheduled = false;
+                    if (video && typeof window.__kasetAttemptAutoplayRecovery === 'function') {
+                        return window.__kasetAttemptAutoplayRecovery(video, playBtn);
+                    }
+                }
+                playBtn.click();
+                return 'clicked';
+            }
+            const video = document.querySelector('video');
+            if (video) {
+                if (video.paused) {
+                    window.__kasetAutoplayPending = true;
+                    window.__kasetPlaybackSuppressed = false;
+                    window.__kasetAutoplayAttempts = 0;
+                    window.__kasetAutoplayRetryScheduled = false;
+                    if (typeof window.__kasetAttemptAutoplayRecovery === 'function') {
+                        return window.__kasetAttemptAutoplayRecovery(video, null);
+                    }
+                    video.play();
+                    return 'played';
+                } else {
+                    window.__kasetAutoplayPending = false;
+                    window.__kasetPlaybackSuppressed = true;
+                    video.pause();
+                    return 'paused';
+                }
+            }
+            return 'no-element';
+        })();
+        """
+    }
+
     /// Toggle play/pause.
     func playPause() {
         guard let webView else { return }
+        let generation = self.documentGeneration.currentGeneration
+        guard self.documentGeneration.accepts(generation: generation) else { return }
 
         let script = """
-            (function() {
-                const playBtn = document.querySelector('.play-pause-button.ytmusic-player-bar');
-                if (playBtn) { playBtn.click(); return 'clicked'; }
-                const video = document.querySelector('video');
-                if (video) {
-                    if (video.paused) { video.play(); return 'played'; }
-                    else { video.pause(); return 'paused'; }
-                }
-                return 'no-element';
-            })();
+            if (window.__kasetDocumentGeneration === \(generation)) {
+                \(Self.playPauseCommandScript)
+            }
         """
         webView.evaluateJavaScript(script) { [weak self] _, error in
             if let error {
@@ -118,18 +156,65 @@ extension SingletonPlayerWebView {
         }
     }
 
+    nonisolated static var playCommandScript: String {
+        """
+        (function() {
+            window.__kasetAutoplayPending = true;
+            window.__kasetPlaybackSuppressed = false;
+            window.__kasetResumeAdOnly = false;
+            window.__kasetAutoplayAttempts = 0;
+            window.__kasetAutoplayRetryScheduled = false;
+            const video = document.querySelector('video');
+            if (video && video.paused) {
+                if (typeof window.__kasetAttemptAutoplayRecovery === 'function') {
+                    return window.__kasetAttemptAutoplayRecovery(video, null);
+                }
+                video.play();
+                return 'played';
+            }
+            return video ? 'already-playing' : 'pending-media';
+        })();
+        """
+    }
+
     /// Play (resume).
     func play() {
         guard let webView else { return }
+        let generation = self.documentGeneration.currentGeneration
+        guard self.documentGeneration.accepts(generation: generation) else { return }
+        webView.evaluateJavaScript("""
+            if (window.__kasetDocumentGeneration === \(generation)) {
+                \(Self.playCommandScript)
+            }
+        """, completionHandler: nil)
+    }
 
-        let script = """
+    /// During restored playback, a paused preroll ad must advance before the
+    /// content seek can be reconciled. Never unsuppress ordinary content here.
+    func resumeReadyAdvertisementIfPresent() {
+        guard let webView else { return }
+        let generation = self.documentGeneration.currentGeneration
+        guard self.documentGeneration.accepts(generation: generation) else { return }
+        webView.evaluateJavaScript("""
             (function() {
+                if (window.__kasetDocumentGeneration !== \(generation)) return 'stale';
+                const player = document.getElementById('movie_player');
+                const isAd = !!(player && player.classList.contains('ad-showing'));
                 const video = document.querySelector('video');
-                if (video && video.paused) { video.play(); return 'played'; }
-                return 'already-playing';
+                if (!isAd || !video || !video.currentSrc || video.readyState < 1) return 'not-ready-ad';
+                window.__kasetPlaybackSuppressed = false;
+                window.__kasetAutoplayPending = true;
+                window.__kasetResumeAdOnly = true;
+                if (video.paused) {
+                    if (typeof window.__kasetAttemptAutoplayRecovery === 'function') {
+                        window.__kasetAttemptAutoplayRecovery(video, null);
+                    } else {
+                        video.play();
+                    }
+                }
+                return 'playing-ad';
             })();
-        """
-        webView.evaluateJavaScript(script, completionHandler: nil)
+        """, completionHandler: nil)
     }
 
     /// Pause.
@@ -138,6 +223,8 @@ extension SingletonPlayerWebView {
 
         let script = """
             (function() {
+            window.__kasetAutoplayPending = false;
+            window.__kasetPlaybackSuppressed = true;
                 const video = document.querySelector('video');
                 if (video && !video.paused) { video.pause(); return 'paused'; }
                 return 'already-paused';
@@ -216,6 +303,9 @@ extension SingletonPlayerWebView {
 
     /// Seeks to the start and resumes playback without a full page load (repeat-one, same-URL recovery).
     func restartInPlaceFromBeginning() {
+        if let generation = self.coordinator?.playerService.currentMusicPlaybackOccurrence?.nativeGeneration {
+            self.setNativePlaybackGeneration(generation)
+        }
         self.seek(to: 0)
         self.play()
     }

--- a/Sources/Kaset/Views/SingletonPlayerWebView+PlaybackPreferences.swift
+++ b/Sources/Kaset/Views/SingletonPlayerWebView+PlaybackPreferences.swift
@@ -140,11 +140,19 @@ extension SingletonPlayerWebView {
                     ms.setActionHandler('seekbackward', null);
                     ms.setActionHandler('nexttrack', function() {
                         window.webkit.messageHandlers.singletonPlayer
-                            .postMessage({ type: 'REMOTE_NEXT' });
+                            .postMessage({
+                                type: 'REMOTE_NEXT',
+                                documentGeneration: window.__kasetDocumentGeneration,
+                                commandIssuedAtMilliseconds: Date.now()
+                            });
                     });
                     ms.setActionHandler('previoustrack', function() {
                         window.webkit.messageHandlers.singletonPlayer
-                            .postMessage({ type: 'REMOTE_PREVIOUS' });
+                            .postMessage({
+                                type: 'REMOTE_PREVIOUS',
+                                documentGeneration: window.__kasetDocumentGeneration,
+                                commandIssuedAtMilliseconds: Date.now()
+                            });
                     });
                 } catch (e) {}
             }

--- a/Sources/Kaset/Views/SingletonPlayerWebView+PlaybackPreferences.swift
+++ b/Sources/Kaset/Views/SingletonPlayerWebView+PlaybackPreferences.swift
@@ -119,6 +119,7 @@ extension SingletonPlayerWebView {
     static var mediaControlOverrideScript: String {
         """
         (function() {
+            \(eventTimestampFunctionJS)
             if (typeof window.__kasetUseNextPrev !== 'boolean') {
                 try {
                     window.__kasetUseNextPrev =
@@ -143,7 +144,7 @@ extension SingletonPlayerWebView {
                             .postMessage({
                                 type: 'REMOTE_NEXT',
                                 documentGeneration: window.__kasetDocumentGeneration,
-                                commandIssuedAtMilliseconds: Date.now()
+                                commandIssuedAtMilliseconds: __kasetEventTimestampMilliseconds()
                             });
                     });
                     ms.setActionHandler('previoustrack', function() {
@@ -151,7 +152,7 @@ extension SingletonPlayerWebView {
                             .postMessage({
                                 type: 'REMOTE_PREVIOUS',
                                 documentGeneration: window.__kasetDocumentGeneration,
-                                commandIssuedAtMilliseconds: Date.now()
+                                commandIssuedAtMilliseconds: __kasetEventTimestampMilliseconds()
                             });
                     });
                 } catch (e) {}

--- a/Sources/Kaset/Views/YouTube/YouTubeWatchWebView+Coordinator.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeWatchWebView+Coordinator.swift
@@ -1,0 +1,284 @@
+import WebKit
+
+extension YouTubeWatchWebView {
+    // MARK: - Coordinator
+
+    final class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler {
+        let playerService: YouTubePlayerService
+
+        init(playerService: YouTubePlayerService) {
+            self.playerService = playerService
+        }
+
+        func userContentController(_: WKUserContentController, didReceive message: WKScriptMessage) {
+            let watchWebView = YouTubeWatchWebView.shared
+            guard let body = message.body as? [String: Any],
+                  let messageDocumentGeneration = WebPlaybackDocumentGeneration.decode(
+                      body["documentGeneration"]
+                  ),
+                  YouTubeWatchWebView.acceptsBridgeSource(
+                      isMainFrame: message.frameInfo.isMainFrame,
+                      sourceScheme: message.frameInfo.securityOrigin.protocol,
+                      sourceHost: message.frameInfo.securityOrigin.host
+                  ),
+                  YouTubeWatchWebView.acceptsBridgeMessage(
+                      sourceWebView: message.webView,
+                      currentWebView: watchWebView.webView,
+                      documentGeneration: watchWebView.documentGeneration,
+                      rawDocumentGeneration: messageDocumentGeneration
+                  ),
+                  let type = body["type"] as? String
+            else { return }
+
+            switch type {
+            case "STATE_UPDATE":
+                self.handleStateUpdate(body, documentGeneration: messageDocumentGeneration)
+            case "VIDEO_ENDED":
+                self.handleVideoEnded(body, documentGeneration: messageDocumentGeneration)
+            default:
+                return
+            }
+        }
+
+        private func handleStateUpdate(
+            _ body: [String: Any],
+            documentGeneration: UInt64
+        ) {
+            let update = YouTubePlayerService.PlaybackUpdate(
+                isPlaying: body["isPlaying"] as? Bool ?? false,
+                progress: body["progress"] as? Double ?? 0,
+                duration: body["duration"] as? Double ?? 0,
+                hasReadyMedia: body["hasReadyMedia"] as? Bool ?? false,
+                videoId: (body["videoId"] as? String).flatMap { $0.isEmpty ? nil : $0 },
+                boundVideoId: (body["boundVideoId"] as? String)
+                    .flatMap { $0.isEmpty ? nil : $0 },
+                title: body["title"] as? String,
+                isAd: body["isAd"] as? Bool ?? false,
+                didApplyPendingSeek: body["pendingSeekApplied"] as? Bool ?? false,
+                didFailPendingSeek: body["pendingSeekFailed"] as? Bool ?? false,
+                pendingSeekTarget: body["pendingSeekTarget"] as? Double,
+                pendingSeekVideoId: (body["pendingSeekVideoId"] as? String)
+                    .flatMap { $0.isEmpty ? nil : $0 },
+                pendingSeekAttempt: WebPlaybackDocumentGeneration.decode(
+                    body["pendingSeekAttempt"]
+                ),
+                nativePausePending: body["nativePausePending"] as? Bool ?? false,
+                eventIssuedAtMilliseconds: body["eventIssuedAtMilliseconds"] as? Double,
+                playbackOccurrence: Self.playbackOccurrence(
+                    from: body,
+                    documentGeneration: documentGeneration
+                )
+            )
+            // WebKit has already admitted this main-frame message for the active
+            // document. Persist the recovery-only marker synchronously so a
+            // process-termination callback cannot invalidate the generation first.
+            self.playerService.recordPostConclusionAutoplayTransitionIfNeeded(update)
+            Task { @MainActor in
+                guard YouTubeWatchWebView.shared.documentGeneration.accepts(
+                    generation: documentGeneration
+                ) else { return }
+                guard self.playerService.acceptsPlaybackOccurrence(
+                    update.playbackOccurrence
+                ) else { return }
+                var validatedUpdate = update
+                if update.didApplyPendingSeek,
+                   let target = update.pendingSeekTarget,
+                   let pendingSeekVideoId = update.pendingSeekVideoId,
+                   let pendingSeekAttempt = update.pendingSeekAttempt
+                {
+                    let didAcceptSeek = YouTubeWatchWebView.shared.completePendingSeek(
+                        generation: documentGeneration,
+                        attemptID: pendingSeekAttempt,
+                        target: target,
+                        videoId: pendingSeekVideoId
+                    )
+                    if !didAcceptSeek {
+                        validatedUpdate.didApplyPendingSeek = false
+                    }
+                }
+                self.playerService.updatePlaybackState(validatedUpdate)
+                self.reconcilePendingSeek(
+                    after: validatedUpdate,
+                    documentGeneration: documentGeneration
+                )
+            }
+        }
+
+        @MainActor
+        private func reconcilePendingSeek(
+            after update: YouTubePlayerService.PlaybackUpdate,
+            documentGeneration: UInt64
+        ) {
+            if !update.isAd, update.hasReadyMedia {
+                YouTubeWatchWebView.shared.discardPendingSeekIfActiveVideoChanged(
+                    generation: documentGeneration
+                )
+            }
+            guard let target = update.pendingSeekTarget,
+                  let pendingSeekVideoId = update.pendingSeekVideoId,
+                  let pendingSeekAttempt = update.pendingSeekAttempt
+            else { return }
+
+            if update.didFailPendingSeek {
+                let didExhaustRetries = YouTubeWatchWebView.shared.retryPendingSeek(
+                    generation: documentGeneration,
+                    target: target,
+                    videoId: pendingSeekVideoId,
+                    attemptID: pendingSeekAttempt
+                )
+                if didExhaustRetries {
+                    self.playerService.handlePendingSeekExhausted(
+                        videoId: pendingSeekVideoId,
+                        target: target
+                    )
+                }
+            }
+        }
+
+        private func handleVideoEnded(
+            _ body: [String: Any],
+            documentGeneration: UInt64
+        ) {
+            let videoId = (body["videoId"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+            let endedDuringAd = body["isAd"] as? Bool ?? false
+            let playbackOccurrence = Self.playbackOccurrence(
+                from: body,
+                documentGeneration: documentGeneration
+            )
+            let endedSeekAttempt = WebPlaybackDocumentGeneration.decode(
+                body["pendingSeekAttempt"]
+            )
+            let eventIssuedAtMilliseconds = body["eventIssuedAtMilliseconds"] as? Double
+            guard !endedDuringAd else { return }
+            // The outer bridge admission already validated WebView identity and
+            // document generation. Commit this terminal occurrence synchronously;
+            // a process-termination callback may invalidate the document next.
+            let didAcceptEnd = self.playerService.handleVideoEnded(
+                videoId: videoId,
+                playbackOccurrence: playbackOccurrence,
+                eventIssuedAtMilliseconds: eventIssuedAtMilliseconds
+            )
+            if didAcceptEnd, let endedSeekAttempt {
+                YouTubeWatchWebView.shared.completePendingSeek(
+                    generation: documentGeneration,
+                    attemptID: endedSeekAttempt
+                )
+            }
+        }
+
+        private static func playbackOccurrence(
+            from body: [String: Any],
+            documentGeneration: UInt64
+        ) -> YouTubePlaybackOccurrence? {
+            guard let mediaGeneration = WebPlaybackDocumentGeneration.decode(
+                body["mediaGeneration"]
+            ), mediaGeneration > 0 else { return nil }
+            return YouTubePlaybackOccurrence(
+                documentGeneration: documentGeneration,
+                mediaGeneration: mediaGeneration
+            )
+        }
+
+        func webView(
+            _ webView: WKWebView,
+            decidePolicyFor navigationAction: WKNavigationAction,
+            decisionHandler: @escaping @MainActor (WKNavigationActionPolicy) -> Void
+        ) {
+            YouTubeWatchWebView.shared.decideNavigationPolicy(
+                webView: webView,
+                navigationAction: navigationAction,
+                decisionHandler: decisionHandler
+            )
+        }
+
+        func webView(
+            _: WKWebView,
+            decidePolicyFor navigationResponse: WKNavigationResponse,
+            decisionHandler: @escaping @MainActor (WKNavigationResponsePolicy) -> Void
+        ) {
+            guard navigationResponse.isForMainFrame else {
+                decisionHandler(.allow)
+                return
+            }
+            let watchWebView = YouTubeWatchWebView.shared
+            let isAllowed = YouTubeWatchWebView.acceptsMainFrameResponse(
+                navigationResponse.response,
+                expectedVideoID: watchWebView.currentVideoId
+                    ?? self.playerService.currentVideo?.videoId,
+                documentGeneration: watchWebView.documentGeneration
+            )
+            if isAllowed {
+                watchWebView.recordAcceptedMainFrameResponse(navigationResponse.response)
+            }
+            decisionHandler(isAllowed ? .allow : .cancel)
+        }
+
+        func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+            YouTubeWatchWebView.shared.trackDocumentNavigationStart(navigation, webView: webView)
+            YouTubeWatchWebView.shared.webKitManager?.extensionHostWebViewDidStartNavigation(webView)
+        }
+
+        func webView(_ webView: WKWebView, didReceiveServerRedirectForProvisionalNavigation navigation: WKNavigation!) {
+            YouTubeWatchWebView.shared.handleDocumentNavigationRedirect(navigation, webView: webView)
+        }
+
+        func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
+            YouTubeWatchWebView.shared.commitDocumentNavigation(navigation, webView: webView)
+        }
+
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            guard YouTubeWatchWebView.shared.finishDocumentNavigation(
+                navigation,
+                webView: webView
+            ) else {
+                YouTubeWatchWebView.shared.webKitManager?.extensionHostWebViewDidFailNavigation(webView)
+                return
+            }
+            YouTubeWatchWebView.shared.webKitManager?.extensionHostWebViewDidFinishNavigation(webView)
+            guard WebPlaybackDocumentGeneration.isExpectedPlaybackURL(
+                webView.url,
+                host: "www.youtube.com"
+            ) else { return }
+            DiagnosticsLogger.player.info(
+                "YouTube watch WebView finished loading: \(webView.url?.absoluteString ?? "nil")"
+            )
+
+            // The resume-seek for an identity-switch reload is applied by the
+            // observer's applyPendingSeek (gated on the <video> existing and being
+            // seekable), not here: at didFinish the element often does not exist
+            // yet, so a one-shot seek would be lost. Clear the Swift-side copy now
+            // that the per-load bootstrap has carried the value into the page.
+            YouTubeWatchWebView.shared.pendingSeek = nil
+
+            let savedVolume = self.playerService.volume
+            webView.evaluateJavaScript(
+                """
+                (function() {
+                    window.__kasetTargetVolume = \(savedVolume);
+                    const video = document.querySelector('video');
+                    if (video) { video.volume = \(savedVolume); }
+                    if (window.__kasetExtractVideo) { window.__kasetExtractVideo(); }
+                })();
+                """,
+                completionHandler: nil
+            )
+        }
+
+        func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+            YouTubeWatchWebView.shared.handleDocumentNavigationFailure(navigation, webView: webView, error: error)
+        }
+
+        func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+            YouTubeWatchWebView.shared.handleDocumentNavigationFailure(navigation, webView: webView, error: error)
+        }
+
+        func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+            DiagnosticsLogger.player.error("YouTube watch WebView content process terminated, recovering")
+            let resumeAt = YouTubeWatchWebView.shared.pendingSeekForActiveNavigation()
+            guard YouTubeWatchWebView.shared.beginContentProcessRecovery(webView: webView) else { return }
+            self.playerService.recoverAfterWebContentProcessTermination(
+                resumeAtOverride: resumeAt
+            )
+        }
+    }
+}

--- a/Sources/Kaset/Views/YouTube/YouTubeWatchWebView+DocumentGeneration.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeWatchWebView+DocumentGeneration.swift
@@ -1,0 +1,105 @@
+import Foundation
+
+extension YouTubeWatchWebView {
+    /// Document-start state handed to each new watch page.
+    ///
+    /// `documentGeneration` scopes bridge messages to this page. `pendingSeek`,
+    /// when present, is a resume position (seconds) applied by the observer once
+    /// the `<video>` element exists and is seekable (see `applyPendingSeek` in the
+    /// observer script). Injected at document start so both values are in place
+    /// before the player boots and naturally scoped to this one navigation.
+    nonisolated static func pageBootstrapScript(
+        targetVolume: Double,
+        documentGeneration _: UInt64,
+        pendingSeek: Double? = nil,
+        pendingSeekVideoId: String? = nil,
+        pendingSeekAttemptID: UInt64? = nil
+    ) -> String {
+        let clamped = targetVolume.isFinite ? min(max(targetVolume, 0), 1) : 1.0
+        var script = """
+        (function() {
+            try {
+                const queryGeneration = new URLSearchParams(window.location.search)
+                    .get('\(WebPlaybackDocumentGeneration.urlQueryKey)');
+                const fragmentGeneration = new URLSearchParams(
+                    window.location.hash.replace(/^#/, '')
+                ).get('\(WebPlaybackDocumentGeneration.urlQueryKey)');
+                const rawGeneration = queryGeneration || fragmentGeneration;
+                const parsedGeneration = rawGeneration === null || rawGeneration === ''
+                    ? Number.NaN
+                    : Number(rawGeneration);
+                window.__kasetDocumentGeneration =
+                    Number.isSafeInteger(parsedGeneration) && parsedGeneration >= 0
+                        ? parsedGeneration
+                        : -1;
+            } catch (e) {
+                window.__kasetDocumentGeneration = -1;
+            }
+        })();
+        window.__kasetTargetVolume = \(clamped);
+        window.__kasetNativePausePending = false;
+        """
+        if let pendingSeek, pendingSeek.isFinite, pendingSeek >= 0 {
+            let attemptID = pendingSeekAttemptID ?? 1
+            script += " window.__kasetPendingSeek = \(pendingSeek); window.__kasetPendingSeekWaits = 0; window.__kasetPendingSeekApplied = false; window.__kasetPendingSeekFailed = false; window.__kasetPendingSeekAttempt = \(attemptID); window.__kasetPendingSeekInFlightAttempt = null;"
+            if let pendingSeekVideoId {
+                let literal = WebPlaybackDocumentGeneration.javaScriptStringLiteral(pendingSeekVideoId)
+                script += " window.__kasetPendingSeekVideoId = \(literal);"
+            }
+        }
+        return script
+    }
+
+    nonisolated static func watchURL(videoId: String, documentGeneration: UInt64) -> URL? {
+        var components = URLComponents(string: "https://www.youtube.com/watch")
+        components?.queryItems = [
+            URLQueryItem(name: "v", value: videoId),
+            URLQueryItem(
+                name: WebPlaybackDocumentGeneration.urlQueryKey,
+                value: String(documentGeneration)
+            ),
+        ]
+        components?.fragment = "\(WebPlaybackDocumentGeneration.urlQueryKey)=\(documentGeneration)"
+        return components?.url
+    }
+
+    nonisolated static func userScriptDocumentGeneration(
+        from documentGeneration: WebPlaybackDocumentGeneration
+    ) -> UInt64 {
+        documentGeneration.userScriptGeneration
+    }
+
+    nonisolated static func acceptsBridgeMessage(
+        sourceWebView: AnyObject?,
+        currentWebView: AnyObject?,
+        documentGeneration: WebPlaybackDocumentGeneration,
+        rawDocumentGeneration: Any?
+    ) -> Bool {
+        guard let sourceWebView,
+              let currentWebView,
+              sourceWebView === currentWebView
+        else { return false }
+        return documentGeneration.accepts(rawGeneration: rawDocumentGeneration)
+    }
+
+    nonisolated static func acceptsBridgeSource(
+        isMainFrame: Bool,
+        sourceScheme: String,
+        sourceHost: String
+    ) -> Bool {
+        isMainFrame && sourceScheme == "https" && sourceHost == "www.youtube.com"
+    }
+
+    nonisolated static func acceptsMainFrameResponse(
+        _ response: URLResponse,
+        expectedVideoID: String?,
+        documentGeneration: WebPlaybackDocumentGeneration
+    ) -> Bool {
+        WebPlaybackDocumentGeneration.acceptsMainFrameResponse(
+            response,
+            expectedHost: "www.youtube.com",
+            expectedVideoID: expectedVideoID,
+            allowsInternalBlank: documentGeneration.ownsBlankNavigation(response.url)
+        )
+    }
+}

--- a/Sources/Kaset/Views/YouTube/YouTubeWatchWebView+RecoverySeek.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeWatchWebView+RecoverySeek.swift
@@ -1,0 +1,311 @@
+import WebKit
+
+extension YouTubeWatchWebView {
+    private var activePlaybackVideoId: String? {
+        self.coordinator?.playerService.currentVideo?.videoId ?? self.currentVideoId
+    }
+
+    func pendingSeekForActiveNavigation() -> Double? {
+        let generation = self.documentGeneration.pendingGeneration
+            ?? self.documentGeneration.inFlightGeneration
+            ?? self.documentGeneration.currentGeneration
+        return Self.recoverySeek(
+            candidate: self.pendingSeeksByGeneration[generation],
+            candidateVideoId: self.pendingSeekVideoIdsByGeneration[generation],
+            activeVideoId: self.activePlaybackVideoId
+        )
+    }
+
+    nonisolated static func recoverySeek(
+        candidate: Double?,
+        candidateVideoId: String?,
+        activeVideoId: String?
+    ) -> Double? {
+        guard let activeVideoId, candidateVideoId == activeVideoId else { return nil }
+        return candidate
+    }
+
+    @discardableResult
+    func beginPendingSeekAttempt(generation: UInt64) -> UInt64 {
+        self.nextPendingSeekAttemptID &+= 1
+        self.pendingSeekAttemptIDsByGeneration[generation] = self.nextPendingSeekAttemptID
+        self.cancelledPendingSeekGenerations.remove(generation)
+        return self.nextPendingSeekAttemptID
+    }
+
+    @discardableResult
+    func completePendingSeek(
+        generation: UInt64,
+        attemptID: UInt64,
+        target: Double? = nil,
+        videoId: String? = nil
+    ) -> Bool {
+        guard let currentTarget = self.pendingSeeksByGeneration[generation] else { return false }
+        guard self.pendingSeekAttemptIDsByGeneration[generation] == attemptID else { return false }
+        if let target,
+           currentTarget != target
+        {
+            return false
+        }
+        let currentVideoId = self.pendingSeekVideoIdsByGeneration[generation]
+        if let videoId, currentVideoId != videoId {
+            return false
+        }
+        self.pendingSeeksByGeneration.removeValue(forKey: generation)
+        self.pendingSeekVideoIdsByGeneration.removeValue(forKey: generation)
+        self.pendingSeekAttemptIDsByGeneration.removeValue(forKey: generation)
+        self.pendingSeekRetryCounts.removeValue(forKey: generation)
+        self.directSeekGenerations.remove(generation)
+        if self.pendingSeek == currentTarget {
+            self.pendingSeek = nil
+        }
+        for (key, var navigation) in self.documentNavigations
+            where navigation.generation == generation
+        {
+            navigation.pendingSeek = nil
+            self.documentNavigations[key] = navigation
+        }
+        if let webView = self.webView {
+            webView.evaluateJavaScript(
+                Self.pendingSeekCompletionScript(
+                    documentGeneration: generation,
+                    attemptID: attemptID,
+                    target: currentTarget,
+                    videoId: currentVideoId
+                ),
+                completionHandler: nil
+            )
+        }
+        return true
+    }
+
+    func seekWithRecovery(to seconds: Double) {
+        self.pendingSeek = seconds
+        let generation = self.documentGeneration.pendingGeneration
+            ?? self.documentGeneration.inFlightGeneration
+            ?? self.documentGeneration.currentGeneration
+        self.pendingSeeksByGeneration[generation] = seconds
+        let videoId = self.coordinator?.playerService.currentVideo?.videoId ?? self.currentVideoId
+        if let videoId {
+            self.pendingSeekVideoIdsByGeneration[generation] = videoId
+        }
+        self.directSeekGenerations.insert(generation)
+        self.pendingSeekRetryCounts[generation] = 0
+        self.beginPendingSeekAttempt(generation: generation)
+        for (key, var navigation) in self.documentNavigations
+            where navigation.generation == generation
+        {
+            navigation.pendingSeek = seconds
+            self.documentNavigations[key] = navigation
+        }
+        guard let webView = self.webView else { return }
+        if self.documentGeneration.pendingGeneration != nil
+            || self.documentGeneration.inFlightGeneration != nil
+        {
+            let targetVolume = self.coordinator?.playerService.volume ?? 1.0
+            self.installUserScripts(
+                on: webView.configuration.userContentController,
+                targetVolume: targetVolume,
+                documentGeneration: generation,
+                pendingSeek: seconds,
+                pendingSeekVideoId: self.pendingSeekVideoIdsByGeneration[generation],
+                pendingSeekAttemptID: self.pendingSeekAttemptIDsByGeneration[generation]
+            )
+        }
+        guard let attemptID = self.pendingSeekAttemptIDsByGeneration[generation] else { return }
+        let videoIdLiteral = WebPlaybackDocumentGeneration.javaScriptStringLiteral(
+            self.pendingSeekVideoIdsByGeneration[generation]
+        )
+        webView.evaluateJavaScript(
+            Self.seekWithRecoveryScript(
+                documentGeneration: generation,
+                target: seconds,
+                videoIdLiteral: videoIdLiteral,
+                attemptID: attemptID
+            ),
+            completionHandler: nil
+        )
+    }
+
+    nonisolated static func seekWithRecoveryScript(
+        documentGeneration: UInt64,
+        target: Double,
+        videoIdLiteral: String,
+        attemptID: UInt64
+    ) -> String {
+        """
+        (function() {
+            if (window.__kasetDocumentGeneration !== \(documentGeneration)) { return false; }
+            window.__kasetPendingSeek = \(target);
+            window.__kasetPendingSeekVideoId = \(videoIdLiteral);
+            window.__kasetPendingSeekWaits = 0;
+            window.__kasetPendingSeekApplied = false;
+            window.__kasetPendingSeekFailed = false;
+            window.__kasetPendingSeekAttempt = \(attemptID);
+            window.__kasetPendingSeekInFlightAttempt = null;
+
+            const video = document.querySelector('video');
+            const player = document.getElementById('movie_player');
+            const isAd = !!(player && player.classList && player.classList.contains('ad-showing'));
+            const expectedVideoId = \(videoIdLiteral);
+            if (isAd || !video || video.readyState < 1 || !video.currentSrc) { return 'armed'; }
+            if (expectedVideoId && (video.__kasetBoundVideoId || '') !== expectedVideoId) { return 'armed'; }
+            if (!video.seekable || video.seekable.length === 0) { return 'armed'; }
+            video.currentTime = \(target);
+            return 'seeked';
+        })();
+        """
+    }
+
+    func cancelPendingRecoverySeek() {
+        let generations = Set([
+            self.documentGeneration.currentGeneration,
+            self.documentGeneration.inFlightGeneration,
+            self.documentGeneration.pendingGeneration,
+        ].compactMap(\.self))
+        let provisionalGenerations = Set([
+            self.documentGeneration.inFlightGeneration,
+            self.documentGeneration.pendingGeneration,
+        ].compactMap(\.self))
+        self.cancelledPendingSeekGenerations.formUnion(provisionalGenerations)
+
+        self.pendingSeek = nil
+        self.pendingSeeksByGeneration.removeAll()
+        self.pendingSeekVideoIdsByGeneration.removeAll()
+        self.pendingSeekAttemptIDsByGeneration.removeAll()
+        self.pendingSeekRetryCounts.removeAll()
+        self.directSeekGenerations.removeAll()
+        for (key, var navigation) in self.documentNavigations {
+            navigation.pendingSeek = nil
+            self.documentNavigations[key] = navigation
+        }
+
+        guard let webView = self.webView else { return }
+        for generation in generations {
+            webView.evaluateJavaScript(
+                Self.pendingSeekCancellationScript(documentGeneration: generation),
+                completionHandler: nil
+            )
+        }
+    }
+
+    nonisolated static func pendingSeekCancellationScript(documentGeneration: UInt64) -> String {
+        """
+        (function() {
+            if (window.__kasetDocumentGeneration !== \(documentGeneration)) { return false; }
+            window.__kasetPendingSeek = null;
+            window.__kasetPendingSeekVideoId = null;
+            window.__kasetPendingSeekWaits = 0;
+            window.__kasetPendingSeekApplied = false;
+            window.__kasetPendingSeekFailed = false;
+            window.__kasetPendingSeekResultTarget = null;
+            window.__kasetPendingSeekResultVideoId = null;
+            window.__kasetPendingSeekAttempt = (window.__kasetPendingSeekAttempt || 0) + 1;
+            window.__kasetPendingSeekInFlightAttempt = null;
+            return true;
+        })();
+        """
+    }
+
+    nonisolated static func pendingSeekCompletionScript(
+        documentGeneration: UInt64,
+        attemptID: UInt64,
+        target: Double,
+        videoId: String?
+    ) -> String {
+        let videoIdLiteral = WebPlaybackDocumentGeneration.javaScriptStringLiteral(videoId)
+        return """
+        (function() {
+            if (window.__kasetDocumentGeneration !== \(documentGeneration)) { return false; }
+            if (window.__kasetPendingSeekAttempt !== \(attemptID)) { return false; }
+            if (window.__kasetPendingSeek !== \(target)) { return false; }
+            if (window.__kasetPendingSeekVideoId !== \(videoIdLiteral)) { return false; }
+            window.__kasetPendingSeek = null;
+            window.__kasetPendingSeekVideoId = null;
+            window.__kasetPendingSeekWaits = 0;
+            window.__kasetPendingSeekApplied = false;
+            window.__kasetPendingSeekFailed = false;
+            window.__kasetPendingSeekResultTarget = null;
+            window.__kasetPendingSeekResultVideoId = null;
+            window.__kasetPendingSeekAttempt = (window.__kasetPendingSeekAttempt || 0) + 1;
+            window.__kasetPendingSeekInFlightAttempt = null;
+            return true;
+        })();
+        """
+    }
+
+    @discardableResult
+    func retryPendingSeek(
+        generation: UInt64,
+        target acknowledgedTarget: Double,
+        videoId acknowledgedVideoId: String,
+        attemptID acknowledgedAttemptID: UInt64
+    ) -> Bool {
+        guard self.pendingSeekVideoIdsByGeneration[generation] == acknowledgedVideoId,
+              self.pendingSeekAttemptIDsByGeneration[generation] == acknowledgedAttemptID,
+              acknowledgedVideoId == self.activePlaybackVideoId,
+              let target = self.pendingSeeksByGeneration[generation],
+              target == acknowledgedTarget
+        else {
+            return false
+        }
+        let retryCount = (self.pendingSeekRetryCounts[generation] ?? 0) + 1
+        guard retryCount <= 3 else {
+            self.completePendingSeek(
+                generation: generation,
+                attemptID: acknowledgedAttemptID,
+                target: target,
+                videoId: acknowledgedVideoId
+            )
+            return true
+        }
+        self.pendingSeekRetryCounts[generation] = retryCount
+        self.beginPendingSeekAttempt(generation: generation)
+        self.injectPendingSeekIfNeeded(generation: generation)
+        return false
+    }
+
+    func injectPendingSeekIfNeeded(generation: UInt64, webView: WKWebView? = nil) {
+        guard let target = self.pendingSeeksByGeneration[generation],
+              let targetWebView = webView ?? self.webView
+        else { return }
+        let videoIdLiteral = WebPlaybackDocumentGeneration.javaScriptStringLiteral(
+            self.pendingSeekVideoIdsByGeneration[generation]
+        )
+        guard let attemptID = self.pendingSeekAttemptIDsByGeneration[generation] else { return }
+        targetWebView.evaluateJavaScript("""
+            if (window.__kasetDocumentGeneration === \(generation)) {
+                window.__kasetPendingSeek = \(target);
+                window.__kasetPendingSeekVideoId = \(videoIdLiteral);
+                window.__kasetPendingSeekWaits = 0;
+                window.__kasetPendingSeekApplied = false;
+                window.__kasetPendingSeekFailed = false;
+                window.__kasetPendingSeekAttempt = \(attemptID);
+                window.__kasetPendingSeekInFlightAttempt = null;
+            }
+        """, completionHandler: nil)
+    }
+
+    func discardPendingSeekIfActiveVideoChanged(generation: UInt64) {
+        guard let expectedVideoId = self.pendingSeekVideoIdsByGeneration[generation],
+              Self.shouldDiscardPendingSeek(
+                  expectedVideoId: expectedVideoId,
+                  activeVideoId: self.activePlaybackVideoId
+              )
+        else { return }
+        self.completePendingSeek(
+            generation: generation,
+            attemptID: self.pendingSeekAttemptIDsByGeneration[generation] ?? 0,
+            target: self.pendingSeeksByGeneration[generation],
+            videoId: expectedVideoId
+        )
+    }
+
+    nonisolated static func shouldDiscardPendingSeek(
+        expectedVideoId: String,
+        activeVideoId: String?
+    ) -> Bool {
+        guard let activeVideoId else { return false }
+        return activeVideoId != expectedVideoId
+    }
+}

--- a/Sources/Kaset/Views/YouTube/YouTubeWatchWebView+Scripts.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeWatchWebView+Scripts.swift
@@ -3,6 +3,21 @@ import Foundation
 // MARK: - Observer & Extraction Scripts
 
 extension YouTubeWatchWebView {
+    func markCurrentPlaybackOccurrenceEnded() {
+        guard let webView = self.webView else { return }
+        let generation = self.documentGeneration.currentGeneration
+        guard self.documentGeneration.accepts(generation: generation) else { return }
+        webView.evaluateJavaScript(
+            """
+            if (window.__kasetDocumentGeneration === \(generation)) {
+                const video = document.querySelector('video');
+                if (video) { video.__kasetEndedReported = true; }
+            }
+            """,
+            completionHandler: nil
+        )
+    }
+
     /// Observer script for youtube.com watch pages.
     ///
     /// Posts `STATE_UPDATE` (1 Hz + media events) and `VIDEO_ENDED` to the
@@ -14,7 +29,11 @@ extension YouTubeWatchWebView {
             'use strict';
 
             const bridge = window.webkit.messageHandlers.youtubePlayer;
-            let lastVideoId = '';
+            let mediaGeneration = 0;
+            let mediaVideoId = '';
+            let mediaSource = '';
+            let lastMediaCurrentTime = 0;
+            let mediaIdentityNeedsRefresh = false;
 
             function moviePlayer() {
                 return document.getElementById('movie_player');
@@ -52,27 +71,119 @@ extension YouTubeWatchWebView {
                 try {
                     const video = videoEl();
                     if (!video) { return; }
+                    bindVideoIdentity(video, false);
                     applyPendingSeek(video);
                     const videoId = currentVideoId();
-                    if (videoId !== '') { lastVideoId = videoId; }
+                    const hasReadyMedia = !!(video.currentSrc && video.readyState >= 1);
+                    const pendingSeekApplied = window.__kasetPendingSeekApplied === true;
+                    const pendingSeekFailed = window.__kasetPendingSeekFailed === true;
+                    const pendingSeekTarget = window.__kasetPendingSeekResultTarget;
+                    const pendingSeekVideoId = window.__kasetPendingSeekResultVideoId || '';
+                    const pendingSeekAttempt = window.__kasetPendingSeekAttempt;
+                    const nativePausePending = window.__kasetNativePausePending === true;
                     bridge.postMessage({
                         type: 'STATE_UPDATE',
+                        documentGeneration: window.__kasetDocumentGeneration,
+                        mediaGeneration: video.__kasetMediaGeneration || mediaGeneration,
                         isPlaying: !video.paused && !video.ended,
                         progress: video.currentTime || 0,
                         duration: (video.duration && isFinite(video.duration)) ? video.duration : 0,
+                        hasReadyMedia: hasReadyMedia,
                         videoId: videoId,
+                        boundVideoId: video.__kasetBoundVideoId || '',
                         title: currentTitle(),
-                        isAd: isAdShowing()
+                        isAd: isAdShowing(),
+                        pendingSeekApplied: pendingSeekApplied,
+                        pendingSeekFailed: pendingSeekFailed,
+                        pendingSeekTarget: pendingSeekTarget,
+                        pendingSeekVideoId: pendingSeekVideoId,
+                        pendingSeekAttempt: pendingSeekAttempt,
+                        nativePausePending: nativePausePending
+                        ,eventIssuedAtMilliseconds: (typeof performance !== 'undefined'
+                            && Number.isFinite(performance.timeOrigin)
+                            && typeof performance.now === 'function')
+                            ? performance.timeOrigin + performance.now()
+                            : Date.now()
                     });
+                    if (pendingSeekApplied) window.__kasetPendingSeekApplied = false;
+                    if (pendingSeekFailed) window.__kasetPendingSeekFailed = false;
+                    if (pendingSeekApplied || pendingSeekFailed) {
+                        window.__kasetPendingSeekResultTarget = null;
+                        window.__kasetPendingSeekResultVideoId = null;
+                    }
                 } catch (e) {
                     console.log('[KasetYT] update error: ' + e);
                 }
             }
 
-            function sendEnded() {
+            function bindVideoIdentity(video, transitionEvidence) {
+                if (!video || video !== videoEl()) { return; }
+                const videoId = currentVideoId();
+                const resolvedVideoId = videoId
+                    || (!video.__kasetBoundVideoId
+                        ? (window.__kasetPendingSeekVideoId || '')
+                        : '');
+                const source = video.currentSrc || video.src || '';
+                const currentTime = Number.isFinite(video.currentTime) ? video.currentTime : 0;
+                const hasBoundOccurrence = !!video.__kasetMediaGeneration;
+                const isReplacementElement = !hasBoundOccurrence && mediaGeneration > 0;
+                const previousMediaVideoId = mediaVideoId;
+                const sourceChanged = hasBoundOccurrence && source !== mediaSource;
+                const mediaTimeReset = hasBoundOccurrence && currentTime + 2 < lastMediaCurrentTime;
+                const identityChanged = !!resolvedVideoId
+                    && !!mediaVideoId
+                    && resolvedVideoId !== mediaVideoId;
+                const identityBecameKnown = !!resolvedVideoId && !mediaVideoId;
+                const shouldBind = !hasBoundOccurrence
+                    || sourceChanged
+                    || mediaTimeReset
+                    || (identityChanged && transitionEvidence === true);
+
+                if (!shouldBind) {
+                    if (identityBecameKnown || (identityChanged && mediaIdentityNeedsRefresh)) {
+                        mediaVideoId = resolvedVideoId;
+                        video.__kasetBoundVideoId = resolvedVideoId;
+                        mediaIdentityNeedsRefresh = false;
+                    }
+                    if (!identityChanged) lastMediaCurrentTime = currentTime;
+                    return;
+                }
+
+                mediaGeneration += 1;
+                mediaVideoId = resolvedVideoId;
+                mediaSource = source;
+                lastMediaCurrentTime = currentTime;
+                mediaIdentityNeedsRefresh = (isReplacementElement || sourceChanged || mediaTimeReset)
+                    && (!resolvedVideoId || resolvedVideoId === previousMediaVideoId);
+                video.__kasetMediaGeneration = mediaGeneration;
+                video.__kasetEndedReported = false;
+                video.__kasetBoundVideoId = resolvedVideoId;
+                window.__kasetPendingSeekInFlightAttempt = null;
+            }
+
+            function armEndedOccurrence(video) {
+                if (!video || video !== videoEl() || video.ended) { return; }
+                bindVideoIdentity(video, false);
+                if (video.__kasetEndedReported === true) {
+                    mediaGeneration += 1;
+                    video.__kasetMediaGeneration = mediaGeneration;
+                }
+                video.__kasetEndedReported = false;
+            }
+
+            function sendEnded(video) {
+                if (video !== videoEl() || !video.ended || video.__kasetEndedReported === true) {
+                    return;
+                }
+                video.__kasetEndedReported = true;
                 bridge.postMessage({
                     type: 'VIDEO_ENDED',
-                    videoId: lastVideoId || currentVideoId()
+                    documentGeneration: window.__kasetDocumentGeneration,
+                    mediaGeneration: video.__kasetMediaGeneration || mediaGeneration,
+                    pendingSeekAttempt: window.__kasetPendingSeekAttempt,
+                    eventIssuedAtMilliseconds: Date.now(),
+                    videoId: video.__kasetBoundVideoId || currentVideoId(),
+                    isAd: isAdShowing()
                 });
             }
 
@@ -104,22 +215,86 @@ extension YouTubeWatchWebView {
             function applyPendingSeek(video) {
                 const target = window.__kasetPendingSeek;
                 if (typeof target !== 'number') { return; }
-                // Don't seek (or consume the pending value) on a preroll-ad video
-                // element — wait for the real content player, or the content would
-                // start from 0 after the ad.
+                // An ad can expose the creative's video ID; never consume the
+                // requested content seek against advertisement media.
                 if (isAdShowing()) { return; }
-                if (video.readyState < 1) { return; }
+                if (video.readyState < 1 || !video.currentSrc) { return; }
+                const expectedVideoId = window.__kasetPendingSeekVideoId;
+                const boundVideoId = video.__kasetBoundVideoId || '';
+                if (expectedVideoId && boundVideoId !== expectedVideoId) {
+                    // Metadata can lead the physical media during SPA changes.
+                    // Keep the target armed until this element is actually bound
+                    // to the requested content occurrence.
+                    return;
+                }
+                if (!video.seekable || video.seekable.length === 0) { return; }
+                const seekAttempt = window.__kasetPendingSeekAttempt || 0;
+                window.__kasetPendingSeekAttempt = seekAttempt;
+                if (window.__kasetPendingSeekInFlightAttempt === seekAttempt) { return; }
+                window.__kasetPendingSeekInFlightAttempt = seekAttempt;
                 try {
-                    video.currentTime = target;
-                    // Re-assert once if the player clobbers currentTime back near 0.
-                    setTimeout(function() {
-                        if (typeof window.__kasetPendingSeek === 'number' &&
-                            Math.abs(video.currentTime - target) > 1.5) {
-                            try { video.currentTime = target; } catch (e) {}
+                    const seekMediaGeneration = video.__kasetMediaGeneration || 0;
+                    const seekSource = video.currentSrc;
+                    function stillOwnsSeekOperation() {
+                        return video === videoEl()
+                            && window.__kasetPendingSeek === target
+                            && (window.__kasetPendingSeekVideoId || '') === (expectedVideoId || '')
+                            && (video.__kasetBoundVideoId || '') === (expectedVideoId || '')
+                            && (video.__kasetMediaGeneration || 0) === seekMediaGeneration
+                            && video.currentSrc === seekSource
+                            && window.__kasetPendingSeekAttempt === seekAttempt
+                            && window.__kasetPendingSeekInFlightAttempt === seekAttempt;
+                    }
+                    const firstSeekable = video.seekable.start(0);
+                    const lastSeekable = video.seekable.end(video.seekable.length - 1);
+                    const hasFiniteDuration = video.duration && isFinite(video.duration);
+                    const resolvedTarget = hasFiniteDuration
+                        ? Math.min(Math.max(target, 0), video.duration)
+                        : Math.min(Math.max(target, firstSeekable), lastSeekable);
+                    window.__kasetPendingSeekWaits = 0;
+                    video.currentTime = resolvedTarget;
+                    function reportSeekResult() {
+                        if (!stillOwnsSeekOperation()) return;
+                        if (Math.abs(video.currentTime - resolvedTarget) <= 1.5) {
+                            window.__kasetPendingSeek = null;
+                            window.__kasetPendingSeekVideoId = null;
+                            window.__kasetPendingSeekWaits = 0;
+                            window.__kasetPendingSeekApplied = true;
+                            window.__kasetPendingSeekResultTarget = target;
+                            window.__kasetPendingSeekResultVideoId = expectedVideoId
+                                || currentVideoId()
+                                || video.__kasetBoundVideoId
+                                || '';
+                        } else {
+                            window.__kasetPendingSeek = null;
+                            window.__kasetPendingSeekVideoId = null;
+                            window.__kasetPendingSeekWaits = 0;
+                            window.__kasetPendingSeekFailed = true;
+                            window.__kasetPendingSeekResultTarget = target;
+                            window.__kasetPendingSeekResultVideoId = expectedVideoId
+                                || currentVideoId()
+                                || video.__kasetBoundVideoId
+                                || '';
                         }
-                        window.__kasetPendingSeek = null;
+                        window.__kasetPendingSeekInFlightAttempt = null;
+                        sendUpdate();
+                    }
+                    // Re-assert once if the player clobbers currentTime back near 0,
+                    // then wait again before reporting success.
+                    setTimeout(function() {
+                        if (!stillOwnsSeekOperation()) return;
+                        if (Math.abs(video.currentTime - resolvedTarget) > 1.5) {
+                            try { video.currentTime = resolvedTarget; } catch (e) {}
+                            setTimeout(reportSeekResult, 400);
+                            return;
+                        }
+                        reportSeekResult();
                     }, 400);
-                } catch (e) {}
+                } catch (e) {
+                    if (window.__kasetPendingSeekInFlightAttempt === seekAttempt) {
+                        window.__kasetPendingSeekInFlightAttempt = null;
+                    }
+                }
             }
 
             function disableAutonav() {
@@ -137,11 +312,26 @@ extension YouTubeWatchWebView {
                 if (!video) { return; }
                 if (video.__kasetAttached) { return; }
                 video.__kasetAttached = true;
+                video.__kasetEndedReported = false;
+                bindVideoIdentity(video, video.readyState >= 1);
 
                 ['play', 'playing', 'pause', 'seeked', 'loadedmetadata'].forEach(function(evt) {
-                    video.addEventListener(evt, sendUpdate);
+                    video.addEventListener(evt, function() {
+                        if (evt === 'pause') window.__kasetNativePausePending = false;
+                        if (evt === 'playing' || evt === 'loadedmetadata') {
+                            bindVideoIdentity(video, evt === 'loadedmetadata');
+                        }
+                        if (evt === 'play' || evt === 'playing'
+                            || evt === 'seeked' || evt === 'loadedmetadata') {
+                            armEndedOccurrence(video);
+                        }
+                        sendUpdate();
+                    });
                 });
-                video.addEventListener('ended', sendEnded);
+                video.addEventListener('ended', function(event) {
+                    const endedVideo = event.currentTarget;
+                    sendEnded(endedVideo);
+                });
                 video.addEventListener('volumechange', function() {
                     enforceVolume(video);
                 });
@@ -312,7 +502,15 @@ extension YouTubeWatchWebView {
             (function() {
                 const video = document.querySelector('#movie_player video') || document.querySelector('video');
                 if (!video) { return 'no-video'; }
-                if (video.paused) { video.play(); return 'playing'; } else { video.pause(); return 'paused'; }
+                if (video.paused) {
+                    window.__kasetNativePausePending = false;
+                    video.play();
+                    return 'playing';
+                } else {
+                    window.__kasetNativePausePending = true;
+                    video.pause();
+                    return 'paused';
+                }
             })();
             """,
             completionHandler: nil
@@ -324,6 +522,7 @@ extension YouTubeWatchWebView {
         self.webView?.evaluateJavaScript(
             """
             (function() {
+                window.__kasetNativePausePending = false;
                 const video = document.querySelector('#movie_player video') || document.querySelector('video');
                 if (video && video.paused) { video.play(); }
             })();
@@ -337,6 +536,7 @@ extension YouTubeWatchWebView {
         self.webView?.evaluateJavaScript(
             """
             (function() {
+                window.__kasetNativePausePending = true;
                 const video = document.querySelector('#movie_player video') || document.querySelector('video');
                 if (video && !video.paused) { video.pause(); }
             })();

--- a/Sources/Kaset/Views/YouTube/YouTubeWatchWebView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeWatchWebView.swift
@@ -418,6 +418,7 @@ extension YouTubeWatchWebView {
 
     private func refreshDocumentUserScripts(on webView: WKWebView) {
         let targetVolume = self.coordinator?.playerService.volume ?? 1.0
+        let scriptGeneration = self.documentGeneration.userScriptGeneration
         let pendingSeek: Double? = if self.documentGeneration.pendingGeneration != nil
             || self.documentGeneration.inFlightGeneration != nil
         {
@@ -428,9 +429,12 @@ extension YouTubeWatchWebView {
         self.installUserScripts(
             on: webView.configuration.userContentController,
             targetVolume: targetVolume,
-            documentGeneration: self.documentGeneration.userScriptGeneration,
+            documentGeneration: scriptGeneration,
             pendingSeek: pendingSeek,
-            pendingSeekVideoId: pendingSeek == nil ? nil : self.currentVideoId
+            pendingSeekVideoId: pendingSeek == nil ? nil : self.currentVideoId,
+            pendingSeekAttemptID: pendingSeek == nil
+                ? nil
+                : self.pendingSeekAttemptIDsByGeneration[scriptGeneration]
         )
     }
 
@@ -540,7 +544,8 @@ extension YouTubeWatchWebView {
             targetVolume: targetVolume,
             documentGeneration: trackedNavigation.generation,
             pendingSeek: trackedNavigation.pendingSeek,
-            pendingSeekVideoId: self.pendingSeekVideoIdsByGeneration[trackedNavigation.generation]
+            pendingSeekVideoId: self.pendingSeekVideoIdsByGeneration[trackedNavigation.generation],
+            pendingSeekAttemptID: self.pendingSeekAttemptIDsByGeneration[trackedNavigation.generation]
         )
     }
 

--- a/Sources/Kaset/Views/YouTube/YouTubeWatchWebView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeWatchWebView.swift
@@ -38,6 +38,18 @@ final class YouTubeWatchWebView {
     /// superseded, so a stale reload can't navigate over a newer selection.
     private var loadGeneration = 0
 
+    /// Tracks which full-page watch document may publish playback bridge events.
+    private(set) var documentGeneration = WebPlaybackDocumentGeneration()
+    var documentNavigations: [ObjectIdentifier: WebPlaybackTrackedNavigation] = [:]
+    var continuationGenerationsAwaitingStart: Set<UInt64> = []
+    var pendingSeeksByGeneration: [UInt64: Double] = [:]
+    var pendingSeekVideoIdsByGeneration: [UInt64: String] = [:]
+    var pendingSeekAttemptIDsByGeneration: [UInt64: UInt64] = [:]
+    var nextPendingSeekAttemptID: UInt64 = 0
+    var cancelledPendingSeekGenerations: Set<UInt64> = []
+    var directSeekGenerations: Set<UInt64> = []
+    var pendingSeekRetryCounts: [UInt64: Int] = [:]
+
     private init() {}
 
     /// Get or create the watch WebView.
@@ -66,7 +78,8 @@ final class YouTubeWatchWebView {
         configuration.userContentController.add(self.coordinator!, name: "youtubePlayer")
         self.installUserScripts(
             on: configuration.userContentController,
-            targetVolume: playerService.volume
+            targetVolume: playerService.volume,
+            documentGeneration: Self.userScriptDocumentGeneration(from: self.documentGeneration)
         )
 
         let newWebView = WKWebView(frame: .zero, configuration: configuration)
@@ -127,9 +140,74 @@ final class YouTubeWatchWebView {
         self.load(videoId: videoId)
     }
 
-    func cancelPendingLoad() {
+    @discardableResult
+    func cancelPendingLoad() -> Bool {
         self.loadGeneration += 1
+        var didCancelDocumentNavigation = false
+        var cancelledResumeAt = self.pendingSeek
+        var cancelledSelectedGeneration = false
+        if let generation = self.documentGeneration.pendingGeneration {
+            cancelledSelectedGeneration = true
+            cancelledResumeAt = self.pendingSeeksByGeneration[generation] ?? cancelledResumeAt
+            self.pendingSeeksByGeneration.removeValue(forKey: generation)
+            self.pendingSeekVideoIdsByGeneration.removeValue(forKey: generation)
+            self.pendingSeekAttemptIDsByGeneration.removeValue(forKey: generation)
+            self.pendingSeekRetryCounts.removeValue(forKey: generation)
+            self.directSeekGenerations.remove(generation)
+            self.documentGeneration.cancelPendingNavigation()
+            didCancelDocumentNavigation = true
+        }
+        if let generation = self.documentGeneration.inFlightGeneration,
+           self.documentGeneration.cancelInFlightNavigation(generation)
+        {
+            cancelledSelectedGeneration = true
+            cancelledResumeAt = self.pendingSeeksByGeneration[generation] ?? cancelledResumeAt
+            self.documentNavigations = self.documentNavigations.filter {
+                $0.value.generation != generation
+            }
+            self.pendingSeeksByGeneration.removeValue(forKey: generation)
+            self.pendingSeekVideoIdsByGeneration.removeValue(forKey: generation)
+            self.pendingSeekAttemptIDsByGeneration.removeValue(forKey: generation)
+            self.pendingSeekRetryCounts.removeValue(forKey: generation)
+            self.directSeekGenerations.remove(generation)
+            didCancelDocumentNavigation = true
+        }
+        let committedLoadingGenerations = self.documentNavigations.values.compactMap { navigation in
+            navigation.didCommit && navigation.generation == self.documentGeneration.currentGeneration
+                ? navigation.generation
+                : nil
+        }
+        if !committedLoadingGenerations.isEmpty {
+            self.documentNavigations = self.documentNavigations.filter { _, navigation in
+                !committedLoadingGenerations.contains(navigation.generation)
+            }
+            for generation in committedLoadingGenerations {
+                if !cancelledSelectedGeneration {
+                    cancelledResumeAt = self.pendingSeeksByGeneration[generation] ?? cancelledResumeAt
+                }
+                self.pendingSeeksByGeneration.removeValue(forKey: generation)
+                self.pendingSeekVideoIdsByGeneration.removeValue(forKey: generation)
+                self.pendingSeekAttemptIDsByGeneration.removeValue(forKey: generation)
+                self.pendingSeekRetryCounts.removeValue(forKey: generation)
+                self.directSeekGenerations.remove(generation)
+            }
+            didCancelDocumentNavigation = true
+        }
+        if didCancelDocumentNavigation, let webView = self.webView {
+            // PlayerService already owns the newly selected video. Re-authorizing
+            // the outgoing document would split native/WebView identity, so keep
+            // the selected video as a deferred reload for explicit resume.
+            self.pauseSurvivingDocument(webView)
+            self.currentVideoId = nil
+            self.pendingSeek = nil
+            self.documentGeneration.invalidate()
+            self.coordinator?.playerService.handleWebNavigationCancellation(
+                resumeAtOverride: cancelledResumeAt
+            )
+            self.refreshDocumentUserScripts(on: webView)
+        }
         self.webView?.stopLoading()
+        return didCancelDocumentNavigation
     }
 
     private func load(videoId: String) {
@@ -139,43 +217,82 @@ final class YouTubeWatchWebView {
         }
 
         self.logger.info("Loading YouTube video: \(videoId) (was: \(self.currentVideoId ?? "none"))")
+        self.cancelActiveDocumentNavigation(on: webView)
         self.currentVideoId = videoId
 
         self.loadGeneration += 1
-        let myLoadGeneration = self.loadGeneration
-
+        let navigationPendingSeek = self.pendingSeek
+        let replacedGeneration = self.documentGeneration.currentGeneration
+        if let replacedAttemptID = self.pendingSeekAttemptIDsByGeneration[replacedGeneration] {
+            self.completePendingSeek(
+                generation: replacedGeneration,
+                attemptID: replacedAttemptID
+            )
+        }
+        self.pendingSeek = navigationPendingSeek
+        if let supersededGeneration = self.documentGeneration.pendingGeneration {
+            self.pendingSeeksByGeneration.removeValue(forKey: supersededGeneration)
+            self.pendingSeekVideoIdsByGeneration.removeValue(forKey: supersededGeneration)
+            self.pendingSeekAttemptIDsByGeneration.removeValue(forKey: supersededGeneration)
+            self.pendingSeekRetryCounts.removeValue(forKey: supersededGeneration)
+            self.directSeekGenerations.remove(supersededGeneration)
+        }
+        let navigationGeneration = self.documentGeneration.beginNavigation()
+        if let navigationPendingSeek {
+            self.pendingSeeksByGeneration[navigationGeneration] = navigationPendingSeek
+            self.pendingSeekVideoIdsByGeneration[navigationGeneration] = videoId
+            self.pendingSeekRetryCounts[navigationGeneration] = 0
+            self.beginPendingSeekAttempt(generation: navigationGeneration)
+        }
         let targetVolume = self.coordinator?.playerService.volume ?? 1.0
         self.installUserScripts(
             on: webView.configuration.userContentController,
             targetVolume: targetVolume,
-            pendingSeek: self.pendingSeek
+            documentGeneration: navigationGeneration,
+            pendingSeek: navigationPendingSeek,
+            pendingSeekVideoId: navigationPendingSeek == nil ? nil : videoId,
+            pendingSeekAttemptID: self.pendingSeekAttemptIDsByGeneration[navigationGeneration]
         )
 
-        guard let url = URL(string: "https://www.youtube.com/watch?v=\(videoId)") else { return }
-        webView.evaluateJavaScript("document.querySelector('video')?.pause()") { [weak self] _, _ in
-            guard let self, let webView = self.webView else { return }
-            // Bail if a newer load was requested while the pause callback was
-            // pending — otherwise this stale URL would navigate over the newer
-            // selection and the observer would follow the wrong video.
-            guard myLoadGeneration == self.loadGeneration,
-                  self.currentVideoId == videoId
-            else {
-                self.logger.debug("YouTube load superseded before navigation; skipping stale \(url.absoluteString)")
-                return
-            }
-            webView.evaluateJavaScript("window.__kasetTargetVolume = \(targetVolume);", completionHandler: nil)
-            webView.load(URLRequest(url: url))
+        guard let url = Self.watchURL(
+            videoId: videoId,
+            documentGeneration: navigationGeneration
+        ) else {
+            self.handlePendingDocumentNavigationFailure(webView: webView)
+            return
         }
+        // Do not wait for WebContent to acknowledge suppression. A provisional
+        // process can defer the callback for seconds during rapid replacement;
+        // document-generation gates reject stale bridge events and the immediate
+        // navigation tears down outgoing media.
+        webView.evaluateJavaScript(
+            WebPlaybackDocumentGeneration.mediaSuppressionScript,
+            completionHandler: nil
+        )
+        webView.evaluateJavaScript(
+            "window.__kasetTargetVolume = \(targetVolume);",
+            completionHandler: nil
+        )
+        self.startDocumentNavigation(
+            on: webView,
+            request: URLRequest(url: url),
+            generation: navigationGeneration,
+            pendingSeek: navigationPendingSeek,
+            url: url
+        )
     }
 
     /// Stops playback and blanks the page (called when video playback is closed).
     func tearDown() {
+        let blankURL = self.beginBlankDocumentNavigation()
         guard let webView else { return }
         self.logger.info("Tearing down YouTube watch WebView")
         self.loadGeneration += 1
         self.currentVideoId = nil
         webView.evaluateJavaScript("document.querySelector('video')?.pause()") { _, _ in }
-        webView.loadHTMLString("", baseURL: nil)
+        if let blankURL {
+            webView.load(URLRequest(url: blankURL))
+        }
         webView.removeFromSuperview()
         self.webKitManager?.extensionHostWebViewDidDeactivate(role: .youtubeWatch)
         self.webView = nil
@@ -183,18 +300,501 @@ final class YouTubeWatchWebView {
         self.currentContainer = nil
         self.usesCookieFreeDataStore = nil
     }
+}
 
+extension YouTubeWatchWebView {
     // MARK: - User Scripts
 
-    private func installUserScripts(
+    private func beginBlankDocumentNavigation() -> URL? {
+        self.documentNavigations.removeAll()
+        self.continuationGenerationsAwaitingStart.removeAll()
+        self.pendingSeeksByGeneration.removeAll()
+        self.pendingSeekVideoIdsByGeneration.removeAll()
+        self.pendingSeekAttemptIDsByGeneration.removeAll()
+        self.cancelledPendingSeekGenerations.removeAll()
+        self.directSeekGenerations.removeAll()
+        self.pendingSeekRetryCounts.removeAll()
+        let generation = self.documentGeneration.beginBlankNavigation()
+        return WebPlaybackDocumentGeneration.blankURL(generation: generation)
+    }
+
+    func recordAcceptedMainFrameResponse(_ response: URLResponse) {
+        guard let currentVideoId = self.currentVideoId else { return }
+        _ = self.documentGeneration.recordSuccessfulPlaybackResponse(
+            url: response.url,
+            host: "www.youtube.com",
+            videoID: currentVideoId
+        )
+    }
+
+    func decideNavigationPolicy(
+        webView: WKWebView,
+        navigationAction: WKNavigationAction,
+        decisionHandler: @escaping @MainActor (WKNavigationActionPolicy) -> Void
+    ) {
+        guard navigationAction.targetFrame?.isMainFrame == true else {
+            decisionHandler(.allow)
+            return
+        }
+
+        if WebPlaybackDocumentGeneration.isInternalBlankNavigation(navigationAction.request.url) {
+            decisionHandler(
+                self.documentGeneration.ownsBlankNavigation(navigationAction.request.url)
+                    ? .allow
+                    : .cancel
+            )
+            return
+        }
+
+        if WebPlaybackDocumentGeneration.isFragmentOnlyNavigation(
+            from: webView.url,
+            to: navigationAction.request.url
+        ) {
+            self.webKitManager?.extensionHostWebViewWillNavigate(
+                webView,
+                to: navigationAction.request.url
+            )
+            decisionHandler(.allow)
+            return
+        }
+
+        if self.documentGeneration.pendingGeneration != nil {
+            decisionHandler(.cancel)
+            return
+        }
+
+        if let inFlightGeneration = self.documentGeneration.inFlightGeneration {
+            guard WebPlaybackDocumentGeneration.requestBelongsToNavigationChain(
+                navigationAction.request,
+                currentURL: webView.url,
+                generation: inFlightGeneration,
+                playbackHost: "www.youtube.com",
+                committedIntermediaryGeneration: self.documentGeneration.committedIntermediaryGeneration
+            ) else {
+                decisionHandler(.cancel)
+                return
+            }
+            if WebPlaybackDocumentGeneration.generation(from: navigationAction.request.url)
+                != inFlightGeneration
+            {
+                decisionHandler(.cancel)
+                self.continuationGenerationsAwaitingStart.insert(inFlightGeneration)
+                if let boundRequest = WebPlaybackDocumentGeneration.requestByBindingGeneration(
+                    navigationAction.request,
+                    generation: inFlightGeneration
+                ) {
+                    Task { @MainActor in
+                        self.startBoundNavigationContinuation(
+                            on: webView,
+                            request: boundRequest,
+                            generation: inFlightGeneration
+                        )
+                    }
+                }
+                return
+            }
+            self.webKitManager?.extensionHostWebViewWillNavigate(
+                webView,
+                to: navigationAction.request.url
+            )
+            decisionHandler(.allow)
+            return
+        }
+
+        decisionHandler(.cancel)
+    }
+
+    private func refreshDocumentUserScripts(on webView: WKWebView) {
+        let targetVolume = self.coordinator?.playerService.volume ?? 1.0
+        let pendingSeek: Double? = if self.documentGeneration.pendingGeneration != nil
+            || self.documentGeneration.inFlightGeneration != nil
+        {
+            self.pendingSeek
+        } else {
+            nil
+        }
+        self.installUserScripts(
+            on: webView.configuration.userContentController,
+            targetVolume: targetVolume,
+            documentGeneration: self.documentGeneration.userScriptGeneration,
+            pendingSeek: pendingSeek,
+            pendingSeekVideoId: pendingSeek == nil ? nil : self.currentVideoId
+        )
+    }
+
+    private func startDocumentNavigation(
+        on webView: WKWebView,
+        request: URLRequest,
+        generation: UInt64,
+        pendingSeek: Double?,
+        url: URL
+    ) {
+        guard webView === self.webView else {
+            if self.documentGeneration.pendingGeneration == generation {
+                self.handlePendingDocumentNavigationFailure(webView: webView)
+            }
+            return
+        }
+        guard self.documentGeneration.startNavigation(generation) else {
+            self.logger.debug("YouTube load superseded before navigation; skipping stale \(url.absoluteString)")
+            return
+        }
+        guard let navigation = webView.load(request) else {
+            self.handleCurrentDocumentNavigationFailure(generation, webView: webView)
+            return
+        }
+        self.documentNavigations[ObjectIdentifier(navigation)] = WebPlaybackTrackedNavigation(
+            generation: generation,
+            pendingSeek: self.pendingSeeksByGeneration[generation] ?? pendingSeek
+        )
+    }
+
+    private func startBoundNavigationContinuation(
+        on webView: WKWebView,
+        request: URLRequest,
+        generation: UInt64
+    ) {
+        guard webView === self.webView,
+              self.documentGeneration.inFlightGeneration == generation,
+              self.documentGeneration.pendingGeneration == nil
+        else {
+            self.continuationGenerationsAwaitingStart.remove(generation)
+            return
+        }
+        guard let navigation = webView.load(request) else {
+            self.continuationGenerationsAwaitingStart.remove(generation)
+            self.handleCurrentDocumentNavigationFailure(generation, webView: webView)
+            return
+        }
+        self.documentNavigations[ObjectIdentifier(navigation)] = WebPlaybackTrackedNavigation(
+            generation: generation,
+            pendingSeek: self.pendingSeeksByGeneration[generation]
+        )
+        self.continuationGenerationsAwaitingStart.remove(generation)
+    }
+
+    private func cancelActiveDocumentNavigation(on webView: WKWebView) {
+        guard let generation = self.documentGeneration.inFlightGeneration else { return }
+        self.documentNavigations = self.documentNavigations.filter {
+            $0.value.generation != generation
+        }
+        self.pendingSeeksByGeneration.removeValue(forKey: generation)
+        self.pendingSeekVideoIdsByGeneration.removeValue(forKey: generation)
+        self.pendingSeekAttemptIDsByGeneration.removeValue(forKey: generation)
+        self.directSeekGenerations.remove(generation)
+        self.pendingSeekRetryCounts.removeValue(forKey: generation)
+        _ = self.documentGeneration.cancelInFlightNavigation(generation)
+        self.continuationGenerationsAwaitingStart.remove(generation)
+        webView.stopLoading()
+    }
+
+    func trackDocumentNavigationStart(_ navigation: WKNavigation?, webView: WKWebView) {
+        guard webView === self.webView,
+              let navigation,
+              self.documentNavigations[ObjectIdentifier(navigation)] == nil,
+              let generation = WebPlaybackDocumentGeneration.generation(from: webView.url)
+              ?? (self.documentGeneration.committedIntermediaryGeneration
+                  == self.documentGeneration.inFlightGeneration
+                  && WebPlaybackDocumentGeneration.isAllowedPlaybackNavigationURL(
+                      webView.url,
+                      playbackHost: "www.youtube.com"
+                  ) ? self.documentGeneration.inFlightGeneration : nil),
+              generation == self.documentGeneration.inFlightGeneration
+        else { return }
+        self.documentNavigations[ObjectIdentifier(navigation)] = WebPlaybackTrackedNavigation(
+            generation: generation,
+            pendingSeek: self.pendingSeeksByGeneration[generation]
+        )
+    }
+
+    func handleDocumentNavigationRedirect(_ navigation: WKNavigation?, webView: WKWebView) {
+        guard webView === self.webView,
+              let navigation,
+              let trackedNavigation = self.documentNavigations[ObjectIdentifier(navigation)],
+              trackedNavigation.generation == self.documentGeneration.inFlightGeneration,
+              self.documentGeneration.pendingGeneration == nil
+        else { return }
+        let targetVolume = self.coordinator?.playerService.volume ?? 1.0
+        self.installUserScripts(
+            on: webView.configuration.userContentController,
+            targetVolume: targetVolume,
+            documentGeneration: trackedNavigation.generation,
+            pendingSeek: trackedNavigation.pendingSeek,
+            pendingSeekVideoId: self.pendingSeekVideoIdsByGeneration[trackedNavigation.generation]
+        )
+    }
+
+    func commitDocumentNavigation(_ navigation: WKNavigation?, webView: WKWebView) {
+        guard webView === self.webView else { return }
+        if WebPlaybackDocumentGeneration.isInternalBlankNavigation(webView.url) {
+            guard self.documentGeneration.ownsBlankNavigation(webView.url) else {
+                self.handleUnexpectedBlankDocumentCommit(navigation, webView: webView)
+                return
+            }
+            return
+        }
+        guard let navigation,
+              var trackedNavigation = self.documentNavigations[ObjectIdentifier(navigation)]
+        else { return }
+        trackedNavigation.didCommit = true
+        if let currentVideoId = self.currentVideoId,
+           WebPlaybackDocumentGeneration.isExpectedPlaybackURL(
+               webView.url,
+               host: "www.youtube.com",
+               videoID: currentVideoId
+           )
+        {
+            guard self.documentGeneration.commitNavigation(
+                trackedNavigation.generation,
+                expectedVideoID: currentVideoId
+            ) else { return }
+            trackedNavigation.didActivatePlaybackOrigin = true
+        } else if WebPlaybackDocumentGeneration.isTrustedIntermediaryURL(webView.url) {
+            guard self.documentGeneration.commitIntermediaryNavigation(
+                trackedNavigation.generation
+            ) else { return }
+        }
+        self.documentNavigations[ObjectIdentifier(navigation)] = trackedNavigation
+        if trackedNavigation.didActivatePlaybackOrigin {
+            if self.cancelledPendingSeekGenerations.remove(trackedNavigation.generation) != nil {
+                webView.evaluateJavaScript(
+                    Self.pendingSeekCancellationScript(
+                        documentGeneration: trackedNavigation.generation
+                    ),
+                    completionHandler: nil
+                )
+            } else {
+                self.injectPendingSeekIfNeeded(
+                    generation: trackedNavigation.generation,
+                    webView: webView
+                )
+            }
+        }
+    }
+
+    func finishDocumentNavigation(_ navigation: WKNavigation?, webView: WKWebView) -> Bool {
+        guard webView === self.webView else { return false }
+        if WebPlaybackDocumentGeneration.isInternalBlankNavigation(webView.url) {
+            guard self.documentGeneration.ownsBlankNavigation(webView.url) else {
+                self.handleUnexpectedBlankDocumentCommit(navigation, webView: webView)
+                return false
+            }
+            return true
+        }
+        guard let navigation,
+              let trackedNavigation = self.documentNavigations.removeValue(
+                  forKey: ObjectIdentifier(navigation)
+              )
+        else { return false }
+        guard trackedNavigation.didCommit else {
+            self.handleCurrentDocumentNavigationFailure(
+                trackedNavigation.generation,
+                webView: webView
+            )
+            return false
+        }
+        if !trackedNavigation.didActivatePlaybackOrigin {
+            return WebPlaybackDocumentGeneration.isAllowedPlaybackNavigationURL(
+                webView.url,
+                playbackHost: "www.youtube.com"
+            ) && trackedNavigation.generation == self.documentGeneration.inFlightGeneration
+        }
+        guard self.documentGeneration.canFinishNavigation(
+            trackedNavigation.generation
+        ) else { return false }
+        if trackedNavigation.pendingSeek == nil {
+            self.pendingSeeksByGeneration.removeValue(forKey: trackedNavigation.generation)
+            self.pendingSeekVideoIdsByGeneration.removeValue(forKey: trackedNavigation.generation)
+            self.pendingSeekAttemptIDsByGeneration.removeValue(forKey: trackedNavigation.generation)
+            self.pendingSeekRetryCounts.removeValue(forKey: trackedNavigation.generation)
+            self.directSeekGenerations.remove(trackedNavigation.generation)
+        }
+        return true
+    }
+
+    private func handleUnexpectedBlankDocumentCommit(
+        _ navigation: WKNavigation?,
+        webView: WKWebView
+    ) {
+        guard webView === self.webView else { return }
+        if let navigation,
+           self.documentNavigations[ObjectIdentifier(navigation)] != nil
+        {
+            self.failDocumentNavigation(navigation, webView: webView)
+            return
+        }
+        if let generation = self.documentGeneration.inFlightGeneration {
+            let resumeAt = self.pendingSeeksByGeneration[generation]
+            self.documentNavigations = self.documentNavigations.filter {
+                $0.value.generation != generation
+            }
+            self.continuationGenerationsAwaitingStart.remove(generation)
+            self.handleCurrentDocumentNavigationFailure(
+                generation,
+                webView: webView,
+                resumeAtOverride: resumeAt
+            )
+        } else if self.documentGeneration.pendingGeneration != nil {
+            self.handlePendingDocumentNavigationFailure(webView: webView)
+        } else if self.currentVideoId != nil {
+            self.handleCommittedDocumentNavigationFailure(
+                self.documentGeneration.currentGeneration,
+                webView: webView,
+                resumeAtOverride: self.pendingSeek
+            )
+        }
+    }
+
+    private func failDocumentNavigation(_ navigation: WKNavigation?, webView: WKWebView) {
+        guard webView === self.webView,
+              let navigation,
+              let trackedNavigation = self.documentNavigations.removeValue(
+                  forKey: ObjectIdentifier(navigation)
+              )
+        else { return }
+        let resumeAt = trackedNavigation.pendingSeek
+        self.pendingSeeksByGeneration.removeValue(forKey: trackedNavigation.generation)
+        self.pendingSeekVideoIdsByGeneration.removeValue(forKey: trackedNavigation.generation)
+        self.pendingSeekAttemptIDsByGeneration.removeValue(forKey: trackedNavigation.generation)
+        self.pendingSeekRetryCounts.removeValue(forKey: trackedNavigation.generation)
+        self.directSeekGenerations.remove(trackedNavigation.generation)
+        if trackedNavigation.didActivatePlaybackOrigin {
+            self.handleCommittedDocumentNavigationFailure(
+                trackedNavigation.generation,
+                webView: webView,
+                resumeAtOverride: resumeAt
+            )
+        } else {
+            self.handleCurrentDocumentNavigationFailure(
+                trackedNavigation.generation,
+                webView: webView,
+                resumeAtOverride: resumeAt
+            )
+        }
+    }
+
+    private func handleCurrentDocumentNavigationFailure(
+        _ generation: UInt64,
+        webView: WKWebView,
+        resumeAtOverride: Double? = nil
+    ) {
+        guard self.documentGeneration.cancelInFlightNavigation(generation) else { return }
+        self.pendingSeeksByGeneration.removeValue(forKey: generation)
+        self.pendingSeekVideoIdsByGeneration.removeValue(forKey: generation)
+        self.pendingSeekAttemptIDsByGeneration.removeValue(forKey: generation)
+        self.pendingSeekRetryCounts.removeValue(forKey: generation)
+        self.directSeekGenerations.remove(generation)
+        self.pauseSurvivingDocument(webView)
+        self.currentVideoId = nil
+        self.documentGeneration.invalidate()
+        self.coordinator?.playerService.handleWebNavigationFailure(
+            resumeAtOverride: resumeAtOverride
+        )
+        self.refreshDocumentUserScripts(on: webView)
+    }
+
+    private func handlePendingDocumentNavigationFailure(webView: WKWebView) {
+        let resumeAt = self.pendingSeek
+            ?? self.documentGeneration.pendingGeneration.flatMap { self.pendingSeeksByGeneration[$0] }
+        self.documentGeneration.cancelPendingNavigation()
+        self.pendingSeeksByGeneration.removeAll()
+        self.pendingSeekVideoIdsByGeneration.removeAll()
+        self.pendingSeekAttemptIDsByGeneration.removeAll()
+        self.cancelledPendingSeekGenerations.removeAll()
+        self.directSeekGenerations.removeAll()
+        self.pauseSurvivingDocument(webView)
+        self.currentVideoId = nil
+        self.documentGeneration.invalidate()
+        self.coordinator?.playerService.handleWebNavigationFailure(resumeAtOverride: resumeAt)
+        self.refreshDocumentUserScripts(on: webView)
+    }
+
+    private func handleCommittedDocumentNavigationFailure(
+        _ generation: UInt64,
+        webView: WKWebView,
+        resumeAtOverride: Double? = nil
+    ) {
+        guard self.documentGeneration.currentGeneration == generation,
+              self.documentGeneration.pendingGeneration == nil,
+              self.documentGeneration.inFlightGeneration == nil
+        else { return }
+        self.pauseSurvivingDocument(webView)
+        self.currentVideoId = nil
+        self.documentGeneration.invalidate()
+        self.coordinator?.playerService.handleWebNavigationFailure(
+            resumeAtOverride: resumeAtOverride
+        )
+        self.refreshDocumentUserScripts(on: webView)
+    }
+
+    func handleDocumentNavigationFailure(
+        _ navigation: WKNavigation?,
+        webView: WKWebView,
+        error: Error
+    ) {
+        if WebPlaybackNavigationFailure.isRetryableCancellation(error) {
+            guard let navigation,
+                  let trackedNavigation = self.documentNavigations[ObjectIdentifier(navigation)]
+            else {
+                self.webKitManager?.extensionHostWebViewDidFailNavigation(webView)
+                return
+            }
+            let hasSameGenerationSuccessor = self.documentNavigations.contains { key, candidate in
+                key != ObjectIdentifier(navigation)
+                    && candidate.generation == trackedNavigation.generation
+            }
+            if !trackedNavigation.didActivatePlaybackOrigin,
+               hasSameGenerationSuccessor
+               || self.continuationGenerationsAwaitingStart.contains(trackedNavigation.generation)
+            {
+                self.documentNavigations.removeValue(forKey: ObjectIdentifier(navigation))
+                self.webKitManager?.extensionHostWebViewDidFailNavigation(webView)
+                return
+            }
+        }
+        self.failDocumentNavigation(navigation, webView: webView)
+        self.webKitManager?.extensionHostWebViewDidFailNavigation(webView)
+    }
+
+    private func pauseSurvivingDocument(_ webView: WKWebView) {
+        webView.stopLoading()
+        webView.evaluateJavaScript(
+            WebPlaybackDocumentGeneration.mediaSuppressionScript,
+            completionHandler: nil
+        )
+    }
+
+    func beginContentProcessRecovery(webView: WKWebView) -> Bool {
+        guard webView === self.webView else { return false }
+        self.documentNavigations.removeAll()
+        self.documentGeneration.invalidate()
+        self.pendingSeeksByGeneration.removeAll()
+        self.pendingSeekVideoIdsByGeneration.removeAll()
+        self.pendingSeekAttemptIDsByGeneration.removeAll()
+        self.directSeekGenerations.removeAll()
+        self.pendingSeekRetryCounts.removeAll()
+        self.currentVideoId = nil
+        return true
+    }
+
+    func installUserScripts(
         on contentController: WKUserContentController,
         targetVolume: Double,
-        pendingSeek: Double? = nil
+        documentGeneration: UInt64,
+        pendingSeek: Double? = nil,
+        pendingSeekVideoId: String? = nil,
+        pendingSeekAttemptID: UInt64? = nil
     ) {
         contentController.removeAllUserScripts()
 
         let bootstrap = WKUserScript(
-            source: Self.pageBootstrapScript(targetVolume: targetVolume, pendingSeek: pendingSeek),
+            source: Self.pageBootstrapScript(
+                targetVolume: targetVolume,
+                documentGeneration: documentGeneration,
+                pendingSeek: pendingSeek,
+                pendingSeekVideoId: pendingSeekVideoId,
+                pendingSeekAttemptID: pendingSeekAttemptID
+            ),
             injectionTime: .atDocumentStart,
             forMainFrameOnly: true
         )
@@ -221,128 +821,5 @@ final class YouTubeWatchWebView {
             forMainFrameOnly: true
         )
         contentController.addUserScript(extraction)
-    }
-
-    /// Document-start state handed to each new watch page.
-    ///
-    /// `pendingSeek`, when present, is a resume position (seconds) applied by the
-    /// observer once the `<video>` element exists and is seekable (see
-    /// `applyPendingSeek` in the observer script). Injected at document start so
-    /// it is in place before the player boots, and naturally scoped to this one
-    /// navigation.
-    nonisolated static func pageBootstrapScript(targetVolume: Double, pendingSeek: Double? = nil) -> String {
-        let clamped = targetVolume.isFinite ? min(max(targetVolume, 0), 1) : 1.0
-        var script = "window.__kasetTargetVolume = \(clamped);"
-        if let pendingSeek, pendingSeek.isFinite, pendingSeek >= 0 {
-            script += " window.__kasetPendingSeek = \(pendingSeek);"
-        }
-        return script
-    }
-
-    // MARK: - Coordinator
-
-    final class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler {
-        let playerService: YouTubePlayerService
-
-        init(playerService: YouTubePlayerService) {
-            self.playerService = playerService
-        }
-
-        func userContentController(_: WKUserContentController, didReceive message: WKScriptMessage) {
-            guard let body = message.body as? [String: Any],
-                  let type = body["type"] as? String
-            else { return }
-
-            switch type {
-            case "STATE_UPDATE":
-                let update = YouTubePlayerService.PlaybackUpdate(
-                    isPlaying: body["isPlaying"] as? Bool ?? false,
-                    progress: body["progress"] as? Double ?? 0,
-                    duration: body["duration"] as? Double ?? 0,
-                    videoId: (body["videoId"] as? String).flatMap { $0.isEmpty ? nil : $0 },
-                    title: body["title"] as? String,
-                    isAd: body["isAd"] as? Bool ?? false
-                )
-                Task { @MainActor in
-                    self.playerService.updatePlaybackState(update)
-                }
-            case "VIDEO_ENDED":
-                let videoId = body["videoId"] as? String
-                Task { @MainActor in
-                    self.playerService.handleVideoEnded(videoId: videoId)
-                }
-            default:
-                return
-            }
-        }
-
-        func webView(
-            _ webView: WKWebView,
-            decidePolicyFor navigationAction: WKNavigationAction,
-            decisionHandler: @escaping @MainActor (WKNavigationActionPolicy) -> Void
-        ) {
-            guard navigationAction.targetFrame?.isMainFrame == true else {
-                decisionHandler(.allow)
-                return
-            }
-
-            YouTubeWatchWebView.shared.webKitManager?.extensionHostWebViewWillNavigate(
-                webView,
-                to: navigationAction.request.url
-            )
-            decisionHandler(.allow)
-        }
-
-        func webView(_ webView: WKWebView, didStartProvisionalNavigation _: WKNavigation!) {
-            YouTubeWatchWebView.shared.webKitManager?.extensionHostWebViewDidStartNavigation(webView)
-        }
-
-        func webView(_ webView: WKWebView, didFinish _: WKNavigation!) {
-            YouTubeWatchWebView.shared.webKitManager?.extensionHostWebViewDidFinishNavigation(webView)
-            DiagnosticsLogger.player.info(
-                "YouTube watch WebView finished loading: \(webView.url?.absoluteString ?? "nil")"
-            )
-
-            // The resume-seek for an identity-switch reload is applied by the
-            // observer's applyPendingSeek (gated on the <video> existing and being
-            // seekable), not here: at didFinish the element often does not exist
-            // yet, so a one-shot seek would be lost. Clear the Swift-side copy now
-            // that the per-load bootstrap has carried the value into the page.
-            YouTubeWatchWebView.shared.pendingSeek = nil
-
-            let savedVolume = self.playerService.volume
-            webView.evaluateJavaScript(
-                """
-                (function() {
-                    window.__kasetTargetVolume = \(savedVolume);
-                    const video = document.querySelector('video');
-                    if (video) { video.volume = \(savedVolume); }
-                    if (window.__kasetExtractVideo) { window.__kasetExtractVideo(); }
-                })();
-                """,
-                completionHandler: nil
-            )
-        }
-
-        func webView(_ webView: WKWebView, didFail _: WKNavigation!, withError _: Error) {
-            YouTubeWatchWebView.shared.webKitManager?.extensionHostWebViewDidFailNavigation(webView)
-        }
-
-        func webView(_ webView: WKWebView, didFailProvisionalNavigation _: WKNavigation!, withError _: Error) {
-            YouTubeWatchWebView.shared.webKitManager?.extensionHostWebViewDidFailNavigation(webView)
-        }
-
-        func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
-            DiagnosticsLogger.player.error("YouTube watch WebView content process terminated, recovering")
-            let videoId = YouTubeWatchWebView.shared.currentVideoId
-            webView.reload()
-            if let videoId {
-                Task { @MainActor in
-                    try? await Task.sleep(for: .seconds(1))
-                    YouTubeWatchWebView.shared.currentVideoId = nil
-                    YouTubeWatchWebView.shared.loadVideo(videoId: videoId)
-                }
-            }
-        }
     }
 }

--- a/Tests/KasetTests/AlbumPlaybackActionsTests.swift
+++ b/Tests/KasetTests/AlbumPlaybackActionsTests.swift
@@ -39,6 +39,117 @@ struct AlbumPlaybackActionsTests {
         #expect(self.playerService.queue.first?.isExplicit == true)
     }
 
+    @Test("A delayed album cannot replace a newer direct queue")
+    func delayedAlbumCannotReplaceNewerQueue() async {
+        let album = TestFixtures.makeAlbum(id: "MPRE-delayed", title: "Delayed", artistName: "Artist")
+        let playlist = TestFixtures.makePlaylist(id: album.id, title: album.title)
+        self.mockClient.playlistDetails[album.id] = PlaylistDetail(
+            playlist: playlist,
+            tracks: [Song(id: "stale", title: "Stale", artists: [], videoId: "stale")],
+            duration: nil
+        )
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        self.mockClient.beforeGetPlaylistReturn = { _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+
+        let albumTask = AlbumPlaybackActions.playAlbum(
+            album,
+            client: self.mockClient,
+            playerService: self.playerService
+        )
+        await requestStarted.wait()
+        let replacement = Song(
+            id: "replacement",
+            title: "Replacement",
+            artists: [],
+            videoId: "replacement"
+        )
+        await self.playerService.playQueue([replacement], startingAt: 0)
+        let replacementEntryIDs = self.playerService.queueEntryIDs
+
+        await releaseRequest.open()
+        await albumTask.value
+
+        #expect(self.playerService.queue == [replacement])
+        #expect(self.playerService.queueEntryIDs == replacementEntryIDs)
+        #expect(self.playerService.currentTrack?.videoId == replacement.videoId)
+    }
+
+    @Test("A delayed album addition cannot target a replacement queue")
+    func delayedAlbumAdditionCannotMutateReplacementQueue() async {
+        let album = TestFixtures.makeAlbum(id: "MPRE-add-delayed", title: "Delayed", artistName: "Artist")
+        let playlist = TestFixtures.makePlaylist(id: album.id, title: album.title)
+        self.mockClient.playlistDetails[album.id] = PlaylistDetail(
+            playlist: playlist,
+            tracks: [Song(id: "stale", title: "Stale", artists: [], videoId: "stale")],
+            duration: nil
+        )
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        self.mockClient.beforeGetPlaylistReturn = { _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+        let original = Song(id: "original", title: "Original", artists: [], videoId: "original")
+        await self.playerService.playQueue([original], startingAt: 0)
+
+        let additionTask = AlbumPlaybackActions.addAlbumToQueueLast(
+            album,
+            client: self.mockClient,
+            playerService: self.playerService
+        )
+        await requestStarted.wait()
+        let replacement = Song(
+            id: "replacement",
+            title: "Replacement",
+            artists: [],
+            videoId: "replacement"
+        )
+        await self.playerService.playQueue([replacement], startingAt: 0)
+        let replacementEntryIDs = self.playerService.queueEntryIDs
+
+        await releaseRequest.open()
+        await additionTask.value
+
+        #expect(self.playerService.queue == [replacement])
+        #expect(self.playerService.queueEntryIDs == replacementEntryIDs)
+    }
+
+    @Test("Pausing does not cancel a pending album addition")
+    func pausePreservesPendingAlbumAddition() async {
+        let album = TestFixtures.makeAlbum(id: "MPRE-add-pause", title: "Delayed", artistName: "Artist")
+        let playlist = TestFixtures.makePlaylist(id: album.id, title: album.title)
+        let albumSong = Song(id: "album-song", title: "Album Song", artists: [], videoId: "album-song")
+        self.mockClient.playlistDetails[album.id] = PlaylistDetail(
+            playlist: playlist,
+            tracks: [albumSong],
+            duration: nil
+        )
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        self.mockClient.beforeGetPlaylistReturn = { _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+        let current = Song(id: "current", title: "Current", artists: [], videoId: "current")
+        await self.playerService.playQueue([current], startingAt: 0)
+
+        let additionTask = AlbumPlaybackActions.addAlbumToQueueLast(
+            album,
+            client: self.mockClient,
+            playerService: self.playerService
+        )
+        await requestStarted.wait()
+        await self.playerService.pause()
+        await releaseRequest.open()
+        await additionTask.value
+
+        #expect(self.playerService.queue.map(\.videoId) == [current.videoId, albumSong.videoId])
+    }
+
     private func awaitQueueCount(_ expectedCount: Int) async {
         let clock = ContinuousClock()
         let deadline = clock.now.advanced(by: .seconds(1))

--- a/Tests/KasetTests/AutoplayRecoveryTests.swift
+++ b/Tests/KasetTests/AutoplayRecoveryTests.swift
@@ -31,7 +31,7 @@ struct AutoplayRecoveryJSTests {
         #expect(ctx.evaluateScript("clicked").toBool() == true)
         #expect(ctx.evaluateScript("played").toBool() == false)
         #expect(ctx.evaluateScript("result").toString() == "clicked")
-        #expect(ctx.evaluateScript("window.__kasetAutoplayPending").toBool() == false)
+        #expect(ctx.evaluateScript("window.__kasetAutoplayPending").toBool() == true)
     }
 
     @Test("Falls back to video.play() when the player-bar button is not mounted")
@@ -47,7 +47,7 @@ struct AutoplayRecoveryJSTests {
         )
         #expect(ctx.evaluateScript("played").toBool() == true)
         #expect(ctx.evaluateScript("result").toString() == "played")
-        #expect(ctx.evaluateScript("window.__kasetAutoplayPending").toBool() == false)
+        #expect(ctx.evaluateScript("window.__kasetAutoplayPending").toBool() == true)
     }
 
     @Test("Does nothing and clears the flag when the video is already playing")
@@ -65,6 +65,44 @@ struct AutoplayRecoveryJSTests {
         #expect(ctx.evaluateScript("clicked").toBool() == false)
         #expect(ctx.evaluateScript("result").toString() == "noop")
         #expect(ctx.evaluateScript("window.__kasetAutoplayPending").toBool() == false)
+    }
+
+    @Test("Bounds repeated autoplay attempts while preserving future intent")
+    func boundsAutoplayAttempts() {
+        let ctx = self.makeContext()
+        ctx.evaluateScript(
+            """
+            window.__kasetAutoplayPending = true;
+            window.__kasetAutoplayAttempts = 5;
+            var played = false;
+            var video = { paused: true, play: function() { played = true; } };
+            globalThis.result = __kasetAttemptAutoplayRecovery(video, null);
+            """
+        )
+
+        #expect(ctx.evaluateScript("result").toString() == "exhausted")
+        #expect(ctx.evaluateScript("played").toBool() == false)
+        #expect(ctx.evaluateScript("window.__kasetAutoplayPending").toBool() == true)
+    }
+
+    @Test("Exhausted autoplay attempts wait for a fresh lifecycle or native play")
+    func exhaustedAttemptsDoNotScheduleCooldown() {
+        let ctx = self.makeContext()
+        ctx.evaluateScript(
+            """
+            window.__kasetAutoplayPending = true;
+            window.__kasetAutoplayAttempts = 5;
+            var scheduled = 0;
+            globalThis.setTimeout = function() { scheduled += 1; };
+            var video = { paused: true, play: function() {} };
+            globalThis.result = __kasetAttemptAutoplayRecovery(video, null);
+            """
+        )
+
+        #expect(ctx.evaluateScript("result").toString() == "exhausted")
+        #expect(ctx.evaluateScript("scheduled").toInt32() == 0)
+        #expect(ctx.evaluateScript("window.__kasetAutoplayAttempts").toInt32() == 5)
+        #expect(ctx.evaluateScript("window.__kasetAutoplayPending").toBool() == true)
     }
 
     @Test("Does nothing when the autoplay flag is not set")
@@ -99,7 +137,7 @@ struct AutoplayRecoveryJSTests {
             """
         )
         #expect(ctx.evaluateScript("result").toString() == "error")
-        #expect(ctx.evaluateScript("window.__kasetAutoplayPending").toBool() == false)
+        #expect(ctx.evaluateScript("window.__kasetAutoplayPending").toBool() == true)
     }
 
     @Test("Observer script embeds the recovery function")
@@ -110,6 +148,71 @@ struct AutoplayRecoveryJSTests {
     @Test("Observer script clears autoplay intent on successful playback")
     func observerScriptClearsAutoplayIntentOnPlayback() {
         #expect(SingletonPlayerWebView.observerScript.contains("window.__kasetAutoplayPending = false;"))
+        #expect(SingletonPlayerWebView.observerScript.contains("window.__kasetAutoplayAttempts = 0;"))
+    }
+
+    @Test("Explicit play controls reset an exhausted autoplay retry budget")
+    func explicitPlayControlsResetRetryBudget() {
+        #expect(SingletonPlayerWebView.playCommandScript.contains("window.__kasetAutoplayAttempts = 0;"))
+        #expect(SingletonPlayerWebView.playPauseCommandScript.contains("window.__kasetAutoplayAttempts = 0;"))
+    }
+
+    @Test("Explicit play controls share bounded autoplay recovery")
+    func explicitPlayControlsUseSharedRecovery() {
+        for script in [
+            SingletonPlayerWebView.playCommandScript,
+            SingletonPlayerWebView.playPauseCommandScript,
+        ] {
+            #expect(script.contains("window.__kasetAttemptAutoplayRecovery"))
+        }
+        #expect(SingletonPlayerWebView.observerScript.contains(
+            "window.__kasetAttemptAutoplayRecovery = __kasetAttemptAutoplayRecovery;"
+        ))
+    }
+
+    @Test("Observer retries asynchronous autoplay failures without dropping intent")
+    func observerRetriesAsynchronousAutoplayFailures() {
+        let script = SingletonPlayerWebView.autoplayRecoveryFunctionJS
+
+        #expect(script.contains("playResult.catch"))
+        #expect(script.contains("scheduleRetry()"))
+        #expect(script.contains("attempts >= 5"))
+    }
+
+    @Test("A fresh native play request resets the bounded retry budget")
+    func nativePlayResetsRetryBudget() {
+        for script in [
+            SingletonPlayerWebView.playCommandScript,
+            SingletonPlayerWebView.playPauseCommandScript,
+        ] {
+            #expect(script.contains("window.__kasetAutoplayAttempts = 0;"))
+            #expect(script.contains("window.__kasetAutoplayRetryScheduled = false;"))
+        }
+    }
+
+    @Test("Committed autoplay synchronization is generation guarded")
+    func autoplaySynchronizationIsGenerationGuarded() {
+        let script = SingletonPlayerWebView.autoplayIntentSynchronizationScript(
+            shouldAutoplay: false,
+            nativePlaybackGeneration: 9,
+            documentGeneration: 7
+        )
+
+        #expect(script.contains("window.__kasetDocumentGeneration !== 7"))
+        #expect(script.contains("window.__kasetNativePlaybackGeneration = 9"))
+        #expect(script.contains("window.__kasetAutoplayPending = false"))
+        #expect(script.contains("window.__kasetPlaybackSuppressed = true"))
+    }
+
+    @Test("Restoration resume only unsuppresses ready advertisement media")
+    func restoredAdResumeIsGated() {
+        let source = try? String(contentsOfFile: #filePath.replacingOccurrences(
+            of: "Tests/KasetTests/AutoplayRecoveryTests.swift",
+            with: "Sources/Kaset/Views/SingletonPlayerWebView+PlaybackControls.swift"
+        ))
+        #expect(source?.contains("if (!isAd || !video || !video.currentSrc") == true)
+        #expect(source?.contains("window.__kasetDocumentGeneration !==") == true)
+        #expect(source?.contains("window.__kasetAttemptAutoplayRecovery(video, null)") == true)
     }
 
     @Test("Observer script retries recovery when media is already ready")
@@ -123,6 +226,13 @@ struct AutoplayRecoveryJSTests {
 
         #expect(script.contains("trailingUpdateTimeoutId"))
         #expect(script.contains("sendUpdate(true);"))
+    }
+
+    @Test("Observer uses media time updates when hidden timers are throttled")
+    func observerUsesMediaTimeUpdates() {
+        #expect(SingletonPlayerWebView.observerScript.contains(
+            "video.addEventListener('timeupdate', () => sendUpdate());"
+        ))
     }
 }
 
@@ -142,24 +252,428 @@ struct AutoplayIntentScriptTests {
         #expect(script == "window.__kasetAutoplayPending = false;")
     }
 
-    @Test("Page bootstrap seeds autoplay intent and target volume")
-    func pageBootstrapSeedsIntentAndTargetVolume() {
+    @Test("Explicit paused intent clears autoplay outside restoration")
+    func clearsPendingForExplicitPausedIntent() {
+        let script = SingletonPlayerWebView.autoplayIntentScript(shouldAutoplay: false)
+        #expect(script == "window.__kasetAutoplayPending = false;")
+    }
+
+    @Test("Page bootstrap seeds document generation, autoplay intent, and target volume")
+    func pageBootstrapSeedsDocumentGenerationIntentAndTargetVolume() {
         let script = SingletonPlayerWebView.pageBootstrapScript(
             isRestoringPlaybackSession: false,
-            targetVolume: 0.42
+            targetVolume: 0.42,
+            documentGeneration: 42,
+            nativePlaybackGeneration: 9
         )
 
+        #expect(script.contains("window.location.search"))
+        #expect(script.contains(".get('kasetDocumentGeneration')"))
+        #expect(script.contains("rawGeneration === null"))
+        #expect(script.contains("window.location.hash"))
+        #expect(script.contains("window.__kasetDocumentGeneration = -1;"))
         #expect(script.contains("window.__kasetAutoplayPending = true;"))
+        #expect(script.contains("window.__kasetAutoplayAttempts = 0;"))
         #expect(script.contains("window.__kasetTargetVolume = 0.42;"))
+        #expect(script.contains("window.__kasetNativePlaybackGeneration = 9;"))
     }
 
     @Test("Page bootstrap clamps invalid target volume")
     func pageBootstrapClampsInvalidTargetVolume() {
         let script = SingletonPlayerWebView.pageBootstrapScript(
             isRestoringPlaybackSession: false,
-            targetVolume: .infinity
+            targetVolume: .infinity,
+            documentGeneration: 7
         )
 
         #expect(script.contains("window.__kasetTargetVolume = 1.0;"))
+    }
+}
+
+// MARK: - MusicPlaybackOccurrenceJSTests
+
+@Suite(.tags(.service))
+struct MusicPlaybackOccurrenceJSTests {
+    private func makeContext() -> JSContext {
+        let context = JSContext()!
+        context.evaluateScript(SingletonPlayerWebView.playbackOccurrenceFunctionJS)
+        return context
+    }
+
+    private func makeObserverContext() -> JSContext {
+        let context = JSContext()!
+        context.evaluateScript(
+            """
+            var messages = [];
+            var listeners = {};
+            function addListener(name, callback) {
+                if (!listeners[name]) listeners[name] = [];
+                listeners[name].push(callback);
+            }
+            function dispatch(name) {
+                (listeners[name] || []).forEach(function(callback) { callback({ currentTarget: video }); });
+            }
+            function setTimeout() { return 1; }
+            function clearTimeout() {}
+            function setInterval() { return 1; }
+            function clearInterval() {}
+            function MutationObserver() { this.observe = function() {}; }
+
+            var currentDataVideoId = 'v1';
+            var video = {
+                paused: false,
+                ended: false,
+                currentSrc: 'https://media.example/v1',
+                src: '',
+                currentTime: 179,
+                duration: 180,
+                readyState: 4,
+                volume: 1,
+                webkitCurrentPlaybackTargetIsWireless: false,
+                addEventListener: addListener,
+                pause: function() { this.paused = true; },
+                play: function() { this.paused = false; }
+            };
+            var player = {
+                playerApi: {
+                    getVideoData: function() {
+                        return { video_id: currentDataVideoId, title: currentDataVideoId, author: 'Artist' };
+                    },
+                    setVolume: function() {}
+                }
+            };
+            var moviePlayer = {
+                classList: { contains: function() { return false; } },
+                getVideoData: function() { return { video_id: currentDataVideoId }; },
+                setVolume: function() {}
+            };
+            var playerBar = {};
+            var progressBar = {
+                getAttribute: function(name) { return name === 'value' ? '179' : '180'; }
+            };
+            var titleElement = { textContent: 'v1' };
+            var artistElement = { textContent: 'Artist' };
+            var document = {
+                readyState: 'complete',
+                body: {},
+                addEventListener: function() {},
+                getElementById: function(id) { return id === 'movie_player' ? moviePlayer : null; },
+                querySelectorAll: function() { return []; },
+                querySelector: function(selector) {
+                    if (selector === 'video') return video;
+                    if (selector === 'ytmusic-player') return player;
+                    if (selector === 'ytmusic-player-bar') return playerBar;
+                    if (selector === '#progress-bar') return progressBar;
+                    if (selector === '.ytmusic-player-bar.title') return titleElement;
+                    if (selector === '.ytmusic-player-bar.byline') return artistElement;
+                    return null;
+                }
+            };
+            var window = globalThis;
+            window.location = { href: 'https://music.youtube.com/watch?v=v1' };
+            window.__kasetDocumentGeneration = 7;
+            window.__kasetTargetVolume = 1;
+            window.__kasetAutoplayPending = false;
+            window.__kasetPlaybackSuppressed = false;
+            window.webkit = {
+                messageHandlers: {
+                    singletonPlayer: {
+                        postMessage: function(message) { messages.push(message); }
+                    }
+                }
+            };
+            """
+        )
+        context.evaluateScript(SingletonPlayerWebView.observerScript)
+        return context
+    }
+
+    @Test("Leading metadata alone does not rebind the ending media occurrence")
+    func leadingMetadataDoesNotRebindOccurrence() {
+        let context = self.makeContext()
+
+        #expect(context.evaluateScript(
+            "__kasetShouldBindMediaOccurrence(true, false, false, true, false)"
+        ).toBool() == false)
+        #expect(context.evaluateScript(
+            "__kasetShouldBindMediaOccurrence(true, true, false, true, false)"
+        ).toBool() == true)
+        #expect(context.evaluateScript(
+            "__kasetShouldBindMediaOccurrence(true, false, true, false, false)"
+        ).toBool() == true)
+        #expect(context.evaluateScript(
+            "__kasetShouldBindMediaOccurrence(true, false, true, true, false)"
+        ).toBool() == false)
+        #expect(context.evaluateScript(
+            "__kasetShouldBindMediaOccurrence(true, false, false, true, true)"
+        ).toBool() == true)
+    }
+
+    @Test("A replay after ended advances only the consumed occurrence")
+    func replayAfterEndedAdvancesOccurrence() {
+        let context = self.makeContext()
+
+        #expect(context.evaluateScript(
+            "__kasetShouldAdvanceEndedOccurrence(4, 4)"
+        ).toBool() == true)
+        #expect(context.evaluateScript(
+            "__kasetShouldAdvanceEndedOccurrence(4, 5)"
+        ).toBool() == false)
+        #expect(context.evaluateScript(
+            "__kasetShouldAdvanceEndedOccurrence(null, 4)"
+        ).toBool() == false)
+    }
+
+    @Test("Observer state and ended payloads carry the media occurrence")
+    func observerPayloadsCarryOccurrence() {
+        let script = SingletonPlayerWebView.observerScript
+
+        #expect(script.contains("mediaVideoId: mediaVideoId"))
+        #expect(script.contains("mediaGeneration: mediaGeneration"))
+        #expect(script.contains("mediaGeneration: occurrenceGeneration"))
+        #expect(script.contains("video.__kasetEndedOccurrenceGeneration"))
+        #expect(script.contains("video.__kasetBoundVideoId || lastVideoId || currentVideoId()"))
+    }
+
+    @Test("Late ended keeps the outgoing occurrence after metadata leads")
+    func lateEndedKeepsOutgoingOccurrence() {
+        let context = self.makeObserverContext()
+        #expect(context.exception == nil)
+
+        context.evaluateScript(
+            """
+            messages = [];
+            currentDataVideoId = 'v2';
+            titleElement.textContent = 'v2';
+            dispatch('waiting');
+            video.paused = true;
+            video.ended = true;
+            dispatch('ended');
+            """
+        )
+
+        #expect(context.evaluateScript(
+            "messages.filter(function(message) { return message.type === 'TRACK_ENDED'; })[0].videoId"
+        ).toString() == "v1")
+        #expect(context.evaluateScript(
+            "messages.filter(function(message) { return message.type === 'TRACK_ENDED'; })[0].mediaGeneration"
+        ).toInt32() == 1)
+
+        context.evaluateScript(
+            """
+            video.currentSrc = 'https://media.example/v2';
+            video.currentTime = 0;
+            video.paused = false;
+            video.ended = false;
+            dispatch('loadedmetadata');
+            video.paused = true;
+            video.ended = true;
+            dispatch('ended');
+            """
+        )
+
+        #expect(context.evaluateScript(
+            """
+            messages.filter(function(message) { return message.type === 'TRACK_ENDED'; })
+                .map(function(message) { return message.videoId; }).join(',')
+            """
+        ).toString() == "v1,v2")
+        #expect(context.evaluateScript(
+            """
+            messages.filter(function(message) { return message.type === 'TRACK_ENDED'; })
+                .map(function(message) { return message.mediaGeneration; }).join(',')
+            """
+        ).toString() == "1,2")
+    }
+
+    @Test("A queued ended callback cannot end a replayed media occurrence")
+    func queuedEndedAfterReplayIsIgnored() {
+        let context = self.makeObserverContext()
+        context.evaluateScript(
+            """
+            messages = [];
+            video.paused = true;
+            video.ended = true;
+            dispatch('ended');
+            video.paused = false;
+            video.ended = false;
+            dispatch('play');
+            dispatch('ended');
+            """
+        )
+
+        #expect(context.evaluateScript(
+            "messages.filter(function(message) { return message.type === 'TRACK_ENDED'; }).length"
+        ).toInt32() == 1)
+    }
+
+    @Test("A backward seek cannot rebind old media to leading metadata")
+    func backwardSeekDoesNotPermitLeadingIdentityRepair() {
+        let context = self.makeObserverContext()
+        context.evaluateScript(
+            """
+            messages = [];
+            var initialGeneration = video.__kasetMediaGeneration;
+            currentDataVideoId = 'v2';
+            titleElement.textContent = 'v2';
+            video.currentTime = 30;
+            dispatch('seeked');
+            var backwardSeekGeneration = video.__kasetMediaGeneration;
+            dispatch('waiting');
+            video.paused = true;
+            video.ended = true;
+            dispatch('ended');
+            """
+        )
+
+        #expect(context.evaluateScript("video.__kasetBoundVideoId").toString() == "v1")
+        #expect(context.evaluateScript(
+            "video.__kasetMediaGeneration === backwardSeekGeneration"
+        ).toBool() == true)
+        #expect(context.evaluateScript(
+            "backwardSeekGeneration === initialGeneration"
+        ).toBool() == true)
+        #expect(context.evaluateScript(
+            "messages.filter(function(message) { return message.type === 'TRACK_ENDED'; })[0].videoId"
+        ).toString() == "v1")
+        #expect(context.evaluateScript(
+            """
+            messages.filter(function(message) { return message.type === 'TRACK_ENDED'; })[0].mediaGeneration
+                === backwardSeekGeneration
+            """
+        ).toBool() == true)
+    }
+
+    @Test("Music source transition repairs identity when metadata catches up")
+    func sourceTransitionRepairsLeadingIdentity() {
+        let context = self.makeObserverContext()
+        context.evaluateScript(
+            """
+            messages = [];
+            video.currentSrc = 'https://media.example/v2';
+            video.currentTime = 0;
+            dispatch('loadedmetadata');
+            currentDataVideoId = 'v2';
+            titleElement.textContent = 'v2';
+            dispatch('waiting');
+            video.paused = true;
+            video.ended = true;
+            dispatch('ended');
+            """
+        )
+
+        #expect(context.evaluateScript(
+            "messages.filter(function(message) { return message.type === 'TRACK_ENDED'; })[0].videoId"
+        ).toString() == "v2")
+    }
+
+    @Test("A backward seek preserves deferred source-transition identity repair")
+    func backwardSeekPreservesDeferredIdentityRepair() {
+        let context = self.makeObserverContext()
+        context.evaluateScript(
+            """
+            messages = [];
+            video.currentSrc = 'https://media.example/v2';
+            video.currentTime = 0;
+            dispatch('loadedmetadata');
+            video.currentTime = 30;
+            dispatch('timeupdate');
+            video.currentTime = 5;
+            dispatch('seeked');
+            currentDataVideoId = 'v2';
+            titleElement.textContent = 'v2';
+            dispatch('waiting');
+            video.paused = true;
+            video.ended = true;
+            dispatch('ended');
+            """
+        )
+
+        #expect(context.evaluateScript("video.__kasetBoundVideoId").toString() == "v2")
+        #expect(context.evaluateScript(
+            "messages.filter(function(message) { return message.type === 'TRACK_ENDED'; })[0].videoId"
+        ).toString() == "v2")
+    }
+}
+
+// MARK: - MusicPlaybackClockJSTests
+
+@Suite(.tags(.service))
+struct MusicPlaybackClockJSTests {
+    private func makeContext() -> JSContext {
+        let context = JSContext()!
+        context.evaluateScript(SingletonPlayerWebView.playbackClockFunctionJS)
+        return context
+    }
+
+    @Test("Ready media clock wins over a lagging player bar")
+    func readyMediaClockWins() {
+        let context = self.makeContext()
+        context.evaluateScript(
+            """
+            var media = { currentTime: 1.75, duration: 182 };
+            var progressBar = {
+                getAttribute: function(name) {
+                    return name === 'value' ? '0' : '183';
+                }
+            };
+            globalThis.clock = __kasetPlaybackClock(media, progressBar, true);
+            """
+        )
+
+        #expect(context.evaluateScript("clock.progress").toDouble() == 1.75)
+        #expect(context.evaluateScript("clock.duration").toDouble() == 182)
+    }
+
+    @Test("Unready media falls back to player bar clock")
+    func unreadyMediaFallsBackToPlayerBar() {
+        let context = self.makeContext()
+        context.evaluateScript(
+            """
+            var media = { currentTime: 0, duration: Number.NaN };
+            var progressBar = {
+                getAttribute: function(name) {
+                    return name === 'value' ? '42' : '180';
+                }
+            };
+            globalThis.clock = __kasetPlaybackClock(media, progressBar, false);
+            """
+        )
+
+        #expect(context.evaluateScript("clock.progress").toDouble() == 42)
+        #expect(context.evaluateScript("clock.duration").toDouble() == 180)
+    }
+
+    @Test("Invalid clocks degrade to zero")
+    func invalidClocksDegradeToZero() {
+        let context = self.makeContext()
+        context.evaluateScript(
+            """
+            var media = { currentTime: Number.NaN, duration: Number.POSITIVE_INFINITY };
+            var progressBar = { getAttribute: function() { return 'not-a-number'; } };
+            globalThis.clock = __kasetPlaybackClock(media, progressBar, true);
+            """
+        )
+
+        #expect(context.evaluateScript("clock.progress").toDouble() == 0)
+        #expect(context.evaluateScript("clock.duration").toDouble() == 0)
+    }
+}
+
+// MARK: - MusicPlaybackBridgeDecodingTests
+
+@Suite(.tags(.service))
+struct MusicPlaybackBridgeDecodingTests {
+    @Test("Playback bridge preserves fractional media clocks")
+    func preservesFractionalClocks() {
+        #expect(SingletonPlayerWebView.finitePlaybackBridgeDouble(from: NSNumber(value: 1.75)) == 1.75)
+        #expect(SingletonPlayerWebView.finitePlaybackBridgeDouble(from: 42) == 42)
+    }
+
+    @Test("Playback bridge rejects non-finite and Boolean clocks")
+    func rejectsInvalidClocks() {
+        #expect(SingletonPlayerWebView.finitePlaybackBridgeDouble(from: Double.infinity) == nil)
+        #expect(SingletonPlayerWebView.finitePlaybackBridgeDouble(from: true) == nil)
+        #expect(SingletonPlayerWebView.finitePlaybackBridgeDouble(from: "1.75") == nil)
     }
 }

--- a/Tests/KasetTests/AutoplayRecoveryTests.swift
+++ b/Tests/KasetTests/AutoplayRecoveryTests.swift
@@ -431,6 +431,13 @@ struct MusicPlaybackOccurrenceJSTests {
         #expect(script.contains("mediaVideoId: mediaVideoId"))
         #expect(script.contains("mediaGeneration: mediaGeneration"))
         #expect(script.contains("mediaGeneration: occurrenceGeneration"))
+        #expect(script.contains("function __kasetEventTimestampMilliseconds()"))
+        #expect(script.contains("Number(performance.timeOrigin) + Number(performance.now())"))
+        #expect(script.contains("eventIssuedAtMilliseconds: __kasetEventTimestampMilliseconds()"))
+        #expect(script.contains("eventIssuedAtMilliseconds: now"))
+        #expect(script.contains("setTimeout(() => retryTrackEnded(video, endedPayload), 16)"))
+        #expect(script.contains("function trackEndedPayload(video)"))
+        #expect(script.contains("function retryTrackEnded(video, payload)"))
         #expect(script.contains("video.__kasetEndedOccurrenceGeneration"))
         #expect(script.contains("video.__kasetBoundVideoId || lastVideoId || currentVideoId()"))
     }
@@ -642,6 +649,33 @@ struct MusicPlaybackClockJSTests {
 
         #expect(context.evaluateScript("clock.progress").toDouble() == 42)
         #expect(context.evaluateScript("clock.duration").toDouble() == 180)
+    }
+
+    @Test("Clock restoration script pauses and seeks physical media")
+    func restorationScriptSeeksPhysicalMedia() throws {
+        let context = try #require(JSContext())
+        context.evaluateScript(
+            """
+            var pauseCount = 0;
+            var media = {
+                currentTime: 30,
+                pause: function() { pauseCount += 1; }
+            };
+            var document = {
+                querySelector: function(selector) {
+                    return selector === 'video' ? media : null;
+                }
+            };
+            """
+        )
+
+        let result = context.evaluateScript(
+            SingletonPlayerWebView.seekAndPauseScript(to: 10)
+        )
+
+        #expect(result?.toString() == "seeked-paused")
+        #expect(context.evaluateScript("media.currentTime").toDouble() == 10)
+        #expect(context.evaluateScript("pauseCount").toInt32() == 2)
     }
 
     @Test("Invalid clocks degrade to zero")

--- a/Tests/KasetTests/ChartsViewModelTests.swift
+++ b/Tests/KasetTests/ChartsViewModelTests.swift
@@ -14,6 +14,23 @@ struct ChartsViewModelTests {
         self.viewModel = ChartsViewModel(client: self.mockClient)
     }
 
+    private func waitForBackgroundLoading(
+        timeout: Duration = .seconds(3),
+        until condition: @escaping () -> Bool
+    ) async {
+        let clock = ContinuousClock()
+        let deadline = clock.now + timeout
+
+        while clock.now < deadline {
+            if condition() {
+                return
+            }
+            try? await Task.sleep(for: .milliseconds(25))
+        }
+
+        Issue.record("Timed out waiting for background chart loading")
+    }
+
     // MARK: - Initial State Tests
 
     @Test("Initial state is idle with empty sections")
@@ -95,12 +112,12 @@ struct ChartsViewModelTests {
         self.mockClient.chartsContinuationSections = [continuationSections]
 
         await self.viewModel.load()
-
-        // Wait for background loading to complete
-        try? await Task.sleep(for: .milliseconds(500))
+        await self.waitForBackgroundLoading {
+            self.viewModel.sections.count == 2
+        }
 
         #expect(self.viewModel.sections.count == 2)
-        #expect(self.viewModel.sections[1].title == "More Charts")
+        #expect(self.viewModel.sections.last?.title == "More Charts")
     }
 
     @Test("hasMoreSections updates after continuations")
@@ -111,9 +128,9 @@ struct ChartsViewModelTests {
         // No continuation sections
 
         await self.viewModel.load()
-
-        // Wait for background loading to complete
-        try? await Task.sleep(for: .milliseconds(500))
+        await self.waitForBackgroundLoading {
+            self.viewModel.hasMoreSections == false
+        }
 
         #expect(self.viewModel.hasMoreSections == false)
     }
@@ -148,7 +165,9 @@ struct ChartsViewModelTests {
         ]
 
         await self.viewModel.load()
-        try? await Task.sleep(for: .milliseconds(500))
+        await self.waitForBackgroundLoading {
+            self.viewModel.hasMoreSections == false
+        }
 
         // After load, hasMoreSections should be false (continuations exhausted)
         #expect(self.viewModel.hasMoreSections == false)

--- a/Tests/KasetTests/CommandBarViewModelTests.swift
+++ b/Tests/KasetTests/CommandBarViewModelTests.swift
@@ -218,6 +218,58 @@ struct CommandBarViewModelTests {
         viewModel.cancelActiveRequest()
     }
 
+    @Test("Canceled request cleanup cannot release a newer single-flight request")
+    func canceledCleanupCannotClearNewerRequest() async {
+        let playerService = MockPlayerService()
+        let recorder = Recorder()
+        let firstStarted = AsyncGate()
+        let releaseFirst = AsyncGate()
+        let secondStarted = AsyncGate()
+        let releaseSecond = AsyncGate()
+        let aiCallCounter = Counter()
+
+        let aiClient = self.makeAIClient { query, _ in
+            await aiCallCounter.increment()
+            if query.contains("first") {
+                await firstStarted.open()
+                await releaseFirst.wait()
+            } else if query.contains("second") {
+                await secondStarted.open()
+                await releaseSecond.wait()
+            }
+            return Self.makeParsedCommand(action: .search, subject: query)
+        }
+        let viewModel = self.makeViewModel(
+            playerService: playerService,
+            aiClient: aiClient,
+            recorder: recorder,
+            requestTimeout: .seconds(5)
+        )
+
+        viewModel.inputText = "find first obscure request"
+        viewModel.submit()
+        await firstStarted.wait()
+        viewModel.cancelActiveRequest()
+
+        viewModel.inputText = "find second obscure request"
+        viewModel.submit()
+        await secondStarted.wait()
+        await releaseFirst.open()
+        try? await Task.sleep(for: .milliseconds(50))
+
+        #expect(viewModel.isProcessing)
+        #expect(viewModel.isInteractionDisabled)
+        viewModel.inputText = "find third obscure request"
+        viewModel.submit()
+        try? await Task.sleep(for: .milliseconds(25))
+        #expect(await aiCallCounter.get() == 2)
+
+        await releaseSecond.open()
+        await self.waitUntil {
+            !viewModel.isProcessing
+        }
+    }
+
     @Test("Timeout falls back to deterministic search routing")
     func timeoutFallsBackToSearchRouting() async {
         let playerService = MockPlayerService()
@@ -244,6 +296,36 @@ struct CommandBarViewModelTests {
 
         #expect(recorder.routedQueries == ["Billie Eilish"])
         #expect(viewModel.lastFallbackReason == .timedOut)
+    }
+
+    @Test("Timeout does not await a cancellation-insensitive resolver")
+    func hardTimeoutDoesNotAwaitResolver() async {
+        let playerService = MockPlayerService()
+        let recorder = Recorder()
+        let resolverStarted = AsyncGate()
+        let releaseResolver = AsyncGate()
+        let aiClient = self.makeAIClient { _, _ in
+            await resolverStarted.open()
+            await releaseResolver.wait()
+            return Self.makeParsedCommand(action: .play)
+        }
+        let viewModel = self.makeViewModel(
+            playerService: playerService,
+            aiClient: aiClient,
+            recorder: recorder,
+            requestTimeout: .milliseconds(20)
+        )
+
+        viewModel.inputText = "Search for cancellation insensitive music"
+        viewModel.submit()
+        await resolverStarted.wait()
+        await self.waitUntil(timeout: .milliseconds(250)) {
+            viewModel.lastFallbackReason == .timedOut
+        }
+
+        #expect(viewModel.lastFallbackReason == .timedOut)
+        #expect(recorder.routedQueries == ["cancellation insensitive music"])
+        await releaseResolver.open()
     }
 
     @Test("Dismiss cancels an in-flight request")

--- a/Tests/KasetTests/CommandExecutorTests.swift
+++ b/Tests/KasetTests/CommandExecutorTests.swift
@@ -41,4 +41,136 @@ struct CommandExecutorTests {
         #expect(outcome.shouldDismiss == false)
         #expect(outcome.searchQueryToOpen == nil)
     }
+
+    @Test("A cancelled command cannot claim or exercise playback ownership")
+    func cancelledCommandCannotClaimPlayback() async {
+        let playerService = MockPlayerService()
+        let executor = CommandExecutor(client: MockYTMusicClient(), playerService: playerService)
+        let reservation = playerService.reserveMusicPlaybackIntent()
+        let gate = AsyncGate()
+        let task = Task { @MainActor in
+            await gate.wait()
+            return await executor.execute(.skip, reservation: reservation)
+        }
+        task.cancel()
+        await gate.open()
+
+        let outcome = await task.value
+
+        #expect(outcome == .ignored)
+        #expect(playerService.nextCallCount == 0)
+        #expect(playerService.claimMusicPlaybackIntent(reservation) != nil)
+    }
+
+    @Test("A delayed command search cannot resurrect playback after stop")
+    func delayedPlaySearchCannotResurrectAfterStop() async {
+        let playerService = PlayerService()
+        let client = MockYTMusicClient()
+        let searchStarted = AsyncGate()
+        let releaseSearch = AsyncGate()
+        client.songsSearchResponse = SearchResponse(
+            songs: [self.makeSong(title: "Stale", artist: "Artist", videoId: "stale")],
+            albums: [],
+            artists: [],
+            playlists: []
+        )
+        client.beforeSearchReturn = { _, endpoint in
+            guard endpoint == .songs else { return }
+            await searchStarted.open()
+            await releaseSearch.wait()
+        }
+        let executor = CommandExecutor(client: client, playerService: playerService)
+        let reservation = playerService.reserveMusicPlaybackIntent()
+
+        let commandTask = Task { @MainActor in
+            await executor.execute(
+                .playSearch(query: "stale", description: ""),
+                reservation: reservation
+            )
+        }
+        await searchStarted.wait()
+        await playerService.stop()
+        await releaseSearch.open()
+        let outcome = await commandTask.value
+
+        #expect(outcome == .ignored)
+        #expect(playerService.state == .idle)
+        #expect(playerService.queue.isEmpty)
+        #expect(playerService.currentTrack == nil)
+    }
+
+    @Test("A parsed queue command cannot acquire ownership after queue replacement")
+    func parsedQueueCommandCannotAdoptReplacementQueue() async {
+        let playerService = PlayerService()
+        let client = MockYTMusicClient()
+        let executor = CommandExecutor(client: client, playerService: playerService)
+        let initial = self.makeSong(title: "Initial", artist: "Artist", videoId: "initial")
+        await playerService.playQueue([initial], startingAt: 0)
+        let submissionReservation = playerService.reserveMusicPlaybackIntent()
+        let replacement = self.makeSong(
+            title: "Replacement",
+            artist: "Artist",
+            videoId: "replacement"
+        )
+        await playerService.playQueue([replacement], startingAt: 0)
+        let replacementEntryIDs = playerService.queueEntryIDs
+        client.songsSearchResponse = SearchResponse(
+            songs: [self.makeSong(title: "Stale", artist: "Artist", videoId: "stale")],
+            albums: [],
+            artists: [],
+            playlists: []
+        )
+
+        let outcome = await executor.execute(
+            .queueSearch(query: "stale", description: ""),
+            reservation: submissionReservation
+        )
+
+        #expect(outcome == .ignored)
+        #expect(playerService.queue == [replacement])
+        #expect(playerService.queueEntryIDs == replacementEntryIDs)
+        #expect(client.searchQueries.isEmpty)
+    }
+
+    @Test("A delayed queue command cannot append into a replacement queue")
+    func delayedQueueSearchCannotAppendToReplacement() async {
+        let playerService = PlayerService()
+        let client = MockYTMusicClient()
+        let searchStarted = AsyncGate()
+        let releaseSearch = AsyncGate()
+        client.songsSearchResponse = SearchResponse(
+            songs: [self.makeSong(title: "Stale", artist: "Artist", videoId: "stale")],
+            albums: [],
+            artists: [],
+            playlists: []
+        )
+        client.beforeSearchReturn = { _, endpoint in
+            guard endpoint == .songs else { return }
+            await searchStarted.open()
+            await releaseSearch.wait()
+        }
+        let executor = CommandExecutor(client: client, playerService: playerService)
+        let reservation = playerService.reserveMusicPlaybackIntent()
+
+        let commandTask = Task { @MainActor in
+            await executor.execute(
+                .queueSearch(query: "stale", description: ""),
+                reservation: reservation
+            )
+        }
+        await searchStarted.wait()
+        let replacement = self.makeSong(
+            title: "Replacement",
+            artist: "Artist",
+            videoId: "replacement"
+        )
+        await playerService.playQueue([replacement], startingAt: 0)
+        let replacementEntryIDs = playerService.queueEntryIDs
+        await releaseSearch.open()
+        let outcome = await commandTask.value
+
+        #expect(outcome == .ignored)
+        #expect(playerService.queue == [replacement])
+        #expect(playerService.queueEntryIDs == replacementEntryIDs)
+    }
 }

--- a/Tests/KasetTests/EqualizerServiceTests.swift
+++ b/Tests/KasetTests/EqualizerServiceTests.swift
@@ -49,6 +49,21 @@ struct EqualizerServiceTests {
         return TestHarness(service: service, mock: mock, defaults: defaults)
     }
 
+    private func waitUntil(
+        timeout: Duration = .seconds(3),
+        condition: () -> Bool
+    ) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now + timeout
+        while clock.now < deadline {
+            if condition() {
+                return true
+            }
+            try? await Task.sleep(for: .milliseconds(25))
+        }
+        return false
+    }
+
     // MARK: - Preset application
 
     @Test("Applying a preset replaces every band gain")
@@ -316,7 +331,10 @@ struct EqualizerServiceTests {
         // Simulate playback starting: source becomes available.
         mock.startResult = .success(())
         service.retryStartIfEnabled()
-        try? await Task.sleep(for: .milliseconds(700))
+        let didStart = await self.waitUntil {
+            mock.startCallCount > firstAttempt && service.status == .active
+        }
+        #expect(didStart)
         #expect(mock.startCallCount > firstAttempt)
         #expect(service.status == .active)
     }
@@ -345,8 +363,16 @@ struct EqualizerServiceTests {
         service.setPreamp(-2)
         service.setGain(forBandAt: 1, to: 3.5)
 
-        // Persistence is debounced; wait past the debounce window.
-        try? await Task.sleep(for: .milliseconds(400))
+        let didPersist = await self.waitUntil {
+            let revived = EqualizerService(
+                engine: MockEqualizerAudioEngine(),
+                defaults: defaults
+            )
+            return revived.settings.preset == .custom
+                && revived.settings.preampDB == -2
+                && revived.settings.bandGainsDB[1] == 3.5
+        }
+        #expect(didPersist)
 
         // New service should load the same settings from the same suite.
         let mock = MockEqualizerAudioEngine()
@@ -438,7 +464,13 @@ struct EqualizerServiceTests {
             Issue.record("Expected .permissionNeeded status, got \(service.status)")
         }
 
-        try? await Task.sleep(for: .milliseconds(400))
+        let didPersist = await self.waitUntil {
+            EqualizerService(
+                engine: MockEqualizerAudioEngine(),
+                defaults: defaults
+            ).settings.isEnabled
+        }
+        #expect(didPersist)
 
         let revived = EqualizerService(engine: MockEqualizerAudioEngine(), defaults: defaults)
         #expect(revived.settings.isEnabled == true)
@@ -458,8 +490,11 @@ struct EqualizerServiceTests {
         for _ in 0 ..< 5 {
             service.retryStartIfEnabled()
         }
-        try? await Task.sleep(for: .milliseconds(700))
+        let didRetry = await self.waitUntil {
+            mock.startCallCount == baseline + 1
+        }
 
+        #expect(didRetry)
         #expect(mock.startCallCount == baseline + 1)
     }
 }

--- a/Tests/KasetTests/Helpers/MockPlayerService.swift
+++ b/Tests/KasetTests/Helpers/MockPlayerService.swift
@@ -12,6 +12,13 @@ final class MockPlayerService: PlayerServiceProtocol {
     var repeatMode: PlayerService.RepeatMode = .off
     var queue: [Song] = []
     var currentIndex = 0
+    var activePlaybackQueueIndex: Int? {
+        guard let currentTrack,
+              queue[safe: currentIndex]?.videoId == currentTrack.videoId
+        else { return nil }
+        return self.currentIndex
+    }
+
     var showMiniPlayer = false
     var isMiniPlayerVisible = false
     var miniPlayerMode: PlayerService.MiniPlayerMode = .auxiliary
@@ -41,13 +48,18 @@ final class MockPlayerService: PlayerServiceProtocol {
     private(set) var playQueueCallCount = 0
     private(set) var likeCallCount = 0
     private(set) var dislikeCallCount = 0
+    private var musicPlaybackIntentGeneration: UInt64 = 0
+    private var musicPlaybackReservationGeneration: UInt64 = 0
+    private var queueMutationGeneration = 0
 
     func play(videoId: String) async {
+        self.advancePlaybackOwnership()
         self.playedVideoIds.append(videoId)
         self.state = .playing
     }
 
     func play(song: Song) async {
+        self.advancePlaybackOwnership()
         self.playedSongs.append(song)
         self.currentTrack = song
         self.state = .playing
@@ -62,24 +74,29 @@ final class MockPlayerService: PlayerServiceProtocol {
     }
 
     func pause() async {
+        self.advancePlaybackOwnership()
         self.pauseCallCount += 1
         self.state = .paused
     }
 
     func resume() async {
+        self.advancePlaybackOwnership()
         self.resumeCallCount += 1
         self.state = .playing
     }
 
     func next() async {
+        self.advancePlaybackOwnership()
         self.nextCallCount += 1
     }
 
     func previous() async {
+        self.advancePlaybackOwnership()
         self.previousCallCount += 1
     }
 
     func seek(to time: TimeInterval) async {
+        self.advancePlaybackOwnership()
         self.progress = time
     }
 
@@ -92,6 +109,7 @@ final class MockPlayerService: PlayerServiceProtocol {
     }
 
     func toggleShuffle() {
+        self.advancePlaybackOwnership()
         self.shuffleEnabled.toggle()
     }
 
@@ -150,11 +168,18 @@ final class MockPlayerService: PlayerServiceProtocol {
     }
 
     func stop() async {
+        self.musicPlaybackIntentGeneration &+= 1
+        self.musicPlaybackReservationGeneration &+= 1
+        self.queueMutationGeneration += 1
         self.state = .idle
         self.currentTrack = nil
     }
 
     func playQueue(_ songs: [Song], startingAt index: Int) async {
+        guard !songs.isEmpty else { return }
+        self.musicPlaybackIntentGeneration &+= 1
+        self.musicPlaybackReservationGeneration &+= 1
+        self.queueMutationGeneration += 1
         self.playQueueCallCount += 1
         self.queue = songs
         let safeIndex = min(max(index, 0), max(0, songs.count - 1))
@@ -163,14 +188,87 @@ final class MockPlayerService: PlayerServiceProtocol {
         self.state = .playing
     }
 
+    private func advancePlaybackOwnership() {
+        self.musicPlaybackIntentGeneration &+= 1
+        self.musicPlaybackReservationGeneration &+= 1
+    }
+
+    func reserveMusicPlaybackIntent() -> MusicPlaybackReservation {
+        self.musicPlaybackReservationGeneration &+= 1
+        return MusicPlaybackReservation(
+            playbackGeneration: self.musicPlaybackIntentGeneration,
+            reservationGeneration: self.musicPlaybackReservationGeneration,
+            queueMutationGeneration: self.queueMutationGeneration,
+            queueEntryID: nil,
+            videoID: self.currentTrack?.videoId
+        )
+    }
+
+    func acceptsMusicPlaybackReservation(_ reservation: MusicPlaybackReservation) -> Bool {
+        reservation.playbackGeneration == self.musicPlaybackIntentGeneration
+            && reservation.reservationGeneration == self.musicPlaybackReservationGeneration
+            && reservation.videoID == self.currentTrack?.videoId
+    }
+
+    func claimMusicPlaybackIntent(_ reservation: MusicPlaybackReservation) -> MusicPlaybackIntent? {
+        guard reservation.playbackGeneration == self.musicPlaybackIntentGeneration,
+              reservation.reservationGeneration == self.musicPlaybackReservationGeneration
+        else { return nil }
+        self.musicPlaybackIntentGeneration &+= 1
+        self.musicPlaybackReservationGeneration &+= 1
+        return MusicPlaybackIntent(generation: self.musicPlaybackIntentGeneration)
+    }
+
+    func acceptsMusicPlaybackIntent(_ intent: MusicPlaybackIntent) -> Bool {
+        intent.generation == self.musicPlaybackIntentGeneration
+    }
+
+    func reserveQueueMutation() -> Int {
+        self.queueMutationGeneration
+    }
+
+    func acceptsQueueMutation(_ generation: Int) -> Bool {
+        generation == self.queueMutationGeneration
+    }
+
+    func playQueue(
+        _ songs: [Song],
+        startingAt index: Int,
+        deferringSmartShuffleFill: Bool,
+        intent: MusicPlaybackIntent
+    ) async -> Int? {
+        guard self.acceptsMusicPlaybackIntent(intent), !songs.isEmpty else { return nil }
+        self.queueMutationGeneration += 1
+        self.playQueueCallCount += 1
+        self.queue = songs
+        self.currentIndex = min(max(index, 0), max(0, songs.count - 1))
+        self.currentTrack = songs[safe: self.currentIndex]
+        self.state = songs.isEmpty ? .idle : .playing
+        return deferringSmartShuffleFill ? self.queueMutationGeneration : nil
+    }
+
     func playWithRadio(song: Song) async {
+        self.advancePlaybackOwnership()
+        self.queueMutationGeneration += 1
         self.currentTrack = song
         self.state = .playing
     }
 
-    func playWithMix(playlistId _: String, startVideoId _: String?) async {}
+    func playWithMix(
+        playlistId _: String,
+        startVideoId _: String?,
+        intent suppliedIntent: MusicPlaybackIntent?
+    ) async {
+        if let suppliedIntent {
+            guard self.acceptsMusicPlaybackIntent(suppliedIntent) else { return }
+        } else {
+            self.advancePlaybackOwnership()
+        }
+    }
 
     func clearQueue() {
+        self.advancePlaybackOwnership()
+        self.queueMutationGeneration += 1
         self.clearQueueCallCount += 1
         if let currentTrack = self.currentTrack {
             self.queue = [currentTrack]
@@ -182,6 +280,7 @@ final class MockPlayerService: PlayerServiceProtocol {
     }
 
     func shuffleQueue() {
+        self.advancePlaybackOwnership()
         self.shuffleQueueCallCount += 1
         self.queue = Array(self.queue.reversed())
     }

--- a/Tests/KasetTests/Helpers/MockYTMusicClient.swift
+++ b/Tests/KasetTests/Helpers/MockYTMusicClient.swift
@@ -74,6 +74,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     var subscribeToArtistDelay: Duration?
     var unsubscribeFromArtistDelay: Duration?
     var rateSongDelay: Duration?
+    var editSongLibraryStatusResponseDelays: [Duration] = []
     var getSongDelay: Duration?
     var getPodcastsDelay: Duration?
     var getPlaylistDelay: Duration?
@@ -182,10 +183,36 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     private(set) var completedSearchEndpoints: [SearchEndpoint] = []
 
     var beforeSearchReturn: (@Sendable (String, SearchEndpoint) async -> Void)?
+    var beforeGetSongReturn: (@Sendable (String) async -> Void)?
+    var beforeGetPlaylistReturn: (@Sendable (String) async -> Void)?
+    var beforePlaylistContinuationReturn: (@Sendable (String) async -> Void)?
+    var beforeMixQueueReturn: (@Sendable (String, String?) async -> Void)?
+    var beforeMixQueueContinuationReturn: (@Sendable (String) async -> Void)?
+    var beforeRadioQueueReturn: (@Sendable (String) async -> Void)?
+    var beforeRateSongReturn: (@Sendable (String, LikeStatus) async -> Void)?
+    var beforeEditSongLibraryStatusReturn: (@Sendable ([String]) async -> Void)?
 
     private func waitBeforeSearchReturn(query: String, endpoint: SearchEndpoint) async {
         if let beforeSearchReturn {
             await beforeSearchReturn(query, endpoint)
+        }
+    }
+
+    private func waitBeforeMixQueueReturn(playlistId: String, startVideoId: String?) async {
+        if let beforeMixQueueReturn {
+            await beforeMixQueueReturn(playlistId, startVideoId)
+        }
+    }
+
+    private func waitBeforeMixQueueContinuationReturn(_ continuation: String) async {
+        if let beforeMixQueueContinuationReturn {
+            await beforeMixQueueContinuationReturn(continuation)
+        }
+    }
+
+    private func waitBeforeRadioQueueReturn(videoId: String) async {
+        if let beforeRadioQueueReturn {
+            await beforeRadioQueueReturn(videoId)
         }
     }
 
@@ -211,10 +238,12 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     private(set) var rateSongCalled = false
     private(set) var rateSongVideoIds: [String] = []
     private(set) var rateSongRatings: [LikeStatus] = []
+    private(set) var appliedRateSongRatings: [LikeStatus] = []
     private(set) var resetSessionStateForAccountSwitchCalled = false
     private(set) var resetSessionStateForAccountSwitchCallCount = 0
     private(set) var editSongLibraryStatusCalled = false
     private(set) var editSongLibraryStatusTokens: [[String]] = []
+    private(set) var appliedEditSongLibraryStatusTokens: [[String]] = []
     private(set) var subscribeToPlaylistCalled = false
     private(set) var subscribeToPlaylistIds: [String] = []
     private(set) var deletePlaylistCalled = false
@@ -261,14 +290,18 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.getHomeCalled = true
         self.getHomeCallCount += 1
         self._homeContinuationIndex = 0
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return self.homeResponse
     }
 
     func getHomeContinuation() async throws -> [HomeSection]? {
         self.getHomeContinuationCalled = true
         self.getHomeContinuationCallCount += 1
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         guard self._homeContinuationIndex < self.homeContinuationSections.count else {
             return nil
         }
@@ -281,14 +314,18 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.getPersonalizedRecommendationsCalled = true
         self.getPersonalizedRecommendationsCallCount += 1
         self._personalizedRecommendationsContinuationIndex = 0
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return self.personalizedRecommendationsResponse
     }
 
     func getPersonalizedRecommendationsContinuation() async throws -> [HomeSection]? {
         self.getPersonalizedRecommendationsContinuationCalled = true
         self.getPersonalizedRecommendationsContinuationCallCount += 1
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         guard self._personalizedRecommendationsContinuationIndex < self.personalizedRecommendationsContinuationSections.count else {
             return nil
         }
@@ -301,14 +338,18 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.getExploreCalled = true
         self.getExploreCallCount += 1
         self._exploreContinuationIndex = 0
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return self.exploreResponse
     }
 
     func getExploreContinuation() async throws -> [HomeSection]? {
         self.getExploreContinuationCalled = true
         self.getExploreContinuationCallCount += 1
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         guard self._exploreContinuationIndex < self.exploreContinuationSections.count else {
             return nil
         }
@@ -321,12 +362,16 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.getChartsCalled = true
         self.getChartsCallCount += 1
         self._chartsContinuationIndex = 0
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return self.chartsResponse
     }
 
     func getChartsContinuation() async throws -> [HomeSection]? {
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         guard self._chartsContinuationIndex < self.chartsContinuationSections.count else {
             return nil
         }
@@ -337,12 +382,16 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
 
     func getMoodsAndGenres() async throws -> HomeResponse {
         self._moodsAndGenresContinuationIndex = 0
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return self.moodsAndGenresResponse
     }
 
     func getMoodsAndGenresContinuation() async throws -> [HomeSection]? {
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         guard self._moodsAndGenresContinuationIndex < self.moodsAndGenresContinuationSections.count else {
             return nil
         }
@@ -353,12 +402,16 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
 
     func getNewReleases() async throws -> HomeResponse {
         self._newReleasesContinuationIndex = 0
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return self.newReleasesResponse
     }
 
     func getNewReleasesContinuation() async throws -> [HomeSection]? {
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         guard self._newReleasesContinuationIndex < self.newReleasesContinuationSections.count else {
             return nil
         }
@@ -370,7 +423,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     func getHistory() async throws -> HomeResponse {
         self.getHistoryCallCount += 1
         self._historyContinuationIndex = 0
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         if !self.historyResponseSequence.isEmpty {
             return self.historyResponseSequence.removeFirst()
         }
@@ -378,7 +433,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     }
 
     func getHistoryContinuation() async throws -> [HomeSection]? {
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         guard self._historyContinuationIndex < self.historyContinuationSections.count else {
             return nil
         }
@@ -393,12 +450,16 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         if let delay = self.getPodcastsDelay {
             try await Task.sleep(for: delay)
         }
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return self.podcastsSections
     }
 
     func getPodcastsContinuation() async throws -> [PodcastSection]? {
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         guard self._podcastsContinuationIndex < self.podcastsContinuationSections.count else {
             return nil
         }
@@ -408,7 +469,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     }
 
     func getPodcastShow(browseId _: String) async throws -> PodcastShowDetail {
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return PodcastShowDetail(
             show: PodcastShow(id: "test", title: "Test Show", author: nil, description: nil, thumbnailURL: nil, episodeCount: nil),
             episodes: [],
@@ -418,7 +481,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     }
 
     func getPodcastEpisodesContinuation(token _: String) async throws -> PodcastEpisodesContinuation {
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return PodcastEpisodesContinuation(episodes: [], continuationToken: nil)
     }
 
@@ -428,7 +493,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self._searchContinuationIndex = 0
         await self.waitBeforeSearchReturn(query: query, endpoint: .mixed)
         defer { self.completedSearchEndpoints.append(.mixed) }
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return self.mixedSearchResponse ?? self.searchResponse
     }
 
@@ -437,7 +504,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.searchQueries.append(query)
         await self.waitBeforeSearchReturn(query: query, endpoint: .songs)
         defer { self.completedSearchEndpoints.append(.songs) }
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return (self.songsSearchResponse ?? self.searchResponse).songs
     }
 
@@ -447,7 +516,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self._searchContinuationIndex = 0
         await self.waitBeforeSearchReturn(query: query, endpoint: .songsWithPagination)
         defer { self.completedSearchEndpoints.append(.songsWithPagination) }
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         let hasMore = !self.searchContinuationResponses.isEmpty
         let response = self.songsSearchResponse ?? self.searchResponse
         return SearchResponse(
@@ -465,7 +536,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self._searchContinuationIndex = 0
         await self.waitBeforeSearchReturn(query: query, endpoint: .albums)
         defer { self.completedSearchEndpoints.append(.albums) }
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         let hasMore = !self.searchContinuationResponses.isEmpty
         let response = self.albumsSearchResponse ?? self.searchResponse
         return SearchResponse(
@@ -483,7 +556,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self._searchContinuationIndex = 0
         await self.waitBeforeSearchReturn(query: query, endpoint: .artists)
         defer { self.completedSearchEndpoints.append(.artists) }
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         let hasMore = !self.searchContinuationResponses.isEmpty
         let response = self.artistsSearchResponse ?? self.searchResponse
         return SearchResponse(
@@ -501,7 +576,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self._searchContinuationIndex = 0
         await self.waitBeforeSearchReturn(query: query, endpoint: .playlists)
         defer { self.completedSearchEndpoints.append(.playlists) }
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         let hasMore = !self.searchContinuationResponses.isEmpty
         let response = self.playlistsSearchResponse ?? self.searchResponse
         return SearchResponse(
@@ -519,7 +596,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self._searchContinuationIndex = 0
         await self.waitBeforeSearchReturn(query: query, endpoint: .featuredPlaylists)
         defer { self.completedSearchEndpoints.append(.featuredPlaylists) }
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         let hasMore = !self.searchContinuationResponses.isEmpty
         let response = self.featuredPlaylistsSearchResponse ?? self.searchResponse
         return SearchResponse(
@@ -537,7 +616,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self._searchContinuationIndex = 0
         await self.waitBeforeSearchReturn(query: query, endpoint: .communityPlaylists)
         defer { self.completedSearchEndpoints.append(.communityPlaylists) }
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         let hasMore = !self.searchContinuationResponses.isEmpty
         let response = self.communityPlaylistsSearchResponse ?? self.searchResponse
         return SearchResponse(
@@ -555,7 +636,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self._searchContinuationIndex = 0
         await self.waitBeforeSearchReturn(query: query, endpoint: .podcasts)
         defer { self.completedSearchEndpoints.append(.podcasts) }
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         let hasMore = !self.searchContinuationResponses.isEmpty
         let response = self.podcastsSearchResponse ?? self.searchResponse
         return SearchResponse(
@@ -569,7 +652,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     }
 
     func getSearchContinuation() async throws -> SearchResponse? {
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         guard self._searchContinuationIndex < self.searchContinuationResponses.count else {
             return nil
         }
@@ -599,13 +684,17 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     func getSearchSuggestions(query: String) async throws -> [SearchSuggestion] {
         self.getSearchSuggestionsCalled = true
         self.getSearchSuggestionsQueries.append(query)
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return self.searchSuggestions
     }
 
     func getLibraryPlaylists() async throws -> [Playlist] {
         self.getLibraryPlaylistsCalled = true
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return self.libraryPlaylists
     }
 
@@ -622,7 +711,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
             let delay = self.libraryContentResponseDelays.removeFirst()
             try? await Task.sleep(for: delay)
         }
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         if !self.libraryContentResponses.isEmpty {
             return self.libraryContentResponses.removeFirst()
         }
@@ -642,7 +733,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     func getLikedSongs() async throws -> LikedSongsResponse {
         self.getLikedSongsCalled = true
         self._likedSongsContinuationIndex = 0
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         let hasMore = !self.likedSongsContinuationSongs.isEmpty
         return LikedSongsResponse(songs: self.likedSongs, continuationToken: hasMore ? "mock-token" : nil)
     }
@@ -650,7 +743,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     func getLikedSongsContinuation() async throws -> LikedSongsResponse? {
         self.getLikedSongsContinuationCalled = true
         self.getLikedSongsContinuationCallCount += 1
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         guard self._likedSongsContinuationIndex < self.likedSongsContinuationSongs.count else {
             return nil
         }
@@ -666,7 +761,12 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         if let getPlaylistDelay {
             try? await Task.sleep(for: getPlaylistDelay)
         }
-        if let error = shouldThrowError { throw error }
+        if let beforeGetPlaylistReturn {
+            await beforeGetPlaylistReturn(id)
+        }
+        if let error = shouldThrowError {
+            throw error
+        }
         guard let detail = playlistDetails[id] else {
             throw YTMusicError.parseError(message: "Playlist not found: \(id)")
         }
@@ -688,7 +788,12 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         if let playlistContinuationDelay {
             try? await Task.sleep(for: playlistContinuationDelay)
         }
-        if let error = shouldThrowError { throw error }
+        if let beforePlaylistContinuationReturn {
+            await beforePlaylistContinuationReturn(token)
+        }
+        if let error = shouldThrowError {
+            throw error
+        }
         guard let (playlistId, index) = Self.parsePlaylistContinuationToken(token),
               let continuations = playlistContinuationTracks[playlistId],
               index < continuations.count
@@ -705,7 +810,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     }
 
     func getPlaylistAllTracks(playlistId: String) async throws -> [Song] {
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         if let tracks = self.playlistAllTracks[playlistId] {
             return tracks
         }
@@ -724,7 +831,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     func getArtist(id: String) async throws -> ArtistDetail {
         self.getArtistCalled = true
         self.getArtistIds.append(id)
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         guard let detail = artistDetails[id] else {
             throw YTMusicError.parseError(message: "Artist not found: \(id)")
         }
@@ -734,7 +843,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     func getArtistSongs(browseId: String, params _: String?) async throws -> [Song] {
         self.getArtistSongsCalled = true
         self.getArtistSongsBrowseIds.append(browseId)
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         // Return artistSongsResponse if set, otherwise fall back to dictionary lookup
         if !self.artistSongsResponse.isEmpty {
             return self.artistSongsResponse
@@ -743,12 +854,16 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     }
 
     func getArtistDiscography(browseId _: String, params _: String?) async throws -> [Album] {
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return []
     }
 
     func getArtistEpisodesList(browseId _: String, params _: String?) async throws -> [ArtistEpisode] {
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return []
     }
 
@@ -759,19 +874,37 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         if let rateSongDelay = self.rateSongDelay {
             try? await Task.sleep(for: rateSongDelay)
         }
-        if let error = shouldThrowError { throw error }
+        if let beforeRateSongReturn {
+            await beforeRateSongReturn(videoId, rating)
+        }
+        if let error = shouldThrowError {
+            throw error
+        }
+        self.appliedRateSongRatings.append(rating)
     }
 
     func editSongLibraryStatus(feedbackTokens: [String]) async throws {
         self.editSongLibraryStatusCalled = true
         self.editSongLibraryStatusTokens.append(feedbackTokens)
-        if let error = shouldThrowError { throw error }
+        if !self.editSongLibraryStatusResponseDelays.isEmpty {
+            let delay = self.editSongLibraryStatusResponseDelays.removeFirst()
+            try? await Task.sleep(for: delay)
+        }
+        if let beforeEditSongLibraryStatusReturn {
+            await beforeEditSongLibraryStatusReturn(feedbackTokens)
+        }
+        if let error = shouldThrowError {
+            throw error
+        }
+        self.appliedEditSongLibraryStatusTokens.append(feedbackTokens)
     }
 
     func subscribeToPlaylist(playlistId: String) async throws {
         self.subscribeToPlaylistCalled = true
         self.subscribeToPlaylistIds.append(playlistId)
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
 
         let playlistKey = LibraryContentIdentity.playlistKey(for: playlistId)
         if self.shouldAutoUpdatePlaylistLibraryOnMutation,
@@ -784,7 +917,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     func deletePlaylist(playlistId: String) async throws {
         self.deletePlaylistCalled = true
         self.deletePlaylistIds.append(playlistId)
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
 
         let playlistKey = LibraryContentIdentity.playlistKey(for: playlistId)
         if self.shouldAutoUpdatePlaylistLibraryOnMutation {
@@ -798,7 +933,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
 
     func getAddToPlaylistOptions(videoId: String) async throws -> AddToPlaylistMenu {
         self.getAddToPlaylistOptionsVideoIds.append(videoId)
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return self.addToPlaylistMenus[videoId] ?? self.defaultAddToPlaylistMenu
     }
 
@@ -814,13 +951,17 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
             privacyStatus: privacyStatus,
             videoIds: videoIds
         ))
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return "PLCREATED"
     }
 
     func addSongToPlaylist(videoId: String, playlistId: String, allowDuplicate: Bool) async throws {
         self.addSongToPlaylistCalls.append(AddSongToPlaylistCall(videoId: videoId, playlistId: playlistId, allowDuplicate: allowDuplicate))
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
 
         let playlistKey = LibraryContentIdentity.playlistKey(for: playlistId)
         guard self.shouldAutoUpdatePlaylistLibraryOnMutation,
@@ -849,7 +990,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     func unsubscribeFromPlaylist(playlistId: String) async throws {
         self.unsubscribeFromPlaylistCalled = true
         self.unsubscribeFromPlaylistIds.append(playlistId)
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
 
         let playlistKey = LibraryContentIdentity.playlistKey(for: playlistId)
         if self.shouldAutoUpdatePlaylistLibraryOnMutation {
@@ -858,7 +1001,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     }
 
     func subscribeToPodcast(showId: String) async throws {
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         // Validate podcast show ID format (mirrors real YTMusicClient behavior)
         if showId.hasPrefix("MPSPP") {
             let suffix = String(showId.dropFirst(5))
@@ -878,7 +1023,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     }
 
     func unsubscribeFromPodcast(showId: String) async throws {
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         // Validate podcast show ID format (mirrors real YTMusicClient behavior)
         if showId.hasPrefix("MPSPP") {
             let suffix = String(showId.dropFirst(5))
@@ -901,7 +1048,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         if let delay = self.subscribeToArtistDelay {
             try? await Task.sleep(for: delay)
         }
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
 
         let artistKey = LibraryContentIdentity.artistKey(for: channelId)
         let artist = self.artistDetails.values.first(where: { $0.channelId == channelId })?.artist
@@ -920,7 +1069,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         if let delay = self.unsubscribeFromArtistDelay {
             try? await Task.sleep(for: delay)
         }
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
 
         let artistKey = LibraryContentIdentity.artistKey(for: channelId)
         if self.shouldAutoUpdateArtistLibraryOnMutation {
@@ -931,12 +1082,16 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     func getLyrics(videoId: String) async throws -> Lyrics {
         self.getLyricsCalled = true
         self.getLyricsVideoIds.append(videoId)
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return self.lyricsResponses[videoId] ?? .unavailable
     }
 
     func getTimedLyrics(videoId _: String) async throws -> LyricResult {
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return .unavailable
     }
 
@@ -946,7 +1101,12 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         if let getSongDelay = self.getSongDelay {
             try? await Task.sleep(for: getSongDelay)
         }
-        if let error = shouldThrowError { throw error }
+        if let beforeGetSongReturn {
+            await beforeGetSongReturn(videoId)
+        }
+        if let error = shouldThrowError {
+            throw error
+        }
         return self.songResponses[videoId] ?? Song(
             id: videoId,
             title: "Mock Song",
@@ -961,40 +1121,55 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         if let getRadioQueueDelay {
             try? await Task.sleep(for: getRadioQueueDelay)
         }
-        if let error = shouldThrowError { throw error }
-        if let error = radioQueueErrors[videoId] { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
+        if let error = radioQueueErrors[videoId] {
+            throw error
+        }
+        await self.waitBeforeRadioQueueReturn(videoId: videoId)
         return self.radioQueueSongs[videoId] ?? []
     }
 
-    func getMixQueue(playlistId _: String, startVideoId _: String?) async throws -> RadioQueueResult {
+    func getMixQueue(playlistId: String, startVideoId: String?) async throws -> RadioQueueResult {
         if let mixQueueDelay {
             try? await Task.sleep(for: mixQueueDelay)
         }
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
+        await self.waitBeforeMixQueueReturn(playlistId: playlistId, startVideoId: startVideoId)
         return self.mixQueueResult
     }
 
-    func getMixQueueContinuation(continuationToken _: String) async throws -> RadioQueueResult {
+    func getMixQueueContinuation(continuationToken continuation: String) async throws -> RadioQueueResult {
         self.getMixQueueContinuationCallCount += 1
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
+        await self.waitBeforeMixQueueContinuationReturn(continuation)
         return self.mixQueueContinuationResult
     }
 
     func getMoodCategory(browseId _: String, params _: String?) async throws -> HomeResponse {
         self.moodCategoryCalled = true
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return self.moodCategoryResponse
     }
 
     func fetchAccountsList() async throws -> AccountsListResponse {
-        if let error = shouldThrowError { throw error }
+        if let error = shouldThrowError {
+            throw error
+        }
         return self.accountsListResponse
     }
 
     // MARK: - Helper Methods
 
     /// Resets all call tracking.
-    func reset() {
+    func reset() { // swiftlint:disable:this function_body_length
         self.getHomeCalled = false
         self.getHomeCallCount = 0
         self.getHomeContinuationCalled = false
@@ -1022,6 +1197,14 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.searchQueries = []
         self.completedSearchEndpoints = []
         self.beforeSearchReturn = nil
+        self.beforeGetSongReturn = nil
+        self.beforeGetPlaylistReturn = nil
+        self.beforePlaylistContinuationReturn = nil
+        self.beforeMixQueueReturn = nil
+        self.beforeMixQueueContinuationReturn = nil
+        self.beforeRadioQueueReturn = nil
+        self.beforeRateSongReturn = nil
+        self.beforeEditSongLibraryStatusReturn = nil
         self.getSearchSuggestionsCalled = false
         self.getSearchSuggestionsQueries = []
         self.getLibraryContentCalled = false
@@ -1052,10 +1235,12 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.rateSongCalled = false
         self.rateSongVideoIds = []
         self.rateSongRatings = []
+        self.appliedRateSongRatings = []
         self.resetSessionStateForAccountSwitchCalled = false
         self.resetSessionStateForAccountSwitchCallCount = 0
         self.editSongLibraryStatusCalled = false
         self.editSongLibraryStatusTokens = []
+        self.appliedEditSongLibraryStatusTokens = []
         self.subscribeToPlaylistCalled = false
         self.subscribeToPlaylistIds = []
         self.deletePlaylistCalled = false
@@ -1073,6 +1258,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.unsubscribeFromArtistIds = []
         self.unsubscribeFromArtistDelay = nil
         self.rateSongDelay = nil
+        self.editSongLibraryStatusResponseDelays = []
         self.getSongDelay = nil
         self.mixQueueDelay = nil
         self.getRadioQueueDelay = nil

--- a/Tests/KasetTests/Helpers/MockYTMusicClient.swift
+++ b/Tests/KasetTests/Helpers/MockYTMusicClient.swift
@@ -76,7 +76,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     var subscribeToArtistDelay: Duration?
     var unsubscribeFromArtistDelay: Duration?
     var rateSongDelay: Duration?
+    var rateSongErrors: [(any Error)?] = []
     var editSongLibraryStatusResponseDelays: [Duration] = []
+    var editSongLibraryStatusErrors: [(any Error)?] = []
     var getSongDelay: Duration?
     var getHistoryDelay: Duration?
     var getPodcastsDelay: Duration?
@@ -910,6 +912,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         if let beforeRateSongReturn {
             await beforeRateSongReturn(videoId, rating)
         }
+        if !self.rateSongErrors.isEmpty, let error = self.rateSongErrors.removeFirst() {
+            throw error
+        }
         if let error = shouldThrowError {
             throw error
         }
@@ -925,6 +930,11 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         }
         if let beforeEditSongLibraryStatusReturn {
             await beforeEditSongLibraryStatusReturn(feedbackTokens)
+        }
+        if !self.editSongLibraryStatusErrors.isEmpty,
+           let error = self.editSongLibraryStatusErrors.removeFirst()
+        {
+            throw error
         }
         if let error = shouldThrowError {
             throw error
@@ -1337,7 +1347,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.unsubscribeFromArtistIds = []
         self.unsubscribeFromArtistDelay = nil
         self.rateSongDelay = nil
+        self.rateSongErrors = []
         self.editSongLibraryStatusResponseDelays = []
+        self.editSongLibraryStatusErrors = []
         self.getSongDelay = nil
         self.getHistoryDelay = nil
         self.mixQueueDelay = nil

--- a/Tests/KasetTests/Helpers/MockYouTubeClient.swift
+++ b/Tests/KasetTests/Helpers/MockYouTubeClient.swift
@@ -28,6 +28,7 @@ final class MockYouTubeClient: YouTubeClientProtocol {
 
     private(set) var homeFeedCallCount = 0
     private(set) var searchCallCount = 0
+    private(set) var watchNextCallCount = 0
     private(set) var lastSearchQuery: String?
     private(set) var lastSearchFilter: YouTubeSearchFilter?
 
@@ -164,8 +165,16 @@ final class MockYouTubeClient: YouTubeClientProtocol {
         return response
     }
 
+    /// Awaited inside `getWatchNext` before it returns, so tests can hold one
+    /// successor lookup open while playback intent changes.
+    var beforeWatchNextReturn: (@Sendable (Int) async -> Void)?
+
     func getWatchNext(videoId _: String) async throws -> WatchNextData {
         if let error { throw error }
+        self.watchNextCallCount += 1
+        if let beforeWatchNextReturn {
+            await beforeWatchNextReturn(self.watchNextCallCount)
+        }
         return self.watchNextData
     }
 

--- a/Tests/KasetTests/LibraryMutationActionsTests.swift
+++ b/Tests/KasetTests/LibraryMutationActionsTests.swift
@@ -301,6 +301,26 @@ struct LibraryMutationActionsTests {
         SidebarPinnedItemsManager.shared.remove(contentId: "PL-delete-fails")
     }
 
+    @Test("Failed playlist deletion restores every library model that observed the optimistic removal")
+    func deletePlaylistRestoresAllAffectedLibraryModels() async {
+        let playlist = TestFixtures.makePlaylist(id: "VL-delete-multi-window", title: "Shared Playlist")
+        let otherLibraryViewModel = LibraryViewModel(client: self.mockClient)
+        self.libraryViewModel.addToLibrary(playlist: playlist)
+        otherLibraryViewModel.addToLibrary(playlist: playlist)
+        self.mockClient.shouldThrowError = URLError(.notConnectedToInternet)
+
+        await #expect(throws: (any Error).self) {
+            try await LibraryMutationActions.deletePlaylist(
+                playlist,
+                client: self.mockClient,
+                libraryViewModel: nil
+            )
+        }
+
+        #expect(self.libraryViewModel.isInLibrary(playlistId: playlist.id))
+        #expect(otherLibraryViewModel.isInLibrary(playlistId: playlist.id))
+    }
+
     private func waitUntil(_ condition: @autoclosure () -> Bool, timeout: Duration = .seconds(1)) async -> Bool {
         let clock = ContinuousClock()
         let deadline = clock.now.advanced(by: timeout)

--- a/Tests/KasetTests/MusicPlaybackBridgeGenerationTests.swift
+++ b/Tests/KasetTests/MusicPlaybackBridgeGenerationTests.swift
@@ -677,6 +677,19 @@ struct MusicPlaybackBridgeGenerationTests {
         #expect(source.contains("window.__kasetAutoplayRetryScheduled = false;"))
     }
 
+    @Test("Authoritative bridge clocks retain the observed video identity")
+    func authoritativeBridgeClockUsesObservedVideoIdentity() throws {
+        let source = try String(
+            contentsOfFile: #filePath.replacingOccurrences(
+                of: "Tests/KasetTests/MusicPlaybackBridgeGenerationTests.swift",
+                with: "Sources/Kaset/Views/MiniPlayerWebView+Coordinator.swift"
+            ),
+            encoding: .utf8
+        )
+
+        #expect(source.contains("duration: Double(duration),\n                    observedVideoId: observedVideoId"))
+    }
+
     private func objectPayloads(in script: String, marker: String, terminator: String) -> [String] {
         script.components(separatedBy: marker).dropFirst().compactMap { suffix in
             suffix.components(separatedBy: terminator).first

--- a/Tests/KasetTests/MusicPlaybackBridgeGenerationTests.swift
+++ b/Tests/KasetTests/MusicPlaybackBridgeGenerationTests.swift
@@ -1,0 +1,685 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+@Suite("YouTube Music playback bridge generation", .tags(.service))
+@MainActor
+struct MusicPlaybackBridgeGenerationTests {
+    @Test("Bridge acceptance requires current WebView identity and active generation")
+    func bridgeAcceptanceRequiresIdentityAndGeneration() {
+        let currentWebView = NSObject()
+        let replacedWebView = NSObject()
+        var documentGeneration = WebPlaybackDocumentGeneration()
+        let activeGeneration = documentGeneration.beginNavigation()
+        let didStart = documentGeneration.startNavigation(activeGeneration)
+        let didCommit = documentGeneration.commitNavigation(activeGeneration)
+        #expect(didStart)
+        #expect(didCommit)
+
+        #expect(SingletonPlayerWebView.acceptsBridgeMessage(
+            sourceWebView: currentWebView,
+            currentWebView: currentWebView,
+            documentGeneration: documentGeneration,
+            rawDocumentGeneration: activeGeneration
+        ))
+        #expect(!SingletonPlayerWebView.acceptsBridgeMessage(
+            sourceWebView: replacedWebView,
+            currentWebView: currentWebView,
+            documentGeneration: documentGeneration,
+            rawDocumentGeneration: activeGeneration
+        ))
+        #expect(!SingletonPlayerWebView.acceptsBridgeMessage(
+            sourceWebView: currentWebView,
+            currentWebView: currentWebView,
+            documentGeneration: documentGeneration,
+            rawDocumentGeneration: activeGeneration + 1
+        ))
+        #expect(!SingletonPlayerWebView.acceptsBridgeSource(
+            isMainFrame: false,
+            sourceScheme: "https",
+            sourceHost: "music.youtube.com"
+        ))
+        #expect(!SingletonPlayerWebView.acceptsBridgeSource(
+            isMainFrame: true,
+            sourceScheme: "https",
+            sourceHost: "www.youtube.com"
+        ))
+    }
+
+    @Test("Pending navigation suppresses the outgoing generation until commit")
+    func pendingNavigationSuppressesOutgoingGeneration() {
+        let currentWebView = NSObject()
+        var documentGeneration = WebPlaybackDocumentGeneration()
+        let committedGeneration = documentGeneration.beginNavigation()
+        let didStartCommittedGeneration = documentGeneration.startNavigation(committedGeneration)
+        let didCommitCommittedGeneration = documentGeneration.commitNavigation(committedGeneration)
+        #expect(didStartCommittedGeneration)
+        #expect(didCommitCommittedGeneration)
+
+        let pendingGeneration = documentGeneration.beginNavigation()
+        #expect(!SingletonPlayerWebView.acceptsBridgeMessage(
+            sourceWebView: currentWebView,
+            currentWebView: currentWebView,
+            documentGeneration: documentGeneration,
+            rawDocumentGeneration: committedGeneration
+        ))
+        #expect(!SingletonPlayerWebView.acceptsBridgeMessage(
+            sourceWebView: currentWebView,
+            currentWebView: currentWebView,
+            documentGeneration: documentGeneration,
+            rawDocumentGeneration: pendingGeneration
+        ))
+
+        let didStartPendingGeneration = documentGeneration.startNavigation(pendingGeneration)
+        #expect(didStartPendingGeneration)
+        #expect(!SingletonPlayerWebView.acceptsBridgeMessage(
+            sourceWebView: currentWebView,
+            currentWebView: currentWebView,
+            documentGeneration: documentGeneration,
+            rawDocumentGeneration: pendingGeneration
+        ))
+        let didCommitPendingGeneration = documentGeneration.commitNavigation(pendingGeneration)
+        #expect(didCommitPendingGeneration)
+        #expect(SingletonPlayerWebView.acceptsBridgeMessage(
+            sourceWebView: currentWebView,
+            currentWebView: currentWebView,
+            documentGeneration: documentGeneration,
+            rawDocumentGeneration: pendingGeneration
+        ))
+        #expect(!SingletonPlayerWebView.acceptsBridgeMessage(
+            sourceWebView: currentWebView,
+            currentWebView: currentWebView,
+            documentGeneration: documentGeneration,
+            rawDocumentGeneration: committedGeneration
+        ))
+    }
+
+    @Test("User scripts select a pending generation before the active generation")
+    func userScriptsSelectPendingBeforeActiveGeneration() {
+        var documentGeneration = WebPlaybackDocumentGeneration()
+
+        #expect(SingletonPlayerWebView.userScriptDocumentGeneration(from: documentGeneration) == 0)
+
+        let pendingGeneration = documentGeneration.beginNavigation()
+        #expect(
+            SingletonPlayerWebView.userScriptDocumentGeneration(from: documentGeneration)
+                == pendingGeneration
+        )
+
+        let bootstrap = SingletonPlayerWebView.pageBootstrapScript(
+            isRestoringPlaybackSession: false,
+            targetVolume: 0.5,
+            documentGeneration: SingletonPlayerWebView.userScriptDocumentGeneration(from: documentGeneration)
+        )
+        #expect(bootstrap.contains("window.__kasetDocumentGeneration = -1;"))
+
+        let didStart = documentGeneration.startNavigation(pendingGeneration)
+        let didCommit = documentGeneration.commitNavigation(pendingGeneration)
+        #expect(didStart)
+        #expect(didCommit)
+        #expect(
+            SingletonPlayerWebView.userScriptDocumentGeneration(from: documentGeneration)
+                == documentGeneration.currentGeneration
+        )
+    }
+
+    @Test("Playback URL binds its document generation to the navigation")
+    func playbackURLBindsDocumentGeneration() throws {
+        let url = try #require(SingletonPlayerWebView.playbackURL(
+            videoId: "video",
+            documentGeneration: 42
+        ))
+
+        #expect(WebPlaybackDocumentGeneration.generation(from: url) == 42)
+    }
+
+    @Test("Standard same-video requests do not advance playback occurrence")
+    func standardSameVideoRequestIsDeduplicated() {
+        #expect(!SingletonPlayerWebView.acceptsPlaybackRequest(
+            videoId: "abc",
+            currentVideoId: "abc",
+            hasWebView: true,
+            strategy: .standard
+        ))
+        #expect(SingletonPlayerWebView.acceptsPlaybackRequest(
+            videoId: "abc",
+            currentVideoId: "abc",
+            hasWebView: true,
+            strategy: .preferInPlaceWhenSameVideoId
+        ))
+        #expect(SingletonPlayerWebView.acceptsPlaybackRequest(
+            videoId: "abc",
+            currentVideoId: nil,
+            hasWebView: false,
+            strategy: .standard
+        ))
+    }
+
+    @Test("Canceled navigation commit suppression targets only the canceled document")
+    func canceledNavigationCommitSuppressionIsScoped() {
+        let canceledURL = URL(string: "https://music.youtube.com/watch?v=a&kasetDocumentGeneration=1")
+        let replacementURL = URL(string: "https://music.youtube.com/watch?v=b&kasetDocumentGeneration=2")
+
+        #expect(SingletonPlayerWebView.shouldSuppressCancelledNavigationCommit(
+            cancelledGeneration: 1,
+            committedURL: canceledURL,
+            pendingGeneration: nil,
+            inFlightGeneration: 2,
+            currentGeneration: 1
+        ))
+        #expect(!SingletonPlayerWebView.shouldSuppressCancelledNavigationCommit(
+            cancelledGeneration: 1,
+            committedURL: replacementURL,
+            pendingGeneration: nil,
+            inFlightGeneration: 2,
+            currentGeneration: 1
+        ))
+        #expect(SingletonPlayerWebView.shouldSuppressCancelledNavigationCommit(
+            cancelledGeneration: 1,
+            committedURL: nil,
+            pendingGeneration: nil,
+            inFlightGeneration: nil,
+            currentGeneration: 1
+        ))
+        #expect(SingletonPlayerWebView.shouldSuppressCancelledNavigationCommit(
+            cancelledGeneration: 1,
+            committedURL: nil,
+            pendingGeneration: nil,
+            inFlightGeneration: 2,
+            currentGeneration: 1
+        ))
+        #expect(!SingletonPlayerWebView.shouldSuppressCancelledNavigationCommit(
+            cancelledGeneration: 1,
+            committedURL: replacementURL,
+            pendingGeneration: nil,
+            inFlightGeneration: nil,
+            currentGeneration: 2
+        ))
+    }
+
+    @Test("Music main-frame response requires expected successful watch document")
+    func mainFrameResponseRequiresExpectedSuccessfulWatchDocument() throws {
+        var documentGeneration = WebPlaybackDocumentGeneration()
+        let generation = documentGeneration.beginNavigation()
+        let didStart = documentGeneration.startNavigation(generation)
+        #expect(didStart)
+        let expectedURL = try #require(SingletonPlayerWebView.playbackURL(
+            videoId: "video",
+            documentGeneration: generation
+        ))
+        let success = try #require(HTTPURLResponse(
+            url: expectedURL,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        ))
+        let failure = try #require(HTTPURLResponse(
+            url: expectedURL,
+            statusCode: 500,
+            httpVersion: nil,
+            headerFields: nil
+        ))
+
+        #expect(SingletonPlayerWebView.acceptsMainFrameResponse(
+            success,
+            expectedVideoID: "video",
+            documentGeneration: documentGeneration
+        ))
+        #expect(!SingletonPlayerWebView.acceptsMainFrameResponse(
+            failure,
+            expectedVideoID: "video",
+            documentGeneration: documentGeneration
+        ))
+        #expect(!SingletonPlayerWebView.acceptsMainFrameResponse(
+            success,
+            expectedVideoID: "other",
+            documentGeneration: documentGeneration
+        ))
+    }
+
+    @Test("Content-process recovery preserves seek and playing intent")
+    func contentProcessRecoveryPreservesPlayingIntent() {
+        let plan = SingletonPlayerWebView.contentProcessRecoveryPlan(
+            state: .playing,
+            progress: 42,
+            isShowingAd: false,
+            lastNonAdContentProgress: 0
+        )
+
+        #expect(plan.pendingSeek == 42)
+        #expect(plan.shouldReload)
+        #expect(plan.shouldAutoResume)
+    }
+
+    @Test("Content-process recovery keeps paused and ended playback from auto-resuming")
+    func contentProcessRecoveryPreservesPausedIntent() {
+        let pausedPlan = SingletonPlayerWebView.contentProcessRecoveryPlan(
+            state: .paused,
+            progress: 42,
+            isShowingAd: false,
+            lastNonAdContentProgress: 0
+        )
+        let endedPlan = SingletonPlayerWebView.contentProcessRecoveryPlan(
+            state: .ended,
+            progress: 100,
+            isShowingAd: false,
+            lastNonAdContentProgress: 0
+        )
+
+        #expect(pausedPlan.pendingSeek == 42)
+        #expect(pausedPlan.shouldReload)
+        #expect(!pausedPlan.shouldAutoResume)
+        #expect(endedPlan.pendingSeek == nil)
+        #expect(!endedPlan.shouldReload)
+        #expect(!endedPlan.shouldAutoResume)
+    }
+
+    @Test("Content-process recovery does not resurrect terminal playback states")
+    func contentProcessRecoverySkipsTerminalStates() {
+        for state in [PlayerService.PlaybackState.idle, .ended, .error("test")] {
+            let plan = SingletonPlayerWebView.contentProcessRecoveryPlan(
+                state: state,
+                progress: 42,
+                isShowingAd: false,
+                lastNonAdContentProgress: 42
+            )
+
+            #expect(!plan.shouldReload)
+            #expect(plan.pendingSeek == nil)
+            #expect(!plan.shouldAutoResume)
+        }
+    }
+
+    @Test("Deferred restored load remains gated after WebContent termination")
+    func deferredRestoredLoadRemainsExplicitResumeOnly() {
+        let plan = SingletonPlayerWebView.contentProcessRecoveryPlan(
+            state: .paused,
+            progress: 42,
+            isShowingAd: false,
+            lastNonAdContentProgress: 42,
+            isPendingRestoredLoadDeferred: true
+        )
+
+        #expect(!plan.shouldReload)
+        #expect(plan.pendingSeek == nil)
+        #expect(!plan.shouldAutoResume)
+    }
+
+    @Test("Fresh loading recovery never seeks to a stale prior-track clock")
+    func freshLoadingRecoveryDoesNotReuseProgress() {
+        let plan = SingletonPlayerWebView.contentProcessRecoveryPlan(
+            state: .loading,
+            progress: 99,
+            isShowingAd: false,
+            lastNonAdContentProgress: 0
+        )
+
+        #expect(plan.shouldReload)
+        #expect(plan.shouldAutoResume)
+        #expect(plan.pendingSeek == nil)
+    }
+
+    @Test("Content-process recovery never uses ad elapsed time as the music seek")
+    func contentProcessRecoveryUsesLastContentProgressDuringAds() {
+        let knownContentPlan = SingletonPlayerWebView.contentProcessRecoveryPlan(
+            state: .playing,
+            progress: 12,
+            isShowingAd: true,
+            lastNonAdContentProgress: 42
+        )
+        let prerollPlan = SingletonPlayerWebView.contentProcessRecoveryPlan(
+            state: .playing,
+            progress: 12,
+            isShowingAd: true,
+            lastNonAdContentProgress: 0
+        )
+
+        #expect(knownContentPlan.pendingSeek == 42)
+        #expect(prerollPlan.pendingSeek == nil)
+    }
+
+    @Test("Non-ad recovery clocks are scoped to their content video")
+    func nonAdRecoveryClockIsVideoScoped() {
+        let playerService = PlayerService()
+        playerService.updateAdPlaybackState(
+            isShowingAd: false,
+            observedProgress: 42,
+            observedVideoId: "video-a",
+            isAuthoritativeContent: true
+        )
+
+        #expect(playerService.lastNonAdContentProgress(for: "video-a") == 42)
+        #expect(playerService.lastNonAdContentProgress(for: "video-b") == 0)
+
+        playerService.updateAdPlaybackState(
+            isShowingAd: true,
+            observedProgress: 3,
+            observedVideoId: "video-b",
+            isAuthoritativeContent: false
+        )
+        #expect(playerService.lastNonAdContentProgress(for: "video-b") == 0)
+    }
+
+    @Test("Ready ad transport updates do not overwrite the content clock")
+    func adTransportPreservesContentClock() {
+        let playerService = PlayerService()
+        playerService.progress = 42
+        playerService.duration = 180
+        playerService.state = .loading
+        playerService.shouldResumeAfterInterruption = true
+
+        playerService.updatePlaybackTransportState(isPlaying: true)
+
+        #expect(playerService.state == .playing)
+        #expect(playerService.progress == 42)
+        #expect(playerService.duration == 180)
+
+        playerService.state = .loading
+        playerService.updatePlaybackTransportState(isPlaying: false)
+        #expect(playerService.state == .paused)
+        #expect(playerService.shouldResumeAfterInterruption)
+
+        playerService.state = .ended
+        playerService.updatePlaybackTransportState(isPlaying: true)
+        #expect(playerService.state == .ended)
+    }
+
+    @Test("Ready preroll ads resume only for auto-resuming restoration")
+    func readyAdRestorationIntent() {
+        let playerService = PlayerService()
+        playerService.pendingRestoredSeek = 42
+        playerService.beginRestoredPlaybackLoad(autoResumeAfterSeek: true)
+        #expect(playerService.shouldResumeReadyAdDuringRestoration)
+
+        playerService.shouldAutoResumeAfterRestoredLoad = false
+        #expect(!playerService.shouldResumeReadyAdDuringRestoration)
+        #expect(playerService.pendingRestoredSeek == 42)
+    }
+
+    @Test("Only ready non-ad media can mutate the canonical content clock")
+    func authoritativePlaybackSampleRequiresReadyContentMedia() {
+        #expect(SingletonPlayerWebView.isAuthoritativePlaybackSample(
+            hasReadyMedia: true,
+            isShowingAd: false
+        ))
+        #expect(!SingletonPlayerWebView.isAuthoritativePlaybackSample(
+            hasReadyMedia: false,
+            isShowingAd: false
+        ))
+        #expect(!SingletonPlayerWebView.isAuthoritativePlaybackSample(
+            hasReadyMedia: true,
+            isShowingAd: true
+        ))
+    }
+
+    @Test("Navigation failure defers restoration without losing its seek")
+    func navigationFailurePreservesRestoredSeek() async {
+        let playerService = PlayerService()
+        playerService.pendingPlayVideoId = "retry-video"
+        playerService.pendingRestoredSeek = 42
+        playerService.beginRestoredPlaybackLoad(autoResumeAfterSeek: true)
+
+        playerService.deferRestoredPlaybackAfterNavigationFailure()
+
+        #expect(playerService.pendingRestoredSeek == 42)
+        #expect(playerService.isPendingRestoredLoadDeferred)
+        #expect(playerService.shouldForcePendingRestoredLoad)
+        #expect(!playerService.isRestoringPlaybackSession)
+        #expect(playerService.state == .paused)
+        #expect(playerService.pendingRestoredSeekForWebRecovery(videoId: "retry-video") == 42)
+        #expect(playerService.pendingRestoredSeekForWebRecovery(videoId: "other-video") == nil)
+
+        playerService.currentWebPlaybackVideoId = { nil }
+        await playerService.resume()
+
+        #expect(playerService.pendingRestoredSeek == 42)
+        #expect(playerService.isRestoringPlaybackSession)
+        #expect(playerService.state == .loading)
+    }
+
+    @Test("Committed navigation failure captures the active non-ad content clock")
+    func committedNavigationFailureCapturesActiveProgress() {
+        let playerService = PlayerService()
+        playerService.pendingPlayVideoId = "retry-video"
+        playerService.state = .playing
+        playerService.progress = 42
+
+        playerService.deferRestoredPlaybackAfterNavigationFailure()
+
+        #expect(playerService.pendingRestoredSeek == 42)
+        #expect(playerService.isPendingRestoredLoadDeferred)
+        #expect(playerService.shouldForcePendingRestoredLoad)
+    }
+
+    @Test("Navigation failure ignores an ad fallback clock owned by another track")
+    func navigationFailureScopesAdFallbackClock() {
+        let playerService = PlayerService()
+        playerService.pendingPlayVideoId = "video-b"
+        playerService.state = .playing
+        playerService.progress = 3
+        playerService.isShowingAd = true
+        playerService.lastNonAdContentProgress = 42
+        playerService.lastNonAdContentVideoId = "video-a"
+
+        playerService.deferRestoredPlaybackAfterNavigationFailure()
+
+        #expect(playerService.pendingRestoredSeek == nil)
+    }
+
+    @Test("Play/pause resumes deferred restoration without clearing its seek")
+    func playPausePreservesDeferredRestoredSeek() async {
+        let playerService = PlayerService()
+        playerService.pendingPlayVideoId = "retry-video"
+        playerService.pendingRestoredSeek = 42
+        playerService.beginRestoredPlaybackLoad(autoResumeAfterSeek: true)
+        playerService.deferRestoredPlaybackAfterNavigationFailure()
+        playerService.currentWebPlaybackVideoId = { nil }
+
+        await playerService.playPause()
+
+        #expect(playerService.pendingRestoredSeek == 42)
+        #expect(playerService.isRestoringPlaybackSession)
+        #expect(playerService.state == .loading)
+    }
+
+    @Test("Play/pause cancels an active restored auto-resume")
+    func playPauseCancelsActiveRestoredAutoResume() async {
+        let playerService = PlayerService()
+        playerService.pendingPlayVideoId = "restore-video"
+        playerService.pendingRestoredSeek = 42
+        playerService.beginRestoredPlaybackLoad(autoResumeAfterSeek: true)
+
+        await playerService.playPause()
+
+        #expect(playerService.state == .paused)
+        #expect(playerService.isPendingRestoredLoadDeferred)
+        #expect(!playerService.shouldAutoResumeAfterRestoredLoad)
+        #expect(playerService.pendingRestoredSeek == 42)
+    }
+
+    @Test("Repeated resume during restoration preserves the seek")
+    func repeatedResumeDuringRestorationPreservesSeek() async {
+        let playerService = PlayerService()
+        playerService.pendingPlayVideoId = "restore-video"
+        playerService.pendingRestoredSeek = 42
+        playerService.beginRestoredPlaybackLoad(autoResumeAfterSeek: true)
+        playerService.currentWebPlaybackVideoId = { "restore-video" }
+
+        await playerService.resume()
+
+        #expect(playerService.pendingRestoredSeek == 42)
+        #expect(playerService.isRestoringPlaybackSession)
+        #expect(playerService.shouldAutoResumeAfterRestoredLoad)
+    }
+
+    @Test("Repeated process recovery preserves paused restored intent")
+    func repeatedRecoveryPreservesPausedIntent() {
+        let playerService = PlayerService()
+        playerService.pendingPlayVideoId = "restore-video"
+        playerService.pendingRestoredSeek = 42
+        playerService.beginRestoredPlaybackLoad(autoResumeAfterSeek: false)
+        playerService.state = .loading
+
+        let plan = SingletonPlayerWebView.contentProcessRecoveryPlan(
+            state: playerService.state,
+            progress: playerService.progress,
+            isShowingAd: false,
+            lastNonAdContentProgress: 0
+        )
+        let shouldAutoResume = playerService.isRestoringPlaybackSession
+            ? playerService.shouldAutoResumeAfterRestoredLoad
+            : plan.shouldAutoResume
+
+        #expect(!shouldAutoResume)
+    }
+
+    @Test("Music document autoplay follows native intent outside restoration")
+    func playbackDocumentAutoplayFollowsNativeIntent() {
+        let playerService = PlayerService()
+
+        playerService.state = .loading
+        playerService.shouldResumeAfterInterruption = true
+        #expect(playerService.shouldAutoplayPlaybackDocument)
+
+        playerService.pendingRestoredSeek = 42
+        playerService.beginRestoredPlaybackLoad(autoResumeAfterSeek: true)
+        #expect(!playerService.shouldAutoplayPlaybackDocument)
+
+        playerService.clearRestoredPlaybackSessionState()
+        playerService.state = .paused
+        playerService.shouldResumeAfterInterruption = false
+        #expect(!playerService.shouldAutoplayPlaybackDocument)
+    }
+
+    @Test("A new play intent clears an in-progress stop fence")
+    func newPlayClearsStopFence() async {
+        let playerService = PlayerService()
+        playerService.isStoppingPlayback = true
+
+        await playerService.play(videoId: "new-video")
+
+        #expect(!playerService.isStoppingPlayback)
+    }
+
+    @Test("Clearing WebView identity leaves the pending music video retryable on resume")
+    func clearedWebViewIdentityRetriesPendingVideo() async {
+        let playerService = PlayerService()
+        playerService.pendingPlayVideoId = "retry-video"
+        playerService.state = .paused
+        playerService.currentWebPlaybackVideoId = { nil }
+
+        await playerService.resume()
+
+        #expect(playerService.pendingPlayVideoId == "retry-video")
+        #expect(playerService.state == .loading)
+        #expect(playerService.shouldLoadPendingVideoBeforePlayback)
+    }
+
+    @Test("Every singletonPlayer observer payload carries document generation")
+    func everyObserverPayloadCarriesDocumentGeneration() {
+        let script = SingletonPlayerWebView.observerScript
+        let payloads = self.objectPayloads(
+            in: script,
+            marker: "bridge.postMessage({",
+            terminator: "});"
+        )
+
+        #expect(self.occurrenceCount(of: "postMessage(", in: script) == 6)
+        #expect(payloads.count == 6)
+        for payload in payloads {
+            #expect(payload.contains("documentGeneration: window.__kasetDocumentGeneration"))
+            if payload.contains("type: 'STATE_UPDATE'")
+                || payload.contains("type: 'TRACK_ENDED'")
+            {
+                #expect(payload.contains(
+                    "nativePlaybackGeneration: window.__kasetNativePlaybackGeneration || 0"
+                ))
+            }
+        }
+
+        for messageType in ["STATE_UPDATE", "TRACK_ENDED", "LYRICS_TIME", "AIRPLAY_STATUS"] {
+            #expect(payloads.contains { $0.contains("type: '\(messageType)'") })
+        }
+        let endedPayload = payloads.first { $0.contains("type: 'TRACK_ENDED'") }
+        #expect(endedPayload?.contains("isAd: isAdShowing()") == true)
+        let lyricsPayload = payloads.first { $0.contains("type: 'LYRICS_TIME'") }
+        #expect(lyricsPayload?.contains("isAd: isAdShowing()") == true)
+        let statePayload = payloads.first { $0.contains("type: 'STATE_UPDATE'") }
+        #expect(statePayload?.contains("isAd: isAd") == true)
+        #expect(statePayload?.contains("hasReadyMedia: hasReadyMedia") == true)
+        #expect(script.contains("video.__kasetBoundVideoId = videoId"))
+        #expect(!script.contains("const videoId = currentVideoId() || lastVideoId"))
+        #expect(script.contains("video.__kasetBoundVideoId || lastVideoId || currentVideoId()"))
+    }
+
+    @Test("Every media-control payload carries document generation")
+    func everyMediaControlPayloadCarriesDocumentGeneration() {
+        let script = SingletonPlayerWebView.mediaControlOverrideScript
+        let payloads = self.objectPayloads(
+            in: script,
+            marker: ".postMessage({",
+            terminator: "});"
+        )
+
+        #expect(self.occurrenceCount(of: "postMessage(", in: script) == 2)
+        #expect(payloads.count == 2)
+        for payload in payloads {
+            #expect(payload.contains("documentGeneration: window.__kasetDocumentGeneration"))
+        }
+        #expect(payloads.contains { $0.contains("type: 'REMOTE_NEXT'") })
+        #expect(payloads.contains { $0.contains("type: 'REMOTE_PREVIOUS'") })
+        for payload in payloads where payload.contains("type: 'REMOTE_") {
+            #expect(payload.contains("commandIssuedAtMilliseconds: Date.now()"))
+        }
+    }
+
+    @Test("Playback audio-quality stats payload carries document generation")
+    func playbackAudioQualityStatsCarriesDocumentGeneration() {
+        let script = SingletonPlayerWebView.playbackAudioQualityOverrideScript
+        let snapshots = self.objectPayloads(
+            in: script,
+            marker: "var snapshot = {",
+            terminator: "};"
+        )
+
+        #expect(self.occurrenceCount(of: "postMessage(", in: script) == 1)
+        #expect(snapshots.count == 1)
+        #expect(snapshots.first?.contains("type: 'PLAYBACK_AUDIO_QUALITY_STATS'") == true)
+        #expect(
+            snapshots.first?.contains("documentGeneration: window.__kasetDocumentGeneration") == true
+        )
+        #expect(script.contains("handler.postMessage(snapshot);"))
+    }
+
+    @Test("Ended reporting rejects replaced media elements and duplicate end events")
+    func endedReportingRejectsStaleOrDuplicateMediaElements() {
+        let script = SingletonPlayerWebView.observerScript
+
+        #expect(script.contains("video !== document.querySelector('video')"))
+        #expect(script.contains("video.__kasetEndedReported"))
+        #expect(script.contains("video.__kasetEndedReported = false"))
+        #expect(script.contains("sendTrackEnded(video)"))
+    }
+
+    @Test("Navigation failure pause clears autoplay retry intent")
+    func navigationFailurePauseClearsAutoplayRetryIntent() throws {
+        let source = try String(contentsOfFile: #filePath.replacingOccurrences(
+            of: "Tests/KasetTests/MusicPlaybackBridgeGenerationTests.swift",
+            with: "Sources/Kaset/Views/MiniPlayerWebView.swift"
+        ))
+
+        #expect(source.contains("window.__kasetAutoplayPending = false;"))
+        #expect(source.contains("window.__kasetAutoplayAttempts = 0;"))
+        #expect(source.contains("window.__kasetAutoplayRetryScheduled = false;"))
+    }
+
+    private func objectPayloads(in script: String, marker: String, terminator: String) -> [String] {
+        script.components(separatedBy: marker).dropFirst().compactMap { suffix in
+            suffix.components(separatedBy: terminator).first
+        }
+    }
+
+    private func occurrenceCount(of needle: String, in haystack: String) -> Int {
+        haystack.components(separatedBy: needle).count - 1
+    }
+}

--- a/Tests/KasetTests/MusicPlaybackBridgeGenerationTests.swift
+++ b/Tests/KasetTests/MusicPlaybackBridgeGenerationTests.swift
@@ -585,23 +585,23 @@ struct MusicPlaybackBridgeGenerationTests {
         )
 
         #expect(self.occurrenceCount(of: "postMessage(", in: script) == 6)
-        #expect(payloads.count == 6)
+        #expect(payloads.count == 5)
         for payload in payloads {
             #expect(payload.contains("documentGeneration: window.__kasetDocumentGeneration"))
-            if payload.contains("type: 'STATE_UPDATE'")
-                || payload.contains("type: 'TRACK_ENDED'")
-            {
+            if payload.contains("type: 'STATE_UPDATE'") {
                 #expect(payload.contains(
                     "nativePlaybackGeneration: window.__kasetNativePlaybackGeneration || 0"
                 ))
             }
         }
 
-        for messageType in ["STATE_UPDATE", "TRACK_ENDED", "LYRICS_TIME", "AIRPLAY_STATUS"] {
+        for messageType in ["STATE_UPDATE", "LYRICS_TIME", "AIRPLAY_STATUS"] {
             #expect(payloads.contains { $0.contains("type: '\(messageType)'") })
         }
-        let endedPayload = payloads.first { $0.contains("type: 'TRACK_ENDED'") }
-        #expect(endedPayload?.contains("isAd: isAdShowing()") == true)
+        #expect(script.contains("function trackEndedPayload(video)"))
+        #expect(script.contains("type: 'TRACK_ENDED'"))
+        #expect(script.contains("isAd: isAdShowing()"))
+        #expect(script.contains("bridge.postMessage(payload)"))
         let lyricsPayload = payloads.first { $0.contains("type: 'LYRICS_TIME'") }
         #expect(lyricsPayload?.contains("isAd: isAdShowing()") == true)
         let statePayload = payloads.first { $0.contains("type: 'STATE_UPDATE'") }
@@ -628,8 +628,12 @@ struct MusicPlaybackBridgeGenerationTests {
         }
         #expect(payloads.contains { $0.contains("type: 'REMOTE_NEXT'") })
         #expect(payloads.contains { $0.contains("type: 'REMOTE_PREVIOUS'") })
+        #expect(script.contains("function __kasetEventTimestampMilliseconds()"))
+        #expect(script.contains("Number(performance.timeOrigin) + Number(performance.now())"))
         for payload in payloads where payload.contains("type: 'REMOTE_") {
-            #expect(payload.contains("commandIssuedAtMilliseconds: Date.now()"))
+            #expect(payload.contains(
+                "commandIssuedAtMilliseconds: __kasetEventTimestampMilliseconds()"
+            ))
         }
     }
 
@@ -658,7 +662,7 @@ struct MusicPlaybackBridgeGenerationTests {
         #expect(script.contains("video !== document.querySelector('video')"))
         #expect(script.contains("video.__kasetEndedReported"))
         #expect(script.contains("video.__kasetEndedReported = false"))
-        #expect(script.contains("sendTrackEnded(video)"))
+        #expect(script.contains("sendTrackEnded(endedPayload)"))
     }
 
     @Test("Navigation failure pause clears autoplay retry intent")

--- a/Tests/KasetTests/MusicPlaybackOccurrenceRegressionTests.swift
+++ b/Tests/KasetTests/MusicPlaybackOccurrenceRegressionTests.swift
@@ -39,6 +39,14 @@ struct MusicPlaybackOccurrenceRegressionTests {
         let nativeOccurrence = playerService.beginNativeMusicPlaybackOccurrence(videoId: "v1")
         #expect(playerService.claimTerminalMusicPlaybackOccurrence(nativeOccurrence))
 
+        let prospectiveWebOccurrence = MusicPlaybackOccurrence.web(
+            documentGeneration: 7,
+            mediaGeneration: 1,
+            nativeGeneration: nativeOccurrence.nativeGeneration,
+            videoId: "v2"
+        )
+        #expect(playerService.acceptsWebMusicPlaybackOccurrence(prospectiveWebOccurrence))
+
         let webOccurrence = try #require(playerService.bindWebMusicPlaybackOccurrence(
             documentGeneration: 7,
             mediaGeneration: 1,

--- a/Tests/KasetTests/MusicPlaybackOccurrenceRegressionTests.swift
+++ b/Tests/KasetTests/MusicPlaybackOccurrenceRegressionTests.swift
@@ -1,0 +1,137 @@
+import Testing
+@testable import Kaset
+
+@Suite("Music playback occurrence regressions", .tags(.service))
+@MainActor
+struct MusicPlaybackOccurrenceRegressionTests {
+    @Test("An unresolved Web identity inherits a consumed native occurrence")
+    func unresolvedIdentityInheritsConsumedNativeOccurrence() throws {
+        let identityPairs: [(native: String?, web: String?)] = [
+            (nil, nil),
+            (nil, "v1"),
+            ("v1", nil),
+        ]
+
+        for identityPair in identityPairs {
+            let playerService = PlayerService()
+            let nativeOccurrence = playerService.beginNativeMusicPlaybackOccurrence(
+                videoId: identityPair.native
+            )
+            #expect(playerService.claimTerminalMusicPlaybackOccurrence(nativeOccurrence))
+
+            let webOccurrence = try #require(playerService.bindWebMusicPlaybackOccurrence(
+                documentGeneration: 7,
+                mediaGeneration: 1,
+                nativeGeneration: nativeOccurrence.nativeGeneration,
+                videoId: identityPair.web
+            ))
+
+            let didClaimWebOccurrence = playerService.claimTerminalMusicPlaybackOccurrence(
+                webOccurrence
+            )
+            #expect(!didClaimWebOccurrence)
+        }
+    }
+
+    @Test("A confirmed identity mismatch does not inherit a consumed native occurrence")
+    func confirmedIdentityMismatchStartsUnconsumedWebOccurrence() throws {
+        let playerService = PlayerService()
+        let nativeOccurrence = playerService.beginNativeMusicPlaybackOccurrence(videoId: "v1")
+        #expect(playerService.claimTerminalMusicPlaybackOccurrence(nativeOccurrence))
+
+        let webOccurrence = try #require(playerService.bindWebMusicPlaybackOccurrence(
+            documentGeneration: 7,
+            mediaGeneration: 1,
+            nativeGeneration: nativeOccurrence.nativeGeneration,
+            videoId: "v2"
+        ))
+
+        let didClaimWebOccurrence = playerService.claimTerminalMusicPlaybackOccurrence(
+            webOccurrence
+        )
+        #expect(didClaimWebOccurrence)
+    }
+
+    @Test("Resuming a consumed Web occurrence starts a fresh native occurrence")
+    func resumeConsumedWebOccurrenceStartsNativeReplay() async throws {
+        let playerService = PlayerService()
+        let song = Song(
+            id: "1",
+            title: "Song 1",
+            artists: [],
+            album: nil,
+            duration: 10,
+            thumbnailURL: nil,
+            videoId: "v1"
+        )
+        playerService.currentTrack = song
+        playerService.pendingPlayVideoId = song.videoId
+        playerService.duration = 10
+        playerService.state = .ended
+        let nativeOccurrence = playerService.beginNativeMusicPlaybackOccurrence(videoId: "v1")
+        let webOccurrence = try #require(playerService.bindWebMusicPlaybackOccurrence(
+            documentGeneration: 7,
+            mediaGeneration: 1,
+            nativeGeneration: nativeOccurrence.nativeGeneration,
+            videoId: "v1"
+        ))
+        #expect(playerService.claimTerminalMusicPlaybackOccurrence(webOccurrence))
+
+        await playerService.resume()
+
+        let replayOccurrence = try #require(playerService.currentMusicPlaybackOccurrence)
+        #expect(replayOccurrence.documentGeneration == nil)
+        #expect(replayOccurrence.nativeGeneration > webOccurrence.nativeGeneration)
+        #expect(playerService.state == .loading)
+        #expect(playerService.progress == 0)
+
+        let reboundWebOccurrence = try #require(playerService.bindWebMusicPlaybackOccurrence(
+            documentGeneration: 7,
+            mediaGeneration: 1,
+            nativeGeneration: replayOccurrence.nativeGeneration,
+            videoId: "v1"
+        ))
+        #expect(playerService.acceptsWebMusicPlaybackOccurrence(reboundWebOccurrence))
+        #expect(playerService.claimTerminalMusicPlaybackOccurrence(reboundWebOccurrence))
+    }
+
+    @Test("A terminal event older than the current Web occurrence is rejected")
+    func staleTerminalEventOlderThanCurrentOccurrenceIsRejected() throws {
+        let playerService = PlayerService()
+        let nativeOccurrence = playerService.beginNativeMusicPlaybackOccurrence(videoId: "v1")
+        let staleOccurrence = try #require(playerService.bindWebMusicPlaybackOccurrence(
+            documentGeneration: 7,
+            mediaGeneration: 1,
+            nativeGeneration: nativeOccurrence.nativeGeneration,
+            videoId: "v1"
+        ))
+        let currentOccurrence = try #require(playerService.bindWebMusicPlaybackOccurrence(
+            documentGeneration: 7,
+            mediaGeneration: 2,
+            nativeGeneration: nativeOccurrence.nativeGeneration,
+            videoId: "v1"
+        ))
+
+        let didClaimStaleOccurrence = playerService.claimTerminalMusicPlaybackOccurrence(
+            staleOccurrence
+        )
+
+        #expect(!didClaimStaleOccurrence)
+        #expect(playerService.currentMusicPlaybackOccurrence == currentOccurrence)
+    }
+
+    @Test("Stopped playback cannot resurrect a consumed occurrence without media")
+    func stoppedPlaybackDoesNotResurrectConsumedOccurrence() async {
+        let playerService = PlayerService()
+        let occurrence = playerService.beginNativeMusicPlaybackOccurrence(videoId: "v1")
+        #expect(playerService.claimTerminalMusicPlaybackOccurrence(occurrence))
+
+        await playerService.stop()
+        await playerService.playPause()
+
+        #expect(playerService.state == .idle)
+        #expect(playerService.currentTrack == nil)
+        #expect(playerService.pendingPlayVideoId == nil)
+        #expect(playerService.currentMusicPlaybackOccurrence == nil)
+    }
+}

--- a/Tests/KasetTests/MusicPlaybackRequestDedupTests.swift
+++ b/Tests/KasetTests/MusicPlaybackRequestDedupTests.swift
@@ -2,6 +2,8 @@ import Foundation
 import Testing
 @testable import Kaset
 
+// MARK: - MusicPlaybackRequestDedupTests
+
 @Suite("Music playback request deduplication", .serialized, .tags(.service))
 @MainActor
 struct MusicPlaybackRequestDedupTests {
@@ -60,48 +62,248 @@ struct MusicPlaybackRequestDedupTests {
         #expect(playerService.shouldResumeAfterInterruption)
     }
 
-    @Test("Distinct queue entries sharing a video ID start a fresh occurrence")
-    func distinctSameVideoQueueEntriesStartFreshPlayback() async throws {
-        let videoId = "same-video"
-        let (playerService, webKitManager) = self.makeLoadedPlayer(videoId: videoId)
+    @Test("A same-video direct request supersedes a different deferred restored load")
+    func sameVideoDirectRequestSupersedesStalePendingRestore() async {
+        let requestedVideoID = "visible-video"
+        let staleVideoID = "stale-restored-video"
+        let (playerService, webKitManager) = self.makeLoadedPlayer(videoId: requestedVideoID)
         _ = webKitManager
         defer { SingletonPlayerWebView.shared.tearDown() }
-        let firstSong = Song(
-            id: "first",
-            title: "First occurrence",
-            artists: [],
-            album: nil,
-            duration: 180,
-            thumbnailURL: nil,
-            videoId: videoId
+        let mockClient = MockYTMusicClient()
+        playerService.setYTMusicClient(mockClient)
+        mockClient.songResponses[requestedVideoID] = Song(
+            id: requestedVideoID,
+            title: "Visible Metadata",
+            artists: [Artist(id: "visible-artist", name: "Visible Artist")],
+            videoId: requestedVideoID
         )
-        let secondSong = Song(
-            id: "second",
-            title: "Second occurrence",
+        let staleSong = Song(
+            id: staleVideoID,
+            title: "Stale Restored Song",
             artists: [],
-            album: nil,
             duration: 180,
-            thumbnailURL: nil,
-            videoId: videoId
+            videoId: staleVideoID
         )
+        playerService.applyRestoredPlaybackSession(
+            queue: [staleSong],
+            currentIndex: 0,
+            progress: 60,
+            duration: 180
+        )
+        #expect(playerService.isPendingRestoredLoadDeferred)
+        #expect(playerService.pendingPlayVideoId == staleVideoID)
+
+        await playerService.play(videoId: requestedVideoID)
+
+        #expect(playerService.pendingPlayVideoId == requestedVideoID)
+        #expect(playerService.currentTrack?.videoId == requestedVideoID)
+        #expect(playerService.currentTrack?.title == "Visible Metadata")
+        #expect(!playerService.isPendingRestoredLoadDeferred)
+        #expect(playerService.pendingRestoredSeek == nil)
+        #expect(SingletonPlayerWebView.shared.currentVideoId == requestedVideoID)
+        #expect(mockClient.getSongVideoIds == [requestedVideoID])
+    }
+
+    @Test("A direct deduplicated video request detaches ownership under a fresh occurrence")
+    func deduplicatedDirectVideoRequestDetachesQueueOwnership() async throws {
+        let first = Song(
+            id: "direct-same-first",
+            title: "Direct Same First",
+            artists: [],
+            duration: 180,
+            videoId: "direct-same-video"
+        )
+        let second = Song(
+            id: "direct-same-second",
+            title: "Direct Same Second",
+            artists: [],
+            duration: 180,
+            videoId: "direct-same-next"
+        )
+        let (playerService, webKitManager) = self.makeLoadedPlayer(videoId: first.videoId)
+        _ = webKitManager
+        defer { SingletonPlayerWebView.shared.tearDown() }
+        let firstEntryID = UUID()
         playerService.setQueue(entries: [
-            QueueEntry(id: UUID(), song: firstSong),
-            QueueEntry(id: UUID(), song: secondSong),
+            QueueEntry(id: firstEntryID, song: first),
+            QueueEntry(id: UUID(), song: second),
         ])
         playerService.currentIndex = 0
-        await playerService.play(song: firstSong)
+        self.seedPausedPlayback(playerService, song: first)
+        playerService.isShowingAd = false
+        playerService.activePlaybackQueueEntryID = firstEntryID
+        let occurrence = playerService.beginNativeMusicPlaybackOccurrence(videoId: first.videoId)
+
+        await playerService.play(videoId: first.videoId)
+
+        let detachedOccurrence = try #require(playerService.currentMusicPlaybackOccurrence)
+        #expect(playerService.activePlaybackQueueEntryID == nil)
+        #expect(detachedOccurrence.nativeGeneration > occurrence.nativeGeneration)
+        #expect(playerService.progress == 42)
+        #expect(playerService.currentIndex == 0)
+
+        await playerService.handleTrackEnded(
+            observedVideoId: first.videoId,
+            playbackOccurrence: occurrence
+        )
+
+        #expect(playerService.currentIndex == 0)
+        #expect(playerService.currentTrack?.videoId == first.videoId)
+        #expect(playerService.state == .paused)
+
+        await playerService.handleTrackEnded(
+            observedVideoId: first.videoId,
+            playbackOccurrence: detachedOccurrence
+        )
+
+        #expect(playerService.state == .ended)
+    }
+
+    @Test("Direct same-video detachment replaces queue-owned metadata work")
+    func directSameVideoDetachmentReplacesQueueOwnedMetadataWork() async {
+        let videoID = "direct-metadata-handoff"
+        let (playerService, webKitManager) = self.makeLoadedPlayer(videoId: videoID)
+        _ = webKitManager
+        defer { SingletonPlayerWebView.shared.tearDown() }
+        let mockClient = MockYTMusicClient()
+        playerService.setYTMusicClient(mockClient)
+        let incomplete = Song(
+            id: videoID,
+            title: "Loading...",
+            artists: [],
+            videoId: videoID
+        )
+        let entryID = UUID()
+        playerService.setQueue(entries: [QueueEntry(id: entryID, song: incomplete)])
+        playerService.currentIndex = 0
+        playerService.currentTrack = incomplete
+        playerService.pendingPlayVideoId = videoID
+        playerService.activePlaybackQueueEntryID = entryID
+        playerService.state = .paused
+        playerService.beginNativeMusicPlaybackOccurrence(videoId: videoID)
+        let authoritativeTokens = FeedbackTokens(add: "detached-add", remove: "detached-remove")
+        mockClient.songResponses[videoID] = Song(
+            id: videoID,
+            title: "Detached Metadata",
+            artists: [Artist(id: "artist", name: "Artist")],
+            videoId: videoID,
+            feedbackTokens: authoritativeTokens
+        )
+        let firstRequestStarted = AsyncGate()
+        let releaseFirstRequest = AsyncGate()
+        let requestCounter = PlaybackRequestCounter()
+        mockClient.beforeGetSongReturn = { _ in
+            if await requestCounter.increment() == 1 {
+                await firstRequestStarted.open()
+                await releaseFirstRequest.wait()
+            }
+        }
+        let queuedFetch = Task { @MainActor in
+            await playerService.fetchSongMetadata(
+                videoId: videoID,
+                queueOwner: .entry(entryID)
+            )
+        }
+        await firstRequestStarted.wait()
+
+        await playerService.play(videoId: videoID)
+
+        #expect(mockClient.getSongVideoIds == [videoID, videoID])
+        #expect(playerService.activePlaybackQueueEntryID == nil)
+        #expect(playerService.currentTrack?.title == "Detached Metadata")
+        #expect(playerService.currentTrackFeedbackTokens == authoritativeTokens)
+        #expect(playerService.queue[0].title == "Loading...")
+        #expect(playerService.queue[0].feedbackTokens == authoritativeTokens)
+
+        await releaseFirstRequest.open()
+        await queuedFetch.value
+        #expect(playerService.currentTrack?.title == "Detached Metadata")
+        #expect(playerService.queue[0].title == "Loading...")
+    }
+
+    @Test("Direct same-video playback clears artist episode semantics")
+    func directSameVideoPlaybackClearsArtistEpisodeSemantics() async throws {
+        let videoID = "direct-episode-handoff"
+        let (playerService, webKitManager) = self.makeLoadedPlayer(videoId: videoID)
+        _ = webKitManager
+        defer { SingletonPlayerWebView.shared.tearDown() }
+        let song = Song(
+            id: videoID,
+            title: "Episode Representative",
+            artists: [],
+            duration: 180,
+            videoId: videoID,
+            feedbackTokens: FeedbackTokens(add: nil, remove: nil)
+        )
+        self.seedPausedPlayback(playerService, song: song)
+        playerService.isShowingAd = false
+        playerService.currentEpisode = ArtistEpisode(
+            videoId: videoID,
+            title: "Live Episode",
+            isLive: true
+        )
+        let occurrence = playerService.beginNativeMusicPlaybackOccurrence(videoId: videoID)
+
+        await playerService.play(videoId: videoID)
+
+        let detachedOccurrence = try #require(playerService.currentMusicPlaybackOccurrence)
+        #expect(playerService.currentEpisode == nil)
+        #expect(!playerService.isCurrentItemLive)
+        #expect(detachedOccurrence.nativeGeneration > occurrence.nativeGeneration)
+        #expect(playerService.progress == 42)
+        #expect(playerService.duration == 180)
+    }
+
+    @Test("Distinct queue entry IDs for the same song start fresh, while reselecting one entry deduplicates")
+    func exactSameSongQueueEntriesUseLogicalEntryIdentity() async throws {
+        let videoId = "same-video"
+        let singleton = SingletonPlayerWebView.shared
+        singleton.tearDown()
+        singleton.currentVideoId = nil
+        defer {
+            singleton.tearDown()
+            singleton.currentVideoId = nil
+        }
+        let playerService = PlayerService()
+        let song = Song(
+            id: "same-song",
+            title: "Same Song",
+            artists: [],
+            album: nil,
+            duration: 180,
+            thumbnailURL: nil,
+            videoId: videoId
+        )
+        let firstEntryID = UUID()
+        let secondEntryID = UUID()
+        playerService.setQueue(entries: [
+            QueueEntry(id: firstEntryID, song: song),
+            QueueEntry(id: secondEntryID, song: song),
+        ])
+
+        await playerService.playFromQueue(at: 0)
         let firstOccurrence = try #require(playerService.currentMusicPlaybackOccurrence)
+        #expect(playerService.activePlaybackQueueEntryID == firstEntryID)
         playerService.progress = 42
         playerService.currentTimeMs = 42000
 
         await playerService.playFromQueue(at: 1)
-
         let secondOccurrence = try #require(playerService.currentMusicPlaybackOccurrence)
-        #expect(playerService.currentTrack?.id == "second")
+        #expect(playerService.currentTrack == song)
         #expect(playerService.currentIndex == 1)
+        #expect(playerService.activePlaybackQueueEntryID == secondEntryID)
         #expect(playerService.progress == 0)
-        #expect(secondOccurrence != firstOccurrence)
         #expect(secondOccurrence.nativeGeneration > firstOccurrence.nativeGeneration)
+
+        playerService.progress = 17
+        playerService.currentTimeMs = 17000
+        await playerService.playFromQueue(at: 1)
+
+        let reselectedOccurrence = try #require(playerService.currentMusicPlaybackOccurrence)
+        #expect(reselectedOccurrence == secondOccurrence)
+        #expect(playerService.activePlaybackQueueEntryID == secondEntryID)
+        #expect(playerService.progress == 17)
+        #expect(playerService.currentTimeMs == 17000)
     }
 
     @Test("Fresh same-video occurrence forces navigation while an ad is active")
@@ -226,6 +428,9 @@ struct MusicPlaybackRequestDedupTests {
         let singleton = SingletonPlayerWebView.shared
         singleton.tearDown()
         let playerService = PlayerService()
+        let likeStatusManager = SongLikeStatusManager()
+        likeStatusManager.setActiveAccountID(nil)
+        playerService.setSongLikeStatusManager(likeStatusManager)
         let webKitManager = WebKitManager.makeTestInstance()
         _ = singleton.getWebView(
             webKitManager: webKitManager,
@@ -244,5 +449,16 @@ struct MusicPlaybackRequestDedupTests {
         playerService.currentTimeMs = 42000
         playerService.duration = 180
         playerService.isShowingAd = true
+    }
+}
+
+// MARK: - PlaybackRequestCounter
+
+private actor PlaybackRequestCounter {
+    private var count = 0
+
+    func increment() -> Int {
+        self.count += 1
+        return self.count
     }
 }

--- a/Tests/KasetTests/MusicPlaybackRequestDedupTests.swift
+++ b/Tests/KasetTests/MusicPlaybackRequestDedupTests.swift
@@ -1,0 +1,248 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+@Suite("Music playback request deduplication", .serialized, .tags(.service))
+@MainActor
+struct MusicPlaybackRequestDedupTests {
+    @Test("A deduplicated same-song request preserves native playback state")
+    func deduplicatedSongRequestPreservesPlaybackState() async {
+        let videoId = "same-video"
+        let (playerService, webKitManager) = self.makeLoadedPlayer(videoId: videoId)
+        _ = webKitManager
+        defer { SingletonPlayerWebView.shared.tearDown() }
+        let song = Song(
+            id: "same-song",
+            title: "Same Song",
+            artists: [],
+            album: nil,
+            duration: 180,
+            thumbnailURL: nil,
+            videoId: videoId
+        )
+        self.seedPausedPlayback(playerService, song: song)
+
+        await playerService.play(song: song)
+
+        #expect(playerService.state == .paused)
+        #expect(playerService.progress == 42)
+        #expect(playerService.currentTimeMs == 42000)
+        #expect(playerService.duration == 180)
+        #expect(playerService.isShowingAd)
+        #expect(playerService.shouldResumeAfterInterruption)
+    }
+
+    @Test("A deduplicated same-video-ID request preserves native playback state")
+    func deduplicatedVideoIDRequestPreservesPlaybackState() async {
+        let videoId = "same-video"
+        let (playerService, webKitManager) = self.makeLoadedPlayer(videoId: videoId)
+        _ = webKitManager
+        defer { SingletonPlayerWebView.shared.tearDown() }
+        let song = Song(
+            id: "existing-song",
+            title: "Existing Song",
+            artists: [],
+            album: nil,
+            duration: 180,
+            thumbnailURL: nil,
+            videoId: videoId
+        )
+        self.seedPausedPlayback(playerService, song: song)
+
+        await playerService.play(videoId: videoId)
+
+        #expect(playerService.state == .paused)
+        #expect(playerService.progress == 42)
+        #expect(playerService.currentTimeMs == 42000)
+        #expect(playerService.duration == 180)
+        #expect(playerService.isShowingAd)
+        #expect(playerService.currentTrack?.title == "Existing Song")
+        #expect(playerService.shouldResumeAfterInterruption)
+    }
+
+    @Test("Distinct queue entries sharing a video ID start a fresh occurrence")
+    func distinctSameVideoQueueEntriesStartFreshPlayback() async throws {
+        let videoId = "same-video"
+        let (playerService, webKitManager) = self.makeLoadedPlayer(videoId: videoId)
+        _ = webKitManager
+        defer { SingletonPlayerWebView.shared.tearDown() }
+        let firstSong = Song(
+            id: "first",
+            title: "First occurrence",
+            artists: [],
+            album: nil,
+            duration: 180,
+            thumbnailURL: nil,
+            videoId: videoId
+        )
+        let secondSong = Song(
+            id: "second",
+            title: "Second occurrence",
+            artists: [],
+            album: nil,
+            duration: 180,
+            thumbnailURL: nil,
+            videoId: videoId
+        )
+        playerService.setQueue(entries: [
+            QueueEntry(id: UUID(), song: firstSong),
+            QueueEntry(id: UUID(), song: secondSong),
+        ])
+        playerService.currentIndex = 0
+        await playerService.play(song: firstSong)
+        let firstOccurrence = try #require(playerService.currentMusicPlaybackOccurrence)
+        playerService.progress = 42
+        playerService.currentTimeMs = 42000
+
+        await playerService.playFromQueue(at: 1)
+
+        let secondOccurrence = try #require(playerService.currentMusicPlaybackOccurrence)
+        #expect(playerService.currentTrack?.id == "second")
+        #expect(playerService.currentIndex == 1)
+        #expect(playerService.progress == 0)
+        #expect(secondOccurrence != firstOccurrence)
+        #expect(secondOccurrence.nativeGeneration > firstOccurrence.nativeGeneration)
+    }
+
+    @Test("Fresh same-video occurrence forces navigation while an ad is active")
+    func sameVideoOccurrenceUsesFullNavigationDuringAd() {
+        #expect(SingletonPlayerWebView.freshSameIDPlaybackStrategy(isShowingAd: true)
+            == .forceFullPageWhenSameVideoId)
+        #expect(SingletonPlayerWebView.freshSameIDPlaybackStrategy(isShowingAd: false)
+            == .preferInPlaceWhenSameVideoId)
+    }
+
+    @Test("Rapid music toggles follow native command intent before observer catch-up")
+    func rapidMusicTogglesAlternateIntent() async {
+        let playerService = PlayerService()
+        playerService.currentTrack = Song(
+            id: "song",
+            title: "Song",
+            artists: [],
+            album: nil,
+            duration: 180,
+            thumbnailURL: nil,
+            videoId: "video"
+        )
+        playerService.pendingPlayVideoId = "video"
+        playerService.state = .paused
+        playerService.shouldResumeAfterInterruption = false
+
+        await playerService.playPause()
+        #expect(playerService.shouldResumeAfterInterruption)
+        #expect(playerService.isAwaitingPlaybackConfirmation)
+        await playerService.playPause()
+
+        #expect(!playerService.shouldResumeAfterInterruption)
+        #expect(!playerService.isAwaitingPlaybackConfirmation)
+    }
+
+    @Test("A settled ready-paused autoplay failure resumes on the first toggle")
+    func settledAutoplayFailureResumesOnFirstToggle() async {
+        let playerService = PlayerService()
+        playerService.currentTrack = Song(
+            id: "song",
+            title: "Song",
+            artists: [],
+            album: nil,
+            duration: 180,
+            thumbnailURL: nil,
+            videoId: "video"
+        )
+        playerService.pendingPlayVideoId = "video"
+        playerService.currentWebPlaybackVideoId = { "video" }
+        playerService.state = .loading
+        playerService.shouldResumeAfterInterruption = true
+        playerService.isAwaitingPlaybackConfirmation = true
+        playerService.updatePlaybackState(isPlaying: false, progress: 0, duration: 180)
+
+        await playerService.playPause()
+
+        #expect(playerService.shouldResumeAfterInterruption)
+        #expect(playerService.isAwaitingPlaybackConfirmation)
+    }
+
+    @Test("A ready paused advertisement settles play confirmation")
+    func readyPausedAdSettlesConfirmation() async {
+        let playerService = PlayerService()
+        playerService.currentTrack = Song(
+            id: "song",
+            title: "Song",
+            artists: [],
+            album: nil,
+            duration: 180,
+            thumbnailURL: nil,
+            videoId: "video"
+        )
+        playerService.pendingPlayVideoId = "video"
+        playerService.currentWebPlaybackVideoId = { "video" }
+        playerService.state = .loading
+        playerService.shouldResumeAfterInterruption = true
+        playerService.isAwaitingPlaybackConfirmation = true
+
+        playerService.updatePlaybackTransportState(isPlaying: false)
+        await playerService.playPause()
+
+        #expect(playerService.shouldResumeAfterInterruption)
+        #expect(playerService.isAwaitingPlaybackConfirmation)
+    }
+
+    @Test("A late playing sample cannot reverse an explicit music pause")
+    func latePlayingSampleDoesNotReversePause() async {
+        let playerService = PlayerService()
+        playerService.currentTrack = Song(
+            id: "song",
+            title: "Song",
+            artists: [],
+            album: nil,
+            duration: 180,
+            thumbnailURL: nil,
+            videoId: "video"
+        )
+        playerService.pendingPlayVideoId = "video"
+        playerService.state = .playing
+        playerService.shouldResumeAfterInterruption = true
+        await playerService.pause()
+
+        playerService.updatePlaybackState(isPlaying: true, progress: 10, duration: 180)
+
+        #expect(playerService.state == .paused)
+        #expect(!playerService.shouldResumeAfterInterruption)
+    }
+
+    @Test("Ending music clears an outstanding resume confirmation")
+    func endedPlaybackClearsConfirmation() {
+        let playerService = PlayerService()
+        playerService.isAwaitingPlaybackConfirmation = true
+        playerService.shouldResumeAfterInterruption = true
+
+        playerService.markPlaybackEnded()
+
+        #expect(!playerService.isAwaitingPlaybackConfirmation)
+        #expect(!playerService.shouldResumeAfterInterruption)
+    }
+
+    private func makeLoadedPlayer(videoId: String) -> (PlayerService, WebKitManager) {
+        let singleton = SingletonPlayerWebView.shared
+        singleton.tearDown()
+        let playerService = PlayerService()
+        let webKitManager = WebKitManager.makeTestInstance()
+        _ = singleton.getWebView(
+            webKitManager: webKitManager,
+            playerService: playerService
+        )
+        singleton.currentVideoId = videoId
+        return (playerService, webKitManager)
+    }
+
+    private func seedPausedPlayback(_ playerService: PlayerService, song: Song) {
+        playerService.currentTrack = song
+        playerService.pendingPlayVideoId = song.videoId
+        playerService.state = .paused
+        playerService.shouldResumeAfterInterruption = false
+        playerService.progress = 42
+        playerService.currentTimeMs = 42000
+        playerService.duration = 180
+        playerService.isShowingAd = true
+    }
+}

--- a/Tests/KasetTests/MusicQueueEntryIdentityTests.swift
+++ b/Tests/KasetTests/MusicQueueEntryIdentityTests.swift
@@ -1,0 +1,444 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+@Suite("Music queue entry identity", .serialized, .tags(.service))
+@MainActor
+struct MusicQueueEntryIdentityTests {
+    @Test("Stale metadata cannot overwrite a newer same-video queue entry")
+    func staleMetadataCannotOverwriteNewerEntry() async throws {
+        let (playerService, mockClient) = self.makePlayerService()
+        defer { SingletonPlayerWebView.shared.tearDown() }
+        let metadataStarted = AsyncGate()
+        let releaseMetadata = AsyncGate()
+        let first = self.song(id: "first", title: "First", videoId: "shared")
+        let second = self.song(id: "second", title: "Second", videoId: "shared")
+        let firstID = UUID()
+        let secondID = UUID()
+        playerService.setQueue(entries: [
+            QueueEntry(id: firstID, song: first),
+            QueueEntry(id: secondID, song: second),
+        ])
+        mockClient.songResponses["shared"] = self.song(
+            id: "stale",
+            title: "Stale metadata",
+            videoId: "shared"
+        )
+        mockClient.beforeGetSongReturn = { _ in
+            await metadataStarted.open()
+            await releaseMetadata.wait()
+        }
+
+        await playerService.playFromQueue(at: 0)
+        let metadataTask = Task { @MainActor in
+            await playerService.fetchSongMetadata(videoId: "shared")
+        }
+        await metadataStarted.wait()
+
+        mockClient.beforeGetSongReturn = nil
+        await playerService.playFromQueue(at: 1)
+        let secondOccurrence = try #require(playerService.currentMusicPlaybackOccurrence)
+        await releaseMetadata.open()
+        await metadataTask.value
+
+        #expect(playerService.currentQueueEntryID == secondID)
+        #expect(playerService.activePlaybackQueueEntryID == secondID)
+        #expect(playerService.currentTrack?.id == second.id)
+        #expect(playerService.currentTrack?.title == second.title)
+        #expect(playerService.currentMusicPlaybackOccurrence == secondOccurrence)
+        #expect(playerService.queueEntries[1].song.title == second.title)
+    }
+
+    @Test("Metadata enrichment updates the active duplicate entry, not the first match")
+    func metadataUpdatesExactActiveEntry() async {
+        let (playerService, mockClient) = self.makePlayerService()
+        defer { SingletonPlayerWebView.shared.tearDown() }
+        let first = self.song(id: "first", title: "First complete", videoId: "shared")
+        let second = Song(
+            id: "second",
+            title: "Loading...",
+            artists: [],
+            duration: 180,
+            videoId: "shared"
+        )
+        let firstID = UUID()
+        let secondID = UUID()
+        playerService.setQueue(entries: [
+            QueueEntry(id: firstID, song: first),
+            QueueEntry(id: secondID, song: second),
+        ])
+        mockClient.songResponses["shared"] = Song(
+            id: "api",
+            title: "Enriched second",
+            artists: [Artist(id: "artist", name: "Artist")],
+            duration: 180,
+            videoId: "shared",
+            feedbackTokens: .init(add: nil, remove: nil)
+        )
+
+        await playerService.playFromQueue(at: 1)
+
+        #expect(playerService.queueEntries[0].id == firstID)
+        #expect(playerService.queueEntries[0].song.title == first.title)
+        #expect(playerService.queueEntries[1].id == secondID)
+        #expect(playerService.queueEntries[1].song.title == "Enriched second")
+        #expect(playerService.activePlaybackQueueEntryID == secondID)
+    }
+
+    @Test("Background queue enrichment follows the entry ID across reorder")
+    func queueEnrichmentFollowsEntryAcrossReorder() async throws {
+        let (playerService, mockClient) = self.makePlayerService()
+        let enrichmentStarted = AsyncGate()
+        let releaseEnrichment = AsyncGate()
+        let targetID = UUID()
+        let currentID = UUID()
+        let target = Song(
+            id: "target",
+            title: "Loading...",
+            artists: [],
+            videoId: "target"
+        )
+        let current = self.song(id: "current", title: "Current", videoId: "current")
+        playerService.setQueue(entries: [
+            QueueEntry(id: targetID, song: target),
+            QueueEntry(id: currentID, song: current),
+        ])
+        playerService.currentIndex = 1
+        mockClient.songResponses["target"] = self.song(
+            id: "target",
+            title: "Enriched target",
+            videoId: "target"
+        )
+        mockClient.beforeGetSongReturn = { _ in
+            await enrichmentStarted.open()
+            await releaseEnrichment.wait()
+        }
+
+        let enrichmentTask = Task { @MainActor in
+            await playerService.enrichQueueMetadata()
+        }
+        await enrichmentStarted.wait()
+        playerService.reorderQueue(from: IndexSet(integer: 0), to: 2)
+        await releaseEnrichment.open()
+        await enrichmentTask.value
+
+        let targetEntry = try #require(playerService.queueEntries.first(where: { $0.id == targetID }))
+        #expect(targetEntry.song.title == "Enriched target")
+        #expect(playerService.currentQueueEntryID == currentID)
+    }
+
+    @Test("Clearing a detached playback queue gives the standalone song a fresh entry ID")
+    func clearQueueDoesNotReassignUnrelatedEntryID() async throws {
+        let (playerService, _) = self.makePlayerService()
+        defer { SingletonPlayerWebView.shared.tearDown() }
+        let first = self.song(id: "first", title: "First", videoId: "first")
+        let second = self.song(id: "second", title: "Second", videoId: "second")
+        let standalone = self.song(id: "standalone", title: "Standalone", videoId: "standalone")
+        await playerService.playQueue([first, second], startingAt: 0)
+        let oldEntryID = try #require(playerService.currentQueueEntryID)
+
+        await playerService.play(song: standalone)
+        playerService.clearQueue()
+
+        #expect(playerService.queue == [standalone])
+        #expect(playerService.queueEntryIDs.count == 1)
+        #expect(playerService.queueEntryIDs[0] != oldEntryID)
+        #expect(playerService.activePlaybackQueueEntryID == nil)
+    }
+
+    @Test("Detached playback persists its own song and clock")
+    func detachedPlaybackPersistsOwnIdentity() async {
+        let (playerService, _) = self.makePlayerService()
+        defer {
+            playerService.clearSavedQueue()
+            SingletonPlayerWebView.shared.tearDown()
+        }
+        playerService.clearSavedQueue()
+        let queued = self.song(id: "queued", title: "Queued", videoId: "queued")
+        let standalone = self.song(
+            id: "standalone",
+            title: "Standalone",
+            videoId: "standalone"
+        )
+        await playerService.playQueue([queued], startingAt: 0)
+        await playerService.play(song: standalone)
+        playerService.progress = 42
+        playerService.duration = 180
+        playerService.saveQueueForPersistence()
+
+        let restored = PlayerService()
+        #expect(restored.restoreQueueFromPersistence())
+
+        #expect(restored.queue == [standalone])
+        #expect(restored.currentTrack?.videoId == standalone.videoId)
+        #expect(restored.progress == 42)
+        #expect(restored.duration == 180)
+    }
+
+    @Test("Deferred queue selection follows the captured entry ID after insertion")
+    func deferredSelectionFollowsEntryID() async {
+        let (playerService, _) = self.makePlayerService()
+        defer { SingletonPlayerWebView.shared.tearDown() }
+        let first = self.song(id: "first", title: "First", videoId: "first")
+        let selected = self.song(id: "selected", title: "Selected", videoId: "selected")
+        let inserted = self.song(id: "inserted", title: "Inserted", videoId: "inserted")
+        let firstID = UUID()
+        let selectedID = UUID()
+        playerService.setQueue(entries: [
+            QueueEntry(id: firstID, song: first),
+            QueueEntry(id: selectedID, song: selected),
+        ])
+        let intent = playerService.beginMusicPlaybackIntent()
+
+        playerService.setQueue(entries: [
+            QueueEntry(id: UUID(), song: inserted),
+            QueueEntry(id: firstID, song: first),
+            QueueEntry(id: selectedID, song: selected),
+        ])
+        await playerService.playFromQueue(entryID: selectedID, intent: intent)
+
+        #expect(playerService.currentQueueEntryID == selectedID)
+        #expect(playerService.activePlaybackQueueEntryID == selectedID)
+        #expect(playerService.currentTrack == selected)
+        #expect(playerService.currentIndex == 2)
+    }
+
+    @Test("Direct video metadata has no queue-entry owner")
+    func directVideoMetadataDoesNotEnrichPreviousQueueEntry() async {
+        let (playerService, mockClient) = self.makePlayerService()
+        defer { SingletonPlayerWebView.shared.tearDown() }
+        let queued = Song(
+            id: "queued",
+            title: "Loading...",
+            artists: [],
+            videoId: "queued"
+        )
+        await playerService.playQueue([queued], startingAt: 0)
+        let queuedEntryID = playerService.queueEntryIDs[0]
+        mockClient.songResponses["standalone"] = self.song(
+            id: "standalone",
+            title: "Standalone metadata",
+            videoId: "standalone"
+        )
+
+        await playerService.play(videoId: "standalone")
+
+        #expect(playerService.currentTrack?.videoId == "standalone")
+        #expect(playerService.queueEntryIDs == [queuedEntryID])
+        #expect(playerService.queue[0].videoId == queued.videoId)
+        #expect(playerService.queue[0].title != "Standalone metadata")
+    }
+
+    @Test("Direct video playback matching a queued song remains detached")
+    func directVideoPlaybackDoesNotAdoptMatchingQueueEntry() async {
+        let (playerService, mockClient) = self.makePlayerService()
+        defer { SingletonPlayerWebView.shared.tearDown() }
+        let queued = self.song(id: "queued-logical", title: "Queued", videoId: "shared-video")
+        let other = self.song(id: "other", title: "Other", videoId: "other-video")
+        mockClient.songResponses[queued.videoId] = self.song(
+            id: "api-identity",
+            title: "Direct metadata",
+            videoId: queued.videoId
+        )
+        await playerService.playQueue([queued, other], startingAt: 0)
+        await playerService.play(song: self.song(id: "detached", title: "Detached", videoId: "detached"))
+
+        await playerService.play(videoId: queued.videoId)
+
+        #expect(playerService.currentTrack?.videoId == queued.videoId)
+        #expect(playerService.activePlaybackQueueEntryID == nil)
+        #expect(playerService.queueEntryIDOwningCurrentPlayback == nil)
+    }
+
+    @Test("Metadata identity changes preserve exact queue ownership and persistence")
+    func metadataIdentityChangeKeepsQueueOwner() async {
+        let (playerService, mockClient) = self.makePlayerService()
+        defer {
+            playerService.clearSavedQueue()
+            SingletonPlayerWebView.shared.tearDown()
+        }
+        playerService.clearSavedQueue()
+        let incomplete = Song(
+            id: "logical-id",
+            title: "Loading...",
+            artists: [],
+            duration: 180,
+            videoId: "shared-video"
+        )
+        let second = self.song(id: "second", title: "Second", videoId: "second-video")
+        mockClient.songResponses[incomplete.videoId] = self.song(
+            id: "api-id",
+            title: "Enriched",
+            videoId: incomplete.videoId
+        )
+
+        await playerService.playQueue([incomplete, second], startingAt: 0)
+        let activeEntryID = playerService.queueEntryIDs[0]
+        playerService.saveQueueForPersistence()
+
+        #expect(playerService.activePlaybackQueueEntryID == activeEntryID)
+        #expect(playerService.queueEntryIDOwningCurrentPlayback == activeEntryID)
+        let restored = PlayerService()
+        #expect(restored.restoreQueueFromPersistence())
+        #expect(restored.queue.count == 2)
+        #expect(restored.currentIndex == 0)
+        #expect(restored.queue[0].videoId == incomplete.videoId)
+    }
+
+    @Test("Background enrichment cannot overwrite newer complete entry metadata")
+    func backgroundEnrichmentPreservesNewerEntryMetadata() async {
+        let (playerService, mockClient) = self.makePlayerService()
+        defer { SingletonPlayerWebView.shared.tearDown() }
+        let entryID = UUID()
+        let incomplete = Song(
+            id: "enrichment-logical",
+            title: "Loading...",
+            artists: [],
+            videoId: "enrichment-video",
+            isPlayable: false
+        )
+        playerService.setQueue(entries: [QueueEntry(id: entryID, song: incomplete)])
+        mockClient.songResponses[incomplete.videoId] = self.song(
+            id: "stale-api",
+            title: "Stale",
+            videoId: incomplete.videoId
+        )
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        mockClient.beforeGetSongReturn = { _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+
+        let enrichmentTask = Task { @MainActor in
+            await playerService.enrichQueueMetadata()
+        }
+        await requestStarted.wait()
+        let fresh = Song(
+            id: incomplete.id,
+            title: "Fresh",
+            artists: [Artist(id: "fresh-artist", name: "Fresh Artist")],
+            thumbnailURL: URL(string: "https://example.com/fresh.jpg"),
+            videoId: incomplete.videoId,
+            isPlayable: false
+        )
+        playerService.setQueue(entries: [QueueEntry(id: entryID, song: fresh)])
+        await releaseRequest.open()
+        await enrichmentTask.value
+
+        #expect(playerService.queueEntries[0].id == entryID)
+        #expect(playerService.queue[0].title == "Fresh")
+        #expect(playerService.queue[0].artists.first?.name == "Fresh Artist")
+        #expect(!playerService.queue[0].isPlayable)
+    }
+
+    @Test("Pausing does not discard metadata for the same active entry")
+    func pausePreservesActiveEntryMetadataRequest() async {
+        let (playerService, mockClient) = self.makePlayerService()
+        defer { SingletonPlayerWebView.shared.tearDown() }
+        let song = Song(
+            id: "metadata",
+            title: "Loading...",
+            artists: [],
+            videoId: "metadata"
+        )
+        mockClient.songResponses[song.videoId] = self.song(
+            id: song.id,
+            title: "Enriched",
+            videoId: song.videoId
+        )
+        let metadataStarted = AsyncGate()
+        let releaseMetadata = AsyncGate()
+        mockClient.beforeGetSongReturn = { _ in
+            await metadataStarted.open()
+            await releaseMetadata.wait()
+        }
+
+        let playTask = Task { @MainActor in
+            await playerService.playQueue([song], startingAt: 0)
+        }
+        await metadataStarted.wait()
+        await playerService.pause()
+        await releaseMetadata.open()
+        await playTask.value
+
+        #expect(playerService.currentTrack?.title == "Enriched")
+        #expect(playerService.queue[0].title == "Enriched")
+        #expect(playerService.state == .paused)
+    }
+
+    @Test("Duplicate removal retains the active entry owning in-flight metadata")
+    func duplicateRemovalRetainsActiveMetadataOwner() async {
+        let (playerService, mockClient) = self.makePlayerService()
+        defer { SingletonPlayerWebView.shared.tearDown() }
+        let first = self.song(id: "first", title: "First complete", videoId: "shared")
+        let active = Song(
+            id: "active",
+            title: "Loading...",
+            artists: [],
+            duration: 180,
+            videoId: "shared"
+        )
+        let firstID = UUID()
+        let activeID = UUID()
+        playerService.setQueue(entries: [
+            QueueEntry(id: firstID, song: first),
+            QueueEntry(id: activeID, song: active),
+        ])
+        playerService.currentIndex = 1
+        playerService.currentTrack = active
+        playerService.pendingPlayVideoId = active.videoId
+        playerService.activePlaybackQueueEntryID = activeID
+        mockClient.songResponses[active.videoId] = self.song(
+            id: active.id,
+            title: "Enriched active",
+            videoId: active.videoId
+        )
+        let metadataStarted = AsyncGate()
+        let releaseMetadata = AsyncGate()
+        mockClient.beforeGetSongReturn = { _ in
+            await metadataStarted.open()
+            await releaseMetadata.wait()
+        }
+        let metadataTask = Task { @MainActor in
+            await playerService.fetchSongMetadata(
+                videoId: active.videoId,
+                queueOwner: .entry(activeID)
+            )
+        }
+        await metadataStarted.wait()
+
+        playerService.removeDuplicateQueueEntries()
+
+        #expect(playerService.queueEntryIDs == [activeID])
+        #expect(playerService.currentQueueEntryID == activeID)
+        #expect(playerService.activePlaybackQueueEntryID == activeID)
+        await releaseMetadata.open()
+        await metadataTask.value
+
+        #expect(playerService.currentTrack?.title == "Enriched active")
+        #expect(playerService.queueEntries[0].id == activeID)
+        #expect(playerService.queue[0].title == "Enriched active")
+    }
+
+    private func makePlayerService() -> (PlayerService, MockYTMusicClient) {
+        SingletonPlayerWebView.shared.tearDown()
+        SingletonPlayerWebView.shared.currentVideoId = nil
+        let mockClient = MockYTMusicClient()
+        let playerService = PlayerService()
+        playerService.setSongLikeStatusManager(SongLikeStatusManager())
+        playerService.setYTMusicClient(mockClient)
+        return (playerService, mockClient)
+    }
+
+    private func song(id: String, title: String, videoId: String) -> Song {
+        Song(
+            id: id,
+            title: title,
+            artists: [Artist(id: "artist", name: "Artist")],
+            duration: 180,
+            videoId: videoId,
+            feedbackTokens: .init(add: nil, remove: nil)
+        )
+    }
+}

--- a/Tests/KasetTests/PlayerServiceDeferredQueueWorkTests.swift
+++ b/Tests/KasetTests/PlayerServiceDeferredQueueWorkTests.swift
@@ -1,0 +1,173 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+@Suite("Player service deferred queue work", .serialized, .tags(.service))
+@MainActor
+struct PlayerServiceDeferredQueueWorkTests {
+    @Test("A transport intent does not orphan a committed deferred queue load")
+    func pauseDoesNotOrphanDeferredQueueLoad() async throws {
+        let client = MockYTMusicClient()
+        let playerService = PlayerService()
+        playerService.setYTMusicClient(client)
+        let metadataStarted = AsyncGate()
+        let releaseMetadata = AsyncGate()
+        let song = Song(id: "initial", title: "Initial", artists: [], videoId: "initial")
+        client.songResponses[song.videoId] = song
+        client.beforeGetSongReturn = { _ in
+            await metadataStarted.open()
+            await releaseMetadata.wait()
+        }
+
+        let playTask = Task { @MainActor in
+            await playerService.playQueue(
+                [song],
+                startingAt: 0,
+                deferringSmartShuffleFill: true
+            )
+        }
+        await metadataStarted.wait()
+        await playerService.pause()
+        await releaseMetadata.open()
+        let loadGeneration = try #require(await playTask.value)
+
+        #expect(playerService.isCurrentQueueLoad(loadGeneration))
+        #expect(playerService.isQueueLoading)
+        #expect(playerService.restoredPlaybackSessionOwnerScope != nil)
+
+        await playerService.endQueueLoading(loadGeneration)
+        #expect(!playerService.isQueueLoading)
+    }
+
+    @Test("Playlist continuation cannot append after stop")
+    func continuationCannotAppendAfterStop() async {
+        let context = self.makeDelayedPlaylistContext(id: "stop")
+        let task = PlaylistPlaybackActions.playPlaylist(
+            context.playlist,
+            client: context.client,
+            playerService: context.playerService
+        )
+        await context.continuationStarted.wait()
+
+        await context.playerService.stop()
+        await context.releaseContinuation.open()
+        await task.value
+
+        #expect(context.playerService.queue.map(\.videoId) == ["initial-stop"])
+        #expect(!context.playerService.isQueueLoading)
+    }
+
+    @Test("Playlist continuation cannot repopulate a cleared queue")
+    func continuationCannotAppendAfterClear() async {
+        let context = self.makeDelayedPlaylistContext(id: "clear")
+        let task = PlaylistPlaybackActions.playPlaylist(
+            context.playlist,
+            client: context.client,
+            playerService: context.playerService
+        )
+        await context.continuationStarted.wait()
+
+        await context.playerService.clearQueueEntirely()
+        await context.releaseContinuation.open()
+        await task.value
+
+        #expect(context.playerService.queue.isEmpty)
+        #expect(!context.playerService.isQueueLoading)
+    }
+
+    @Test("Playlist continuation cannot repopulate playback after privacy clearing")
+    func continuationCannotAppendAfterPrivacyClear() async {
+        let context = self.makeDelayedPlaylistContext(id: "privacy")
+        let task = PlaylistPlaybackActions.playPlaylist(
+            context.playlist,
+            client: context.client,
+            playerService: context.playerService
+        )
+        await context.continuationStarted.wait()
+
+        context.playerService.clearPlaybackForSignOut()
+        await context.releaseContinuation.open()
+        await task.value
+
+        #expect(context.playerService.queue.isEmpty)
+        #expect(context.playerService.currentTrack == nil)
+        #expect(!context.playerService.isQueueLoading)
+    }
+
+    @Test("Playlist continuation cannot append into an adopted restored queue")
+    func continuationCannotAppendIntoRestoredQueue() async {
+        let context = self.makeDelayedPlaylistContext(id: "restore")
+        let task = PlaylistPlaybackActions.playPlaylist(
+            context.playlist,
+            client: context.client,
+            playerService: context.playerService
+        )
+        await context.continuationStarted.wait()
+        let restored = Song(
+            id: "restored",
+            title: "Restored",
+            artists: [],
+            duration: 180,
+            videoId: "restored",
+            feedbackTokens: .init(add: nil, remove: nil)
+        )
+
+        context.playerService.applyRestoredPlaybackSession(
+            queue: [restored],
+            currentIndex: 0,
+            progress: 12,
+            duration: 180
+        )
+        await context.releaseContinuation.open()
+        await task.value
+
+        #expect(context.playerService.queue == [restored])
+        #expect(context.playerService.currentTrack == restored)
+        #expect(!context.playerService.isQueueLoading)
+    }
+
+    private func makeDelayedPlaylistContext(id: String) -> Context {
+        let client = MockYTMusicClient()
+        let playerService = PlayerService()
+        let continuationStarted = AsyncGate()
+        let releaseContinuation = AsyncGate()
+        let playlist = TestFixtures.makePlaylist(id: "VL-\(id)", title: id)
+        let initial = Song(
+            id: "initial-\(id)",
+            title: "Initial",
+            artists: [],
+            videoId: "initial-\(id)"
+        )
+        let continuation = Song(
+            id: "continuation-\(id)",
+            title: "Continuation",
+            artists: [],
+            videoId: "continuation-\(id)"
+        )
+        client.playlistDetails[playlist.id] = PlaylistDetail(
+            playlist: playlist,
+            tracks: [initial],
+            duration: nil
+        )
+        client.playlistContinuationTracks[playlist.id] = [[continuation]]
+        client.beforePlaylistContinuationReturn = { _ in
+            await continuationStarted.open()
+            await releaseContinuation.wait()
+        }
+        return Context(
+            client: client,
+            playerService: playerService,
+            playlist: playlist,
+            continuationStarted: continuationStarted,
+            releaseContinuation: releaseContinuation
+        )
+    }
+
+    private struct Context {
+        let client: MockYTMusicClient
+        let playerService: PlayerService
+        let playlist: Playlist
+        let continuationStarted: AsyncGate
+        let releaseContinuation: AsyncGate
+    }
+}

--- a/Tests/KasetTests/PlayerServiceLibraryTests.swift
+++ b/Tests/KasetTests/PlayerServiceLibraryTests.swift
@@ -1,3 +1,5 @@
+// swiftlint:disable file_length
+
 import Foundation
 import Testing
 @testable import Kaset
@@ -5,7 +7,7 @@ import Testing
 /// Tests for PlayerService+Library extension (like/dislike/library actions).
 @Suite(.serialized, .tags(.service))
 @MainActor
-struct PlayerServiceLibraryTests {
+struct PlayerServiceLibraryTests { // swiftlint:disable:this type_body_length
     var playerService: PlayerService
     var mockClient: MockYTMusicClient
     var authService: AuthService
@@ -13,12 +15,13 @@ struct PlayerServiceLibraryTests {
     init() {
         self.mockClient = MockYTMusicClient()
         self.authService = AuthService(webKitManager: MockWebKitManager())
-        self.authService.completeLogin(sapisid: "test-sapisid")
+        self.authService.completeLogin(sapisid: "REDACTED")
         self.playerService = PlayerService()
+        let likeStatusManager = SongLikeStatusManager()
+        likeStatusManager.setActiveAccountID(nil)
+        self.playerService.setSongLikeStatusManager(likeStatusManager)
         self.playerService.setYTMusicClient(self.mockClient)
         self.playerService.setAuthService(self.authService)
-        SongLikeStatusManager.shared.clearCache()
-        SongLikeStatusManager.shared.setActiveAccountID(nil)
     }
 
     // MARK: - Like Current Track Tests
@@ -44,10 +47,9 @@ struct PlayerServiceLibraryTests {
 
         #expect(self.playerService.currentTrackLikeStatus == .like)
 
-        // Wait for the async API call
-        try? await Task.sleep(for: .milliseconds(200))
+        let didCallAPI = await self.waitUntilRateSongCalled()
 
-        #expect(self.mockClient.rateSongCalled == true)
+        #expect(didCallAPI)
         #expect(self.mockClient.rateSongVideoIds.first == "test-video")
         #expect(self.mockClient.rateSongRatings.first == .like)
     }
@@ -61,8 +63,9 @@ struct PlayerServiceLibraryTests {
 
         #expect(self.playerService.currentTrackLikeStatus == .indifferent)
 
-        try? await Task.sleep(for: .milliseconds(200))
+        let didCallAPI = await self.waitUntilRateSongCallCount(1)
 
+        #expect(didCallAPI)
         #expect(self.mockClient.rateSongRatings.first == .indifferent)
     }
 
@@ -75,8 +78,9 @@ struct PlayerServiceLibraryTests {
 
         #expect(self.playerService.currentTrackLikeStatus == .like)
 
-        try? await Task.sleep(for: .milliseconds(200))
+        let didCallAPI = await self.waitUntilRateSongCallCount(1)
 
+        #expect(didCallAPI)
         #expect(self.mockClient.rateSongRatings.first == .like)
     }
 
@@ -115,20 +119,73 @@ struct PlayerServiceLibraryTests {
         #expect(self.playerService.currentTrackLikeStatus == .indifferent)
     }
 
+    @Test("A delayed like completion cannot overwrite a newer dislike")
+    func latestRatingOperationWins() async {
+        let song = TestFixtures.makeSong(id: "latest-rating")
+        self.playerService.currentTrack = song
+        self.playerService.currentTrackLikeStatus = .indifferent
+        self.mockClient.rateSongDelay = .milliseconds(200)
+
+        self.playerService.likeCurrentTrack()
+        try? await Task.sleep(for: .milliseconds(25))
+        self.mockClient.rateSongDelay = nil
+        self.playerService.dislikeCurrentTrack()
+        _ = await self.waitUntilRateSongCallCount(2)
+
+        #expect(self.playerService.currentTrackLikeStatus == .dislike)
+        #expect(self.mockClient.rateSongRatings == [.like, .dislike])
+    }
+
+    @Test("Stale metadata cannot overwrite a newer rating")
+    func staleMetadataPreservesNewerRating() async {
+        let song = TestFixtures.makeSong(id: "metadata-rating")
+        self.playerService.currentTrack = song
+        self.playerService.currentTrackLikeStatus = .indifferent
+        let metadataStarted = AsyncGate()
+        let releaseMetadata = AsyncGate()
+        self.mockClient.songResponses[song.videoId] = Song(
+            id: song.id,
+            title: song.title,
+            artists: song.artists,
+            videoId: song.videoId,
+            likeStatus: .indifferent
+        )
+        self.mockClient.beforeGetSongReturn = { _ in
+            await metadataStarted.open()
+            await releaseMetadata.wait()
+        }
+
+        let metadataTask = Task { @MainActor in
+            await self.playerService.fetchSongMetadata(videoId: song.videoId, queueOwner: .none)
+        }
+        await metadataStarted.wait()
+        self.playerService.likeCurrentTrack()
+        let clock = ContinuousClock()
+        let deadline = clock.now + .seconds(1)
+        while !self.mockClient.rateSongCalled, clock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        await releaseMetadata.open()
+        await metadataTask.value
+
+        #expect(self.playerService.currentTrackLikeStatus == .like)
+    }
+
     @Test("likeCurrentTrack uses captured client even if singleton client changes before task runs")
     func likeCurrentTrackUsesCapturedClient() async {
         let replacementClient = MockYTMusicClient()
-        let originalClient = SongLikeStatusManager.shared.currentClient
-        defer { SongLikeStatusManager.shared.setClient(originalClient) }
+        let originalClient = self.playerService.songLikeStatusManager.currentClient
+        defer { self.playerService.songLikeStatusManager.setClient(originalClient) }
 
         self.playerService.currentTrack = TestFixtures.makeSong(id: "test-video")
         self.playerService.currentTrackLikeStatus = .like
 
         self.playerService.likeCurrentTrack()
-        SongLikeStatusManager.shared.setClient(replacementClient)
+        self.playerService.songLikeStatusManager.setClient(replacementClient)
 
-        try? await Task.sleep(for: .milliseconds(200))
+        let didCallAPI = await self.waitUntilRateSongCallCount(1)
 
+        #expect(didCallAPI)
         #expect(self.mockClient.rateSongRatings.first == .indifferent)
         #expect(replacementClient.rateSongCalled == false)
     }
@@ -171,9 +228,9 @@ struct PlayerServiceLibraryTests {
 
         #expect(self.playerService.currentTrackLikeStatus == .dislike)
 
-        try? await Task.sleep(for: .milliseconds(200))
+        let didCallAPI = await self.waitUntilRateSongCallCount(1)
 
-        #expect(self.mockClient.rateSongCalled == true)
+        #expect(didCallAPI)
         #expect(self.mockClient.rateSongRatings.first == .dislike)
     }
 
@@ -186,8 +243,9 @@ struct PlayerServiceLibraryTests {
 
         #expect(self.playerService.currentTrackLikeStatus == .indifferent)
 
-        try? await Task.sleep(for: .milliseconds(200))
+        let didCallAPI = await self.waitUntilRateSongCallCount(1)
 
+        #expect(didCallAPI)
         #expect(self.mockClient.rateSongRatings.first == .indifferent)
     }
 
@@ -200,8 +258,9 @@ struct PlayerServiceLibraryTests {
 
         #expect(self.playerService.currentTrackLikeStatus == .dislike)
 
-        try? await Task.sleep(for: .milliseconds(200))
+        let didCallAPI = await self.waitUntilRateSongCallCount(1)
 
+        #expect(didCallAPI)
         #expect(self.mockClient.rateSongRatings.first == .dislike)
     }
 
@@ -308,9 +367,9 @@ struct PlayerServiceLibraryTests {
 
         #expect(self.playerService.currentTrackInLibrary == true)
 
-        try? await Task.sleep(for: .milliseconds(100))
+        let didCallAPI = await self.waitUntilLibraryEditCallCount(1)
 
-        #expect(self.mockClient.editSongLibraryStatusCalled == true)
+        #expect(didCallAPI)
         #expect(self.mockClient.editSongLibraryStatusTokens.first?.first == "add-token")
     }
 
@@ -324,10 +383,156 @@ struct PlayerServiceLibraryTests {
 
         #expect(self.playerService.currentTrackInLibrary == false)
 
-        try? await Task.sleep(for: .milliseconds(100))
+        let didCallAPI = await self.waitUntilLibraryEditCallCount(1)
 
-        #expect(self.mockClient.editSongLibraryStatusCalled == true)
+        #expect(didCallAPI)
         #expect(self.mockClient.editSongLibraryStatusTokens.first?.first == "remove-token")
+    }
+
+    @Test("Library toggle updates the complete owning queue entry")
+    func libraryToggleUpdatesOwningQueueEntry() async {
+        let song = Song(
+            id: "queue-library",
+            title: "Queue Library",
+            artists: [Artist(id: "artist", name: "Artist")],
+            thumbnailURL: URL(string: "https://example.com/art.jpg"),
+            videoId: "queue-library",
+            isInLibrary: false,
+            feedbackTokens: FeedbackTokens(add: "add-token", remove: "remove-token")
+        )
+        await self.playerService.playQueue([song], startingAt: 0)
+
+        self.playerService.toggleLibraryStatus()
+
+        #expect(self.playerService.queue[0].isInLibrary == true)
+        #expect(self.playerService.queue[0].feedbackTokens == FeedbackTokens(
+            add: "remove-token",
+            remove: "add-token"
+        ))
+    }
+
+    @Test("Library state stays synchronized across duplicate video occurrences")
+    func libraryStateSynchronizesAcrossDuplicateOccurrences() async {
+        let oldTokens = FeedbackTokens(add: "duplicate-old-add", remove: "duplicate-old-remove")
+        let authoritativeTokens = FeedbackTokens(add: "duplicate-new-add", remove: "duplicate-new-remove")
+        let first = Song(
+            id: "duplicate-first",
+            title: "First Duplicate",
+            artists: [],
+            videoId: "duplicate-library-video",
+            isInLibrary: false,
+            feedbackTokens: oldTokens
+        )
+        let second = Song(
+            id: "duplicate-second",
+            title: "Second Duplicate",
+            artists: [],
+            videoId: "duplicate-library-video",
+            isInLibrary: false,
+            feedbackTokens: oldTokens
+        )
+        self.mockClient.songResponses[first.videoId] = Song(
+            id: first.id,
+            title: first.title,
+            artists: first.artists,
+            videoId: first.videoId,
+            isInLibrary: true,
+            feedbackTokens: authoritativeTokens
+        )
+        await self.playerService.playQueue([first, second], startingAt: 0)
+
+        await self.playerService.fetchSongMetadata(videoId: first.videoId)
+
+        #expect(self.playerService.queue.allSatisfy { $0.isInLibrary == true })
+        #expect(self.playerService.queue.allSatisfy { $0.feedbackTokens == authoritativeTokens })
+        let metadataCallCount = self.mockClient.getSongVideoIds.count
+        await self.playerService.playFromQueue(at: 1)
+        #expect(self.mockClient.getSongVideoIds.count == metadataCallCount)
+        #expect(self.playerService.currentTrackInLibrary)
+        #expect(self.playerService.currentTrackFeedbackTokens == authoritativeTokens)
+
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        self.mockClient.beforeEditSongLibraryStatusReturn = { _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+        self.playerService.toggleLibraryStatus()
+        await requestStarted.wait()
+        #expect(self.playerService.queue.allSatisfy { $0.isInLibrary == false })
+
+        self.mockClient.shouldThrowError = YTMusicError.networkError(
+            underlying: URLError(.notConnectedToInternet)
+        )
+        await releaseRequest.open()
+        for _ in 0 ..< 100 where !self.playerService.currentTrackInLibrary {
+            await Task.yield()
+        }
+
+        #expect(self.playerService.currentTrackInLibrary)
+        #expect(self.playerService.currentTrackFeedbackTokens == authoritativeTokens)
+        #expect(self.playerService.queue.allSatisfy { $0.isInLibrary == true })
+        #expect(self.playerService.queue.allSatisfy { $0.feedbackTokens == authoritativeTokens })
+    }
+
+    @Test("A delayed library toggle cannot overwrite a newer toggle")
+    func latestLibraryToggleWins() async {
+        self.playerService.currentTrack = TestFixtures.makeSong(id: "latest-library")
+        self.playerService.currentTrackInLibrary = false
+        self.playerService.currentTrackFeedbackTokens = FeedbackTokens(
+            add: "add-token",
+            remove: "remove-token"
+        )
+        self.mockClient.editSongLibraryStatusResponseDelays = [
+            .milliseconds(200),
+            .zero,
+        ]
+
+        self.playerService.toggleLibraryStatus()
+        self.playerService.toggleLibraryStatus()
+        let mutationKey = self.playerService.songLikeStatusManager.activeAccountID
+            + "\u{0}latest-library"
+        let latestRevision = self.playerService.libraryMutationRevisionCounter
+        #expect(self.playerService.libraryMutationTailGenerations[mutationKey] == latestRevision)
+        #expect(self.playerService.libraryMutationTails[mutationKey] != nil)
+
+        let didFinish = await self.waitUntil {
+            self.mockClient.editSongLibraryStatusTokens.count == 2
+                && self.playerService.libraryMutationTails[mutationKey] == nil
+                && !self.playerService.currentTrackInLibrary
+        }
+
+        #expect(didFinish)
+        #expect(!self.playerService.currentTrackInLibrary)
+        #expect(self.playerService.currentTrack?.isInLibrary == false)
+        #expect(self.mockClient.editSongLibraryStatusTokens.count == 2)
+    }
+
+    @Test("Overlapping failed library toggles restore the confirmed baseline")
+    func overlappingLibraryFailuresRestoreConfirmedState() async {
+        let originalTokens = FeedbackTokens(add: "add-token", remove: "remove-token")
+        self.playerService.currentTrack = Song(
+            id: "failed-library-chain",
+            title: "Failed Library Chain",
+            artists: [],
+            videoId: "failed-library-chain",
+            isInLibrary: false,
+            feedbackTokens: originalTokens
+        )
+        self.playerService.currentTrackInLibrary = false
+        self.playerService.currentTrackFeedbackTokens = originalTokens
+        self.mockClient.editSongLibraryStatusResponseDelays = [.milliseconds(200), .zero]
+        self.mockClient.shouldThrowError = YTMusicError.networkError(
+            underlying: URLError(.notConnectedToInternet)
+        )
+
+        self.playerService.toggleLibraryStatus()
+        self.playerService.toggleLibraryStatus()
+        try? await Task.sleep(for: .milliseconds(350))
+
+        #expect(!self.playerService.currentTrackInLibrary)
+        #expect(self.playerService.currentTrackFeedbackTokens == originalTokens)
+        #expect(self.playerService.currentTrack?.isInLibrary == false)
     }
 
     @Test("toggleLibraryStatus reverts on API failure")
@@ -341,9 +546,197 @@ struct PlayerServiceLibraryTests {
 
         #expect(self.playerService.currentTrackInLibrary == true)
 
-        try? await Task.sleep(for: .milliseconds(100))
+        let didRevert = await self.waitUntil {
+            self.playerService.currentTrackInLibrary == false
+        }
 
+        #expect(didRevert)
         #expect(self.playerService.currentTrackInLibrary == false)
+    }
+
+    @Test("Failed library mutation restores its original queue entry after track change")
+    func failedLibraryMutationRestoresOriginalQueueEntry() async {
+        let first = Song(
+            id: "rollback-first",
+            title: "First",
+            artists: [],
+            videoId: "rollback-first",
+            isInLibrary: false,
+            feedbackTokens: FeedbackTokens(add: "add-token", remove: "remove-token")
+        )
+        let second = TestFixtures.makeSong(id: "rollback-second")
+        await self.playerService.playQueue([first, second], startingAt: 0)
+        let firstEntryID = self.playerService.queueEntryIDs[0]
+        self.mockClient.editSongLibraryStatusResponseDelays = [.milliseconds(200)]
+        self.mockClient.shouldThrowError = YTMusicError.networkError(
+            underlying: URLError(.notConnectedToInternet)
+        )
+
+        self.playerService.toggleLibraryStatus()
+        await self.playerService.playFromQueue(at: 1)
+        let didRestore = await self.waitUntil {
+            self.playerService.queueEntries.first(where: { $0.id == firstEntryID })?.song.isInLibrary == false
+                && self.playerService.queueEntries.first(where: { $0.id == firstEntryID })?.song.feedbackTokens == first.feedbackTokens
+        }
+
+        let restoredEntry = self.playerService.queueEntries.first(where: { $0.id == firstEntryID })
+        #expect(didRestore)
+        #expect(restoredEntry?.song.isInLibrary == false)
+        #expect(restoredEntry?.song.feedbackTokens == first.feedbackTokens)
+        #expect(self.playerService.currentTrack?.videoId == second.videoId)
+    }
+
+    @Test("A stale library completion cannot repopulate confirmed state after an identity switch")
+    func staleLibraryCompletionCannotRepopulateConfirmedStateAfterIdentitySwitch() async {
+        let song = Song(
+            id: "stale-library-session",
+            title: "Stale Library Session",
+            artists: [Artist(id: "artist", name: "Artist")],
+            videoId: "stale-library-session",
+            isInLibrary: false,
+            feedbackTokens: FeedbackTokens(add: "old-add-token", remove: "old-remove-token")
+        )
+        self.playerService.currentTrack = song
+        self.playerService.currentTrackInLibrary = false
+        self.playerService.currentTrackFeedbackTokens = song.feedbackTokens
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        self.mockClient.beforeEditSongLibraryStatusReturn = { _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+
+        self.playerService.toggleLibraryStatus()
+        await requestStarted.wait()
+        #expect(!self.playerService.confirmedLibraryStateByKey.isEmpty)
+
+        self.playerService.reloadCurrentTrackForIdentitySwitch()
+        #expect(self.playerService.confirmedLibraryStateByKey.isEmpty)
+        await releaseRequest.open()
+        for _ in 0 ..< 20 where self.mockClient.appliedEditSongLibraryStatusTokens.isEmpty {
+            await Task.yield()
+        }
+        for _ in 0 ..< 20 {
+            await Task.yield()
+        }
+
+        #expect(self.mockClient.appliedEditSongLibraryStatusTokens == [["old-add-token"]])
+        #expect(self.playerService.confirmedLibraryStateByKey.isEmpty)
+    }
+
+    @Test("Metadata cannot replace rollback state while a library mutation is pending")
+    func metadataCannotReplacePendingLibraryMutationBaseline() async {
+        let originalTokens = FeedbackTokens(add: "fresh-add", remove: "fresh-remove")
+        let optimisticTokens = FeedbackTokens(add: "fresh-remove", remove: "fresh-add")
+        let staleTokens = FeedbackTokens(add: "stale-add", remove: "stale-remove")
+        let song = Song(
+            id: "pending-library-metadata",
+            title: "Pending Library Metadata",
+            artists: [Artist(id: "artist", name: "Artist")],
+            videoId: "pending-library-metadata",
+            isInLibrary: true,
+            feedbackTokens: originalTokens
+        )
+        await self.playerService.playQueue([song], startingAt: 0)
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        self.mockClient.beforeEditSongLibraryStatusReturn = { _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+        self.mockClient.songResponses[song.videoId] = Song(
+            id: song.id,
+            title: song.title,
+            artists: song.artists,
+            videoId: song.videoId,
+            isInLibrary: false,
+            feedbackTokens: staleTokens
+        )
+
+        self.playerService.toggleLibraryStatus()
+        await requestStarted.wait()
+        #expect(!self.playerService.currentTrackInLibrary)
+        #expect(self.playerService.currentTrackFeedbackTokens == optimisticTokens)
+
+        await self.playerService.fetchSongMetadata(videoId: song.videoId)
+        #expect(!self.playerService.currentTrackInLibrary)
+        #expect(self.playerService.currentTrackFeedbackTokens == optimisticTokens)
+        #expect(self.playerService.queue[0].feedbackTokens == optimisticTokens)
+
+        self.mockClient.shouldThrowError = YTMusicError.networkError(
+            underlying: URLError(.notConnectedToInternet)
+        )
+        await releaseRequest.open()
+        for _ in 0 ..< 100 where !self.playerService.currentTrackInLibrary {
+            await Task.yield()
+        }
+
+        #expect(self.playerService.currentTrackInLibrary)
+        #expect(self.playerService.currentTrackFeedbackTokens == originalTokens)
+        #expect(self.playerService.queue[0].isInLibrary == true)
+        #expect(self.playerService.queue[0].feedbackTokens == originalTokens)
+    }
+
+    @Test("Successful library refresh preserves server tokens and rollback baseline")
+    func successfulLibraryRefreshPreservesServerTokensAndRollbackBaseline() async {
+        let song = Song(
+            id: "rotated-library-token",
+            title: "Rotated Library Token",
+            artists: [Artist(id: "artist", name: "Artist")],
+            videoId: "rotated-library-token",
+            isInLibrary: false,
+            feedbackTokens: FeedbackTokens(add: "old-add", remove: "old-remove")
+        )
+        let serverTokens = FeedbackTokens(add: "server-add-v2", remove: "server-remove-v2")
+        self.mockClient.songResponses[song.videoId] = Song(
+            id: song.id,
+            title: song.title,
+            artists: song.artists,
+            videoId: song.videoId,
+            isInLibrary: true,
+            feedbackTokens: serverTokens
+        )
+        await self.playerService.playQueue([song], startingAt: 0)
+        let refreshStarted = AsyncGate()
+        let releaseRefresh = AsyncGate()
+        self.mockClient.beforeGetSongReturn = { _ in
+            await refreshStarted.open()
+            await releaseRefresh.wait()
+        }
+
+        self.playerService.toggleLibraryStatus()
+        await refreshStarted.wait()
+        await releaseRefresh.open()
+        for _ in 0 ..< 100 where self.playerService.currentTrackFeedbackTokens != serverTokens {
+            await Task.yield()
+        }
+
+        let mutationKey = self.playerService.songLikeStatusManager.activeAccountID
+            + "\u{0}" + song.videoId
+        #expect(self.playerService.currentTrackInLibrary)
+        #expect(self.playerService.currentTrackFeedbackTokens == serverTokens)
+        #expect(self.playerService.currentTrack?.feedbackTokens == serverTokens)
+        #expect(self.playerService.queue[0].feedbackTokens == serverTokens)
+        #expect(self.playerService.confirmedLibraryStateByKey[mutationKey] == MusicLibraryConfirmedState(
+            isInLibrary: true,
+            feedbackTokens: serverTokens
+        ))
+
+        self.mockClient.beforeGetSongReturn = nil
+        self.mockClient.shouldThrowError = YTMusicError.networkError(
+            underlying: URLError(.notConnectedToInternet)
+        )
+        self.playerService.toggleLibraryStatus()
+        let didSubmitRemoval = await self.waitUntilLibraryEditCallCount(2)
+        for _ in 0 ..< 100 where !self.playerService.currentTrackInLibrary {
+            await Task.yield()
+        }
+
+        #expect(didSubmitRemoval)
+        #expect(self.mockClient.editSongLibraryStatusTokens.last == ["server-remove-v2"])
+        #expect(self.playerService.currentTrackInLibrary)
+        #expect(self.playerService.currentTrackFeedbackTokens == serverTokens)
+        #expect(self.playerService.queue[0].feedbackTokens == serverTokens)
     }
 
     @Test("toggleLibraryStatus preserves optimistic add when metadata refresh is stale")
@@ -396,6 +789,57 @@ struct PlayerServiceLibraryTests {
         #expect(self.playerService.currentTrackFeedbackTokens == FeedbackTokens(add: "remove-token", remove: "add-token"))
     }
 
+    @Test("A stale account owner cannot create a captured queue playlist")
+    func staleAccountOwnerCannotCreateCapturedQueuePlaylist() async {
+        let songs = [TestFixtures.makeSong(id: "stale-playlist-owner")]
+        let owner = self.playerService.currentAccountMutationOwner
+        self.playerService.songLikeStatusManager.setActiveAccountID("brand-account")
+
+        await #expect(throws: CancellationError.self) {
+            _ = try await self.playerService.saveQueueAsPlaylist(
+                title: "Stale Snapshot",
+                songs: songs,
+                owner: owner
+            )
+        }
+
+        #expect(self.mockClient.createPlaylistCalls.isEmpty)
+    }
+
+    @Test("An account switch during playlist reconciliation removes the stale optimistic playlist")
+    func accountSwitchDuringPlaylistReconciliationRemovesOptimisticPlaylist() async {
+        let libraryViewModel = LibraryViewModel(client: self.mockClient)
+        let songs = [TestFixtures.makeSong(id: "reconcile-account-switch")]
+        let owner = self.playerService.currentAccountMutationOwner
+        self.mockClient.shouldWaitForLibraryContentResponse = true
+
+        var saveTask: Task<Playlist, any Error>!
+        await withCheckedContinuation { continuation in
+            self.mockClient.onGetLibraryContent = {
+                self.mockClient.onGetLibraryContent = nil
+                continuation.resume()
+            }
+            saveTask = Task { @MainActor in
+                try await self.playerService.saveQueueAsPlaylist(
+                    title: "Old Account Playlist",
+                    songs: songs,
+                    owner: owner
+                )
+            }
+        }
+
+        #expect(libraryViewModel.isInLibrary(playlistId: "PLCREATED"))
+        self.playerService.songLikeStatusManager.setActiveAccountID("brand-account")
+        self.mockClient.shouldWaitForLibraryContentResponse = false
+        self.mockClient.resumeNextLibraryContentResponse()
+
+        await #expect(throws: CancellationError.self) {
+            _ = try await saveTask.value
+        }
+        #expect(!libraryViewModel.isInLibrary(playlistId: "PLCREATED"))
+        #expect(!libraryViewModel.playlists.contains { $0.id == "PLCREATED" })
+    }
+
     // MARK: - Update Like Status Tests
 
     @Test("updateLikeStatus updates status")
@@ -412,12 +856,46 @@ struct PlayerServiceLibraryTests {
         #expect(self.playerService.currentTrackLikeStatus == .indifferent)
     }
 
+    @Test("Account metadata refresh updates a complete owning queue entry")
+    func metadataRefreshUpdatesCompleteQueueAccountFields() async {
+        let song = Song(
+            id: "account-metadata",
+            title: "Complete",
+            artists: [Artist(id: "artist", name: "Artist")],
+            thumbnailURL: URL(string: "https://example.com/complete.jpg"),
+            videoId: "account-metadata",
+            likeStatus: .like,
+            isInLibrary: true,
+            feedbackTokens: FeedbackTokens(add: "old-add", remove: "old-remove")
+        )
+        self.mockClient.songResponses[song.videoId] = Song(
+            id: song.id,
+            title: song.title,
+            artists: song.artists,
+            thumbnailURL: song.thumbnailURL,
+            videoId: song.videoId,
+            likeStatus: .dislike,
+            isInLibrary: false,
+            feedbackTokens: FeedbackTokens(add: "new-add", remove: "new-remove")
+        )
+        await self.playerService.playQueue([song], startingAt: 0)
+
+        await self.playerService.fetchSongMetadata(videoId: song.videoId)
+
+        #expect(self.playerService.queue[0].likeStatus == .dislike)
+        #expect(self.playerService.queue[0].isInLibrary == false)
+        #expect(self.playerService.queue[0].feedbackTokens == FeedbackTokens(
+            add: "new-add",
+            remove: "new-remove"
+        ))
+    }
+
     @Test("fetchSongMetadata preserves cached like status when API like status is unknown")
     func fetchSongMetadataPreservesCachedLikeStatusWhenAPILikeStatusIsUnknown() async {
         let song = TestFixtures.makeSong(id: "test-video")
         self.playerService.currentTrack = song
         self.playerService.currentTrackLikeStatus = .like
-        SongLikeStatusManager.shared.setStatus(.like, for: song.videoId)
+        self.playerService.songLikeStatusManager.setStatus(.like, for: song.videoId)
         self.mockClient.songResponses[song.videoId] = Song(
             id: song.videoId,
             title: "Fetched Song",
@@ -428,7 +906,7 @@ struct PlayerServiceLibraryTests {
 
         await self.playerService.fetchSongMetadata(videoId: song.videoId)
 
-        #expect(SongLikeStatusManager.shared.status(for: song.videoId) == .like)
+        #expect(self.playerService.songLikeStatusManager.status(for: song.videoId) == .like)
         #expect(self.playerService.currentTrackLikeStatus == .like)
         #expect(self.playerService.currentTrack?.likeStatus == .like)
     }
@@ -446,6 +924,61 @@ struct PlayerServiceLibraryTests {
         #expect(self.playerService.currentTrackLikeStatus == .indifferent)
         #expect(self.playerService.currentTrackInLibrary == false)
         #expect(self.playerService.currentTrackFeedbackTokens == nil)
+    }
+
+    private func waitUntil(
+        attempts: Int = 1000,
+        pollInterval: Duration = .milliseconds(10),
+        condition: () -> Bool
+    ) async -> Bool {
+        for _ in 0 ..< attempts {
+            if condition() {
+                return true
+            }
+            try? await Task.sleep(for: pollInterval)
+        }
+        return false
+    }
+
+    private func waitUntilRateSongCallCount(
+        _ expectedCount: Int,
+        attempts: Int = 1000,
+        pollInterval: Duration = .milliseconds(10)
+    ) async -> Bool {
+        for _ in 0 ..< attempts {
+            if self.mockClient.rateSongRatings.count >= expectedCount {
+                return true
+            }
+            try? await Task.sleep(for: pollInterval)
+        }
+        return false
+    }
+
+    private func waitUntilLibraryEditCallCount(
+        _ expectedCount: Int,
+        attempts: Int = 1000,
+        pollInterval: Duration = .milliseconds(10)
+    ) async -> Bool {
+        for _ in 0 ..< attempts {
+            if self.mockClient.editSongLibraryStatusTokens.count >= expectedCount {
+                return true
+            }
+            try? await Task.sleep(for: pollInterval)
+        }
+        return false
+    }
+
+    private func waitUntilRateSongCalled(
+        attempts: Int = 1000,
+        pollInterval: Duration = .milliseconds(10)
+    ) async -> Bool {
+        for _ in 0 ..< attempts {
+            if self.mockClient.rateSongCalled {
+                return true
+            }
+            try? await Task.sleep(for: pollInterval)
+        }
+        return false
     }
 
     private func waitUntilLikeStatus(

--- a/Tests/KasetTests/PlayerServiceLibraryTests.swift
+++ b/Tests/KasetTests/PlayerServiceLibraryTests.swift
@@ -111,7 +111,7 @@ struct PlayerServiceLibraryTests { // swiftlint:disable:this type_body_length
         let song = TestFixtures.makeSong(id: "stale-like-cache-video")
         self.playerService.currentTrack = song
         self.playerService.currentTrackLikeStatus = .indifferent
-        self.playerService.songLikeStatusManager.setStatus(.like, for: song.videoId)
+        self.playerService.songLikeStatusManager.setCachedStatus(.like, for: song.videoId)
         self.mockClient.shouldThrowError = YTMusicError.networkError(underlying: URLError(.notConnectedToInternet))
 
         self.playerService.likeCurrentTrack()
@@ -451,8 +451,8 @@ struct PlayerServiceLibraryTests { // swiftlint:disable:this type_body_length
 
         #expect(self.playerService.queue[0].isInLibrary == true)
         #expect(self.playerService.queue[0].feedbackTokens == FeedbackTokens(
-            add: "remove-token",
-            remove: "add-token"
+            add: "add-token",
+            remove: "remove-token"
         ))
     }
 
@@ -672,7 +672,7 @@ struct PlayerServiceLibraryTests { // swiftlint:disable:this type_body_length
     @Test("Metadata cannot replace rollback state while a library mutation is pending")
     func metadataCannotReplacePendingLibraryMutationBaseline() async {
         let originalTokens = FeedbackTokens(add: "fresh-add", remove: "fresh-remove")
-        let optimisticTokens = FeedbackTokens(add: "fresh-remove", remove: "fresh-add")
+        let optimisticTokens = originalTokens
         let staleTokens = FeedbackTokens(add: "stale-add", remove: "stale-remove")
         let song = Song(
             id: "pending-library-metadata",
@@ -806,7 +806,7 @@ struct PlayerServiceLibraryTests { // swiftlint:disable:this type_body_length
 
         #expect(self.playerService.currentTrackInLibrary == true)
         #expect(self.playerService.currentTrack?.isInLibrary == true)
-        #expect(self.playerService.currentTrackFeedbackTokens == FeedbackTokens(add: "remove-token", remove: "add-token"))
+        #expect(self.playerService.currentTrackFeedbackTokens == FeedbackTokens(add: "add-token", remove: "remove-token"))
     }
 
     @Test("toggleLibraryStatus preserves optimistic removal when metadata refresh is stale")
@@ -831,7 +831,7 @@ struct PlayerServiceLibraryTests { // swiftlint:disable:this type_body_length
 
         #expect(self.playerService.currentTrackInLibrary == false)
         #expect(self.playerService.currentTrack?.isInLibrary == false)
-        #expect(self.playerService.currentTrackFeedbackTokens == FeedbackTokens(add: "remove-token", remove: "add-token"))
+        #expect(self.playerService.currentTrackFeedbackTokens == FeedbackTokens(add: "add-token", remove: "remove-token"))
     }
 
     @Test("A stale account owner cannot create a captured queue playlist")
@@ -969,6 +969,133 @@ struct PlayerServiceLibraryTests { // swiftlint:disable:this type_body_length
         #expect(self.playerService.currentTrackLikeStatus == .indifferent)
         #expect(self.playerService.currentTrackInLibrary == false)
         #expect(self.playerService.currentTrackFeedbackTokens == nil)
+    }
+
+    @Test("A failed newer rating rolls back to a successful predecessor")
+    func failedNewerRatingRollsBackToSuccessfulPredecessor() async {
+        let song = TestFixtures.makeSong(id: "rating-success-then-failure")
+        let failure = YTMusicError.networkError(
+            underlying: URLError(.notConnectedToInternet)
+        )
+        self.playerService.currentTrack = song
+        self.playerService.currentTrackLikeStatus = .indifferent
+        self.mockClient.rateSongDelay = .milliseconds(150)
+        self.mockClient.rateSongErrors = [nil, failure]
+
+        self.playerService.likeCurrentTrack()
+        let didStartLike = await self.waitUntilRateSongCallCount(1)
+        #expect(didStartLike)
+
+        self.mockClient.rateSongDelay = nil
+        self.playerService.dislikeCurrentTrack()
+        let didAttemptDislike = await self.waitUntilRateSongCallCount(2)
+        #expect(didAttemptDislike)
+        let didRollbackToLike = await self.waitUntilLikeStatus(.like)
+        #expect(didRollbackToLike)
+        #expect(self.mockClient.appliedRateSongRatings == [.like])
+    }
+
+    @Test("A failed newer library toggle rolls back to a successful predecessor")
+    func failedNewerLibraryToggleRollsBackToSuccessfulPredecessor() async {
+        let failure = YTMusicError.networkError(
+            underlying: URLError(.notConnectedToInternet)
+        )
+        let tokens = FeedbackTokens(add: "add-token", remove: "remove-token")
+        let song = Song(
+            id: "library-success-then-failure",
+            title: "Library Success Then Failure",
+            artists: [],
+            videoId: "library-success-then-failure",
+            isInLibrary: false,
+            feedbackTokens: tokens
+        )
+        self.playerService.currentTrack = song
+        self.playerService.currentTrackInLibrary = false
+        self.playerService.currentTrackFeedbackTokens = tokens
+        self.mockClient.editSongLibraryStatusResponseDelays = [.milliseconds(150), .zero]
+        self.mockClient.editSongLibraryStatusErrors = [nil, failure]
+
+        self.playerService.toggleLibraryStatus()
+        let didStartAdd = await self.waitUntilLibraryEditCallCount(1)
+        #expect(didStartAdd)
+
+        self.playerService.toggleLibraryStatus()
+        let didAttemptRemove = await self.waitUntilLibraryEditCallCount(2)
+        #expect(didAttemptRemove)
+        let didRollbackToAdded = await self.waitUntil {
+            self.playerService.currentTrackInLibrary
+        }
+        #expect(didRollbackToAdded)
+        #expect(self.playerService.currentTrackFeedbackTokens == tokens)
+        #expect(self.mockClient.appliedEditSongLibraryStatusTokens == [["add-token"]])
+    }
+
+    @Test("Rapid rating submissions preserve user action order")
+    func rapidRatingSubmissionsPreserveOrder() async {
+        let song = TestFixtures.makeSong(id: "rapid-rating-order")
+        self.playerService.currentTrack = song
+        self.playerService.currentTrackLikeStatus = .indifferent
+
+        self.playerService.likeCurrentTrack()
+        self.playerService.dislikeCurrentTrack()
+
+        let didSubmitBoth = await self.waitUntilRateSongCallCount(2)
+        #expect(didSubmitBoth)
+        let didApplyBoth = await self.waitUntil {
+            self.mockClient.appliedRateSongRatings.count == 2
+        }
+        #expect(didApplyBoth)
+        let didSettle = await self.waitUntilLikeStatus(.dislike)
+        #expect(didSettle)
+        #expect(self.mockClient.rateSongRatings == [.like, .dislike])
+        #expect(self.mockClient.appliedRateSongRatings == [.like, .dislike])
+    }
+
+    @Test("Rapid rating failures preserve the API-confirmed baseline")
+    func rapidRatingFailuresPreserveConfirmedBaseline() async {
+        let song = TestFixtures.makeSong(id: "rapid-rating-baseline")
+        self.playerService.currentTrack = song
+        self.playerService.currentTrackLikeStatus = .indifferent
+        self.mockClient.rateSongDelay = .milliseconds(200)
+        self.mockClient.shouldThrowError = YTMusicError.networkError(
+            underlying: URLError(.notConnectedToInternet)
+        )
+
+        self.playerService.likeCurrentTrack()
+        let didStartLike = await self.waitUntilRateSongCallCount(1)
+        #expect(didStartLike)
+
+        self.mockClient.rateSongDelay = nil
+        self.playerService.dislikeCurrentTrack()
+        let didAttemptDislike = await self.waitUntilRateSongCallCount(2)
+        #expect(didAttemptDislike)
+        let didRollback = await self.waitUntilLikeStatus(.indifferent)
+        #expect(didRollback)
+    }
+
+    @Test("Rapid add/remove uses the action token for each requested state")
+    func rapidLibraryToggleUsesDistinctActionTokens() async {
+        let song = Song(
+            id: "rapid-library-token",
+            title: "Rapid Library Token",
+            artists: [],
+            videoId: "rapid-library-token",
+            isInLibrary: false,
+            feedbackTokens: FeedbackTokens(add: "add-token", remove: "remove-token")
+        )
+        self.playerService.currentTrack = song
+        self.playerService.currentTrackInLibrary = false
+        self.playerService.currentTrackFeedbackTokens = song.feedbackTokens
+
+        self.playerService.toggleLibraryStatus()
+        self.playerService.toggleLibraryStatus()
+
+        let didCallTwice = await self.waitUntilLibraryEditCallCount(2)
+        #expect(didCallTwice)
+        #expect(self.mockClient.editSongLibraryStatusTokens == [
+            ["add-token"],
+            ["remove-token"],
+        ])
     }
 
     private func waitUntil(

--- a/Tests/KasetTests/PlayerServicePlaybackIntentTests.swift
+++ b/Tests/KasetTests/PlayerServicePlaybackIntentTests.swift
@@ -950,6 +950,65 @@ struct PlayerServicePlaybackIntentTests { // swiftlint:disable:this type_body_le
         #expect(mockClient.getMixQueueContinuationCallCount == 1)
     }
 
+    @Test("Queue-only intents accept an already-admitted terminal callback")
+    func priorIntentTerminalCallbackRemainsAccepted() {
+        let playerService = PlayerService()
+        let admittedIntent = playerService.beginMusicPlaybackIntent(
+            issuedAtMilliseconds: 1000
+        )
+        let queueOnlyIntent = playerService.beginMusicPlaybackIntent(
+            issuedAtMilliseconds: 2000,
+            allowsPriorTerminalEvent: true
+        )
+
+        #expect(playerService.currentMusicPlaybackIntent == queueOnlyIntent)
+        #expect(playerService.acceptsMusicTerminalBridgeEvent(
+            intent: admittedIntent,
+            eventIssuedAtMilliseconds: 1500
+        ))
+    }
+
+    @Test("Consecutive queue-only intents preserve terminal callback admission")
+    func consecutiveQueueOnlyIntentsPreserveTerminalCallbackAdmission() {
+        let playerService = PlayerService()
+        let admittedIntent = playerService.beginMusicPlaybackIntent(
+            issuedAtMilliseconds: 1000
+        )
+        _ = playerService.beginMusicPlaybackIntent(
+            issuedAtMilliseconds: 2000,
+            allowsPriorTerminalEvent: true
+        )
+        _ = playerService.beginMusicPlaybackIntent(
+            issuedAtMilliseconds: 3000,
+            allowsPriorTerminalEvent: true
+        )
+
+        #expect(playerService.acceptsMusicTerminalBridgeEvent(
+            intent: admittedIntent,
+            eventIssuedAtMilliseconds: 1500
+        ))
+    }
+
+    @Test("A normal playback intent closes prior terminal callback admission")
+    func normalIntentClosesPriorTerminalCallbackAdmission() {
+        let playerService = PlayerService()
+        let staleIntent = playerService.beginMusicPlaybackIntent(
+            issuedAtMilliseconds: 1000
+        )
+        _ = playerService.beginMusicPlaybackIntent(
+            issuedAtMilliseconds: 2000,
+            allowsPriorTerminalEvent: true
+        )
+        _ = playerService.beginMusicPlaybackIntent(
+            issuedAtMilliseconds: 3000
+        )
+
+        #expect(!playerService.acceptsMusicTerminalBridgeEvent(
+            intent: staleIntent,
+            eventIssuedAtMilliseconds: 1500
+        ))
+    }
+
     private func makePlayerService() -> (PlayerService, MockYTMusicClient) {
         self.resetSingletonPlayer()
         let mockClient = MockYTMusicClient()

--- a/Tests/KasetTests/PlayerServicePlaybackIntentTests.swift
+++ b/Tests/KasetTests/PlayerServicePlaybackIntentTests.swift
@@ -1,0 +1,976 @@
+// swiftlint:disable file_length
+
+import Foundation
+import Testing
+@testable import Kaset
+
+@Suite("Player service playback intents", .serialized, .tags(.service))
+@MainActor
+struct PlayerServicePlaybackIntentTests { // swiftlint:disable:this type_body_length
+    @Test("A newer reservation invalidates an older unclaimed request")
+    func newerReservationWinsBeforePlaybackChanges() {
+        let playerService = PlayerService()
+        let older = playerService.reserveMusicPlaybackIntent()
+        let newer = playerService.reserveMusicPlaybackIntent()
+
+        #expect(playerService.claimMusicPlaybackIntent(older) == nil)
+        #expect(playerService.claimMusicPlaybackIntent(newer) != nil)
+    }
+
+    @Test("Track-specific validation rejects drift while a generic claim remains valid")
+    func reservationSeparatesValidationFromClaiming() {
+        let playerService = PlayerService()
+        playerService.currentTrack = self.makeSong(id: "first")
+        let reservation = playerService.reserveMusicPlaybackIntent()
+
+        playerService.currentTrack = self.makeSong(id: "second")
+
+        #expect(!playerService.acceptsMusicPlaybackReservation(reservation))
+        #expect(playerService.claimMusicPlaybackIntent(reservation) != nil)
+    }
+
+    @Test("Bridge events use sub-millisecond ordering around the current intent")
+    func bridgeEventTimeCannotAdoptNewerIntent() {
+        let playerService = PlayerService()
+        let intent = playerService.beginMusicPlaybackIntent()
+        playerService.musicPlaybackIntentIssuedAtMilliseconds = 1000.25
+
+        #expect(!playerService.acceptsMusicBridgeEvent(
+            intent: intent,
+            eventIssuedAtMilliseconds: 1000.20
+        ))
+        #expect(!playerService.acceptsMusicBridgeEvent(
+            intent: intent,
+            eventIssuedAtMilliseconds: 1000.25
+        ))
+        #expect(playerService.acceptsMusicBridgeEvent(
+            intent: intent,
+            eventIssuedAtMilliseconds: 1000.75
+        ))
+    }
+
+    @Test("Queue-only reservation survives pause but not queue replacement")
+    func queueReservationIgnoresTransportIntent() async {
+        let playerService = PlayerService()
+        await playerService.playQueue([self.makeSong(id: "initial")], startingAt: 0)
+        let queueGeneration = playerService.reserveQueueMutation()
+
+        await playerService.pause()
+        #expect(playerService.acceptsQueueMutation(queueGeneration))
+
+        await playerService.playQueue([self.makeSong(id: "replacement")], startingAt: 0)
+        #expect(!playerService.acceptsQueueMutation(queueGeneration))
+    }
+
+    @Test("Rapid remote commands execute in admission order under one intent")
+    func remoteCommandAdmissionOrdersIntents() async {
+        let playerService = PlayerService()
+        await playerService.playQueue([
+            self.makeSong(id: "first"),
+            self.makeSong(id: "second"),
+            self.makeSong(id: "third"),
+        ], startingAt: 0)
+        playerService.musicPlaybackIntentIssuedAtMilliseconds = 1000
+
+        let initialIntent = playerService.currentMusicPlaybackIntent
+        #expect(playerService.acceptsMusicRemoteCommand(
+            intent: initialIntent,
+            commandIssuedAtMilliseconds: 1001
+        ))
+        playerService.enqueueRemoteMusicTransportCommand(.next, issuedAtMilliseconds: 1001)
+
+        let batchIntent = playerService.currentMusicPlaybackIntent
+        #expect(playerService.acceptsMusicRemoteCommand(
+            intent: batchIntent,
+            commandIssuedAtMilliseconds: 1001
+        ))
+        playerService.enqueueRemoteMusicTransportCommand(.next, issuedAtMilliseconds: 1001)
+
+        let task = playerService.remoteMusicTransportTask
+        await task?.value
+
+        #expect(playerService.currentIndex == 2)
+        #expect(playerService.currentTrack?.videoId == "third")
+    }
+
+    @Test("Overlapping remote skips preserve every delta in admission order")
+    func overlappingRemoteSkipsPreserveEveryDelta() async {
+        let (playerService, _) = self.makePlayerService()
+        defer { self.resetSingletonPlayer() }
+        let song = self.makeSong(id: "remote-skip")
+        await playerService.playQueue([song], startingAt: 0)
+        playerService.musicPlaybackIntentIssuedAtMilliseconds = 1000
+        playerService.progress = 10
+        playerService.duration = 100
+        let firstSnapshotStarted = AsyncGate()
+        let releaseFirstSnapshot = AsyncGate()
+        var snapshotCallCount = 0
+        playerService.currentMusicPlaybackSnapshot = {
+            snapshotCallCount += 1
+            if snapshotCallCount == 1 {
+                await firstSnapshotStarted.open()
+                await releaseFirstSnapshot.wait()
+            }
+            return SingletonPlayerWebView.PlaybackSnapshot(
+                progress: 10,
+                duration: 100,
+                videoId: song.videoId
+            )
+        }
+        let admittedAt = ContinuousClock.now
+
+        playerService.enqueueRemoteMusicTransportCommand(
+            .relativeSeek(delta: -15, admittedAt: admittedAt),
+            issuedAtMilliseconds: 1001
+        )
+        let batchIntent = playerService.currentMusicPlaybackIntent
+        await firstSnapshotStarted.wait()
+        playerService.enqueueRemoteMusicTransportCommand(
+            .relativeSeek(delta: 15, admittedAt: admittedAt),
+            issuedAtMilliseconds: 1002
+        )
+        #expect(playerService.currentMusicPlaybackIntent == batchIntent)
+        let remoteTask = playerService.remoteMusicTransportTask
+
+        await releaseFirstSnapshot.open()
+        await remoteTask?.value
+
+        #expect(snapshotCallCount == 2)
+        #expect(playerService.progress == 15)
+        #expect(playerService.remoteMusicTransportCommands.isEmpty)
+        #expect(playerService.remoteMusicTransportIntent == nil)
+    }
+
+    @Test("Remote Next commands do not wait for intermediate metadata")
+    func remoteNextCommandsDoNotWaitForIntermediateMetadata() async {
+        let (playerService, mockClient) = self.makePlayerService()
+        defer { self.resetSingletonPlayer() }
+        let first = self.makeSong(id: "metadata-first")
+        let second = Song(
+            id: "metadata-second",
+            title: "metadata-second",
+            artists: [],
+            duration: 180,
+            videoId: "metadata-second"
+        )
+        let third = Song(
+            id: "metadata-third",
+            title: "metadata-third",
+            artists: [],
+            duration: 180,
+            videoId: "metadata-third"
+        )
+        mockClient.songResponses[third.videoId] = self.makeSong(id: third.id)
+        await playerService.playQueue([first, second, third], startingAt: 0)
+        playerService.musicPlaybackIntentIssuedAtMilliseconds = 1000
+        let thirdEntryID = playerService.queueEntryIDs[2]
+        let metadataStarted = AsyncGate()
+        let releaseMetadata = AsyncGate()
+        mockClient.beforeGetSongReturn = { _ in
+            await metadataStarted.open()
+            await releaseMetadata.wait()
+        }
+
+        playerService.enqueueRemoteMusicTransportCommand(
+            .next,
+            issuedAtMilliseconds: 1001
+        )
+        playerService.enqueueRemoteMusicTransportCommand(
+            .next,
+            issuedAtMilliseconds: 1002
+        )
+        await metadataStarted.wait()
+
+        #expect(playerService.currentIndex == 2)
+        #expect(playerService.activePlaybackQueueEntryID == thirdEntryID)
+        #expect(playerService.currentTrack?.videoId == third.videoId)
+        #expect(mockClient.getSongVideoIds == [third.videoId])
+
+        let metadataTask = playerService.remoteMusicMetadataFollowUpTask
+        await releaseMetadata.open()
+        await metadataTask?.value
+        #expect(playerService.currentTrack?.videoId == third.videoId)
+    }
+
+    @Test("Remote Next commands do not wait for materialized mix prefetch")
+    func remoteNextCommandsDoNotWaitForMixPrefetch() async {
+        let (playerService, mockClient) = self.makePlayerService()
+        defer { self.resetSingletonPlayer() }
+        let queue = [
+            self.makeSong(id: "prefetch-first"),
+            self.makeSong(id: "prefetch-second"),
+            self.makeSong(id: "prefetch-third"),
+            self.makeSong(id: "prefetch-fourth"),
+        ]
+        let appended = self.makeSong(id: "prefetch-appended")
+        await playerService.playQueue(queue, startingAt: 0)
+        playerService.musicPlaybackIntentIssuedAtMilliseconds = 1000
+        let thirdEntryID = playerService.queueEntryIDs[2]
+        playerService[keyPath: \.mixContinuationToken] = "mock-token"
+        mockClient.mixQueueContinuationResult = RadioQueueResult(
+            songs: [appended],
+            continuationToken: nil
+        )
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        mockClient.beforeMixQueueContinuationReturn = { _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+
+        playerService.enqueueRemoteMusicTransportCommand(
+            .next,
+            issuedAtMilliseconds: 1001
+        )
+        playerService.enqueueRemoteMusicTransportCommand(
+            .next,
+            issuedAtMilliseconds: 1002
+        )
+        await requestStarted.wait()
+
+        #expect(playerService.currentIndex == 2)
+        #expect(playerService.activePlaybackQueueEntryID == thirdEntryID)
+        #expect(playerService.currentTrack?.videoId == queue[2].videoId)
+
+        let queueTask = playerService.remoteMusicQueueFollowUpTask
+        await releaseRequest.open()
+        await queueTask?.value
+
+        #expect(playerService.currentTrack?.videoId == queue[2].videoId)
+        #expect(playerService.queue.contains { $0.videoId == appended.videoId })
+        #expect(mockClient.getMixQueueContinuationCallCount == 1)
+    }
+
+    @Test("A newer native seek invalidates pending remote skips")
+    func newerNativeSeekInvalidatesPendingRemoteSkips() async {
+        let (playerService, _) = self.makePlayerService()
+        defer { self.resetSingletonPlayer() }
+        let song = self.makeSong(id: "stale-remote-skip")
+        await playerService.playQueue([song], startingAt: 0)
+        playerService.musicPlaybackIntentIssuedAtMilliseconds = 1000
+        playerService.progress = 10
+        playerService.duration = 100
+        let snapshotStarted = AsyncGate()
+        let releaseSnapshot = AsyncGate()
+        playerService.currentMusicPlaybackSnapshot = {
+            await snapshotStarted.open()
+            await releaseSnapshot.wait()
+            return SingletonPlayerWebView.PlaybackSnapshot(
+                progress: 10,
+                duration: 100,
+                videoId: song.videoId
+            )
+        }
+
+        playerService.enqueueRemoteMusicTransportCommand(
+            .relativeSeek(delta: 15, admittedAt: ContinuousClock.now),
+            issuedAtMilliseconds: 1001
+        )
+        let batchIntent = playerService.currentMusicPlaybackIntent
+        let remoteTask = playerService.remoteMusicTransportTask
+        await snapshotStarted.wait()
+
+        await playerService.seek(to: 60)
+        #expect(playerService.currentMusicPlaybackIntent != batchIntent)
+        await releaseSnapshot.open()
+        await remoteTask?.value
+
+        #expect(playerService.progress == 60)
+        #expect(playerService.remoteMusicTransportCommands.isEmpty)
+        #expect(playerService.remoteMusicTransportIntent == nil)
+    }
+
+    @Test("A disappeared queue entry cannot claim a playback reservation")
+    func disappearedQueueEntryCannotClaimPlaybackReservation() async {
+        let playerService = PlayerService()
+        let current = self.makeSong(id: "reservation-current")
+        let target = self.makeSong(id: "reservation-target")
+        await playerService.playQueue([current, target], startingAt: 0)
+        let targetEntryID = playerService.queueEntryIDs[1]
+        let reservation = playerService.reserveMusicPlaybackIntent()
+        let intent = playerService.currentMusicPlaybackIntent
+        playerService.removeFromQueue(entryIDs: [targetEntryID])
+
+        let claimedIntent = playerService.claimMusicPlaybackIntent(
+            reservation,
+            queueEntryID: targetEntryID
+        )
+
+        #expect(claimedIntent == nil)
+        #expect(playerService.currentMusicPlaybackIntent == intent)
+        #expect(playerService.currentTrack?.videoId == current.videoId)
+    }
+
+    @Test("Mock player service preserves production ownership transitions")
+    func mockPlayerServiceOwnershipContract() async throws {
+        let mock = MockPlayerService()
+        let playbackReservation = mock.reserveMusicPlaybackIntent()
+        await mock.pause()
+        #expect(mock.claimMusicPlaybackIntent(playbackReservation) == nil)
+
+        let queueReservation = mock.reserveMusicPlaybackIntent()
+        let intent = try #require(mock.claimMusicPlaybackIntent(queueReservation))
+        let queueGeneration = mock.reserveQueueMutation()
+        let loadGeneration = await mock.playQueue(
+            [self.makeSong(id: "mock-replacement")],
+            startingAt: 0,
+            deferringSmartShuffleFill: true,
+            intent: intent
+        )
+        #expect(!mock.acceptsQueueMutation(queueGeneration))
+        #expect(loadGeneration != nil)
+        if let loadGeneration {
+            #expect(mock.acceptsQueueMutation(loadGeneration))
+        }
+
+        let mixReservation = mock.reserveMusicPlaybackIntent()
+        await mock.playWithMix(playlistId: "RDEM-mock", startVideoId: nil)
+        #expect(mock.claimMusicPlaybackIntent(mixReservation) == nil)
+    }
+
+    @Test("Remote transport backlog is bounded while a command is pending")
+    func remoteTransportBacklogIsBounded() {
+        let playerService = PlayerService()
+        playerService.musicPlaybackIntentIssuedAtMilliseconds = 0
+        playerService.enqueueRemoteMusicTransportCommand(.next, issuedAtMilliseconds: 1)
+        for offset in 2 ... 200 {
+            playerService.enqueueRemoteMusicTransportCommand(
+                .next,
+                issuedAtMilliseconds: Double(offset)
+            )
+        }
+
+        let pendingCount = playerService.remoteMusicTransportCommands.count
+            - playerService.remoteMusicTransportCommandReadIndex
+        #expect(pendingCount <= 64)
+        _ = playerService.beginMusicPlaybackIntent()
+    }
+
+    @Test("A stale clear intent cannot erase a newer queue")
+    func staleClearIntentCannotEraseNewerQueue() async {
+        let playerService = PlayerService()
+        let staleClearIntent = playerService.beginMusicPlaybackIntent()
+        let replacement = self.makeSong(id: "replacement")
+        await playerService.playQueue([replacement], startingAt: 0)
+        let replacementEntryIDs = playerService.queueEntryIDs
+
+        playerService.clearQueueEntriesAfterStop(intent: staleClearIntent)
+
+        #expect(playerService.queue == [replacement])
+        #expect(playerService.queueEntryIDs == replacementEntryIDs)
+    }
+
+    @Test("A delayed mix cannot replace a newer direct queue")
+    func delayedMixCannotReplaceNewerDirectQueue() async {
+        let (playerService, mockClient) = self.makePlayerService()
+        defer { self.resetSingletonPlayer() }
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        mockClient.mixQueueResult = RadioQueueResult(
+            songs: [self.makeSong(id: "stale-mix")],
+            continuationToken: "stale-mix-token"
+        )
+        mockClient.beforeMixQueueReturn = { _, _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+
+        let mixTask = Task { @MainActor in
+            await playerService.playWithMix(playlistId: "RDEM-stale", startVideoId: nil)
+        }
+        await requestStarted.wait()
+
+        let replacementSongs = [
+            self.makeSong(id: "replacement-current"),
+            self.makeSong(id: "replacement-next"),
+        ]
+        await playerService.playQueue(replacementSongs, startingAt: 0)
+        let replacementEntryIDs = playerService.queueEntryIDs
+
+        await releaseRequest.open()
+        await mixTask.value
+
+        #expect(playerService.queue == replacementSongs)
+        #expect(playerService.queueEntryIDs == replacementEntryIDs)
+        #expect(playerService.currentTrack == replacementSongs[0])
+        #expect(playerService.mixContinuationToken == nil)
+    }
+
+    @Test("Undo after a delayed mix restores queue edits admitted while pending")
+    func delayedMixUndoCapturesCommitTimeQueue() async {
+        let (playerService, mockClient) = self.makePlayerService()
+        defer { self.resetSingletonPlayer() }
+        let original = self.makeSong(id: "mix-history-original")
+        let appended = self.makeSong(id: "mix-history-appended")
+        let mixSong = self.makeSong(id: "mix-history-result")
+        await playerService.playQueue([original], startingAt: 0)
+        playerService.clearQueueUndoRedoHistory()
+        mockClient.mixQueueResult = RadioQueueResult(
+            songs: [mixSong],
+            continuationToken: "mix-history-token"
+        )
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        mockClient.beforeMixQueueReturn = { _, _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+
+        let mixTask = Task { @MainActor in
+            await playerService.playWithMix(
+                playlistId: "RDEM-history",
+                startVideoId: nil
+            )
+        }
+        await requestStarted.wait()
+        let pendingIntent = playerService.currentMusicPlaybackIntent
+        let queueGeneration = playerService.reserveQueueMutation()
+        playerService.appendToQueue([appended])
+        let editedEntryIDs = playerService.queueEntryIDs
+
+        #expect(playerService.acceptsMusicPlaybackIntent(pendingIntent))
+        #expect(playerService.acceptsQueueMutation(queueGeneration))
+        await releaseRequest.open()
+        await mixTask.value
+        await playerService.undoQueue()
+
+        #expect(playerService.queue.map(\.videoId) == [original.videoId, appended.videoId])
+        #expect(playerService.queueEntryIDs == editedEntryIDs)
+    }
+
+    @Test("A transport intent cannot orphan a committed mix queue")
+    func transportIntentCannotOrphanCommittedMixQueue() async {
+        let (playerService, mockClient) = self.makePlayerService()
+        let persistenceSuiteName = "com.kaset.tests.mix-persistence.\(UUID().uuidString)"
+        guard let persistenceDefaults = UserDefaults(suiteName: persistenceSuiteName) else {
+            Issue.record("Unable to create isolated queue persistence defaults")
+            return
+        }
+        persistenceDefaults.removePersistentDomain(forName: persistenceSuiteName)
+        playerService.queuePersistenceDefaults = persistenceDefaults
+        defer {
+            playerService.clearSavedQueue()
+            persistenceDefaults.removePersistentDomain(forName: persistenceSuiteName)
+            self.resetSingletonPlayer()
+        }
+        let original = self.makeSong(id: "mix-persist-original")
+        let mixSong = Song(
+            id: "mix-persist-result",
+            title: "Mix Persist Result",
+            artists: [],
+            duration: 180,
+            videoId: "mix-persist-result"
+        )
+        await playerService.playQueue([original], startingAt: 0)
+        mockClient.mixQueueResult = RadioQueueResult(
+            songs: [mixSong],
+            continuationToken: "mix-persist-token"
+        )
+        mockClient.songResponses[mixSong.videoId] = mixSong
+        let metadataStarted = AsyncGate()
+        let releaseMetadata = AsyncGate()
+        mockClient.beforeGetSongReturn = { videoID in
+            guard videoID == mixSong.videoId else { return }
+            await metadataStarted.open()
+            await releaseMetadata.wait()
+        }
+
+        let mixTask = Task { @MainActor in
+            await playerService.playWithMix(
+                playlistId: "RDEM-persist",
+                startVideoId: nil
+            )
+        }
+        await metadataStarted.wait()
+        await playerService.pause()
+        mockClient.shouldThrowError = YTMusicError.networkError(
+            underlying: URLError(.notConnectedToInternet)
+        )
+        await releaseMetadata.open()
+        await mixTask.value
+
+        #expect(playerService.queue.map(\.videoId) == [mixSong.videoId])
+        let restored = PlayerService()
+        restored.queuePersistenceDefaults = persistenceDefaults
+        #expect(restored.restoreQueueFromPersistence())
+        #expect(restored.queue.map(\.videoId) == [mixSong.videoId])
+    }
+
+    @Test("An empty mix response does not create queue undo history")
+    func emptyMixDoesNotCreateUndoHistory() async {
+        let (playerService, mockClient) = self.makePlayerService()
+        defer { self.resetSingletonPlayer() }
+        playerService.clearQueueUndoRedoHistory()
+        mockClient.mixQueueResult = RadioQueueResult(songs: [], continuationToken: nil)
+
+        await playerService.playWithMix(playlistId: "RDEM-empty", startVideoId: nil)
+
+        #expect(!playerService.canUndoQueue)
+    }
+
+    @Test("A delayed mix cannot resurrect playback after a fully awaited stop")
+    func delayedMixCannotResurrectAfterStop() async {
+        let (playerService, mockClient) = self.makePlayerService()
+        defer { self.resetSingletonPlayer() }
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        mockClient.mixQueueResult = RadioQueueResult(
+            songs: [self.makeSong(id: "stale-mix")],
+            continuationToken: "stale-mix-token"
+        )
+        mockClient.beforeMixQueueReturn = { _, _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+
+        let mixTask = Task { @MainActor in
+            await playerService.playWithMix(playlistId: "RDEM-stale", startVideoId: nil)
+        }
+        await requestStarted.wait()
+
+        await playerService.stop()
+        #expect(playerService.state == .idle)
+        #expect(playerService.currentTrack == nil)
+        #expect(playerService.pendingPlayVideoId == nil)
+
+        await releaseRequest.open()
+        await mixTask.value
+
+        #expect(playerService.state == .idle)
+        #expect(playerService.queue.isEmpty)
+        #expect(playerService.currentTrack == nil)
+        #expect(playerService.pendingPlayVideoId == nil)
+        #expect(playerService.mixContinuationToken == nil)
+    }
+
+    @Test("Verified identity switch invalidates idle playback work and queue history")
+    func identitySwitchInvalidatesPendingMixAndHistory() async {
+        let (playerService, mockClient) = self.makePlayerService()
+        defer { self.resetSingletonPlayer() }
+        await playerService.playQueue([self.makeSong(id: "history-a")], startingAt: 0)
+        await playerService.playQueue([self.makeSong(id: "history-b")], startingAt: 0)
+        #expect(playerService.canUndoQueue)
+        await playerService.stop()
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        mockClient.mixQueueResult = RadioQueueResult(
+            songs: [self.makeSong(id: "stale-account-mix")],
+            continuationToken: nil
+        )
+        mockClient.beforeMixQueueReturn = { _, _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+        let mixTask = Task { @MainActor in
+            await playerService.playWithMix(playlistId: "RDEM-account", startVideoId: nil)
+        }
+        await requestStarted.wait()
+
+        playerService.reloadCurrentTrackForIdentitySwitch()
+        await releaseRequest.open()
+        await mixTask.value
+
+        #expect(!playerService.canUndoQueue)
+        #expect(playerService.queue == [self.makeSong(id: "history-b")])
+        #expect(playerService.currentTrack == nil)
+        #expect(playerService.mixContinuationToken == nil)
+    }
+
+    @Test("Queue shuffle supersedes an older pending mix")
+    func shuffleSupersedesPendingMix() async {
+        let (playerService, mockClient) = self.makePlayerService()
+        defer { self.resetSingletonPlayer() }
+        let originalSongs = [
+            self.makeSong(id: "one"),
+            self.makeSong(id: "two"),
+            self.makeSong(id: "three"),
+        ]
+        await playerService.playQueue(originalSongs, startingAt: 0)
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        mockClient.mixQueueResult = RadioQueueResult(
+            songs: [self.makeSong(id: "stale")],
+            continuationToken: nil
+        )
+        mockClient.beforeMixQueueReturn = { _, _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+
+        let mixTask = Task { @MainActor in
+            await playerService.playWithMix(playlistId: "RDEM-stale", startVideoId: nil)
+        }
+        await requestStarted.wait()
+        playerService.shuffleQueue()
+        let shuffledEntryIDs = Set(playerService.queueEntryIDs)
+        await releaseRequest.open()
+        await mixTask.value
+
+        #expect(Set(playerService.queueEntryIDs) == shuffledEntryIDs)
+        #expect(Set(playerService.queue.map(\.videoId)) == Set(originalSongs.map(\.videoId)))
+    }
+
+    @Test("Player-bar shuffle cycling supersedes an older pending mix")
+    func cycleShuffleSupersedesPendingMix() async {
+        let (playerService, mockClient) = self.makePlayerService()
+        defer { self.resetSingletonPlayer() }
+        let originalSongs = self.makeSong(id: "cycle-one")
+        await playerService.playQueue([originalSongs, self.makeSong(id: "cycle-two")], startingAt: 0)
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        mockClient.mixQueueResult = RadioQueueResult(
+            songs: [self.makeSong(id: "cycle-stale")],
+            continuationToken: nil
+        )
+        mockClient.beforeMixQueueReturn = { _, _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+        let mixTask = Task { @MainActor in
+            await playerService.playWithMix(playlistId: "RDEM-cycle", startVideoId: nil)
+        }
+        await requestStarted.wait()
+
+        playerService.smartShuffleFeatureEnabled = { true }
+        playerService.cycleShuffleMode()
+        let retainedVideoIDs = Set(playerService.queue.map(\.videoId))
+        await releaseRequest.open()
+        await mixTask.value
+
+        #expect(Set(playerService.queue.map(\.videoId)) == retainedVideoIDs)
+        #expect(!playerService.queue.contains(where: { $0.videoId == "cycle-stale" }))
+    }
+
+    @Test("A stale same-video radio result cannot replace a newer queue entry")
+    func staleSameVideoRadioCannotReplaceNewerQueueEntry() async {
+        let (playerService, mockClient) = self.makePlayerService()
+        defer { self.resetSingletonPlayer() }
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        let seed = self.makeSong(id: "shared-song", videoId: "shared-video")
+        let staleRadioSong = self.makeSong(id: "stale-radio")
+        mockClient.radioQueueSongs[seed.videoId] = [seed, staleRadioSong]
+        mockClient.beforeRadioQueueReturn = { _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+
+        let radioTask = Task { @MainActor in
+            await playerService.playWithRadio(song: seed)
+        }
+        await requestStarted.wait()
+
+        let replacementSongs = [
+            seed,
+            self.makeSong(id: "replacement-next"),
+        ]
+        await playerService.playQueue(replacementSongs, startingAt: 0)
+        let replacementEntryIDs = playerService.queueEntryIDs
+
+        await releaseRequest.open()
+        await radioTask.value
+
+        #expect(playerService.queue == replacementSongs)
+        #expect(playerService.queueEntryIDs == replacementEntryIDs)
+        #expect(playerService.currentQueueEntryID == replacementEntryIDs[0])
+        #expect(playerService.currentTrack == seed)
+    }
+
+    @Test("Radio expansion preserves the active seed entry identity")
+    func radioExpansionPreservesSeedEntryIdentity() async throws {
+        let (playerService, mockClient) = self.makePlayerService()
+        defer { self.resetSingletonPlayer() }
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        let seed = self.makeSong(id: "seed")
+        mockClient.radioQueueSongs[seed.videoId] = [
+            seed,
+            self.makeSong(id: "related"),
+        ]
+        mockClient.beforeRadioQueueReturn = { _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+
+        let radioTask = Task { @MainActor in
+            await playerService.playWithRadio(song: seed)
+        }
+        await requestStarted.wait()
+        let seedEntryID = try #require(playerService.activePlaybackQueueEntryID)
+        #expect(playerService.currentQueueEntryID == seedEntryID)
+
+        await releaseRequest.open()
+        await radioTask.value
+
+        #expect(playerService.queueEntryIDs.first == seedEntryID)
+        #expect(playerService.currentQueueEntryID == seedEntryID)
+        #expect(playerService.activePlaybackQueueEntryID == seedEntryID)
+    }
+
+    @Test("Pausing does not cancel queue-owned radio expansion")
+    func pausePreservesPendingRadioExpansion() async {
+        let (playerService, mockClient) = self.makePlayerService()
+        defer { self.resetSingletonPlayer() }
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        let seed = self.makeSong(id: "seed")
+        let related = self.makeSong(id: "related")
+        mockClient.radioQueueSongs[seed.videoId] = [seed, related]
+        mockClient.beforeRadioQueueReturn = { _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+
+        let radioTask = Task { @MainActor in
+            await playerService.playWithRadio(song: seed)
+        }
+        await requestStarted.wait()
+        await playerService.pause()
+        await releaseRequest.open()
+        await radioTask.value
+
+        #expect(playerService.queue.map(\.videoId).contains(related.videoId))
+        #expect(playerService.state == .paused)
+    }
+
+    @Test("Radio expansion preserves queue edits made while the request is pending")
+    func radioExpansionMergesPendingQueueEdits() async {
+        let (playerService, mockClient) = self.makePlayerService()
+        defer { self.resetSingletonPlayer() }
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        let seed = self.makeSong(id: "seed")
+        let userAdded = self.makeSong(id: "user-added")
+        let related = self.makeSong(id: "related")
+        mockClient.radioQueueSongs[seed.videoId] = [seed, related]
+        mockClient.beforeRadioQueueReturn = { _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+
+        let radioTask = Task { @MainActor in
+            await playerService.playWithRadio(song: seed)
+        }
+        await requestStarted.wait()
+        playerService.toggleShuffle()
+        playerService.appendToQueue([userAdded])
+        await releaseRequest.open()
+        await radioTask.value
+
+        #expect(playerService.queue.map(\.videoId).contains(userAdded.videoId))
+        #expect(playerService.queue.map(\.videoId).contains(related.videoId))
+        #expect(playerService.activePlaybackQueueEntryID == playerService.currentQueueEntryID)
+        #expect(playerService.queueOrderBeforeShuffle?.map(\.song.videoId) == [
+            seed.videoId,
+            userAdded.videoId,
+            related.videoId,
+        ])
+        playerService.toggleShuffle()
+        #expect(playerService.queue.map(\.videoId) == [
+            seed.videoId,
+            userAdded.videoId,
+            related.videoId,
+        ])
+    }
+
+    @Test("Pending shuffled radio expansion does not resurrect removed entries")
+    func radioExpansionPreservesRemovalFromShuffledQueue() async {
+        let (playerService, mockClient) = self.makePlayerService()
+        defer { self.resetSingletonPlayer() }
+        let seed = self.makeSong(id: "radio-seed")
+        let removed = self.makeSong(id: "radio-removed")
+        let related = self.makeSong(id: "radio-related")
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        mockClient.radioQueueSongs[seed.videoId] = [related]
+        mockClient.beforeRadioQueueReturn = { _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+
+        let radioTask = Task { @MainActor in
+            await playerService.playWithRadio(song: seed)
+        }
+        await requestStarted.wait()
+        playerService.appendToQueue([removed])
+        playerService.setShuffleMode(.on)
+        let removedEntryID = try? #require(
+            playerService.queueEntries.first(where: { $0.song.videoId == removed.videoId })?.id
+        )
+        if let removedEntryID {
+            playerService.removeFromQueue(entryIDs: [removedEntryID])
+        }
+        await releaseRequest.open()
+        await radioTask.value
+
+        #expect(!playerService.queue.contains(where: { $0.videoId == removed.videoId }))
+        #expect(playerService.queue.contains(where: { $0.videoId == related.videoId }))
+    }
+
+    @Test("A stale mix continuation cannot append or restore its token after queue replacement")
+    func staleMixContinuationCannotMutateReplacementQueue() async {
+        let (playerService, mockClient) = self.makePlayerService()
+        defer { self.resetSingletonPlayer() }
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        let initialSongs = [
+            self.makeSong(id: "initial-current"),
+            self.makeSong(id: "initial-next"),
+        ]
+        await playerService.playQueue(initialSongs, startingAt: 1)
+        playerService[keyPath: \.mixContinuationToken] = "mock-token"
+        mockClient.mixQueueContinuationResult = RadioQueueResult(
+            songs: [self.makeSong(id: "stale-continuation-song")],
+            continuationToken: "REDACTED"
+        )
+        mockClient.beforeMixQueueContinuationReturn = { _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+
+        let continuationTask = Task { @MainActor in
+            await playerService.fetchMoreMixSongsIfNeeded()
+        }
+        await requestStarted.wait()
+
+        let replacementSongs = [
+            self.makeSong(id: "replacement-current"),
+            self.makeSong(id: "replacement-next"),
+        ]
+        await playerService.playQueue(replacementSongs, startingAt: 0)
+        let replacementEntryIDs = playerService.queueEntryIDs
+        #expect(playerService.mixContinuationToken == nil)
+
+        await releaseRequest.open()
+        await continuationTask.value
+
+        #expect(playerService.queue == replacementSongs)
+        #expect(playerService.queueEntryIDs == replacementEntryIDs)
+        #expect(playerService.mixContinuationToken == nil)
+    }
+
+    @Test("Pausing preserves queue-owned mix continuation work")
+    func pausePreservesMixContinuation() async {
+        let (playerService, mockClient) = self.makePlayerService()
+        defer { self.resetSingletonPlayer() }
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        await playerService.playQueue([self.makeSong(id: "current")], startingAt: 0)
+        playerService[keyPath: \.mixContinuationToken] = "mock-token"
+        mockClient.mixQueueContinuationResult = RadioQueueResult(
+            songs: [self.makeSong(id: "later")],
+            continuationToken: nil
+        )
+        mockClient.beforeMixQueueContinuationReturn = { _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+
+        let firstFetch = Task { @MainActor in
+            await playerService.fetchMoreMixSongsIfNeeded()
+        }
+        await requestStarted.wait()
+        await playerService.pause()
+        await releaseRequest.open()
+        await firstFetch.value
+
+        #expect(!playerService.isFetchingMoreMixSongs)
+        #expect(playerService.activeMixContinuationRequestID == nil)
+        #expect(playerService.queue.map(\.videoId).contains("later"))
+        #expect(mockClient.getMixQueueContinuationCallCount == 1)
+    }
+
+    @Test("The newest Next waits for an active mix continuation and advances")
+    func concurrentNextCoalescesOnMixContinuation() async {
+        let (playerService, mockClient) = self.makePlayerService()
+        defer { self.resetSingletonPlayer() }
+        let current = self.makeSong(id: "current")
+        let appended = self.makeSong(id: "appended")
+        await playerService.playQueue([current], startingAt: 0)
+        playerService[keyPath: \.mixContinuationToken] = "mock-token"
+        mockClient.mixQueueContinuationResult = RadioQueueResult(
+            songs: [appended],
+            continuationToken: nil
+        )
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        mockClient.beforeMixQueueContinuationReturn = { _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+
+        let firstNext = Task { @MainActor in await playerService.next() }
+        await requestStarted.wait()
+        let secondNext = Task { @MainActor in await playerService.next() }
+        await Task.yield()
+        await releaseRequest.open()
+        await firstNext.value
+        await secondNext.value
+
+        #expect(playerService.currentIndex == 1)
+        #expect(playerService.currentTrack?.videoId == appended.videoId)
+        #expect(mockClient.getMixQueueContinuationCallCount == 1)
+    }
+
+    @Test("Ordered remote Next commands advance once per admitted press after continuation")
+    func remoteNextBatchAdvancesForEveryCommand() async {
+        let (playerService, mockClient) = self.makePlayerService()
+        defer { self.resetSingletonPlayer() }
+        let current = self.makeSong(id: "remote-current")
+        let firstAppended = self.makeSong(id: "remote-first")
+        let secondAppended = self.makeSong(id: "remote-second")
+        await playerService.playQueue([current], startingAt: 0)
+        playerService[keyPath: \.mixContinuationToken] = "mock-token"
+        mockClient.mixQueueContinuationResult = RadioQueueResult(
+            songs: [firstAppended, secondAppended],
+            continuationToken: nil
+        )
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        mockClient.beforeMixQueueContinuationReturn = { _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+
+        playerService.enqueueRemoteMusicTransportCommand(
+            .next,
+            issuedAtMilliseconds: Date().timeIntervalSince1970 * 1000
+        )
+        await requestStarted.wait()
+        playerService.enqueueRemoteMusicTransportCommand(
+            .next,
+            issuedAtMilliseconds: Date().timeIntervalSince1970 * 1000
+        )
+        let remoteTask = playerService.remoteMusicTransportTask
+        await releaseRequest.open()
+        await remoteTask?.value
+
+        #expect(playerService.currentIndex == 2)
+        #expect(playerService.currentTrack?.videoId == secondAppended.videoId)
+        #expect(mockClient.getMixQueueContinuationCallCount == 1)
+    }
+
+    private func makePlayerService() -> (PlayerService, MockYTMusicClient) {
+        self.resetSingletonPlayer()
+        let mockClient = MockYTMusicClient()
+        let playerService = PlayerService()
+        playerService.setYTMusicClient(mockClient)
+        return (playerService, mockClient)
+    }
+
+    private func resetSingletonPlayer() {
+        SingletonPlayerWebView.shared.tearDown()
+        SingletonPlayerWebView.shared.currentVideoId = nil
+    }
+
+    private func makeSong(id: String, videoId: String? = nil) -> Song {
+        Song(
+            id: id,
+            title: id,
+            artists: [],
+            duration: 180,
+            videoId: videoId ?? id,
+            feedbackTokens: .init(add: nil, remove: nil)
+        )
+    }
+}

--- a/Tests/KasetTests/PlayerServiceQueueHistoryTests.swift
+++ b/Tests/KasetTests/PlayerServiceQueueHistoryTests.swift
@@ -582,11 +582,7 @@ extension PlayerServiceQueueTests {
         #expect(self.playerService.acceptsQueueMutation(restoreQueueGeneration))
         await releaseMetadata.open()
         await undoTask.value
-        for _ in 0 ..< 100 where !self.mockClient.getRadioQueueCalled {
-            await Task.yield()
-        }
-        let fillTask = self.playerService.smartShuffleFillTask
-        await fillTask?.value
+        await self.playerService.fillSmartShuffleWindow()
 
         #expect(self.playerService.shuffleMode == .smart)
         #expect(self.playerService.state == .paused)

--- a/Tests/KasetTests/PlayerServiceQueueHistoryTests.swift
+++ b/Tests/KasetTests/PlayerServiceQueueHistoryTests.swift
@@ -1,0 +1,793 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+extension PlayerServiceQueueTests {
+    @Test("Adopting a restored session clears prior queue history")
+    func restoredSessionAdoptionClearsQueueHistory() async {
+        let first = TestFixtures.makeSong(id: "restore-history-first")
+        let second = TestFixtures.makeSong(id: "restore-history-second")
+        let restored = TestFixtures.makeSong(id: "restore-history-adopted")
+        await self.playerService.playQueue([first], startingAt: 0)
+        await self.playerService.playQueue([second], startingAt: 0)
+        #expect(self.playerService.canUndoQueue)
+
+        self.playerService.applyRestoredPlaybackSession(
+            queue: [restored],
+            currentIndex: 0,
+            progress: 12,
+            duration: 180
+        )
+
+        #expect(!self.playerService.canUndoQueue)
+        #expect(!self.playerService.canRedoQueue)
+        await self.playerService.undoQueue()
+        #expect(self.playerService.queue == [restored])
+    }
+
+    @Test("A stale footer undo intent cannot replace newer playback")
+    func staleUndoIntentCannotReplaceNewerPlayback() async {
+        let first = TestFixtures.makeSong(id: "footer-first")
+        let second = TestFixtures.makeSong(id: "footer-second")
+        let newer = TestFixtures.makeSong(id: "footer-newer")
+        await self.playerService.playQueue([first], startingAt: 0)
+        await self.playerService.playQueue([second], startingAt: 0)
+        let staleUndoIntent = self.playerService.beginMusicPlaybackIntent()
+        await self.playerService.playQueue([newer], startingAt: 0)
+
+        await self.playerService.undoQueue(intent: staleUndoIntent)
+
+        #expect(self.playerService.queue == [newer])
+        #expect(self.playerService.currentTrack?.videoId == newer.videoId)
+    }
+
+    @Test("Undo restores mix continuation ownership")
+    func undoRestoresMixContinuation() async {
+        let songs = TestFixtures.makeSongs(count: 2)
+        await self.playerService.playQueue(songs, startingAt: 0)
+        self.playerService[keyPath: \.mixContinuationToken] = "mock-token"
+        self.playerService.mixContinuationRequiresAuth = true
+
+        self.playerService.clearQueue()
+        #expect(self.playerService.mixContinuationToken == nil)
+        await self.playerService.undoQueue()
+
+        #expect(self.playerService.mixContinuationToken == "mock-token")
+        #expect(self.playerService.mixContinuationRequiresAuth)
+    }
+
+    @Test("Queue history snapshots strip account-scoped song metadata")
+    func queueHistorySnapshotsStripAccountMetadata() {
+        let queued = Song(
+            id: "history-account-queued",
+            title: "Queued",
+            artists: [],
+            videoId: "history-account-queued",
+            likeStatus: .like,
+            isInLibrary: true,
+            feedbackTokens: FeedbackTokens(add: "queued-add", remove: "queued-remove")
+        )
+        let detached = Song(
+            id: "history-account-detached",
+            title: "Detached",
+            artists: [],
+            videoId: "history-account-detached",
+            likeStatus: .dislike,
+            isInLibrary: false,
+            feedbackTokens: FeedbackTokens(add: "detached-add", remove: "detached-remove")
+        )
+        let queuedEntry = QueueEntry(id: UUID(), song: queued)
+        self.playerService.setQueue(entries: [queuedEntry])
+        self.playerService.queueOrderBeforeShuffle = [queuedEntry]
+        self.playerService.currentTrack = detached
+        self.playerService.activePlaybackQueueEntryID = nil
+
+        let snapshot = self.playerService.makeQueueStateSnapshot()
+
+        #expect(snapshot.entries[0].song.likeStatus == nil)
+        #expect(snapshot.entries[0].song.isInLibrary == nil)
+        #expect(snapshot.entries[0].song.feedbackTokens == nil)
+        #expect(snapshot.queueOrderBeforeShuffle?[0].song.likeStatus == nil)
+        #expect(snapshot.queueOrderBeforeShuffle?[0].song.isInLibrary == nil)
+        #expect(snapshot.queueOrderBeforeShuffle?[0].song.feedbackTokens == nil)
+        guard case let .detached(song, _, _, _) = snapshot.playbackOwner else {
+            Issue.record("Expected detached playback owner")
+            return
+        }
+        #expect(song.likeStatus == nil)
+        #expect(song.isInLibrary == nil)
+        #expect(song.feedbackTokens == nil)
+    }
+
+    @Test("Undo refreshes account metadata instead of replaying stale action tokens")
+    func undoRefreshesAccountMetadata() async {
+        let stale = Song(
+            id: "history-refresh",
+            title: "History Refresh",
+            artists: [],
+            videoId: "history-refresh",
+            likeStatus: .like,
+            isInLibrary: false,
+            feedbackTokens: FeedbackTokens(add: "old-add", remove: "old-remove")
+        )
+        let replacement = Song(
+            id: "history-refresh-replacement",
+            title: "Replacement",
+            artists: [],
+            videoId: "history-refresh-replacement",
+            feedbackTokens: FeedbackTokens(add: "replacement-add", remove: "replacement-remove")
+        )
+        let authoritativeTokens = FeedbackTokens(add: "new-add", remove: "new-remove")
+        self.mockClient.songResponses[stale.videoId] = Song(
+            id: stale.id,
+            title: stale.title,
+            artists: stale.artists,
+            videoId: stale.videoId,
+            likeStatus: .dislike,
+            isInLibrary: true,
+            feedbackTokens: authoritativeTokens
+        )
+        await self.playerService.playQueue([stale], startingAt: 0)
+        await self.playerService.playQueue([replacement], startingAt: 0)
+
+        await self.playerService.undoQueue()
+
+        #expect(self.mockClient.getSongVideoIds.contains(stale.videoId))
+        #expect(self.playerService.currentTrackLikeStatus == .dislike)
+        #expect(self.playerService.currentTrackInLibrary)
+        #expect(self.playerService.currentTrackFeedbackTokens == authoritativeTokens)
+        #expect(self.playerService.queue[0].likeStatus == .dislike)
+        #expect(self.playerService.queue[0].isInLibrary == true)
+        #expect(self.playerService.queue[0].feedbackTokens == authoritativeTokens)
+    }
+
+    @Test("Same-track undo refreshes stripped account metadata")
+    func sameTrackUndoRefreshesAccountMetadata() async {
+        let stale = Song(
+            id: "same-track-history-refresh",
+            title: "Same Track History Refresh",
+            artists: [],
+            duration: 180,
+            videoId: "same-track-history-refresh",
+            likeStatus: .like,
+            isInLibrary: false,
+            feedbackTokens: FeedbackTokens(add: "same-old-add", remove: "same-old-remove")
+        )
+        let appended = TestFixtures.makeSong(id: "same-track-appended")
+        let authoritativeTokens = FeedbackTokens(add: "same-new-add", remove: "same-new-remove")
+        self.mockClient.songResponses[stale.videoId] = Song(
+            id: stale.id,
+            title: stale.title,
+            artists: stale.artists,
+            duration: stale.duration,
+            videoId: stale.videoId,
+            likeStatus: .dislike,
+            isInLibrary: true,
+            feedbackTokens: authoritativeTokens
+        )
+        await self.playerService.playQueue([stale], startingAt: 0)
+        let activeEntryID = self.playerService.activePlaybackQueueEntryID
+        self.playerService.appendToQueue([appended])
+
+        await self.playerService.undoQueue()
+
+        #expect(self.playerService.activePlaybackQueueEntryID == activeEntryID)
+        #expect(self.mockClient.getSongVideoIds.contains(stale.videoId))
+        #expect(self.playerService.currentTrackLikeStatus == .dislike)
+        #expect(self.playerService.currentTrackInLibrary)
+        #expect(self.playerService.currentTrackFeedbackTokens == authoritativeTokens)
+        #expect(self.playerService.queue[0].feedbackTokens == authoritativeTokens)
+    }
+
+    @Test("Ended queue history refreshes account metadata")
+    func endedQueueHistoryRefreshesAccountMetadata() async {
+        let stale = Song(
+            id: "ended-history-refresh",
+            title: "Ended History Refresh",
+            artists: [],
+            duration: 180,
+            videoId: "ended-history-refresh",
+            likeStatus: .like,
+            isInLibrary: false,
+            feedbackTokens: FeedbackTokens(add: "ended-old-add", remove: "ended-old-remove")
+        )
+        let authoritativeTokens = FeedbackTokens(add: "ended-new-add", remove: "ended-new-remove")
+        self.mockClient.songResponses[stale.videoId] = Song(
+            id: stale.id,
+            title: stale.title,
+            artists: stale.artists,
+            duration: stale.duration,
+            videoId: stale.videoId,
+            likeStatus: .dislike,
+            isInLibrary: true,
+            feedbackTokens: authoritativeTokens
+        )
+        await self.playerService.playQueue([stale], startingAt: 0)
+        self.playerService.markPlaybackEnded()
+
+        await self.playerService.stopAndClearQueue()
+        await self.playerService.undoQueue()
+
+        #expect(self.playerService.state == .ended)
+        #expect(self.mockClient.getSongVideoIds.contains(stale.videoId))
+        #expect(self.playerService.currentTrackLikeStatus == .dislike)
+        #expect(self.playerService.currentTrackInLibrary)
+        #expect(self.playerService.currentTrackFeedbackTokens == authoritativeTokens)
+        #expect(self.playerService.queue[0].feedbackTokens == authoritativeTokens)
+    }
+
+    @Test("Undo restores the authored order backing a shuffled queue")
+    func undoRestoresPreShuffleBackingOrder() async {
+        let songs = TestFixtures.makeSongs(count: 4)
+        await self.playerService.playQueue(songs, startingAt: 1)
+        let originalEntryIDs = self.playerService.queueEntryIDs
+        self.playerService.setShuffleMode(.on)
+        #expect(self.playerService.queueOrderBeforeShuffle?.map(\.id) == originalEntryIDs)
+
+        self.playerService.clearQueue()
+        #expect(self.playerService.queueOrderBeforeShuffle == nil)
+        await self.playerService.undoQueue()
+
+        #expect(self.playerService.queueOrderBeforeShuffle?.map(\.id) == originalEntryIDs)
+        self.playerService.setShuffleMode(.off)
+        #expect(self.playerService.queueEntryIDs == originalEntryIDs)
+    }
+
+    @Test("Redo preserves the authored order backing a shuffled queue")
+    func redoPreservesPreShuffleBackingOrder() async {
+        let songs = TestFixtures.makeSongs(count: 4)
+        await self.playerService.playQueue(songs, startingAt: 1)
+        let authoredState = self.playerService.makeQueueStateSnapshot()
+        let originalEntryIDs = self.playerService.queueEntryIDs
+
+        self.playerService.setShuffleMode(.on)
+        #expect(self.playerService.queueOrderBeforeShuffle?.map(\.id) == originalEntryIDs)
+        self.playerService.clearQueueUndoRedoHistory()
+        self.playerService.recordQueueStateForUndo(authoredState)
+
+        await self.playerService.undoQueue()
+        #expect(self.playerService.shuffleMode == .off)
+        await self.playerService.redoQueue()
+
+        #expect(self.playerService.shuffleMode == .on)
+        #expect(self.playerService.queueOrderBeforeShuffle?.map(\.id) == originalEntryIDs)
+        self.playerService.setShuffleMode(.off)
+        #expect(self.playerService.queueEntryIDs == originalEntryIDs)
+    }
+
+    @Test("Queue undo preserves detached playback")
+    func undoDoesNotReplaceDetachedPlayback() async {
+        let queued = TestFixtures.makeSong(id: "queued")
+        let detached = TestFixtures.makeSong(id: "detached")
+        let appended = TestFixtures.makeSong(id: "appended")
+        await self.playerService.playQueue([queued], startingAt: 0)
+        await self.playerService.play(song: detached)
+        self.playerService.appendToQueue([appended])
+
+        await self.playerService.undoQueue()
+
+        #expect(self.playerService.queue == [queued])
+        #expect(self.playerService.currentTrack?.videoId == detached.videoId)
+        #expect(self.playerService.activePlaybackQueueEntryID == nil)
+    }
+
+    @Test("Undo and redo preserve detached artist episode identity")
+    func undoRedoPreservesDetachedArtistEpisodeIdentity() async {
+        let episode = ArtistEpisode(
+            videoId: "history-live-episode",
+            title: "History Live Episode",
+            subtitle: "Live now",
+            description: "A standalone live stream",
+            isLive: true
+        )
+        let appended = TestFixtures.makeSong(id: "episode-history-appended")
+        await self.playerService.playEpisode(episode)
+        self.playerService.state = .playing
+        self.playerService.shouldResumeAfterInterruption = true
+        self.playerService.progress = 42
+        self.playerService.currentTimeMs = 42000
+        self.playerService.duration = 0
+        self.playerService.appendToQueue([appended])
+
+        await self.playerService.undoQueue()
+
+        #expect(self.playerService.queue.isEmpty)
+        #expect(self.playerService.currentEpisode == episode)
+        #expect(self.playerService.isCurrentItemLive)
+        #expect(self.playerService.currentTrack?.videoId == episode.videoId)
+        #expect(self.playerService.activePlaybackQueueEntryID == nil)
+        #expect(self.playerService.pendingRestoredSeek == nil)
+        #expect(!self.playerService.isRestoringPlaybackSession)
+        #expect(self.playerService.shouldResumeAfterInterruption)
+
+        await self.playerService.redoQueue()
+
+        #expect(self.playerService.queue == [appended])
+        #expect(self.playerService.currentEpisode == episode)
+        #expect(self.playerService.isCurrentItemLive)
+        #expect(self.playerService.currentTrack?.videoId == episode.videoId)
+        #expect(self.playerService.activePlaybackQueueEntryID == nil)
+        #expect(self.playerService.pendingRestoredSeek == nil)
+        #expect(!self.playerService.isRestoringPlaybackSession)
+        #expect(self.playerService.shouldResumeAfterInterruption)
+    }
+
+    @Test("Paused live episode restore suppresses autoplay before navigation")
+    func pausedLiveEpisodeRestoreSuppressesAutoplayBeforeNavigation() async {
+        let singleton = SingletonPlayerWebView.shared
+        singleton.tearDown()
+        singleton.currentVideoId = nil
+        defer {
+            singleton.tearDown()
+            singleton.currentVideoId = nil
+        }
+        let webKitManager = WebKitManager.makeTestInstance()
+        _ = singleton.getWebView(
+            webKitManager: webKitManager,
+            playerService: self.playerService
+        )
+        singleton.currentVideoId = "currently-loaded-video"
+        let episode = ArtistEpisode(
+            videoId: "paused-live-history",
+            title: "Paused Live History",
+            isLive: true
+        )
+        let representative = Song(
+            id: episode.videoId,
+            title: episode.title,
+            artists: [],
+            videoId: episode.videoId,
+            feedbackTokens: FeedbackTokens(add: nil, remove: nil)
+        )
+        let state = QueueState(
+            entries: [],
+            currentIndex: 0,
+            shouldResumePlayback: false,
+            playbackOwner: .detached(
+                song: representative,
+                episode: episode,
+                progress: 42,
+                duration: 0
+            )
+        )
+        self.playerService.currentTrack = TestFixtures.makeSong(id: "currently-loaded-video")
+        self.playerService.pendingPlayVideoId = "currently-loaded-video"
+        self.playerService.state = .playing
+        self.playerService.clearQueueUndoRedoHistory()
+        self.playerService.recordQueueStateForUndo(state)
+        var capturedAutoplayIntent: Bool?
+        self.playerService.onMusicPlaybackNavigationRequested = { videoID, shouldAutoplay in
+            guard videoID == episode.videoId else { return }
+            capturedAutoplayIntent = shouldAutoplay
+        }
+
+        await self.playerService.undoQueue()
+
+        #expect(capturedAutoplayIntent == false)
+        #expect(self.playerService.state == .paused)
+        #expect(!self.playerService.shouldResumeAfterInterruption)
+        #expect(self.playerService.isExplicitPauseIntentActive)
+        #expect(self.playerService.pendingRestoredSeek == nil)
+    }
+
+    @Test("Undo restores the detached item captured before queue replacement")
+    func undoRestoresCapturedDetachedPlayback() async {
+        let queued = TestFixtures.makeSong(id: "queued-before-detached")
+        let detached = TestFixtures.makeSong(id: "captured-detached")
+        let replacement = TestFixtures.makeSong(id: "replacement-queue")
+        await self.playerService.playQueue([queued], startingAt: 0)
+        await self.playerService.play(song: detached)
+        self.playerService.progress = 24
+        await self.playerService.playQueue([replacement], startingAt: 0)
+
+        await self.playerService.undoQueue()
+
+        #expect(self.playerService.queue == [queued])
+        #expect(self.playerService.currentTrack?.videoId == detached.videoId)
+        #expect(self.playerService.activePlaybackQueueEntryID == nil)
+        #expect(self.playerService.progress == 24)
+    }
+
+    @Test("Clearing the entire queue removes persisted playback even when paused")
+    func clearEntireQueueRemovesPersistence() async {
+        let song = TestFixtures.makeSong(id: "clear-persisted")
+        defer { self.playerService.clearSavedQueue() }
+        await self.playerService.playQueue([song], startingAt: 0)
+        await self.playerService.pause()
+        SingletonPlayerWebView.shared.currentVideoId = song.videoId
+
+        await self.playerService.clearQueueEntirely()
+
+        #expect(self.playerService.queue.isEmpty)
+        #expect(self.playerService.currentTrack == nil)
+        #expect(self.playerService.currentEpisode == nil)
+        #expect(self.playerService.pendingPlayVideoId == nil)
+        #expect(self.playerService.state == .idle)
+        #expect(SingletonPlayerWebView.shared.currentVideoId == nil)
+        self.playerService.saveQueueForPersistence()
+        let restored = PlayerService()
+        #expect(!restored.restoreQueueFromPersistence())
+    }
+
+    @Test("Undo aligns playback with the restored queue occurrence")
+    func undoAlignsPlaybackOccurrence() async {
+        let first = TestFixtures.makeSong(id: "undo-first")
+        let second = TestFixtures.makeSong(id: "undo-second")
+        await self.playerService.playQueue([first], startingAt: 0)
+        await self.playerService.playQueue([second], startingAt: 0)
+
+        await self.playerService.undoQueue()
+
+        #expect(self.playerService.queue == [first])
+        #expect(self.playerService.currentTrack?.videoId == first.videoId)
+        #expect(self.playerService.activePlaybackQueueEntryID == self.playerService.currentQueueEntryID)
+        #expect(self.playerService.activePlaybackQueueEntryID == self.playerService.queueEntryIDs.first)
+    }
+
+    @Test("Undo restores the queue-owned playback clock")
+    func undoRestoresQueuePlaybackClock() async {
+        let song = TestFixtures.makeSong(id: "clock")
+        await self.playerService.playQueue([song], startingAt: 0)
+        self.playerService.progress = 42
+        self.playerService.duration = 180
+
+        await self.playerService.clearQueueEntirely()
+        await self.playerService.undoQueue()
+
+        #expect(self.playerService.currentTrack?.videoId == song.videoId)
+        #expect(self.playerService.progress == 42)
+        #expect(self.playerService.duration == 180)
+    }
+
+    @Test("Undo routes a retained occurrence through pending-seek reconciliation")
+    func undoRestoresPhysicalPlaybackClock() async {
+        let first = TestFixtures.makeSong(id: "physical-clock")
+        let second = TestFixtures.makeSong(id: "physical-clock-next")
+        let firstEntryID = UUID()
+        self.playerService.setQueue(entries: [
+            QueueEntry(id: firstEntryID, song: first),
+            QueueEntry(id: UUID(), song: second),
+        ])
+        self.playerService.currentIndex = 0
+        self.playerService.activePlaybackQueueEntryID = firstEntryID
+        self.playerService.currentTrack = first
+        self.playerService.pendingPlayVideoId = first.videoId
+        self.playerService.state = .playing
+        self.playerService.shouldResumeAfterInterruption = true
+        self.playerService.progress = 10
+        self.playerService.currentTimeMs = 10000
+        self.playerService.duration = 180
+
+        self.playerService.clearQueue()
+        await self.playerService.undoQueue()
+
+        #expect(self.playerService.progress == 10)
+        #expect(self.playerService.currentTimeMs == 10000)
+        #expect(self.playerService.pendingRestoredSeek == 10)
+        #expect(self.playerService.isRestoringPlaybackSession)
+        #expect(self.playerService.shouldAutoResumeAfterRestoredLoad)
+    }
+
+    @Test("Undo preserves a paused queue transport intent")
+    func undoPreservesPausedTransport() async {
+        let songs = TestFixtures.makeSongs(count: 2)
+        await self.playerService.playQueue(songs, startingAt: 0)
+        await self.playerService.pause()
+        self.playerService.clearQueue()
+
+        await self.playerService.undoQueue()
+
+        #expect(self.playerService.queue == songs)
+        #expect(self.playerService.state == .paused)
+        #expect(!self.playerService.shouldResumeAfterInterruption)
+    }
+
+    @Test("Paused undo stays paused while metadata is still loading")
+    func pausedUndoDoesNotAutoplayDuringMetadataFetch() async {
+        let firstQueue = TestFixtures.makeSongs(count: 2)
+        let replacement = TestFixtures.makeSong(id: "replacement")
+        await self.playerService.playQueue(firstQueue, startingAt: 0)
+        await self.playerService.pause()
+        self.playerService.progress = 42
+        self.playerService.duration = 180
+        await self.playerService.playQueue([replacement], startingAt: 0)
+        let metadataStarted = AsyncGate()
+        let releaseMetadata = AsyncGate()
+        self.mockClient.beforeGetSongReturn = { _ in
+            await metadataStarted.open()
+            await releaseMetadata.wait()
+        }
+
+        let undoTask = Task { @MainActor in
+            await self.playerService.undoQueue()
+        }
+        await metadataStarted.wait()
+
+        #expect(self.playerService.state == .paused)
+        #expect(!self.playerService.shouldResumeAfterInterruption)
+        #expect(self.playerService.currentTrack?.videoId == firstQueue[0].videoId)
+        #expect(self.playerService.progress == 42)
+
+        await releaseMetadata.open()
+        await undoTask.value
+        #expect(self.playerService.state == .paused)
+    }
+
+    @Test("Pause during undo metadata preserves structural finalization")
+    func pauseDuringUndoMetadataPreservesStructuralFinalization() async {
+        let settings = SettingsManager.shared
+        let savedAhead = settings.smartShuffleSuggestionsAhead
+        let savedEveryN = settings.smartShuffleSuggestEveryN
+        let savedBurst = settings.smartShuffleBurst
+        self.playerService.smartShuffleFeatureEnabled = { true }
+        settings.smartShuffleSuggestionsAhead = 1
+        settings.smartShuffleSuggestEveryN = 1
+        settings.smartShuffleBurst = 1
+        defer {
+            settings.smartShuffleSuggestionsAhead = savedAhead
+            settings.smartShuffleSuggestEveryN = savedEveryN
+            settings.smartShuffleBurst = savedBurst
+        }
+
+        let restored = Song(
+            id: "pause-undo-restored",
+            title: "Pause Undo Restored",
+            artists: [],
+            duration: 180,
+            videoId: "pause-undo-restored",
+            feedbackTokens: FeedbackTokens(add: "old-add", remove: "old-remove")
+        )
+        let replacement = Song(
+            id: "pause-undo-replacement",
+            title: "Pause Undo Replacement",
+            artists: [],
+            duration: 180,
+            videoId: "pause-undo-replacement",
+            feedbackTokens: FeedbackTokens(add: "replacement-add", remove: "replacement-remove")
+        )
+        await self.playerService.playQueue([restored], startingAt: 0)
+        self.playerService.shuffleMode = .smart
+        let smartState = self.playerService.makeQueueStateSnapshot()
+        self.playerService.shuffleMode = .off
+        await self.playerService.playQueue([replacement], startingAt: 0)
+        self.playerService.clearQueueUndoRedoHistory()
+        self.playerService.recordQueueStateForUndo(smartState)
+        self.mockClient.songResponses[restored.videoId] = Song(
+            id: restored.id,
+            title: restored.title,
+            artists: restored.artists,
+            duration: restored.duration,
+            videoId: restored.videoId,
+            feedbackTokens: FeedbackTokens(add: "new-add", remove: "new-remove")
+        )
+        self.mockClient.radioQueueSongs[restored.videoId] = [
+            TestFixtures.makeSong(id: "pause-undo-suggestion"),
+        ]
+        let metadataStarted = AsyncGate()
+        let releaseMetadata = AsyncGate()
+        self.mockClient.beforeGetSongReturn = { videoID in
+            guard videoID == restored.videoId else { return }
+            await metadataStarted.open()
+            await releaseMetadata.wait()
+        }
+        let undoIntent = self.playerService.beginMusicPlaybackIntent()
+        let undoTask = Task { @MainActor in
+            await self.playerService.undoQueue(intent: undoIntent)
+        }
+        await metadataStarted.wait()
+        let restoreQueueGeneration = self.playerService.reserveQueueMutation()
+
+        await self.playerService.pause()
+        #expect(!self.playerService.acceptsMusicPlaybackIntent(undoIntent))
+        #expect(self.playerService.acceptsQueueMutation(restoreQueueGeneration))
+        await releaseMetadata.open()
+        await undoTask.value
+        for _ in 0 ..< 100 where !self.mockClient.getRadioQueueCalled {
+            await Task.yield()
+        }
+        let fillTask = self.playerService.smartShuffleFillTask
+        await fillTask?.value
+
+        #expect(self.playerService.shuffleMode == .smart)
+        #expect(self.playerService.state == .paused)
+        #expect(self.playerService.queue.contains { $0.videoId == "pause-undo-suggestion" })
+    }
+
+    @Test("Pause during Previous metadata preserves the committed queue index")
+    func pauseDuringPreviousMetadataPersistsCommittedIndex() async {
+        let persistenceSuiteName = "com.kaset.tests.previous-persistence.\(UUID().uuidString)"
+        guard let persistenceDefaults = UserDefaults(suiteName: persistenceSuiteName) else {
+            Issue.record("Unable to create isolated queue persistence defaults")
+            return
+        }
+        persistenceDefaults.removePersistentDomain(forName: persistenceSuiteName)
+        self.playerService.queuePersistenceDefaults = persistenceDefaults
+        let first = Song(
+            id: "previous-persist-first",
+            title: "First",
+            artists: [],
+            videoId: "previous-persist-first",
+            feedbackTokens: FeedbackTokens(add: "first-add", remove: "first-remove")
+        )
+        let second = Song(
+            id: "previous-persist-second",
+            title: "Loading...",
+            artists: [],
+            videoId: "previous-persist-second"
+        )
+        let third = Song(
+            id: "previous-persist-third",
+            title: "Third",
+            artists: [],
+            videoId: "previous-persist-third",
+            feedbackTokens: FeedbackTokens(add: "third-add", remove: "third-remove")
+        )
+        defer {
+            self.playerService.clearSavedQueue()
+            persistenceDefaults.removePersistentDomain(forName: persistenceSuiteName)
+        }
+        await self.playerService.playQueue([first, second, third], startingAt: 2)
+        self.playerService.progress = 0
+        let metadataStarted = AsyncGate()
+        let releaseMetadata = AsyncGate()
+        self.mockClient.beforeGetSongReturn = { videoID in
+            guard videoID == second.videoId else { return }
+            await metadataStarted.open()
+            await releaseMetadata.wait()
+        }
+        self.mockClient.songResponses[second.videoId] = second
+        let previousIntent = self.playerService.beginMusicPlaybackIntent()
+        let previousTask = Task { @MainActor in
+            await self.playerService.previous(intent: previousIntent)
+        }
+        await metadataStarted.wait()
+
+        await self.playerService.pause()
+        self.mockClient.shouldThrowError = YTMusicError.networkError(
+            underlying: URLError(.notConnectedToInternet)
+        )
+        await releaseMetadata.open()
+        await previousTask.value
+
+        #expect(self.playerService.currentIndex == 1)
+        #expect(self.playerService.state == .paused)
+        let restored = PlayerService()
+        restored.queuePersistenceDefaults = persistenceDefaults
+        #expect(restored.restoreQueueFromPersistence())
+        #expect(restored.currentIndex == 1)
+        #expect(restored.currentTrack?.videoId == second.videoId)
+    }
+
+    @Test("Undoing footer clear restores the pre-stop playback owner and clock")
+    func undoStopAndClearRestoresPlaybackSnapshot() async {
+        let song = TestFixtures.makeSong(id: "footer-clear")
+        await self.playerService.playQueue([song], startingAt: 0)
+        let entryID = self.playerService.queueEntryIDs[0]
+        await self.playerService.pause()
+        self.playerService.progress = 42
+        self.playerService.currentTimeMs = 42000
+        self.playerService.duration = 180
+
+        await self.playerService.stopAndClearQueue()
+        await self.playerService.undoQueue()
+
+        #expect(self.playerService.queue == [song])
+        #expect(self.playerService.activePlaybackQueueEntryID == entryID)
+        #expect(self.playerService.currentQueueEntryID == entryID)
+        #expect(self.playerService.currentTrack?.videoId == song.videoId)
+        #expect(self.playerService.progress == 42)
+        #expect(self.playerService.currentTimeMs == 42000)
+        #expect(self.playerService.duration == 180)
+        #expect(self.playerService.state == .paused)
+        #expect(!self.playerService.shouldResumeAfterInterruption)
+    }
+
+    @Test("Undoing a terminal clear preserves ended playback state")
+    func undoEndedStopAndClearRemainsEnded() async throws {
+        let song = TestFixtures.makeSong(id: "ended-clear")
+        await self.playerService.playQueue([song], startingAt: 0)
+        let entryID = self.playerService.queueEntryIDs[0]
+        self.playerService.progress = song.duration ?? 180
+        self.playerService.currentTimeMs = Int(self.playerService.progress * 1000)
+        self.playerService.duration = song.duration ?? 180
+        self.playerService.markPlaybackEnded()
+
+        await self.playerService.stopAndClearQueue()
+        await self.playerService.undoQueue()
+
+        #expect(self.playerService.state == .ended)
+        #expect(self.playerService.activePlaybackQueueEntryID == entryID)
+        #expect(self.playerService.currentTrack?.videoId == song.videoId)
+        #expect(self.playerService.progress == (song.duration ?? 180))
+        #expect(!self.playerService.shouldResumeAfterInterruption)
+        #expect(!self.playerService.isAwaitingPlaybackConfirmation)
+        #expect(self.playerService.isExplicitPauseIntentActive)
+        #expect(self.playerService.shouldSuppressAutoplayAfterQueueEnd)
+        let endedOccurrence = try #require(self.playerService.currentMusicPlaybackOccurrence)
+
+        await self.playerService.resume()
+        let replayOccurrence = try #require(self.playerService.currentMusicPlaybackOccurrence)
+        #expect(replayOccurrence.nativeGeneration > endedOccurrence.nativeGeneration)
+        #expect(self.playerService.progress == 0)
+    }
+
+    @Test("Undoing an ended entry refreshes video availability synchronously")
+    func undoEndedEntryRefreshesVideoAvailability() async {
+        let audioOnly = Song(
+            id: "ended-audio-only",
+            title: "Audio Only",
+            artists: [],
+            duration: 180,
+            videoId: "ended-audio-only",
+            musicVideoType: .atv,
+            feedbackTokens: FeedbackTokens(add: nil, remove: nil)
+        )
+        let video = Song(
+            id: "ended-video-capable",
+            title: "Video",
+            artists: [],
+            duration: 180,
+            videoId: "ended-video-capable",
+            musicVideoType: .omv,
+            feedbackTokens: FeedbackTokens(add: nil, remove: nil)
+        )
+        await self.playerService.playQueue([audioOnly], startingAt: 0)
+        self.playerService.markPlaybackEnded()
+        await self.playerService.playQueue([video], startingAt: 0)
+        self.playerService.currentTrackHasVideo = true
+        self.mockClient.shouldThrowError = YTMusicError.networkError(
+            underlying: URLError(.notConnectedToInternet)
+        )
+
+        await self.playerService.undoQueue()
+
+        #expect(self.playerService.currentTrack?.videoId == audioOnly.videoId)
+        #expect(self.playerService.state == .ended)
+        #expect(!self.playerService.currentTrackHasVideo)
+    }
+
+    @Test("Undoing a terminal clear preserves detached artist episode identity")
+    func undoEndedArtistEpisodeClearPreservesEpisodeIdentity() async {
+        let episode = ArtistEpisode(
+            videoId: "ended-history-episode",
+            title: "Ended History Episode",
+            subtitle: "Replay",
+            isLive: false
+        )
+        await self.playerService.playEpisode(episode)
+        self.playerService.markPlaybackEnded()
+
+        await self.playerService.stopAndClearQueue()
+        await self.playerService.undoQueue()
+
+        #expect(self.playerService.state == .ended)
+        #expect(self.playerService.currentEpisode == episode)
+        #expect(self.playerService.currentTrack?.videoId == episode.videoId)
+        #expect(self.playerService.activePlaybackQueueEntryID == nil)
+    }
+
+    @Test("Undo and redo of a stopped clear remain stopped")
+    func stoppedClearHistoryDoesNotStartPlayback() async {
+        let song = TestFixtures.makeSong(id: "redo-stop")
+        defer { self.playerService.clearSavedQueue() }
+        await self.playerService.playQueue([song], startingAt: 0)
+        await self.playerService.stop()
+        await self.playerService.clearQueueEntirely()
+
+        await self.playerService.undoQueue()
+        #expect(self.playerService.queue == [song])
+        #expect(self.playerService.currentTrack == nil)
+        #expect(self.playerService.state == .idle)
+        let restoredUndo = PlayerService()
+        #expect(restoredUndo.restoreQueueFromPersistence())
+        #expect(restoredUndo.queue.map(\.videoId) == [song.videoId])
+
+        await self.playerService.redoQueue()
+
+        #expect(self.playerService.queue.isEmpty)
+        #expect(self.playerService.currentTrack == nil)
+        #expect(self.playerService.state == .idle)
+        let restoredRedo = PlayerService()
+        #expect(!restoredRedo.restoreQueueFromPersistence())
+    }
+}

--- a/Tests/KasetTests/PlayerServiceQueueIdentityFollowUpTests.swift
+++ b/Tests/KasetTests/PlayerServiceQueueIdentityFollowUpTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+extension PlayerServiceQueueTests {
+    @Test("Reorder allows inserting an entry immediately above the current track")
+    func reorderQueueAllowsDestinationAtCurrentIndex() async {
+        let songs = TestFixtures.makeSongs(count: 4)
+        await self.playerService.playQueue(songs, startingAt: 2)
+        let currentEntryID = self.playerService.currentQueueEntryID
+
+        self.playerService.reorderQueue(from: IndexSet(integer: 3), to: 2)
+
+        #expect(self.playerService.queue.map(\.videoId) == ["video-0", "video-1", "video-3", "video-2"])
+        #expect(self.playerService.currentQueueEntryID == currentEntryID)
+        #expect(self.playerService.currentIndex == 3)
+    }
+
+    @Test("Entry-ID reorder follows the intended rows after an insertion")
+    func reorderQueueByEntryIDSurvivesSnapshotDrift() async {
+        let songs = TestFixtures.makeSongs(count: 4)
+        await self.playerService.playQueue(songs, startingAt: 0)
+        let movedEntryID = self.playerService.queueEntryIDs[3]
+        let beforeEntryID = self.playerService.queueEntryIDs[2]
+        let inserted = QueueEntry(id: UUID(), song: TestFixtures.makeSong(id: "inserted"))
+        self.playerService.setQueue(entries: [
+            self.playerService.queueEntries[0],
+            inserted,
+            self.playerService.queueEntries[1],
+            self.playerService.queueEntries[2],
+            self.playerService.queueEntries[3],
+        ])
+
+        self.playerService.reorderQueue(entryID: movedEntryID, before: beforeEntryID)
+
+        #expect(self.playerService.queue.map(\.videoId) == [
+            "video-0",
+            "inserted",
+            "video-1",
+            "video-3",
+            "video-2",
+        ])
+    }
+
+    @Test("Entry-ID reorder ignores a disappeared destination")
+    func reorderQueueByEntryIDIgnoresMissingTarget() async {
+        let songs = TestFixtures.makeSongs(count: 3)
+        await self.playerService.playQueue(songs, startingAt: 1)
+        let sourceID = self.playerService.queueEntryIDs[0]
+        let targetID = self.playerService.queueEntryIDs[2]
+        self.playerService.removeFromQueue(entryIDs: [targetID])
+        let before = self.playerService.queueEntryIDs
+
+        self.playerService.reorderQueue(entryID: sourceID, before: targetID)
+
+        #expect(self.playerService.queueEntryIDs == before)
+    }
+
+    @Test("Detached playback allows reordering the leftover queue cursor row")
+    func detachedPlaybackAllowsCursorRowReorder() async {
+        let songs = TestFixtures.makeSongs(count: 2)
+        await self.playerService.playQueue(songs, startingAt: 1)
+        let secondEntryID = self.playerService.queueEntryIDs[1]
+        let firstEntryID = self.playerService.queueEntryIDs[0]
+        await self.playerService.play(song: TestFixtures.makeSong(id: "detached-reorder"))
+
+        self.playerService.reorderQueue(entryID: secondEntryID, before: firstEntryID)
+
+        #expect(self.playerService.queue.map(\.videoId) == [songs[1].videoId, songs[0].videoId])
+    }
+
+    @Test("Partial video-ID reorder clamps a removed current cursor")
+    func partialVideoIDReorderClampsCurrentIndex() async {
+        let songs = TestFixtures.makeSongs(count: 3)
+        await self.playerService.playQueue(songs, startingAt: 2)
+
+        self.playerService.reorderQueue(videoIds: [songs[0].videoId])
+
+        #expect(self.playerService.queue == [songs[0]])
+        #expect(self.playerService.currentIndex == 0)
+        #expect(self.playerService.currentQueueEntryID == self.playerService.queueEntryIDs.first)
+    }
+}

--- a/Tests/KasetTests/PlayerServiceQueueTests.swift
+++ b/Tests/KasetTests/PlayerServiceQueueTests.swift
@@ -1,3 +1,5 @@
+// swiftlint:disable file_length
+
 import Foundation
 import Testing
 @testable import Kaset
@@ -138,19 +140,28 @@ struct PlayerServiceQueueTests {
         #expect(self.playerService.currentIndex == 0)
     }
 
-    @Test("Remove duplicate queue entries keeps first occurrence and realigns current track")
-    func removeDuplicateQueueEntriesKeepsFirstOccurrence() async throws {
+    @Test("Remove duplicate queue entries retains the active occurrence at the first video position")
+    func removeDuplicateQueueEntriesRetainsActiveOccurrence() async throws {
         let duplicateSong = TestFixtures.makeSong(id: "dup", title: "Duplicate Song")
         let otherSong = TestFixtures.makeSong(id: "other", title: "Other Song")
         await self.playerService.playQueue([duplicateSong, otherSong, duplicateSong, duplicateSong], startingAt: 2)
-        let firstDuplicateEntryID = try #require(self.playerService.queueEntryIDs.first)
+        let activeDuplicateEntryID = try #require(self.playerService.activePlaybackQueueEntryID)
+        let endingOccurrence = self.playerService.currentMusicPlaybackOccurrence
 
         self.playerService.removeDuplicateQueueEntries()
 
         #expect(self.playerService.queue.count == 2)
         #expect(self.playerService.queue.map(\.videoId) == ["dup", "other"])
         #expect(self.playerService.currentIndex == 0)
-        #expect(self.playerService.currentQueueEntryID == firstDuplicateEntryID)
+        #expect(self.playerService.currentQueueEntryID == activeDuplicateEntryID)
+        #expect(self.playerService.activePlaybackQueueEntryID == activeDuplicateEntryID)
+
+        await self.playerService.handleTrackEnded(
+            observedVideoId: duplicateSong.videoId,
+            playbackOccurrence: endingOccurrence
+        )
+        #expect(self.playerService.currentIndex == 1)
+        #expect(self.playerService.currentTrack?.videoId == otherSong.videoId)
     }
 
     @Test("queueHasDuplicateEntries reflects duplicate video IDs")
@@ -224,7 +235,7 @@ struct PlayerServiceQueueTests {
         self.playerService.clearQueue()
         #expect(self.playerService.queue.count == 1)
 
-        self.playerService.undoQueue()
+        await self.playerService.undoQueue()
 
         // Assert
         #expect(self.playerService.queue.count == originalQueue.count)
@@ -239,10 +250,10 @@ struct PlayerServiceQueueTests {
 
         // Act - Clear, undo, then redo
         self.playerService.clearQueue()
-        self.playerService.undoQueue()
+        await self.playerService.undoQueue()
         #expect(!self.playerService.queue.isEmpty)
 
-        self.playerService.redoQueue()
+        await self.playerService.redoQueue()
 
         // Assert - clearQueue() keeps the current track, so queue has 1 item
         #expect(self.playerService.queue.count == 1)
@@ -263,7 +274,7 @@ struct PlayerServiceQueueTests {
         #expect(self.playerService.canUndoQueue == true)
 
         // Act - Undo all history
-        self.playerService.undoQueue()
+        await self.playerService.undoQueue()
 
         // Assert - Can't undo anymore
         #expect(self.playerService.canUndoQueue == false)
@@ -280,13 +291,13 @@ struct PlayerServiceQueueTests {
 
         // Act
         self.playerService.clearQueue()
-        self.playerService.undoQueue()
+        await self.playerService.undoQueue()
 
         // Assert - Can redo after undo
         #expect(self.playerService.canRedoQueue == true)
 
         // Act
-        self.playerService.redoQueue()
+        await self.playerService.redoQueue()
 
         // Assert - Can't redo anymore
         #expect(self.playerService.canRedoQueue == false)
@@ -306,10 +317,10 @@ struct PlayerServiceQueueTests {
         #expect(self.playerService.queue.count == 4)
 
         // Act - Undo multiple times
-        self.playerService.undoQueue()
+        await self.playerService.undoQueue()
         #expect(self.playerService.queue.count == 2)
 
-        self.playerService.undoQueue()
+        await self.playerService.undoQueue()
         #expect(self.playerService.queue.count == 3)
     }
 
@@ -323,12 +334,12 @@ struct PlayerServiceQueueTests {
 
         // Act - Undo 10 times (should work)
         for _ in 1 ... 10 {
-            self.playerService.undoQueue()
+            await self.playerService.undoQueue()
         }
 
         // The 11th undo should not change anything (oldest state dropped)
         let queueAfter10Undos = self.playerService.queue.count
-        self.playerService.undoQueue()
+        await self.playerService.undoQueue()
 
         // Assert - Queue unchanged after 10 undos
         #expect(self.playerService.queue.count == queueAfter10Undos)
@@ -409,6 +420,38 @@ struct PlayerServiceQueueTests {
         #expect(newService.currentIndex == 1)
         #expect(newService.currentTrack?.videoId == duplicateSong.videoId)
         #expect(newService.pendingPlayVideoId == duplicateSong.videoId)
+    }
+
+    @Test("Identity switch persists sanitized account metadata")
+    func identitySwitchPersistsSanitizedAccountMetadata() async {
+        let song = Song(
+            id: "identity-persist-sanitized",
+            title: "Identity Persist Sanitized",
+            artists: [],
+            duration: 180,
+            videoId: "identity-persist-sanitized",
+            likeStatus: .like,
+            isInLibrary: true,
+            feedbackTokens: FeedbackTokens(add: "old-add", remove: "old-remove")
+        )
+        defer { self.playerService.clearSavedQueue() }
+        await self.playerService.playQueue([song], startingAt: 0)
+        self.playerService.saveQueueForPersistence()
+        self.playerService.currentWebPlaybackVideoId = { nil }
+
+        self.playerService.reloadCurrentTrackForIdentitySwitch()
+
+        #expect(self.playerService.currentTrack?.likeStatus == nil)
+        #expect(self.playerService.currentTrack?.isInLibrary == nil)
+        #expect(self.playerService.currentTrack?.feedbackTokens == nil)
+        let restored = PlayerService()
+        #expect(restored.restoreQueueFromPersistence())
+        #expect(restored.queue[0].likeStatus == nil)
+        #expect(restored.queue[0].isInLibrary == nil)
+        #expect(restored.queue[0].feedbackTokens == nil)
+        #expect(restored.currentTrack?.likeStatus == nil)
+        #expect(restored.currentTrack?.isInLibrary == nil)
+        #expect(restored.currentTrack?.feedbackTokens == nil)
     }
 
     @Test("Authenticated startup clears guest-owned restored playback")
@@ -700,6 +743,35 @@ struct PlayerServiceQueueTests {
         #expect(self.playerService.queue[0].artists[0].name == "Enriched Artist")
     }
 
+    @Test("Background enrichment preserves browse-derived unplayable state")
+    func enrichmentPreservesUnplayableState() async {
+        let incomplete = Song(
+            id: "unplayable-enrichment",
+            title: "Loading...",
+            artists: [],
+            thumbnailURL: nil,
+            videoId: "unplayable-enrichment",
+            isPlayable: false
+        )
+        self.mockClient.songResponses[incomplete.videoId] = Song(
+            id: incomplete.id,
+            title: "Enriched Unavailable Song",
+            artists: [Artist(id: "artist", name: "Artist")],
+            thumbnailURL: URL(string: "https://example.com/enriched-unavailable.jpg"),
+            videoId: incomplete.videoId,
+            isPlayable: true
+        )
+        let entryID = UUID()
+        self.playerService.setQueue(entries: [QueueEntry(id: entryID, song: incomplete)])
+
+        await self.playerService.enrichQueueMetadata()
+
+        #expect(self.playerService.queueEntries[0].id == entryID)
+        #expect(self.playerService.queue[0].title == "Enriched Unavailable Song")
+        #expect(self.playerService.queue[0].artists.first?.name == "Artist")
+        #expect(!self.playerService.queue[0].isPlayable)
+    }
+
     @Test("Enrichment preserves the .suggested source of a Smart Shuffle entry")
     func enrichmentPreservesSuggestedSource() async {
         // Arrange: a complete original plus an incomplete Smart Shuffle suggestion.
@@ -784,9 +856,9 @@ struct PlayerServiceQueueTests {
         await self.playerService.play(song: completeSong)
         try? await Task.sleep(for: .milliseconds(100))
 
-        // Assert - Queue entry was enriched because thumbnailURL was nil (triggers needsUpdate)
-        #expect(self.playerService.queue[0].title == "Different Title")
-        #expect(self.playerService.queue[0].artists[0].name == "Different Artist")
+        // Assert - only missing fields are enriched; newer good title/artist stay authoritative.
+        #expect(self.playerService.queue[0].title == "Good Title")
+        #expect(self.playerService.queue[0].artists[0].name == "Good Artist")
     }
 
     @Test("Metadata enrichment handles API errors gracefully")

--- a/Tests/KasetTests/PlayerServiceSmartShuffleTests.swift
+++ b/Tests/KasetTests/PlayerServiceSmartShuffleTests.swift
@@ -224,9 +224,15 @@ struct PlayerServiceSmartShuffleTests {
     @Test("Pausing initial playback keeps Smart Shuffle fill eligible")
     func pauseKeepsSmartShuffleFillEligible() async {
         self.playerService.shuffleMode = .smart
-        let song = TestFixtures.makeSong(id: "seed")
-        self.mockClient.songResponses[song.videoId] = song
-        self.mockClient.radioQueueSongs[song.videoId] = [TestFixtures.makeSong(id: "suggestion")]
+        let songs = (0 ..< SettingsManager.smartShuffleSuggestEveryNRange.upperBound).map {
+            TestFixtures.makeSong(id: "seed-\($0)")
+        }
+        self.mockClient.songResponses[songs[0].videoId] = songs[0]
+        for song in songs {
+            self.mockClient.radioQueueSongs[song.videoId] = [
+                TestFixtures.makeSong(id: "suggestion-\(song.videoId)"),
+            ]
+        }
         let metadataStarted = AsyncGate()
         let releaseMetadata = AsyncGate()
         self.mockClient.beforeGetSongReturn = { _ in
@@ -235,7 +241,7 @@ struct PlayerServiceSmartShuffleTests {
         }
 
         let playTask = Task { @MainActor in
-            await self.playerService.playQueue([song], startingAt: 0)
+            await self.playerService.playQueue(songs, startingAt: 0)
         }
         await metadataStarted.wait()
         await self.playerService.pause()

--- a/Tests/KasetTests/PlayerServiceSmartShuffleTests.swift
+++ b/Tests/KasetTests/PlayerServiceSmartShuffleTests.swift
@@ -242,6 +242,13 @@ struct PlayerServiceSmartShuffleTests {
         await releaseMetadata.open()
         await playTask.value
 
+        let deadline = ContinuousClock.now + .seconds(5)
+        while !self.playerService.queueEntries.contains(where: { $0.source == .suggested }),
+              ContinuousClock.now < deadline
+        {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+
         #expect(self.playerService.queueEntries.contains { $0.source == .suggested })
     }
 

--- a/Tests/KasetTests/PlayerServiceSmartShuffleTests.swift
+++ b/Tests/KasetTests/PlayerServiceSmartShuffleTests.swift
@@ -221,8 +221,8 @@ struct PlayerServiceSmartShuffleTests {
         #expect(!self.playerService.queueEntries.contains { $0.source == .suggested })
     }
 
-    @Test("Pausing initial playback does not skip committed Smart Shuffle fill")
-    func pauseDoesNotSkipCommittedSmartShuffleFill() async {
+    @Test("Pausing initial playback keeps Smart Shuffle fill eligible")
+    func pauseKeepsSmartShuffleFillEligible() async {
         self.playerService.shuffleMode = .smart
         let song = TestFixtures.makeSong(id: "seed")
         self.mockClient.songResponses[song.videoId] = song
@@ -241,13 +241,9 @@ struct PlayerServiceSmartShuffleTests {
         await self.playerService.pause()
         await releaseMetadata.open()
         await playTask.value
-
-        let deadline = ContinuousClock.now + .seconds(5)
-        while !self.playerService.queueEntries.contains(where: { $0.source == .suggested }),
-              ContinuousClock.now < deadline
-        {
-            try? await Task.sleep(for: .milliseconds(10))
-        }
+        // Drive the single-flight fill explicitly so the assertion does not
+        // depend on executor timing after the metadata gate is released.
+        await self.playerService.fillSmartShuffleWindow()
 
         #expect(self.playerService.queueEntries.contains { $0.source == .suggested })
     }

--- a/Tests/KasetTests/PlayerServiceSmartShuffleTests.swift
+++ b/Tests/KasetTests/PlayerServiceSmartShuffleTests.swift
@@ -2,6 +2,19 @@ import Foundation
 import Testing
 @testable import Kaset
 
+// MARK: - SmartShuffleFeatureGate
+
+@MainActor
+private final class SmartShuffleFeatureGate {
+    var isEnabled: Bool
+
+    init(isEnabled: Bool) {
+        self.isEnabled = isEnabled
+    }
+}
+
+// MARK: - PlayerServiceSmartShuffleTests
+
 @Suite(.serialized, .tags(.service))
 @MainActor
 struct PlayerServiceSmartShuffleTests {
@@ -11,6 +24,7 @@ struct PlayerServiceSmartShuffleTests {
     init() {
         self.mockClient = MockYTMusicClient()
         self.playerService = PlayerService()
+        self.playerService.smartShuffleFeatureEnabled = { true }
         self.playerService.setYTMusicClient(self.mockClient)
         self.playerService.confirmPlaybackStarted()
     }
@@ -95,10 +109,8 @@ struct PlayerServiceSmartShuffleTests {
 
     @Test("disabling Smart Shuffle while a fill is in flight prevents late insertions")
     func disablingSmartShuffleStopsInFlightFill() async {
-        let settings = SettingsManager.shared
-        let savedEnabled = settings.smartShuffleEnabled
-        settings.smartShuffleEnabled = true
-        defer { settings.smartShuffleEnabled = savedEnabled }
+        let featureGate = SmartShuffleFeatureGate(isEnabled: true)
+        self.playerService.smartShuffleFeatureEnabled = { featureGate.isEnabled }
 
         let songs = TestFixtures.makeSongs(count: 6)
         await self.playerService.playQueue(songs, startingAt: 0)
@@ -108,19 +120,129 @@ struct PlayerServiceSmartShuffleTests {
 
         let fill = Task { await self.playerService.fillSmartShuffleWindow() }
         try? await Task.sleep(for: .milliseconds(20))
-        settings.smartShuffleEnabled = false
+        featureGate.isEnabled = false
         await fill.value
 
         #expect(!self.playerService.queueEntries.contains { $0.source == .suggested })
     }
 
+    @Test("Redoing Smart Shuffle restarts the canceled recommendation fill")
+    func redoSmartShuffleRestartsCanceledFill() async {
+        let settings = SettingsManager.shared
+        let savedAhead = settings.smartShuffleSuggestionsAhead
+        let savedEveryN = settings.smartShuffleSuggestEveryN
+        let savedBurst = settings.smartShuffleBurst
+        settings.smartShuffleSuggestionsAhead = 1
+        settings.smartShuffleSuggestEveryN = 1
+        settings.smartShuffleBurst = 1
+        defer {
+            settings.smartShuffleSuggestionsAhead = savedAhead
+            settings.smartShuffleSuggestEveryN = savedEveryN
+            settings.smartShuffleBurst = savedBurst
+        }
+
+        let songs = TestFixtures.makeSongs(count: 3)
+        await self.playerService.playQueue(songs, startingAt: 0)
+        for song in songs {
+            self.mockClient.radioQueueSongs[song.videoId] = [
+                TestFixtures.makeSong(id: "redo-rec-\(song.videoId)"),
+            ]
+        }
+        let releaseRequests = AsyncGate()
+        self.mockClient.beforeRadioQueueReturn = { _ in
+            await releaseRequests.wait()
+        }
+
+        self.playerService.setShuffleMode(.smart)
+        for _ in 0 ..< 20 where self.mockClient.getRadioQueueVideoIds.count < 1 {
+            await Task.yield()
+        }
+        #expect(self.mockClient.getRadioQueueVideoIds.count == 1)
+
+        await self.playerService.undoQueue()
+        #expect(self.playerService.shuffleMode == .off)
+        await self.playerService.redoQueue()
+        #expect(self.playerService.shuffleMode == .smart)
+        for _ in 0 ..< 20 where self.mockClient.getRadioQueueVideoIds.count < 2 {
+            await Task.yield()
+        }
+
+        let restoredFill = self.playerService.smartShuffleFillTask
+        #expect(self.mockClient.getRadioQueueVideoIds.count == 2)
+        await releaseRequests.open()
+        await restoredFill?.value
+        #expect(self.playerService.queueEntries.contains { $0.source == .suggested })
+    }
+
+    @Test("Stop cancels an in-flight Smart Shuffle fill")
+    func stopCancelsInFlightSmartShuffleFill() async {
+        let songs = TestFixtures.makeSongs(count: 6)
+        await self.playerService.playQueue(songs, startingAt: 0)
+        self.playerService.shuffleMode = .smart
+        self.mockClient.radioQueueSongs["video-0"] = [TestFixtures.makeSong(id: "late-rec")]
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        self.mockClient.beforeRadioQueueReturn = { _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+
+        let entryIDs = self.playerService.queueEntryIDs
+        let fill = Task { @MainActor in
+            await self.playerService.fillSmartShuffleWindow()
+        }
+        await requestStarted.wait()
+        await self.playerService.stop()
+        await releaseRequest.open()
+        await fill.value
+
+        #expect(self.playerService.queueEntryIDs == entryIDs)
+        #expect(!self.playerService.queueEntries.contains { $0.source == .suggested })
+        #expect(!self.playerService.isApplyingSmartShuffle)
+    }
+
+    @Test("Stop invalidates a scheduled Smart Shuffle fill before it starts")
+    func stopInvalidatesScheduledSmartShuffleFill() async {
+        let songs = TestFixtures.makeSongs(count: 3)
+        await self.playerService.playQueue(songs, startingAt: 0)
+        self.mockClient.radioQueueSongs[songs[0].videoId] = [TestFixtures.makeSong(id: "late")]
+
+        self.playerService.setShuffleMode(.smart)
+        await self.playerService.stop()
+        for _ in 0 ..< 10 {
+            await Task.yield()
+        }
+
+        #expect(!self.mockClient.getRadioQueueCalled)
+        #expect(!self.playerService.queueEntries.contains { $0.source == .suggested })
+    }
+
+    @Test("Pausing initial playback does not skip committed Smart Shuffle fill")
+    func pauseDoesNotSkipCommittedSmartShuffleFill() async {
+        self.playerService.shuffleMode = .smart
+        let song = TestFixtures.makeSong(id: "seed")
+        self.mockClient.songResponses[song.videoId] = song
+        self.mockClient.radioQueueSongs[song.videoId] = [TestFixtures.makeSong(id: "suggestion")]
+        let metadataStarted = AsyncGate()
+        let releaseMetadata = AsyncGate()
+        self.mockClient.beforeGetSongReturn = { _ in
+            await metadataStarted.open()
+            await releaseMetadata.wait()
+        }
+
+        let playTask = Task { @MainActor in
+            await self.playerService.playQueue([song], startingAt: 0)
+        }
+        await metadataStarted.wait()
+        await self.playerService.pause()
+        await releaseMetadata.open()
+        await playTask.value
+
+        #expect(self.playerService.queueEntries.contains { $0.source == .suggested })
+    }
+
     @Test("undo cancels an in-flight Smart Shuffle fill for the replaced queue")
     func undoCancelsInFlightSmartShuffleFill() async {
-        let settings = SettingsManager.shared
-        let savedEnabled = settings.smartShuffleEnabled
-        settings.smartShuffleEnabled = true
-        defer { settings.smartShuffleEnabled = savedEnabled }
-
         let songs = TestFixtures.makeSongs(count: 4)
         await self.playerService.playQueue(songs, startingAt: 0)
         self.playerService.shuffleMode = .smart
@@ -134,7 +256,7 @@ struct PlayerServiceSmartShuffleTests {
 
         let fill = Task { await self.playerService.fillSmartShuffleWindow() }
         try? await Task.sleep(for: .milliseconds(20))
-        self.playerService.undoQueue()
+        await self.playerService.undoQueue()
         await fill.value
 
         #expect(!self.playerService.queueEntries.contains { $0.source == .suggested })
@@ -159,6 +281,7 @@ struct PlayerServiceSmartShuffleTests {
         ])
         self.playerService.currentIndex = 2
         self.playerService.currentTrack = suggestion.song
+        self.playerService.activePlaybackQueueEntryID = suggestion.id
         self.playerService.queueOrderBeforeShuffle = originals
         self.playerService.shuffleMode = .smart
 
@@ -227,6 +350,7 @@ struct PlayerServiceSmartShuffleTests {
         self.playerService.setQueue(entries: [originalBefore, currentSuggestion, originalAfter])
         self.playerService.currentIndex = 1
         self.playerService.currentTrack = currentSuggestion.song
+        self.playerService.activePlaybackQueueEntryID = currentSuggestion.id
         self.playerService.saveQueueForPersistence()
         defer { self.playerService.clearSavedQueue() }
 
@@ -235,6 +359,177 @@ struct PlayerServiceSmartShuffleTests {
         #expect(restored.queue.map(\.videoId) == ["video-before", "rec-current", "video-after"])
         #expect(restored.queueEntries.map(\.source) == [.queued, .suggested, .queued])
         #expect(restored.currentIndex == 1)
+    }
+
+    @Test("Detached playback does not preserve a queue-cursor suggestion when leaving Smart Shuffle")
+    func detachedPlaybackDoesNotKeepSuggestedCursor() {
+        let original = QueueEntry(id: UUID(), song: TestFixtures.makeSong(id: "detached-original"))
+        let suggestion = QueueEntry(
+            id: UUID(),
+            song: TestFixtures.makeSong(id: "detached-suggestion"),
+            source: .suggested
+        )
+        let trailing = QueueEntry(id: UUID(), song: TestFixtures.makeSong(id: "detached-trailing"))
+        self.playerService.setQueue(entries: [original, suggestion, trailing])
+        self.playerService.queueOrderBeforeShuffle = [original, trailing]
+        self.playerService.currentIndex = 1
+        self.playerService.currentTrack = TestFixtures.makeSong(id: "detached-track")
+        self.playerService.activePlaybackQueueEntryID = nil
+        self.playerService.shuffleMode = .smart
+
+        self.playerService.setShuffleMode(.off)
+
+        #expect(!self.playerService.queueEntries.contains(where: { $0.source == .suggested }))
+        #expect(self.playerService.queueEntryIDs == [original.id, trailing.id])
+    }
+
+    @Test("A stopped queue cursor does not persist a Smart Shuffle suggestion")
+    func stoppedQueueCursorDoesNotPersistSuggestion() {
+        let original = QueueEntry(id: UUID(), song: TestFixtures.makeSong(id: "stopped-original"))
+        let suggestion = QueueEntry(
+            id: UUID(),
+            song: TestFixtures.makeSong(id: "stopped-suggestion"),
+            source: .suggested
+        )
+        self.playerService.setQueue(entries: [original, suggestion])
+        self.playerService.currentIndex = 1
+        self.playerService.currentTrack = nil
+        self.playerService.activePlaybackQueueEntryID = nil
+        self.playerService.saveQueueForPersistence()
+        defer { self.playerService.clearSavedQueue() }
+
+        let restored = PlayerService()
+        #expect(restored.restoreQueueFromPersistence())
+        #expect(restored.queue.map(\.videoId) == [original.song.videoId])
+    }
+
+    @Test("Undoing shuffle restores both mode and authored order")
+    func undoShuffleRestoresModeAndOrder() async {
+        let songs = TestFixtures.makeSongs(count: 4)
+        await self.playerService.playQueue(songs, startingAt: 1)
+        let originalEntryIDs = self.playerService.queueEntryIDs
+
+        self.playerService.setShuffleMode(.on)
+        await self.playerService.undoQueue()
+
+        #expect(self.playerService.shuffleMode == .off)
+        #expect(self.playerService.queueEntryIDs == originalEntryIDs)
+        #expect(self.playerService.queueOrderBeforeShuffle == nil)
+    }
+
+    @Test("Persisted shuffle can restore authored order after relaunch")
+    func persistedShuffleRestoresAuthoredOrder() async {
+        let songs = TestFixtures.makeSongs(count: 4)
+        await self.playerService.playQueue(songs, startingAt: 2)
+        self.playerService.setShuffleMode(.on)
+        self.playerService.saveQueueForPersistence()
+        defer { self.playerService.clearSavedQueue() }
+
+        let restored = PlayerService()
+        #expect(restored.restoreQueueFromPersistence())
+        #expect(restored.shuffleMode == .on)
+        restored.setShuffleMode(.off)
+
+        #expect(restored.queue.map(\.videoId) == songs.map(\.videoId))
+    }
+
+    @Test("Persisted shuffle preserves the active identical duplicate occurrence")
+    func persistedShufflePreservesActiveDuplicate() async {
+        let duplicate = TestFixtures.makeSong(id: "persisted-duplicate")
+        let middle = TestFixtures.makeSong(id: "persisted-middle")
+        await self.playerService.playQueue([duplicate, middle, duplicate], startingAt: 2)
+        self.playerService.setShuffleMode(.on)
+        self.playerService.saveQueueForPersistence()
+        defer { self.playerService.clearSavedQueue() }
+
+        let restored = PlayerService()
+        #expect(restored.restoreQueueFromPersistence())
+        restored.setShuffleMode(.off)
+
+        #expect(restored.queue.map(\.videoId) == [duplicate.videoId, middle.videoId, duplicate.videoId])
+        #expect(restored.activePlaybackQueueIndex == 2)
+    }
+
+    @Test("Persisted pre-shuffle order preserves non-active duplicate payloads")
+    func persistedPreShuffleOrderPreservesDuplicatePayloads() {
+        let firstDuplicate = Song(
+            id: "shared-duplicate",
+            title: "First authored occurrence",
+            artists: [],
+            videoId: "shared-duplicate"
+        )
+        let secondDuplicate = Song(
+            id: "shared-duplicate",
+            title: "Second authored occurrence",
+            artists: [],
+            videoId: "shared-duplicate"
+        )
+        let active = TestFixtures.makeSong(id: "duplicate-active", title: "Active")
+        let firstEntry = QueueEntry(id: UUID(), song: firstDuplicate)
+        let secondEntry = QueueEntry(id: UUID(), song: secondDuplicate)
+        let activeEntry = QueueEntry(id: UUID(), song: active)
+        self.playerService.setQueue(entries: [activeEntry, secondEntry, firstEntry])
+        self.playerService.currentIndex = 0
+        self.playerService.activePlaybackQueueEntryID = activeEntry.id
+        self.playerService.currentTrack = active
+        self.playerService.pendingPlayVideoId = active.videoId
+        self.playerService.queueOrderBeforeShuffle = [firstEntry, secondEntry, activeEntry]
+        self.playerService.shuffleMode = .on
+        self.playerService.saveQueueForPersistence()
+        defer { self.playerService.clearSavedQueue() }
+
+        let restored = PlayerService()
+        #expect(restored.restoreQueueFromPersistence())
+        restored.setShuffleMode(.off)
+
+        #expect(restored.queue.map(\.title) == [
+            "First authored occurrence",
+            "Second authored occurrence",
+            "Active",
+        ])
+        #expect(restored.currentIndex == 2)
+        #expect(restored.currentTrack?.videoId == active.videoId)
+    }
+
+    @Test("Queue history downgrades Smart Shuffle when the feature is disabled")
+    func queueHistorySmartShuffleRespectsDisabledSetting() async {
+        await self.playerService.playQueue(TestFixtures.makeSongs(count: 3), startingAt: 0)
+        let originalEntries = self.playerService.queueEntries
+        let suggestion = QueueEntry(
+            id: UUID(),
+            song: TestFixtures.makeSong(id: "disabled-history-suggestion"),
+            source: .suggested
+        )
+        self.playerService.setQueue(entries: [originalEntries[0], suggestion] + Array(originalEntries.dropFirst()))
+        self.playerService.currentIndex = 0
+        self.playerService.activePlaybackQueueEntryID = originalEntries[0].id
+        self.playerService.shuffleMode = .smart
+        let smartState = self.playerService.makeQueueStateSnapshot()
+        self.playerService.shuffleMode = .off
+        self.playerService.clearQueueUndoRedoHistory()
+        self.playerService.recordQueueStateForUndo(smartState)
+        self.playerService.smartShuffleFeatureEnabled = { false }
+
+        await self.playerService.undoQueue()
+        for _ in 0 ..< 10 {
+            await Task.yield()
+        }
+
+        #expect(self.playerService.shuffleMode == .on)
+        #expect(!self.playerService.queueEntries.contains { $0.source == .suggested })
+        #expect(!self.mockClient.getRadioQueueCalled)
+    }
+
+    @Test("Persisted Smart Shuffle downgrades when the feature is disabled")
+    func persistedSmartShuffleRespectsDisabledSetting() async {
+        await self.playerService.playQueue(TestFixtures.makeSongs(count: 3), startingAt: 0)
+        self.playerService.setShuffleMode(.smart)
+        self.playerService.saveQueueForPersistence()
+        defer { self.playerService.clearSavedQueue() }
+        let restored = PlayerService()
+        restored.smartShuffleFeatureEnabled = { false }
+        #expect(restored.restoreQueueFromPersistence())
+        #expect(restored.shuffleMode == .on)
     }
 
     @Test("suggestions are ephemeral: not persisted across a save/restore")
@@ -260,22 +555,9 @@ struct PlayerServiceSmartShuffleTests {
         #expect(Set(restored.queue.map(\.videoId)) == originalIds)
     }
 
-    @Test("a persisted smart mode downgrades to .on when Smart Shuffle is disabled in settings")
+    @Test("a persisted smart mode resolves to .on when Smart Shuffle is disabled")
     func disabledSmartDowngradesOnLaunch() {
-        let settings = SettingsManager.shared
-        let savedRemember = settings.rememberPlaybackSettings
-        let savedEnabled = settings.smartShuffleEnabled
-        settings.rememberPlaybackSettings = true
-        settings.smartShuffleEnabled = false
-        UserDefaults.standard.set("smart", forKey: "playerShuffleMode")
-        defer {
-            UserDefaults.standard.removeObject(forKey: "playerShuffleMode")
-            settings.rememberPlaybackSettings = savedRemember
-            settings.smartShuffleEnabled = savedEnabled
-        }
-
-        let service = PlayerService()
-        #expect(service.shuffleMode == .on)
+        #expect(PlayerService.resolvedShuffleMode(.smart, smartShuffleEnabled: false) == .on)
     }
 
     @Test("clamped Smart Shuffle numeric settings persist the corrected values")
@@ -342,7 +624,9 @@ struct PlayerServiceSmartShuffleTests {
             TestFixtures.makeSong(id: "video-4"),
             TestFixtures.makeSong(id: "video-5"),
         ])
-        if let loadGeneration { await self.playerService.endQueueLoading(loadGeneration) }
+        if let loadGeneration {
+            await self.playerService.endQueueLoading(loadGeneration)
+        }
 
         let videoIds = self.playerService.queue.map(\.videoId)
         let suggested = self.playerService.queueEntries.filter { $0.source == .suggested }.map(\.song.videoId)
@@ -364,7 +648,9 @@ struct PlayerServiceSmartShuffleTests {
             TestFixtures.makeSong(id: "video-1"),
             TestFixtures.makeSong(id: "video-2"),
         ])
-        if let loadGeneration { await self.playerService.endQueueLoading(loadGeneration) }
+        if let loadGeneration {
+            await self.playerService.endQueueLoading(loadGeneration)
+        }
 
         #expect(self.playerService.queue.map(\.videoId) == ["video-0", "video-1", "video-1", "video-2"])
     }
@@ -377,7 +663,9 @@ struct PlayerServiceSmartShuffleTests {
 
         let remaining = (4 ..< 24).map { TestFixtures.makeSong(id: "video-\($0)") }
         self.playerService.appendOriginalTracks(remaining)
-        if let loadGeneration { await self.playerService.endQueueLoading(loadGeneration) }
+        if let loadGeneration {
+            await self.playerService.endQueueLoading(loadGeneration)
+        }
 
         let originalOrder = (0 ..< 24).map { "video-\($0)" }
         #expect(Set(self.playerService.queue.map(\.videoId)) == Set(originalOrder))
@@ -392,7 +680,9 @@ struct PlayerServiceSmartShuffleTests {
         let initial = TestFixtures.makeSongs(count: 4)
         let loadGeneration = await self.playerService.playQueue(initial, startingAt: 0, deferringSmartShuffleFill: true)
         self.playerService.appendOriginalTracks((4 ..< 8).map { TestFixtures.makeSong(id: "video-\($0)") })
-        if let loadGeneration { await self.playerService.endQueueLoading(loadGeneration) }
+        if let loadGeneration {
+            await self.playerService.endQueueLoading(loadGeneration)
+        }
 
         #expect(self.playerService.queue.map(\.videoId) == (0 ..< 8).map { "video-\($0)" })
         #expect(!self.playerService.queueEntries.contains { $0.source == .suggested })

--- a/Tests/KasetTests/PlayerServiceTests.swift
+++ b/Tests/KasetTests/PlayerServiceTests.swift
@@ -261,8 +261,17 @@ struct PlayerServiceTests {
 
     @Test("Play empty queue does nothing")
     func playQueueEmptyDoesNothing() async {
+        let song = TestFixtures.makeSong(id: "empty-noop-current")
+        await self.playerService.playQueue([song], startingAt: 0)
+        let intent = self.playerService.currentMusicPlaybackIntent
+        let occurrence = self.playerService.currentMusicPlaybackOccurrence
+
         await self.playerService.playQueue([], startingAt: 0)
-        #expect(self.playerService.queue.isEmpty)
+
+        #expect(self.playerService.queue == [song])
+        #expect(self.playerService.currentTrack == song)
+        #expect(self.playerService.currentMusicPlaybackIntent == intent)
+        #expect(self.playerService.currentMusicPlaybackOccurrence == occurrence)
     }
 
     // MARK: - User Interaction Tests

--- a/Tests/KasetTests/PlayerServiceWebQueueSyncFollowUpTests.swift
+++ b/Tests/KasetTests/PlayerServiceWebQueueSyncFollowUpTests.swift
@@ -3,6 +3,382 @@ import Testing
 @testable import Kaset
 
 extension PlayerServiceWebQueueSyncTests {
+    @Test("Web metadata cannot replace detached playback with a leftover queue")
+    func detachedPlaybackIgnoresQueueEnforcement() async {
+        let queued = Song(id: "queued", title: "Queued", artists: [], duration: 180, videoId: "queued")
+        let detached = Song(
+            id: "detached",
+            title: "Detached",
+            artists: [],
+            duration: 180,
+            videoId: "detached",
+            feedbackTokens: .init(add: nil, remove: nil)
+        )
+        await self.playerService.playQueue([queued], startingAt: 0)
+        await self.playerService.play(song: detached)
+
+        self.playerService.updateTrackMetadata(
+            title: "Observed Detached",
+            artist: "",
+            thumbnailUrl: "",
+            videoId: detached.videoId
+        )
+        for _ in 0 ..< 10 {
+            await Task.yield()
+        }
+
+        #expect(self.playerService.queue == [queued])
+        #expect(self.playerService.currentTrack?.videoId == detached.videoId)
+        #expect(self.playerService.activePlaybackQueueEntryID == nil)
+    }
+
+    @Test("Detached manual transport does not adopt the leftover queue")
+    func detachedManualTransportIgnoresLeftoverQueue() async {
+        let queue = [
+            Song(id: "manual-queued-1", title: "Queued 1", artists: [], duration: 180, videoId: "manual-queued-1"),
+            Song(id: "manual-queued-2", title: "Queued 2", artists: [], duration: 180, videoId: "manual-queued-2"),
+        ]
+        let detached = Song(
+            id: "manual-detached",
+            title: "Detached",
+            artists: [],
+            duration: 180,
+            videoId: "manual-detached",
+            feedbackTokens: FeedbackTokens(add: nil, remove: nil)
+        )
+        await self.playerService.playQueue(queue, startingAt: 0)
+        await self.playerService.play(song: detached)
+
+        await self.playerService.next()
+
+        #expect(self.playerService.currentIndex == 0)
+        #expect(self.playerService.currentTrack?.videoId == detached.videoId)
+        #expect(self.playerService.activePlaybackQueueEntryID == nil)
+
+        self.playerService.currentIndex = 1
+        self.playerService.progress = 0
+        await self.playerService.previous()
+
+        #expect(self.playerService.currentIndex == 1)
+        #expect(self.playerService.currentTrack?.videoId == detached.videoId)
+        #expect(self.playerService.activePlaybackQueueEntryID == nil)
+    }
+
+    @Test("Stopped queue transport can still navigate the native queue")
+    func stoppedQueueTransportStillNavigatesNativeQueue() async {
+        let queue = [
+            Song(id: "stopped-nav-1", title: "Queued 1", artists: [], duration: 180, videoId: "stopped-nav-1"),
+            Song(id: "stopped-nav-2", title: "Queued 2", artists: [], duration: 180, videoId: "stopped-nav-2"),
+        ]
+        await self.playerService.playQueue(queue, startingAt: 0)
+        await self.playerService.stop()
+
+        await self.playerService.next()
+
+        #expect(self.playerService.currentIndex == 1)
+        #expect(self.playerService.currentTrack?.videoId == queue[1].videoId)
+        #expect(self.playerService.activePlaybackQueueEntryID == self.playerService.queueEntryIDs[1])
+    }
+
+    @Test("Detached playback ending does not advance the leftover queue")
+    func detachedTrackEndIgnoresLeftoverQueue() async {
+        let queue = [
+            Song(id: "queued-1", title: "Queued 1", artists: [], duration: 180, videoId: "queued-1"),
+            Song(id: "queued-2", title: "Queued 2", artists: [], duration: 180, videoId: "queued-2"),
+        ]
+        let detached = Song(
+            id: "detached-end",
+            title: "Detached",
+            artists: [],
+            duration: 180,
+            videoId: "detached-end",
+            feedbackTokens: .init(add: nil, remove: nil)
+        )
+        await self.playerService.playQueue(queue, startingAt: 0)
+        await self.playerService.play(song: detached)
+        let occurrence = self.playerService.currentMusicPlaybackOccurrence
+
+        await self.playerService.handleTrackEnded(
+            observedVideoId: detached.videoId,
+            playbackOccurrence: occurrence
+        )
+
+        #expect(self.playerService.currentIndex == 0)
+        #expect(self.playerService.queue == queue)
+        #expect(self.playerService.currentTrack?.videoId == detached.videoId)
+        #expect(self.playerService.state == .ended)
+    }
+
+    @Test("Observed queue drift persists only after playback ownership realigns")
+    func observedQueueDriftPersistsRealignedOwnership() async {
+        self.playerService.clearSavedQueue()
+        defer { self.playerService.clearSavedQueue() }
+        let songs = [
+            Song(id: "persist-v1", title: "Persist 1", artists: [], duration: 180, videoId: "persist-v1"),
+            Song(id: "persist-v2", title: "Persist 2", artists: [], duration: 180, videoId: "persist-v2"),
+            Song(id: "persist-v3", title: "Persist 3", artists: [], duration: 180, videoId: "persist-v3"),
+        ]
+        await self.playerService.playQueue(songs, startingAt: 0)
+        let matchedEntryID = self.playerService.queueEntryIDs[1]
+        self.playerService.updateTrackMetadata(
+            title: songs[0].title,
+            artist: "",
+            thumbnailUrl: "",
+            videoId: songs[0].videoId
+        )
+
+        self.playerService.updateTrackMetadata(
+            title: songs[1].title,
+            artist: "",
+            thumbnailUrl: "",
+            videoId: songs[1].videoId
+        )
+
+        #expect(self.playerService.currentIndex == 1)
+        #expect(self.playerService.currentQueueEntryID == matchedEntryID)
+        #expect(self.playerService.activePlaybackQueueEntryID == matchedEntryID)
+        #expect(self.playerService.currentTrack?.videoId == songs[1].videoId)
+
+        let restored = PlayerService()
+        #expect(restored.restoreQueueFromPersistence())
+        #expect(restored.queue.map(\.videoId) == songs.map(\.videoId))
+        #expect(restored.currentIndex == 1)
+        #expect(restored.currentTrack?.videoId == songs[1].videoId)
+
+        await self.playerService.handleTrackEnded(observedVideoId: songs[1].videoId)
+        #expect(self.playerService.currentIndex == 2)
+        #expect(self.playerService.currentTrack?.videoId == songs[2].videoId)
+    }
+
+    @Test("Ambiguous duplicate video IDs do not select the first queue entry")
+    func ambiguousObservedVideoIDDoesNotSelectFirstDuplicate() async {
+        let current = Song(
+            id: "current",
+            title: "Current",
+            artists: [],
+            duration: 180,
+            videoId: "v1",
+            feedbackTokens: .init(add: nil, remove: nil)
+        )
+        let duplicate = Song(
+            id: "duplicate",
+            title: "Duplicate",
+            artists: [],
+            duration: 180,
+            videoId: "v2",
+            feedbackTokens: .init(add: nil, remove: nil)
+        )
+        let currentEntryID = UUID()
+        self.playerService.setQueue(entries: [
+            QueueEntry(id: currentEntryID, song: current),
+            QueueEntry(id: UUID(), song: duplicate),
+            QueueEntry(id: UUID(), song: duplicate),
+        ])
+        await self.playerService.playFromQueue(at: 0)
+        self.playerService.isKasetInitiatedPlayback = false
+
+        self.playerService.updateTrackMetadata(
+            title: duplicate.title,
+            artist: "",
+            thumbnailUrl: "",
+            videoId: duplicate.videoId
+        )
+        for _ in 0 ..< 10 {
+            await Task.yield()
+        }
+
+        #expect(self.playerService.currentIndex == 0)
+        #expect(self.playerService.currentQueueEntryID == currentEntryID)
+        #expect(self.playerService.activePlaybackQueueEntryID == currentEntryID)
+        #expect(self.playerService.currentTrack?.videoId == current.videoId)
+    }
+
+    @Test("A scheduled drift replay cannot replace a newer queue")
+    func scheduledDriftReplayCannotReplaceNewerQueue() async {
+        let oldSong = Song(
+            id: "old",
+            title: "Old",
+            artists: [],
+            duration: 180,
+            videoId: "old",
+            feedbackTokens: .init(add: nil, remove: nil)
+        )
+        let newSong = Song(
+            id: "new",
+            title: "New",
+            artists: [],
+            duration: 180,
+            videoId: "new",
+            feedbackTokens: .init(add: nil, remove: nil)
+        )
+        await self.playerService.playQueue([oldSong], startingAt: 0)
+        self.playerService.isKasetInitiatedPlayback = false
+
+        self.playerService.updateTrackMetadata(
+            title: "Unexpected",
+            artist: "",
+            thumbnailUrl: "",
+            videoId: "unexpected"
+        )
+        await self.playerService.playQueue([newSong], startingAt: 0)
+        for _ in 0 ..< 10 {
+            await Task.yield()
+        }
+
+        #expect(self.playerService.queue == [newSong])
+        #expect(self.playerService.currentTrack?.videoId == newSong.videoId)
+        #expect(self.playerService.activePlaybackQueueEntryID == self.playerService.currentQueueEntryID)
+    }
+
+    @Test("An admitted end cannot advance after a newer pause intent")
+    func staleIntentTrackEndCannotAdvanceQueue() async {
+        let songs = [
+            Song(id: "1", title: "One", artists: [], duration: 180, videoId: "v1"),
+            Song(id: "2", title: "Two", artists: [], duration: 180, videoId: "v2"),
+        ]
+        await self.playerService.playQueue(songs, startingAt: 0)
+        let endedOccurrence = self.playerService.currentMusicPlaybackOccurrence
+        let admittedIntent = self.playerService.currentMusicPlaybackIntent
+
+        await self.playerService.pause()
+        await self.playerService.handleTrackEnded(
+            observedVideoId: "v1",
+            playbackOccurrence: endedOccurrence,
+            intent: admittedIntent
+        )
+
+        #expect(self.playerService.currentIndex == 0)
+        #expect(self.playerService.currentTrack?.videoId == "v1")
+        #expect(self.playerService.state == .paused)
+    }
+
+    @Test("An end emitted after pause is consumed without advancing the queue")
+    func currentPauseIntentTrackEndCannotAdvanceQueue() async {
+        let songs = [
+            Song(id: "pause-end-1", title: "One", artists: [], duration: 180, videoId: "pause-end-v1"),
+            Song(id: "pause-end-2", title: "Two", artists: [], duration: 180, videoId: "pause-end-v2"),
+        ]
+        await self.playerService.playQueue(songs, startingAt: 0)
+        let endedOccurrence = self.playerService.currentMusicPlaybackOccurrence
+        let pauseIntent = self.playerService.beginMusicPlaybackIntent()
+        await self.playerService.pause(intent: pauseIntent)
+
+        await self.playerService.handleTrackEnded(
+            observedVideoId: songs[0].videoId,
+            playbackOccurrence: endedOccurrence,
+            intent: pauseIntent
+        )
+
+        #expect(self.playerService.currentIndex == 0)
+        #expect(self.playerService.currentTrack?.videoId == songs[0].videoId)
+        #expect(self.playerService.state == .paused)
+        #expect(!self.playerService.shouldResumeAfterInterruption)
+    }
+
+    @Test("Shuffle admits an already-emitted end for the active occurrence")
+    func shuffleDoesNotDiscardPendingTrackEnd() async {
+        let songs = [
+            Song(id: "shuffle-end-a", title: "A", artists: [], duration: 180, videoId: "shuffle-end-a"),
+            Song(id: "shuffle-end-b", title: "B", artists: [], duration: 180, videoId: "shuffle-end-b"),
+        ]
+        await self.playerService.playQueue(songs, startingAt: 0)
+        let occurrence = self.playerService.currentMusicPlaybackOccurrence
+        let emittedAt = Date().timeIntervalSince1970 * 1000
+
+        self.playerService.shuffleQueue()
+        let shuffleIntent = self.playerService.currentMusicPlaybackIntent
+        #expect(self.playerService.acceptsMusicTerminalBridgeEvent(
+            intent: shuffleIntent,
+            eventIssuedAtMilliseconds: emittedAt
+        ))
+        await self.playerService.handleTrackEnded(
+            observedVideoId: songs[0].videoId,
+            playbackOccurrence: occurrence,
+            intent: shuffleIntent
+        )
+
+        #expect(self.playerService.currentTrack?.videoId == songs[1].videoId)
+    }
+
+    @Test("Clear queue admits an already-emitted end for the retained occurrence")
+    func clearQueueDoesNotDiscardPendingTrackEnd() async throws {
+        self.playerService.shuffleMode = .off
+        while self.playerService.repeatMode != .off {
+            self.playerService.advanceRepeatMode()
+        }
+        let songs = [
+            Song(id: "clear-end-a", title: "A", artists: [], duration: 180, videoId: "clear-end-a"),
+            Song(id: "clear-end-b", title: "B", artists: [], duration: 180, videoId: "clear-end-b"),
+        ]
+        await self.playerService.playQueue(songs, startingAt: 0)
+        let occurrence = try #require(self.playerService.currentMusicPlaybackOccurrence)
+        let retainedEntryID = try #require(self.playerService.activePlaybackQueueEntryID)
+
+        self.playerService.clearQueue()
+        let clearIntent = self.playerService.currentMusicPlaybackIntent
+        self.playerService.musicPlaybackIntentIssuedAtMilliseconds = 1000
+
+        #expect(self.playerService.currentMusicPlaybackOccurrence == occurrence)
+        #expect(self.playerService.activePlaybackQueueEntryID == retainedEntryID)
+        #expect(!self.playerService.acceptsMusicBridgeEvent(
+            intent: clearIntent,
+            eventIssuedAtMilliseconds: 999
+        ))
+        try #require(self.playerService.acceptsMusicTerminalBridgeEvent(
+            intent: clearIntent,
+            eventIssuedAtMilliseconds: 999
+        ))
+
+        await self.playerService.handleTrackEnded(
+            observedVideoId: songs[0].videoId,
+            playbackOccurrence: occurrence,
+            intent: clearIntent
+        )
+
+        #expect(self.playerService.queueEntryIDs == [retainedEntryID])
+        #expect(self.playerService.state == .ended)
+        #expect(self.playerService.shouldSuppressAutoplayAfterQueueEnd)
+    }
+
+    @Test("Near-end metadata cannot rekey consecutive duplicate video entries")
+    func nearEndDuplicateVideoDefersUntilEnded() async throws {
+        let first = Song(id: "first", title: "First", artists: [], duration: 180, videoId: "shared")
+        let second = Song(id: "second", title: "Second", artists: [], duration: 180, videoId: "shared")
+        let third = Song(id: "third", title: "Third", artists: [], duration: 180, videoId: "third")
+        let firstID = UUID()
+        let secondID = UUID()
+        self.playerService.setQueue(entries: [
+            QueueEntry(id: firstID, song: first),
+            QueueEntry(id: secondID, song: second),
+            QueueEntry(id: UUID(), song: third),
+        ])
+        await self.playerService.playFromQueue(at: 0)
+        self.playerService.isKasetInitiatedPlayback = false
+        self.playerService.songNearingEnd = true
+        let outgoingOccurrence = try #require(self.playerService.currentMusicPlaybackOccurrence)
+
+        self.playerService.updateTrackMetadata(
+            title: second.title,
+            artist: "",
+            thumbnailUrl: "",
+            videoId: second.videoId,
+            playbackOccurrence: outgoingOccurrence
+        )
+
+        #expect(self.playerService.currentIndex == 0)
+        #expect(self.playerService.currentQueueEntryID == firstID)
+        #expect(self.playerService.activePlaybackQueueEntryID == firstID)
+
+        await self.playerService.handleTrackEnded(
+            observedVideoId: first.videoId,
+            playbackOccurrence: outgoingOccurrence
+        )
+
+        #expect(self.playerService.currentIndex == 1)
+        #expect(self.playerService.currentQueueEntryID == secondID)
+        #expect(self.playerService.activePlaybackQueueEntryID == secondID)
+    }
+
     @Test("Near-end queue correction owns a late ended callback")
     func nearEndQueueCorrectionThenLateEndedDoesNotDoubleAdvance() async {
         let songs = [
@@ -86,9 +462,11 @@ extension PlayerServiceWebQueueSyncTests {
         ]
 
         await playerService.playQueue(songs, startingAt: 0)
+        let intent = self.playerService.currentMusicPlaybackIntent
         await self.playerService.playFromQueue(at: 5)
 
         #expect(self.playerService.currentIndex == 0)
+        #expect(self.playerService.currentMusicPlaybackIntent == intent)
     }
 
     @Test("Play from queue negative index does nothing")
@@ -98,9 +476,24 @@ extension PlayerServiceWebQueueSyncTests {
         ]
 
         await playerService.playQueue(songs, startingAt: 0)
+        let intent = self.playerService.currentMusicPlaybackIntent
         await self.playerService.playFromQueue(at: -1)
 
         #expect(self.playerService.currentIndex == 0)
+        #expect(self.playerService.currentMusicPlaybackIntent == intent)
+    }
+
+    @Test("Play from queue missing entry ID does nothing")
+    func playFromQueueMissingEntryIDDoesNothing() async {
+        let song = Song(id: "missing-entry", title: "Song", artists: [], duration: 180, videoId: "missing-entry")
+        await self.playerService.playQueue([song], startingAt: 0)
+        let intent = self.playerService.currentMusicPlaybackIntent
+
+        await self.playerService.playFromQueue(entryID: UUID())
+
+        #expect(self.playerService.currentIndex == 0)
+        #expect(self.playerService.currentTrack?.videoId == song.videoId)
+        #expect(self.playerService.currentMusicPlaybackIntent == intent)
     }
 
     // MARK: - Play With Radio Tests

--- a/Tests/KasetTests/PlayerServiceWebQueueSyncFollowUpTests.swift
+++ b/Tests/KasetTests/PlayerServiceWebQueueSyncFollowUpTests.swift
@@ -3,6 +3,65 @@ import Testing
 @testable import Kaset
 
 extension PlayerServiceWebQueueSyncTests {
+    @Test("Near-end queue correction owns a late ended callback")
+    func nearEndQueueCorrectionThenLateEndedDoesNotDoubleAdvance() async {
+        let songs = [
+            Song(id: "1", title: "Song 1", artists: [], album: nil, duration: 180, thumbnailURL: nil, videoId: "v1"),
+            Song(id: "2", title: "Song 2", artists: [], album: nil, duration: 200, thumbnailURL: nil, videoId: "v2"),
+            Song(id: "3", title: "Song 3", artists: [], album: nil, duration: 220, thumbnailURL: nil, videoId: "v3"),
+        ]
+
+        await self.playerService.playQueue(songs, startingAt: 0)
+        self.playerService.isKasetInitiatedPlayback = false
+        self.playerService.songNearingEnd = true
+        let outgoingOccurrence = self.playerService.currentMusicPlaybackOccurrence
+
+        self.playerService.updateTrackMetadata(
+            title: "Unexpected autoplay",
+            artist: "Someone else",
+            thumbnailUrl: "",
+            videoId: "unexpected",
+            playbackOccurrence: outgoingOccurrence
+        )
+        try? await Task.sleep(for: .milliseconds(100))
+        #expect(self.playerService.currentIndex == 1)
+
+        await self.playerService.handleTrackEnded(
+            observedVideoId: "v1",
+            playbackOccurrence: outgoingOccurrence
+        )
+
+        #expect(self.playerService.currentIndex == 1)
+        #expect(self.playerService.currentTrack?.videoId == "v2")
+    }
+
+    @Test("In-place repeat-one replay clears the terminal pause fence")
+    func repeatOneReplayClearsPauseFence() async {
+        let song = Song(
+            id: "1",
+            title: "Song 1",
+            artists: [],
+            album: nil,
+            duration: 180,
+            thumbnailURL: nil,
+            videoId: "v1"
+        )
+        await self.playerService.playQueue([song], startingAt: 0)
+        self.playerService.markUserInteractedThisSession()
+        self.playerService.currentWebPlaybackVideoId = { "v1" }
+        self.playerService.cycleRepeatMode()
+        self.playerService.cycleRepeatMode()
+
+        await self.playerService.handleTrackEnded(
+            observedVideoId: "v1",
+            playbackOccurrence: self.playerService.currentMusicPlaybackOccurrence
+        )
+
+        #expect(!self.playerService.isExplicitPauseIntentActive)
+        #expect(self.playerService.isAwaitingPlaybackConfirmation)
+        #expect(self.playerService.shouldResumeAfterInterruption)
+    }
+
     // MARK: - Play From Queue Tests
 
     @Test("Play from queue valid index")
@@ -257,6 +316,37 @@ extension PlayerServiceWebQueueSyncTests {
 
         #expect(self.playerService.currentIndex == 1)
         #expect(self.playerService.pendingPlayVideoId == "v2")
+    }
+
+    @Test("Resuming a pre-bind terminal occurrence starts a fresh native occurrence")
+    func resumeAfterPreBindTerminalStartsFreshOccurrence() async throws {
+        let song = Song(
+            id: "1",
+            title: "Song 1",
+            artists: [],
+            album: nil,
+            duration: 180,
+            thumbnailURL: nil,
+            videoId: "v1"
+        )
+        await self.playerService.play(song: song)
+        let endedOccurrence = self.playerService.beginNativeMusicPlaybackOccurrence(videoId: "v1")
+
+        await self.playerService.seek(to: 180)
+        #expect(self.playerService.state == .ended)
+        #expect(self.playerService.currentMusicPlaybackOccurrence == endedOccurrence)
+
+        await self.playerService.resume()
+        let replayOccurrence = try #require(self.playerService.currentMusicPlaybackOccurrence)
+        #expect(replayOccurrence.nativeGeneration > endedOccurrence.nativeGeneration)
+
+        let firstWebOccurrence = try #require(self.playerService.bindWebMusicPlaybackOccurrence(
+            documentGeneration: 7,
+            mediaGeneration: 1,
+            nativeGeneration: replayOccurrence.nativeGeneration,
+            videoId: "v1"
+        ))
+        #expect(self.playerService.acceptsWebMusicPlaybackOccurrence(firstWebOccurrence))
     }
 
     @Test("Manual seek to mid-track does not advance queue")

--- a/Tests/KasetTests/PlayerServiceWebQueueSyncTests.swift
+++ b/Tests/KasetTests/PlayerServiceWebQueueSyncTests.swift
@@ -170,11 +170,16 @@ struct PlayerServiceWebQueueSyncTests {
         self.playerService.cycleRepeatMode()
         self.playerService.cycleRepeatMode()
         #expect(self.playerService.repeatMode == .one)
+        self.playerService.lastNonAdContentProgress = 179
+        self.playerService.lastNonAdContentVideoId = "v1"
 
         await self.playerService.handleTrackEnded(observedVideoId: "v1")
 
         #expect(self.playerService.currentIndex == 0)
         #expect(self.playerService.pendingPlayVideoId == "v1")
+        #expect(self.playerService.lastNonAdContentProgress == 0)
+        #expect(self.playerService.lastNonAdContentVideoId == nil)
+        #expect(self.playerService.shouldResumeAfterInterruption)
     }
 
     @Test("Repeat one recovers when title drifts before videoId is sent")
@@ -515,6 +520,294 @@ struct PlayerServiceWebQueueSyncTests {
         #expect(self.playerService.currentIndex == 1)
         #expect(self.playerService.currentTrack?.videoId == "v2")
         #expect(self.playerService.currentTrack?.title == "Song 2")
+    }
+
+    @Test("Near-end metadata transition is not advanced again by a late ended callback")
+    func nearEndMetadataThenLateEndedDoesNotDoubleAdvance() async {
+        let songs = [
+            Song(id: "1", title: "Song 1", artists: [], album: nil, duration: 180, thumbnailURL: nil, videoId: "v1"),
+            Song(id: "2", title: "Song 2", artists: [], album: nil, duration: 200, thumbnailURL: nil, videoId: "v2"),
+            Song(id: "3", title: "Song 3", artists: [], album: nil, duration: 220, thumbnailURL: nil, videoId: "v3"),
+        ]
+
+        await self.playerService.playQueue(songs, startingAt: 0)
+        self.playerService.isKasetInitiatedPlayback = false
+        self.playerService.songNearingEnd = true
+        let outgoingOccurrence = self.playerService.currentMusicPlaybackOccurrence
+        self.playerService.updateTrackMetadata(
+            title: "Song 2",
+            artist: "",
+            thumbnailUrl: "",
+            videoId: "v2",
+            playbackOccurrence: outgoingOccurrence
+        )
+        #expect(self.playerService.currentIndex == 1)
+        let incomingOccurrence = MusicPlaybackOccurrence.web(
+            documentGeneration: 7,
+            mediaGeneration: 2,
+            nativeGeneration: self.playerService.currentNativeMusicPlaybackGeneration,
+            videoId: "v2"
+        )
+        _ = self.playerService.bindWebMusicPlaybackOccurrence(
+            documentGeneration: 7,
+            mediaGeneration: 2,
+            nativeGeneration: incomingOccurrence.nativeGeneration,
+            videoId: "v2"
+        )
+
+        await self.playerService.handleTrackEnded(
+            observedVideoId: "v1",
+            playbackOccurrence: outgoingOccurrence
+        )
+
+        #expect(self.playerService.currentIndex == 1)
+        #expect(self.playerService.currentTrack?.videoId == "v2")
+
+        await self.playerService.handleTrackEnded(
+            observedVideoId: "v2",
+            playbackOccurrence: incomingOccurrence
+        )
+
+        #expect(self.playerService.currentIndex == 2)
+        #expect(self.playerService.currentTrack?.videoId == "v3")
+    }
+
+    @Test("Duplicate ended callback replays repeat one only once")
+    func duplicateEndedCallbackReplaysRepeatOneOnlyOnce() async {
+        let songs = [
+            Song(id: "1", title: "Song 1", artists: [], album: nil, duration: 180, thumbnailURL: nil, videoId: "v1"),
+            Song(id: "2", title: "Song 2", artists: [], album: nil, duration: 200, thumbnailURL: nil, videoId: "v2"),
+        ]
+
+        await self.playerService.playQueue(songs, startingAt: 0)
+        self.playerService.cycleRepeatMode()
+        self.playerService.cycleRepeatMode()
+        let endedOccurrence = self.playerService.currentMusicPlaybackOccurrence
+
+        await self.playerService.handleTrackEnded(
+            observedVideoId: "v1",
+            playbackOccurrence: endedOccurrence
+        )
+        let replayOccurrence = self.playerService.currentMusicPlaybackOccurrence
+        await self.playerService.handleTrackEnded(
+            observedVideoId: "v1",
+            playbackOccurrence: endedOccurrence
+        )
+
+        #expect(self.playerService.currentIndex == 0)
+        #expect(replayOccurrence != endedOccurrence)
+        #expect(self.playerService.currentMusicPlaybackOccurrence == replayOccurrence)
+    }
+
+    @Test("Duplicate ended callback does not skip a repeated video ID in repeat all")
+    func duplicateEndedCallbackDoesNotSkipRepeatedVideoIdInRepeatAll() async {
+        let songs = [
+            Song(id: "1a", title: "Song 1A", artists: [], album: nil, duration: 180, thumbnailURL: nil, videoId: "v1"),
+            Song(id: "1b", title: "Song 1B", artists: [], album: nil, duration: 180, thumbnailURL: nil, videoId: "v1"),
+            Song(id: "2", title: "Song 2", artists: [], album: nil, duration: 200, thumbnailURL: nil, videoId: "v2"),
+        ]
+
+        await self.playerService.playQueue(songs, startingAt: 0)
+        self.playerService.cycleRepeatMode()
+        let endedOccurrence = self.playerService.currentMusicPlaybackOccurrence
+
+        await self.playerService.handleTrackEnded(
+            observedVideoId: "v1",
+            playbackOccurrence: endedOccurrence
+        )
+        await self.playerService.handleTrackEnded(
+            observedVideoId: "v1",
+            playbackOccurrence: endedOccurrence
+        )
+
+        #expect(self.playerService.currentIndex == 1)
+        #expect(self.playerService.currentTrack?.title == "Song 1B")
+    }
+
+    @Test("Duplicate ended callback replays no-queue repeat one only once")
+    func duplicateEndedCallbackReplaysNoQueueRepeatOneOnlyOnce() async {
+        let song = Song(
+            id: "solo",
+            title: "Solo",
+            artists: [],
+            album: nil,
+            duration: 180,
+            thumbnailURL: nil,
+            videoId: "solo-video"
+        )
+        await self.playerService.play(song: song)
+        self.playerService.cycleRepeatMode()
+        self.playerService.cycleRepeatMode()
+        let endedOccurrence = self.playerService.currentMusicPlaybackOccurrence
+
+        await self.playerService.handleTrackEnded(
+            observedVideoId: "solo-video",
+            playbackOccurrence: endedOccurrence
+        )
+        let replayOccurrence = self.playerService.currentMusicPlaybackOccurrence
+        await self.playerService.handleTrackEnded(
+            observedVideoId: "solo-video",
+            playbackOccurrence: endedOccurrence
+        )
+
+        #expect(self.playerService.queue.isEmpty)
+        #expect(replayOccurrence != endedOccurrence)
+        #expect(self.playerService.currentMusicPlaybackOccurrence == replayOccurrence)
+        #expect(self.playerService.state != .ended)
+    }
+
+    @Test("A later observer occurrence can end after the previous occurrence was consumed")
+    func laterObserverOccurrenceCanEnd() async {
+        let songs = [
+            Song(id: "1", title: "Song 1", artists: [], album: nil, duration: 180, thumbnailURL: nil, videoId: "v1"),
+            Song(id: "2", title: "Song 2", artists: [], album: nil, duration: 200, thumbnailURL: nil, videoId: "v2"),
+            Song(id: "3", title: "Song 3", artists: [], album: nil, duration: 220, thumbnailURL: nil, videoId: "v3"),
+        ]
+        await self.playerService.playQueue(songs, startingAt: 0)
+        let firstOccurrence = self.playerService.bindWebMusicPlaybackOccurrence(
+            documentGeneration: 7,
+            mediaGeneration: 1,
+            nativeGeneration: self.playerService.currentNativeMusicPlaybackGeneration,
+            videoId: "v1"
+        )
+
+        await self.playerService.handleTrackEnded(
+            observedVideoId: "v1",
+            playbackOccurrence: firstOccurrence
+        )
+        let secondOccurrence = self.playerService.bindWebMusicPlaybackOccurrence(
+            documentGeneration: 7,
+            mediaGeneration: 2,
+            nativeGeneration: self.playerService.currentNativeMusicPlaybackGeneration,
+            videoId: "v2"
+        )
+        await self.playerService.handleTrackEnded(
+            observedVideoId: "v2",
+            playbackOccurrence: secondOccurrence
+        )
+
+        #expect(self.playerService.currentIndex == 2)
+        #expect(self.playerService.currentTrack?.videoId == "v3")
+    }
+
+    @Test("Near-end state does not bind an incoming occurrence before metadata handoff")
+    func nearEndDefersIncomingOccurrenceBinding() async {
+        let songs = [
+            Song(id: "1", title: "Song 1", artists: [], album: nil, duration: 180, thumbnailURL: nil, videoId: "v1"),
+            Song(id: "2", title: "Song 2", artists: [], album: nil, duration: 200, thumbnailURL: nil, videoId: "v2"),
+        ]
+        await self.playerService.playQueue(songs, startingAt: 0)
+        let nativeGeneration = self.playerService.currentNativeMusicPlaybackGeneration
+        let outgoingOccurrence = self.playerService.bindWebMusicPlaybackOccurrence(
+            documentGeneration: 7,
+            mediaGeneration: 1,
+            nativeGeneration: nativeGeneration,
+            videoId: "v1"
+        )
+        self.playerService.songNearingEnd = true
+
+        let incomingOccurrence = self.playerService.bindWebMusicPlaybackOccurrence(
+            documentGeneration: 7,
+            mediaGeneration: 2,
+            nativeGeneration: nativeGeneration,
+            videoId: "v2"
+        )
+
+        #expect(incomingOccurrence == nil)
+        #expect(self.playerService.currentMusicPlaybackOccurrence == outgoingOccurrence)
+    }
+
+    @Test("Music occurrence identity can refine its video ID without becoming newer")
+    func occurrenceVideoIdentityCanRefine() async {
+        let songs = [
+            Song(id: "1", title: "Song 1", artists: [], album: nil, duration: 180, thumbnailURL: nil, videoId: "v1"),
+        ]
+        await self.playerService.playQueue(songs, startingAt: 0)
+        let nativeGeneration = self.playerService.currentNativeMusicPlaybackGeneration
+        let provisional = self.playerService.bindWebMusicPlaybackOccurrence(
+            documentGeneration: 7,
+            mediaGeneration: 1,
+            nativeGeneration: nativeGeneration,
+            videoId: nil
+        )
+        let refined = self.playerService.bindWebMusicPlaybackOccurrence(
+            documentGeneration: 7,
+            mediaGeneration: 1,
+            nativeGeneration: nativeGeneration,
+            videoId: "v1"
+        )
+
+        #expect(provisional == refined)
+        #expect(self.playerService.currentMusicPlaybackOccurrence?.videoId == "v1")
+    }
+
+    @Test("A claimed native occurrence consumes its matching first Web occurrence")
+    func claimedNativeOccurrenceTransfersToMatchingWebOccurrence() async {
+        let songs = [
+            Song(id: "1", title: "Song 1", artists: [], album: nil, duration: 180, thumbnailURL: nil, videoId: "v1"),
+            Song(id: "2", title: "Song 2", artists: [], album: nil, duration: 200, thumbnailURL: nil, videoId: "v2"),
+        ]
+        await self.playerService.playQueue(songs, startingAt: 0)
+        let nativeOccurrence = self.playerService.currentMusicPlaybackOccurrence
+
+        #expect(self.playerService.claimTerminalMusicPlaybackOccurrence(nativeOccurrence))
+        let matchingWebOccurrence = self.playerService.bindWebMusicPlaybackOccurrence(
+            documentGeneration: 7,
+            mediaGeneration: 1,
+            nativeGeneration: nativeOccurrence?.nativeGeneration ?? 0,
+            videoId: "v1"
+        )
+
+        #expect(!self.playerService.claimTerminalMusicPlaybackOccurrence(matchingWebOccurrence))
+    }
+
+    @Test("A delayed Web occurrence cannot replace a newer native replay")
+    func delayedWebOccurrenceCannotReplaceNativeReplay() async {
+        let songs = [
+            Song(id: "1", title: "Song 1", artists: [], album: nil, duration: 180, thumbnailURL: nil, videoId: "v1"),
+        ]
+        await self.playerService.playQueue(songs, startingAt: 0)
+        let endedNativeOccurrence = self.playerService.currentMusicPlaybackOccurrence
+        #expect(self.playerService.claimTerminalMusicPlaybackOccurrence(endedNativeOccurrence))
+
+        let replayOccurrence = self.playerService.beginNativeMusicPlaybackOccurrence(videoId: "v1")
+        let delayedWebOccurrence = MusicPlaybackOccurrence.web(
+            documentGeneration: 7,
+            mediaGeneration: 1,
+            nativeGeneration: endedNativeOccurrence?.nativeGeneration ?? 0,
+            videoId: "v1"
+        )
+
+        let boundOccurrence = self.playerService.bindWebMusicPlaybackOccurrence(
+            documentGeneration: delayedWebOccurrence.documentGeneration ?? 0,
+            mediaGeneration: delayedWebOccurrence.mediaGeneration,
+            nativeGeneration: delayedWebOccurrence.nativeGeneration,
+            videoId: delayedWebOccurrence.videoId
+        )
+
+        #expect(boundOccurrence == nil)
+        #expect(!self.playerService.claimTerminalMusicPlaybackOccurrence(delayedWebOccurrence))
+        #expect(self.playerService.currentMusicPlaybackOccurrence == replayOccurrence)
+    }
+
+    @Test("Manual seek-to-end and a late ended callback share one occurrence")
+    func manualSeekToEndThenLateEndedDoesNotDoubleAdvance() async {
+        let songs = [
+            Song(id: "1", title: "Song 1", artists: [], album: nil, duration: 180, thumbnailURL: nil, videoId: "v1"),
+            Song(id: "2", title: "Song 2", artists: [], album: nil, duration: 200, thumbnailURL: nil, videoId: "v2"),
+            Song(id: "3", title: "Song 3", artists: [], album: nil, duration: 220, thumbnailURL: nil, videoId: "v3"),
+        ]
+        await self.playerService.playQueue(songs, startingAt: 0)
+        let endedOccurrence = self.playerService.currentMusicPlaybackOccurrence
+
+        await self.playerService.seek(to: 180)
+        await self.playerService.handleTrackEnded(
+            observedVideoId: "v1",
+            playbackOccurrence: endedOccurrence
+        )
+
+        #expect(self.playerService.currentIndex == 1)
+        #expect(self.playerService.currentTrack?.videoId == "v2")
     }
 
     @Test("Stale track-ended events do not double-advance the queue")

--- a/Tests/KasetTests/PlaylistPlaybackActionsTests.swift
+++ b/Tests/KasetTests/PlaylistPlaybackActionsTests.swift
@@ -129,6 +129,46 @@ struct PlaylistPlaybackActionsTests {
         #expect(playerService.currentTrack == nil)
     }
 
+    @Test("A delayed playlist cannot replace a newer direct queue")
+    func delayedPlaylistCannotReplaceNewerQueue() async {
+        let playlist = TestFixtures.makePlaylist(id: "VL-delayed-intent", title: "Delayed")
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        let staleSong = Song(id: "stale", title: "Stale", artists: [], videoId: "stale")
+        self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(
+            playlist: playlist,
+            tracks: [staleSong],
+            duration: nil
+        )
+        self.mockClient.beforeGetPlaylistReturn = { _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+        let playerService = PlayerService()
+
+        let playlistTask = PlaylistPlaybackActions.playPlaylist(
+            playlist,
+            client: self.mockClient,
+            playerService: playerService
+        )
+        await requestStarted.wait()
+        let replacement = Song(
+            id: "replacement",
+            title: "Replacement",
+            artists: [],
+            videoId: "replacement"
+        )
+        await playerService.playQueue([replacement], startingAt: 0)
+        let replacementEntryIDs = playerService.queueEntryIDs
+
+        await releaseRequest.open()
+        await playlistTask.value
+
+        #expect(playerService.queue == [replacement])
+        #expect(playerService.queueEntryIDs == replacementEntryIDs)
+        #expect(playerService.currentTrack?.videoId == replacement.videoId)
+    }
+
     @Test("Playlist continuations preserve authored duplicate songs")
     func playlistContinuationsPreserveAuthoredDuplicates() async {
         let playlist = TestFixtures.makePlaylist(id: "VL-duplicates", title: "Duplicates")

--- a/Tests/KasetTests/PodcastsViewModelTests.swift
+++ b/Tests/KasetTests/PodcastsViewModelTests.swift
@@ -13,6 +13,23 @@ struct PodcastsViewModelTests {
         self.viewModel = PodcastsViewModel(client: self.mockClient)
     }
 
+    private func waitForBackgroundLoading(
+        timeout: Duration = .seconds(3),
+        until condition: @escaping () -> Bool
+    ) async {
+        let clock = ContinuousClock()
+        let deadline = clock.now + timeout
+
+        while clock.now < deadline {
+            if condition() {
+                return
+            }
+            try? await Task.sleep(for: .milliseconds(25))
+        }
+
+        Issue.record("Timed out waiting for background podcast loading")
+    }
+
     // MARK: - Initial State
 
     @Test
@@ -129,12 +146,13 @@ struct PodcastsViewModelTests {
         ]
 
         await self.viewModel.load()
-
-        // Background loading starts automatically; wait for it to complete
-        try? await Task.sleep(for: .milliseconds(500))
+        await self.waitForBackgroundLoading {
+            self.viewModel.sections.count == 2 && self.viewModel.hasMoreSections == false
+        }
 
         // After background loading, continuation should have been consumed
-        #expect(self.viewModel.sections.count >= 1)
+        #expect(self.viewModel.sections.count == 2)
+        #expect(self.viewModel.hasMoreSections == false)
     }
 
     @Test
@@ -146,12 +164,12 @@ struct PodcastsViewModelTests {
         self.mockClient.podcastsContinuationSections = [[continuationSection]]
 
         await self.viewModel.load()
-
-        // Wait for background loading to complete (300ms delay + processing)
-        try? await Task.sleep(for: .milliseconds(600))
+        await self.waitForBackgroundLoading {
+            self.viewModel.sections.count == 2
+        }
 
         #expect(self.viewModel.sections.count == 2)
-        #expect(self.viewModel.sections[1].title == "Continuation")
+        #expect(self.viewModel.sections.last?.title == "Continuation")
     }
 
     @Test
@@ -161,9 +179,9 @@ struct PodcastsViewModelTests {
         // No continuation sections
 
         await self.viewModel.load()
-
-        // Wait for any background loading attempt
-        try? await Task.sleep(for: .milliseconds(500))
+        await self.waitForBackgroundLoading {
+            self.viewModel.hasMoreSections == false
+        }
 
         #expect(self.viewModel.sections.count == 1)
         #expect(self.viewModel.hasMoreSections == false)

--- a/Tests/KasetTests/RemoteMusicCommandIngressTests.swift
+++ b/Tests/KasetTests/RemoteMusicCommandIngressTests.swift
@@ -1,0 +1,97 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+@Suite("Remote music command ingress", .serialized, .tags(.service))
+struct RemoteMusicCommandIngressTests {
+    @Test("Callbacks preserve capture order under one scheduled drain")
+    func callbacksPreserveCaptureOrderUnderOneDrain() {
+        let ingress = RemoteMusicCommandIngress()
+        let admittedAt = ContinuousClock.now
+
+        #expect(ingress.capture(
+            .play,
+            issuedAtMilliseconds: 1000,
+            admittedAt: admittedAt
+        ))
+        #expect(!ingress.capture(
+            .nextPrevious(direction: .forward),
+            issuedAtMilliseconds: 1001,
+            admittedAt: admittedAt
+        ))
+
+        let firstBatch = ingress.takePendingCommands()
+        #expect(firstBatch.map(\.sequence) == [0, 1])
+        #expect(firstBatch.map(\.payload) == [
+            .play,
+            .nextPrevious(direction: .forward),
+        ])
+        #expect(firstBatch.map(\.issuedAtMilliseconds) == [1000, 1001])
+
+        // A callback arriving while the scheduled drain is handling its first
+        // batch must be consumed by that same drain, not schedule a competing task.
+        #expect(!ingress.capture(
+            .absoluteSeek(position: 42),
+            issuedAtMilliseconds: 1002,
+            admittedAt: admittedAt
+        ))
+        #expect(ingress.finishDrainBatch())
+
+        let secondBatch = ingress.takePendingCommands()
+        #expect(secondBatch.map(\.sequence) == [2])
+        #expect(secondBatch.map(\.payload) == [.absoluteSeek(position: 42)])
+        #expect(!ingress.finishDrainBatch())
+
+        // Once the drain atomically finishes, the next callback rearms it.
+        #expect(ingress.capture(
+            .pause,
+            issuedAtMilliseconds: 1003,
+            admittedAt: admittedAt
+        ))
+    }
+
+    @Test("A callback captured before a newer native intent is stale when delivered")
+    @MainActor
+    func capturedCallbackCannotSupersedeNewerIntent() async {
+        let ingress = RemoteMusicCommandIngress()
+        let playerService = PlayerService()
+        await playerService.playQueue([
+            self.makeSong(id: "current"),
+            self.makeSong(id: "next"),
+        ], startingAt: 0)
+        playerService.musicPlaybackIntentIssuedAtMilliseconds = 999
+
+        #expect(ingress.capture(
+            .nextPrevious(direction: .forward),
+            issuedAtMilliseconds: 1000,
+            admittedAt: ContinuousClock.now
+        ))
+        let newerIntent = playerService.beginMusicPlaybackIntent(issuedAtMilliseconds: 1001)
+
+        let captured = ingress.takePendingCommands()
+        #expect(captured.count == 1)
+        if let command = captured.first {
+            playerService.enqueueRemoteMusicTransportCommand(
+                .next,
+                issuedAtMilliseconds: command.issuedAtMilliseconds
+            )
+        }
+
+        #expect(playerService.currentMusicPlaybackIntent == newerIntent)
+        #expect(playerService.currentIndex == 0)
+        #expect(playerService.currentTrack?.videoId == "current")
+        #expect(playerService.remoteMusicTransportTask == nil)
+        #expect(!ingress.finishDrainBatch())
+    }
+
+    private func makeSong(id: String) -> Song {
+        Song(
+            id: id,
+            title: id,
+            artists: [],
+            duration: 180,
+            videoId: id,
+            feedbackTokens: .init(add: nil, remove: nil)
+        )
+    }
+}

--- a/Tests/KasetTests/RemoteMusicCommandIngressTests.swift
+++ b/Tests/KasetTests/RemoteMusicCommandIngressTests.swift
@@ -84,6 +84,22 @@ struct RemoteMusicCommandIngressTests {
         #expect(!ingress.finishDrainBatch())
     }
 
+    @Test("Absolute seek routes to video only while video owns media keys")
+    func absoluteSeekRouting() {
+        #expect(NowPlayingManager.routesAbsoluteSeekToVideo(
+            routesToYouTubeVideo: true,
+            hasYouTubePlayer: true
+        ))
+        #expect(!NowPlayingManager.routesAbsoluteSeekToVideo(
+            routesToYouTubeVideo: false,
+            hasYouTubePlayer: true
+        ))
+        #expect(!NowPlayingManager.routesAbsoluteSeekToVideo(
+            routesToYouTubeVideo: true,
+            hasYouTubePlayer: false
+        ))
+    }
+
     private func makeSong(id: String) -> Song {
         Song(
             id: id,

--- a/Tests/KasetTests/ScriptCommandsTests.swift
+++ b/Tests/KasetTests/ScriptCommandsTests.swift
@@ -507,6 +507,26 @@ struct ScriptCommandsTests {
         PlayerService.shared = nil
     }
 
+    @Test("GetPlayQueue reports no active queue row for detached playback")
+    func getPlayQueueReportsDetachedPlayback() async {
+        let playerService = PlayerService()
+        await playerService.playQueue([
+            TestFixtures.makeSong(id: "queued-a"),
+            TestFixtures.makeSong(id: "queued-b"),
+        ], startingAt: 1)
+        await playerService.play(song: TestFixtures.makeSong(id: "detached"))
+        PlayerService.shared = playerService
+        defer { PlayerService.shared = nil }
+
+        let result = GetPlayQueueCommand().performDefaultImplementation() as? String
+        let json = result?.data(using: .utf8).flatMap {
+            try? JSONSerialization.jsonObject(with: $0) as? [String: Any]
+        }
+
+        #expect(json?["currentIndex"] as? Int == 0)
+        #expect((json?["tracks"] as? [[String: Any]])?.count == 2)
+    }
+
     // MARK: - PlayTrackAtIndexCommand Tests
 
     @Test("PlayTrackAtIndex sets error when PlayerService is nil")

--- a/Tests/KasetTests/ScrobblingCoordinatorTests.swift
+++ b/Tests/KasetTests/ScrobblingCoordinatorTests.swift
@@ -495,11 +495,13 @@ struct ScrobblingCoordinatorTests {
         playerService.duration = 100
         playerService.setPlaybackStateVideoId("song1")
         let queue = ScrobbleQueue(directory: dir)
+        var now = Date(timeIntervalSince1970: 1000)
         let coordinator = ScrobblingCoordinator(
             playerService: playerService,
             settingsManager: settings,
             services: [mockService],
-            queue: queue
+            queue: queue,
+            now: { now }
         )
         coordinator.startMonitoring()
         defer { coordinator.stopMonitoring() }
@@ -508,8 +510,9 @@ struct ScrobblingCoordinatorTests {
         await self.waitUntil { mockService.nowPlayingTracks.count == 1 }
         playerService.progress = 1.1
         await self.waitUntil { queue.count == 1 }
-        let firstTimestamp = queue.pendingTracks.first?.timestamp
+        let firstTimestamp = try #require(queue.pendingTracks.first?.timestamp)
 
+        now = now.addingTimeInterval(1)
         playerService.progress = 50
         try await Task.sleep(for: .milliseconds(20))
         playerService.progress = 0.1
@@ -517,6 +520,7 @@ struct ScrobblingCoordinatorTests {
         playerService.progress = 1.1
         await self.waitUntil { queue.count == 2 }
 
+        #expect(queue.pendingTracks.last?.timestamp == now)
         #expect(queue.pendingTracks.last?.timestamp != firstTimestamp)
     }
 

--- a/Tests/KasetTests/SongActionsHelperTests.swift
+++ b/Tests/KasetTests/SongActionsHelperTests.swift
@@ -37,6 +37,21 @@ struct SongActionsHelperTests {
         }
     }
 
+    private func waitUntil(
+        timeout: Duration = .seconds(3),
+        condition: () -> Bool
+    ) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while clock.now < deadline {
+            if condition() {
+                return true
+            }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        return false
+    }
+
     private func awaitQueueCount(_ expectedCount: Int, in playerService: PlayerService) async {
         let clock = ContinuousClock()
         let deadline = clock.now.advanced(by: .seconds(1))
@@ -55,6 +70,105 @@ struct SongActionsHelperTests {
             guard clock.now < deadline else { return }
             try? await Task.sleep(for: .milliseconds(10))
         }
+    }
+
+    @Test("Add to Library cannot toggle a newer track")
+    func addToLibraryCannotMutateNewerTrack() async {
+        let playerService = PlayerService()
+        let authService = AuthService(webKitManager: MockWebKitManager())
+        authService.completeLogin(sapisid: "REDACTED")
+        playerService.setAuthService(authService)
+        playerService.setYTMusicClient(self.mockClient)
+        let songA = TestFixtures.makeSong(id: "library-a")
+        let songB = TestFixtures.makeSong(id: "library-b")
+        self.mockClient.songResponses[songA.videoId] = Song(
+            id: songA.id,
+            title: songA.title,
+            artists: songA.artists,
+            videoId: songA.videoId,
+            feedbackTokens: FeedbackTokens(add: "a-add", remove: "a-remove")
+        )
+        let metadataStarted = AsyncGate()
+        let releaseMetadata = AsyncGate()
+        self.mockClient.beforeGetSongReturn = { videoID in
+            guard videoID == songA.videoId else { return }
+            await metadataStarted.open()
+            await releaseMetadata.wait()
+        }
+
+        let addTask = SongActionsHelper.addToLibrary(songA, playerService: playerService)
+        await metadataStarted.wait()
+        await playerService.play(song: songB)
+        await releaseMetadata.open()
+        await addTask.value
+
+        #expect(playerService.currentTrack?.videoId == songB.videoId)
+        #expect(!playerService.currentTrackInLibrary)
+        #expect(!self.mockClient.editSongLibraryStatusCalled)
+    }
+
+    @Test("Add to Library waits for tokens on an already-loading song")
+    func addToLibraryWaitsForLoadingMetadata() async {
+        let playerService = PlayerService()
+        let authService = AuthService(webKitManager: MockWebKitManager())
+        authService.completeLogin(sapisid: "REDACTED")
+        playerService.setAuthService(authService)
+        playerService.setYTMusicClient(self.mockClient)
+        let song = TestFixtures.makeSong(id: "loading-library")
+        self.mockClient.songResponses[song.videoId] = Song(
+            id: song.id,
+            title: song.title,
+            artists: song.artists,
+            videoId: song.videoId,
+            feedbackTokens: FeedbackTokens(add: "mock-token", remove: "test-cookie")
+        )
+        let metadataStarted = AsyncGate()
+        let releaseMetadata = AsyncGate()
+        self.mockClient.beforeGetSongReturn = { videoID in
+            guard videoID == song.videoId else { return }
+            await metadataStarted.open()
+            await releaseMetadata.wait()
+        }
+
+        let initialPlay = Task { @MainActor in
+            await playerService.play(song: song)
+        }
+        await metadataStarted.wait()
+        let addTask = SongActionsHelper.addToLibrary(song, playerService: playerService)
+        await releaseMetadata.open()
+        await initialPlay.value
+        await addTask.value
+        let clock = ContinuousClock()
+        let deadline = clock.now + .seconds(1)
+        while !self.mockClient.editSongLibraryStatusCalled, clock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+
+        #expect(self.mockClient.editSongLibraryStatusCalled)
+    }
+
+    @Test("Add to Library does not remove an already-saved song")
+    func addToLibraryDoesNotToggleSavedSong() async {
+        let playerService = PlayerService()
+        let authService = AuthService(webKitManager: MockWebKitManager())
+        authService.completeLogin(sapisid: "REDACTED")
+        playerService.setAuthService(authService)
+        playerService.setYTMusicClient(self.mockClient)
+        let song = Song(
+            id: "already-saved",
+            title: "Already Saved",
+            artists: [],
+            videoId: "already-saved",
+            isInLibrary: true,
+            feedbackTokens: FeedbackTokens(add: nil, remove: "mock-token")
+        )
+
+        let task = SongActionsHelper.addToLibrary(song, playerService: playerService)
+        await task.value
+        try? await Task.sleep(for: .milliseconds(25))
+
+        #expect(playerService.currentTrackInLibrary)
+        #expect(!self.mockClient.editSongLibraryStatusCalled)
     }
 
     @Test("canQuickPlayPlaylist rejects mood category browse IDs")
@@ -390,11 +504,16 @@ struct SongActionsHelperTests {
         ]
         self.mockClient.libraryContentResponseDelays = [.milliseconds(700)]
 
-        let initialLoadTask = Task {
-            await self.libraryViewModel.load()
+        var initialLoadTask: Task<Void, Never>!
+        await withCheckedContinuation { continuation in
+            self.mockClient.onGetLibraryContent = {
+                self.mockClient.onGetLibraryContent = nil
+                continuation.resume()
+            }
+            initialLoadTask = Task {
+                await self.libraryViewModel.load()
+            }
         }
-
-        try await Task.sleep(for: .milliseconds(100))
 
         try await SongActionsHelper.unsubscribeFromArtist(
             staleArtist,
@@ -404,9 +523,14 @@ struct SongActionsHelperTests {
         )
 
         await initialLoadTask.value
-        try await Task.sleep(for: .milliseconds(100))
+        let didDiscardStaleLoad = await self.waitUntil {
+            self.mockClient.getLibraryContentCallCount >= 2
+                && !self.libraryViewModel.isInLibrary(artistId: "UC-channel-123")
+                && self.libraryViewModel.artists.isEmpty
+        }
 
-        #expect(self.mockClient.getLibraryContentCallCount == 2)
+        #expect(didDiscardStaleLoad)
+        #expect(self.mockClient.getLibraryContentCallCount >= 2)
         #expect(self.libraryViewModel.isInLibrary(artistId: "UC-channel-123") == false)
         #expect(self.libraryViewModel.artists.isEmpty)
     }

--- a/Tests/KasetTests/SongLikeStatusManagerTests.swift
+++ b/Tests/KasetTests/SongLikeStatusManagerTests.swift
@@ -10,8 +10,7 @@ struct SongLikeStatusManagerTests {
     var mockClient: MockYTMusicClient
 
     init() {
-        // Use the shared singleton (init is private)
-        self.manager = SongLikeStatusManager.shared
+        self.manager = SongLikeStatusManager()
         self.mockClient = MockYTMusicClient()
         self.manager.clearCache()
         self.manager.setActiveAccountID(nil)
@@ -157,6 +156,85 @@ struct SongLikeStatusManagerTests {
 
         // Should remove the entry entirely
         #expect(self.manager.status(for: "new-video") == nil)
+    }
+
+    @Test("A delayed rating completion cannot overwrite a newer rating")
+    func latestRatingCompletionWins() async {
+        let song = TestFixtures.makeSong(id: "latest-rating-manager")
+        let accountID = "latest-rating-account"
+        self.manager.setActiveAccountID(accountID)
+        self.mockClient.rateSongDelay = .milliseconds(200)
+        let likeTask = Task { @MainActor in
+            await self.manager.like(
+                song,
+                accountID: accountID,
+                client: self.mockClient
+            )
+        }
+        try? await Task.sleep(for: .milliseconds(25))
+        self.mockClient.rateSongDelay = nil
+
+        let dislikeStatus = await self.manager.dislike(
+            song,
+            accountID: accountID,
+            client: self.mockClient
+        )
+        let lateLikeStatus = await likeTask.value
+
+        #expect(dislikeStatus == .dislike)
+        #expect(lateLikeStatus == .dislike)
+        #expect(self.manager.status(for: song.videoId, accountID: accountID) == .dislike)
+        #expect(self.mockClient.appliedRateSongRatings.last == .dislike)
+    }
+
+    @Test("A stale successful rating cannot seed rollback state after session invalidation")
+    func staleSuccessfulRatingCannotSeedRollbackAfterSessionInvalidation() async {
+        let song = TestFixtures.makeSong(id: "stale-rating-session")
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        self.mockClient.beforeRateSongReturn = { _, _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+
+        let staleLike = Task { @MainActor in
+            await self.manager.like(song, client: self.mockClient)
+        }
+        await requestStarted.wait()
+        self.manager.invalidateSession()
+        #expect(self.manager.status(for: song.videoId) == nil)
+
+        await releaseRequest.open()
+        _ = await staleLike.value
+        self.mockClient.beforeRateSongReturn = nil
+        self.mockClient.shouldThrowError = YTMusicError.networkError(
+            underlying: URLError(.notConnectedToInternet)
+        )
+
+        let finalStatus = await self.manager.dislike(song, client: self.mockClient)
+
+        #expect(finalStatus == .indifferent)
+        #expect(self.manager.status(for: song.videoId) == nil)
+    }
+
+    @Test("Overlapping failed ratings roll back to the confirmed baseline")
+    func overlappingRatingFailuresRestoreConfirmedState() async {
+        let song = TestFixtures.makeSong(id: "failed-rating-chain")
+        self.mockClient.rateSongDelay = .milliseconds(200)
+        self.mockClient.shouldThrowError = YTMusicError.networkError(
+            underlying: URLError(.notConnectedToInternet)
+        )
+        let likeTask = Task { @MainActor in
+            await self.manager.like(song, client: self.mockClient)
+        }
+        try? await Task.sleep(for: .milliseconds(25))
+        self.mockClient.rateSongDelay = nil
+        let dislikeStatus = await self.manager.dislike(song, client: self.mockClient)
+        let likeStatus = await likeTask.value
+
+        #expect(dislikeStatus == .indifferent)
+        #expect(likeStatus == .dislike || likeStatus == .indifferent)
+        #expect(self.manager.status(for: song.videoId) == nil)
     }
 
     @Test("dislike reverts cache on API failure")

--- a/Tests/KasetTests/WebPlaybackDocumentGenerationTests.swift
+++ b/Tests/KasetTests/WebPlaybackDocumentGenerationTests.swift
@@ -1,0 +1,621 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+@Suite("Web playback document generation")
+struct WebPlaybackDocumentGenerationTests {
+    @Test("JavaScript string literals escape untrusted video identifiers")
+    func javascriptLiteralEscaping() {
+        let literal = WebPlaybackDocumentGeneration.javaScriptStringLiteral("x';alert(1)//")
+
+        #expect(literal.hasPrefix("\""))
+        #expect(literal.hasSuffix("\""))
+        #expect(!literal.hasPrefix("'"))
+        #expect(WebPlaybackDocumentGeneration.javaScriptStringLiteral(nil) == "null")
+    }
+
+    @Test("Suppression script keeps an invalidated document from restarting media")
+    func mediaSuppressionScriptIsPersistent() {
+        let script = WebPlaybackDocumentGeneration.mediaSuppressionScript
+
+        #expect(script.contains("window.__kasetPlaybackSuppressed = true"))
+        #expect(script.contains("document.addEventListener('play'"))
+        #expect(script.contains("}, true);"))
+        #expect(script.contains("media.pause()"))
+    }
+
+    @Test("Retryable WebKit cancellation errors do not terminally fail navigation")
+    func retryableCancellationClassification() {
+        let cancelled = NSError(
+            domain: NSURLErrorDomain,
+            code: URLError.cancelled.rawValue
+        )
+        let policyChange = NSError(domain: "WebKitErrorDomain", code: 102)
+        let offline = NSError(domain: NSURLErrorDomain, code: URLError.notConnectedToInternet.rawValue)
+
+        #expect(WebPlaybackNavigationFailure.isRetryableCancellation(cancelled))
+        #expect(WebPlaybackNavigationFailure.isRetryableCancellation(policyChange))
+        #expect(!WebPlaybackNavigationFailure.isRetryableCancellation(offline))
+    }
+
+    @Test("Tracked navigation retains one-shot bootstrap seek across redirects")
+    func trackedNavigationRetainsSeek() {
+        let navigation = WebPlaybackTrackedNavigation(generation: 42, pendingSeek: 12.5)
+
+        #expect(navigation.generation == 42)
+        #expect(navigation.pendingSeek == 12.5)
+        #expect(!navigation.didCommit)
+        #expect(!navigation.didActivatePlaybackOrigin)
+    }
+
+    @Test("Pending and provisional navigation suppress the outgoing document until commit")
+    func navigationSuppressesOutgoingDocumentUntilCommit() {
+        var generation = WebPlaybackDocumentGeneration()
+
+        #expect(generation.accepts(rawGeneration: 0))
+
+        let next = generation.beginNavigation()
+        #expect(next == 1)
+        #expect(generation.pendingGeneration == next)
+        #expect(generation.userScriptGeneration == next)
+        #expect(!generation.accepts(rawGeneration: 0))
+        #expect(!generation.acceptsUserCommand(
+            generation: 0,
+            issuedAtMilliseconds: nil,
+            navigationStartedAtMilliseconds: 100
+        ))
+        #expect(!generation.acceptsUserCommand(
+            generation: 0,
+            issuedAtMilliseconds: 99,
+            navigationStartedAtMilliseconds: 100
+        ))
+        #expect(generation.acceptsUserCommand(
+            generation: 0,
+            issuedAtMilliseconds: 100,
+            navigationStartedAtMilliseconds: 100
+        ))
+        #expect(!generation.accepts(rawGeneration: next))
+
+        let didStart = generation.startNavigation(next)
+        #expect(didStart)
+        #expect(generation.currentGeneration == 0)
+        #expect(generation.inFlightGeneration == next)
+        #expect(generation.userScriptGeneration == next)
+        #expect(!generation.accepts(rawGeneration: 0))
+        #expect(generation.acceptsUserCommand(
+            generation: 0,
+            issuedAtMilliseconds: 101,
+            navigationStartedAtMilliseconds: 100
+        ))
+        #expect(!generation.accepts(rawGeneration: next))
+
+        let didCommit = generation.commitNavigation(next)
+        #expect(didCommit)
+        #expect(generation.currentGeneration == next)
+        #expect(generation.inFlightGeneration == nil)
+        #expect(generation.accepts(rawGeneration: next))
+        #expect(!generation.acceptsUserCommand(
+            generation: 0,
+            issuedAtMilliseconds: 101,
+            navigationStartedAtMilliseconds: 100
+        ))
+        #expect(!generation.accepts(rawGeneration: 0))
+    }
+
+    @Test("Current media-key commands are accepted when no navigation is active")
+    func currentUserCommandAcceptedWithoutNavigation() {
+        let generation = WebPlaybackDocumentGeneration()
+
+        #expect(generation.acceptsUserCommand(
+            generation: 0,
+            issuedAtMilliseconds: nil,
+            navigationStartedAtMilliseconds: nil
+        ))
+    }
+
+    @Test("Superseded navigation cannot start over the newer request")
+    func supersededNavigationCannotStart() {
+        var generation = WebPlaybackDocumentGeneration()
+
+        let first = generation.beginNavigation()
+        let second = generation.beginNavigation()
+
+        let startedFirst = generation.startNavigation(first)
+        #expect(!startedFirst)
+        #expect(generation.pendingGeneration == second)
+        let startedSecond = generation.startNavigation(second)
+        #expect(startedSecond)
+        #expect(generation.inFlightGeneration == second)
+    }
+
+    @Test("Cancelling a pre-navigation request restores the committed document")
+    func cancellingPendingNavigationRestoresCommittedDocument() {
+        var generation = WebPlaybackDocumentGeneration()
+        let first = generation.beginNavigation()
+        let didStartFirst = generation.startNavigation(first)
+        let didCommitFirst = generation.commitNavigation(first)
+        #expect(didStartFirst)
+        #expect(didCommitFirst)
+
+        _ = generation.beginNavigation()
+        #expect(!generation.accepts(rawGeneration: first))
+
+        generation.cancelPendingNavigation()
+
+        #expect(generation.pendingGeneration == nil)
+        #expect(generation.accepts(rawGeneration: first))
+    }
+
+    @Test("Cancelling a provisional navigation restores the committed document")
+    func cancellingInFlightNavigationRestoresCommittedDocument() {
+        var generation = WebPlaybackDocumentGeneration()
+        let first = generation.beginNavigation()
+        let didStartFirst = generation.startNavigation(first)
+        let didCommitFirst = generation.commitNavigation(first)
+        #expect(didStartFirst)
+        #expect(didCommitFirst)
+
+        let second = generation.beginNavigation()
+        let didStartSecond = generation.startNavigation(second)
+        #expect(didStartSecond)
+        #expect(!generation.accepts(rawGeneration: first))
+        #expect(!generation.accepts(rawGeneration: second))
+
+        let didCancel = generation.cancelInFlightNavigation(second)
+        #expect(didCancel)
+        #expect(generation.inFlightGeneration == nil)
+        #expect(generation.currentGeneration == first)
+        #expect(generation.accepts(rawGeneration: first))
+    }
+
+    @Test("An earlier commit is recorded while a newer request remains pending")
+    func commitWhileNewerRequestIsPending() {
+        var generation = WebPlaybackDocumentGeneration()
+        let first = generation.beginNavigation()
+        let didStartFirst = generation.startNavigation(first)
+        #expect(didStartFirst)
+
+        let second = generation.beginNavigation()
+        let didCommitFirst = generation.commitNavigation(first)
+        #expect(didCommitFirst)
+
+        #expect(generation.currentGeneration == first)
+        #expect(generation.pendingGeneration == second)
+        #expect(!generation.accepts(rawGeneration: first))
+        #expect(generation.userScriptGeneration == second)
+    }
+
+    @Test("A committed document cannot finish after a newer selection begins")
+    func staleCommittedDocumentCannotFinish() {
+        var generation = WebPlaybackDocumentGeneration()
+        let first = generation.beginNavigation()
+        let didStartFirst = generation.startNavigation(first)
+        let didCommitFirst = generation.commitNavigation(first)
+        #expect(didStartFirst)
+        #expect(didCommitFirst)
+        #expect(generation.canFinishNavigation(first))
+
+        let second = generation.beginNavigation()
+        #expect(!generation.canFinishNavigation(first))
+        let didStartSecond = generation.startNavigation(second)
+        #expect(didStartSecond)
+        #expect(!generation.canFinishNavigation(first))
+        let didCommitSecond = generation.commitNavigation(second)
+        #expect(didCommitSecond)
+        #expect(!generation.canFinishNavigation(first))
+        #expect(generation.canFinishNavigation(second))
+    }
+
+    @Test("An earlier commit is recorded while a newer navigation is in flight")
+    func commitWhileNewerNavigationIsInFlight() {
+        var generation = WebPlaybackDocumentGeneration()
+        let first = generation.beginNavigation()
+        let didStartFirst = generation.startNavigation(first)
+        #expect(didStartFirst)
+
+        let second = generation.beginNavigation()
+        let didStartSecond = generation.startNavigation(second)
+        #expect(didStartSecond)
+
+        let didCommitFirst = generation.commitNavigation(first)
+        #expect(didCommitFirst)
+        #expect(generation.currentGeneration == first)
+        #expect(generation.inFlightGeneration == second)
+        #expect(!generation.accepts(rawGeneration: first))
+
+        let didCommitSecond = generation.commitNavigation(second)
+        #expect(didCommitSecond)
+        #expect(generation.currentGeneration == second)
+        #expect(generation.inFlightGeneration == nil)
+        #expect(generation.accepts(rawGeneration: second))
+    }
+
+    @Test("Invalidation rejects every document that existed before teardown")
+    func invalidationRejectsExistingDocuments() {
+        var generation = WebPlaybackDocumentGeneration()
+        let first = generation.beginNavigation()
+        let didStartFirst = generation.startNavigation(first)
+        let didCommitFirst = generation.commitNavigation(first)
+        #expect(didStartFirst)
+        #expect(didCommitFirst)
+
+        generation.invalidate()
+
+        #expect(generation.currentGeneration > first)
+        #expect(!generation.accepts(rawGeneration: first))
+        #expect(generation.accepts(rawGeneration: generation.currentGeneration))
+    }
+
+    @Test("Malformed or unrelated URL query values do not decode a document generation")
+    func malformedURLQueryValuesDoNotDecode() throws {
+        let unrelated = try #require(URL(string: "https://example.test/watch?other=42"))
+        let malformed = try #require(URL(string: "https://example.test/watch?kasetDocumentGeneration=nope"))
+
+        #expect(WebPlaybackDocumentGeneration.generation(from: unrelated) == nil)
+        #expect(WebPlaybackDocumentGeneration.generation(from: malformed) == nil)
+        #expect(WebPlaybackDocumentGeneration.generation(from: nil) == nil)
+        let fragment = try #require(URL(
+            string: "https://example.test/watch#kasetDocumentGeneration=42"
+        ))
+        #expect(WebPlaybackDocumentGeneration.generation(from: fragment) == 42)
+    }
+
+    @Test("A query-dropping redirect remains associated through mainDocumentURL")
+    func redirectedRequestKeepsGenerationAssociation() throws {
+        let original = try #require(URL(
+            string: "https://example.test/watch?v=video&kasetDocumentGeneration=42"
+        ))
+        let redirect = try #require(URL(string: "https://consent.example.test/continue"))
+        var request = URLRequest(url: redirect)
+        request.mainDocumentURL = original
+
+        #expect(WebPlaybackDocumentGeneration.request(request, belongsTo: 42))
+        #expect(!WebPlaybackDocumentGeneration.request(request, belongsTo: 41))
+
+        var unrelated = URLRequest(url: redirect)
+        unrelated.mainDocumentURL = try #require(URL(
+            string: "https://example.test/watch?v=old&kasetDocumentGeneration=41"
+        ))
+        #expect(!WebPlaybackDocumentGeneration.request(unrelated, belongsTo: 42))
+    }
+
+    @Test("Conflicting request and main-document generations are rejected")
+    func conflictingRequestGenerationsAreRejected() throws {
+        let current = try #require(URL(
+            string: "https://music.youtube.com/watch?v=current&kasetDocumentGeneration=42"
+        ))
+        let stale = try #require(URL(
+            string: "https://consent.youtube.com/m?kasetDocumentGeneration=41"
+        ))
+        var request = URLRequest(url: stale)
+        request.mainDocumentURL = current
+
+        #expect(!WebPlaybackDocumentGeneration.request(request, belongsTo: 41))
+        #expect(!WebPlaybackDocumentGeneration.request(request, belongsTo: 42))
+        #expect(!WebPlaybackDocumentGeneration.requestBelongsToNavigationChain(
+            request,
+            currentURL: current,
+            generation: 42,
+            playbackHost: "music.youtube.com"
+        ))
+    }
+
+    @Test("Tokenless allowed-host continuation cannot borrow a newer generation")
+    func tokenlessContinuationCannotBorrowNewerGeneration() throws {
+        let staleCurrent = try #require(URL(
+            string: "https://music.youtube.com/watch?v=old&kasetDocumentGeneration=41"
+        ))
+        let tokenlessConsent = try URLRequest(url: #require(URL(
+            string: "https://consent.youtube.com/m"
+        )))
+
+        #expect(!WebPlaybackDocumentGeneration.requestBelongsToNavigationChain(
+            tokenlessConsent,
+            currentURL: staleCurrent,
+            generation: 42,
+            playbackHost: "music.youtube.com"
+        ))
+    }
+
+    @Test("Tokenless continuation requires a committed same-generation intermediary")
+    func tokenlessContinuationRequiresCommittedIntermediary() throws {
+        var documentGeneration = WebPlaybackDocumentGeneration()
+        let generation = documentGeneration.beginNavigation()
+        let didStart = documentGeneration.startNavigation(generation)
+        #expect(didStart)
+
+        let consent = try #require(URL(string: "https://consent.youtube.com/m"))
+        let returnRequest = try URLRequest(url: #require(URL(
+            string: "https://music.youtube.com/watch?v=video"
+        )))
+
+        #expect(!WebPlaybackDocumentGeneration.requestBelongsToNavigationChain(
+            returnRequest,
+            currentURL: consent,
+            generation: generation,
+            playbackHost: "music.youtube.com",
+            committedIntermediaryGeneration: documentGeneration.committedIntermediaryGeneration
+        ))
+        let didCommitIntermediary = documentGeneration.commitIntermediaryNavigation(generation)
+        #expect(didCommitIntermediary)
+        #expect(WebPlaybackDocumentGeneration.requestBelongsToNavigationChain(
+            returnRequest,
+            currentURL: consent,
+            generation: generation,
+            playbackHost: "music.youtube.com",
+            committedIntermediaryGeneration: documentGeneration.committedIntermediaryGeneration
+        ))
+
+        _ = documentGeneration.beginNavigation()
+        #expect(documentGeneration.committedIntermediaryGeneration == nil)
+        #expect(!WebPlaybackDocumentGeneration.requestBelongsToNavigationChain(
+            returnRequest,
+            currentURL: consent,
+            generation: generation + 1,
+            playbackHost: "music.youtube.com",
+            committedIntermediaryGeneration: documentGeneration.committedIntermediaryGeneration
+        ))
+    }
+
+    @Test("Playback navigation only trusts the expected HTTPS origin")
+    func playbackNavigationRequiresExpectedOrigin() throws {
+        let expected = try #require(URL(string: "https://music.youtube.com/watch?v=video"))
+        let wrongHost = try #require(URL(string: "https://consent.youtube.com/continue"))
+        let wrongScheme = try #require(URL(string: "http://music.youtube.com/watch?v=video"))
+
+        #expect(WebPlaybackDocumentGeneration.isExpectedPlaybackURL(
+            expected,
+            host: "music.youtube.com"
+        ))
+        #expect(!WebPlaybackDocumentGeneration.isExpectedPlaybackURL(
+            wrongHost,
+            host: "music.youtube.com"
+        ))
+        #expect(!WebPlaybackDocumentGeneration.isExpectedPlaybackURL(
+            wrongScheme,
+            host: "music.youtube.com"
+        ))
+        #expect(!WebPlaybackDocumentGeneration.isExpectedPlaybackURL(
+            nil,
+            host: "music.youtube.com"
+        ))
+    }
+
+    @Test("Fragment-only navigation is distinguished from a document-changing URL")
+    func fragmentOnlyNavigationDetection() throws {
+        let current = try #require(URL(string: "https://example.test/watch?v=video#one"))
+        let fragmentChange = try #require(URL(string: "https://example.test/watch?v=video#two"))
+        let queryChange = try #require(URL(string: "https://example.test/watch?v=other#two"))
+
+        #expect(WebPlaybackDocumentGeneration.isFragmentOnlyNavigation(
+            from: current,
+            to: fragmentChange
+        ))
+        #expect(!WebPlaybackDocumentGeneration.isFragmentOnlyNavigation(
+            from: current,
+            to: queryChange
+        ))
+        #expect(!WebPlaybackDocumentGeneration.isFragmentOnlyNavigation(
+            from: current,
+            to: current
+        ))
+    }
+
+    @Test("Internal blank navigations are recognized")
+    func internalBlankNavigationDetection() throws {
+        #expect(WebPlaybackDocumentGeneration.isInternalBlankNavigation(nil))
+        #expect(try WebPlaybackDocumentGeneration.isInternalBlankNavigation(
+            #require(URL(string: "about:blank"))
+        ))
+        #expect(try WebPlaybackDocumentGeneration.isInternalBlankNavigation(
+            #require(URL(string: "data:text/html,"))
+        ))
+        #expect(try !WebPlaybackDocumentGeneration.isInternalBlankNavigation(
+            #require(URL(string: "https://example.test"))
+        ))
+    }
+
+    @Test("Only an explicitly owned blank URL is accepted")
+    func internalBlankNavigationRequiresOwnership() throws {
+        var documentGeneration = WebPlaybackDocumentGeneration()
+        let blankGeneration = documentGeneration.beginBlankNavigation()
+        let ownedBlank = try #require(WebPlaybackDocumentGeneration.blankURL(
+            generation: blankGeneration
+        ))
+        let ownedData = try #require(URL(
+            string: "data:text/html,%3Chtml%3E%3C/html%3E#kasetBlankGeneration=\(blankGeneration)"
+        ))
+        let unownedBlank = try #require(URL(string: "about:blank"))
+
+        #expect(documentGeneration.ownsBlankNavigation(ownedBlank))
+        #expect(documentGeneration.ownsBlankNavigation(ownedData))
+        #expect(!documentGeneration.ownsBlankNavigation(unownedBlank))
+
+        let ownedResponse = URLResponse(
+            url: ownedBlank,
+            mimeType: "text/html",
+            expectedContentLength: 0,
+            textEncodingName: "utf-8"
+        )
+        #expect(WebPlaybackDocumentGeneration.acceptsMainFrameResponse(
+            ownedResponse,
+            expectedHost: "music.youtube.com",
+            expectedVideoID: nil,
+            allowsInternalBlank: documentGeneration.ownsBlankNavigation(ownedBlank)
+        ))
+        let ownedDataResponse = URLResponse(
+            url: ownedData,
+            mimeType: "text/html",
+            expectedContentLength: 0,
+            textEncodingName: "utf-8"
+        )
+        #expect(WebPlaybackDocumentGeneration.acceptsMainFrameResponse(
+            ownedDataResponse,
+            expectedHost: "music.youtube.com",
+            expectedVideoID: nil,
+            allowsInternalBlank: documentGeneration.ownsBlankNavigation(ownedData)
+        ))
+
+        _ = documentGeneration.beginNavigation()
+        #expect(!documentGeneration.ownsBlankNavigation(ownedBlank))
+    }
+
+    @Test("Main-frame response validation allows playback and trusted consent origins")
+    func mainFrameResponseValidation() throws {
+        #expect(try WebPlaybackDocumentGeneration.acceptsMainFrameResponse(
+            #require(URL(string: "https://music.youtube.com/watch")),
+            expectedHost: "music.youtube.com"
+        ))
+        #expect(try WebPlaybackDocumentGeneration.acceptsMainFrameResponse(
+            #require(URL(string: "https://consent.youtube.com/")),
+            expectedHost: "music.youtube.com"
+        ))
+        #expect(try !WebPlaybackDocumentGeneration.acceptsMainFrameResponse(
+            #require(URL(string: "http://music.youtube.com/watch")),
+            expectedHost: "music.youtube.com"
+        ))
+        #expect(try !WebPlaybackDocumentGeneration.acceptsMainFrameResponse(
+            #require(URL(string: "about:blank")),
+            expectedHost: "music.youtube.com"
+        ))
+        #expect(try !WebPlaybackDocumentGeneration.acceptsMainFrameResponse(
+            #require(URL(string: "data:text/html,")),
+            expectedHost: "music.youtube.com"
+        ))
+    }
+
+    @Test("Playback response requires 2xx status and the expected watch identity")
+    func playbackResponseRequiresSuccessAndExpectedIdentity() throws {
+        var documentGeneration = WebPlaybackDocumentGeneration()
+        let generation = documentGeneration.beginNavigation()
+        let didStart = documentGeneration.startNavigation(generation)
+        #expect(didStart)
+        let expectedURL = try #require(URL(
+            string: "https://music.youtube.com/watch?v=video&kasetDocumentGeneration=\(generation)"
+        ))
+        let wrongVideoURL = try #require(URL(
+            string: "https://music.youtube.com/watch?v=other&kasetDocumentGeneration=\(generation)"
+        ))
+        let consentURL = try #require(URL(string: "https://consent.youtube.com/m"))
+
+        let success = try #require(HTTPURLResponse(
+            url: expectedURL,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        ))
+        let serverError = try #require(HTTPURLResponse(
+            url: expectedURL,
+            statusCode: 503,
+            httpVersion: nil,
+            headerFields: nil
+        ))
+        let wrongVideo = try #require(HTTPURLResponse(
+            url: wrongVideoURL,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        ))
+        let consent = try #require(HTTPURLResponse(
+            url: consentURL,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        ))
+
+        #expect(WebPlaybackDocumentGeneration.acceptsMainFrameResponse(
+            success,
+            expectedHost: "music.youtube.com",
+            expectedVideoID: "video",
+            allowsInternalBlank: false
+        ))
+        #expect(!WebPlaybackDocumentGeneration.acceptsMainFrameResponse(
+            serverError,
+            expectedHost: "music.youtube.com",
+            expectedVideoID: "video",
+            allowsInternalBlank: false
+        ))
+        #expect(!WebPlaybackDocumentGeneration.acceptsMainFrameResponse(
+            wrongVideo,
+            expectedHost: "music.youtube.com",
+            expectedVideoID: "video",
+            allowsInternalBlank: false
+        ))
+        #expect(WebPlaybackDocumentGeneration.acceptsMainFrameResponse(
+            consent,
+            expectedHost: "music.youtube.com",
+            expectedVideoID: "video",
+            allowsInternalBlank: false
+        ))
+
+        let didRecordResponse = documentGeneration.recordSuccessfulPlaybackResponse(
+            url: expectedURL,
+            host: "music.youtube.com",
+            videoID: "video"
+        )
+        #expect(didRecordResponse)
+        let didCommitWrongVideo = documentGeneration.commitNavigation(
+            generation,
+            expectedVideoID: "other"
+        )
+        #expect(!didCommitWrongVideo)
+        let didCommitExpectedVideo = documentGeneration.commitNavigation(
+            generation,
+            expectedVideoID: "video"
+        )
+        #expect(didCommitExpectedVideo)
+    }
+
+    @Test("Trusted consent continuations remain in the same navigation generation")
+    func trustedRedirectContinuation() throws {
+        let original = try #require(URL(
+            string: "https://music.youtube.com/watch?v=x&kasetDocumentGeneration=42"
+        ))
+        let consent = try #require(URL(string: "https://consent.youtube.com/m"))
+        var redirectRequest = URLRequest(url: consent)
+        redirectRequest.mainDocumentURL = original
+        #expect(WebPlaybackDocumentGeneration.requestBelongsToNavigationChain(
+            redirectRequest,
+            currentURL: original,
+            generation: 42,
+            playbackHost: "music.youtube.com"
+        ))
+
+        let returnRequest = try URLRequest(url: #require(URL(string: "https://music.youtube.com/watch?v=x")))
+        #expect(WebPlaybackDocumentGeneration.requestBelongsToNavigationChain(
+            returnRequest,
+            currentURL: consent,
+            generation: 42,
+            playbackHost: "music.youtube.com",
+            committedIntermediaryGeneration: 42
+        ))
+
+        let untrusted = try URLRequest(url: #require(URL(string: "https://example.test/")))
+        #expect(!WebPlaybackDocumentGeneration.requestBelongsToNavigationChain(
+            untrusted,
+            currentURL: consent,
+            generation: 42,
+            playbackHost: "music.youtube.com"
+        ))
+
+        let rebound = try #require(WebPlaybackDocumentGeneration.requestByBindingGeneration(
+            returnRequest,
+            generation: 42
+        ))
+        #expect(WebPlaybackDocumentGeneration.generation(from: rebound.url) == 42)
+    }
+
+    @Test("Bridge generation decoding rejects malformed values")
+    func bridgeGenerationDecoding() {
+        let generation = WebPlaybackDocumentGeneration()
+
+        #expect(generation.accepts(rawGeneration: NSNumber(value: 0)))
+        #expect(generation.accepts(rawGeneration: 0))
+        #expect(!generation.accepts(rawGeneration: -1))
+        #expect(!generation.accepts(rawGeneration: 0.5))
+        #expect(!generation.accepts(rawGeneration: "0"))
+        #expect(!generation.accepts(rawGeneration: true))
+        #expect(!generation.accepts(rawGeneration: Double(UInt64.max)))
+        #expect(!generation.accepts(rawGeneration: nil))
+    }
+}

--- a/Tests/KasetTests/WebPlaybackDocumentGenerationTests.swift
+++ b/Tests/KasetTests/WebPlaybackDocumentGenerationTests.swift
@@ -429,6 +429,12 @@ struct WebPlaybackDocumentGenerationTests {
 
         #expect(documentGeneration.ownsBlankNavigation(ownedBlank))
         #expect(documentGeneration.ownsBlankNavigation(ownedData))
+        #expect(try documentGeneration.ownsBlankNavigation(#require(URL(
+            string: "about:blank%23kasetBlankGeneration=\(blankGeneration)"
+        ))))
+        #expect(try documentGeneration.ownsBlankNavigation(#require(URL(
+            string: "data:text/html,%3Chtml%3E%3C/html%3E%23kasetBlankGeneration=\(blankGeneration)"
+        ))))
         #expect(!documentGeneration.ownsBlankNavigation(unownedBlank))
 
         let ownedResponse = URLResponse(

--- a/Tests/KasetTests/YouTubeNavigationScriptOwnershipTests.swift
+++ b/Tests/KasetTests/YouTubeNavigationScriptOwnershipTests.swift
@@ -1,0 +1,21 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+@Suite("YouTube navigation script ownership", .tags(.service))
+struct YouTubeNavigationScriptOwnershipTests {
+    @Test("Redirect script reinstall preserves the pending seek attempt id")
+    func redirectReinstallPreservesPendingSeekAttempt() throws {
+        let source = try String(
+            contentsOfFile: #filePath.replacingOccurrences(
+                of: "Tests/KasetTests/YouTubeNavigationScriptOwnershipTests.swift",
+                with: "Sources/Kaset/Views/YouTube/YouTubeWatchWebView.swift"
+            ),
+            encoding: .utf8
+        )
+
+        #expect(source.contains(
+            "pendingSeekAttemptID: self.pendingSeekAttemptIDsByGeneration[trackedNavigation.generation]"
+        ))
+    }
+}

--- a/Tests/KasetTests/YouTubePlaybackBridgeGenerationTests.swift
+++ b/Tests/KasetTests/YouTubePlaybackBridgeGenerationTests.swift
@@ -1,0 +1,167 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+@Suite("YouTube playback bridge generation", .tags(.service))
+@MainActor
+struct YouTubePlaybackBridgeGenerationTests {
+    @Test("Bridge acceptance requires current WebView identity and active generation")
+    func bridgeAcceptanceRequiresIdentityAndGeneration() {
+        let currentWebView = NSObject()
+        let replacedWebView = NSObject()
+        var documentGeneration = WebPlaybackDocumentGeneration()
+        let activeGeneration = documentGeneration.beginNavigation()
+        let didStartGeneration = documentGeneration.startNavigation(activeGeneration)
+        let didCommitGeneration = documentGeneration.commitNavigation(activeGeneration)
+        #expect(didStartGeneration)
+        #expect(didCommitGeneration)
+
+        #expect(YouTubeWatchWebView.acceptsBridgeMessage(
+            sourceWebView: currentWebView,
+            currentWebView: currentWebView,
+            documentGeneration: documentGeneration,
+            rawDocumentGeneration: activeGeneration
+        ))
+        #expect(!YouTubeWatchWebView.acceptsBridgeMessage(
+            sourceWebView: replacedWebView,
+            currentWebView: currentWebView,
+            documentGeneration: documentGeneration,
+            rawDocumentGeneration: activeGeneration
+        ))
+        #expect(!YouTubeWatchWebView.acceptsBridgeMessage(
+            sourceWebView: currentWebView,
+            currentWebView: currentWebView,
+            documentGeneration: documentGeneration,
+            rawDocumentGeneration: activeGeneration + 1
+        ))
+        #expect(!YouTubeWatchWebView.acceptsBridgeSource(
+            isMainFrame: false,
+            sourceScheme: "https",
+            sourceHost: "www.youtube.com"
+        ))
+        #expect(!YouTubeWatchWebView.acceptsBridgeSource(
+            isMainFrame: true,
+            sourceScheme: "https",
+            sourceHost: "music.youtube.com"
+        ))
+    }
+
+    @Test("Pending navigation suppresses bridge acceptance until cancel or activation")
+    func pendingNavigationSuppressesBridgeAcceptance() {
+        let currentWebView = NSObject()
+        var documentGeneration = WebPlaybackDocumentGeneration()
+        let committedGeneration = documentGeneration.beginNavigation()
+        let didStartCommittedGeneration = documentGeneration.startNavigation(committedGeneration)
+        let didCommitCommittedGeneration = documentGeneration.commitNavigation(committedGeneration)
+        #expect(didStartCommittedGeneration)
+        #expect(didCommitCommittedGeneration)
+
+        let pendingGeneration = documentGeneration.beginNavigation()
+        #expect(!YouTubeWatchWebView.acceptsBridgeMessage(
+            sourceWebView: currentWebView,
+            currentWebView: currentWebView,
+            documentGeneration: documentGeneration,
+            rawDocumentGeneration: committedGeneration
+        ))
+
+        documentGeneration.cancelPendingNavigation()
+        #expect(YouTubeWatchWebView.acceptsBridgeMessage(
+            sourceWebView: currentWebView,
+            currentWebView: currentWebView,
+            documentGeneration: documentGeneration,
+            rawDocumentGeneration: committedGeneration
+        ))
+
+        let replacementGeneration = documentGeneration.beginNavigation()
+        #expect(replacementGeneration > pendingGeneration)
+        let didStartReplacementGeneration = documentGeneration.startNavigation(replacementGeneration)
+        let didCommitReplacementGeneration = documentGeneration.commitNavigation(replacementGeneration)
+        #expect(didStartReplacementGeneration)
+        #expect(didCommitReplacementGeneration)
+        documentGeneration.cancelPendingNavigation()
+        #expect(YouTubeWatchWebView.acceptsBridgeMessage(
+            sourceWebView: currentWebView,
+            currentWebView: currentWebView,
+            documentGeneration: documentGeneration,
+            rawDocumentGeneration: replacementGeneration
+        ))
+        #expect(!documentGeneration.accepts(rawGeneration: committedGeneration))
+    }
+
+    @Test("User-script bootstrap selects pending generation, otherwise active generation")
+    func userScriptBootstrapSelectsPendingOrActiveGeneration() {
+        var documentGeneration = WebPlaybackDocumentGeneration()
+
+        #expect(YouTubeWatchWebView.userScriptDocumentGeneration(from: documentGeneration) == 0)
+
+        let pendingGeneration = documentGeneration.beginNavigation()
+        #expect(
+            YouTubeWatchWebView.userScriptDocumentGeneration(from: documentGeneration)
+                == pendingGeneration
+        )
+        let pendingBootstrap = YouTubeWatchWebView.pageBootstrapScript(
+            targetVolume: 0.5,
+            documentGeneration: YouTubeWatchWebView.userScriptDocumentGeneration(from: documentGeneration)
+        )
+        #expect(pendingBootstrap.contains("window.__kasetDocumentGeneration = -1;"))
+
+        documentGeneration.cancelPendingNavigation()
+        #expect(
+            YouTubeWatchWebView.userScriptDocumentGeneration(from: documentGeneration)
+                == documentGeneration.currentGeneration
+        )
+    }
+
+    @Test("Watch URL binds its document generation to the navigation")
+    func watchURLBindsDocumentGeneration() throws {
+        let url = try #require(YouTubeWatchWebView.watchURL(
+            videoId: "video",
+            documentGeneration: 42
+        ))
+
+        #expect(WebPlaybackDocumentGeneration.generation(from: url) == 42)
+    }
+
+    @Test("YouTube main-frame response rejects non-2xx and mismatched watch documents")
+    func mainFrameResponseRequiresExpectedSuccessfulWatchDocument() throws {
+        var documentGeneration = WebPlaybackDocumentGeneration()
+        let generation = documentGeneration.beginNavigation()
+        let didStart = documentGeneration.startNavigation(generation)
+        #expect(didStart)
+        let expectedURL = try #require(YouTubeWatchWebView.watchURL(
+            videoId: "video",
+            documentGeneration: generation
+        ))
+        let success = try #require(HTTPURLResponse(
+            url: expectedURL,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: nil
+        ))
+        let failure = try #require(HTTPURLResponse(
+            url: expectedURL,
+            statusCode: 404,
+            httpVersion: nil,
+            headerFields: nil
+        ))
+
+        #expect(WebPlaybackDocumentGeneration.acceptsMainFrameResponse(
+            success,
+            expectedHost: "www.youtube.com",
+            expectedVideoID: "video",
+            allowsInternalBlank: documentGeneration.ownsBlankNavigation(success.url)
+        ))
+        #expect(!WebPlaybackDocumentGeneration.acceptsMainFrameResponse(
+            failure,
+            expectedHost: "www.youtube.com",
+            expectedVideoID: "video",
+            allowsInternalBlank: documentGeneration.ownsBlankNavigation(failure.url)
+        ))
+        #expect(!WebPlaybackDocumentGeneration.acceptsMainFrameResponse(
+            success,
+            expectedHost: "www.youtube.com",
+            expectedVideoID: "other",
+            allowsInternalBlank: documentGeneration.ownsBlankNavigation(success.url)
+        ))
+    }
+}

--- a/Tests/KasetTests/YouTubePlaybackIntentOwnershipTests.swift
+++ b/Tests/KasetTests/YouTubePlaybackIntentOwnershipTests.swift
@@ -1,0 +1,146 @@
+import Testing
+@testable import Kaset
+
+@Suite("YouTube playback intent ownership", .serialized, .tags(.service), .timeLimit(.minutes(1)))
+@MainActor
+struct YouTubePlaybackIntentOwnershipTests {
+    @Test("SPA drift uses bridge event time for remote-command admission")
+    func driftUsesBridgeEventTimeForRemoteCommandAdmission() {
+        let controller = MockYouTubeWatchPlaybackController()
+        let service = YouTubePlayerService(playbackController: controller)
+        service.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        service.youtubePlaybackIntentIssuedAtMilliseconds = 1000
+
+        service.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 0,
+            duration: 60,
+            videoId: "xyz",
+            title: "Drifted Title",
+            eventIssuedAtMilliseconds: 1500
+        ))
+        service.handleRemotePause(issuedAtMilliseconds: 1600)
+
+        #expect(controller.pauseCount == 1)
+    }
+
+    @Test("A same-timestamp native intent invalidates an older delayed skip")
+    func sameTimestampNativeIntentInvalidatesDelayedSkip() async {
+        let service = YouTubePlayerService(playbackController: MockYouTubeWatchPlaybackController())
+        let client = MockYouTubeClient()
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        client.watchNextData = WatchNextData(
+            videoTitle: nil,
+            viewCountText: nil,
+            publishedText: nil,
+            channel: nil,
+            related: [MockYouTubeClient.makeVideo(videoId: "stale-next")]
+        )
+        client.beforeWatchNextReturn = { _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+        service.youtubeClient = client
+        service.play(video: MockYouTubeClient.makeVideo(videoId: "current"))
+
+        let skipTask = Task { @MainActor in
+            await service.skipForward()
+        }
+        await requestStarted.wait()
+        service.beginYouTubePlaybackIntent(
+            issuedAtMilliseconds: service.youtubePlaybackIntentIssuedAtMilliseconds
+        )
+        await releaseRequest.open()
+        await skipTask.value
+
+        #expect(service.currentVideo?.videoId == "current")
+    }
+
+    @Test("Remote resume preserves its captured timestamp for ended-event ordering")
+    func remoteResumePreservesCapturedTimestamp() {
+        let service = YouTubePlayerService(playbackController: MockYouTubeWatchPlaybackController())
+        let video = MockYouTubeClient.makeVideo(videoId: "remote-resume-timestamp")
+        service.play(video: video)
+        service.youtubePlaybackIntentIssuedAtMilliseconds = 1000
+
+        service.handleRemoteResume(issuedAtMilliseconds: 2000)
+
+        #expect(service.handleVideoEnded(
+            videoId: video.videoId,
+            eventIssuedAtMilliseconds: 2100
+        ))
+    }
+
+    @Test("Remote toggle resume preserves its captured timestamp for ended-event ordering")
+    func remoteToggleResumePreservesCapturedTimestamp() {
+        let service = YouTubePlayerService(playbackController: MockYouTubeWatchPlaybackController())
+        let video = MockYouTubeClient.makeVideo(videoId: "remote-toggle-timestamp")
+        service.play(video: video)
+        service.performPause()
+        service.youtubePlaybackIntentIssuedAtMilliseconds = 1000
+
+        service.handleRemoteTogglePlayPause(issuedAtMilliseconds: 2000)
+
+        #expect(service.handleVideoEnded(
+            videoId: video.videoId,
+            eventIssuedAtMilliseconds: 2100
+        ))
+    }
+
+    @Test("A native intent resets a future-poisoned remote-command boundary")
+    func nativeIntentResetsFutureBoundary() {
+        let controller = MockYouTubeWatchPlaybackController()
+        let service = YouTubePlayerService(playbackController: controller)
+        service.youtubePlaybackIntentIssuedAtMilliseconds = 9_000_000_000_000_000
+
+        service.beginYouTubePlaybackIntent()
+        let recoveredBoundary = service.youtubePlaybackIntentIssuedAtMilliseconds
+        service.handleRemoteResume(issuedAtMilliseconds: 9_000_000_000_000_000)
+        service.handleRemotePause(issuedAtMilliseconds: recoveredBoundary + 1)
+
+        #expect(recoveredBoundary < 9_000_000_000_000_000)
+        #expect(controller.playCount == 0)
+        #expect(controller.pauseCount == 1)
+    }
+
+    @Test("An equal-timestamp native intent clears remote-command ownership")
+    func equalTimestampNativeIntentClearsRemoteOwnership() {
+        let controller = MockYouTubeWatchPlaybackController()
+        let service = YouTubePlayerService(playbackController: controller)
+        service.youtubePlaybackIntentIssuedAtMilliseconds = 1000
+        service.handleRemotePause(issuedAtMilliseconds: 2000)
+
+        service.beginYouTubePlaybackIntent(issuedAtMilliseconds: 2000)
+        service.handleRemoteResume(issuedAtMilliseconds: 2000)
+
+        #expect(controller.pauseCount == 1)
+        #expect(controller.playCount == 0)
+    }
+
+    @Test("An older bridge intent preserves newer remote-command ownership")
+    func olderBridgeIntentPreservesRemoteOwnership() {
+        let controller = MockYouTubeWatchPlaybackController()
+        let service = YouTubePlayerService(playbackController: controller)
+        service.youtubePlaybackIntentIssuedAtMilliseconds = 1000
+        service.handleRemotePause(issuedAtMilliseconds: 2000)
+
+        service.beginYouTubePlaybackIntent(issuedAtMilliseconds: 1500)
+        service.handleRemoteResume(issuedAtMilliseconds: 2000)
+
+        #expect(controller.pauseCount == 1)
+        #expect(controller.playCount == 1)
+    }
+
+    @Test("A stale remote next command cannot navigate after a newer native intent")
+    func staleRemoteNextCannotNavigate() async {
+        let service = YouTubePlayerService(playbackController: MockYouTubeWatchPlaybackController())
+        service.play(video: MockYouTubeClient.makeVideo(videoId: "current"))
+        service.setUpNext([MockYouTubeClient.makeVideo(videoId: "stale-next")])
+        service.beginYouTubePlaybackIntent(issuedAtMilliseconds: 2000)
+
+        await service.handleRemoteSkipForward(issuedAtMilliseconds: 1000)
+
+        #expect(service.currentVideo?.videoId == "current")
+    }
+}

--- a/Tests/KasetTests/YouTubePlayerRaceRegressionTests.swift
+++ b/Tests/KasetTests/YouTubePlayerRaceRegressionTests.swift
@@ -1,0 +1,388 @@
+import Testing
+@testable import Kaset
+
+@Suite("YouTube player race regressions", .serialized, .tags(.service))
+@MainActor
+struct YouTubePlayerRaceRegressionTests {
+    private let controller: MockYouTubeWatchPlaybackController
+    private let sut: YouTubePlayerService
+
+    init() {
+        self.controller = MockYouTubeWatchPlaybackController()
+        self.sut = YouTubePlayerService(playbackController: self.controller)
+    }
+
+    @Test("Paused identity drift preserves the new video's ready position")
+    func pausedIdentityDriftPreservesReadyPosition() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 12,
+            duration: 100,
+            hasReadyMedia: true,
+            videoId: "a",
+            boundVideoId: "a"
+        ))
+        self.sut.pause()
+        self.sut.reloadCurrentVideoForIdentitySwitch()
+
+        self.sut.updatePlaybackState(.init(
+            isPlaying: false,
+            progress: 37,
+            duration: 90,
+            hasReadyMedia: true,
+            videoId: "b",
+            boundVideoId: "b",
+            title: "B"
+        ))
+        self.sut.resume()
+
+        #expect(self.sut.currentVideo?.videoId == "b")
+        #expect(self.controller.reloadedVideoIds == ["b"])
+        #expect(self.controller.reloadResumeSeconds == [37])
+    }
+
+    @Test("Native seek-to-end immediately after replay concludes the new watch")
+    func nativeSeekToEndAfterReplayConcludesNewWatch() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        let endedOccurrence = YouTubePlaybackOccurrence(
+            documentGeneration: 7,
+            mediaGeneration: 1
+        )
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 9,
+            duration: 10,
+            hasReadyMedia: true,
+            videoId: "a",
+            boundVideoId: "a",
+            playbackOccurrence: endedOccurrence
+        ))
+        var endedCount = 0
+        self.sut.onVideoEnded = { _ in endedCount += 1 }
+        #expect(self.sut.handleVideoEnded(
+            videoId: "a",
+            playbackOccurrence: endedOccurrence
+        ))
+
+        self.sut.resume()
+        self.sut.seek(to: 10)
+
+        #expect(endedCount == 2)
+        #expect(self.sut.watchConclusionGeneration == 2)
+        #expect(self.controller.markCurrentPlaybackOccurrenceEndedCount == 1)
+        #expect(!self.sut.handleVideoEnded(
+            videoId: "a",
+            playbackOccurrence: endedOccurrence
+        ))
+        #expect(endedCount == 2)
+    }
+
+    @Test("Identity reload preserves an unacknowledged user seek")
+    func identityReloadPreservesPendingUserSeek() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 12,
+            duration: 100,
+            hasReadyMedia: true,
+            videoId: "a",
+            boundVideoId: "a"
+        ))
+
+        self.sut.seek(to: 45)
+        self.sut.reloadCurrentVideoForIdentitySwitch()
+
+        #expect(self.controller.pendingRecoverySeeks == [45])
+        #expect(self.controller.reloadedVideoIds == ["a"])
+        #expect(self.controller.reloadResumeSeconds == [45])
+    }
+
+    @Test("A bridge end in the resume millisecond is not stale")
+    func sameMillisecondBridgeEndIsNotStale() {
+        #expect(!YouTubePlayerService.isEndEventStale(
+            eventIssuedAtMilliseconds: 1000,
+            lastResumeIssuedAtMilliseconds: 1000.8
+        ))
+        #expect(YouTubePlayerService.isEndEventStale(
+            eventIssuedAtMilliseconds: 999,
+            lastResumeIssuedAtMilliseconds: 1000.8
+        ))
+    }
+
+    @Test("Stop suppresses a late admitted playing update")
+    func stopSuppressesLatePlayingUpdate() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 5,
+            duration: 10,
+            hasReadyMedia: true,
+            videoId: "a",
+            boundVideoId: "a"
+        ))
+        self.controller.resetCommandLog()
+
+        self.sut.stop()
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 6,
+            duration: 10,
+            hasReadyMedia: true,
+            videoId: "a",
+            boundVideoId: "a"
+        ))
+
+        #expect(!self.sut.isPlaying)
+        #expect(self.sut.currentVideo == nil)
+        #expect(self.sut.progress == 0)
+        #expect(self.sut.duration == 0)
+        #expect(!self.sut.isShowingAd)
+        #expect(!self.sut.isPlaybackLoading)
+        #expect(self.controller.commandLog == ["pause"])
+    }
+
+    @Test("Exhausted seek retries do not resurrect an abandoned user target")
+    func exhaustedSeekDoesNotResurrectUserTarget() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 12,
+            duration: 100,
+            hasReadyMedia: true,
+            videoId: "a",
+            boundVideoId: "a"
+        ))
+        self.sut.seek(to: 45)
+
+        self.sut.handlePendingSeekExhausted(videoId: "a", target: 45)
+        self.sut.reloadCurrentVideoForIdentitySwitch()
+
+        #expect(self.controller.reloadResumeSeconds == [12])
+    }
+
+    @Test("Exhausted seek retries clear an unacknowledged explicit start")
+    func exhaustedSeekClearsExplicitStartTarget() {
+        let controller = MockYouTubeWatchPlaybackController()
+        let service = YouTubePlayerService(playbackController: controller)
+        service.play(
+            video: MockYouTubeClient.makeVideo(videoId: "a"),
+            startAt: 45
+        )
+
+        service.handlePendingSeekExhausted(videoId: "a", target: 45)
+        service.handleWebNavigationFailure()
+        service.resume()
+
+        #expect(controller.reloadResumeSeconds.count == 2)
+        #expect(controller.reloadResumeSeconds[0] == 45)
+        #expect(controller.reloadResumeSeconds[1] == nil)
+    }
+
+    @Test("Exhausted seek retries repair a deferred identity reload target")
+    func exhaustedSeekRepairsDeferredIdentityReload() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: false,
+            progress: 12,
+            duration: 100,
+            hasReadyMedia: true,
+            videoId: "a",
+            boundVideoId: "a"
+        ))
+        self.sut.pause()
+        self.sut.reloadCurrentVideoForIdentitySwitch()
+        self.sut.seek(to: 45)
+
+        self.sut.handlePendingSeekExhausted(videoId: "a", target: 45)
+        self.sut.resume()
+
+        #expect(self.controller.reloadResumeSeconds == [12])
+        #expect(!self.sut.userUpdatedPendingPausedIdentityReloadSeek)
+    }
+
+    @Test("Terminal seek does not recreate an identity reload at the duration")
+    func terminalSeekClearsInFlightIdentityReloadTarget() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 50,
+            duration: 100,
+            hasReadyMedia: true,
+            videoId: "a",
+            boundVideoId: "a"
+        ))
+        self.sut.reloadCurrentVideoForIdentitySwitch()
+        #expect(self.controller.reloadResumeSeconds == [50])
+
+        self.sut.seek(to: 100)
+        self.sut.resume()
+
+        #expect(self.controller.reloadResumeSeconds == [50])
+        #expect(self.sut.pendingPausedIdentityReloadVideoId == nil)
+        #expect(self.sut.pendingPausedIdentityReloadResumeAt == nil)
+    }
+
+    @Test("A pause-pending playing sample cannot confirm a newer resume")
+    func pausePendingSampleDoesNotConfirmResume() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 10,
+            duration: 100,
+            hasReadyMedia: true,
+            videoId: "a",
+            boundVideoId: "a"
+        ))
+        self.sut.pause()
+        self.sut.resume()
+
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 10,
+            duration: 100,
+            hasReadyMedia: true,
+            videoId: "a",
+            boundVideoId: "a",
+            nativePausePending: true
+        ))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: false,
+            progress: 10,
+            duration: 100,
+            hasReadyMedia: true,
+            videoId: "a",
+            boundVideoId: "a"
+        ))
+        self.sut.recoverAfterWebContentProcessTermination()
+
+        #expect(self.controller.reloadedVideoIds == ["a"])
+        #expect(self.sut.pendingPausedIdentityReloadVideoId == nil)
+    }
+
+    @Test("A preroll ad creative is never promoted as the recovery target")
+    func prerollAdCreativeIsNotRecoveryTarget() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        let firstOccurrence = YouTubePlaybackOccurrence(
+            documentGeneration: 7,
+            mediaGeneration: 1
+        )
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 59,
+            duration: 60,
+            hasReadyMedia: true,
+            videoId: "a",
+            boundVideoId: "a",
+            playbackOccurrence: firstOccurrence
+        ))
+        self.sut.handleVideoEnded(
+            videoId: "a",
+            playbackOccurrence: firstOccurrence
+        )
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 7,
+            duration: 15,
+            hasReadyMedia: true,
+            videoId: "b",
+            boundVideoId: "b",
+            title: "B",
+            isAd: true,
+            playbackOccurrence: YouTubePlaybackOccurrence(
+                documentGeneration: 7,
+                mediaGeneration: 2
+            )
+        ))
+        self.sut.setUpNext([MockYouTubeClient.makeVideo(videoId: "b")])
+
+        self.sut.recoverAfterWebContentProcessTermination()
+
+        #expect(self.sut.currentVideo?.videoId == "a")
+        #expect(self.controller.reloadedVideoIds.isEmpty)
+        #expect(!self.sut.isPlaying)
+        #expect(self.sut.pendingPausedIdentityReloadVideoId == nil)
+
+        self.sut.resume()
+        #expect(self.sut.currentVideo?.videoId == "b")
+        #expect(self.controller.loadedVideoIds.last == "b")
+    }
+
+    @Test("A ready paused preroll remains a retryable autoplay transition")
+    func pausedPrerollSurvivesProcessRecovery() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        let firstOccurrence = YouTubePlaybackOccurrence(
+            documentGeneration: 7,
+            mediaGeneration: 1
+        )
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 59,
+            duration: 60,
+            videoId: "a",
+            playbackOccurrence: firstOccurrence
+        ))
+        self.sut.handleVideoEnded(videoId: "a", playbackOccurrence: firstOccurrence)
+        self.sut.setUpNext([MockYouTubeClient.makeVideo(videoId: "b")])
+        self.sut.updatePlaybackState(.init(
+            isPlaying: false,
+            progress: 0,
+            duration: 15,
+            hasReadyMedia: true,
+            videoId: "creative",
+            isAd: true,
+            playbackOccurrence: YouTubePlaybackOccurrence(
+                documentGeneration: 7,
+                mediaGeneration: 2
+            )
+        ))
+
+        self.sut.recoverAfterWebContentProcessTermination()
+        #expect(self.controller.reloadedVideoIds.isEmpty)
+        self.sut.resume()
+
+        #expect(self.sut.currentVideo?.videoId == "b")
+        #expect(self.controller.loadedVideoIds.last == "b")
+    }
+
+    @Test("Failed autoplay recovery remains retryable without stale advancement")
+    func failedAutoplayRecoveryRemainsRetryable() async {
+        let client = MockYouTubeClient()
+        self.sut.youtubeClient = client
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        let firstOccurrence = YouTubePlaybackOccurrence(
+            documentGeneration: 7,
+            mediaGeneration: 1
+        )
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 59,
+            duration: 60,
+            videoId: "a",
+            playbackOccurrence: firstOccurrence
+        ))
+        self.sut.handleVideoEnded(videoId: "a", playbackOccurrence: firstOccurrence)
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 2,
+            duration: 15,
+            hasReadyMedia: true,
+            videoId: "creative",
+            isAd: true,
+            playbackOccurrence: YouTubePlaybackOccurrence(
+                documentGeneration: 7,
+                mediaGeneration: 2
+            )
+        ))
+        self.sut.recoverAfterWebContentProcessTermination()
+
+        self.sut.resume()
+        await Task.yield()
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "newer"))
+        await Task.yield()
+
+        #expect(self.sut.currentVideo?.videoId == "newer")
+        self.sut.playPause()
+        #expect(self.controller.pauseCount >= 1)
+    }
+}

--- a/Tests/KasetTests/YouTubePlayerRecoveryTests.swift
+++ b/Tests/KasetTests/YouTubePlayerRecoveryTests.swift
@@ -1,0 +1,784 @@
+import Testing
+@testable import Kaset
+
+@Suite("YouTube player recovery", .serialized, .tags(.service))
+@MainActor
+struct YouTubePlayerRecoveryTests {
+    private let controller: MockYouTubeWatchPlaybackController
+    private let sut: YouTubePlayerService
+
+    init() {
+        self.controller = MockYouTubeWatchPlaybackController()
+        self.sut = YouTubePlayerService(playbackController: self.controller)
+    }
+
+    @Test("WebContent recovery reloads a playing video at its content position")
+    func webContentRecoveryReloadsPlayingVideo() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 42,
+            duration: 100,
+            hasReadyMedia: true,
+            videoId: "abc",
+            boundVideoId: "abc"
+        ))
+
+        self.sut.recoverAfterWebContentProcessTermination()
+
+        #expect(self.controller.reloadedVideoIds == ["abc"])
+        #expect(self.controller.reloadResumeSeconds == [42])
+        #expect(self.sut.isPlaybackLoading)
+        #expect(!self.sut.isPlaying)
+    }
+
+    @Test("Recovery clock follows ready bound media, not leading metadata")
+    func recoveryClockIsBoundToPhysicalVideo() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 42,
+            duration: 100,
+            hasReadyMedia: true,
+            videoId: "a",
+            boundVideoId: "a"
+        ))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 43,
+            duration: 100,
+            hasReadyMedia: true,
+            videoId: "b",
+            boundVideoId: "a",
+            title: "B"
+        ))
+
+        self.sut.reloadCurrentVideoForIdentitySwitch()
+        #expect(self.controller.reloadResumeSeconds.count == 1)
+        #expect(self.controller.reloadResumeSeconds[0] == nil)
+
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 5,
+            duration: 100,
+            hasReadyMedia: true,
+            videoId: "b",
+            boundVideoId: "b",
+            title: "B"
+        ))
+        self.sut.reloadCurrentVideoForIdentitySwitch()
+        #expect(self.controller.reloadResumeSeconds.last == 5)
+    }
+
+    @Test("A stale terminal seek attempt cannot clear a newer recovery seek")
+    func staleTerminalAttemptCannotClearNewSeek() {
+        let webView = YouTubeWatchWebView.shared
+        let generation: UInt64 = 42
+        webView.pendingSeeksByGeneration[generation] = 30
+        webView.pendingSeekVideoIdsByGeneration[generation] = "abc"
+        webView.pendingSeekAttemptIDsByGeneration[generation] = 2
+        defer {
+            webView.pendingSeeksByGeneration.removeValue(forKey: generation)
+            webView.pendingSeekVideoIdsByGeneration.removeValue(forKey: generation)
+            webView.pendingSeekAttemptIDsByGeneration.removeValue(forKey: generation)
+        }
+
+        let didAcceptStaleAttempt = webView.completePendingSeek(
+            generation: generation,
+            attemptID: 1,
+            target: 30,
+            videoId: "abc"
+        )
+
+        #expect(!didAcceptStaleAttempt)
+        #expect(webView.pendingSeeksByGeneration[generation] == 30)
+
+        let didAcceptCurrentAttempt = webView.completePendingSeek(
+            generation: generation,
+            attemptID: 2,
+            target: 30,
+            videoId: "abc"
+        )
+
+        #expect(didAcceptCurrentAttempt)
+        #expect(webView.pendingSeeksByGeneration[generation] == nil)
+    }
+
+    @Test("Bound-media skew does not discard the active video's pending seek")
+    func pendingSeekDiscardUsesNativeVideoIdentity() {
+        #expect(!YouTubeWatchWebView.shouldDiscardPendingSeek(
+            expectedVideoId: "b",
+            activeVideoId: "b"
+        ))
+        #expect(YouTubeWatchWebView.shouldDiscardPendingSeek(
+            expectedVideoId: "a",
+            activeVideoId: "b"
+        ))
+        #expect(!YouTubeWatchWebView.shouldDiscardPendingSeek(
+            expectedVideoId: "b",
+            activeVideoId: nil
+        ))
+    }
+
+    @Test("WebContent recovery keeps a paused video deferred until explicit resume")
+    func webContentRecoveryDefersPausedVideo() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: false,
+            progress: 42,
+            duration: 100,
+            hasReadyMedia: true,
+            videoId: "abc",
+            boundVideoId: "abc"
+        ))
+        self.sut.pause()
+
+        self.sut.recoverAfterWebContentProcessTermination()
+
+        #expect(self.controller.reloadedVideoIds.isEmpty)
+        #expect(self.sut.pendingPausedIdentityReloadVideoId == "abc")
+        #expect(self.sut.pendingPausedIdentityReloadResumeAt == 42)
+        #expect(!self.sut.isPlaying)
+        #expect(!self.sut.isPlaybackLoading)
+
+        self.sut.resume()
+
+        #expect(self.controller.reloadedVideoIds == ["abc"])
+        #expect(self.controller.reloadResumeSeconds == [42])
+    }
+
+    @Test("Transient paused observer state while loading keeps automatic recovery intent")
+    func transientPausedLoadingStateKeepsRecoveryIntent() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: false,
+            progress: 42,
+            duration: 100,
+            hasReadyMedia: true,
+            videoId: "abc",
+            boundVideoId: "abc"
+        ))
+
+        self.sut.recoverAfterWebContentProcessTermination()
+
+        #expect(self.controller.reloadedVideoIds == ["abc"])
+        #expect(self.controller.reloadResumeSeconds == [42])
+        #expect(self.sut.pendingPausedIdentityReloadVideoId == nil)
+    }
+
+    @Test("A settled never-started page resumes on the first toggle")
+    func neverStartedPageNeedsOnePlayToggle() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: false,
+            progress: 0,
+            duration: 100,
+            hasReadyMedia: true,
+            videoId: "abc"
+        ))
+
+        self.sut.playPause()
+
+        #expect(self.controller.playCount == 1)
+        #expect(self.controller.pauseCount == 0)
+    }
+
+    @Test("A ready paused live stream resumes on the first toggle")
+    func pausedLiveStreamNeedsOnePlayToggle() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "live"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: false,
+            progress: 0,
+            duration: 0,
+            hasReadyMedia: true,
+            videoId: "live"
+        ))
+
+        self.sut.playPause()
+
+        #expect(self.controller.playCount == 1)
+    }
+
+    @Test("A ready paused preroll ad resumes on the first toggle")
+    func pausedPrerollNeedsOnePlayToggle() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: false,
+            progress: 0,
+            duration: 15,
+            hasReadyMedia: true,
+            videoId: "abc",
+            isAd: true
+        ))
+
+        self.sut.playPause()
+
+        #expect(self.controller.playCount == 1)
+    }
+
+    @Test("Rapid toggles follow native command intent before observer catch-up")
+    func rapidTogglesAlternateCommands() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 10,
+            duration: 100,
+            hasReadyMedia: true,
+            videoId: "abc",
+            boundVideoId: "abc"
+        ))
+
+        self.sut.playPause()
+        self.sut.playPause()
+
+        #expect(self.controller.pauseCount == 1)
+        #expect(self.controller.playCount == 1)
+    }
+
+    @Test("A second toggle pauses while resume confirmation is outstanding")
+    func secondToggleCancelsUnconfirmedResume() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: false,
+            progress: 10,
+            duration: 100,
+            hasReadyMedia: true,
+            videoId: "abc",
+            boundVideoId: "abc"
+        ))
+
+        self.sut.playPause()
+        self.sut.updatePlaybackState(.init(
+            isPlaying: false,
+            progress: 10,
+            duration: 100,
+            hasReadyMedia: true,
+            videoId: "abc"
+        ))
+        self.sut.playPause()
+
+        #expect(self.controller.playCount == 1)
+        #expect(self.controller.pauseCount == 1)
+    }
+
+    @Test("Skipping clears the previous watch resume confirmation")
+    func skipClearsResumeConfirmation() async {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        self.sut.resume()
+        self.sut.setUpNext([MockYouTubeClient.makeVideo(videoId: "b")])
+
+        await self.sut.skipForward()
+        self.sut.updatePlaybackState(.init(
+            isPlaying: false,
+            progress: 0,
+            duration: 100,
+            hasReadyMedia: true,
+            videoId: "b"
+        ))
+        self.sut.playPause()
+
+        #expect(self.controller.pauseCount == 0)
+        #expect(self.controller.playCount == 2)
+    }
+
+    @Test("A failed resume reload retries on the first subsequent toggle")
+    func failedResumeReloadNeedsOneToggle() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        self.sut.resume()
+        self.sut.handleWebNavigationFailure()
+
+        self.sut.playPause()
+
+        #expect(self.controller.pauseCount == 0)
+        #expect(self.controller.reloadedVideoIds.last == "abc")
+    }
+
+    @Test("A late pause acknowledgement cannot overwrite a newer resume")
+    func latePauseAfterResumeKeepsPlayIntent() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 10,
+            duration: 100,
+            hasReadyMedia: true,
+            videoId: "abc"
+        ))
+        self.sut.pause()
+        self.sut.resume()
+        self.sut.updatePlaybackState(.init(
+            isPlaying: false,
+            progress: 10,
+            duration: 100,
+            hasReadyMedia: true,
+            videoId: "abc"
+        ))
+
+        self.sut.recoverAfterWebContentProcessTermination()
+
+        #expect(self.controller.reloadedVideoIds == ["abc"])
+        #expect(self.sut.pendingPausedIdentityReloadVideoId == nil)
+    }
+
+    @Test("An established playing-to-paused observer state becomes recovery pause intent")
+    func observerPauseBecomesRecoveryIntent() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 10,
+            duration: 100,
+            hasReadyMedia: true,
+            videoId: "abc",
+            boundVideoId: "abc"
+        ))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: false,
+            progress: 10,
+            duration: 100,
+            hasReadyMedia: true,
+            videoId: "abc",
+            boundVideoId: "abc"
+        ))
+
+        self.sut.recoverAfterWebContentProcessTermination()
+
+        #expect(self.controller.reloadedVideoIds.isEmpty)
+        #expect(self.sut.pendingPausedIdentityReloadVideoId == "abc")
+        #expect(self.sut.pendingPausedIdentityReloadResumeAt == 10)
+    }
+
+    @Test("Play-pause explicitly pauses after cancelling an in-flight navigation")
+    func consumedCancellationUsesExplicitPause() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 1,
+            duration: 60,
+            videoId: "abc"
+        ))
+        self.sut.reloadCurrentVideoForIdentitySwitch()
+        self.controller.cancelPendingLoadResult = true
+
+        self.sut.playPause()
+
+        #expect(self.controller.cancelPendingLoadCount == 1)
+        #expect(self.controller.pauseCount == 1)
+        #expect(self.controller.playPauseCount == 0)
+        #expect(!self.sut.isPlaying)
+    }
+
+    @Test("A late playing sample cannot overwrite explicit pause intent")
+    func latePlayingSampleDoesNotOverwriteExplicitPause() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 10,
+            duration: 60,
+            videoId: "abc"
+        ))
+
+        self.sut.pause()
+        let pausesAfterCommand = self.controller.pauseCount
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 10,
+            duration: 60,
+            videoId: "abc",
+            nativePausePending: true
+        ))
+
+        #expect(!self.sut.isPlaying)
+        #expect(self.controller.pauseCount == pausesAfterCommand + 1)
+
+        self.sut.playPause()
+
+        #expect(self.controller.playCount == 1)
+        #expect(self.controller.pauseCount == pausesAfterCommand + 1)
+    }
+
+    @Test("Playing after a pause acknowledgement remains suppressed until native resume")
+    func playingAfterPauseAcknowledgementRemainsSuppressed() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 10,
+            duration: 60,
+            videoId: "abc"
+        ))
+        self.sut.pause()
+        self.sut.updatePlaybackState(.init(
+            isPlaying: false,
+            progress: 10,
+            duration: 60,
+            videoId: "abc"
+        ))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 10,
+            duration: 60,
+            videoId: "abc"
+        ))
+
+        #expect(!self.sut.isPlaying)
+        self.sut.resume()
+        #expect(self.controller.playCount == 1)
+    }
+
+    @Test("A page-originated pause becomes authoritative after playback is established")
+    func pagePauseUpdatesDesiredIntent() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 10,
+            duration: 60,
+            videoId: "abc"
+        ))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: false,
+            progress: 10,
+            duration: 60,
+            hasReadyMedia: true,
+            videoId: "abc"
+        ))
+
+        self.sut.playPause()
+
+        #expect(self.controller.playCount == 1)
+    }
+
+    @Test("Explicit start target remains authoritative before its seek applies")
+    func explicitStartTargetSurvivesPreSeekProgress() {
+        self.sut.play(
+            video: MockYouTubeClient.makeVideo(videoId: "abc"),
+            startAt: 120
+        )
+        self.sut.updatePlaybackState(.init(
+            isPlaying: false,
+            progress: 1,
+            duration: 300,
+            videoId: "abc"
+        ))
+
+        self.sut.recoverAfterWebContentProcessTermination()
+
+        #expect(self.controller.reloadResumeSeconds.last == 120)
+    }
+
+    @Test("Remembered progress far beyond an explicit start does not acknowledge the seek")
+    func explicitStartTargetSurvivesUnrelatedLaterProgress() {
+        self.sut.play(
+            video: MockYouTubeClient.makeVideo(videoId: "abc"),
+            startAt: 120
+        )
+        self.sut.updatePlaybackState(.init(
+            isPlaying: false,
+            progress: 300,
+            duration: 400,
+            videoId: "abc"
+        ))
+
+        self.sut.recoverAfterWebContentProcessTermination()
+
+        #expect(self.controller.reloadResumeSeconds.last == 120)
+    }
+
+    @Test("A transient pending-seek failure preserves the native start target")
+    func explicitStartTargetSurvivesSeekFailure() {
+        self.sut.play(
+            video: MockYouTubeClient.makeVideo(videoId: "abc"),
+            startAt: 120
+        )
+        self.sut.updatePlaybackState(.init(
+            isPlaying: false,
+            progress: 0,
+            duration: 300,
+            hasReadyMedia: true,
+            videoId: "abc",
+            didFailPendingSeek: true
+        ))
+
+        self.sut.handleWebNavigationFailure()
+        self.sut.resume()
+
+        #expect(self.controller.reloadResumeSeconds == [120, 120])
+    }
+
+    @Test("An applied explicit start stays attributable before getVideoData is ready")
+    func explicitStartAcknowledgementUsesPendingSeekIdentity() {
+        self.sut.play(
+            video: MockYouTubeClient.makeVideo(videoId: "abc"),
+            startAt: 120
+        )
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 120,
+            duration: 300,
+            videoId: nil,
+            didApplyPendingSeek: true,
+            pendingSeekTarget: 120,
+            pendingSeekVideoId: "abc"
+        ))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 180,
+            duration: 300,
+            hasReadyMedia: true,
+            videoId: "abc",
+            boundVideoId: "abc"
+        ))
+
+        self.sut.recoverAfterWebContentProcessTermination()
+
+        #expect(self.controller.reloadResumeSeconds == [120, 180])
+    }
+
+    @Test("Process recovery rejects a seek owned by a different active video")
+    func processRecoveryRejectsPreviousVideoSeek() {
+        let resumeAt = YouTubeWatchWebView.recoverySeek(
+            candidate: 12,
+            candidateVideoId: "video-a",
+            activeVideoId: "video-b"
+        )
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "video-b"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 80,
+            duration: 100,
+            hasReadyMedia: true,
+            videoId: "video-b",
+            boundVideoId: "video-b"
+        ))
+
+        self.sut.recoverAfterWebContentProcessTermination(resumeAtOverride: resumeAt)
+
+        #expect(resumeAt == nil)
+        #expect(self.controller.reloadResumeSeconds == [80])
+    }
+
+    @Test("Navigation failure becomes retryable on explicit resume")
+    func navigationFailureBecomesRetryable() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 42,
+            duration: 100,
+            hasReadyMedia: true,
+            videoId: "abc",
+            boundVideoId: "abc"
+        ))
+
+        self.sut.handleWebNavigationFailure()
+
+        #expect(!self.sut.isPlaying)
+        #expect(!self.sut.isPlaybackLoading)
+        #expect(self.sut.pendingPausedIdentityReloadVideoId == "abc")
+        #expect(self.sut.pendingPausedIdentityReloadResumeAt == 42)
+
+        self.sut.resume()
+
+        #expect(self.controller.reloadedVideoIds == ["abc"])
+        #expect(self.controller.reloadResumeSeconds == [42])
+    }
+
+    @Test("Intentional navigation cancellation preserves the selected video for resume")
+    func navigationCancellationPreservesSelectedVideo() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 42,
+            duration: 100,
+            hasReadyMedia: true,
+            videoId: "abc",
+            boundVideoId: "abc"
+        ))
+
+        self.sut.handleWebNavigationCancellation()
+
+        #expect(!self.sut.isPlaying)
+        #expect(self.sut.pendingPausedIdentityReloadVideoId == "abc")
+        #expect(self.sut.pendingPausedIdentityReloadResumeAt == 42)
+
+        self.sut.resume()
+        #expect(self.controller.reloadedVideoIds == ["abc"])
+        #expect(self.controller.reloadResumeSeconds == [42])
+    }
+
+    @Test("Accepted autoplay restores requested-play intent for process recovery")
+    func autoplayRestoresRecoveryIntent() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 42,
+            duration: 100,
+            videoId: "abc"
+        ))
+        self.sut.handleVideoEnded(videoId: "abc")
+
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 7,
+            duration: 80,
+            hasReadyMedia: true,
+            videoId: "def",
+            boundVideoId: "def",
+            title: "Autoplayed"
+        ))
+        self.sut.recoverAfterWebContentProcessTermination()
+
+        #expect(self.sut.currentVideo?.videoId == "def")
+        #expect(self.controller.reloadedVideoIds == ["def"])
+        #expect(self.sut.pendingPausedIdentityReloadVideoId == nil)
+    }
+
+    @Test("A different-video playing sample queued before explicit pause stays suppressed")
+    func differentVideoDoesNotBypassExplicitPause() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 42,
+            duration: 100,
+            videoId: "abc"
+        ))
+        self.sut.pause()
+
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 1,
+            duration: 80,
+            videoId: "def",
+            title: "Queued autoplay",
+
+            nativePausePending: true
+        ))
+        self.sut.recoverAfterWebContentProcessTermination()
+
+        #expect(!self.sut.isPlaying)
+        #expect(self.sut.currentVideo?.videoId == "def")
+        #expect(self.controller.reloadedVideoIds.isEmpty)
+        #expect(self.sut.pendingPausedIdentityReloadVideoId == "def")
+    }
+
+    @Test("A queued ended event cannot clear a newer explicit pause")
+    func endedEventPreservesNewerExplicitPause() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 79,
+            duration: 80,
+            videoId: "abc"
+        ))
+        self.sut.pause()
+        self.sut.handleVideoEnded(videoId: "abc")
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 1,
+            duration: 90,
+            hasReadyMedia: true,
+            videoId: "def",
+            boundVideoId: "def",
+            title: "Autoplay",
+            nativePausePending: true
+        ))
+
+        self.sut.recoverAfterWebContentProcessTermination()
+
+        #expect(!self.sut.isPlaying)
+        #expect(self.controller.reloadedVideoIds.isEmpty)
+        #expect(self.sut.pendingPausedIdentityReloadVideoId == "def")
+    }
+
+    @Test("Interrupted explicit start targets survive every early recovery path")
+    func interruptedStartAtIsPreserved() {
+        let failureController = MockYouTubeWatchPlaybackController()
+        let failureService = YouTubePlayerService(playbackController: failureController)
+        failureService.play(
+            video: MockYouTubeClient.makeVideo(videoId: "failure"),
+            startAt: 42
+        )
+        failureService.handleWebNavigationFailure()
+        failureService.resume()
+        #expect(failureController.reloadResumeSeconds == [42, 42])
+
+        let cancellationController = MockYouTubeWatchPlaybackController()
+        let cancellationService = YouTubePlayerService(playbackController: cancellationController)
+        cancellationService.play(
+            video: MockYouTubeClient.makeVideo(videoId: "cancellation"),
+            startAt: 84
+        )
+        cancellationService.handleWebNavigationCancellation()
+        cancellationService.resume()
+        #expect(cancellationController.reloadResumeSeconds == [84, 84])
+
+        let processController = MockYouTubeWatchPlaybackController()
+        let processService = YouTubePlayerService(playbackController: processController)
+        processService.play(
+            video: MockYouTubeClient.makeVideo(videoId: "process"),
+            startAt: 126
+        )
+        processService.updatePlaybackState(.init(
+            isPlaying: false,
+            progress: 0,
+            duration: 300,
+            videoId: "process"
+        ))
+        processService.recoverAfterWebContentProcessTermination()
+        #expect(processController.reloadResumeSeconds == [126, 126])
+
+        let confirmedController = MockYouTubeWatchPlaybackController()
+        let confirmedService = YouTubePlayerService(playbackController: confirmedController)
+        confirmedService.play(
+            video: MockYouTubeClient.makeVideo(videoId: "confirmed"),
+            startAt: 168
+        )
+        confirmedService.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 168,
+            duration: 300,
+            videoId: "confirmed",
+            didApplyPendingSeek: true
+        ))
+        confirmedService.updatePlaybackState(.init(
+            isPlaying: false,
+            progress: 0,
+            duration: 300,
+            videoId: "confirmed"
+        ))
+        confirmedService.handleWebNavigationFailure()
+        confirmedService.resume()
+        #expect(confirmedController.reloadResumeSeconds == [168, nil])
+    }
+
+    @Test("A user seek replaces an unconfirmed explicit start target for recovery")
+    func userSeekInvalidatesExplicitStartTarget() {
+        self.sut.play(
+            video: MockYouTubeClient.makeVideo(videoId: "abc"),
+            startAt: 120
+        )
+
+        self.sut.seek(to: 30)
+        #expect(self.controller.pendingRecoverySeeks == [30])
+        self.sut.handleWebNavigationFailure(resumeAtOverride: 30)
+        self.sut.resume()
+
+        #expect(self.controller.reloadResumeSeconds == [120, 30])
+    }
+
+    @Test("Explicit start positions reject non-finite values and clamp oversized input")
+    func explicitStartPositionsAreBounded() {
+        #expect(YouTubePlayerService.normalizedExplicitStartAt(nil) == nil)
+        #expect(YouTubePlayerService.normalizedExplicitStartAt(-1) == nil)
+        #expect(YouTubePlayerService.normalizedExplicitStartAt(.infinity) == nil)
+        #expect(YouTubePlayerService.normalizedExplicitStartAt(.nan) == nil)
+        #expect(YouTubePlayerService.normalizedExplicitStartAt(42) == 42)
+        #expect(YouTubePlayerService.normalizedExplicitStartAt(1_000_000) == 1_000_000)
+    }
+
+    @Test("WebContent recovery honors pause before the first observer update")
+    func webContentRecoveryHonorsEarlyPause() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        self.sut.pause()
+        self.sut.recoverAfterWebContentProcessTermination()
+
+        #expect(self.controller.reloadedVideoIds.isEmpty)
+        #expect(self.sut.pendingPausedIdentityReloadVideoId == "abc")
+    }
+}

--- a/Tests/KasetTests/YouTubePlayerServiceTests.swift
+++ b/Tests/KasetTests/YouTubePlayerServiceTests.swift
@@ -1689,4 +1689,61 @@ struct PlaybackArbiterTests {
         #expect(controller.pauseCount == 0)
         #expect(arbiter.activeSource == .music)
     }
+
+    @Test("A queued video pause cannot pause music that reclaimed playback")
+    func staleVideoPauseDoesNotPauseNewMusicIntent() async {
+        let playerService = PlayerService()
+        let controller = MockYouTubeWatchPlaybackController()
+        let youtubePlayer = YouTubePlayerService(playbackController: controller)
+        let arbiter = PlaybackArbiter(playerService: playerService, youtubePlayerService: youtubePlayer)
+        playerService.state = .playing
+
+        arbiter.videoWillStartPlaying()
+        await playerService.play(song: Song(
+            id: "new",
+            title: "New",
+            artists: [],
+            duration: 180,
+            videoId: "new",
+            feedbackTokens: .init(add: nil, remove: nil)
+        ))
+        for _ in 0 ..< 10 {
+            await Task.yield()
+        }
+
+        #expect(playerService.state == .loading)
+        #expect(playerService.currentTrack?.videoId == "new")
+    }
+
+    @Test("Video ownership supersedes a pending Music API intent")
+    func videoSupersedesPendingMusicIntent() async {
+        let playerService = PlayerService()
+        let musicClient = MockYTMusicClient()
+        playerService.setYTMusicClient(musicClient)
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        musicClient.mixQueueResult = RadioQueueResult(
+            songs: [Song(id: "stale", title: "Stale", artists: [], videoId: "stale")],
+            continuationToken: nil
+        )
+        musicClient.beforeMixQueueReturn = { _, _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+        let controller = MockYouTubeWatchPlaybackController()
+        let youtubePlayer = YouTubePlayerService(playbackController: controller)
+        let arbiter = PlaybackArbiter(playerService: playerService, youtubePlayerService: youtubePlayer)
+
+        let mixTask = Task { @MainActor in
+            await playerService.playWithMix(playlistId: "RDEM-stale", startVideoId: nil)
+        }
+        await requestStarted.wait()
+        arbiter.videoWillStartPlaying()
+        await releaseRequest.open()
+        await mixTask.value
+
+        #expect(arbiter.activeSource == .video)
+        #expect(playerService.queue.isEmpty)
+        #expect(playerService.currentTrack == nil)
+    }
 }

--- a/Tests/KasetTests/YouTubePlayerServiceTests.swift
+++ b/Tests/KasetTests/YouTubePlayerServiceTests.swift
@@ -7,7 +7,7 @@ import Testing
 
 /// Records playback commands without touching a real WebView.
 @MainActor
-private final class MockYouTubeWatchPlaybackController: YouTubeWatchPlaybackControlling {
+final class MockYouTubeWatchPlaybackController: YouTubeWatchPlaybackControlling {
     private(set) var loadedVideoIds: [String] = []
     private(set) var reloadedVideoIds: [String] = []
     private(set) var reloadResumeSeconds: [Double?] = []
@@ -15,10 +15,17 @@ private final class MockYouTubeWatchPlaybackController: YouTubeWatchPlaybackCont
     private(set) var playCount = 0
     private(set) var pauseCount = 0
     private(set) var seeks: [Double] = []
+    private(set) var pendingRecoverySeeks: [Double] = []
+    private(set) var cancelPendingRecoverySeekCount = 0
+    private(set) var markCurrentPlaybackOccurrenceEndedCount = 0
+    private(set) var commandLog: [String] = []
     private(set) var volumes: [Double] = []
     private(set) var tearDownCount = 0
     private(set) var prepareCount = 0
     private(set) var cancelPendingLoadCount = 0
+    var cancelPendingLoadResult = false
+    var onLoadVideo: ((String) -> Void)?
+    var onSeek: ((Double) -> Void)?
 
     func prepare(webKitManager _: WebKitManager, playerService _: YouTubePlayerService, usesCookieFreeDataStore _: Bool) {
         self.prepareCount += 1
@@ -26,6 +33,7 @@ private final class MockYouTubeWatchPlaybackController: YouTubeWatchPlaybackCont
 
     func loadVideo(videoId: String) {
         self.loadedVideoIds.append(videoId)
+        self.onLoadVideo?(videoId)
     }
 
     func reloadVideo(videoId: String, resumeAt seconds: Double?) {
@@ -33,8 +41,9 @@ private final class MockYouTubeWatchPlaybackController: YouTubeWatchPlaybackCont
         self.reloadResumeSeconds.append(seconds)
     }
 
-    func cancelPendingLoad() {
+    func cancelPendingLoad() -> Bool {
         self.cancelPendingLoadCount += 1
+        return self.cancelPendingLoadResult
     }
 
     func playPause() {
@@ -42,15 +51,43 @@ private final class MockYouTubeWatchPlaybackController: YouTubeWatchPlaybackCont
     }
 
     func play() {
+        self.commandLog.append("play")
         self.playCount += 1
     }
 
     func pause() {
+        self.commandLog.append("pause")
         self.pauseCount += 1
     }
 
     func seek(to time: Double) {
+        self.commandLog.append("seek")
         self.seeks.append(time)
+        self.onSeek?(time)
+    }
+
+    func replacePendingRecoverySeek(with seconds: Double) {
+        self.commandLog.append("replacePendingRecoverySeek")
+        self.pendingRecoverySeeks.append(seconds)
+    }
+
+    func seekWithRecovery(to seconds: Double) {
+        self.replacePendingRecoverySeek(with: seconds)
+        self.seek(to: seconds)
+    }
+
+    func cancelPendingRecoverySeek() {
+        self.commandLog.append("cancelPendingRecoverySeek")
+        self.cancelPendingRecoverySeekCount += 1
+    }
+
+    func markCurrentPlaybackOccurrenceEnded() {
+        self.commandLog.append("markCurrentPlaybackOccurrenceEnded")
+        self.markCurrentPlaybackOccurrenceEndedCount += 1
+    }
+
+    func resetCommandLog() {
+        self.commandLog.removeAll()
     }
 
     func setVolume(_ volume: Double) {
@@ -173,7 +210,14 @@ struct YouTubePlayerServiceTests {
     func reloadDuringAdUsesContentProgress() {
         self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
         // Content reaches 600s...
-        self.sut.updatePlaybackState(.init(isPlaying: true, progress: 600, duration: 1200, videoId: "abc"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 600,
+            duration: 1200,
+            hasReadyMedia: true,
+            videoId: "abc",
+            boundVideoId: "abc"
+        ))
         // ...then a midroll ad starts, dragging self.progress down to the ad time.
         self.sut.updatePlaybackState(.init(isPlaying: true, progress: 8, duration: 30, videoId: "abc", isAd: true))
         #expect(self.sut.progress == 8)
@@ -187,7 +231,9 @@ struct YouTubePlayerServiceTests {
     func pausedReloadDefersUntilResume() {
         self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
         self.sut.updatePlaybackState(.init(isPlaying: false, progress: 12, duration: 60, videoId: "abc"))
+        self.sut.pause()
         #expect(self.sut.isPlaying == false)
+        let pausesBefore = self.controller.pauseCount
         var willStartCount = 0
         self.sut.playbackWillStart = { willStartCount += 1 }
 
@@ -195,7 +241,7 @@ struct YouTubePlayerServiceTests {
 
         // No autoplaying watch page is loaded while the user left the video paused.
         #expect(self.controller.reloadedVideoIds.isEmpty)
-        #expect(self.controller.pauseCount == 0)
+        #expect(self.controller.pauseCount == pausesBefore)
         #expect(self.sut.isPlaying == false)
         #expect(willStartCount == 0)
 
@@ -243,6 +289,16 @@ struct YouTubePlayerServiceTests {
     func relativeSeekToEndConcludesWithoutExactDurationSeek() {
         self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
         self.sut.updatePlaybackState(.init(isPlaying: true, progress: 90, duration: 100, videoId: "abc"))
+        self.controller.replacePendingRecoverySeek(with: 12)
+        self.controller.resetCommandLog()
+        self.controller.onSeek = { _ in
+            self.sut.updatePlaybackState(.init(
+                isPlaying: true,
+                progress: 100,
+                duration: 100,
+                videoId: "abc"
+            ))
+        }
         var endedVideoId: String?
         self.sut.onVideoEnded = { endedVideoId = $0 }
         let activityBefore = self.sut.watchActivityGeneration
@@ -255,7 +311,14 @@ struct YouTubePlayerServiceTests {
         #expect(endedVideoId == "abc")
         #expect(self.sut.watchActivityGeneration == activityBefore + 1)
         #expect(self.sut.watchConclusionGeneration == conclusionBefore + 1)
-        #expect(self.controller.pauseCount == 1)
+        #expect(self.controller.cancelPendingRecoverySeekCount == 1)
+        #expect(self.controller.markCurrentPlaybackOccurrenceEndedCount == 1)
+        #expect(self.controller.commandLog.first == "cancelPendingRecoverySeek")
+        #expect(self.controller.commandLog.dropFirst().first == "markCurrentPlaybackOccurrenceEnded")
+        #expect(self.controller.commandLog.dropFirst(2).first == "seek")
+        // The re-entrant playing update emitted from seek() is suppressed before
+        // the terminal command's own pause, proving the native fence was active.
+        #expect(self.controller.pauseCount == 2)
         #expect(self.controller.seeks.count == 1)
         #expect(self.controller.seeks[0] < 100)
         #expect(self.controller.seeks[0] >= 99)
@@ -265,6 +328,7 @@ struct YouTubePlayerServiceTests {
     func deferredPausedReloadSurvivesObserverUpdatesBeforeResume() {
         self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
         self.sut.updatePlaybackState(.init(isPlaying: false, progress: 3, duration: 60, videoId: "abc"))
+        self.sut.pause()
         var willStartCount = 0
         self.sut.playbackWillStart = { willStartCount += 1 }
 
@@ -282,6 +346,72 @@ struct YouTubePlayerServiceTests {
         #expect(willStartCount == 1)
     }
 
+    @Test("The first accepted update completes an identity reload")
+    func acceptedUpdateCompletesIdentityReload() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 12,
+            duration: 60,
+            videoId: "abc"
+        ))
+        self.sut.reloadCurrentVideoForIdentitySwitch()
+
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 12,
+            duration: 60,
+            videoId: "abc"
+        ))
+        self.sut.pause()
+        self.sut.resume()
+
+        #expect(self.controller.reloadedVideoIds == ["abc"])
+        #expect(self.controller.playCount == 1)
+    }
+
+    @Test("A paused completed identity reload does not reload again on resume")
+    func pausedCompletedIdentityReloadDoesNotRepeat() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 12,
+            duration: 60,
+            videoId: "abc"
+        ))
+        self.sut.reloadCurrentVideoForIdentitySwitch()
+        self.sut.pause()
+
+        self.sut.updatePlaybackState(.init(
+            isPlaying: false,
+            progress: 12,
+            duration: 60,
+            hasReadyMedia: true,
+            videoId: "abc"
+        ))
+        self.sut.resume()
+
+        #expect(self.controller.reloadedVideoIds == ["abc"])
+        #expect(self.controller.playCount == 1)
+    }
+
+    @Test("An explicit pause at zero defers identity recovery until resume")
+    func pauseAtZeroDefersIdentityRecovery() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        self.sut.pause()
+
+        self.sut.reloadCurrentVideoForIdentitySwitch()
+
+        #expect(self.controller.reloadedVideoIds.isEmpty)
+        #expect(self.sut.pendingPausedIdentityReloadVideoId == "abc")
+        #expect(self.sut.pendingPausedIdentityReloadResumeAt == nil)
+
+        self.sut.resume()
+
+        #expect(self.controller.reloadedVideoIds == ["abc"])
+        #expect(self.controller.reloadResumeSeconds == [nil])
+    }
+
     @Test("Loading video identity reload happens immediately")
     func loadingIdentityReloadHappensImmediately() {
         // A just-requested video has not reported playing yet, so isPlaying is
@@ -289,6 +419,12 @@ struct YouTubePlayerServiceTests {
         // in that loading window, the reload must happen immediately before the
         // old-identity page can start and emit watch-history pings.
         self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: false,
+            progress: 0,
+            duration: 60,
+            videoId: "abc"
+        ))
         var willStartCount = 0
         self.sut.playbackWillStart = { willStartCount += 1 }
 
@@ -303,6 +439,7 @@ struct YouTubePlayerServiceTests {
     func deferredPausedReloadClearsOnNewVideo() {
         self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "abc"))
         self.sut.updatePlaybackState(.init(isPlaying: false, progress: 3, duration: 60, videoId: "abc"))
+        self.sut.pause()
         self.sut.reloadCurrentVideoForIdentitySwitch()
 
         self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "def"))
@@ -500,10 +637,213 @@ struct YouTubePlayerServiceTests {
         var endedVideoId: String?
         self.sut.onVideoEnded = { endedVideoId = $0 }
 
-        self.sut.handleVideoEnded(videoId: "abc")
+        let didAcceptEnd = self.sut.handleVideoEnded(videoId: "abc")
 
         #expect(self.sut.isPlaying == false)
         #expect(endedVideoId == "abc")
+        #expect(didAcceptEnd)
+    }
+
+    @Test("Duplicate ended callbacks run one-shot effects once and later autoplay can end")
+    func duplicateEndedCallbacksAreIdempotentPerWatch() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true, progress: 59, duration: 60,
+            videoId: "a", title: nil, isAd: false
+        ))
+        var endedVideoIds: [String?] = []
+        self.sut.onVideoEnded = { endedVideoIds.append($0) }
+
+        self.sut.handleVideoEnded(videoId: "a")
+        self.sut.handleVideoEnded(videoId: "a")
+
+        #expect(endedVideoIds == ["a"])
+
+        // A genuine same-document autoplay drift starts a new watch occurrence.
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true, progress: 1, duration: 80,
+            hasReadyMedia: true, videoId: "b", boundVideoId: "b",
+            title: "Autoplay", isAd: false
+        ))
+        self.sut.handleVideoEnded(videoId: "b")
+
+        #expect(endedVideoIds == ["a", "b"])
+    }
+
+    @Test("A queued ended occurrence cannot conclude a newer same-document replay")
+    func staleEndedOccurrenceCannotConcludeReplay() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        let firstOccurrence = YouTubePlaybackOccurrence(
+            documentGeneration: 7,
+            mediaGeneration: 1
+        )
+        let replayOccurrence = YouTubePlaybackOccurrence(
+            documentGeneration: 7,
+            mediaGeneration: 2
+        )
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 9,
+            duration: 10,
+            videoId: "a",
+            playbackOccurrence: firstOccurrence
+        ))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 1,
+            duration: 10,
+            videoId: "a",
+            playbackOccurrence: replayOccurrence
+        ))
+        var endedCount = 0
+        self.sut.onVideoEnded = { _ in endedCount += 1 }
+
+        self.sut.handleVideoEnded(
+            videoId: "a",
+            playbackOccurrence: firstOccurrence
+        )
+
+        #expect(self.sut.isPlaying)
+        #expect(endedCount == 0)
+
+        self.sut.handleVideoEnded(
+            videoId: "a",
+            playbackOccurrence: replayOccurrence
+        )
+
+        #expect(!self.sut.isPlaying)
+        #expect(endedCount == 1)
+    }
+
+    @Test("A native terminal transition consumes the current bridge occurrence")
+    func nativeEndConsumesCurrentBridgeOccurrence() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        let occurrence = YouTubePlaybackOccurrence(
+            documentGeneration: 7,
+            mediaGeneration: 1
+        )
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 9,
+            duration: 10,
+            videoId: "a",
+            playbackOccurrence: occurrence
+        ))
+
+        #expect(self.sut.handleVideoEnded(videoId: "a"))
+        #expect(!self.sut.handleVideoEnded(
+            videoId: "a",
+            playbackOccurrence: occurrence
+        ))
+    }
+
+    @Test("A delayed end cannot overwrite a newer resume intent")
+    func delayedEndDoesNotOverwriteResume() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        let endedOccurrence = YouTubePlaybackOccurrence(
+            documentGeneration: 7,
+            mediaGeneration: 1
+        )
+        self.sut.updatePlaybackState(.init(
+            isPlaying: false,
+            progress: 9.8,
+            duration: 10,
+            hasReadyMedia: true,
+            videoId: "a",
+            playbackOccurrence: endedOccurrence
+        ))
+
+        self.sut.resume()
+        #expect(!self.sut.handleVideoEnded(
+            videoId: "a",
+            playbackOccurrence: endedOccurrence,
+            eventIssuedAtMilliseconds: 0
+        ))
+
+        let replayOccurrence = YouTubePlaybackOccurrence(
+            documentGeneration: 7,
+            mediaGeneration: 2
+        )
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 0,
+            duration: 10,
+            hasReadyMedia: true,
+            videoId: "a",
+            playbackOccurrence: replayOccurrence
+        ))
+        #expect(self.sut.handleVideoEnded(
+            videoId: "a",
+            playbackOccurrence: replayOccurrence
+        ))
+    }
+
+    @Test("A normal pause and resume still accepts the eventual end")
+    func normalResumeDoesNotSuppressEnd() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        let occurrence = YouTubePlaybackOccurrence(
+            documentGeneration: 7,
+            mediaGeneration: 1
+        )
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 5,
+            duration: 10,
+            videoId: "a",
+            playbackOccurrence: occurrence
+        ))
+        self.sut.pause()
+        self.sut.resume()
+
+        #expect(self.sut.handleVideoEnded(
+            videoId: "a",
+            playbackOccurrence: occurrence
+        ))
+    }
+
+    @Test("A newer ended occurrence can bind before its first state update")
+    func newerEndedOccurrenceCanBindFirst() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        let firstOccurrence = YouTubePlaybackOccurrence(
+            documentGeneration: 7,
+            mediaGeneration: 1
+        )
+        let replacementOccurrence = YouTubePlaybackOccurrence(
+            documentGeneration: 8,
+            mediaGeneration: 1
+        )
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 9,
+            duration: 10,
+            videoId: "a",
+            playbackOccurrence: firstOccurrence
+        ))
+        var endedCount = 0
+        self.sut.onVideoEnded = { _ in endedCount += 1 }
+        self.sut.handleVideoEnded(
+            videoId: "a",
+            playbackOccurrence: firstOccurrence
+        )
+        #expect(endedCount == 1)
+
+        self.sut.handleVideoEnded(
+            videoId: "a",
+            playbackOccurrence: replacementOccurrence
+        )
+
+        #expect(!self.sut.isPlaying)
+        #expect(endedCount == 2)
+        #expect(self.sut.currentPlaybackOccurrence == replacementOccurrence)
+
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 1,
+            duration: 10,
+            videoId: "a",
+            playbackOccurrence: replacementOccurrence
+        ))
+        #expect(!self.sut.isPlaying)
     }
 
     @Test("A stale ended event for a no-longer-current video does not conclude the new watch")
@@ -519,8 +859,9 @@ struct YouTubePlayerServiceTests {
 
         // A late VIDEO_ENDED for the previous video "a" arrives — it must be
         // ignored so it doesn't conclude (and dedupe) the current watch of "b".
-        self.sut.handleVideoEnded(videoId: "a")
+        let didAcceptStaleEnd = self.sut.handleVideoEnded(videoId: "a")
         #expect(self.sut.watchConclusionGeneration == conclusionBefore)
+        #expect(!didAcceptStaleEnd)
 
         // The real end of "b" still concludes it.
         self.sut.handleVideoEnded(videoId: "b")
@@ -549,6 +890,344 @@ struct YouTubePlayerServiceTests {
         ))
         self.sut.handleVideoEnded(videoId: "a")
         #expect(self.sut.watchConclusionGeneration == conclusionBefore + 1)
+    }
+
+    @Test("A post-roll ad cannot revive a concluded watch")
+    func postRollAdDoesNotReviveConcludedWatch() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        let contentOccurrence = YouTubePlaybackOccurrence(
+            documentGeneration: 7,
+            mediaGeneration: 1
+        )
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 59,
+            duration: 60,
+            videoId: "a",
+            playbackOccurrence: contentOccurrence
+        ))
+        self.sut.handleVideoEnded(
+            videoId: "a",
+            playbackOccurrence: contentOccurrence
+        )
+        var playbackStartCount = 0
+        self.sut.playbackWillStart = { playbackStartCount += 1 }
+
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 1,
+            duration: 15,
+            hasReadyMedia: true,
+            videoId: "a",
+            isAd: true,
+            playbackOccurrence: YouTubePlaybackOccurrence(
+                documentGeneration: 7,
+                mediaGeneration: 2
+            )
+        ))
+
+        #expect(self.sut.isPlaying)
+        #expect(self.controller.pauseCount == 0)
+        #expect(playbackStartCount == 1)
+
+        self.sut.playPause()
+        #expect(self.controller.pauseCount == 1)
+        #expect(self.controller.playCount == 0)
+    }
+
+    @Test("An end before resume confirmation replays on the first toggle")
+    func endClearsResumeConfirmation() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        self.sut.resume()
+        self.sut.handleVideoEnded(videoId: "a")
+
+        self.sut.playPause()
+
+        #expect(self.controller.pauseCount == 0)
+        #expect(self.controller.playCount == 2)
+    }
+
+    @Test("A newer video's preroll ad can establish autoplay intent")
+    func nextVideoPrerollCanStart() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        let firstOccurrence = YouTubePlaybackOccurrence(
+            documentGeneration: 7,
+            mediaGeneration: 1
+        )
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 59,
+            duration: 60,
+            videoId: "a",
+            boundVideoId: "a",
+            playbackOccurrence: firstOccurrence
+        ))
+        self.sut.handleVideoEnded(
+            videoId: "a",
+            playbackOccurrence: firstOccurrence
+        )
+
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 0,
+            duration: 15,
+            hasReadyMedia: true,
+            videoId: "b",
+            boundVideoId: "b",
+            title: "B",
+            isAd: true,
+            playbackOccurrence: YouTubePlaybackOccurrence(
+                documentGeneration: 7,
+                mediaGeneration: 2
+            )
+        ))
+
+        #expect(self.sut.isPlaying)
+        #expect(self.sut.currentVideo?.videoId == "a")
+        #expect(self.controller.pauseCount == 0)
+
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 1,
+            duration: 80,
+            hasReadyMedia: true,
+            videoId: "b",
+            boundVideoId: "b",
+            title: "B",
+            isAd: false,
+            playbackOccurrence: YouTubePlaybackOccurrence(
+                documentGeneration: 7,
+                mediaGeneration: 2
+            )
+        ))
+        #expect(self.sut.currentVideo?.videoId == "b")
+    }
+}
+
+extension YouTubePlayerServiceTests {
+    @Test("Non-authoritative post-roll placeholders survive process termination")
+    func loadingPostRollPlaceholderTerminationRecoversNextVideo() {
+        for isAd in [true, false] {
+            let controller = MockYouTubeWatchPlaybackController()
+            let sut = YouTubePlayerService(playbackController: controller)
+            let nextVideo = MockYouTubeClient.makeVideo(videoId: "b")
+            sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+            sut.setUpNext([nextVideo])
+            let contentOccurrence = YouTubePlaybackOccurrence(
+                documentGeneration: 7,
+                mediaGeneration: 1
+            )
+            sut.updatePlaybackState(.init(
+                isPlaying: true,
+                progress: 59,
+                duration: 60,
+                hasReadyMedia: true,
+                videoId: "a",
+                boundVideoId: "a",
+                playbackOccurrence: contentOccurrence
+            ))
+            sut.handleVideoEnded(
+                videoId: "a",
+                playbackOccurrence: contentOccurrence
+            )
+
+            sut.updatePlaybackState(.init(
+                isPlaying: false,
+                progress: 0,
+                duration: 0,
+                hasReadyMedia: false,
+                videoId: "b",
+                boundVideoId: "a",
+                isAd: isAd,
+                playbackOccurrence: contentOccurrence
+            ))
+
+            #expect(sut.currentVideo?.videoId == "a")
+
+            sut.recoverAfterWebContentProcessTermination()
+
+            #expect(sut.currentVideo?.videoId == "a")
+            #expect(controller.reloadedVideoIds.isEmpty)
+
+            sut.resume()
+
+            #expect(sut.currentVideo?.videoId == "b")
+            #expect(controller.loadedVideoIds == ["a", "b"])
+            #expect(controller.reloadedVideoIds.isEmpty)
+        }
+    }
+
+    @Test("Explicit replay placeholders recover the concluded video")
+    func explicitReplayPlaceholderTerminationReloadsCurrentVideo() {
+        for isAd in [true, false] {
+            let controller = MockYouTubeWatchPlaybackController()
+            let sut = YouTubePlayerService(playbackController: controller)
+            sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+            sut.setUpNext([MockYouTubeClient.makeVideo(videoId: "b")])
+            let contentOccurrence = YouTubePlaybackOccurrence(
+                documentGeneration: 7,
+                mediaGeneration: 1
+            )
+            sut.updatePlaybackState(.init(
+                isPlaying: true,
+                progress: 59,
+                duration: 60,
+                hasReadyMedia: true,
+                videoId: "a",
+                boundVideoId: "a",
+                playbackOccurrence: contentOccurrence
+            ))
+            sut.handleVideoEnded(
+                videoId: "a",
+                playbackOccurrence: contentOccurrence
+            )
+
+            sut.resume()
+            sut.updatePlaybackState(.init(
+                isPlaying: false,
+                progress: 0,
+                duration: 0,
+                hasReadyMedia: false,
+                videoId: "a",
+                boundVideoId: "a",
+                isAd: isAd,
+                playbackOccurrence: contentOccurrence
+            ))
+            sut.recoverAfterWebContentProcessTermination()
+
+            #expect(sut.currentVideo?.videoId == "a")
+            #expect(controller.reloadedVideoIds == ["a"])
+            #expect(controller.loadedVideoIds == ["a"])
+        }
+    }
+
+    @Test("A post-end user seek supersedes deferred autoplay recovery")
+    func postEndSeekRecoversCurrentVideo() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        self.sut.setUpNext([MockYouTubeClient.makeVideo(videoId: "b")])
+        let contentOccurrence = YouTubePlaybackOccurrence(
+            documentGeneration: 7,
+            mediaGeneration: 1
+        )
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 59,
+            duration: 60,
+            hasReadyMedia: true,
+            videoId: "a",
+            boundVideoId: "a",
+            playbackOccurrence: contentOccurrence
+        ))
+        self.sut.handleVideoEnded(
+            videoId: "a",
+            playbackOccurrence: contentOccurrence
+        )
+        self.sut.updatePlaybackState(.init(
+            isPlaying: false,
+            progress: 0,
+            duration: 0,
+            hasReadyMedia: false,
+            videoId: "b",
+            boundVideoId: "a",
+            playbackOccurrence: contentOccurrence
+        ))
+
+        self.sut.seek(to: 10)
+        // A queued same-occurrence loading sample must not re-arm successor
+        // recovery after the explicit seek has claimed the concluded video.
+        self.sut.updatePlaybackState(.init(
+            isPlaying: false,
+            progress: 0,
+            duration: 0,
+            hasReadyMedia: false,
+            videoId: "b",
+            boundVideoId: "a",
+            playbackOccurrence: contentOccurrence
+        ))
+        self.sut.recoverAfterWebContentProcessTermination()
+
+        #expect(self.sut.currentVideo?.videoId == "a")
+        #expect(self.sut.pendingPausedIdentityReloadVideoId == "a")
+        #expect(self.sut.pendingPausedIdentityReloadResumeAt == 10)
+
+        self.sut.resume()
+
+        #expect(self.controller.reloadedVideoIds == ["a"])
+        #expect(self.controller.reloadResumeSeconds == [10])
+        #expect(self.sut.currentVideo?.videoId == "a")
+    }
+
+    @Test("A canceled successor lookup remains retryable after explicit pause")
+    func canceledAutoplayLookupRemainsRetryable() async {
+        let firstLookupStarted = AsyncGate()
+        let releaseFirstLookup = AsyncGate()
+        let successorLoaded = BooleanBox(false)
+        let nextVideo = MockYouTubeClient.makeVideo(videoId: "b")
+        let client = MockYouTubeClient()
+        client.watchNextData = WatchNextData(
+            videoTitle: nil,
+            viewCountText: nil,
+            publishedText: nil,
+            channel: nil,
+            related: [nextVideo]
+        )
+        client.beforeWatchNextReturn = { callCount in
+            guard callCount == 1 else { return }
+            await firstLookupStarted.open()
+            await releaseFirstLookup.wait()
+        }
+        self.sut.youtubeClient = client
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "a"))
+        self.controller.onLoadVideo = { videoId in
+            guard videoId == "b" else { return }
+            successorLoaded.value = true
+        }
+        let contentOccurrence = YouTubePlaybackOccurrence(
+            documentGeneration: 7,
+            mediaGeneration: 1
+        )
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true,
+            progress: 59,
+            duration: 60,
+            hasReadyMedia: true,
+            videoId: "a",
+            boundVideoId: "a",
+            playbackOccurrence: contentOccurrence
+        ))
+        self.sut.handleVideoEnded(
+            videoId: "a",
+            playbackOccurrence: contentOccurrence
+        )
+        self.sut.updatePlaybackState(.init(
+            isPlaying: false,
+            progress: 0,
+            duration: 0,
+            hasReadyMedia: false,
+            videoId: "creative",
+            boundVideoId: "a",
+            isAd: true,
+            playbackOccurrence: YouTubePlaybackOccurrence(
+                documentGeneration: 7,
+                mediaGeneration: 2
+            )
+        ))
+        self.sut.recoverAfterWebContentProcessTermination()
+
+        self.sut.resume()
+        await firstLookupStarted.wait()
+        self.sut.playPause()
+        self.sut.resume()
+        await releaseFirstLookup.open()
+        for _ in 0 ..< 10 where !successorLoaded.value {
+            await Task.yield()
+        }
+
+        #expect(self.sut.currentVideo?.videoId == "b")
+        #expect(successorLoaded.value)
+        #expect(client.watchNextCallCount == 2)
+        #expect(self.controller.loadedVideoIds == ["a", "b"])
+        #expect(self.controller.playCount == 0)
     }
 
     @Test("Watch-activity generation advances on every watch-state change and survives stop")
@@ -630,7 +1309,8 @@ struct YouTubePlayerServiceTests {
         // finished "a" (conclusion stays put).
         self.sut.updatePlaybackState(.init(
             isPlaying: true, progress: 0, duration: 200,
-            videoId: "b", title: "Next", isAd: false
+            hasReadyMedia: true, videoId: "b", boundVideoId: "b",
+            title: "Next", isAd: false
         ))
         #expect(self.sut.currentVideo?.videoId == "b")
         #expect(self.sut.watchConclusionGeneration == conclusionAfterFinish) // no double-conclude
@@ -907,6 +1587,11 @@ struct YouTubePlayerServiceTests {
 
         // The suppression is one-shot: a later in-app navigation while
         // playing pops out as usual.
+        self.sut.updatePlaybackState(.init(
+            isPlaying: false, progress: 5, duration: 60,
+            videoId: "abc", title: nil, isAd: false
+        ))
+        self.sut.resume()
         self.sut.activeInlineVideoId = "abc"
         self.sut.updatePlaybackState(.init(
             isPlaying: true, progress: 6, duration: 60,

--- a/Tests/KasetTests/YouTubePlayerServiceTests.swift
+++ b/Tests/KasetTests/YouTubePlayerServiceTests.swift
@@ -1682,6 +1682,100 @@ extension YouTubePlayerServiceTests {
         #expect(self.sut.surfaceLocation == .none)
         #expect(self.controller.tearDownCount == 1)
     }
+
+    @Test("An older ended callback cannot break a newer remote-command batch")
+    func staleEndedCallbackPreservesRemoteBatch() {
+        let controller = MockYouTubeWatchPlaybackController()
+        let service = YouTubePlayerService(playbackController: controller)
+        let video = MockYouTubeClient.makeVideo(videoId: "stale-ended-remote-batch")
+        service.play(video: video)
+        service.youtubePlaybackIntentIssuedAtMilliseconds = 1000
+
+        service.handleRemotePause(issuedAtMilliseconds: 1600)
+        #expect(!service.handleVideoEnded(
+            videoId: video.videoId,
+            eventIssuedAtMilliseconds: 1500
+        ))
+        service.handleRemoteResume(issuedAtMilliseconds: 1600)
+
+        #expect(controller.pauseCount == 1)
+        #expect(controller.playCount == 1)
+    }
+
+    @Test("A newer remote pause invalidates an older delayed skip")
+    func remotePauseInvalidatesDelayedSkip() async {
+        let controller = MockYouTubeWatchPlaybackController()
+        let service = YouTubePlayerService(playbackController: controller)
+        let client = MockYouTubeClient()
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        client.watchNextData = WatchNextData(
+            videoTitle: nil,
+            viewCountText: nil,
+            publishedText: nil,
+            channel: nil,
+            related: [MockYouTubeClient.makeVideo(videoId: "stale-next")]
+        )
+        client.beforeWatchNextReturn = { _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+        service.youtubeClient = client
+        service.play(video: MockYouTubeClient.makeVideo(videoId: "current"))
+
+        let skipTask = Task { @MainActor in
+            await service.skipForward()
+        }
+        await requestStarted.wait()
+        service.handleRemotePause(
+            issuedAtMilliseconds: service.youtubePlaybackIntentIssuedAtMilliseconds + 1
+        )
+        await releaseRequest.open()
+        await skipTask.value
+
+        #expect(service.currentVideo?.videoId == "current")
+        #expect(controller.pauseCount == 1)
+    }
+
+    @Test("A remote command issued after an ended event remains admissible")
+    func remoteCommandAfterEndedEventRemainsAdmissible() {
+        let controller = MockYouTubeWatchPlaybackController()
+        let service = YouTubePlayerService(playbackController: controller)
+        let video = MockYouTubeClient.makeVideo(videoId: "ended-remote-order")
+        service.play(video: video)
+        service.youtubePlaybackIntentIssuedAtMilliseconds = 1000
+
+        #expect(service.handleVideoEnded(
+            videoId: video.videoId,
+            eventIssuedAtMilliseconds: 1500
+        ))
+        service.handleRemoteResume(issuedAtMilliseconds: 1600)
+
+        #expect(controller.playCount == 1)
+    }
+
+    @Test("Remote video commands captured before a newer native intent are ignored")
+    func staleRemoteVideoCommandsAreIgnored() {
+        let controller = MockYouTubeWatchPlaybackController()
+        let service = YouTubePlayerService(playbackController: controller)
+        service.beginYouTubePlaybackIntent(issuedAtMilliseconds: 2000)
+
+        service.handleRemotePause(issuedAtMilliseconds: 1000)
+        service.handleRemoteResume(issuedAtMilliseconds: 1000)
+        service.handleRemoteSeek(to: 42, issuedAtMilliseconds: 1000)
+
+        #expect(controller.pauseCount == 0)
+        #expect(controller.playCount == 0)
+        #expect(controller.pendingRecoverySeeks.isEmpty)
+
+        service.handleRemotePause(issuedAtMilliseconds: 2001)
+        service.handleRemoteResume(issuedAtMilliseconds: 2002)
+        service.handleRemoteSeek(to: 42, issuedAtMilliseconds: 2003)
+
+        #expect(controller.pauseCount == 1)
+        #expect(controller.playCount == 1)
+        #expect(controller.pendingRecoverySeeks == [42])
+    }
 }
 
 // MARK: - PlaybackArbiterTests

--- a/Tests/KasetTests/YouTubeWatchScriptTests.swift
+++ b/Tests/KasetTests/YouTubeWatchScriptTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import JavaScriptCore
 import Testing
 @testable import Kaset
 
@@ -13,6 +14,110 @@ struct YouTubeWatchScriptTests {
         #expect(script.contains("VIDEO_ENDED"))
         #expect(script.contains("movie_player"))
         #expect(script.contains("__kasetTargetVolume"))
+        let payloads = self.objectPayloads(
+            in: script,
+            marker: "bridge.postMessage({",
+            terminator: "});"
+        )
+        #expect(self.occurrenceCount(of: "postMessage(", in: script) == 2)
+        #expect(payloads.count == 2)
+        for payload in payloads {
+            #expect(payload.contains("documentGeneration: window.__kasetDocumentGeneration"))
+            #expect(payload.contains("mediaGeneration:"))
+        }
+        #expect(payloads.contains { $0.contains("type: 'STATE_UPDATE'") })
+        #expect(payloads.contains { $0.contains("type: 'VIDEO_ENDED'") })
+        let statePayload = payloads.first { $0.contains("type: 'STATE_UPDATE'") }
+        #expect(statePayload?.contains("hasReadyMedia: hasReadyMedia") == true)
+        #expect(statePayload?.contains("pendingSeekApplied: pendingSeekApplied") == true)
+        #expect(statePayload?.contains("pendingSeekFailed: pendingSeekFailed") == true)
+        #expect(statePayload?.contains("pendingSeekVideoId: pendingSeekVideoId") == true)
+        #expect(statePayload?.contains("nativePausePending: nativePausePending") == true)
+        #expect(statePayload?.contains("pendingSeekAttempt: pendingSeekAttempt") == true)
+        let endedPayload = payloads.first { $0.contains("type: 'VIDEO_ENDED'") }
+        #expect(endedPayload?.contains(
+            "pendingSeekAttempt: window.__kasetPendingSeekAttempt"
+        ) == true)
+    }
+
+    @Test("Observer rejects ended callbacks from stale video elements")
+    func observerRejectsEndedCallbacksFromStaleVideoElements() {
+        let script = YouTubeWatchWebView.observerScript
+        #expect(script.contains("function sendEnded(video)"))
+        #expect(script.contains("if (video !== videoEl() || !video.ended"))
+        #expect(script.contains("function bindVideoIdentity(video, transitionEvidence)"))
+        #expect(script.contains("video.__kasetBoundVideoId = resolvedVideoId"))
+        #expect(script.contains("video.__kasetEndedReported = true"))
+        #expect(script.contains("const endedVideo = event.currentTarget;"))
+        #expect(script.contains("sendEnded(endedVideo);"))
+        #expect(!script.contains("lastVideoId"))
+        #expect(!script.contains("__kasetContentVideoId"))
+    }
+
+    @Test("VIDEO_ENDED reports generation, bound video identity, and event-time ad state")
+    func endedPayloadIncludesBoundIdentityAndAdState() {
+        let payloads = self.objectPayloads(
+            in: YouTubeWatchWebView.observerScript,
+            marker: "bridge.postMessage({",
+            terminator: "});"
+        )
+        let endedPayload = payloads.first { $0.contains("type: 'VIDEO_ENDED'") }
+        #expect(endedPayload?.contains(
+            "documentGeneration: window.__kasetDocumentGeneration"
+        ) == true)
+        #expect(endedPayload?.contains(
+            "videoId: video.__kasetBoundVideoId || currentVideoId()"
+        ) == true)
+        #expect(endedPayload?.contains(
+            "mediaGeneration: video.__kasetMediaGeneration || mediaGeneration"
+        ) == true)
+        #expect(endedPayload?.contains("isAd: isAdShowing()") == true)
+    }
+
+    @Test("VIDEO_ENDED is executable-idempotent per playback occurrence")
+    func endedEventIsIdempotentPerOccurrence() throws {
+        let context = try self.makeObserverContext(videoId: "abc")
+        context.evaluateScript(
+            """
+            messages = [];
+            video.paused = true;
+            video.ended = true;
+            listeners.ended({ currentTarget: video });
+            currentDataVideoId = 'def';
+            listeners.pause({ currentTarget: video });
+            listeners.ended({ currentTarget: video });
+            """
+        )
+
+        #expect(context.evaluateScript(
+            "messages.filter(function(message) { return message.type === 'VIDEO_ENDED'; }).length"
+        ).toInt32() == 1)
+
+        context.evaluateScript(
+            """
+            currentDataVideoId = 'ghi';
+            video.currentSrc = 'https://media.example/ghi';
+            video.paused = false;
+            video.ended = false;
+            listeners.playing({ currentTarget: video });
+            video.paused = true;
+            video.ended = true;
+            listeners.ended({ currentTarget: video });
+            """
+        )
+
+        #expect(context.evaluateScript(
+            """
+            messages.filter(function(message) { return message.type === 'VIDEO_ENDED'; })
+                .map(function(message) { return message.videoId; }).join(',')
+            """
+        ).toString() == "abc,ghi")
+        #expect(context.evaluateScript(
+            """
+            messages.filter(function(message) { return message.type === 'VIDEO_ENDED'; })
+                .map(function(message) { return message.mediaGeneration; }).join(',')
+            """
+        ).toString() == "1,2")
     }
 
     @Test("Extraction script defines the callable hook and visibility chain")
@@ -45,24 +150,96 @@ struct YouTubeWatchScriptTests {
 
     @Test("Bootstrap script clamps the volume target")
     func bootstrapClampsVolume() {
-        #expect(YouTubeWatchWebView.pageBootstrapScript(targetVolume: 2.0)
+        #expect(YouTubeWatchWebView.pageBootstrapScript(targetVolume: 2.0, documentGeneration: 0)
             .contains("__kasetTargetVolume = 1.0"))
-        #expect(YouTubeWatchWebView.pageBootstrapScript(targetVolume: -1)
+        #expect(YouTubeWatchWebView.pageBootstrapScript(targetVolume: -1, documentGeneration: 0)
             .contains("__kasetTargetVolume = 0.0"))
+    }
+
+    @Test("Main-frame playback responses reject expected-origin HTTP failures")
+    func mainFramePlaybackResponsesRejectHTTPFailures() throws {
+        let url = try #require(URL(string: "https://www.youtube.com/watch?v=abc"))
+        let success = try #require(HTTPURLResponse(
+            url: url,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: nil
+        ))
+        let notFound = try #require(HTTPURLResponse(
+            url: url,
+            statusCode: 404,
+            httpVersion: "HTTP/1.1",
+            headerFields: nil
+        ))
+        let serverError = try #require(HTTPURLResponse(
+            url: url,
+            statusCode: 503,
+            httpVersion: "HTTP/1.1",
+            headerFields: nil
+        ))
+        let documentGeneration = WebPlaybackDocumentGeneration()
+
+        #expect(YouTubeWatchWebView.acceptsMainFrameResponse(
+            success,
+            expectedVideoID: "abc",
+            documentGeneration: documentGeneration
+        ))
+        #expect(!YouTubeWatchWebView.acceptsMainFrameResponse(
+            notFound,
+            expectedVideoID: "abc",
+            documentGeneration: documentGeneration
+        ))
+        #expect(!YouTubeWatchWebView.acceptsMainFrameResponse(
+            serverError,
+            expectedVideoID: "abc",
+            documentGeneration: documentGeneration
+        ))
+    }
+
+    @Test("Bootstrap carries its document generation")
+    func bootstrapCarriesDocumentGeneration() {
+        let script = YouTubeWatchWebView.pageBootstrapScript(
+            targetVolume: 1,
+            documentGeneration: 42
+        )
+        #expect(script.contains("window.location.search"))
+        #expect(script.contains(".get('kasetDocumentGeneration')"))
+        #expect(script.contains("rawGeneration === null"))
+        #expect(script.contains("window.location.hash"))
+        #expect(script.contains("window.__kasetDocumentGeneration = -1;"))
     }
 
     @Test("Bootstrap carries a pending resume-seek when present")
     func bootstrapCarriesPendingSeek() {
-        #expect(YouTubeWatchWebView.pageBootstrapScript(targetVolume: 1, pendingSeek: 42.5)
-            .contains("__kasetPendingSeek = 42.5"))
-        #expect(YouTubeWatchWebView.pageBootstrapScript(targetVolume: 1, pendingSeek: 0)
-            .contains("__kasetPendingSeek = 0.0"))
+        #expect(YouTubeWatchWebView.pageBootstrapScript(
+            targetVolume: 1,
+            documentGeneration: 0,
+            pendingSeek: 42.5,
+            pendingSeekVideoId: "video-id"
+        ).contains("__kasetPendingSeek = 42.5"))
+        #expect(YouTubeWatchWebView.pageBootstrapScript(
+            targetVolume: 1,
+            documentGeneration: 0,
+            pendingSeek: 42.5,
+            pendingSeekVideoId: "video-id"
+        ).contains("__kasetPendingSeekVideoId = \"video-id\""))
+        #expect(YouTubeWatchWebView.pageBootstrapScript(
+            targetVolume: 1,
+            documentGeneration: 0,
+            pendingSeek: 0
+        ).contains("__kasetPendingSeek = 0.0"))
         // No seek pending → no marker injected.
-        #expect(!YouTubeWatchWebView.pageBootstrapScript(targetVolume: 1, pendingSeek: nil)
-            .contains("__kasetPendingSeek"))
+        #expect(!YouTubeWatchWebView.pageBootstrapScript(
+            targetVolume: 1,
+            documentGeneration: 0,
+            pendingSeek: nil
+        ).contains("__kasetPendingSeek"))
         // Negative is not a valid seek position.
-        #expect(!YouTubeWatchWebView.pageBootstrapScript(targetVolume: 1, pendingSeek: -1)
-            .contains("__kasetPendingSeek"))
+        #expect(!YouTubeWatchWebView.pageBootstrapScript(
+            targetVolume: 1,
+            documentGeneration: 0,
+            pendingSeek: -1
+        ).contains("__kasetPendingSeek"))
     }
 
     @Test("Observer applies the pending seek gated on a seekable element")
@@ -71,8 +248,124 @@ struct YouTubeWatchScriptTests {
         // The seek is applied by the observer (not a one-shot at didFinish),
         // gated on readyState so it survives YouTube creating <video> late.
         #expect(script.contains("__kasetPendingSeek"))
+        #expect(script.contains("video.seekable.length === 0"))
+        #expect(script.contains("boundVideoId !== expectedVideoId"))
+        #expect(
+            script.range(of: "if (isAdShowing()) { return; }")?.lowerBound
+                ?? script.startIndex
+                < (script.range(of: "boundVideoId !== expectedVideoId")?.lowerBound ?? script.endIndex)
+        )
+        #expect(
+            script.range(of: "!video.currentSrc")?.lowerBound
+                ?? script.startIndex
+                < (script.range(of: "boundVideoId !== expectedVideoId")?.lowerBound ?? script.endIndex)
+        )
+        #expect(script.contains("const hasFiniteDuration = video.duration && isFinite(video.duration)"))
+        #expect(script.contains("function stillOwnsSeekOperation()"))
+        #expect(script.contains("video.__kasetMediaGeneration || 0) === seekMediaGeneration"))
+        #expect(script.contains("video.currentSrc === seekSource"))
+        #expect(script.contains("window.__kasetPendingSeekApplied = true"))
+        #expect(script.contains("window.__kasetPendingSeekFailed = true"))
         #expect(script.contains("applyPendingSeek"))
         #expect(script.contains("readyState"))
+    }
+
+    @Test("Pending-seek acknowledgement carries identity before getVideoData is ready")
+    func pendingSeekAcknowledgementCarriesExpectedIdentity() throws {
+        let context = try self.makeObserverContext(
+            videoId: "",
+            pendingSeek: 42,
+            pendingSeekVideoId: "abc"
+        )
+
+        context.evaluateScript("runNextTimeout();")
+
+        #expect(context.evaluateScript("messages[messages.length - 1].videoId").toString().isEmpty)
+        #expect(context.evaluateScript(
+            "messages[messages.length - 1].pendingSeekApplied"
+        ).toBool())
+        #expect(context.evaluateScript(
+            "messages[messages.length - 1].pendingSeekVideoId"
+        ).toString() == "abc")
+        #expect(context.evaluateScript("window.__kasetPendingSeekVideoId === null").toBool())
+    }
+
+    @Test("Pending-seek cancellation only mutates the matching document generation")
+    func pendingSeekCancellationIsGenerationGated() throws {
+        let context = try #require(JSContext())
+        context.evaluateScript(
+            """
+            var window = globalThis;
+            window.__kasetDocumentGeneration = 8;
+            window.__kasetPendingSeek = 42;
+            window.__kasetPendingSeekVideoId = 'abc';
+            window.__kasetPendingSeekAttempt = 5;
+            window.__kasetPendingSeekApplied = true;
+            window.__kasetPendingSeekFailed = true;
+            window.__kasetPendingSeekResultTarget = 42;
+            window.__kasetPendingSeekResultVideoId = 'abc';
+            """
+        )
+
+        context.evaluateScript(
+            YouTubeWatchWebView.pendingSeekCancellationScript(documentGeneration: 7)
+        )
+        #expect(context.evaluateScript("window.__kasetPendingSeek").toDouble() == 42)
+
+        context.evaluateScript(
+            YouTubeWatchWebView.pendingSeekCancellationScript(documentGeneration: 8)
+        )
+        #expect(context.evaluateScript("window.__kasetPendingSeek === null").toBool())
+        #expect(context.evaluateScript("window.__kasetPendingSeekVideoId === null").toBool())
+        #expect(!context.evaluateScript("window.__kasetPendingSeekApplied").toBool())
+        #expect(!context.evaluateScript("window.__kasetPendingSeekFailed").toBool())
+    }
+
+    @Test("Pending-seek completion is keyed by generation, target, and video")
+    func pendingSeekCompletionIsKeyed() throws {
+        let context = try #require(JSContext())
+        context.evaluateScript(
+            """
+            var window = globalThis;
+            window.__kasetDocumentGeneration = 8;
+            window.__kasetPendingSeek = 42;
+            window.__kasetPendingSeekVideoId = 'abc';
+            window.__kasetPendingSeekAttempt = 5;
+            """
+        )
+
+        context.evaluateScript(YouTubeWatchWebView.pendingSeekCompletionScript(
+            documentGeneration: 8,
+            attemptID: 5,
+            target: 43,
+            videoId: "abc"
+        ))
+        #expect(context.evaluateScript("window.__kasetPendingSeek").toDouble() == 42)
+
+        context.evaluateScript(YouTubeWatchWebView.pendingSeekCompletionScript(
+            documentGeneration: 8,
+            attemptID: 5,
+            target: 42,
+            videoId: "other"
+        ))
+        #expect(context.evaluateScript("window.__kasetPendingSeek").toDouble() == 42)
+
+        context.evaluateScript(YouTubeWatchWebView.pendingSeekCompletionScript(
+            documentGeneration: 8,
+            attemptID: 4,
+            target: 42,
+            videoId: "abc"
+        ))
+        #expect(context.evaluateScript("window.__kasetPendingSeek").toDouble() == 42)
+
+        context.evaluateScript(YouTubeWatchWebView.pendingSeekCompletionScript(
+            documentGeneration: 8,
+            attemptID: 5,
+            target: 42,
+            videoId: "abc"
+        ))
+        #expect(context.evaluateScript("window.__kasetPendingSeek === null").toBool())
+        #expect(context.evaluateScript("window.__kasetPendingSeekVideoId === null").toBool())
     }
 
     @Test("Observer skips the pending seek while an ad is showing")
@@ -81,6 +374,112 @@ struct YouTubeWatchScriptTests {
         // applyPendingSeek must bail on isAdShowing() so a preroll-ad element
         // doesn't consume the seek and leave content starting from 0.
         #expect(script.contains("isAdShowing()"))
+    }
+
+    @Test("Pending seek waits for the bound media identity instead of leading metadata")
+    func pendingSeekWaitsForBoundMediaIdentity() throws {
+        let context = try self.makeObserverContext(
+            videoId: "abc",
+            pendingSeek: 42,
+            pendingSeekVideoId: "def"
+        )
+
+        context.evaluateScript(
+            """
+            currentDataVideoId = 'def';
+            listeners.pause({ currentTarget: video });
+            """
+        )
+
+        #expect(context.evaluateScript("video.currentTime").toDouble() == 0)
+        #expect(context.evaluateScript("window.__kasetPendingSeek").toDouble() == 42)
+        #expect(!context.evaluateScript("window.__kasetPendingSeekApplied").toBool())
+        #expect(!context.evaluateScript("window.__kasetPendingSeekFailed").toBool())
+    }
+
+    @Test("Direct seek arming gates the eager write on bound content media")
+    func directSeekArmingIsMediaGated() {
+        let script = YouTubeWatchWebView.seekWithRecoveryScript(
+            documentGeneration: 7,
+            target: 42,
+            videoIdLiteral: "'abc'",
+            attemptID: 9
+        )
+
+        #expect(script.contains("classList.contains('ad-showing')"))
+        #expect(script.contains("video.readyState < 1"))
+        #expect(script.contains("video.__kasetBoundVideoId"))
+        #expect(script.contains("video.seekable.length === 0"))
+    }
+
+    @Test("A source transition clears stale identity and repairs it when metadata arrives")
+    func sourceTransitionRepairsUnknownIdentity() throws {
+        let context = try self.makeObserverContext(videoId: "abc")
+        context.evaluateScript(
+            """
+            currentDataVideoId = '';
+            video.currentSrc = 'https://media.example/replacement';
+            listeners.loadedmetadata({ currentTarget: video });
+            """
+        )
+        #expect(context.evaluateScript("video.__kasetBoundVideoId").toString().isEmpty)
+
+        context.evaluateScript(
+            """
+            currentDataVideoId = 'def';
+            listeners.pause({ currentTarget: video });
+            """
+        )
+        #expect(context.evaluateScript("video.__kasetBoundVideoId").toString() == "def")
+    }
+
+    @Test("Deferred pending-seek work stops after the media occurrence changes")
+    func pendingSeekDeferredWorkIsOccurrenceGated() throws {
+        let context = try self.makeObserverContext(
+            videoId: "abc",
+            pendingSeek: 42,
+            pendingSeekVideoId: "abc"
+        )
+        context.evaluateScript(
+            """
+            video.currentTime = 0;
+            video.currentSrc = 'https://media.example/replacement';
+            video.__kasetMediaGeneration += 1;
+            runNextTimeout();
+            """
+        )
+
+        #expect(context.evaluateScript("video.currentTime").toDouble() == 0)
+        #expect(context.evaluateScript("window.__kasetPendingSeek").toDouble() == 42)
+        #expect(!context.evaluateScript("window.__kasetPendingSeekApplied").toBool())
+    }
+
+    @Test("Pending seek serializes one timer per retry attempt")
+    func pendingSeekSerializesRetryAttempts() throws {
+        let context = try self.makeObserverContext(
+            videoId: "abc",
+            pendingSeek: 42,
+            pendingSeekVideoId: "abc"
+        )
+        #expect(context.evaluateScript("scheduledTimeouts.length").toInt32() == 1)
+
+        context.evaluateScript("listeners.seeked({ currentTarget: video });")
+        #expect(context.evaluateScript("scheduledTimeouts.length").toInt32() == 1)
+
+        context.evaluateScript(
+            """
+            window.__kasetPendingSeek = 42;
+            window.__kasetPendingSeekVideoId = 'abc';
+            window.__kasetPendingSeekAttempt += 1;
+            window.__kasetPendingSeekInFlightAttempt = null;
+            listeners.seeked({ currentTarget: video });
+            """
+        )
+        #expect(context.evaluateScript("scheduledTimeouts.length").toInt32() == 2)
+
+        context.evaluateScript("runNextTimeout();")
+        #expect(context.evaluateScript("window.__kasetPendingSeek").toDouble() == 42)
+        #expect(!context.evaluateScript("window.__kasetPendingSeekApplied").toBool())
     }
 
     @Test("A normal loadVideo clears a stale pending seek from an interrupted reload")
@@ -92,5 +491,102 @@ struct YouTubeWatchScriptTests {
         // the load is a no-op beyond clearing the field.)
         webView.loadVideo(videoId: "different-video")
         #expect(webView.pendingSeek == nil)
+    }
+
+    private func objectPayloads(in script: String, marker: String, terminator: String) -> [String] {
+        script.components(separatedBy: marker).dropFirst().compactMap { suffix in
+            suffix.components(separatedBy: terminator).first
+        }
+    }
+
+    private func occurrenceCount(of needle: String, in haystack: String) -> Int {
+        haystack.components(separatedBy: needle).count - 1
+    }
+
+    private func makeObserverContext(
+        videoId: String,
+        pendingSeek: Double? = nil,
+        pendingSeekVideoId: String? = nil
+    ) throws -> JSContext {
+        let context = try #require(JSContext())
+        let videoIdLiteral = YouTubeWatchWebView.jsStringLiteral(videoId)
+        let pendingSeekScript = pendingSeek.map {
+            "window.__kasetPendingSeek = \($0);"
+        } ?? ""
+        let pendingSeekVideoIdScript = pendingSeekVideoId.map {
+            "window.__kasetPendingSeekVideoId = \(YouTubeWatchWebView.jsStringLiteral($0));"
+        } ?? ""
+        context.evaluateScript(
+            """
+            var window = globalThis;
+            var messages = [];
+            var scheduledTimeouts = [];
+            var listeners = {};
+            var currentDataVideoId = \(videoIdLiteral);
+            var console = { log: function() {} };
+            function setInterval() { return 0; }
+            function setTimeout(callback) {
+                scheduledTimeouts.push(callback);
+                return scheduledTimeouts.length;
+            }
+            function runNextTimeout() {
+                var callback = scheduledTimeouts.shift();
+                if (callback) { callback(); }
+            }
+            var video = {
+                paused: false,
+                ended: false,
+                currentTime: 0,
+                duration: 100,
+                readyState: 1,
+                currentSrc: 'https://media.example/abc',
+                volume: 1,
+                muted: false,
+                seekable: {
+                    length: 1,
+                    start: function() { return 0; },
+                    end: function() { return 100; }
+                },
+                addEventListener: function(name, callback) { listeners[name] = callback; },
+                play: function() {
+                    this.paused = false;
+                    this.ended = false;
+                    if (listeners.play) { listeners.play({ currentTarget: this }); }
+                    if (listeners.playing) { listeners.playing({ currentTarget: this }); }
+                },
+                pause: function() {
+                    this.paused = true;
+                    if (listeners.pause) { listeners.pause({ currentTarget: this }); }
+                }
+            };
+            var player = {
+                classList: { contains: function() { return false; } },
+                getVideoData: function() {
+                    return { video_id: currentDataVideoId, title: 'Title' };
+                },
+                unMute: function() {}
+            };
+            var document = {
+                title: 'Title - YouTube',
+                getElementById: function(id) { return id === 'movie_player' ? player : null; },
+                querySelector: function(selector) {
+                    if (selector === '.ytp-autonav-toggle-button') { return null; }
+                    return video;
+                }
+            };
+            window.webkit = {
+                messageHandlers: {
+                    youtubePlayer: {
+                        postMessage: function(message) { messages.push(message); }
+                    }
+                }
+            };
+            window.__kasetDocumentGeneration = 7;
+            \(pendingSeekScript)
+            \(pendingSeekVideoIdScript)
+            """
+        )
+        context.evaluateScript(YouTubeWatchWebView.observerScript)
+        return context
     }
 }

--- a/docs/adr/0026-generation-scoped-web-playback-bridge.md
+++ b/docs/adr/0026-generation-scoped-web-playback-bridge.md
@@ -1,0 +1,116 @@
+# ADR-0026: Generation-Scoped Web Playback Bridge Events
+
+## Status
+
+Accepted
+
+## Context
+
+Kaset's YouTube Music and regular YouTube players both keep one persistent
+`WKWebView` and translate JavaScript bridge messages into native playback
+state. Full-page navigation is asynchronous: the outgoing document remains
+alive while Kaset pauses it and prepares the next watch page.
+
+The outgoing page can therefore publish late state, progress, ended, media-key,
+AirPlay, lyrics, or metadata events after native state has already selected the
+next item. A video ID alone is not a safe boundary:
+
+- the old and new documents can report different IDs during one explicit load;
+- same-document YouTube autoplay/SPA transitions legitimately change IDs and
+  must still reach native reconciliation;
+- duplicate queue entries can share an ID;
+- a replaced WebView can retain a message handler long enough to deliver a late
+  callback.
+
+Tests previously exercised `PlayerService` methods directly or inspected script
+strings. They did not establish that an active bridge message came from the one
+WebView document currently allowed to mutate native state.
+
+## Decision
+
+Every full-page playback navigation receives a monotonically increasing
+**document generation** managed by native Swift.
+
+- `WebPlaybackDocumentGeneration` owns committed, pending, provisionally
+  loading, and invalidated generations independently of video identity.
+- Beginning a navigation reserves a generation and temporarily suppresses
+  outgoing-document bridge messages.
+- Immediately before `WKWebView.load`, the still-current reserved generation is
+  marked provisionally loading. A superseded asynchronous callback cannot start
+  an older load.
+- The generation becomes committed only from `WKNavigationDelegate.didCommit`.
+  If WebKit cancels or fails before commit, the previous committed document is
+  not trusted as the requested video: the requested WebView identity is cleared,
+  prior bridge generations are invalidated, and playback becomes explicitly
+  retryable.
+- A superseded request that never reaches `WKWebView.load` drops its reservation.
+  Explicit user cancellation is stricter: it pauses the surviving page,
+  invalidates every prior generation, clears WebView identity, and leaves the
+  selected item as a deferred retry rather than re-authorizing an outgoing page
+  that may represent different content.
+- Main-frame document navigations not initiated by Kaset are cancelled; the
+  hidden playback pages are not user-facing browser tabs. Fragment-only
+  same-document navigation is left alone. While a navigation is reserved, other
+  document-changing page actions are cancelled; while it is provisional, only
+  requests carrying that provisional generation are allowed only across the
+  expected HTTPS playback origin and an explicit allowlist of Google/YouTube
+  consent or authentication origins. Trusted intermediates remain provisional;
+  only the expected playback origin may commit and publish bridge messages.
+  Captive-portal and unrelated error origins are cancelled into the retry path.
+- Starting a newer explicit load cancels the previous provisional load before
+  replacing the WebView-wide user-script list. Server redirects refresh the
+  bootstrap fallback; redirect requests remain associated through the original
+  generation-bearing `mainDocumentURL` even when the redirect target drops the
+  query item. YouTube's one-shot resume seek is retained on that tracked
+  navigation and reinstalled for each redirect hop.
+- Internal `about:blank`/`data:` navigations used to blank a torn-down WebView
+  are allowed; their origins cannot pass the playback bridge source gate.
+- Teardown or WebView replacement invalidates every earlier generation.
+- The reserved generation is encoded in a watch URL query item. A stable
+  document-start bootstrap reads that navigation-bound token into
+  `window.__kasetDocumentGeneration`; this avoids assigning a later token to an
+  earlier provisional document through the WebView-wide user-script list.
+- Every playback bridge payload includes the document generation.
+- Coordinators accept a payload only when both conditions hold:
+  1. It comes from the expected HTTPS YouTube main-frame origin.
+  2. `message.webView` is the current singleton playback WebView.
+  3. The payload generation is the active native generation and no newer
+     navigation is pending.
+- A WebContent-process termination invalidates the terminated document and
+  starts one fresh generation-scoped navigation. Music reuses restored-session
+  reconciliation to preserve seek/play intent, using the last non-ad content
+  clock when an ad is active; terminal music states are not resurrected, and a
+  fresh `.loading` selection never inherits the previous track's clock. YouTube
+  reloads playing content at its content position and defers a paused reload
+  until explicit resume.
+- Music restoration ignores placeholder/no-media and ad clock samples. Its
+  autoplay intent is re-synchronized at document commit and remains retryable
+  across asynchronous `play()` rejection, so pause/stop intent cannot be
+  overwritten by a late `canplay` callback.
+- Navigation records live through `didFinish`/`didFail`, not merely `didCommit`,
+  so a post-commit failure invalidates the failed document. Terminal cancellation
+  (including committed-but-still-loading navigation) or failure clears the
+  requested WebView identity and leaves playback in an explicit retry state
+  rather than re-authorizing the outgoing page.
+
+The gate deliberately does **not** require the observed video ID to match the
+requested video ID. Same-document drift remains visible to existing queue and
+YouTube SPA reconciliation.
+
+## Consequences
+
+- Late events from an outgoing or replaced document cannot overwrite a newer
+  explicit playback intent.
+- The same mechanism applies consistently to music state/ended/lyrics/AirPlay/
+  audio-quality/media-key events and YouTube state/ended events.
+- Core generation transitions, URL trust checks, bridge acceptance, retry plans,
+  and script payload contracts have deterministic unit coverage. WebKit delegate
+  sequencing is still verified through focused packaged runtime probes because
+  `WKNavigation` instances cannot be constructed in a pure unit test.
+- This decision does not yet separate requested/in-flight/committed video IDs,
+  automatically retry ordinary navigation failures, or unify every near-end and
+  ended signal into one native transition. Those reliability improvements build
+  on this document boundary in later increments. Per-element duplicate/stale
+  ended callbacks are rejected at the script boundary in this increment.
+- Any new script that posts to a playback message handler must include the
+  document generation or its messages will be rejected by design.

--- a/docs/adr/0027-native-music-playback-intents-and-queue-entry-identity.md
+++ b/docs/adr/0027-native-music-playback-intents-and-queue-entry-identity.md
@@ -1,0 +1,165 @@
+# ADR-0027: Native Music Playback Intents and Queue-Entry Identity
+
+## Status
+
+Accepted
+
+## Context
+
+ADR-0026 scopes JavaScript bridge events to the active Web document and media
+occurrence. Native playback work has a separate race: a user action can start an
+API request or schedule a corrective task, suspend, and later mutate playback
+after a newer queue selection, pause, resume, or Stop.
+
+The previous `playbackRequestGeneration` advanced only at account/privacy
+boundaries. Mix, radio, playlist, album, and continuation responses therefore
+remained authorized across ordinary playback changes. A delayed initial mix
+could replace a newer direct queue or resurrect playback after Stop. A delayed
+radio response could replace a newer queue when both selected the same video ID,
+and a stale continuation could append songs or restore its token into a
+replacement queue.
+
+Video identity is also not queue-occurrence identity. Authored queues may contain
+the same `Song` or video ID more than once. Matching only `videoId` can resume the
+wrong occurrence, re-key the active radio seed, enrich the first duplicate, or
+realign the queue to an arbitrary duplicate.
+
+## Decision
+
+`PlayerService` owns a monotonically increasing, opaque `MusicPlaybackIntent`.
+
+- Valid user playback commands reserve a new intent synchronously, before
+  suspension. Empty queues, invalid indices, and disappeared UUID selections are
+  preflighted as true no-ops and do not supersede active playback.
+  This includes direct song/video/queue playback, mix/radio selection, playlist
+  and album resolution, queue-entry selection, play/pause/resume, next/previous,
+  seek, Stop, restoration adoption, and queue-replacing clear/undo/redo actions.
+- Work that must parse before its action is known (for example Command Bar AI
+  requests) captures a non-mutating `MusicPlaybackReservation`. It can claim a
+  new intent only if no newer playback action has occurred since submission.
+  Queue-only commands also retain the submission-time queue generation instead
+  of acquiring ownership after parsing finishes.
+- Async work captures the intent that authorized it and checks ownership after
+  every suspension before mutating playback, queue, continuation, persistence,
+  or recovery state. Task cancellation is an optimization, not the correctness
+  boundary.
+- Scheduled Web queue-correction tasks capture both the intent and the expected
+  `QueueEntry.id`. A newer user action or queue replacement makes the task a
+  no-op before it can replay, advance, or pause newer playback. Queue-only
+  mutations that retain the active occurrence may still accept its already-
+  emitted terminal event.
+- Rapid Media Session and native transport commands—including Next/Previous
+  and relative skips—are admitted into one ordered remote-command batch under
+  one intent. Later native actions invalidate the whole batch, while later
+  relative commands do not cancel earlier commands. Relative skips read Web
+  snapshots in FIFO order and coalesce from the last admitted seek target.
+  Materialized transport transitions drain before exact-owner metadata and
+  queue-maintenance follow-up; only end-of-queue target discovery is a barrier.
+- Native `MPRemoteCommand` callbacks first enter a lock-backed ingress that
+  captures callback sequence, wall-clock issuance, monotonic admission time,
+  and scalar payload before scheduling one MainActor drain. Play, Pause, Toggle,
+  Next/Previous, relative seek, and absolute seek therefore preserve callback
+  FIFO, and a callback captured before a newer UI intent is rejected as stale.
+- Bridge ordering uses the highest-resolution shared wall clock WebKit exposes.
+  State/end events must be strictly newer than the native intent; remote commands
+  may share a timestamp only inside the already-admitted batch. Ended signals are
+  retried and remain occurrence-idempotent, and an explicit pause consumes a late
+  end without advancing playback.
+- Mix-continuation requests also have a request-owner UUID. A stale request cannot
+  clear the in-flight state owned by a newer request.
+- Stop, privacy clearing, restoration adoption, and every verified account
+  identity transition invalidate playback, queue-load, mutation, and history
+  ownership before inspecting current media. Idle requests and authenticated
+  continuations therefore cannot cross accounts. Delayed destructive UI writes
+  carry both account ID and session generation from snapshot capture through the
+  preflight and postflight checks.
+- Privacy-boundary invalidation advances the same native intent epoch; document
+  and media generations remain separate Web transport boundaries.
+
+`QueueEntry.id` is the authoritative logical occurrence identity inside a live
+queue.
+
+- Queue callers pass the exact entry ID into the internal play operation instead
+  of asking `play(song:)` to rediscover identity from a video ID.
+- Different entry IDs always create a fresh native occurrence even when their
+  `Song` values and video IDs are identical. Reselecting the same pending/active
+  entry deduplicates into resume. A direct video-ID request detaches queue and
+  episode ownership, starts a fresh native occurrence, clears stale restored
+  load state, installs the requested pending/current identity before resume,
+  and refreshes detached metadata even when the already-loaded Web media can be
+  resumed in place.
+- Radio expansion preserves the existing seed entry ID.
+- Metadata fetches and background enrichment capture an entry ID and relocate it
+  by UUID after suspension; they never update the first matching video ID.
+- Web-reported drift may realign to a unique matching queue entry. Ownership,
+  visible track metadata, and persistence are updated in that order. If multiple
+  entries share the observed video ID, Kaset retains and reasserts native queue
+  ownership rather than selecting the first duplicate.
+- Queue transformations preserve entry IDs for rows they retain. Duplicate
+  removal retains the active occurrence (or stopped current cursor) at the first
+  video-position slot instead of transferring ownership to a different duplicate;
+  unrelated replacements clear ownership. The destructive whole-queue API always
+  stops playback first; `clearQueue()` remains the distinct preserve-current-track
+  operation.
+- UI selection, delayed removal, context menus, swipe actions, drag payloads, and
+  scripting resolve rows by UUID. A stale displayed index cannot mutate a newer
+  row after insertion or reorder.
+- Undo/redo replays the exact restored entry, physical media clock, transport
+  intent, mix continuation, pre-shuffle authored order, and detached artist-
+  episode identity before persisting; live episodes return to the live edge rather
+  than entering fixed-clock restoration, and paused intent is installed before
+  any replacement navigation can capture autoplay. Ended restores synchronously
+  derive video availability from the restored song. The outgoing undo/redo state
+  is captured before playback-context reset so redo cannot lose the pre-shuffle
+  authored permutation. History is structural: it strips account-scoped
+  rating/library fields and refreshes the restored owner instead of
+  replaying stale action tokens. Playback intent gates admission/restoration;
+  once the queue is installed, queue generation owns structural finalization so
+  pause/resume/seek cannot orphan persistence or Smart Shuffle rearming. Adopting
+  a persisted session clears prior live history, and history restore downgrades
+  Smart Shuffle when its feature setting is disabled.
+  Detached playback is persisted as its own
+  singleton occurrence instead of attaching its clock to an unrelated valid
+  queue index.
+- Metadata merging preserves the logical song identity and already-complete
+  display fields. Account metadata is sanitized at identity boundaries; active
+  refreshes update complete rows, while background enrichment never imports
+  rating/library tokens.
+- Rating and library mutations carry latest-operation revisions and are serialized
+  per account/video so both local state and server write order follow the newest
+  user intent. The predecessor/tail is registered synchronously at submission,
+  before any unstructured completion task can begin, so rapid toggles cannot
+  reverse backend write order. Session-generation fences prevent stale identity
+  completions from repopulating account-scoped confirmed rollback baselines, and
+  a matching post-mutation refresh promotes authoritative server action tokens.
+  Metadata reads cannot promote library fields while that account/video/session
+  has a pending serialized mutation. Library membership and action tokens fan out
+  to every duplicate occurrence of the same account/video while display metadata
+  remains exact-entry scoped.
+- Shuffle mode and duplicate-safe authored order are part of queue history and
+  persisted playback sessions, not merely global preferences.
+
+Runtime entry UUIDs remain in-memory only. Persisted queue index continues to
+identify the selected duplicate across launches, while an optional pre-shuffle
+permutation preserves every non-active duplicate occurrence payload. UUID
+persistence is not needed.
+
+## Consequences
+
+- Delayed mix, radio, playlist, album, and continuation work cannot replace a
+  newer direct queue or resurrect playback after Stop.
+- Native corrective tasks cannot pause, replay, or advance after a newer intent.
+- Rapid remote transport commands remain deterministic, and a pause/end race
+  cannot restart Music while regular YouTube owns playback.
+- Duplicate video IDs remain distinct queue occurrences throughout playback,
+  radio expansion, metadata enrichment, and Web drift reconciliation.
+- Internal playback methods accept an intent and optional queue-entry ID, while
+  existing public APIs remain source-compatible wrappers that reserve intent.
+- Queue-only pagination still uses its queue-load generation so a simple pause
+  need not discard already-committed playlist continuation loading.
+- Command Bar ownership is submission-scoped, streaming partials are request-ID
+  scoped, and hard timeouts do not await cancellation-insensitive model work.
+- This decision does not replace ADR-0026 document/media generations and does not
+  claim that a requested video ID proves ready physical media. Authoritative
+  requested/in-flight/observed media readiness and pending-control routing remain
+  a separate follow-up concern.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -60,3 +60,5 @@ What becomes easier or more difficult because of this change?
 | [0023](0023-brand-account-history-session-switch.md) | Brand-Account History via WebView Session-Identity Switch | Accepted |
 | [0024](0024-logged-in-guest-mode.md) | Logged-In Guest Mode | Accepted |
 | [0025](0025-smart-shuffle.md) | Smart Shuffle (tri-state shuffle with interleaved recommendations) | Accepted |
+| [0026](0026-generation-scoped-web-playback-bridge.md) | Generation-Scoped Web Playback Bridge Events | Accepted |
+| [0027](0027-native-music-playback-intents-and-queue-entry-identity.md) | Native Music Playback Intents and Queue-Entry Identity | Accepted |

--- a/docs/api-discovery.md
+++ b/docs/api-discovery.md
@@ -617,7 +617,19 @@ let body = ["feedbackTokens": [addToken]]
 _ = try await request("feedback", body: body)
 ```
 
-Tokens come from `getSong(videoId:)` response.
+Tokens come from `getSong(videoId:)` response. `FeedbackTokens.add` and
+`FeedbackTokens.remove` are action-specific: select the add token when the
+target state is in-library and the remove token when the target state is
+out-of-library. Keep the known pair stable across optimistic UI updates; do not
+swap the fields. A later authoritative metadata response may replace or rotate
+the pair.
+
+`api-explorer` reports library feedback action structure without printing token
+values. It can also inspect a saved response safely:
+
+```bash
+swift run api-explorer analyze-file path/to/response.json
+```
 
 ---
 


### PR DESCRIPTION
## Summary

- add generation-scoped Music and YouTube WebView navigation, bridge-event, terminal-event, and process-recovery ownership
- add native Music playback intents, exact `QueueEntry.id` occurrence ownership, bounded remote-command FIFO ordering, and stale async-work rejection
- harden queue history, persistence, Smart Shuffle, same-video playback, duplicate removal, account-scoped mutations, and playlist reconciliation
- integrate current `main` pagination, lyrics polling, playlist-removal, and mix-scrobbling work with the reliability ownership model
- replace timing-sensitive reliability tests with deterministic generation, gate, persistence, and completion seams

## Root cause

Playback reliability depended on several identities that were either missing or too broad:

- Web callbacks were associated with a requested video rather than the committed document/media generation that emitted them.
- Native async work could complete after a newer user action without an intent fence.
- Duplicate video IDs were treated as interchangeable even when they represented different queue occurrences.
- Queue history, persistence, remote commands, account-scoped writes, and optimistic rating state could finalize under stale ownership.

The changes introduce explicit document/media generations, native playback intents, queue-load generations, exact queue-entry UUID ownership, account-session ownership, ordered callback ingress, and confirmed-versus-optimistic rating state.

## User impact

- stale navigation, bridge, autoplay, metadata, mix/radio, and recovery work can no longer replace newer playback
- Stop and account/privacy boundaries cannot be bypassed by delayed async completions
- rapid media-key commands and seeks execute in callback order
- duplicate songs retain the correct active occurrence, metadata owner, history, and persistence state
- undo/redo preserves transport, authored shuffle order, detached episodes, and exact queue identity
- library and playlist mutations remain ordered and account-scoped
- failed optimistic likes/unlikes roll back to the last API-confirmed state
- cancelled WebView loads cannot revive stale media, stop their replacement navigation, or leave extension-host tabs stuck loading
- video-owned Now Playing scrubber commands seek the active YouTube video instead of hidden music state

## Review follow-ups

- keep detached-current metadata updates while restricting queue enrichment to its exact owner
- retain cancelled-navigation tombstones through terminal WebKit callbacks and distinguish replacement loads from explicit cancellation
- keep optimistic Liked Music synchronization out of the confirmed rating baseline
- compare deterministic, sorted-key playback-session payloads so metadata-only persistence changes are not skipped
- preserve document-generation ownership on the merged event-driven lyrics bridge
- handle macOS 15 percent-encoded internal blank URL fragments and isolate timing-sensitive Smart Shuffle tests
- align Web occurrence acceptance with bind-time video mismatch rules and preserve bridge clock provenance
- carry generation-scoped pending-seek attempt IDs through redirects and script reinstalls

## Validation

- `swiftformat .`
- `swiftlint --strict`
- `swift build`
- focused metadata, rating rollback, persistence, WebView generation, lyrics bridge, playback occurrence, remote-command, and playlist live-sync suites
- `swift test --skip KasetUITests`: **2,243 tests across 171 suites passed**
- Codex structured autoreview: **clean, no actionable findings**
- fresh GitHub Codex review of `8608ee3e28`: **no major issues**
- GitHub Actions: SwiftLint, SwiftFormat, Dev Build, macOS 15/26 unit tests, and macOS 15/26 UI tests all passed

UI tests were not run locally; both CI UI-test jobs passed.