### PR TITLE
fix(player): de-flake Smart Shuffle tests by reading config per-instance

### DIFF
--- a/Sources/Kaset/Services/Player/PlayerService+SmartShuffle.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+SmartShuffle.swift
@@ -4,6 +4,16 @@ import Foundation
 
 @MainActor
 extension PlayerService {
+    /// Numeric tuning for the Smart Shuffle fill loop, read via ``smartShuffleConfigProvider``.
+    /// Injecting it per instance lets tests configure one `PlayerService` instead of mutating the
+    /// shared `SettingsManager` singleton — cross-suite mutation of that singleton races when the
+    /// test suites run in parallel.
+    struct SmartShuffleConfig {
+        let suggestEveryN: Int
+        let burst: Int
+        let suggestionsAhead: Int
+    }
+
     static func resolvedShuffleMode(
         _ mode: ShuffleMode,
         smartShuffleEnabled: Bool
@@ -125,9 +135,10 @@ extension PlayerService {
     /// The actual fill loop, run inside the stored single-flight task. Assumes the entry guards in
     /// ``fillSmartShuffleWindow()`` already passed; bails promptly on cancellation or a mode change.
     private func performSmartShuffleFill() async {
-        let everyN = max(1, SettingsManager.shared.smartShuffleSuggestEveryN)
-        let burst = max(1, SettingsManager.shared.smartShuffleBurst)
-        let target = max(1, SettingsManager.shared.smartShuffleSuggestionsAhead)
+        let config = self.smartShuffleConfigProvider()
+        let everyN = max(1, config.suggestEveryN)
+        let burst = max(1, config.burst)
+        let target = max(1, config.suggestionsAhead)
 
         // Seeds whose radio threw this pass: skipped for the rest of the pass (so later slots still
         // fill) but NOT banned for the session — a transient error should be retried next advance.

--- a/Sources/Kaset/Services/Player/PlayerService.swift
+++ b/Sources/Kaset/Services/Player/PlayerService.swift
@@ -22,6 +22,18 @@ final class PlayerService: NSObject, PlayerServiceProtocol {
         SettingsManager.shared.smartShuffleEnabled
     }
 
+    /// Numeric Smart Shuffle tuning consumed by the fill loop (`performSmartShuffleFill`).
+    /// Injectable like ``smartShuffleFeatureEnabled`` so tests configure a single instance instead
+    /// of mutating the shared `SettingsManager` singleton; mutating that singleton races across the
+    /// test suites that run in parallel. Defaults to the live user settings.
+    @ObservationIgnored var smartShuffleConfigProvider: @MainActor () -> SmartShuffleConfig = {
+        SmartShuffleConfig(
+            suggestEveryN: SettingsManager.shared.smartShuffleSuggestEveryN,
+            burst: SettingsManager.shared.smartShuffleBurst,
+            suggestionsAhead: SettingsManager.shared.smartShuffleSuggestionsAhead
+        )
+    }
+
     @ObservationIgnored var queuePersistenceDefaults: UserDefaults = .standard
 
     @ObservationIgnored var onMusicPlaybackNavigationRequested: ((String, Bool) -> Void)?

--- a/Tests/KasetTests/PlayerServiceQueueHistoryTests.swift
+++ b/Tests/KasetTests/PlayerServiceQueueHistoryTests.swift
@@ -515,18 +515,12 @@ extension PlayerServiceQueueTests {
 
     @Test("Pause during undo metadata preserves structural finalization")
     func pauseDuringUndoMetadataPreservesStructuralFinalization() async {
-        let settings = SettingsManager.shared
-        let savedAhead = settings.smartShuffleSuggestionsAhead
-        let savedEveryN = settings.smartShuffleSuggestEveryN
-        let savedBurst = settings.smartShuffleBurst
         self.playerService.smartShuffleFeatureEnabled = { true }
-        settings.smartShuffleSuggestionsAhead = 1
-        settings.smartShuffleSuggestEveryN = 1
-        settings.smartShuffleBurst = 1
-        defer {
-            settings.smartShuffleSuggestionsAhead = savedAhead
-            settings.smartShuffleSuggestEveryN = savedEveryN
-            settings.smartShuffleBurst = savedBurst
+        // Configure Smart Shuffle on this instance instead of the shared SettingsManager
+        // singleton: the fill loop reads `smartShuffleConfigProvider`, so mutating the global
+        // here would race with the (parallel) Smart Shuffle suite that also touches it.
+        self.playerService.smartShuffleConfigProvider = {
+            PlayerService.SmartShuffleConfig(suggestEveryN: 1, burst: 1, suggestionsAhead: 1)
         }
 
         let restored = Song(

--- a/Tests/KasetTests/PlayerServiceSmartShuffleTests.swift
+++ b/Tests/KasetTests/PlayerServiceSmartShuffleTests.swift
@@ -74,6 +74,54 @@ struct PlayerServiceSmartShuffleTests {
         #expect(self.playerService.queueEntries.contains { $0.source == .suggested })
     }
 
+    /// Regression guard for a cross-suite flake: the fill loop used to read `SettingsManager.shared`
+    /// directly, so a parallel suite mutating those settings changed suggestion output here. Two
+    /// instances given OPPOSITE per-instance configs on identical queues must diverge — which can
+    /// only happen if each honors its own provider. Reading the shared singleton would make both
+    /// read the same value and behave identically, so this asserts the fix independently of whatever
+    /// the ambient global cadence happens to be.
+    @Test("Smart Shuffle fill honors the injected config, not the shared settings singleton")
+    func fillHonorsInjectedConfigOverGlobalSettings() async {
+        func makeService() -> (PlayerService, MockYTMusicClient) {
+            let client = MockYTMusicClient()
+            let service = PlayerService()
+            service.smartShuffleFeatureEnabled = { true }
+            service.useQueuePersistenceNamespaceForTesting("SmartShuffleConfigInjection-\(UUID().uuidString)")
+            service.clearSavedQueue()
+            service.setYTMusicClient(client)
+            service.confirmPlaybackStarted()
+            return (service, client)
+        }
+
+        let songs = TestFixtures.makeSongs(count: 4)
+
+        // Suppressing config: a cadence far larger than the queue leaves no slot to fill.
+        let (suppressed, suppressedClient) = makeService()
+        suppressed.smartShuffleConfigProvider = {
+            PlayerService.SmartShuffleConfig(suggestEveryN: 1000, burst: 1, suggestionsAhead: 1)
+        }
+        // Enabling config: suggest after every track.
+        let (enabled, enabledClient) = makeService()
+        enabled.smartShuffleConfigProvider = {
+            PlayerService.SmartShuffleConfig(suggestEveryN: 1, burst: 1, suggestionsAhead: 1)
+        }
+        for song in songs {
+            suppressedClient.radioQueueSongs[song.videoId] = [TestFixtures.makeSong(id: "rec-\(song.videoId)")]
+            enabledClient.radioQueueSongs[song.videoId] = [TestFixtures.makeSong(id: "rec-\(song.videoId)")]
+        }
+
+        await suppressed.playQueue(songs, startingAt: 0)
+        suppressed.setShuffleMode(.smart)
+        await suppressed.fillSmartShuffleWindow()
+
+        await enabled.playQueue(songs, startingAt: 0)
+        enabled.setShuffleMode(.smart)
+        await enabled.fillSmartShuffleWindow()
+
+        #expect(!suppressed.queueEntries.contains { $0.source == .suggested })
+        #expect(enabled.queueEntries.contains { $0.source == .suggested })
+    }
+
     @Test("leaving smart mode strips suggestions")
     func leavingSmartStrips() async {
         let songs = TestFixtures.makeSongs(count: 6)
@@ -132,17 +180,8 @@ struct PlayerServiceSmartShuffleTests {
 
     @Test("Redoing Smart Shuffle restarts the canceled recommendation fill")
     func redoSmartShuffleRestartsCanceledFill() async {
-        let settings = SettingsManager.shared
-        let savedAhead = settings.smartShuffleSuggestionsAhead
-        let savedEveryN = settings.smartShuffleSuggestEveryN
-        let savedBurst = settings.smartShuffleBurst
-        settings.smartShuffleSuggestionsAhead = 1
-        settings.smartShuffleSuggestEveryN = 1
-        settings.smartShuffleBurst = 1
-        defer {
-            settings.smartShuffleSuggestionsAhead = savedAhead
-            settings.smartShuffleSuggestEveryN = savedEveryN
-            settings.smartShuffleBurst = savedBurst
+        self.playerService.smartShuffleConfigProvider = {
+            PlayerService.SmartShuffleConfig(suggestEveryN: 1, burst: 1, suggestionsAhead: 1)
         }
 
         let songs = TestFixtures.makeSongs(count: 3)
@@ -318,14 +357,12 @@ struct PlayerServiceSmartShuffleTests {
         // Force lazy top-up: a small look-ahead window (min 5) with one slot per original means
         // the engine cannot place every possible suggestion up front, so advancing past them must
         // trigger additional radio fetches.
-        let settings = SettingsManager.shared
-        let savedAhead = settings.smartShuffleSuggestionsAhead
-        let savedEveryN = settings.smartShuffleSuggestEveryN
-        settings.smartShuffleSuggestionsAhead = 5
-        settings.smartShuffleSuggestEveryN = 1
-        defer {
-            settings.smartShuffleSuggestionsAhead = savedAhead
-            settings.smartShuffleSuggestEveryN = savedEveryN
+        self.playerService.smartShuffleConfigProvider = {
+            PlayerService.SmartShuffleConfig(
+                suggestEveryN: 1,
+                burst: SettingsManager.smartShuffleBurstDefault,
+                suggestionsAhead: 5
+            )
         }
 
         let songs = TestFixtures.makeSongs(count: 10) // video-0...video-9
@@ -580,6 +617,10 @@ struct PlayerServiceSmartShuffleTests {
         #expect(PlayerService.resolvedShuffleMode(.smart, smartShuffleEnabled: false) == .on)
     }
 
+    /// This is the only test that still mutates the shared SettingsManager Smart Shuffle values.
+    /// It MUST stay synchronous: with no `await` between the mutation and the `defer` restore it runs
+    /// atomically on the main actor, so it cannot interleave with a parallel suite's default-provider
+    /// fill and clobber it. Do not make it `async` or add an `await` inside the mutation window.
     @Test("clamped Smart Shuffle numeric settings persist the corrected values")
     func clampedSmartShuffleSettingsPersist() {
         let settings = SettingsManager.shared
@@ -751,10 +792,13 @@ struct PlayerServiceSmartShuffleTests {
 
     @Test("switching playlists in smart mode resets seen state so the new queue gets suggestions (#4)")
     func switchingPlaylistsResetsSmartState() async {
-        let settings = SettingsManager.shared
-        let savedEveryN = settings.smartShuffleSuggestEveryN
-        settings.smartShuffleSuggestEveryN = 1
-        defer { settings.smartShuffleSuggestEveryN = savedEveryN }
+        self.playerService.smartShuffleConfigProvider = {
+            PlayerService.SmartShuffleConfig(
+                suggestEveryN: 1,
+                burst: SettingsManager.smartShuffleBurstDefault,
+                suggestionsAhead: SettingsManager.smartShuffleSuggestionsAheadDefault
+            )
+        }
 
         // Playlist A: every seed's radio offers the same "shared-rec".
         let aSongs = (0 ..< 4).map { TestFixtures.makeSong(id: "a-\($0)") }
@@ -780,10 +824,13 @@ struct PlayerServiceSmartShuffleTests {
 
     @Test("a radio error on one seed does not abort the whole fill pass (#9)")
     func radioThrowOnOneSeedStillFillsOthers() async {
-        let settings = SettingsManager.shared
-        let savedEveryN = settings.smartShuffleSuggestEveryN
-        settings.smartShuffleSuggestEveryN = 1
-        defer { settings.smartShuffleSuggestEveryN = savedEveryN }
+        self.playerService.smartShuffleConfigProvider = {
+            PlayerService.SmartShuffleConfig(
+                suggestEveryN: 1,
+                burst: SettingsManager.smartShuffleBurstDefault,
+                suggestionsAhead: SettingsManager.smartShuffleSuggestionsAheadDefault
+            )
+        }
 
         let songs = TestFixtures.makeSongs(count: 6)
         await self.playerService.playQueue(songs, startingAt: 0)


### PR DESCRIPTION
## Summary

Fixes a pre-existing flaky unit test that fails only on the `macos-15` CI runner:
`PlayerServiceQueueHistoryTests` → "Pause during undo metadata preserves
structural finalization". It has been failing on `main` itself and on unrelated
PRs (e.g. a localization-only branch), so it is not tied to any one change — it
is a genuine test-infrastructure race.

## Root cause

The Smart Shuffle fill loop (`performSmartShuffleFill`) read its numeric tuning
straight from the global `SettingsManager.shared` singleton
(`smartShuffleSuggestEveryN` / `smartShuffleBurst` / `smartShuffleSuggestionsAhead`).

Two suites — `PlayerServiceQueueTests` and `PlayerServiceSmartShuffleTests` —
mutate those global values. Both are `@Suite(.serialized)`, but `.serialized`
only orders tests *within* a suite; the two suites still run **in parallel with
each other** (Swift Testing runs suites concurrently, and CI runs
`swift test` without `--no-parallel`). While one suite's async test is suspended
at an `await` with the settings perturbed, the other suite's fill reads the
clobbered values and produces a different number of suggestions — so the
assertion intermittently fails. The slower macos-15 runner hits the bad
interleaving far more often than macos-26.

## Fix

Add a per-instance injection seam, mirroring the existing
`smartShuffleFeatureEnabled` closure: a `smartShuffleConfigProvider` returning a
small `SmartShuffleConfig`. The fill loop reads from it; the default provider
reads the same `SettingsManager` values, so **production behavior is unchanged**.

Tests that exercised the fill now configure their own `PlayerService` instance
instead of mutating the shared singleton, removing the shared mutable state from
the concurrent test path. The lone remaining global mutator
(`clampedSmartShuffleSettingsPersist`) is synchronous and self-contained — it
tests the settings clamping itself and cannot interleave.

A new regression test (`fillHonorsInjectedConfigOverGlobalSettings`) gives two
instances opposite per-instance configs on identical queues and asserts they
diverge — which can only hold if each honors its own provider, independent of
the ambient global. It fails against the old global-reading code and passes
against the fix.

## Testing

- `swift build` — clean
- `swift test --skip KasetUITests` — 2282 tests pass (4 consecutive runs)
- `swiftlint --strict` and `swiftformat --lint` — clean
- Verified the new test is a true regression guard: red on the pre-fix
  global-read, green on the fix.
