### PR TITLE
fix: deliver kaset:// deep links via AppDelegate

### DIFF
--- a/Sources/Kaset/AppDelegate.swift
+++ b/Sources/Kaset/AppDelegate.swift
@@ -1,6 +1,11 @@
 import AppKit
 import UserNotifications
 
+extension Notification.Name {
+    /// Posted by `AppDelegate` when the app receives deep-link URLs.
+    static let kasetOpenURLs = Notification.Name("kasetOpenURLs")
+}
+
 // MARK: - AppDelegate
 
 /// App delegate to control application lifecycle behavior.
@@ -11,6 +16,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Set by KasetApp after initialization.
     weak var playerService: PlayerService?
     weak var scrobblingCoordinator: ScrobblingCoordinator?
+
+    /// URLs received before the SwiftUI scene is ready to observe deep links.
+    private var pendingOpenURLs: [URL] = []
+
+    /// True after `KasetApp` starts observing `.kasetOpenURLs`.
+    private var isOpenURLDeliveryReady = false
 
     /// Reference to the main window for reliable reopen behavior.
     /// Using strong reference to prevent deallocation when window is hidden.
@@ -253,6 +264,29 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Show main window when dock icon is clicked
         self.showMainWindowIfNeeded()
         return true
+    }
+
+    /// Deep-link entry point for custom URL schemes.
+    func application(_: NSApplication, open urls: [URL]) {
+        DiagnosticsLogger.app.info("AppDelegate: open \(urls.count) URL(s)")
+        self.deliverOpenURLs(urls)
+    }
+
+    /// Call once the main scene is observing `.kasetOpenURLs`.
+    func beginOpenURLDelivery() {
+        self.isOpenURLDeliveryReady = true
+        let pending = self.pendingOpenURLs
+        self.pendingOpenURLs.removeAll()
+        self.deliverOpenURLs(pending)
+    }
+
+    private func deliverOpenURLs(_ urls: [URL]) {
+        guard !urls.isEmpty else { return }
+        if self.isOpenURLDeliveryReady {
+            NotificationCenter.default.post(name: .kasetOpenURLs, object: urls)
+        } else {
+            self.pendingOpenURLs.append(contentsOf: urls)
+        }
     }
 
     private var isSwitchedToMiniPlayer: Bool {

--- a/Sources/Kaset/KasetApp.swift
+++ b/Sources/Kaset/KasetApp.swift
@@ -199,8 +199,16 @@ struct KasetApp: App {
                     // Wire up PlayerService to AppDelegate for dock menu and AppleScript actions
                     // This runs synchronously so AppleScript commands can access playerService immediately
                     self.appDelegate.playerService = self.playerService
+                    // Drain any cold-launch URLs once `onReceive` below is subscribed.
+                    self.appDelegate.beginOpenURLDelivery()
                     // Reference notificationService to keep SwiftUI from deallocating it
                     _ = self.notificationService
+                }
+                .onReceive(NotificationCenter.default.publisher(for: .kasetOpenURLs)) { notification in
+                    guard let urls = notification.object as? [URL] else { return }
+                    for url in urls {
+                        self.handleIncomingURL(url)
+                    }
                 }
                 .task {
                     DiagnosticsLogger.app.info("KasetApp: Root task started")
@@ -226,9 +234,9 @@ struct KasetApp: App {
                         await FoundationModelsService.shared.warmup()
                     }
                 }
-                .onOpenURL { url in
-                    self.handleIncomingURL(url)
-                }
+                // Claim deep links for this existing window so macOS does not
+                // spawn/tear down a second scene around `kaset://`.
+                .handlesExternalEvents(preferring: ["*"], allowing: ["*"])
                 .onChange(of: self.playerService.isPlaying) { _, isPlaying in
                     // The Core Audio process tap needs WebKit's GPU
                     // process to be actively emitting audio before it
@@ -270,6 +278,7 @@ struct KasetApp: App {
         }
         .defaultSize(width: MainWindowLayout.defaultWidth, height: MainWindowLayout.defaultHeight)
         .windowResizability(.contentMinSize)
+        .handlesExternalEvents(matching: ["*"])
 
         Settings {
             SettingsView()
@@ -654,6 +663,8 @@ struct KasetApp: App {
 
     /// Handles parsed URL content.
     private func handleParsedContent(_ content: URLHandler.ParsedContent) {
+        self.showMainWindow()
+
         switch content {
         case let .song(videoId):
             DiagnosticsLogger.app.info("Playing song from URL: \(videoId)")
@@ -664,7 +675,8 @@ struct KasetApp: App {
                 videoId: videoId
             )
             Task {
-                await self.playerService.play(song: song)
+                // Match AppleScript `play video` / other external play entry points.
+                await self.playerService.playWithRadio(song: song)
             }
 
         case let .youtubeVideo(videoId):

--- a/Sources/Kaset/KasetApp.swift
+++ b/Sources/Kaset/KasetApp.swift
@@ -77,7 +77,7 @@ struct KasetApp: App {
     /// Incoming app URLs received before auth initialization and guest-startup
     /// cleanup complete. These are replayed only after guest cleanup has run so
     /// cleanup cannot erase URL-started playback.
-    @State private var pendingIncomingURL: URL?
+    @State private var pendingIncomingURLs: [URL] = []
 
     @State private var didCompleteStartupPlaybackCleanup = false
 
@@ -231,7 +231,7 @@ struct KasetApp: App {
                         }
                         self.didCompleteStartupPlaybackCleanup = true
                     }
-                    self.drainPendingIncomingURLIfReady()
+                    self.drainPendingIncomingURLsIfReady()
 
                     // Fetch accounts after login check (for account switcher)
                     await self.accountService?.fetchAccounts()
@@ -649,21 +649,24 @@ struct KasetApp: App {
 
         guard !self.authService.state.isInitializing, self.didCompleteStartupPlaybackCleanup else {
             DiagnosticsLogger.app.info("Startup auth/guest cleanup still running; deferring incoming URL")
-            self.pendingIncomingURL = url
+            self.pendingIncomingURLs.append(url)
             return
         }
 
         self.handleReadyIncomingURL(url)
     }
 
-    private func drainPendingIncomingURLIfReady() {
+    private func drainPendingIncomingURLsIfReady() {
         guard !self.authService.state.isInitializing,
               self.didCompleteStartupPlaybackCleanup,
-              let url = self.pendingIncomingURL
+              !self.pendingIncomingURLs.isEmpty
         else { return }
 
-        self.pendingIncomingURL = nil
-        self.handleReadyIncomingURL(url)
+        let urls = self.pendingIncomingURLs
+        self.pendingIncomingURLs.removeAll()
+        for url in urls {
+            self.handleReadyIncomingURL(url)
+        }
     }
 
     private func handleReadyIncomingURL(_ url: URL) {
@@ -688,9 +691,12 @@ struct KasetApp: App {
                 artists: [],
                 videoId: videoId
             )
+            // Reserve intent synchronously so a later URL in the same batch
+            // invalidates this asynchronous playback before it can start.
+            let intent = self.playerService.beginMusicPlaybackIntent()
             Task {
                 // Match AppleScript `play video` / other external play entry points.
-                await self.playerService.playWithRadio(song: song)
+                await self.playerService.playWithRadio(song: song, intent: intent)
             }
 
         case let .youtubeVideo(videoId):

--- a/Tests/KasetTests/AppDelegateOpenURLTests.swift
+++ b/Tests/KasetTests/AppDelegateOpenURLTests.swift
@@ -1,0 +1,76 @@
+import AppKit
+import Testing
+@testable import Kaset
+
+@Suite("App delegate URL delivery", .serialized)
+@MainActor
+struct AppDelegateOpenURLTests {
+    private final class DeliveryRecorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage: [[URL]] = []
+
+        var deliveries: [[URL]] {
+            self.lock.withLock { self.storage }
+        }
+
+        func record(_ notification: Notification) {
+            guard let urls = notification.object as? [URL] else { return }
+            self.lock.withLock {
+                self.storage.append(urls)
+            }
+        }
+    }
+
+    private func makeURL(_ value: String) throws -> URL {
+        try #require(URL(string: value))
+    }
+
+    private func observeDeliveries(_ recorder: DeliveryRecorder) -> NSObjectProtocol {
+        NotificationCenter.default.addObserver(
+            forName: .kasetOpenURLs,
+            object: nil,
+            queue: nil
+        ) { notification in
+            recorder.record(notification)
+        }
+    }
+
+    @Test("Cold-launch URLs are emitted once in arrival order when delivery begins")
+    func coldLaunchURLsDrainInOrder() throws {
+        let delegate = AppDelegate()
+        let recorder = DeliveryRecorder()
+        let observer = self.observeDeliveries(recorder)
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        let first = try self.makeURL("kaset://play?v=first")
+        let second = try self.makeURL("kaset://play?v=second")
+
+        delegate.application(NSApplication.shared, open: [first])
+        delegate.application(NSApplication.shared, open: [second])
+        #expect(recorder.deliveries.isEmpty)
+
+        delegate.beginOpenURLDelivery()
+        #expect(recorder.deliveries == [[first, second]])
+
+        delegate.beginOpenURLDelivery()
+        #expect(recorder.deliveries == [[first, second]])
+    }
+
+    @Test("URLs received after delivery begins are emitted immediately")
+    func readyDeliveryEmitsImmediately() throws {
+        let delegate = AppDelegate()
+        let recorder = DeliveryRecorder()
+        let observer = self.observeDeliveries(recorder)
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        let first = try self.makeURL("kaset://play?v=first")
+        let second = try self.makeURL("kaset://play?v=second")
+
+        delegate.beginOpenURLDelivery()
+        delegate.application(NSApplication.shared, open: [first])
+        #expect(recorder.deliveries == [[first]])
+
+        delegate.application(NSApplication.shared, open: [second])
+        #expect(recorder.deliveries == [[first], [second]])
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -469,7 +469,7 @@ Parses YouTube Music URLs, regular YouTube watch links, and custom `kaset://` UR
 | `kaset://album?id=xxx` | `.album(id:)` |
 | `kaset://artist?id=xxx` | `.artist(id:)` |
 
-**Usage**: Called from `KasetApp.onOpenURL` to handle deep links. Music song links play through `PlayerService`; regular YouTube watch links switch to the YouTube source and open playback in the floating video window.
+**Usage**: Custom-scheme URLs enter through `AppDelegate.application(_:open:)`. The app delegate buffers cold-launch deliveries until the SwiftUI scene subscribes, then posts `.kasetOpenURLs` for `KasetApp.handleIncomingURL` to parse and route. Music song links play through `PlayerService`; regular YouTube watch links switch to the YouTube source and open playback in the floating video window.
 
 ### ScriptCommands (AppleScript)
 


### PR DESCRIPTION
## Description

Fixes `kaset://` deep links that could hide the main window and fail to start playback. URL delivery now goes through AppDelegate into the existing handler, claims the single `Window` for external events, and focuses the main window before playing.

## AI Prompt (Optional)

<details>
<summary>🤖 AI Prompt Used</summary>

```
Fix #209: kaset:// URL scheme should keep the app window visible and start
playback for open "kaset://play?v=VIDEO_ID".

Deliver custom-scheme URLs via AppDelegate.application(_:open:), claim the
existing Window with handlesExternalEvents, call showMainWindow() before
handling parsed content, and start song links with playWithRadio to match
AppleScript play video. Follow AGENTS.md; keep the change minimal.
```

**AI Tool:** Cursor

</details>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🧪 Test update
- [ ] 🔧 Build/CI configuration

## Related Issues

Fixes #209

## Changes Made

- Route custom-scheme URLs through `AppDelegate.application(_:open:)` with a cold-launch pending queue
- Bridge into `KasetApp.handleIncomingURL` via `.kasetOpenURLs` once the main scene is ready
- Claim the existing main `Window` with `handlesExternalEvents` instead of relying on `onOpenURL` alone
- Call `showMainWindow()` before handling parsed deep-link content
- Start song deep links with `playWithRadio` to match AppleScript `play video`

## Testing

- [x] Unit tests pass (`swift test --skip KasetUITests --filter URLHandlerTests`)
- [x] Manual testing performed
- [x] UI tested on macOS 26+

- [x] `open "kaset://play?v=VIDEO_ID"` with the app already running focuses the window and starts that track
- [x] Cold launch via the same URL starts playback after startup
- [x] AppleScript `play video "VIDEO_ID"` still works

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `swiftlint --strict && swiftformat .`
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally
- [ ] I have updated documentation if needed
- [x] I have checked for any performance implications
- [x] My changes generate no new warnings
