### PR TITLE
fix(l10n): correct Italian subscribe terminology and other strings

### DIFF
--- a/Sources/Kaset/Resources/Localizable.xcstrings
+++ b/Sources/Kaset/Resources/Localizable.xcstrings
@@ -18397,7 +18397,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ripeti"
+            "value": "Ripristina"
           }
         },
         "ko": {
@@ -19543,7 +19543,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Salva playlist e abbonati ai podcast su YouTube Music per vederli qui."
+            "value": "Salva playlist e iscriviti ai podcast su YouTube Music per vederli qui."
           }
         },
         "ko": {
@@ -19631,7 +19631,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Salva playlist, segui artisti e abbonati ai podcast su YouTube Music per vederli qui."
+            "value": "Salva playlist, segui artisti e iscriviti ai podcast su YouTube Music per vederli qui."
           }
         },
         "ko": {
@@ -22010,7 +22010,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Abbonati"
+            "value": "Iscriviti"
           }
         },
         "ko": {
@@ -22098,7 +22098,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Abbonati a %@"
+            "value": "Iscriviti a %@"
           }
         },
         "ko": {
@@ -22186,7 +22186,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Abbonati ai podcast su YouTube Music per vederli qui."
+            "value": "Iscriviti ai podcast su YouTube Music per vederli qui."
           }
         },
         "ko": {
@@ -22274,7 +22274,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Abbonato"
+            "value": "Iscritto"
           }
         },
         "ko": {
@@ -22362,7 +22362,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Errore di abbonamento"
+            "value": "Errore di iscrizione"
           }
         },
         "ko": {
@@ -26326,7 +26326,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Predefinito"
+            "value": "Preimpostazione"
           }
         },
         "ko": {
@@ -40804,7 +40804,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ripeti l'ultima modifica alla coda annullata."
+            "value": "Ripristina l'ultima modifica alla coda annullata."
           }
         },
         "ko": {
@@ -40892,7 +40892,7 @@
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Aggiorna stato IA"
+            "value": "Aggiorna stato AI"
           }
         },
         "ko": {


### PR DESCRIPTION
## Description

Corrects the Italian (`it`) localization of several UI strings. Most importantly, YouTube in Italian uses **"Iscriviti"** for subscribing to a channel/podcast, not **"Abbonati"**, which implies a *paid* subscription. Every other language was already correct — only Italian used the wrong term. A native Italian speaker (me lol 😜) reviewed all affected strings.

This is a strings-only change to `Sources/Kaset/Resources/Localizable.xcstrings`; no Swift code was touched.

## AI Prompt (Optional)

<details>
<summary>🤖 AI Prompt Used</summary>

```
Review the Italian (it) localization in Localizable.xcstrings for correctness.
A native Italian speaker flagged that "Abbonati/Abbonato/Abbonamento" are used
for channel/podcast subscriptions, but Italian YouTube uses "Iscriviti/Iscritto/
Iscrizione" (Abbonati implies a PAID subscription). Also check a few strings for
consistency and terminology collisions (AI vs IA, equalizer Preset, queue Redo).
Apply only the value corrections; do not change keys, other languages, or behavior.
```

**AI Tool:** Claude Code (assisting a native Italian speaker's review)

</details>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [x] 🎨 UI/UX improvement
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🧪 Test update
- [ ] 🔧 Build/CI configuration

## Related Issues

None.

## Changes Made

All changes are Italian (`it`) value corrections in `Localizable.xcstrings`:

**Subscribe terminology (Abbonati → Iscriviti):** Italian YouTube uses "Iscriviti" for subscribing to a channel/podcast; "Abbonati" wrongly implies a paid subscription.
- `Subscribe`: "Abbonati" → "Iscriviti"
- `Subscribe %@`: "Abbonati a %@" → "Iscriviti a %@"
- `Subscribed`: "Abbonato" → "Iscritto"
- `Subscribe to podcasts on YouTube Music to see them here.`: "Abbonati ai podcast…" → "Iscriviti ai podcast…"
- `Save playlists and subscribe to podcasts on YouTube Music to see them here.`: "…abbonati ai podcast…" → "…iscriviti ai podcast…"
- `Save playlists, follow artists, and subscribe to podcasts on YouTube Music to see them here.`: "…abbonati ai podcast…" → "…iscriviti ai podcast…"

**Other corrections:**
- `Subscription Error`: "Errore di abbonamento" → "Errore di iscrizione" (this is a podcast-subscribe failure in `PodcastsView`, not a paid subscription)
- `Refresh AI Status`: "Aggiorna stato IA" → "Aggiorna stato AI" (consistency — every other string in the app uses "AI", never "IA")
- `Preset`: "Predefinito" → "Preimpostazione" (Equalizer preset selector in `EQPreset.swift`; "Predefinito" means "default" and conceptually collides with the existing "Predefinito di sistema" = System Default)
- `Redo`: "Ripeti" → "Ripristina" (queue redo button in `QueueSidePanelFooterActions`; it collided with playback "Repeat", also "Ripeti"; macOS standard is Annulla/Ripristina)
- `Redo the last undone queue change.`: "Ripeti l'ultima…" → "Ripristina l'ultima…"

## Testing

- [ ] Unit tests pass (`xcodebuild test -only-testing:KasetTests`)
- [x] Manual testing performed
- [ ] UI tested on macOS 26+

This is a strings-only `.xcstrings` change, so there is no Swift lint/format impact. `swift build` still succeeds. The corrected strings were reviewed in context by a native Italian speaker.

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have run `swiftlint --strict && swiftformat .` <!-- N/A: strings-only change, no Swift files affected -->
- [ ] I have added tests that prove my fix/feature works <!-- N/A: localization value change -->
- [x] New and existing unit tests pass locally
- [ ] I have updated documentation if needed <!-- N/A -->
- [x] I have checked for any performance implications
- [x] My changes generate no new warnings

## Additional Notes

Only the Italian (`it`) localization was affected. The other 14 languages were reviewed for these same strings and were already correct, so no other locale needed changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
