### PR TITLE
fix(player): keep now-playing like status in sync with the like cache

### DIFF
--- a/Sources/Kaset/Services/Player/PlayerService+Library.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+Library.swift
@@ -324,6 +324,39 @@ extension PlayerService {
         self.currentTrackFeedbackTokens = nil
     }
 
+    /// Refreshes the now-playing track's like status from the `SongLikeStatusManager`
+    /// cache. Bulk sources (e.g. the Liked Music page) seed like state *after* the
+    /// current track may have already resolved to `.indifferent` — its `getSong` fetch
+    /// returns no rating, and the cache can be empty at play time. Without this, the
+    /// player bar / Now Playing surfaces (and the boring.notch mirror) keep showing
+    /// "not liked" for a track that is actually liked. Only fills an unknown status;
+    /// never overrides a known `.like` / `.dislike`.
+    func refreshCurrentTrackLikeStatusFromCache() {
+        guard self.currentTrackLikeStatus == .indifferent,
+              let videoId = self.currentTrack?.videoId,
+              let cached = self.songLikeStatusManager.status(for: videoId)
+        else { return }
+        self.currentTrackLikeStatus = cached
+    }
+
+    /// Keeps the now-playing like status in sync with the like cache. The status has no
+    /// reliable synchronous source (getSong returns no rating; the account-scoped cache is
+    /// seeded asynchronously by the Liked Music page and cleared then refilled across login
+    /// identity switches), so a one-shot read at track load races and leaves it stuck at
+    /// `.indifferent`. Re-resolving whenever the track or the cache changes makes it
+    /// self-correcting the moment the user's likes finish loading.
+    func observeNowPlayingLikeStatus() {
+        withObservationTracking {
+            _ = self.currentTrack?.videoId
+            _ = self.songLikeStatusManager.cacheGeneration
+        } onChange: {
+            Task { @MainActor [weak self] in
+                self?.refreshCurrentTrackLikeStatusFromCache()
+                self?.observeNowPlayingLikeStatus()
+            }
+        }
+    }
+
     private func applyLibraryState(
         videoId: String,
         isInLibrary: Bool,

--- a/Sources/Kaset/Services/Player/PlayerService+PlaybackRestoration.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+PlaybackRestoration.swift
@@ -314,7 +314,12 @@ extension PlayerService {
     /// via the existing restored-session machinery.
     func reloadCurrentTrackForIdentitySwitch() {
         self.accountSessionGeneration &+= 1
-        self.songLikeStatusManager.invalidateSession()
+        // Do NOT wipe the like cache here. On launch this fires AFTER the Liked Music page
+        // seeds its first page (rows 1-100), and the paging re-seed only covers pages 2+,
+        // so clearing permanently drops the top ~100 liked tracks from the cache — the songs
+        // shown first read "not liked". Bump the session generation but keep the cache;
+        // account scoping + the reactive now-playing resolver keep it correct.
+        self.songLikeStatusManager.invalidateSession(clearsActiveCache: false)
         self.beginMusicPlaybackIntent()
         self.cancelDeferredQueueWork()
         self.clearQueueUndoRedoHistory()

--- a/Sources/Kaset/Services/Player/PlayerService.swift
+++ b/Sources/Kaset/Services/Player/PlayerService.swift
@@ -444,6 +444,7 @@ final class PlayerService: NSObject, PlayerServiceProtocol {
 
     override init() {
         super.init()
+        self.observeNowPlayingLikeStatus()
         // Restore saved volume from UserDefaults
         if UserDefaults.standard.object(forKey: Self.volumeKey) != nil {
             let savedVolume = UserDefaults.standard.double(forKey: Self.volumeKey)

--- a/Sources/Kaset/Services/SongLikeStatusManager.swift
+++ b/Sources/Kaset/Services/SongLikeStatusManager.swift
@@ -39,8 +39,16 @@ final class SongLikeStatusManager {
     private static let primaryAccountID = "primary"
     static let guestAccountID = "guest"
 
+    /// Bumped on every cache mutation so observers (the now-playing like status) can
+    /// re-resolve when likes are (re)seeded. The Liked Music seed can land after a track
+    /// already resolved to `.indifferent`, and the cache is cleared then refilled across
+    /// login identity switches — a one-shot read at track load misses it.
+    private(set) var cacheGeneration: UInt64 = 0
+
     /// Cache of account ID to (video ID to like status).
-    private var statusCacheByAccount: [String: [String: LikeStatus]] = [:]
+    private var statusCacheByAccount: [String: [String: LikeStatus]] = [:] {
+        didSet { self.cacheGeneration &+= 1 }
+    }
 
     /// Monotonic latest-operation revisions scoped by account and video ID.
     private var sessionGeneration: UInt64 = 0


### PR DESCRIPTION
## Summary

The now-playing like status (the player-bar heart, and any external Now Playing
surface) can stay stuck at "not liked" for tracks that are actually liked. This
is a regression from #374, which made the now-playing like status depend
entirely on the account-scoped `SongLikeStatusManager` cache.

## Root cause

`getSong` (the `next` endpoint backing the now-playing track) returns no like
rating, so after #374 the now-playing status is populated solely from the
`SongLikeStatusManager` cache. Two things make a one-shot read at track load
unreliable:

1. **Async seed race** — the cache is seeded asynchronously by the Liked Music
   page. If a track resolves to `.indifferent` before that seed lands, nothing
   re-reads it, so it stays "not liked".
2. **First-page wipe on launch** — `reloadCurrentTrackForIdentitySwitch` fires
   on launch, *after* the Liked Music page has already seeded its first page
   (rows 1–100), then calls `invalidateSession()`, which clears the active
   cache. The paging re-seed only covers pages 2+, so the top ~100 liked tracks
   are permanently dropped from the cache and read "not liked".

## Fix

Two small, targeted commits:

1. **Reactive resolver** — add a `cacheGeneration` signal bumped on every cache
   mutation, and have `PlayerService` re-resolve the current track's status via
   `withObservationTracking` whenever the track or the cache changes. The status
   self-corrects the moment the user's likes finish loading. It only fills an
   unknown (`.indifferent`) status and never overrides a known `.like`/`.dislike`.
2. **Preserve the cache across the launch identity reload** —
   `reloadCurrentTrackForIdentitySwitch` now calls
   `invalidateSession(clearsActiveCache: false)`, bumping the session generation
   without wiping the first-page seed. Account scoping plus the reactive resolver
   keep the status correct.

## Testing

- `swift build` — clean
- `swift test --skip KasetUITests` — 2281 tests pass
- `swiftlint --strict` and `swiftformat --lint` on the changed files — clean
- Verified manually: a top-of-list liked track that previously showed "not
  liked" on the now-playing surfaces now shows liked.
