### PR TITLE
fix(library): reconcile liked music rating races

### DIFF
--- a/Sources/Kaset/Services/Auth/AuthService.swift
+++ b/Sources/Kaset/Services/Auth/AuthService.swift
@@ -175,6 +175,7 @@ final class AuthService: AuthServiceProtocol {
         self.logger.warning("Session expired, requiring re-authentication")
         self.needsReauth = true
         self.isGuestModeEnabled = false
+        SongLikeStatusManager.shared.clearCache()
         self.state = .loggedOut
         self.stateBeforeLogin = nil
         // Drop cached personalized responses so a later login in the same

--- a/Sources/Kaset/Services/Player/PlayerService+Library.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+Library.swift
@@ -349,7 +349,7 @@ extension PlayerService {
         withObservationTracking {
             _ = self.currentTrack?.videoId
             _ = self.songLikeStatusManager.cacheGeneration
-        } onChange: {
+        } onChange: { [weak self] in
             Task { @MainActor [weak self] in
                 self?.refreshCurrentTrackLikeStatusFromCache()
                 self?.observeNowPlayingLikeStatus()

--- a/Sources/Kaset/Services/Player/PlayerService+Library.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+Library.swift
@@ -440,9 +440,12 @@ extension PlayerService {
                 && self.accountSessionGeneration == accountSessionGeneration
                 && !libraryMutationWasPending
                 && self.pendingLibraryMutationCountsByKey[pendingMutationKey, default: 0] == 0
-            let resolvedLikeStatus = ratingRevisionIsCurrent
-                ? (songData.likeStatus ?? cachedLikeStatus)
-                : (cachedLikeStatus ?? self.currentTrackLikeStatus)
+            let resolvedLikeStatus = self.resolveFetchedLikeStatus(
+                videoId: videoId,
+                apiLikeStatus: songData.likeStatus,
+                cachedLikeStatus: cachedLikeStatus,
+                ratingRevisionIsCurrent: ratingRevisionIsCurrent
+            )
 
             // Update current track with full metadata if it's still the same song
             if self.currentTrack?.videoId == videoId {
@@ -474,11 +477,8 @@ extension PlayerService {
                 // Update service state and sync with SongLikeStatusManager.
                 // Unknown like status stays out of the cache so it cannot override
                 // a known rating from the WebView or a prior user action.
-                if ratingRevisionIsCurrent, let likeStatus = songData.likeStatus {
-                    self.currentTrackLikeStatus = likeStatus
-                    self.songLikeStatusManager.setStatus(likeStatus, for: videoId)
-                } else if let cachedLikeStatus {
-                    self.currentTrackLikeStatus = cachedLikeStatus
+                if let resolvedLikeStatus {
+                    self.currentTrackLikeStatus = resolvedLikeStatus
                 }
                 if libraryMutationIsCurrent {
                     self.applyLibraryState(
@@ -514,6 +514,21 @@ extension PlayerService {
         } catch {
             self.logger.warning("Failed to fetch song metadata: \(error.localizedDescription)")
         }
+    }
+
+    private func resolveFetchedLikeStatus(
+        videoId: String,
+        apiLikeStatus: LikeStatus?,
+        cachedLikeStatus: LikeStatus?,
+        ratingRevisionIsCurrent: Bool
+    ) -> LikeStatus? {
+        guard ratingRevisionIsCurrent, let apiLikeStatus else {
+            return cachedLikeStatus ?? self.currentTrackLikeStatus
+        }
+        let accepted = self.songLikeStatusManager.setStatus(apiLikeStatus, for: videoId)
+        return accepted
+            ? apiLikeStatus
+            : (self.songLikeStatusManager.status(for: videoId) ?? self.currentTrackLikeStatus)
     }
 
     private func applyFetchedMetadataToQueue(

--- a/Sources/Kaset/Services/SongLikeStatusManager.swift
+++ b/Sources/Kaset/Services/SongLikeStatusManager.swift
@@ -578,12 +578,14 @@ final class SongLikeStatusManager {
     /// - Parameters:
     ///   - videoId: The video ID.
     ///   - status: The like status.
-    func setStatus(_ status: LikeStatus, for videoId: String) {
+    @discardableResult
+    func setStatus(_ status: LikeStatus, for videoId: String) -> Bool {
         let accountID = self.activeAccountID
-        guard !self.shouldPreserveLocalRating(for: videoId, accountID: accountID) else { return }
+        guard !self.shouldPreserveLocalRating(for: videoId, accountID: accountID) else { return false }
         self.setStatus(status, for: videoId, accountID: accountID)
         self.setConfirmedStatus(status, for: videoId, accountID: accountID)
         self.localRatingOverlayByAccount[accountID]?.removeValue(forKey: videoId)
+        return true
     }
 
     /// Updates the visible cache without advancing the API-confirmed rollback baseline.

--- a/Sources/Kaset/Services/SongLikeStatusManager.swift
+++ b/Sources/Kaset/Services/SongLikeStatusManager.swift
@@ -579,9 +579,11 @@ final class SongLikeStatusManager {
     ///   - videoId: The video ID.
     ///   - status: The like status.
     func setStatus(_ status: LikeStatus, for videoId: String) {
-        self.setStatus(status, for: videoId, accountID: self.activeAccountID)
-        self.setConfirmedStatus(status, for: videoId, accountID: self.activeAccountID)
-        self.localRatingOverlayByAccount[self.activeAccountID]?.removeValue(forKey: videoId)
+        let accountID = self.activeAccountID
+        guard !self.shouldPreserveLocalRating(for: videoId, accountID: accountID) else { return }
+        self.setStatus(status, for: videoId, accountID: accountID)
+        self.setConfirmedStatus(status, for: videoId, accountID: accountID)
+        self.localRatingOverlayByAccount[accountID]?.removeValue(forKey: videoId)
     }
 
     /// Updates the visible cache without advancing the API-confirmed rollback baseline.
@@ -604,7 +606,10 @@ final class SongLikeStatusManager {
         let resolvedAccountID = accountID.map(Self.resolvedAccountID) ?? self.activeAccountID
         var cache = self.statusCacheByAccount[resolvedAccountID] ?? [:]
 
-        for videoId in videoIds {
+        for videoId in videoIds where !self.shouldPreserveLocalRating(
+            for: videoId,
+            accountID: resolvedAccountID
+        ) {
             cache[videoId] = status
             self.setConfirmedStatus(status, for: videoId, accountID: resolvedAccountID)
         }
@@ -662,17 +667,24 @@ final class SongLikeStatusManager {
     }
 
     private func restorePendingRatings(for accountID: String) -> [LikeStatusEvent] {
-        (self.pendingRatingByAccount[accountID] ?? [:]).map { videoId, pendingRating in
-            let confirmedStatus = self.confirmedStatus(for: videoId, accountID: accountID)
-            self.restoreStatus(confirmedStatus, for: videoId, accountID: accountID)
-            self.localRatingOverlayByAccount[accountID]?.removeValue(forKey: videoId)
-            return LikeStatusEvent(
-                videoId: videoId,
-                status: confirmedStatus ?? .indifferent,
-                song: pendingRating.song,
-                addsLikedMusicMembership: false
-            )
-        }
+        (self.pendingRatingByAccount[accountID] ?? [:])
+            .sorted { lhs, rhs in lhs.value.revision < rhs.value.revision }
+            .map { videoId, pendingRating in
+                let confirmedStatus = self.confirmedStatus(for: videoId, accountID: accountID)
+                self.restoreStatus(confirmedStatus, for: videoId, accountID: accountID)
+                self.localRatingOverlayByAccount[accountID]?.removeValue(forKey: videoId)
+                return LikeStatusEvent(
+                    videoId: videoId,
+                    status: confirmedStatus ?? .indifferent,
+                    song: pendingRating.song,
+                    addsLikedMusicMembership: false
+                )
+            }
+    }
+
+    private func shouldPreserveLocalRating(for videoId: String, accountID: String) -> Bool {
+        self.pendingRatingByAccount[accountID]?[videoId] != nil
+            || self.localRatingOverlayByAccount[accountID]?[videoId]?.protectedRequestIDs.isEmpty == false
     }
 
     func ratingRevision(for videoId: String, accountID: String? = nil) -> UInt64 {

--- a/Sources/Kaset/Services/SongLikeStatusManager.swift
+++ b/Sources/Kaset/Services/SongLikeStatusManager.swift
@@ -7,11 +7,61 @@ struct LikeStatusEvent: Equatable {
     let videoId: String
     let status: LikeStatus
     let song: Song?
-    private let eventId = UUID()
+    let addsLikedMusicMembership: Bool?
+    private let eventId: UUID
+
+    init(
+        videoId: String,
+        status: LikeStatus,
+        song: Song?,
+        addsLikedMusicMembership: Bool? = nil
+    ) {
+        self.videoId = videoId
+        self.status = status
+        self.song = song
+        self.addsLikedMusicMembership = addsLikedMusicMembership
+        self.eventId = UUID()
+    }
 
     static func == (lhs: LikeStatusEvent, rhs: LikeStatusEvent) -> Bool {
         lhs.eventId == rhs.eventId
     }
+}
+
+// MARK: - LikeStatusEventBatch
+
+struct LikeStatusEventBatch: Equatable {
+    let accountID: String
+    let events: [LikeStatusEvent]
+    private let batchId: UUID
+
+    init(accountID: String, events: [LikeStatusEvent]) {
+        self.accountID = accountID
+        self.events = events
+        self.batchId = UUID()
+    }
+
+    static func == (lhs: LikeStatusEventBatch, rhs: LikeStatusEventBatch) -> Bool {
+        lhs.batchId == rhs.batchId
+    }
+}
+
+// MARK: - LikedMusicRequestSnapshot
+
+struct LikedMusicRequestSnapshot: Equatable {
+    let accountID: String
+    let scopeGeneration: UInt64
+    let requestID: UInt64
+}
+
+// MARK: - LikedMusicReconciliation
+
+struct LikedMusicReconciliation {
+    let tracks: [Song]
+    let filteredVideoIDs: Set<String>
+    let insertedVideoIDs: Set<String>
+    let localOverlayVideoIDs: Set<String>
+    let newLikedMembershipVideoIDs: Set<String>
 }
 
 // MARK: - SongLikeStatusManager
@@ -33,6 +83,20 @@ final class SongLikeStatusManager {
         let sessionGeneration: UInt64
     }
 
+    private struct PendingRating {
+        let revision: UInt64
+        let status: LikeStatus
+        let song: Song
+    }
+
+    private struct LocalRatingOverlay {
+        let revision: UInt64
+        let status: LikeStatus
+        let song: Song
+        let addsLikedMusicMembership: Bool
+        var protectedRequestIDs: Set<UInt64>
+    }
+
     /// Shared singleton instance.
     static let shared = SongLikeStatusManager()
 
@@ -52,9 +116,14 @@ final class SongLikeStatusManager {
 
     /// Monotonic latest-operation revisions scoped by account and video ID.
     private var sessionGeneration: UInt64 = 0
+    private(set) var requestScopeGeneration: UInt64 = 0
+    private var likedMusicRequestCounter: UInt64 = 0
+    private var activeLikedMusicRequestIDsByAccount: [String: Set<UInt64>] = [:]
     private var ratingRevisionCounter: UInt64 = 0
     private var ratingRevisionByAccount: [String: [String: UInt64]] = [:]
     private var confirmedStatusByAccount: [String: [String: ConfirmedRatingStatus]] = [:]
+    private var pendingRatingByAccount: [String: [String: PendingRating]] = [:]
+    private var localRatingOverlayByAccount: [String: [String: LocalRatingOverlay]] = [:]
     @ObservationIgnored private var ratingMutationTails: [String: Task<Result<Void, any Error>, Never>] = [:]
     @ObservationIgnored private var ratingMutationTailRevisions: [String: UInt64] = [:]
 
@@ -63,6 +132,7 @@ final class SongLikeStatusManager {
 
     /// The most recent like status change event, for reactive observation by views.
     private(set) var lastLikeEvent: LikeStatusEvent?
+    private(set) var lastLikeEventBatch: LikeStatusEventBatch?
 
     /// Reference to the YTMusic client for API calls.
     private var client: (any YTMusicClientProtocol)?
@@ -88,8 +158,10 @@ final class SongLikeStatusManager {
         let resolvedAccountID = Self.resolvedAccountID(accountID)
         guard self.activeAccountID != resolvedAccountID else { return }
 
-        self.invalidateSession(clearsActiveCache: false)
+        self.invalidateSession(clearsActiveCache: false, publishesRollbackEvents: false)
         self.activeAccountID = resolvedAccountID
+        self.lastLikeEvent = nil
+        self.lastLikeEventBatch = nil
         DiagnosticsLogger.api.debug("SongLikeStatusManager: Switched cache scope to account \(resolvedAccountID)")
     }
 
@@ -121,6 +193,125 @@ final class SongLikeStatusManager {
     /// - Returns: True if the song is disliked.
     func isDisliked(_ song: Song) -> Bool {
         self.status(for: song) == .dislike
+    }
+
+    func beginLikedMusicRequest() -> LikedMusicRequestSnapshot {
+        let accountID = self.activeAccountID
+        self.likedMusicRequestCounter &+= 1
+        let requestID = self.likedMusicRequestCounter
+        self.activeLikedMusicRequestIDsByAccount[accountID, default: []].insert(requestID)
+        if var overlays = self.localRatingOverlayByAccount[accountID] {
+            for (videoId, var overlay) in overlays
+                where self.pendingRatingByAccount[accountID]?[videoId] != nil
+                || !overlay.protectedRequestIDs.isEmpty
+            {
+                overlay.protectedRequestIDs.insert(requestID)
+                overlays[videoId] = overlay
+            }
+            self.localRatingOverlayByAccount[accountID] = overlays
+        }
+        return LikedMusicRequestSnapshot(
+            accountID: accountID,
+            scopeGeneration: self.requestScopeGeneration,
+            requestID: requestID
+        )
+    }
+
+    func finishLikedMusicRequest(_ snapshot: LikedMusicRequestSnapshot) {
+        self.activeLikedMusicRequestIDsByAccount[snapshot.accountID]?.remove(snapshot.requestID)
+        if self.activeLikedMusicRequestIDsByAccount[snapshot.accountID]?.isEmpty == true {
+            self.activeLikedMusicRequestIDsByAccount.removeValue(forKey: snapshot.accountID)
+        }
+        guard var overlays = self.localRatingOverlayByAccount[snapshot.accountID] else { return }
+        for (videoId, var overlay) in overlays {
+            overlay.protectedRequestIDs.remove(snapshot.requestID)
+            if overlay.protectedRequestIDs.isEmpty,
+               self.pendingRatingByAccount[snapshot.accountID]?[videoId] == nil
+            {
+                overlays.removeValue(forKey: videoId)
+            } else {
+                overlays[videoId] = overlay
+            }
+        }
+        self.localRatingOverlayByAccount[snapshot.accountID] = overlays.isEmpty ? nil : overlays
+    }
+
+    func matchesCurrentScope(_ snapshot: LikedMusicRequestSnapshot) -> Bool {
+        self.activeAccountID == snapshot.accountID
+            && self.requestScopeGeneration == snapshot.scopeGeneration
+    }
+
+    func reconcileLikedMusicTracks(
+        _ tracks: [Song],
+        snapshot: LikedMusicRequestSnapshot,
+        deduplicating: Bool = false
+    ) -> LikedMusicReconciliation? {
+        guard self.matchesCurrentScope(snapshot) else { return nil }
+
+        var acceptedTracks: [Song] = []
+        var filteredVideoIDs: Set<String> = []
+        var insertedVideoIDs: Set<String> = []
+        var localOverlayVideoIDs: Set<String> = []
+        var newLikedMembershipVideoIDs: Set<String> = []
+        var seenVideoIDs: Set<String> = []
+        var cache = self.statusCacheByAccount[snapshot.accountID] ?? [:]
+        let overlays = self.localRatingOverlayByAccount[snapshot.accountID] ?? [:]
+        var didMutateCache = false
+
+        for var song in tracks {
+            if deduplicating, !seenVideoIDs.insert(song.videoId).inserted {
+                continue
+            }
+            if let overlay = overlays[song.videoId],
+               overlay.protectedRequestIDs.contains(snapshot.requestID)
+            {
+                localOverlayVideoIDs.insert(song.videoId)
+                guard overlay.status == .like else {
+                    filteredVideoIDs.insert(song.videoId)
+                    continue
+                }
+                if overlay.addsLikedMusicMembership {
+                    newLikedMembershipVideoIDs.insert(song.videoId)
+                }
+            } else {
+                cache[song.videoId] = .like
+                self.setConfirmedStatus(.like, for: song.videoId, accountID: snapshot.accountID)
+                didMutateCache = true
+            }
+            song.likeStatus = .like
+            acceptedTracks.append(song)
+        }
+
+        var acceptedVideoIDs = Set(acceptedTracks.map(\.videoId))
+        let missingLikedOverlays = overlays.filter { videoId, overlay in
+            overlay.protectedRequestIDs.contains(snapshot.requestID)
+                && overlay.status == .like
+                && !acceptedVideoIDs.contains(videoId)
+        }.sorted { lhs, rhs in
+            lhs.value.revision < rhs.value.revision
+        }
+        for (videoId, overlay) in missingLikedOverlays {
+            var song = overlay.song
+            song.likeStatus = .like
+            acceptedTracks.insert(song, at: 0)
+            acceptedVideoIDs.insert(videoId)
+            insertedVideoIDs.insert(videoId)
+            localOverlayVideoIDs.insert(videoId)
+            if overlay.addsLikedMusicMembership {
+                newLikedMembershipVideoIDs.insert(videoId)
+            }
+        }
+
+        if didMutateCache {
+            self.statusCacheByAccount[snapshot.accountID] = cache
+        }
+        return LikedMusicReconciliation(
+            tracks: acceptedTracks,
+            filteredVideoIDs: filteredVideoIDs,
+            insertedVideoIDs: insertedVideoIDs,
+            localOverlayVideoIDs: localOverlayVideoIDs,
+            newLikedMembershipVideoIDs: newLikedMembershipVideoIDs
+        )
     }
 
     // MARK: - Rating Actions
@@ -230,10 +421,29 @@ final class SongLikeStatusManager {
         if self.confirmedStatusByAccount[resolvedAccountID]?[song.videoId] == nil {
             self.setConfirmedStatus(previousStatus, for: song.videoId, accountID: resolvedAccountID)
         }
+        let addsLikedMusicMembership = status == .like
+            && self.confirmedStatus(for: song.videoId, accountID: resolvedAccountID) != .like
         self.setStatus(status, for: song.videoId, accountID: resolvedAccountID)
         self.publishEvent(
-            LikeStatusEvent(videoId: song.videoId, status: status, song: song),
+            LikeStatusEvent(
+                videoId: song.videoId,
+                status: status,
+                song: song,
+                addsLikedMusicMembership: addsLikedMusicMembership
+            ),
             for: resolvedAccountID
+        )
+        self.pendingRatingByAccount[resolvedAccountID, default: [:]][song.videoId] = PendingRating(
+            revision: revision,
+            status: status,
+            song: song
+        )
+        self.localRatingOverlayByAccount[resolvedAccountID, default: [:]][song.videoId] = LocalRatingOverlay(
+            revision: revision,
+            status: status,
+            song: song,
+            addsLikedMusicMembership: addsLikedMusicMembership,
+            protectedRequestIDs: self.activeLikedMusicRequestIDsByAccount[resolvedAccountID] ?? []
         )
 
         let mutation = RatingMutationRequest(
@@ -304,7 +514,7 @@ final class SongLikeStatusManager {
 
     private func rollbackRatingMutation(
         song: Song,
-        status: LikeStatus,
+        status _: LikeStatus,
         mutation: RatingMutationRequest,
         logsCancellation: Bool
     ) -> LikeStatus {
@@ -313,13 +523,31 @@ final class SongLikeStatusManager {
             videoId: song.videoId,
             accountID: mutation.accountID
         ) else {
-            return self.status(for: song.videoId, accountID: mutation.accountID) ?? status
+            return self.status(for: song.videoId, accountID: mutation.accountID) ?? .indifferent
         }
         let confirmedStatus = self.confirmedStatus(
             for: song.videoId,
             accountID: mutation.accountID
         )
         let rollbackStatus = confirmedStatus ?? .indifferent
+        if let overlay = self.localRatingOverlayByAccount[mutation.accountID]?[song.videoId],
+           overlay.revision == mutation.revision
+        {
+            if overlay.protectedRequestIDs.isEmpty {
+                self.localRatingOverlayByAccount[mutation.accountID]?.removeValue(forKey: song.videoId)
+                if self.localRatingOverlayByAccount[mutation.accountID]?.isEmpty == true {
+                    self.localRatingOverlayByAccount.removeValue(forKey: mutation.accountID)
+                }
+            } else {
+                self.localRatingOverlayByAccount[mutation.accountID]?[song.videoId] = LocalRatingOverlay(
+                    revision: mutation.revision,
+                    status: rollbackStatus,
+                    song: song,
+                    addsLikedMusicMembership: false,
+                    protectedRequestIDs: overlay.protectedRequestIDs
+                )
+            }
+        }
         let sessionIsCurrent = self.sessionGeneration == mutation.sessionGeneration
         let shouldRestoreOldAccount = sessionIsCurrent || self.activeAccountID != mutation.accountID
         if shouldRestoreOldAccount {
@@ -327,7 +555,12 @@ final class SongLikeStatusManager {
         }
         if sessionIsCurrent {
             self.publishEvent(
-                LikeStatusEvent(videoId: song.videoId, status: rollbackStatus, song: song),
+                LikeStatusEvent(
+                    videoId: song.videoId,
+                    status: rollbackStatus,
+                    song: song,
+                    addsLikedMusicMembership: false
+                ),
                 for: mutation.accountID
             )
         }
@@ -348,6 +581,7 @@ final class SongLikeStatusManager {
     func setStatus(_ status: LikeStatus, for videoId: String) {
         self.setStatus(status, for: videoId, accountID: self.activeAccountID)
         self.setConfirmedStatus(status, for: videoId, accountID: self.activeAccountID)
+        self.localRatingOverlayByAccount[self.activeAccountID]?.removeValue(forKey: videoId)
     }
 
     /// Updates the visible cache without advancing the API-confirmed rollback baseline.
@@ -380,21 +614,64 @@ final class SongLikeStatusManager {
 
     /// Clears all cached statuses.
     func clearCache() {
-        self.statusCacheByAccount.removeAll()
-        self.ratingRevisionByAccount.removeAll()
-        self.confirmedStatusByAccount.removeAll()
-        self.lastLikeEvent = nil
-    }
-
-    func invalidateSession(clearsActiveCache: Bool = true) {
+        self.requestScopeGeneration &+= 1
         self.sessionGeneration &+= 1
         for task in self.ratingMutationTails.values {
             task.cancel()
         }
+        self.pendingRatingByAccount.removeAll()
+        self.localRatingOverlayByAccount.removeAll()
+        self.activeLikedMusicRequestIDsByAccount.removeAll()
+        self.statusCacheByAccount.removeAll()
+        self.ratingRevisionByAccount.removeAll()
+        self.confirmedStatusByAccount.removeAll()
+        self.lastLikeEvent = nil
+        self.lastLikeEventBatch = nil
+    }
+
+    func invalidateSession(
+        clearsActiveCache: Bool = true,
+        publishesRollbackEvents: Bool = true
+    ) {
+        let accountID = self.activeAccountID
+        let rollbackEvents = clearsActiveCache
+            ? []
+            : self.restorePendingRatings(for: accountID)
+        self.requestScopeGeneration &+= 1
+        self.sessionGeneration &+= 1
+        for task in self.ratingMutationTails.values {
+            task.cancel()
+        }
+        self.pendingRatingByAccount.removeAll()
+        self.activeLikedMusicRequestIDsByAccount.removeAll()
+        self.localRatingOverlayByAccount.removeAll()
         if clearsActiveCache {
-            self.statusCacheByAccount.removeValue(forKey: self.activeAccountID)
-            self.confirmedStatusByAccount.removeValue(forKey: self.activeAccountID)
+            self.statusCacheByAccount.removeValue(forKey: accountID)
+            self.confirmedStatusByAccount.removeValue(forKey: accountID)
+            self.ratingRevisionByAccount.removeValue(forKey: accountID)
             self.lastLikeEvent = nil
+            self.lastLikeEventBatch = nil
+        } else if publishesRollbackEvents {
+            self.publishEvents(rollbackEvents, for: accountID)
+        }
+    }
+
+    func hasPendingRating(for videoId: String, accountID: String? = nil) -> Bool {
+        let resolvedAccountID = accountID.map(Self.resolvedAccountID) ?? self.activeAccountID
+        return self.pendingRatingByAccount[resolvedAccountID]?[videoId] != nil
+    }
+
+    private func restorePendingRatings(for accountID: String) -> [LikeStatusEvent] {
+        (self.pendingRatingByAccount[accountID] ?? [:]).map { videoId, pendingRating in
+            let confirmedStatus = self.confirmedStatus(for: videoId, accountID: accountID)
+            self.restoreStatus(confirmedStatus, for: videoId, accountID: accountID)
+            self.localRatingOverlayByAccount[accountID]?.removeValue(forKey: videoId)
+            return LikeStatusEvent(
+                videoId: videoId,
+                status: confirmedStatus ?? .indifferent,
+                song: pendingRating.song,
+                addsLikedMusicMembership: false
+            )
         }
     }
 
@@ -464,6 +741,20 @@ final class SongLikeStatusManager {
         guard self.ratingMutationTailRevisions[key] == revision else { return }
         self.ratingMutationTails.removeValue(forKey: key)
         self.ratingMutationTailRevisions.removeValue(forKey: key)
+        if self.pendingRatingByAccount[accountID]?[videoId]?.revision == revision {
+            self.pendingRatingByAccount[accountID]?.removeValue(forKey: videoId)
+            if self.pendingRatingByAccount[accountID]?.isEmpty == true {
+                self.pendingRatingByAccount.removeValue(forKey: accountID)
+            }
+        }
+        if self.localRatingOverlayByAccount[accountID]?[videoId]?.revision == revision,
+           self.localRatingOverlayByAccount[accountID]?[videoId]?.protectedRequestIDs.isEmpty == true
+        {
+            self.localRatingOverlayByAccount[accountID]?.removeValue(forKey: videoId)
+            if self.localRatingOverlayByAccount[accountID]?.isEmpty == true {
+                self.localRatingOverlayByAccount.removeValue(forKey: accountID)
+            }
+        }
     }
 
     private static func ratingMutationKey(accountID: String, videoId: String) -> String {
@@ -512,7 +803,12 @@ final class SongLikeStatusManager {
     }
 
     private func publishEvent(_ event: LikeStatusEvent, for accountID: String) {
-        guard accountID == self.activeAccountID else { return }
-        self.lastLikeEvent = event
+        self.publishEvents([event], for: accountID)
+    }
+
+    private func publishEvents(_ events: [LikeStatusEvent], for accountID: String) {
+        guard accountID == self.activeAccountID, let lastEvent = events.last else { return }
+        self.lastLikeEvent = lastEvent
+        self.lastLikeEventBatch = LikeStatusEventBatch(accountID: accountID, events: events)
     }
 }

--- a/Sources/Kaset/ViewModels/PlaylistDetailViewModel.swift
+++ b/Sources/Kaset/ViewModels/PlaylistDetailViewModel.swift
@@ -1,6 +1,9 @@
+// swiftlint:disable file_length
 import Foundation
 import Observation
 import os
+
+// MARK: - PlaylistDetailViewModel
 
 /// View model for the PlaylistDetailView.
 @MainActor
@@ -8,15 +11,46 @@ import os
 final class PlaylistDetailViewModel {
     private struct LiveSyncTask {
         let id: UUID
+        let snapshot: LikedMusicRequestSnapshot?
         let task: Task<Void, Never>
+    }
+
+    private struct DeferredLikedMusicMetadata {
+        let videoId: String
+        let addsLikedMusicMembership: Bool
     }
 
     private struct ContinuationDrainBatch {
         let generation: Int
         let continuation: String
         let currentDetail: PlaylistDetail
-        let isLikedMusicPlaylist: Bool
-        let requiresAuth: Bool
+        let likedMusicSnapshot: LikedMusicRequestSnapshot?
+    }
+
+    private struct ContinuationReconciliation {
+        let tracks: [Song]
+        let filteredVideoIDs: Set<String>
+        let insertedVideoIDs: Set<String>
+        let localOverlayVideoIDs: Set<String>
+        let newLikedMembershipVideoIDs: Set<String>
+        let deferredMetadata: [DeferredLikedMusicMetadata]
+    }
+
+    private struct InitialLoadContext {
+        let generation: Int
+        let likedMusicSnapshot: LikedMusicRequestSnapshot?
+    }
+
+    private struct InitialLoadResult {
+        let detail: PlaylistDetail
+        let hasMore: Bool
+        let continuationToken: String?
+        let deferredLikedMusicMetadata: [DeferredLikedMusicMetadata]
+    }
+
+    private struct LikedMusicDetailResult {
+        let detail: PlaylistDetail
+        let deferredMetadata: [DeferredLikedMusicMetadata]
     }
 
     struct PlaylistTrackRemovalSnapshot {
@@ -52,9 +86,17 @@ final class PlaylistDetailViewModel {
     @ObservationIgnored
     private var loadedTrackVideoIds: Set<String> = []
 
-    private var removedLikedMusicVideoIDs: Set<String> = []
-    private var countedRemovedLikedMusicVideoIDs: Set<String> = []
-    private var insertedLikedMusicVideoIDs: Set<String> = []
+    @ObservationIgnored
+    private var seenContinuationTokens: Set<String> = []
+
+    @ObservationIgnored
+    private var loadedLikedMusicScope: LikedMusicRequestSnapshot?
+
+    @ObservationIgnored
+    private var loadedLikedMusicAccountID: String?
+
+    @ObservationIgnored
+    private var countedFilteredLikedMusicVideoIDs: Set<String> = []
 
     /// Successful occurrence removals remain tombstoned for this view model's lifetime so
     /// stale refreshes and continuation responses cannot restore them.
@@ -83,8 +125,16 @@ final class PlaylistDetailViewModel {
     }
 
     deinit {
+        self.loadTask?.cancel()
+        self.fullLoadTask?.cancel()
+        self.pagingTask?.cancel()
         for liveSyncTask in self.liveSyncTasks.values {
             liveSyncTask.task.cancel()
+        }
+        if let loadedLikedMusicScope {
+            Task { @MainActor in
+                SongLikeStatusManager.shared.finishLikedMusicRequest(loadedLikedMusicScope)
+            }
         }
     }
 
@@ -162,7 +212,9 @@ final class PlaylistDetailViewModel {
             self.fullLoadTask = nil
         }
     }
+}
 
+extension PlaylistDetailViewModel {
     /// Loads the playlist details including tracks.
     func load() async {
         await self.load(restartingInFlightLoad: false)
@@ -171,129 +223,218 @@ final class PlaylistDetailViewModel {
     private func load(restartingInFlightLoad: Bool) async {
         guard restartingInFlightLoad || (self.loadingState != .loading && self.loadingState != .loadingMore) else { return }
 
-        self.cancelFullLoadTask()
-        self.loadGeneration += 1
-        let generation = self.loadGeneration
-        self.countedPlaylistRemovalSetVideoIDs = []
-        self.removedLikedMusicVideoIDs = []
-        self.countedRemovedLikedMusicVideoIDs = []
-        self.insertedLikedMusicVideoIDs = []
-
-        self.loadingState = .loading
-        self.continuationToken = nil
-        let playlistTitle = self.playlist.title
-        let playlistId = self.playlist.id
-        self.logger.info("Loading playlist: \(playlistTitle), ID: \(playlistId)")
+        let context = self.beginInitialLoad()
+        defer {
+            self.finishInitialLoad(context)
+        }
 
         do {
-            // For radio playlists (RDCLAK prefix), use the queue API to get all tracks at once
-            // This bypasses the broken continuation pagination for these playlists
-            // Check for both VL-prefixed and raw RDCLAK IDs
-            let isRadioPlaylist = playlistId.contains("RDCLAK") || playlistId.hasPrefix("RD")
-            self.logger.debug("Playlist ID: \(playlistId), isRadioPlaylist: \(isRadioPlaylist)")
-
-            let response = try await client.getPlaylist(id: self.playlist.id)
-            guard self.isCurrentLoadGeneration(generation) else { return }
-
-            var detail = response.detail
-            self.hasMore = response.hasMore
-            var nextContinuationToken = response.continuationToken
-
-            // If it's a radio playlist, always fetch all tracks via queue API
-            // The browse API often returns hasMore=false even when there are more tracks
-            if isRadioPlaylist {
-                self.logger.info("Radio playlist detected, fetching all tracks via queue API")
-                do {
-                    let allTracks = try await client.getPlaylistAllTracks(playlistId: self.playlist.id)
-                    guard self.isCurrentLoadGeneration(generation) else { return }
-
-                    if allTracks.count > detail.tracks.count {
-                        self.logger.info("Queue API returned \(allTracks.count) tracks (vs \(detail.tracks.count) from browse)")
-                        // Update the detail with all tracks from queue API
-                        let updatedPlaylist = Playlist(
-                            id: detail.id,
-                            title: detail.title,
-                            description: detail.description,
-                            thumbnailURL: detail.thumbnailURL,
-                            trackCount: allTracks.count,
-                            author: detail.author,
-                            canDelete: detail.canDelete || self.playlist.canDelete
-                        )
-                        detail = PlaylistDetail(
-                            playlist: updatedPlaylist,
-                            tracks: allTracks,
-                            duration: detail.duration
-                        )
-                        self.hasMore = false
-                        nextContinuationToken = nil
-                    }
-                } catch {
-                    // If queue API fails, fall back to browse results
-                    self.logger.warning("Queue API failed, using browse results: \(error.localizedDescription)")
-                }
-            }
-
-            // Determine the best thumbnail to use:
-            // 1. API response header thumbnail
-            // 2. Original playlist thumbnail (from navigation)
-            // 3. First track's thumbnail as fallback
-            let resolvedThumbnailURL = detail.thumbnailURL
-                ?? self.playlist.thumbnailURL
-                ?? detail.tracks.first?.thumbnailURL
-
-            // Check if we need to merge with original playlist info
-            let needsMerge = detail.title == "Unknown Playlist" && self.playlist.title != "Unknown Playlist"
-            let thumbnailMissing = detail.thumbnailURL == nil && resolvedThumbnailURL != nil
-
-            if needsMerge || thumbnailMissing {
-                let mergedTrackCount = max(
-                    detail.tracks.count,
-                    max(detail.trackCount ?? 0, self.playlist.trackCount ?? 0)
-                )
-
-                // Merge with original playlist info or add fallback thumbnail
-                // Strip song counts from fallback author since we display the count separately
-                let mergedPlaylist = Playlist(
-                    id: playlist.id,
-                    title: needsMerge ? self.playlist.title : detail.title,
-                    description: detail.description ?? self.playlist.description,
-                    thumbnailURL: resolvedThumbnailURL,
-                    trackCount: mergedTrackCount,
-                    author: detail.author ?? self.stripSongCountAuthor(from: self.playlist.author),
-                    canDelete: detail.canDelete || self.playlist.canDelete
-                )
-                detail = PlaylistDetail(
-                    playlist: mergedPlaylist,
-                    tracks: detail.tracks,
-                    duration: detail.duration
-                )
-            }
-
-            if self.isLikedMusicPlaylist {
-                detail = self.normalizeLikedMusicDetail(detail)
-            }
-
-            detail = self.filterPlaylistRemovals(from: detail)
-
-            self.playlistDetail = detail
-            self.continuationToken = self.hasMore ? nextContinuationToken : nil
-            self.loadingState = .loaded
-            let loadedTrackCount = detail.tracks.count
-            let totalTrackCount = detail.trackCount ?? loadedTrackCount
-            self.logger.info("Playlist loaded: \(loadedTrackCount) loaded tracks, total: \(totalTrackCount), hasMore: \(self.hasMore)")
-            self.replaceLoadedTrackVideoIds(with: detail.tracks)
+            guard let result = try await self.fetchInitialLoadResult(context) else { return }
+            self.applyInitialLoadResult(result, context: context)
         } catch is CancellationError {
-            guard self.isCurrentLoadGeneration(generation) else { return }
-
-            // Task was cancelled (e.g., user navigated away) — reset to idle so it can retry
-            self.logger.debug("Playlist detail load cancelled")
-            self.loadingState = .idle
+            self.handleInitialLoadCancellation(context)
         } catch {
-            guard self.isCurrentLoadGeneration(generation) else { return }
-
-            self.logger.error("Failed to load playlist: \(error.localizedDescription)")
-            self.loadingState = .error(LoadingError(from: error))
+            self.handleInitialLoadError(error, context: context)
         }
+    }
+
+    private func beginInitialLoad() -> InitialLoadContext {
+        self.cancelFullLoadTask()
+        self.loadGeneration += 1
+        let previousLikedMusicScope = self.loadedLikedMusicScope
+        let likedMusicSnapshot = self.isLikedMusicPlaylist
+            ? SongLikeStatusManager.shared.beginLikedMusicRequest()
+            : nil
+        if let previousLikedMusicScope {
+            SongLikeStatusManager.shared.finishLikedMusicRequest(previousLikedMusicScope)
+            self.loadedLikedMusicScope = nil
+        }
+        self.countedPlaylistRemovalSetVideoIDs = []
+        self.countedFilteredLikedMusicVideoIDs = []
+        self.seenContinuationTokens = []
+        self.loadingState = .loading
+        self.continuationToken = nil
+        self.logger.info("Loading playlist: \(self.playlist.title), ID: \(self.playlist.id)")
+        return InitialLoadContext(
+            generation: self.loadGeneration,
+            likedMusicSnapshot: likedMusicSnapshot
+        )
+    }
+
+    private func finishInitialLoad(_ context: InitialLoadContext) {
+        guard let snapshot = context.likedMusicSnapshot else { return }
+        guard self.loadedLikedMusicScope != snapshot else { return }
+        SongLikeStatusManager.shared.finishLikedMusicRequest(snapshot)
+    }
+
+    private func fetchInitialLoadResult(_ context: InitialLoadContext) async throws -> InitialLoadResult? {
+        let response = try await self.client.getPlaylist(id: self.playlist.id)
+        guard self.canApplyInitialLoad(context) else { return nil }
+
+        var detail = response.detail
+        var hasMore = response.hasMore
+        var continuationToken = response.continuationToken
+        var deferredLikedMusicMetadata: [DeferredLikedMusicMetadata] = []
+
+        if let allTracks = try await self.fetchRadioPlaylistTracksIfNeeded() {
+            guard self.canApplyInitialLoad(context) else { return nil }
+            if allTracks.count > detail.tracks.count {
+                detail = self.detailByReplacingRadioTracks(in: detail, with: allTracks)
+                hasMore = false
+                continuationToken = nil
+            }
+        }
+
+        detail = self.detailByMergingOriginalPlaylistMetadata(into: detail)
+        if let snapshot = context.likedMusicSnapshot {
+            guard let reconciliation = self.reconciledLikedMusicDetail(detail, snapshot: snapshot) else {
+                self.loadingState = .idle
+                return nil
+            }
+            detail = reconciliation.detail
+            deferredLikedMusicMetadata = reconciliation.deferredMetadata
+        }
+
+        return InitialLoadResult(
+            detail: self.filterPlaylistRemovals(from: detail),
+            hasMore: hasMore,
+            continuationToken: continuationToken,
+            deferredLikedMusicMetadata: deferredLikedMusicMetadata
+        )
+    }
+
+    private func fetchRadioPlaylistTracksIfNeeded() async throws -> [Song]? {
+        let playlistID = self.playlist.id
+        let isRadioPlaylist = playlistID.contains("RDCLAK") || playlistID.hasPrefix("RD")
+        self.logger.debug("Playlist ID: \(playlistID), isRadioPlaylist: \(isRadioPlaylist)")
+        guard isRadioPlaylist else { return nil }
+
+        self.logger.info("Radio playlist detected, fetching all tracks via queue API")
+        do {
+            return try await self.client.getPlaylistAllTracks(playlistId: playlistID)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            self.logger.warning("Queue API failed, using browse results: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    private func detailByReplacingRadioTracks(in detail: PlaylistDetail, with allTracks: [Song]) -> PlaylistDetail {
+        self.logger.info("Queue API returned \(allTracks.count) tracks (vs \(detail.tracks.count) from browse)")
+        let playlist = Playlist(
+            id: detail.id,
+            title: detail.title,
+            description: detail.description,
+            thumbnailURL: detail.thumbnailURL,
+            trackCount: allTracks.count,
+            author: detail.author,
+            canDelete: detail.canDelete || self.playlist.canDelete
+        )
+        return PlaylistDetail(playlist: playlist, tracks: allTracks, duration: detail.duration)
+    }
+
+    private func detailByMergingOriginalPlaylistMetadata(into detail: PlaylistDetail) -> PlaylistDetail {
+        let resolvedThumbnailURL = detail.thumbnailURL
+            ?? self.playlist.thumbnailURL
+            ?? detail.tracks.first?.thumbnailURL
+        let needsMerge = detail.title == "Unknown Playlist" && self.playlist.title != "Unknown Playlist"
+        let thumbnailMissing = detail.thumbnailURL == nil && resolvedThumbnailURL != nil
+        guard needsMerge || thumbnailMissing else { return detail }
+
+        let mergedTrackCount = max(
+            detail.tracks.count,
+            max(detail.trackCount ?? 0, self.playlist.trackCount ?? 0)
+        )
+        let playlist = Playlist(
+            id: self.playlist.id,
+            title: needsMerge ? self.playlist.title : detail.title,
+            description: detail.description ?? self.playlist.description,
+            thumbnailURL: resolvedThumbnailURL,
+            trackCount: mergedTrackCount,
+            author: detail.author ?? self.stripSongCountAuthor(from: self.playlist.author),
+            canDelete: detail.canDelete || self.playlist.canDelete
+        )
+        return PlaylistDetail(playlist: playlist, tracks: detail.tracks, duration: detail.duration)
+    }
+
+    private func reconciledLikedMusicDetail(
+        _ detail: PlaylistDetail,
+        snapshot: LikedMusicRequestSnapshot
+    ) -> LikedMusicDetailResult? {
+        guard let reconciliation = SongLikeStatusManager.shared.reconcileLikedMusicTracks(
+            detail.tracks,
+            snapshot: snapshot,
+            deduplicating: true
+        ) else { return nil }
+
+        let deferredMetadata: [DeferredLikedMusicMetadata] = reconciliation.tracks.compactMap { song in
+            guard reconciliation.insertedVideoIDs.contains(song.videoId),
+                  Self.requiresMetadataFetchForLiveSync(song)
+            else { return nil }
+            return DeferredLikedMusicMetadata(
+                videoId: song.videoId,
+                addsLikedMusicMembership: reconciliation.newLikedMembershipVideoIDs.contains(song.videoId)
+            )
+        }
+        let deferredMetadataVideoIDSet = Set(deferredMetadata.map(\.videoId))
+        let visibleTracks = reconciliation.tracks.filter {
+            !deferredMetadataVideoIDSet.contains($0.videoId)
+        }
+        let insertedTrackCount = reconciliation.insertedVideoIDs
+            .intersection(reconciliation.newLikedMembershipVideoIDs)
+            .subtracting(deferredMetadataVideoIDSet)
+            .count
+        self.countedFilteredLikedMusicVideoIDs.formUnion(reconciliation.filteredVideoIDs)
+        let adjustedTrackCount = self.adjustedTrackCount(
+            detail.trackCount,
+            skippedRemovalCount: reconciliation.filteredVideoIDs.count,
+            insertedTrackCount: insertedTrackCount
+        )
+        return LikedMusicDetailResult(
+            detail: self.updatedPlaylistDetail(
+                from: detail,
+                tracks: visibleTracks,
+                trackCount: max(adjustedTrackCount ?? 0, visibleTracks.count)
+            ),
+            deferredMetadata: deferredMetadata
+        )
+    }
+
+    private func applyInitialLoadResult(_ result: InitialLoadResult, context: InitialLoadContext) {
+        guard self.canApplyInitialLoad(context) else { return }
+        self.playlistDetail = result.detail
+        self.loadedLikedMusicAccountID = context.likedMusicSnapshot?.accountID
+        self.loadedLikedMusicScope = result.hasMore ? context.likedMusicSnapshot : nil
+        self.hasMore = result.hasMore
+        self.continuationToken = result.hasMore ? result.continuationToken : nil
+        self.loadingState = .loaded
+        let loadedTrackCount = result.detail.tracks.count
+        let totalTrackCount = result.detail.trackCount ?? loadedTrackCount
+        self.logger.info("Playlist loaded: \(loadedTrackCount) loaded tracks, total: \(totalTrackCount), hasMore: \(result.hasMore)")
+        self.replaceLoadedTrackVideoIds(with: result.detail.tracks)
+        self.startDeferredLikedMusicMetadataTasks(result.deferredLikedMusicMetadata)
+    }
+
+    private func handleInitialLoadCancellation(_ context: InitialLoadContext) {
+        guard self.canApplyInitialLoad(context) else { return }
+        self.logger.debug("Playlist detail load cancelled")
+        self.loadingState = .idle
+    }
+
+    private func handleInitialLoadError(_ error: any Error, context: InitialLoadContext) {
+        guard self.canApplyInitialLoad(context) else { return }
+        self.logger.error("Failed to load playlist: \(error.localizedDescription)")
+        self.loadingState = .error(LoadingError(from: error))
+    }
+
+    private func canApplyInitialLoad(_ context: InitialLoadContext) -> Bool {
+        guard self.isCurrentLoadGeneration(context.generation) else { return false }
+        guard self.isCurrentLikedMusicScope(context.likedMusicSnapshot) else {
+            self.loadingState = .idle
+            return false
+        }
+        return true
     }
 
     /// Loads more tracks via continuation.
@@ -317,20 +458,17 @@ final class PlaylistDetailViewModel {
         }
     }
 
-    private func applyRemainingTracksResponse(_ response: PlaylistContinuationResponse, batch: ContinuationDrainBatch) -> Bool {
+    private func applyRemainingTracksResponse(
+        _ response: PlaylistContinuationResponse,
+        batch: ContinuationDrainBatch
+    ) -> Bool {
         guard batch.generation == self.loadGeneration,
               !Task.isCancelled,
+              self.isCurrentLikedMusicScope(batch.likedMusicSnapshot),
               let latestDetail = self.playlistDetail
         else { return false }
+        self.seenContinuationTokens.insert(batch.continuation)
 
-        let skippedRemovedVideoIDs = batch.isLikedMusicPlaylist
-            ? response.tracks.compactMap { song -> String? in
-                guard self.removedLikedMusicVideoIDs.contains(song.videoId),
-                      self.countedRemovedLikedMusicVideoIDs.insert(song.videoId).inserted
-                else { return nil }
-                return song.videoId
-            }
-            : []
         let skippedConfirmedPlaylistRemovalCount = response.tracks.reduce(into: 0) { count, track in
             guard let setVideoId = track.playlistSetVideoId,
                   self.isPlaylistRemovalTombstoned(setVideoId: setVideoId),
@@ -338,81 +476,149 @@ final class PlaylistDetailViewModel {
             else { return }
             count += 1
         }
-        let skippedRemovalCount = skippedRemovedVideoIDs.count + skippedConfirmedPlaylistRemovalCount
         let playlistFilteredTracks = response.tracks.filter { track in
             guard let setVideoId = track.playlistSetVideoId else { return true }
             return !self.isPlaylistRemovalTombstoned(setVideoId: setVideoId)
         }
-        let candidateTracks = batch.isLikedMusicPlaylist
-            ? playlistFilteredTracks.filter { !self.removedLikedMusicVideoIDs.contains($0.videoId) }
-            : playlistFilteredTracks
-        let skippedLiveRemovedTracks = candidateTracks.count != response.tracks.count
-        let responseContainsLiveInsertedTrack = batch.isLikedMusicPlaylist && response.tracks.contains { self.insertedLikedMusicVideoIDs.contains($0.videoId) }
+
+        guard let reconciliation = self.reconcileContinuationTracks(
+            playlistFilteredTracks,
+            snapshot: batch.likedMusicSnapshot
+        ) else { return false }
+        let skippedLikedMusicCount = reconciliation.filteredVideoIDs.reduce(into: 0) { count, videoId in
+            if self.countedFilteredLikedMusicVideoIDs.insert(videoId).inserted {
+                count += 1
+            }
+        }
+
         let originalExistingVideoIds = Set(batch.currentDetail.tracks.map(\.videoId))
-        let newTracks = candidateTracks.filter {
+        let newTracks = reconciliation.tracks.filter {
             !self.loadedTrackVideoIds.contains($0.videoId)
                 && !originalExistingVideoIds.contains($0.videoId)
         }
+        let skippedRemovalCount = skippedConfirmedPlaylistRemovalCount + skippedLikedMusicCount
+        let insertedTrackCount = newTracks.count {
+            reconciliation.newLikedMembershipVideoIDs.contains($0.videoId)
+                || self.countedFilteredLikedMusicVideoIDs.contains($0.videoId)
+        }
+        let continuationDidNotAdvance = response.continuationToken == nil
+            || response.continuationToken == batch.continuation
 
         if newTracks.isEmpty {
-            let duplicatesWereAlreadyPresent = candidateTracks.allSatisfy { originalExistingVideoIds.contains($0.videoId) }
-            if duplicatesWereAlreadyPresent, !skippedLiveRemovedTracks, !responseContainsLiveInsertedTrack {
-                self.hasMore = false
+            self.applySkippedRemovalCount(skippedRemovalCount, to: latestDetail)
+            self.startDeferredLikedMusicMetadataTasks(reconciliation.deferredMetadata)
+            if response.hasMore,
+               continuationDidNotAdvance
+            {
                 self.continuationToken = nil
+                self.hasMore = false
                 self.loadingState = .loaded
-                self.logger.info("No new unique tracks in continuation, stopping pagination")
+                self.releaseLoadedLikedMusicScope()
+                self.logger.warning("Stopping playlist pagination after a non-advancing duplicate page")
                 return false
             }
-
-            self.applySkippedRemovalCount(skippedRemovalCount, to: latestDetail)
             self.continuationToken = response.continuationToken
             self.hasMore = response.hasMore
             self.loadingState = .loaded
-            self.logger.info("Continuation tracks already live-synced; advancing cursor, hasMore: \(self.hasMore)")
+            if !self.hasMore {
+                self.releaseLoadedLikedMusicScope()
+            }
             return self.hasMore
         }
 
-        let normalizedNewTracks: [Song] = if batch.isLikedMusicPlaylist {
-            self.markSongsAsLiked(newTracks)
-        } else {
-            newTracks
-        }
-
         var allTracks = latestDetail.tracks
-        allTracks.reserveCapacity(latestDetail.tracks.count + normalizedNewTracks.count)
-        allTracks.append(contentsOf: normalizedNewTracks)
-        let adjustedTrackCount = self.adjustedTrackCount(latestDetail.trackCount, skippedRemovalCount: skippedRemovalCount)
+        allTracks.reserveCapacity(latestDetail.tracks.count + newTracks.count)
+        allTracks.append(contentsOf: newTracks)
+        let adjustedTrackCount = self.adjustedTrackCount(
+            latestDetail.trackCount,
+            skippedRemovalCount: skippedRemovalCount,
+            insertedTrackCount: insertedTrackCount
+        )
         let preservedTrackCount = max(allTracks.count, adjustedTrackCount ?? 0)
-        let updatedPlaylist = Playlist(
-            id: latestDetail.id,
-            title: latestDetail.title,
-            description: latestDetail.description,
-            thumbnailURL: latestDetail.thumbnailURL,
-            trackCount: preservedTrackCount,
-            author: latestDetail.author,
-            canDelete: latestDetail.canDelete
-        )
-        self.playlistDetail = PlaylistDetail(
-            playlist: updatedPlaylist,
+        self.playlistDetail = self.updatedPlaylistDetail(
+            from: latestDetail,
             tracks: allTracks,
-            duration: latestDetail.duration
+            trackCount: preservedTrackCount
         )
-        self.insertLoadedTrackVideoIds(from: normalizedNewTracks)
-
-        if batch.isLikedMusicPlaylist {
-            SongLikeStatusManager.shared.setStatus(.like, for: normalizedNewTracks.lazy.map(\.videoId))
+        self.insertLoadedTrackVideoIds(from: newTracks)
+        for track in newTracks {
+            self.countedFilteredLikedMusicVideoIDs.remove(track.videoId)
         }
-
+        self.startDeferredLikedMusicMetadataTasks(reconciliation.deferredMetadata)
         self.continuationToken = response.continuationToken
         self.hasMore = response.hasMore
         self.loadingState = .loaded
-        self.logger.info("Loaded \(normalizedNewTracks.count) new tracks (from \(response.tracks.count)), loaded total: \(allTracks.count), reported total: \(preservedTrackCount), hasMore: \(self.hasMore)")
+        if !self.hasMore {
+            self.releaseLoadedLikedMusicScope()
+        }
+        self.logger.info("Loaded \(newTracks.count) new tracks (from \(response.tracks.count)), loaded total: \(allTracks.count), reported total: \(preservedTrackCount), hasMore: \(self.hasMore)")
         return self.hasMore
     }
 
-    private func adjustedTrackCount(_ trackCount: Int?, skippedRemovalCount: Int) -> Int? {
-        guard skippedRemovalCount > 0, let trackCount else { return trackCount }
-        return max(0, trackCount - skippedRemovalCount)
+    private func reconcileContinuationTracks(
+        _ tracks: [Song],
+        snapshot: LikedMusicRequestSnapshot?
+    ) -> ContinuationReconciliation? {
+        guard let snapshot else {
+            return ContinuationReconciliation(
+                tracks: tracks,
+                filteredVideoIDs: [],
+                insertedVideoIDs: [],
+                localOverlayVideoIDs: [],
+                newLikedMembershipVideoIDs: [],
+                deferredMetadata: []
+            )
+        }
+        guard let reconciliation = SongLikeStatusManager.shared.reconcileLikedMusicTracks(
+            tracks,
+            snapshot: snapshot
+        ) else { return nil }
+
+        let deferredMetadata: [DeferredLikedMusicMetadata] = reconciliation.tracks.compactMap { song in
+            guard reconciliation.insertedVideoIDs.contains(song.videoId),
+                  Self.requiresMetadataFetchForLiveSync(song)
+            else { return nil }
+            return DeferredLikedMusicMetadata(
+                videoId: song.videoId,
+                addsLikedMusicMembership: reconciliation.newLikedMembershipVideoIDs.contains(song.videoId)
+            )
+        }
+        let deferredMetadataVideoIDSet = Set(deferredMetadata.map(\.videoId))
+        return ContinuationReconciliation(
+            tracks: reconciliation.tracks.filter {
+                !deferredMetadataVideoIDSet.contains($0.videoId)
+            },
+            filteredVideoIDs: reconciliation.filteredVideoIDs,
+            insertedVideoIDs: reconciliation.insertedVideoIDs.subtracting(deferredMetadataVideoIDSet),
+            localOverlayVideoIDs: reconciliation.localOverlayVideoIDs,
+            newLikedMembershipVideoIDs: reconciliation.newLikedMembershipVideoIDs.subtracting(
+                deferredMetadataVideoIDSet
+            ),
+            deferredMetadata: deferredMetadata
+        )
+    }
+
+    private func startDeferredLikedMusicMetadataTasks(_ metadata: [DeferredLikedMusicMetadata]) {
+        for item in metadata {
+            if let snapshot = self.liveSyncTasks[item.videoId]?.snapshot,
+               SongLikeStatusManager.shared.matchesCurrentScope(snapshot)
+            {
+                continue
+            }
+            self.startLiveSyncTask(
+                for: item.videoId,
+                addsLikedMusicMembership: item.addsLikedMusicMembership
+            )
+        }
+    }
+
+    private func adjustedTrackCount(
+        _ trackCount: Int?,
+        skippedRemovalCount: Int,
+        insertedTrackCount: Int = 0
+    ) -> Int? {
+        guard let trackCount else { return nil }
+        return max(0, trackCount - skippedRemovalCount + insertedTrackCount)
     }
 
     private func applySkippedRemovalCount(_ skippedRemovalCount: Int, to detail: PlaylistDetail) {
@@ -451,6 +657,19 @@ final class PlaylistDetailViewModel {
               self.isCurrentLoadGeneration(generation)
         else { return false }
 
+        guard self.isCurrentLikedMusicScope(self.loadedLikedMusicScope) else {
+            self.invalidateLikedMusicPagination(generation: generation)
+            return false
+        }
+        guard !self.seenContinuationTokens.contains(continuationToken) else {
+            self.hasMore = false
+            self.continuationToken = nil
+            self.releaseLoadedLikedMusicScope()
+            self.logger.warning("Stopping playlist pagination after a repeated continuation cursor")
+            return false
+        }
+        let requestSnapshot = self.loadedLikedMusicScope
+
         self.loadingState = .loadingMore
         self.logger.info("Loading more playlist tracks")
 
@@ -460,21 +679,33 @@ final class PlaylistDetailViewModel {
                 token: continuation,
                 requiresAuth: currentDetail.requiresPersonalAccountForContinuations
             )
+            guard self.isCurrentLoadGeneration(generation) else { return false }
+            guard self.isCurrentLikedMusicScope(requestSnapshot) else {
+                self.invalidateLikedMusicPagination(generation: generation)
+                return false
+            }
             let batch = ContinuationDrainBatch(
                 generation: generation ?? self.loadGeneration,
                 continuation: continuation,
                 currentDetail: currentDetail,
-                isLikedMusicPlaylist: self.isLikedMusicPlaylist,
-                requiresAuth: currentDetail.requiresPersonalAccountForContinuations
+                likedMusicSnapshot: requestSnapshot
             )
             return self.applyRemainingTracksResponse(response, batch: batch)
         } catch is CancellationError {
             guard self.isCurrentLoadGeneration(generation) else { return false }
+            guard self.isCurrentLikedMusicScope(requestSnapshot) else {
+                self.invalidateLikedMusicPagination(generation: generation)
+                return false
+            }
             self.logger.debug("Playlist continuation cancelled")
             self.loadingState = .loaded
             return false
         } catch {
             guard self.isCurrentLoadGeneration(generation) else { return false }
+            guard self.isCurrentLikedMusicScope(requestSnapshot) else {
+                self.invalidateLikedMusicPagination(generation: generation)
+                return false
+            }
             self.logger.error("Failed to load more playlist tracks: \(error.localizedDescription)")
             // Keep loaded state so user can retry
             self.loadingState = .loaded
@@ -483,31 +714,32 @@ final class PlaylistDetailViewModel {
     }
 
     /// Handles like status updates for the Liked Music playlist.
+    /// Handles immediate optimistic updates for the loaded Liked Music UI.
+    /// Delayed API response correctness is owned by `SongLikeStatusManager` snapshots.
     func handleLikeStatusChange(_ event: LikeStatusEvent) {
         guard self.isLikedMusicPlaylist else { return }
         guard self.loadingState == .loaded || self.loadingState == .loadingMore else { return }
+        guard self.isLoadedLikedMusicAccountCurrent() else { return }
 
         switch event.status {
-        // - Liked songs are inserted at the top.
         case .like:
-            self.removedLikedMusicVideoIDs.remove(event.videoId)
-            self.countedRemovedLikedMusicVideoIDs.remove(event.videoId)
             if let song = event.song, !Self.requiresMetadataFetchForLiveSync(song) {
                 self.cancelLiveSyncTask(for: event.videoId)
-                self.insertLiveSyncedLikedSong(song)
+                self.insertLiveSyncedLikedSong(
+                    song,
+                    addsLikedMusicMembership: event.addsLikedMusicMembership ?? true
+                )
             } else {
                 guard !self.containsTrack(videoId: event.videoId) else { return }
-                self.startLiveSyncTask(for: event.videoId)
+                self.startLiveSyncTask(
+                    for: event.videoId,
+                    addsLikedMusicMembership: event.addsLikedMusicMembership ?? true
+                )
             }
-        // - Unliked/disliked songs are removed immediately.
         case .indifferent, .dislike:
-            let wasLoaded = self.containsTrack(videoId: event.videoId)
-            self.removedLikedMusicVideoIDs.insert(event.videoId)
-            if wasLoaded {
-                self.countedRemovedLikedMusicVideoIDs.insert(event.videoId)
+            if self.containsTrack(videoId: event.videoId) {
+                self.countedFilteredLikedMusicVideoIDs.insert(event.videoId)
             }
-            self.insertedLikedMusicVideoIDs.remove(event.videoId)
-            SongLikeStatusManager.shared.setCachedStatus(event.status, for: event.videoId)
             self.cancelLiveSyncTask(for: event.videoId)
             self.removeLiveSyncedLikedSong(videoId: event.videoId)
         }
@@ -602,6 +834,26 @@ final class PlaylistDetailViewModel {
         }
     }
 
+    private func isCurrentLikedMusicScope(_ snapshot: LikedMusicRequestSnapshot?) -> Bool {
+        guard let snapshot else { return true }
+        return SongLikeStatusManager.shared.matchesCurrentScope(snapshot)
+    }
+
+    private func isLoadedLikedMusicAccountCurrent() -> Bool {
+        guard let loadedLikedMusicAccountID else { return true }
+        return loadedLikedMusicAccountID == SongLikeStatusManager.shared.activeAccountID
+    }
+
+    private func invalidateLikedMusicPagination(generation: Int?) {
+        guard self.isCurrentLoadGeneration(generation) else { return }
+        self.loadGeneration += 1
+        self.fullLoadTask = nil
+        self.hasMore = false
+        self.continuationToken = nil
+        self.replacePlaylistDetail(nil)
+        self.loadingState = .idle
+    }
+
     private func cancelFullLoadTask() {
         self.fullLoadTask?.cancel()
         self.fullLoadTask = nil
@@ -610,18 +862,6 @@ final class PlaylistDetailViewModel {
     private func isCurrentLoadGeneration(_ generation: Int?) -> Bool {
         guard let generation else { return true }
         return generation == self.loadGeneration
-    }
-
-    private func normalizeLikedMusicDetail(_ detail: PlaylistDetail) -> PlaylistDetail {
-        let likedTracks = self.markSongsAsLiked(detail.tracks, deduplicating: true)
-        SongLikeStatusManager.shared.setStatus(.like, for: likedTracks.lazy.map(\.videoId))
-
-        let resolvedTrackCount = max(detail.trackCount ?? 0, likedTracks.count)
-        return self.updatedPlaylistDetail(
-            from: detail,
-            tracks: likedTracks,
-            trackCount: resolvedTrackCount
-        )
     }
 
     private func filterPlaylistRemovals(from detail: PlaylistDetail) -> PlaylistDetail {
@@ -657,20 +897,6 @@ final class PlaylistDetailViewModel {
         waiters.forEach { $0.resume() }
     }
 
-    private func markSongsAsLiked(_ tracks: [Song], deduplicating: Bool = false) -> [Song] {
-        var seenVideoIds = Set<String>()
-
-        return tracks.compactMap { song in
-            if deduplicating, !seenVideoIds.insert(song.videoId).inserted {
-                return nil
-            }
-
-            var likedSong = song
-            likedSong.likeStatus = .like
-            return likedSong
-        }
-    }
-
     private func updatedPlaylistDetail(from detail: PlaylistDetail, tracks: [Song], trackCount: Int?) -> PlaylistDetail {
         let updatedPlaylist = Playlist(
             id: detail.id,
@@ -695,7 +921,17 @@ final class PlaylistDetailViewModel {
 
     private func replacePlaylistDetail(_ detail: PlaylistDetail?) {
         self.playlistDetail = detail
+        if detail == nil {
+            self.releaseLoadedLikedMusicScope()
+            self.loadedLikedMusicAccountID = nil
+        }
         self.replaceLoadedTrackVideoIds(with: detail?.tracks ?? [])
+    }
+
+    private func releaseLoadedLikedMusicScope() {
+        guard let loadedLikedMusicScope else { return }
+        SongLikeStatusManager.shared.finishLikedMusicRequest(loadedLikedMusicScope)
+        self.loadedLikedMusicScope = nil
     }
 
     private func replaceLoadedTrackVideoIds(with tracks: [Song]) {
@@ -709,17 +945,20 @@ final class PlaylistDetailViewModel {
         }
     }
 
-    private func insertLiveSyncedLikedSong(_ song: Song) {
+    private func insertLiveSyncedLikedSong(
+        _ song: Song,
+        addsLikedMusicMembership: Bool
+    ) {
         guard let currentDetail = self.playlistDetail else { return }
         guard !self.loadedTrackVideoIds.contains(song.videoId) else { return }
 
         var likedSong = song
         likedSong.likeStatus = .like
-        self.insertedLikedMusicVideoIDs.insert(song.videoId)
-
         let updatedTracks = [likedSong] + currentDetail.tracks
         let currentTotal = currentDetail.trackCount ?? currentDetail.tracks.count
-        let updatedTrackCount = max(currentTotal + 1, updatedTracks.count)
+        let restoresRemovedMembership = self.countedFilteredLikedMusicVideoIDs.contains(song.videoId)
+        let adjustedTotal = currentTotal + (addsLikedMusicMembership || restoresRemovedMembership ? 1 : 0)
+        let updatedTrackCount = max(adjustedTotal, updatedTracks.count)
 
         self.playlistDetail = self.updatedPlaylistDetail(
             from: currentDetail,
@@ -727,7 +966,7 @@ final class PlaylistDetailViewModel {
             trackCount: updatedTrackCount
         )
         self.loadedTrackVideoIds.insert(song.videoId)
-        SongLikeStatusManager.shared.setCachedStatus(.like, for: song.videoId)
+        self.countedFilteredLikedMusicVideoIDs.remove(song.videoId)
         self.logger.info("Live sync: added song \(song.videoId) to liked music")
     }
 
@@ -749,18 +988,39 @@ final class PlaylistDetailViewModel {
         self.logger.info("Live sync: removed song \(videoId) from liked music")
     }
 
-    private func startLiveSyncTask(for videoId: String) {
+    private func startLiveSyncTask(
+        for videoId: String,
+        addsLikedMusicMembership: Bool
+    ) {
         let taskID = UUID()
+        let snapshot = self.isLikedMusicPlaylist
+            ? SongLikeStatusManager.shared.beginLikedMusicRequest()
+            : nil
         self.cancelLiveSyncTask(for: videoId)
 
-        let task = Task { [weak self] in
+        let task = Task { @MainActor [weak self] in
+            defer {
+                if let snapshot {
+                    SongLikeStatusManager.shared.finishLikedMusicRequest(snapshot)
+                }
+            }
             guard let self else { return }
-            await self.fetchAndInsertLiveSyncedLikedSong(videoId: videoId, taskID: taskID)
+            await self.fetchAndInsertLiveSyncedLikedSong(
+                videoId: videoId,
+                taskID: taskID,
+                snapshot: snapshot,
+                addsLikedMusicMembership: addsLikedMusicMembership
+            )
         }
-        self.liveSyncTasks[videoId] = LiveSyncTask(id: taskID, task: task)
+        self.liveSyncTasks[videoId] = LiveSyncTask(id: taskID, snapshot: snapshot, task: task)
     }
 
-    private func fetchAndInsertLiveSyncedLikedSong(videoId: String, taskID: UUID) async {
+    private func fetchAndInsertLiveSyncedLikedSong(
+        videoId: String,
+        taskID: UUID,
+        snapshot: LikedMusicRequestSnapshot?,
+        addsLikedMusicMembership: Bool
+    ) async {
         defer {
             if self.liveSyncTasks[videoId]?.id == taskID {
                 self.liveSyncTasks.removeValue(forKey: videoId)
@@ -769,6 +1029,7 @@ final class PlaylistDetailViewModel {
 
         guard self.liveSyncTasks[videoId]?.id == taskID else { return }
         guard !Task.isCancelled else { return }
+        guard self.isCurrentLikedMusicScope(snapshot) else { return }
         guard !self.containsTrack(videoId: videoId) else { return }
 
         do {
@@ -776,12 +1037,17 @@ final class PlaylistDetailViewModel {
 
             guard !Task.isCancelled else { return }
             guard self.liveSyncTasks[videoId]?.id == taskID else { return }
+            guard self.isCurrentLikedMusicScope(snapshot) else { return }
+            guard SongLikeStatusManager.shared.status(for: videoId) == .like else { return }
             guard !Self.requiresMetadataFetchForLiveSync(song) else {
                 self.logger.warning("Live sync: skipping incomplete metadata for liked song \(videoId)")
                 return
             }
 
-            self.insertLiveSyncedLikedSong(song)
+            self.insertLiveSyncedLikedSong(
+                song,
+                addsLikedMusicMembership: addsLikedMusicMembership
+            )
         } catch is CancellationError {
             return
         } catch {

--- a/Sources/Kaset/ViewModels/PlaylistDetailViewModel.swift
+++ b/Sources/Kaset/ViewModels/PlaylistDetailViewModel.swift
@@ -74,6 +74,7 @@ final class PlaylistDetailViewModel {
     private let playlist: Playlist
     /// The API client (exposed for add to library action).
     let client: any YTMusicClientProtocol
+    private let likeStatusManager: SongLikeStatusManager
     private let logger = DiagnosticsLogger.api
     private var continuationToken: String?
 
@@ -115,9 +116,14 @@ final class PlaylistDetailViewModel {
         LikedMusicPlaylist.matches(id: self.playlist.id)
     }
 
-    init(playlist: Playlist, client: any YTMusicClientProtocol) {
+    init(
+        playlist: Playlist,
+        client: any YTMusicClientProtocol,
+        likeStatusManager: SongLikeStatusManager = .shared
+    ) {
         self.playlist = playlist
         self.client = client
+        self.likeStatusManager = likeStatusManager
     }
 
     var playlistID: String {
@@ -132,8 +138,9 @@ final class PlaylistDetailViewModel {
             liveSyncTask.task.cancel()
         }
         if let loadedLikedMusicScope {
-            Task { @MainActor in
-                SongLikeStatusManager.shared.finishLikedMusicRequest(loadedLikedMusicScope)
+            let likeStatusManager = self.likeStatusManager
+            Task { @MainActor [likeStatusManager, loadedLikedMusicScope] in
+                likeStatusManager.finishLikedMusicRequest(loadedLikedMusicScope)
             }
         }
     }
@@ -243,10 +250,10 @@ extension PlaylistDetailViewModel {
         self.loadGeneration += 1
         let previousLikedMusicScope = self.loadedLikedMusicScope
         let likedMusicSnapshot = self.isLikedMusicPlaylist
-            ? SongLikeStatusManager.shared.beginLikedMusicRequest()
+            ? self.likeStatusManager.beginLikedMusicRequest()
             : nil
         if let previousLikedMusicScope {
-            SongLikeStatusManager.shared.finishLikedMusicRequest(previousLikedMusicScope)
+            self.likeStatusManager.finishLikedMusicRequest(previousLikedMusicScope)
             self.loadedLikedMusicScope = nil
         }
         self.countedPlaylistRemovalSetVideoIDs = []
@@ -264,7 +271,7 @@ extension PlaylistDetailViewModel {
     private func finishInitialLoad(_ context: InitialLoadContext) {
         guard let snapshot = context.likedMusicSnapshot else { return }
         guard self.loadedLikedMusicScope != snapshot else { return }
-        SongLikeStatusManager.shared.finishLikedMusicRequest(snapshot)
+        self.likeStatusManager.finishLikedMusicRequest(snapshot)
     }
 
     private func fetchInitialLoadResult(_ context: InitialLoadContext) async throws -> InitialLoadResult? {
@@ -362,7 +369,7 @@ extension PlaylistDetailViewModel {
         _ detail: PlaylistDetail,
         snapshot: LikedMusicRequestSnapshot
     ) -> LikedMusicDetailResult? {
-        guard let reconciliation = SongLikeStatusManager.shared.reconcileLikedMusicTracks(
+        guard let reconciliation = self.likeStatusManager.reconcileLikedMusicTracks(
             detail.tracks,
             snapshot: snapshot,
             deduplicating: true
@@ -569,7 +576,7 @@ extension PlaylistDetailViewModel {
                 deferredMetadata: []
             )
         }
-        guard let reconciliation = SongLikeStatusManager.shared.reconcileLikedMusicTracks(
+        guard let reconciliation = self.likeStatusManager.reconcileLikedMusicTracks(
             tracks,
             snapshot: snapshot
         ) else { return nil }
@@ -601,7 +608,7 @@ extension PlaylistDetailViewModel {
     private func startDeferredLikedMusicMetadataTasks(_ metadata: [DeferredLikedMusicMetadata]) {
         for item in metadata {
             if let snapshot = self.liveSyncTasks[item.videoId]?.snapshot,
-               SongLikeStatusManager.shared.matchesCurrentScope(snapshot)
+               self.likeStatusManager.matchesCurrentScope(snapshot)
             {
                 continue
             }
@@ -836,12 +843,12 @@ extension PlaylistDetailViewModel {
 
     private func isCurrentLikedMusicScope(_ snapshot: LikedMusicRequestSnapshot?) -> Bool {
         guard let snapshot else { return true }
-        return SongLikeStatusManager.shared.matchesCurrentScope(snapshot)
+        return self.likeStatusManager.matchesCurrentScope(snapshot)
     }
 
     private func isLoadedLikedMusicAccountCurrent() -> Bool {
         guard let loadedLikedMusicAccountID else { return true }
-        return loadedLikedMusicAccountID == SongLikeStatusManager.shared.activeAccountID
+        return loadedLikedMusicAccountID == self.likeStatusManager.activeAccountID
     }
 
     private func invalidateLikedMusicPagination(generation: Int?) {
@@ -930,7 +937,7 @@ extension PlaylistDetailViewModel {
 
     private func releaseLoadedLikedMusicScope() {
         guard let loadedLikedMusicScope else { return }
-        SongLikeStatusManager.shared.finishLikedMusicRequest(loadedLikedMusicScope)
+        self.likeStatusManager.finishLikedMusicRequest(loadedLikedMusicScope)
         self.loadedLikedMusicScope = nil
     }
 
@@ -994,14 +1001,15 @@ extension PlaylistDetailViewModel {
     ) {
         let taskID = UUID()
         let snapshot = self.isLikedMusicPlaylist
-            ? SongLikeStatusManager.shared.beginLikedMusicRequest()
+            ? self.likeStatusManager.beginLikedMusicRequest()
             : nil
+        let likeStatusManager = self.likeStatusManager
         self.cancelLiveSyncTask(for: videoId)
 
-        let task = Task { @MainActor [weak self] in
+        let task = Task { @MainActor [weak self, likeStatusManager] in
             defer {
                 if let snapshot {
-                    SongLikeStatusManager.shared.finishLikedMusicRequest(snapshot)
+                    likeStatusManager.finishLikedMusicRequest(snapshot)
                 }
             }
             guard let self else { return }
@@ -1038,7 +1046,7 @@ extension PlaylistDetailViewModel {
             guard !Task.isCancelled else { return }
             guard self.liveSyncTasks[videoId]?.id == taskID else { return }
             guard self.isCurrentLikedMusicScope(snapshot) else { return }
-            guard SongLikeStatusManager.shared.status(for: videoId) == .like else { return }
+            guard self.likeStatusManager.status(for: videoId) == .like else { return }
             guard !Self.requiresMetadataFetchForLiveSync(song) else {
                 self.logger.warning("Live sync: skipping incomplete metadata for liked song \(videoId)")
                 return

--- a/Sources/Kaset/Views/LegacyFallbackViews.swift
+++ b/Sources/Kaset/Views/LegacyFallbackViews.swift
@@ -66,10 +66,12 @@ struct SimplePlaylistDetailView: View {
         .refreshable {
             await self.viewModel.refresh()
         }
-        .onChange(of: self.likeStatusManager.lastLikeEvent) { _, event in
-            guard let event else { return }
-            guard LikedMusicPlaylist.matches(id: self.playlist.id) else { return }
-            self.viewModel.handleLikeStatusChange(event)
+        .onChange(of: self.likeStatusManager.lastLikeEventBatch) { _, batch in
+            guard let batch, batch.accountID == self.likeStatusManager.activeAccountID else { return }
+            for event in batch.events {
+                guard LikedMusicPlaylist.matches(id: self.playlist.id) else { return }
+                self.viewModel.handleLikeStatusChange(event)
+            }
         }
     }
 

--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -377,20 +377,21 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
                 using: self.client
             )
         }
-        .onChange(of: self.likeStatusManager.lastLikeEvent) { _, event in
-            guard let event else { return }
+        .onChange(of: self.likeStatusManager.lastLikeEventBatch) { _, batch in
+            guard let batch, batch.accountID == self.likeStatusManager.activeAccountID else { return }
+            for event in batch.events {
+                // Global sync 1: keep PlayerService.currentTrackLikeStatus in sync
+                if let currentVideoId = self.playerService.currentTrack?.videoId,
+                   event.videoId == currentVideoId
+                {
+                    self.playerService.currentTrackLikeStatus = event.status
+                }
 
-            // Global sync 1: keep PlayerService.currentTrackLikeStatus in sync
-            if let currentVideoId = self.playerService.currentTrack?.videoId,
-               event.videoId == currentVideoId
-            {
-                self.playerService.currentTrackLikeStatus = event.status
-            }
-
-            // Global sync 2: keep Liked Music list in sync when the active
-            // Liked Music detail view is not already forwarding this event.
-            if self.navigationSelection != .likedMusic {
-                self.likedMusicViewModel?.handleLikeStatusChange(event)
+                // Global sync 2: keep Liked Music list in sync when the active
+                // Liked Music detail view is not already forwarding this event.
+                if self.navigationSelection != .likedMusic {
+                    self.likedMusicViewModel?.handleLikeStatusChange(event)
+                }
             }
         }
     }

--- a/Sources/Kaset/Views/PlaylistDetailView.swift
+++ b/Sources/Kaset/Views/PlaylistDetailView.swift
@@ -91,10 +91,12 @@ struct PlaylistDetailView: View {
         .refreshable {
             await self.viewModel.refresh()
         }
-        .onChange(of: self.likeStatusManager.lastLikeEvent) { _, event in
-            guard let event else { return }
-            guard LikedMusicPlaylist.matches(id: self.playlist.id) else { return }
-            self.viewModel.handleLikeStatusChange(event)
+        .onChange(of: self.likeStatusManager.lastLikeEventBatch) { _, batch in
+            guard let batch, batch.accountID == self.likeStatusManager.activeAccountID else { return }
+            for event in batch.events {
+                guard LikedMusicPlaylist.matches(id: self.playlist.id) else { return }
+                self.viewModel.handleLikeStatusChange(event)
+            }
         }
         .sheet(isPresented: self.$showRefineSheet) {
             if let detail = viewModel.playlistDetail {

--- a/Tests/KasetTests/AuthServiceTests.swift
+++ b/Tests/KasetTests/AuthServiceTests.swift
@@ -114,6 +114,24 @@ struct AuthServiceTests {
         #expect(self.authService.needsReauth == true)
     }
 
+    @Test("Session expiry clears like state and invalidates liked-music requests")
+    func sessionExpiryClearsLikeStateAndInvalidatesLikedMusicRequests() {
+        self.authService.completeLogin(sapisid: "placeholder")
+
+        let manager = SongLikeStatusManager.shared
+        let videoId = "session-expiry-cached-like"
+        manager.setStatus(.like, for: videoId)
+        let requestSnapshot = manager.beginLikedMusicRequest()
+
+        #expect(manager.status(for: videoId) == .like)
+        #expect(manager.matchesCurrentScope(requestSnapshot))
+
+        self.authService.sessionExpired()
+
+        #expect(manager.status(for: videoId) == nil)
+        #expect(manager.matchesCurrentScope(requestSnapshot) == false)
+    }
+
     @Test("Guest mode transitions clear URL cache")
     func guestModeTransitionsClearURLCache() async throws {
         self.authService.completeLogin(sapisid: "placeholder")

--- a/Tests/KasetTests/Helpers/MockYTMusicClient.swift
+++ b/Tests/KasetTests/Helpers/MockYTMusicClient.swift
@@ -100,6 +100,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     var playlistDetails: [String: PlaylistDetail] = [:]
     var playlistAllTracks: [String: [Song]] = [:]
     var playlistContinuationTracks: [String: [[Song]]] = [:]
+    var forcedPlaylistContinuationResponses: [PlaylistContinuationResponse] = []
     var artistDetails: [String: ArtistDetail] = [:]
     var artistSongs: [String: [Song]] = [:]
     var artistSongsResponse: [Song] = []
@@ -828,6 +829,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         }
         if let error = shouldThrowError {
             throw error
+        }
+        if !self.forcedPlaylistContinuationResponses.isEmpty {
+            return self.forcedPlaylistContinuationResponses.removeFirst()
         }
         guard let (playlistId, index) = Self.parsePlaylistContinuationToken(token),
               let continuations = playlistContinuationTracks[playlistId],

--- a/Tests/KasetTests/PlayerServiceLibraryTests.swift
+++ b/Tests/KasetTests/PlayerServiceLibraryTests.swift
@@ -192,6 +192,46 @@ struct PlayerServiceLibraryTests { // swiftlint:disable:this type_body_length
         #expect(self.playerService.currentTrackLikeStatus == .like)
     }
 
+    @Test("Protected rating remains authoritative after stale metadata returns")
+    func protectedRatingRemainsAuthoritativeAfterStaleMetadata() async {
+        let song = TestFixtures.makeSong(id: "protected-metadata-rating")
+        let manager = self.playerService.songLikeStatusManager
+        self.playerService.currentTrack = song
+        self.playerService.currentTrackLikeStatus = .like
+        manager.setStatus(.like, for: song.videoId)
+        let snapshot = manager.beginLikedMusicRequest()
+        let metadataStarted = AsyncGate()
+        let releaseMetadata = AsyncGate()
+        self.mockClient.songResponses[song.videoId] = Song(
+            id: song.id,
+            title: song.title,
+            artists: song.artists,
+            videoId: song.videoId,
+            likeStatus: .like
+        )
+        self.mockClient.beforeGetSongReturn = { _ in
+            await metadataStarted.open()
+            await releaseMetadata.wait()
+        }
+
+        let metadataTask = Task { @MainActor in
+            await self.playerService.fetchSongMetadata(videoId: song.videoId, queueOwner: .none)
+        }
+        await metadataStarted.wait()
+
+        self.playerService.likeCurrentTrack()
+        _ = await self.waitUntilRateSongCallCount(1)
+        let settled = await self.waitUntilLikeStatus(.indifferent)
+        #expect(settled)
+
+        await releaseMetadata.open()
+        await metadataTask.value
+        manager.finishLikedMusicRequest(snapshot)
+
+        #expect(self.playerService.currentTrackLikeStatus == .indifferent)
+        #expect(self.playerService.currentTrack?.likeStatus == .indifferent)
+    }
+
     @Test("likeCurrentTrack uses captured client even if singleton client changes before task runs")
     func likeCurrentTrackUsesCapturedClient() async {
         let replacementClient = MockYTMusicClient()

--- a/Tests/KasetTests/PlaylistDetailViewModelTests.swift
+++ b/Tests/KasetTests/PlaylistDetailViewModelTests.swift
@@ -9,14 +9,18 @@ import Testing
 // swiftlint:disable:next type_body_length
 struct PlaylistDetailViewModelTests {
     var mockClient: MockYTMusicClient
+    var likeStatusManager: SongLikeStatusManager
     var viewModel: PlaylistDetailViewModel
 
     init() {
         self.mockClient = MockYTMusicClient()
+        self.likeStatusManager = SongLikeStatusManager()
         let playlist = TestFixtures.makePlaylist(id: "VL-test-playlist", title: "Test Playlist")
-        self.viewModel = PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
-        SongLikeStatusManager.shared.clearCache()
-        SongLikeStatusManager.shared.setActiveAccountID(nil)
+        self.viewModel = PlaylistDetailViewModel(
+            playlist: playlist,
+            client: self.mockClient,
+            likeStatusManager: self.likeStatusManager
+        )
     }
 
     private func makeLikedMusicPlaylist(trackCount: Int? = nil) -> Playlist {
@@ -38,7 +42,11 @@ struct PlaylistDetailViewModelTests {
             duration: nil
         )
         self.mockClient.playlistDetails[playlist.id] = detail
-        return PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
+        return PlaylistDetailViewModel(
+            playlist: playlist,
+            client: self.mockClient,
+            likeStatusManager: self.likeStatusManager
+        )
     }
 
     private func waitUntil(
@@ -287,8 +295,8 @@ struct PlaylistDetailViewModelTests {
         #expect(likedMusicViewModel.playlistDetail?.tracks.count == 2)
         #expect(likedMusicViewModel.playlistDetail?.tracks[0].likeStatus == .like)
         #expect(likedMusicViewModel.playlistDetail?.tracks[1].likeStatus == .like)
-        #expect(SongLikeStatusManager.shared.status(for: "liked-1") == .like)
-        #expect(SongLikeStatusManager.shared.status(for: "liked-2") == .like)
+        #expect(self.likeStatusManager.status(for: "liked-1") == .like)
+        #expect(self.likeStatusManager.status(for: "liked-2") == .like)
     }
 
     @Test("Liked Music loadAllRemaining fetches every continuation")
@@ -517,7 +525,7 @@ struct PlaylistDetailViewModelTests {
             description: "overlapping delayed continuation to start"
         )
 
-        let manager = SongLikeStatusManager.shared
+        let manager = self.likeStatusManager
         let rating = manager.enqueueRating(
             initialTracks[0],
             status: .indifferent,
@@ -533,7 +541,7 @@ struct PlaylistDetailViewModelTests {
         )
 
         #expect(likedMusicViewModel.playlistDetail?.trackCount == 1)
-        #expect(SongLikeStatusManager.shared.status(for: "liked-1") != .like)
+        #expect(self.likeStatusManager.status(for: "liked-1") != .like)
     }
 
     @Test("Live-synced removal skips not-yet-loaded continuation track")
@@ -554,7 +562,7 @@ struct PlaylistDetailViewModelTests {
             description: "first delayed continuation to start"
         )
 
-        let manager = SongLikeStatusManager.shared
+        let manager = self.likeStatusManager
         let rating = manager.enqueueRating(
             futureSong,
             status: .indifferent,
@@ -573,7 +581,7 @@ struct PlaylistDetailViewModelTests {
         #expect(videoIds == ["liked-1", "liked-3"])
         #expect(videoIds.contains("future-unliked") == false)
         #expect(likedMusicViewModel.playlistDetail?.trackCount == 2)
-        #expect(SongLikeStatusManager.shared.status(for: "future-unliked") != .like)
+        #expect(self.likeStatusManager.status(for: "future-unliked") != .like)
     }
 
     @Test("Manual load more preserves live removal after background drain failure")
@@ -603,7 +611,7 @@ struct PlaylistDetailViewModelTests {
         self.mockClient.playlistContinuationDelay = nil
 
         #expect(likedMusicViewModel.hasMore == true)
-        let manager = SongLikeStatusManager.shared
+        let manager = self.likeStatusManager
         let requestStarted = AsyncGate()
         let releaseRequest = AsyncGate()
         self.mockClient.beforeRateSongReturn = { _, _ in
@@ -626,7 +634,7 @@ struct PlaylistDetailViewModelTests {
         #expect(videoIds == ["liked-1", "liked-3"])
         #expect(videoIds.contains("future-unliked") == false)
         #expect(likedMusicViewModel.playlistDetail?.trackCount == 2)
-        #expect(SongLikeStatusManager.shared.status(for: "future-unliked") != .like)
+        #expect(self.likeStatusManager.status(for: "future-unliked") != .like)
         #expect(likedMusicViewModel.hasMore == false)
     }
 
@@ -1140,7 +1148,7 @@ struct PlaylistDetailViewModelTests {
 
     @Test("Failed unlike rollback restores the loaded track total")
     func failedUnlikeRollbackRestoresLoadedTrackTotal() async throws {
-        let manager = SongLikeStatusManager.shared
+        let manager = self.likeStatusManager
         let song = TestFixtures.makeSong(id: "rollback-loaded-total", title: "Rollback Loaded")
         let likedMusicViewModel = self.makeLikedMusicViewModel(with: [song], trackCount: 1)
         await likedMusicViewModel.load()
@@ -1189,7 +1197,7 @@ struct PlaylistDetailViewModelTests {
 
     @Test("Liked Music optimistic insertion preserves the confirmed rollback baseline")
     func likedMusicOptimisticInsertionPreservesRollbackBaseline() async throws {
-        let manager = SongLikeStatusManager.shared
+        let manager = self.likeStatusManager
         let accountID = "liked-music-rollback-\(UUID().uuidString)"
         manager.setActiveAccountID(accountID)
         defer { manager.setActiveAccountID(nil) }
@@ -1246,7 +1254,7 @@ struct PlaylistDetailViewModelTests {
             artists: [],
             videoId: videoId
         )
-        SongLikeStatusManager.shared.setCachedStatus(.like, for: videoId)
+        self.likeStatusManager.setCachedStatus(.like, for: videoId)
         likedMusicViewModel.handleLikeStatusChange(
             LikeStatusEvent(videoId: videoId, status: .like, song: placeholderSong)
         )
@@ -1276,7 +1284,7 @@ struct PlaylistDetailViewModelTests {
             videoId: videoId
         )
 
-        SongLikeStatusManager.shared.setCachedStatus(.like, for: videoId)
+        self.likeStatusManager.setCachedStatus(.like, for: videoId)
         likedMusicViewModel.handleLikeStatusChange(
             LikeStatusEvent(
                 videoId: videoId,
@@ -1287,7 +1295,7 @@ struct PlaylistDetailViewModelTests {
 
         try? await Task.sleep(for: .milliseconds(50))
 
-        SongLikeStatusManager.shared.setCachedStatus(.indifferent, for: videoId)
+        self.likeStatusManager.setCachedStatus(.indifferent, for: videoId)
         likedMusicViewModel.handleLikeStatusChange(
             LikeStatusEvent(videoId: videoId, status: .indifferent, song: nil)
         )
@@ -1302,7 +1310,7 @@ struct PlaylistDetailViewModelTests {
 
     @Test("Loaded unlike is counted once when an in-flight continuation returns the removed track")
     func loadedUnlikeIsCountedOnceAcrossContinuationOverlap() async {
-        let manager = SongLikeStatusManager.shared
+        let manager = self.likeStatusManager
         let removedSong = TestFixtures.makeSong(id: "loaded-unlike", title: "Loaded Unlike")
         let continuationSong = TestFixtures.makeSong(id: "continuation-liked", title: "Continuation Liked")
         let reportedTotal = 2429
@@ -1354,7 +1362,7 @@ struct PlaylistDetailViewModelTests {
 
     @Test("Completed unlike survives a later stale continuation from the initial Liked Music load")
     func completedUnlikeSurvivesLaterInitialContinuation() async throws {
-        let manager = SongLikeStatusManager.shared
+        let manager = self.likeStatusManager
         let removedSong = TestFixtures.makeSong(id: "completed-unlike", title: "Completed Unlike")
         let continuationSong = TestFixtures.makeSong(id: "later-liked", title: "Later Liked")
         let reportedTotal = 2
@@ -1414,7 +1422,7 @@ struct PlaylistDetailViewModelTests {
 
     @Test("Same-account invalidation keeps loaded Liked Music live sync active")
     func sameAccountInvalidationKeepsLoadedLikedMusicLiveSyncActive() async {
-        let manager = SongLikeStatusManager.shared
+        let manager = self.likeStatusManager
         let accountID = "same-account-live-sync"
         manager.setActiveAccountID(accountID)
         defer { manager.setActiveAccountID(nil) }
@@ -1452,7 +1460,7 @@ struct PlaylistDetailViewModelTests {
 
     @Test("Initial reconciliation increments the reported total once for an omitted pending complete like")
     func initialReconciliationCountsOmittedPendingCompleteLikeOnce() async {
-        let manager = SongLikeStatusManager.shared
+        let manager = self.likeStatusManager
         let existingSong = TestFixtures.makeSong(id: "existing-liked", title: "Existing Liked")
         let pendingSong = Song(
             id: "pending-complete-like",
@@ -1507,7 +1515,7 @@ struct PlaylistDetailViewModelTests {
 
     @Test("Initial reconciliation does not increment totals for a failed unlike rollback")
     func initialReconciliationDoesNotCountFailedUnlikeRollbackAsInsertion() async {
-        let manager = SongLikeStatusManager.shared
+        let manager = self.likeStatusManager
         let existingSong = TestFixtures.makeSong(id: "rollback-existing", title: "Existing Song")
         let rollbackSong = TestFixtures.makeSong(id: "rollback-liked", title: "Rollback Liked")
         let likedMusicViewModel = self.makeLikedMusicViewModel(with: [existingSong], trackCount: 2)
@@ -1536,7 +1544,7 @@ struct PlaylistDetailViewModelTests {
 
     @Test("Deferred failed-unlike rollback metadata preserves the reported total")
     func deferredFailedUnlikeRollbackMetadataPreservesReportedTotal() async {
-        let manager = SongLikeStatusManager.shared
+        let manager = self.likeStatusManager
         let existingSong = TestFixtures.makeSong(id: "deferred-rollback-existing", title: "Existing Song")
         let videoID = "deferred-rollback-liked"
         let placeholderSong = Song(
@@ -1582,7 +1590,7 @@ struct PlaylistDetailViewModelTests {
 
     @Test("Initial reconciliation resolves an omitted pending placeholder like before insertion")
     func initialReconciliationResolvesOmittedPendingPlaceholderLike() async {
-        let manager = SongLikeStatusManager.shared
+        let manager = self.likeStatusManager
         let existingSong = TestFixtures.makeSong(id: "existing-placeholder-base", title: "Existing Song")
         let videoID = "pending-placeholder-like"
         let placeholderSong = Song(
@@ -1657,7 +1665,7 @@ struct PlaylistDetailViewModelTests {
 
     @Test("Continuation reconciliation reuses an in-flight placeholder metadata request")
     func continuationReconciliationReusesInFlightPlaceholderMetadataRequest() async {
-        let manager = SongLikeStatusManager.shared
+        let manager = self.likeStatusManager
         let videoID = "reused-placeholder-metadata"
         let placeholderSong = Song(
             id: videoID,
@@ -1702,7 +1710,7 @@ struct PlaylistDetailViewModelTests {
 
     @Test("Continuation response metadata for an optimistic like increments the reported total")
     func continuationResponseMetadataForOptimisticLikeIncrementsReportedTotal() async throws {
-        let manager = SongLikeStatusManager.shared
+        let manager = self.likeStatusManager
         let existingSong = TestFixtures.makeSong(id: "existing-liked", title: "Existing Liked")
         let resolvedSong = Song(
             id: "response-backed-like",

--- a/Tests/KasetTests/PlaylistDetailViewModelTests.swift
+++ b/Tests/KasetTests/PlaylistDetailViewModelTests.swift
@@ -499,7 +499,7 @@ struct PlaylistDetailViewModelTests {
     }
 
     @Test("Live-synced loaded removal is not double-counted by continuation overlap")
-    func liveSyncedLoadedRemovalIsNotDoubleCountedByContinuationOverlap() async {
+    func liveSyncedLoadedRemovalIsNotDoubleCountedByContinuationOverlap() async throws {
         let initialTracks = [TestFixtures.makeSong(id: "liked-1", title: "Liked 1")]
         let likedMusicViewModel = self.makeLikedMusicViewModel(with: initialTracks, trackCount: 2)
         self.mockClient.playlistContinuationTracks[LikedMusicPlaylist.id] = [
@@ -517,11 +517,16 @@ struct PlaylistDetailViewModelTests {
             description: "overlapping delayed continuation to start"
         )
 
-        likedMusicViewModel.handleLikeStatusChange(
-            LikeStatusEvent(videoId: "liked-1", status: .indifferent, song: nil)
+        let manager = SongLikeStatusManager.shared
+        let rating = manager.enqueueRating(
+            initialTracks[0],
+            status: .indifferent,
+            client: self.mockClient
         )
+        try likedMusicViewModel.handleLikeStatusChange(#require(manager.lastLikeEvent))
 
         await drainTask.value
+        _ = await rating.value
         await self.waitUntil(
             likedMusicViewModel.playlistDetail?.tracks.map(\.videoId) == ["liked-2"],
             description: "continuation drain to skip loaded unlike overlap"
@@ -532,11 +537,12 @@ struct PlaylistDetailViewModelTests {
     }
 
     @Test("Live-synced removal skips not-yet-loaded continuation track")
-    func liveSyncedRemovalSkipsNotYetLoadedContinuationTrack() async {
+    func liveSyncedRemovalSkipsNotYetLoadedContinuationTrack() async throws {
         let initialTracks = [TestFixtures.makeSong(id: "liked-1", title: "Liked 1")]
         let likedMusicViewModel = self.makeLikedMusicViewModel(with: initialTracks, trackCount: 3)
+        let futureSong = TestFixtures.makeSong(id: "future-unliked", title: "Future Unliked")
         self.mockClient.playlistContinuationTracks[LikedMusicPlaylist.id] = [
-            [TestFixtures.makeSong(id: "future-unliked", title: "Future Unliked")],
+            [futureSong],
             [TestFixtures.makeSong(id: "liked-3", title: "Liked 3")],
         ]
         self.mockClient.playlistContinuationDelay = .milliseconds(200)
@@ -548,11 +554,16 @@ struct PlaylistDetailViewModelTests {
             description: "first delayed continuation to start"
         )
 
-        likedMusicViewModel.handleLikeStatusChange(
-            LikeStatusEvent(videoId: "future-unliked", status: .indifferent, song: nil)
+        let manager = SongLikeStatusManager.shared
+        let rating = manager.enqueueRating(
+            futureSong,
+            status: .indifferent,
+            client: self.mockClient
         )
+        try likedMusicViewModel.handleLikeStatusChange(#require(manager.lastLikeEvent))
 
         await drainTask.value
+        _ = await rating.value
         await self.waitUntil(
             self.mockClient.getPlaylistContinuationCallCount == 2 && likedMusicViewModel.playlistDetail?.tracks.map(\.videoId).contains("liked-3") == true,
             description: "continuation drain to skip not-yet-loaded unlike"
@@ -566,11 +577,12 @@ struct PlaylistDetailViewModelTests {
     }
 
     @Test("Manual load more preserves live removal after background drain failure")
-    func manualLoadMorePreservesLiveRemovalAfterBackgroundDrainFailure() async {
+    func manualLoadMorePreservesLiveRemovalAfterBackgroundDrainFailure() async throws {
         let initialTracks = [TestFixtures.makeSong(id: "liked-1", title: "Liked 1")]
         let likedMusicViewModel = self.makeLikedMusicViewModel(with: initialTracks, trackCount: 3)
+        let futureSong = TestFixtures.makeSong(id: "future-unliked", title: "Future Unliked")
         self.mockClient.playlistContinuationTracks[LikedMusicPlaylist.id] = [
-            [TestFixtures.makeSong(id: "future-unliked", title: "Future Unliked")],
+            [futureSong],
             [TestFixtures.makeSong(id: "liked-3", title: "Liked 3")],
         ]
         self.mockClient.playlistContinuationDelay = .milliseconds(200)
@@ -591,12 +603,24 @@ struct PlaylistDetailViewModelTests {
         self.mockClient.playlistContinuationDelay = nil
 
         #expect(likedMusicViewModel.hasMore == true)
-        likedMusicViewModel.handleLikeStatusChange(
-            LikeStatusEvent(videoId: "future-unliked", status: .indifferent, song: nil)
+        let manager = SongLikeStatusManager.shared
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        self.mockClient.beforeRateSongReturn = { _, _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+        let rating = manager.enqueueRating(
+            futureSong,
+            status: .indifferent,
+            client: self.mockClient
         )
+        try likedMusicViewModel.handleLikeStatusChange(#require(manager.lastLikeEvent))
 
         await likedMusicViewModel.loadMore()
         await likedMusicViewModel.loadMore()
+        await releaseRequest.open()
+        _ = await rating.value
 
         let videoIds = likedMusicViewModel.playlistDetail?.tracks.map(\.videoId) ?? []
         #expect(videoIds == ["liked-1", "liked-3"])
@@ -1114,6 +1138,32 @@ struct PlaylistDetailViewModelTests {
         #expect(likedMusicViewModel.playlistDetail?.tracks.first?.videoId == "liked-2")
     }
 
+    @Test("Failed unlike rollback restores the loaded track total")
+    func failedUnlikeRollbackRestoresLoadedTrackTotal() async throws {
+        let manager = SongLikeStatusManager.shared
+        let song = TestFixtures.makeSong(id: "rollback-loaded-total", title: "Rollback Loaded")
+        let likedMusicViewModel = self.makeLikedMusicViewModel(with: [song], trackCount: 1)
+        await likedMusicViewModel.load()
+        manager.setStatus(.like, for: song.videoId)
+        self.mockClient.rateSongErrors = [
+            YTMusicError.networkError(underlying: URLError(.notConnectedToInternet)),
+        ]
+
+        let rating = manager.enqueueRating(
+            song,
+            status: .indifferent,
+            client: self.mockClient
+        )
+        try likedMusicViewModel.handleLikeStatusChange(#require(manager.lastLikeEvent))
+        #expect(likedMusicViewModel.playlistDetail?.trackCount == 0)
+
+        #expect(await rating.value == .like)
+        try likedMusicViewModel.handleLikeStatusChange(#require(manager.lastLikeEvent))
+
+        #expect(likedMusicViewModel.playlistDetail?.tracks.map(\.videoId) == [song.videoId])
+        #expect(likedMusicViewModel.playlistDetail?.trackCount == 1)
+    }
+
     @Test("Liked Music live sync inserts liked song with complete metadata")
     func likedMusicLiveSyncInsertsLikedSongWithCompleteMetadata() async {
         let tracks = [TestFixtures.makeSong(id: "liked-1", title: "Liked 1")]
@@ -1196,6 +1246,7 @@ struct PlaylistDetailViewModelTests {
             artists: [],
             videoId: videoId
         )
+        SongLikeStatusManager.shared.setCachedStatus(.like, for: videoId)
         likedMusicViewModel.handleLikeStatusChange(
             LikeStatusEvent(videoId: videoId, status: .like, song: placeholderSong)
         )
@@ -1225,6 +1276,7 @@ struct PlaylistDetailViewModelTests {
             videoId: videoId
         )
 
+        SongLikeStatusManager.shared.setCachedStatus(.like, for: videoId)
         likedMusicViewModel.handleLikeStatusChange(
             LikeStatusEvent(
                 videoId: videoId,
@@ -1235,6 +1287,7 @@ struct PlaylistDetailViewModelTests {
 
         try? await Task.sleep(for: .milliseconds(50))
 
+        SongLikeStatusManager.shared.setCachedStatus(.indifferent, for: videoId)
         likedMusicViewModel.handleLikeStatusChange(
             LikeStatusEvent(videoId: videoId, status: .indifferent, song: nil)
         )
@@ -1243,6 +1296,513 @@ struct PlaylistDetailViewModelTests {
 
         #expect(self.mockClient.getSongVideoIds.contains(videoId))
         #expect(likedMusicViewModel.playlistDetail?.tracks.isEmpty == true)
+    }
+
+    // MARK: - Liked Music Reconciliation Regression Tests
+
+    @Test("Loaded unlike is counted once when an in-flight continuation returns the removed track")
+    func loadedUnlikeIsCountedOnceAcrossContinuationOverlap() async {
+        let manager = SongLikeStatusManager.shared
+        let removedSong = TestFixtures.makeSong(id: "loaded-unlike", title: "Loaded Unlike")
+        let continuationSong = TestFixtures.makeSong(id: "continuation-liked", title: "Continuation Liked")
+        let reportedTotal = 2429
+        let likedMusicViewModel = self.makeLikedMusicViewModel(
+            with: [removedSong],
+            trackCount: reportedTotal
+        )
+        self.mockClient.playlistContinuationTracks[LikedMusicPlaylist.id] = [
+            [removedSong, continuationSong],
+        ]
+
+        let continuationStarted = AsyncGate()
+        let releaseContinuation = AsyncGate()
+        let releaseRating = AsyncGate()
+        self.mockClient.beforePlaylistContinuationReturn = { _ in
+            await continuationStarted.open()
+            await releaseContinuation.wait()
+        }
+        self.mockClient.beforeRateSongReturn = { _, _ in
+            await releaseRating.wait()
+        }
+
+        await likedMusicViewModel.load()
+        let drainTask = Task { await likedMusicViewModel.loadAllRemaining() }
+        await continuationStarted.wait()
+
+        let rating = manager.enqueueRating(
+            removedSong,
+            status: .indifferent,
+            client: self.mockClient
+        )
+        if let event = manager.lastLikeEvent {
+            likedMusicViewModel.handleLikeStatusChange(event)
+        } else {
+            Issue.record("Expected an optimistic unlike event")
+        }
+
+        #expect(likedMusicViewModel.playlistDetail?.trackCount == reportedTotal - 1)
+
+        await releaseContinuation.open()
+        await drainTask.value
+
+        #expect(likedMusicViewModel.playlistDetail?.tracks.map(\.videoId) == [continuationSong.videoId])
+        #expect(likedMusicViewModel.playlistDetail?.trackCount == reportedTotal - 1)
+
+        await releaseRating.open()
+        #expect(await rating.value == .indifferent)
+    }
+
+    @Test("Completed unlike survives a later stale continuation from the initial Liked Music load")
+    func completedUnlikeSurvivesLaterInitialContinuation() async throws {
+        let manager = SongLikeStatusManager.shared
+        let removedSong = TestFixtures.makeSong(id: "completed-unlike", title: "Completed Unlike")
+        let continuationSong = TestFixtures.makeSong(id: "later-liked", title: "Later Liked")
+        let reportedTotal = 2
+        let likedMusicViewModel = self.makeLikedMusicViewModel(
+            with: [removedSong],
+            trackCount: reportedTotal
+        )
+        self.mockClient.playlistContinuationTracks[LikedMusicPlaylist.id] = [
+            [removedSong, continuationSong],
+        ]
+
+        let ratingStarted = AsyncGate()
+        let releaseRating = AsyncGate()
+        let continuationStarted = AsyncGate()
+        let releaseContinuation = AsyncGate()
+        self.mockClient.beforeRateSongReturn = { _, _ in
+            await ratingStarted.open()
+            await releaseRating.wait()
+        }
+        self.mockClient.beforePlaylistContinuationReturn = { _ in
+            await continuationStarted.open()
+            await releaseContinuation.wait()
+        }
+
+        await likedMusicViewModel.load()
+        #expect(likedMusicViewModel.hasMore == true)
+        #expect(self.mockClient.getPlaylistContinuationCallCount == 0)
+
+        let rating = manager.enqueueRating(
+            removedSong,
+            status: .indifferent,
+            client: self.mockClient
+        )
+        try likedMusicViewModel.handleLikeStatusChange(#require(manager.lastLikeEvent))
+        await ratingStarted.wait()
+
+        #expect(self.mockClient.getPlaylistContinuationCallCount == 0)
+        #expect(likedMusicViewModel.playlistDetail?.tracks.isEmpty == true)
+        #expect(likedMusicViewModel.playlistDetail?.trackCount == reportedTotal - 1)
+
+        await releaseRating.open()
+        #expect(await rating.value == .indifferent)
+        #expect(self.mockClient.getPlaylistContinuationCallCount == 0)
+
+        let continuationTask = Task { await likedMusicViewModel.loadMore() }
+        await continuationStarted.wait()
+        await releaseContinuation.open()
+        await continuationTask.value
+
+        let videoIDs = likedMusicViewModel.playlistDetail?.tracks.map(\.videoId) ?? []
+        #expect(self.mockClient.getPlaylistContinuationCallCount == 1)
+        #expect(videoIDs == [continuationSong.videoId])
+        #expect(videoIDs.contains(removedSong.videoId) == false)
+        #expect(likedMusicViewModel.playlistDetail?.trackCount == reportedTotal - 1)
+        #expect(likedMusicViewModel.hasMore == false)
+    }
+
+    @Test("Same-account invalidation keeps loaded Liked Music live sync active")
+    func sameAccountInvalidationKeepsLoadedLikedMusicLiveSyncActive() async {
+        let manager = SongLikeStatusManager.shared
+        let accountID = "same-account-live-sync"
+        manager.setActiveAccountID(accountID)
+        defer { manager.setActiveAccountID(nil) }
+
+        let song = TestFixtures.makeSong(id: "same-account-unlike", title: "Same Account Unlike")
+        let likedMusicViewModel = self.makeLikedMusicViewModel(with: [song], trackCount: 1)
+        let releaseRating = AsyncGate()
+        self.mockClient.beforeRateSongReturn = { _, _ in
+            await releaseRating.wait()
+        }
+
+        await likedMusicViewModel.load()
+        manager.invalidateSession(clearsActiveCache: false)
+
+        let rating = manager.enqueueRating(
+            song,
+            status: .indifferent,
+            client: self.mockClient
+        )
+        if let batch = manager.lastLikeEventBatch {
+            #expect(batch.accountID == accountID)
+            for event in batch.events {
+                likedMusicViewModel.handleLikeStatusChange(event)
+            }
+        } else {
+            Issue.record("Expected a current-account unlike event batch")
+        }
+
+        #expect(likedMusicViewModel.playlistDetail?.tracks.isEmpty == true)
+        #expect(likedMusicViewModel.playlistDetail?.trackCount == 0)
+
+        await releaseRating.open()
+        #expect(await rating.value == .indifferent)
+    }
+
+    @Test("Initial reconciliation increments the reported total once for an omitted pending complete like")
+    func initialReconciliationCountsOmittedPendingCompleteLikeOnce() async {
+        let manager = SongLikeStatusManager.shared
+        let existingSong = TestFixtures.makeSong(id: "existing-liked", title: "Existing Liked")
+        let pendingSong = Song(
+            id: "pending-complete-like",
+            title: "Pending Complete Like",
+            artists: [Artist(id: "pending-artist", name: "Pending Artist")],
+            videoId: "pending-complete-like"
+        )
+        let reportedTotal = 2429
+        let likedMusicViewModel = self.makeLikedMusicViewModel(
+            with: [existingSong],
+            trackCount: reportedTotal
+        )
+
+        let initialRequestStarted = AsyncGate()
+        let releaseInitialResponse = AsyncGate()
+        let releaseRating = AsyncGate()
+        self.mockClient.beforeGetPlaylistReturn = { _ in
+            await initialRequestStarted.open()
+            await releaseInitialResponse.wait()
+        }
+        self.mockClient.beforeRateSongReturn = { _, _ in
+            await releaseRating.wait()
+        }
+
+        let loadTask = Task { await likedMusicViewModel.load() }
+        await initialRequestStarted.wait()
+
+        let rating = manager.enqueueRating(
+            pendingSong,
+            status: .like,
+            client: self.mockClient
+        )
+        await releaseInitialResponse.open()
+        await loadTask.value
+
+        let reconciledVideoIDs = likedMusicViewModel.playlistDetail?.tracks.map(\.videoId) ?? []
+        #expect(reconciledVideoIDs.filter { $0 == pendingSong.videoId }.count == 1)
+        #expect(likedMusicViewModel.playlistDetail?.trackCount == reportedTotal + 1)
+
+        if let event = manager.lastLikeEvent {
+            likedMusicViewModel.handleLikeStatusChange(event)
+        } else {
+            Issue.record("Expected an optimistic like event")
+        }
+
+        #expect(likedMusicViewModel.playlistDetail?.tracks.filter { $0.videoId == pendingSong.videoId }.count == 1)
+        #expect(likedMusicViewModel.playlistDetail?.trackCount == reportedTotal + 1)
+
+        await releaseRating.open()
+        #expect(await rating.value == .like)
+    }
+
+    @Test("Initial reconciliation does not increment totals for a failed unlike rollback")
+    func initialReconciliationDoesNotCountFailedUnlikeRollbackAsInsertion() async {
+        let manager = SongLikeStatusManager.shared
+        let existingSong = TestFixtures.makeSong(id: "rollback-existing", title: "Existing Song")
+        let rollbackSong = TestFixtures.makeSong(id: "rollback-liked", title: "Rollback Liked")
+        let likedMusicViewModel = self.makeLikedMusicViewModel(with: [existingSong], trackCount: 2)
+        manager.setStatus(.like, for: rollbackSong.videoId)
+        let initialRequestStarted = AsyncGate()
+        let releaseInitialResponse = AsyncGate()
+        self.mockClient.beforeGetPlaylistReturn = { _ in
+            await initialRequestStarted.open()
+            await releaseInitialResponse.wait()
+        }
+
+        let loadTask = Task { await likedMusicViewModel.load() }
+        await initialRequestStarted.wait()
+        self.mockClient.rateSongErrors = [
+            YTMusicError.networkError(underlying: URLError(.notConnectedToInternet)),
+        ]
+
+        #expect(await manager.unlike(rollbackSong, client: self.mockClient) == .like)
+
+        await releaseInitialResponse.open()
+        await loadTask.value
+
+        #expect(likedMusicViewModel.playlistDetail?.tracks.map(\.videoId) == [rollbackSong.videoId, existingSong.videoId])
+        #expect(likedMusicViewModel.playlistDetail?.trackCount == 2)
+    }
+
+    @Test("Deferred failed-unlike rollback metadata preserves the reported total")
+    func deferredFailedUnlikeRollbackMetadataPreservesReportedTotal() async {
+        let manager = SongLikeStatusManager.shared
+        let existingSong = TestFixtures.makeSong(id: "deferred-rollback-existing", title: "Existing Song")
+        let videoID = "deferred-rollback-liked"
+        let placeholderSong = Song(
+            id: videoID,
+            title: "Loading...",
+            artists: [],
+            videoId: videoID
+        )
+        let resolvedSong = Song(
+            id: videoID,
+            title: "Resolved Rollback Like",
+            artists: [Artist(id: "rollback-artist", name: "Rollback Artist")],
+            videoId: videoID
+        )
+        let likedMusicViewModel = self.makeLikedMusicViewModel(with: [existingSong], trackCount: 2)
+        manager.setStatus(.like, for: videoID)
+        self.mockClient.songResponses[videoID] = resolvedSong
+        let initialRequestStarted = AsyncGate()
+        let releaseInitialResponse = AsyncGate()
+        self.mockClient.beforeGetPlaylistReturn = { _ in
+            await initialRequestStarted.open()
+            await releaseInitialResponse.wait()
+        }
+
+        let loadTask = Task { await likedMusicViewModel.load() }
+        await initialRequestStarted.wait()
+        self.mockClient.rateSongErrors = [
+            YTMusicError.networkError(underlying: URLError(.notConnectedToInternet)),
+        ]
+
+        #expect(await manager.unlike(placeholderSong, client: self.mockClient) == .like)
+
+        await releaseInitialResponse.open()
+        await loadTask.value
+        await self.waitUntil(
+            likedMusicViewModel.playlistDetail?.tracks.contains { $0.videoId == videoID } == true,
+            description: "deferred rollback metadata insertion"
+        )
+
+        #expect(likedMusicViewModel.playlistDetail?.tracks.first?.title == resolvedSong.title)
+        #expect(likedMusicViewModel.playlistDetail?.trackCount == 2)
+    }
+
+    @Test("Initial reconciliation resolves an omitted pending placeholder like before insertion")
+    func initialReconciliationResolvesOmittedPendingPlaceholderLike() async {
+        let manager = SongLikeStatusManager.shared
+        let existingSong = TestFixtures.makeSong(id: "existing-placeholder-base", title: "Existing Song")
+        let videoID = "pending-placeholder-like"
+        let placeholderSong = Song(
+            id: videoID,
+            title: "Loading...",
+            artists: [],
+            videoId: videoID
+        )
+        let resolvedSong = Song(
+            id: videoID,
+            title: "Resolved Pending Like",
+            artists: [Artist(id: "resolved-artist", name: "Resolved Artist")],
+            thumbnailURL: URL(string: "https://example.com/resolved-pending.jpg"),
+            videoId: videoID
+        )
+        let likedMusicViewModel = self.makeLikedMusicViewModel(with: [existingSong], trackCount: 1)
+        self.mockClient.songResponses[videoID] = resolvedSong
+
+        let initialRequestStarted = AsyncGate()
+        let releaseInitialResponse = AsyncGate()
+        let releaseMetadata = AsyncGate()
+        let releaseRating = AsyncGate()
+        self.mockClient.beforeGetPlaylistReturn = { _ in
+            await initialRequestStarted.open()
+            await releaseInitialResponse.wait()
+        }
+        self.mockClient.beforeGetSongReturn = { requestedVideoID in
+            guard requestedVideoID == videoID else { return }
+            await releaseMetadata.wait()
+        }
+        self.mockClient.beforeRateSongReturn = { _, _ in
+            await releaseRating.wait()
+        }
+
+        let loadTask = Task { await likedMusicViewModel.load() }
+        await initialRequestStarted.wait()
+
+        let rating = manager.enqueueRating(
+            placeholderSong,
+            status: .like,
+            client: self.mockClient
+        )
+        await releaseInitialResponse.open()
+        await self.waitUntil(
+            self.mockClient.getSongVideoIds.contains(videoID),
+            description: "pending placeholder metadata request"
+        )
+
+        #expect(likedMusicViewModel.playlistDetail?.tracks.contains { $0.videoId == videoID } == false)
+        #expect(likedMusicViewModel.playlistDetail?.tracks.contains { $0.title == "Loading..." } == false)
+
+        await releaseMetadata.open()
+        await loadTask.value
+        await self.waitUntil(
+            likedMusicViewModel.playlistDetail?.tracks.contains {
+                $0.videoId == videoID && $0.title == resolvedSong.title
+            } == true,
+            description: "resolved pending placeholder insertion"
+        )
+
+        let resolvedTracks = likedMusicViewModel.playlistDetail?.tracks.filter { $0.videoId == videoID } ?? []
+        #expect(self.mockClient.getSongVideoIds.filter { $0 == videoID }.count == 1)
+        #expect(resolvedTracks.count == 1)
+        #expect(resolvedTracks.first?.title == resolvedSong.title)
+        #expect(resolvedTracks.first?.artistsDisplay == resolvedSong.artistsDisplay)
+        #expect(resolvedTracks.first?.likeStatus == .like)
+        #expect(likedMusicViewModel.playlistDetail?.trackCount == 2)
+
+        await releaseRating.open()
+        #expect(await rating.value == .like)
+    }
+
+    @Test("Continuation reconciliation reuses an in-flight placeholder metadata request")
+    func continuationReconciliationReusesInFlightPlaceholderMetadataRequest() async {
+        let manager = SongLikeStatusManager.shared
+        let videoID = "reused-placeholder-metadata"
+        let placeholderSong = Song(
+            id: videoID,
+            title: "Loading...",
+            artists: [],
+            videoId: videoID
+        )
+        let likedMusicViewModel = self.makeLikedMusicViewModel(with: [], trackCount: 0)
+        self.mockClient.playlistContinuationTracks[LikedMusicPlaylist.id] = [[], []]
+        let ratingStarted = AsyncGate()
+        let releaseRating = AsyncGate()
+        let metadataStarted = AsyncGate()
+        let releaseMetadata = AsyncGate()
+        self.mockClient.beforeRateSongReturn = { _, _ in
+            await ratingStarted.open()
+            await releaseRating.wait()
+        }
+        self.mockClient.beforeGetSongReturn = { requestedVideoID in
+            guard requestedVideoID == videoID else { return }
+            await metadataStarted.open()
+            await releaseMetadata.wait()
+        }
+
+        let rating = manager.enqueueRating(
+            placeholderSong,
+            status: .like,
+            client: self.mockClient
+        )
+        await ratingStarted.wait()
+        await likedMusicViewModel.load()
+        await metadataStarted.wait()
+
+        await likedMusicViewModel.loadAllRemaining()
+
+        #expect(self.mockClient.getPlaylistContinuationCallCount == 2)
+        #expect(self.mockClient.getSongVideoIds.filter { $0 == videoID }.count == 1)
+
+        await releaseMetadata.open()
+        await releaseRating.open()
+        _ = await rating.value
+    }
+
+    @Test("Continuation response metadata for an optimistic like increments the reported total")
+    func continuationResponseMetadataForOptimisticLikeIncrementsReportedTotal() async throws {
+        let manager = SongLikeStatusManager.shared
+        let existingSong = TestFixtures.makeSong(id: "existing-liked", title: "Existing Liked")
+        let resolvedSong = Song(
+            id: "response-backed-like",
+            title: "Response Backed Like",
+            artists: [Artist(id: "response-artist", name: "Response Artist")],
+            videoId: "response-backed-like"
+        )
+        let placeholderSong = Song(
+            id: resolvedSong.id,
+            title: "Loading...",
+            artists: [],
+            videoId: resolvedSong.videoId
+        )
+        let likedMusicViewModel = self.makeLikedMusicViewModel(with: [existingSong], trackCount: 1)
+        self.mockClient.playlistContinuationTracks[LikedMusicPlaylist.id] = [[resolvedSong]]
+        let continuationStarted = AsyncGate()
+        let releaseContinuation = AsyncGate()
+        let metadataStarted = AsyncGate()
+        let releaseMetadata = AsyncGate()
+        self.mockClient.beforePlaylistContinuationReturn = { _ in
+            await continuationStarted.open()
+            await releaseContinuation.wait()
+        }
+        self.mockClient.beforeGetSongReturn = { _ in
+            await metadataStarted.open()
+            await releaseMetadata.wait()
+        }
+
+        await likedMusicViewModel.load()
+        let continuationTask = Task { await likedMusicViewModel.loadMore() }
+        await continuationStarted.wait()
+
+        let rating = manager.enqueueRating(
+            placeholderSong,
+            status: .like,
+            client: self.mockClient
+        )
+        try likedMusicViewModel.handleLikeStatusChange(#require(manager.lastLikeEvent))
+        await metadataStarted.wait()
+
+        await releaseContinuation.open()
+        await continuationTask.value
+        _ = await rating.value
+
+        #expect(likedMusicViewModel.playlistDetail?.tracks.map(\.videoId) == [existingSong.videoId, resolvedSong.videoId])
+        #expect(likedMusicViewModel.playlistDetail?.trackCount == 2)
+
+        await releaseMetadata.open()
+    }
+
+    @Test("Continuation drain reaches a later unique page through advancing duplicate-only cursors")
+    func continuationDrainReachesUniquePageAfterAdvancingDuplicates() async {
+        let playlist = Playlist(
+            id: "VL-advancing-duplicate-pages",
+            title: "Advancing Duplicate Pages",
+            description: nil,
+            thumbnailURL: nil,
+            trackCount: 2
+        )
+        let initialSong = TestFixtures.makeSong(id: "duplicate-page-song", title: "Initial Song")
+        let uniqueSong = TestFixtures.makeSong(id: "later-unique-song", title: "Later Unique Song")
+        let detail = PlaylistDetail(playlist: playlist, tracks: [initialSong], duration: nil)
+        let viewModel = PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
+        self.mockClient.playlistDetails[playlist.id] = detail
+        self.mockClient.playlistContinuationTracks[playlist.id] = [
+            [initialSong],
+            [uniqueSong],
+        ]
+
+        await viewModel.loadAllRemaining()
+
+        #expect(self.mockClient.getPlaylistContinuationCallCount == 2)
+        #expect(viewModel.playlistDetail?.tracks.map(\.videoId) == [initialSong.videoId, uniqueSong.videoId])
+        #expect(viewModel.hasMore == false)
+    }
+
+    @Test("Continuation drain stops before refetching a cyclic cursor")
+    func continuationDrainStopsBeforeRefetchingCyclicCursor() async {
+        let playlistID = "VL-cyclic-continuation"
+        let song = TestFixtures.makeSong(id: "cyclic-song", title: "Cyclic Song")
+        let playlist = TestFixtures.makePlaylist(id: playlistID, title: "Cyclic Playlist")
+        self.mockClient.playlistDetails[playlistID] = PlaylistDetail(
+            playlist: playlist,
+            tracks: [song],
+            duration: nil
+        )
+        self.mockClient.playlistContinuationTracks[playlistID] = [[song]]
+        let initialToken = "mock-playlist-continuation|\(playlistID)|0"
+        self.mockClient.forcedPlaylistContinuationResponses = [
+            PlaylistContinuationResponse(tracks: [song], continuationToken: "cycle-b"),
+            PlaylistContinuationResponse(tracks: [song], continuationToken: initialToken),
+        ]
+        let viewModel = PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
+
+        await viewModel.load()
+        await viewModel.loadAllRemaining()
+
+        #expect(self.mockClient.getPlaylistContinuationCallCount == 2)
+        #expect(self.mockClient.getPlaylistContinuationTokens == [initialToken, "cycle-b"])
+        #expect(viewModel.hasMore == false)
     }
 
     // MARK: - Refresh Tests
@@ -1276,7 +1836,7 @@ struct PlaylistDetailViewModelTests {
     func loadUsesOriginalPlaylistInfoForUnknownTitle() async {
         // Create a playlist detail with "Unknown Playlist" title
         let unknownPlaylist = Playlist(
-            id: "VL-test-playlist",
+            id: "test-playlist",
             title: "Unknown Playlist",
             description: nil,
             thumbnailURL: nil,
@@ -1293,6 +1853,7 @@ struct PlaylistDetailViewModelTests {
         await self.viewModel.load()
 
         // Should use original playlist title "Test Playlist" instead of "Unknown Playlist"
+        #expect(self.viewModel.playlistDetail?.id == "VL-test-playlist")
         #expect(self.viewModel.playlistDetail?.title == "Test Playlist")
     }
 

--- a/Tests/KasetTests/SongLikeStatusManagerTests.swift
+++ b/Tests/KasetTests/SongLikeStatusManagerTests.swift
@@ -132,6 +132,291 @@ struct SongLikeStatusManagerTests {
         #expect(self.manager.status(for: "test-video") == .indifferent)
     }
 
+    // MARK: - Liked Music Reconciliation Tests
+
+    @Test("Overlapping Liked Music requests keep a stale unlike filtered until each finishes")
+    func overlappingLikedMusicRequestsKeepStaleUnlikeFiltered() async {
+        let song = TestFixtures.makeSong(id: "request-scoped-unlike")
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        self.manager.setStatus(.like, for: song.videoId)
+        self.mockClient.beforeRateSongReturn = { _, _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+
+        let earlySnapshot = self.manager.beginLikedMusicRequest()
+        let rating = self.manager.enqueueRating(
+            song,
+            status: .indifferent,
+            client: self.mockClient
+        )
+        await requestStarted.wait()
+        let lateSnapshot = self.manager.beginLikedMusicRequest()
+        let pendingEarlyReconciliation = self.manager.reconcileLikedMusicTracks(
+            [song],
+            snapshot: earlySnapshot
+        )
+        let pendingLateReconciliation = self.manager.reconcileLikedMusicTracks(
+            [song],
+            snapshot: lateSnapshot
+        )
+
+        await releaseRequest.open()
+        let finalStatus = await rating.value
+        let settledEarlyReconciliation = self.manager.reconcileLikedMusicTracks(
+            [song],
+            snapshot: earlySnapshot
+        )
+        self.manager.finishLikedMusicRequest(earlySnapshot)
+        let remainingLateReconciliation = self.manager.reconcileLikedMusicTracks(
+            [song],
+            snapshot: lateSnapshot
+        )
+        self.manager.finishLikedMusicRequest(lateSnapshot)
+
+        let freshSnapshot = self.manager.beginLikedMusicRequest()
+        let freshReconciliation = self.manager.reconcileLikedMusicTracks(
+            [song],
+            snapshot: freshSnapshot
+        )
+        self.manager.finishLikedMusicRequest(freshSnapshot)
+
+        let filteredVideoIDs = Set([song.videoId])
+        #expect(finalStatus == .indifferent)
+        #expect(self.manager.hasPendingRating(for: song.videoId) == false)
+        #expect(pendingEarlyReconciliation?.tracks.isEmpty == true)
+        #expect(pendingEarlyReconciliation?.filteredVideoIDs == filteredVideoIDs)
+        #expect(pendingLateReconciliation?.tracks.isEmpty == true)
+        #expect(pendingLateReconciliation?.filteredVideoIDs == filteredVideoIDs)
+        #expect(settledEarlyReconciliation?.tracks.isEmpty == true)
+        #expect(settledEarlyReconciliation?.filteredVideoIDs == filteredVideoIDs)
+        #expect(remainingLateReconciliation?.tracks.isEmpty == true)
+        #expect(remainingLateReconciliation?.filteredVideoIDs == filteredVideoIDs)
+        #expect(freshReconciliation?.tracks.map(\.videoId) == [song.videoId])
+        #expect(freshReconciliation?.filteredVideoIDs.isEmpty == true)
+    }
+
+    @Test("A request begun during a pending like restores a track omitted by stale server snapshots")
+    func likedMusicRequestBegunDuringPendingLikeRestoresOmittedTrack() async {
+        let song = TestFixtures.makeSong(id: "request-scoped-like")
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        self.mockClient.beforeRateSongReturn = { _, _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+
+        let rating = self.manager.enqueueRating(
+            song,
+            status: .like,
+            client: self.mockClient
+        )
+        await requestStarted.wait()
+        let snapshot = self.manager.beginLikedMusicRequest()
+        let pendingReconciliation = self.manager.reconcileLikedMusicTracks(
+            [],
+            snapshot: snapshot
+        )
+
+        await releaseRequest.open()
+        let finalStatus = await rating.value
+        let settledReconciliation = self.manager.reconcileLikedMusicTracks(
+            [],
+            snapshot: snapshot
+        )
+        self.manager.finishLikedMusicRequest(snapshot)
+
+        let freshSnapshot = self.manager.beginLikedMusicRequest()
+        let freshReconciliation = self.manager.reconcileLikedMusicTracks(
+            [],
+            snapshot: freshSnapshot
+        )
+        self.manager.finishLikedMusicRequest(freshSnapshot)
+
+        #expect(finalStatus == .like)
+        #expect(self.manager.hasPendingRating(for: song.videoId) == false)
+        #expect(pendingReconciliation?.tracks.map(\.videoId) == [song.videoId])
+        #expect(pendingReconciliation?.tracks.first?.likeStatus == .like)
+        #expect(pendingReconciliation?.filteredVideoIDs.isEmpty == true)
+        #expect(settledReconciliation?.tracks.map(\.videoId) == [song.videoId])
+        #expect(settledReconciliation?.tracks.first?.likeStatus == .like)
+        #expect(settledReconciliation?.filteredVideoIDs.isEmpty == true)
+        #expect(freshReconciliation?.tracks.isEmpty == true)
+        #expect(freshReconciliation?.filteredVideoIDs.isEmpty == true)
+    }
+
+    @Test("A failed re-like keeps the rollback status protected from an older request")
+    func failedRelikeKeepsRollbackStatusProtectedFromOlderRequest() async {
+        let song = TestFixtures.makeSong(id: "protected-re-like-rollback")
+        self.manager.setStatus(.like, for: song.videoId)
+        let snapshot = self.manager.beginLikedMusicRequest()
+
+        #expect(await self.manager.unlike(song, client: self.mockClient) == .indifferent)
+
+        self.mockClient.shouldThrowError = YTMusicError.networkError(
+            underlying: URLError(.notConnectedToInternet)
+        )
+        #expect(await self.manager.like(song, client: self.mockClient) == .indifferent)
+
+        let reconciliation = self.manager.reconcileLikedMusicTracks(
+            [song],
+            snapshot: snapshot
+        )
+        self.manager.finishLikedMusicRequest(snapshot)
+
+        #expect(reconciliation?.tracks.isEmpty == true)
+        #expect(reconciliation?.filteredVideoIDs == [song.videoId])
+        #expect(self.manager.status(for: song.videoId) == .indifferent)
+    }
+
+    @Test("Queued unlike and re-like preserve the original liked membership baseline")
+    func queuedUnlikeAndRelikePreserveOriginalMembershipBaseline() async {
+        let song = TestFixtures.makeSong(id: "queued-membership-baseline")
+        let unlikeStarted = AsyncGate()
+        let releaseUnlike = AsyncGate()
+        self.manager.setStatus(.like, for: song.videoId)
+        let snapshot = self.manager.beginLikedMusicRequest()
+        self.mockClient.beforeRateSongReturn = { _, rating in
+            guard rating == .indifferent else { return }
+            await unlikeStarted.open()
+            await releaseUnlike.wait()
+        }
+
+        let unlike = self.manager.enqueueRating(
+            song,
+            status: .indifferent,
+            client: self.mockClient
+        )
+        await unlikeStarted.wait()
+        let relike = self.manager.enqueueRating(
+            song,
+            status: .like,
+            client: self.mockClient
+        )
+
+        let reconciliation = self.manager.reconcileLikedMusicTracks(
+            [],
+            snapshot: snapshot
+        )
+
+        #expect(reconciliation?.tracks.map(\.videoId) == [song.videoId])
+        #expect(reconciliation?.newLikedMembershipVideoIDs.isEmpty == true)
+
+        await releaseUnlike.open()
+        _ = await unlike.value
+        _ = await relike.value
+        self.manager.finishLikedMusicRequest(snapshot)
+    }
+
+    @Test("Multiple pending likes reconcile newest first")
+    func multiplePendingLikesReconcileNewestFirst() async {
+        let firstSong = TestFixtures.makeSong(id: "pending-like-first", title: "First")
+        let secondSong = TestFixtures.makeSong(id: "pending-like-second", title: "Second")
+        let releaseRequests = AsyncGate()
+        let snapshot = self.manager.beginLikedMusicRequest()
+        self.mockClient.beforeRateSongReturn = { _, _ in
+            await releaseRequests.wait()
+        }
+
+        let firstRating = self.manager.enqueueRating(
+            firstSong,
+            status: .like,
+            client: self.mockClient
+        )
+        let secondRating = self.manager.enqueueRating(
+            secondSong,
+            status: .like,
+            client: self.mockClient
+        )
+
+        let reconciliation = self.manager.reconcileLikedMusicTracks(
+            [],
+            snapshot: snapshot
+        )
+
+        #expect(reconciliation?.tracks.map(\.videoId) == [secondSong.videoId, firstSong.videoId])
+
+        await releaseRequests.open()
+        _ = await firstRating.value
+        _ = await secondRating.value
+        self.manager.finishLikedMusicRequest(snapshot)
+    }
+
+    @Test("Session invalidation rejects an old Liked Music request snapshot")
+    func sessionInvalidationRejectsOldLikedMusicRequestSnapshot() {
+        let song = TestFixtures.makeSong(id: "invalidated-session-snapshot")
+        self.manager.setStatus(.dislike, for: song.videoId)
+        let snapshot = self.manager.beginLikedMusicRequest()
+
+        self.manager.invalidateSession(clearsActiveCache: false)
+        let reconciliation = self.manager.reconcileLikedMusicTracks(
+            [song],
+            snapshot: snapshot
+        )
+        self.manager.finishLikedMusicRequest(snapshot)
+
+        #expect(self.manager.matchesCurrentScope(snapshot) == false)
+        #expect(reconciliation == nil)
+        #expect(self.manager.status(for: song.videoId) == .dislike)
+    }
+
+    @Test("Session invalidation rollback events retain the pending song metadata")
+    func sessionInvalidationRollbackEventsRetainPendingSongMetadata() async throws {
+        let song = TestFixtures.makeSong(
+            id: "rollback-event-song",
+            title: "Rollback Event Song"
+        )
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        self.manager.setStatus(.like, for: song.videoId)
+        self.mockClient.beforeRateSongReturn = { _, _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+
+        let rating = self.manager.enqueueRating(
+            song,
+            status: .indifferent,
+            client: self.mockClient
+        )
+        await requestStarted.wait()
+
+        self.manager.invalidateSession(clearsActiveCache: false)
+        let event = try #require(
+            self.manager.lastLikeEventBatch?.events.first { $0.videoId == song.videoId }
+        )
+
+        #expect(event.status == .like)
+        #expect(event.song?.videoId == song.videoId)
+        #expect(event.song?.title == song.title)
+
+        await releaseRequest.open()
+        _ = await rating.value
+    }
+
+    @Test("Returning to an account does not revalidate its old Liked Music snapshot")
+    func returningToAccountDoesNotRevalidateOldLikedMusicSnapshot() {
+        let accountID = "snapshot-account"
+        let song = TestFixtures.makeSong(id: "invalidated-account-snapshot")
+        self.manager.setActiveAccountID(accountID)
+        self.manager.setStatus(.dislike, for: song.videoId)
+        let snapshot = self.manager.beginLikedMusicRequest()
+
+        self.manager.setActiveAccountID("other-snapshot-account")
+        self.manager.setActiveAccountID(accountID)
+        let reconciliation = self.manager.reconcileLikedMusicTracks(
+            [song],
+            snapshot: snapshot
+        )
+        self.manager.finishLikedMusicRequest(snapshot)
+
+        #expect(self.manager.activeAccountID == snapshot.accountID)
+        #expect(self.manager.matchesCurrentScope(snapshot) == false)
+        #expect(reconciliation == nil)
+        #expect(self.manager.status(for: song.videoId, accountID: accountID) == .dislike)
+    }
+
     // MARK: - Error Handling Tests
 
     @Test("like reverts cache on API failure")
@@ -210,6 +495,55 @@ struct SongLikeStatusManagerTests {
         #expect(lateLikeStatus == .dislike)
         #expect(self.manager.status(for: song.videoId, accountID: accountID) == .dislike)
         #expect(self.mockClient.appliedRateSongRatings.last == .dislike)
+    }
+
+    @Test("Same-account session invalidation preserves in-flight rating order")
+    func sameAccountSessionInvalidationPreservesInFlightRatingOrder() async {
+        let song = TestFixtures.makeSong(id: "same-account-invalidation-order")
+        let accountID = "same-account-invalidation"
+        let olderRequestStarted = AsyncGate()
+        let releaseOlderRequest = AsyncGate()
+        let newerRequestStarted = AsyncGate()
+        self.manager.setActiveAccountID(accountID)
+        self.mockClient.beforeRateSongReturn = { _, rating in
+            switch rating {
+            case .like:
+                await olderRequestStarted.open()
+                await releaseOlderRequest.wait()
+            case .dislike:
+                await newerRequestStarted.open()
+            case .indifferent:
+                break
+            }
+        }
+
+        let olderRating = self.manager.enqueueRating(
+            song,
+            status: .like,
+            accountID: accountID,
+            client: self.mockClient
+        )
+        await olderRequestStarted.wait()
+
+        self.manager.invalidateSession(clearsActiveCache: false)
+        let newerRating = self.manager.enqueueRating(
+            song,
+            status: .dislike,
+            accountID: accountID,
+            client: self.mockClient
+        )
+        await Task.yield()
+
+        #expect(self.mockClient.rateSongRatings == [.like])
+        #expect(self.mockClient.appliedRateSongRatings.isEmpty)
+
+        await releaseOlderRequest.open()
+        await newerRequestStarted.wait()
+        _ = await olderRating.value
+        _ = await newerRating.value
+
+        #expect(self.mockClient.rateSongRatings == [.like, .dislike])
+        #expect(self.mockClient.appliedRateSongRatings == [.like, .dislike])
     }
 
     @Test("A stale successful rating cannot seed rollback state after session invalidation")

--- a/Tests/KasetTests/SongLikeStatusManagerTests.swift
+++ b/Tests/KasetTests/SongLikeStatusManagerTests.swift
@@ -395,6 +395,38 @@ struct SongLikeStatusManagerTests {
         _ = await rating.value
     }
 
+    @Test("Session invalidation publishes rollback events in submission order")
+    func sessionInvalidationPublishesRollbackEventsInSubmissionOrder() async throws {
+        let firstSong = TestFixtures.makeSong(id: "rollback-order-first", title: "First")
+        let secondSong = TestFixtures.makeSong(id: "rollback-order-second", title: "Second")
+        let releaseRequests = AsyncGate()
+        self.manager.setStatus(.like, for: firstSong.videoId)
+        self.manager.setStatus(.like, for: secondSong.videoId)
+        self.mockClient.beforeRateSongReturn = { _, _ in
+            await releaseRequests.wait()
+        }
+
+        let firstRating = self.manager.enqueueRating(
+            firstSong,
+            status: .indifferent,
+            client: self.mockClient
+        )
+        let secondRating = self.manager.enqueueRating(
+            secondSong,
+            status: .indifferent,
+            client: self.mockClient
+        )
+
+        self.manager.invalidateSession(clearsActiveCache: false)
+        let batch = try #require(self.manager.lastLikeEventBatch)
+
+        #expect(batch.events.map(\.videoId) == [firstSong.videoId, secondSong.videoId])
+
+        await releaseRequests.open()
+        _ = await firstRating.value
+        _ = await secondRating.value
+    }
+
     @Test("Returning to an account does not revalidate its old Liked Music snapshot")
     func returningToAccountDoesNotRevalidateOldLikedMusicSnapshot() {
         let accountID = "snapshot-account"
@@ -466,6 +498,40 @@ struct SongLikeStatusManagerTests {
 
         #expect(await likeTask.value == .indifferent)
         #expect(self.manager.status(for: song.videoId) == .indifferent)
+    }
+
+    @Test("Status seeding preserves a protected optimistic overlay")
+    func statusSeedingPreservesProtectedOptimisticOverlay() async {
+        let song = TestFixtures.makeSong(id: "protected-status-seed")
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        self.manager.setStatus(.like, for: song.videoId)
+        let snapshot = self.manager.beginLikedMusicRequest()
+        self.mockClient.beforeRateSongReturn = { _, _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+
+        let rating = self.manager.enqueueRating(
+            song,
+            status: .indifferent,
+            client: self.mockClient
+        )
+        await requestStarted.wait()
+
+        self.manager.setStatus(.like, for: song.videoId)
+        let reconciliation = self.manager.reconcileLikedMusicTracks(
+            [song],
+            snapshot: snapshot
+        )
+
+        #expect(self.manager.status(for: song.videoId) == .indifferent)
+        #expect(reconciliation?.tracks.isEmpty == true)
+        #expect(reconciliation?.filteredVideoIDs == [song.videoId])
+
+        await releaseRequest.open()
+        _ = await rating.value
+        self.manager.finishLikedMusicRequest(snapshot)
     }
 
     @Test("A delayed rating completion cannot overwrite a newer rating")


### PR DESCRIPTION
## Summary

- move Liked Music rating reconciliation into `SongLikeStatusManager` using account-scoped request snapshots and protected local overlays
- batch like-status events so rollback and session-invalidation updates reach every active consumer
- preserve mutation ordering across account/session invalidation and prevent stale continuations from resurrecting removed tracks
- keep reported track totals correct across optimistic likes, unlikes, rollbacks, deferred metadata, and pagination overlap
- stop repeated/cyclic continuation cursors and reuse only metadata tasks from the current account scope
- add focused regression coverage for rating races, stale pages, account switches, rollback metadata, and session expiry

## Root cause

Optimistic rating mutations and playlist responses updated the cache and Liked Music view independently. A delayed or stale playlist response could overwrite a newer local rating, while session invalidation could discard mutation-ordering barriers. Pagination and deferred metadata paths also lacked enough ownership information to distinguish new membership from rollback/restoration.

## Impact

Liked Music now remains consistent with successful user ratings during refreshes, continuation loading, account switches, failed mutations, and session expiry. Now-playing and playlist consumers receive the same ordered batch of rating updates.

## Validation

- `swift build`
- `swift test --filter SongLikeStatusManagerTests` — 31 passed
- `swift test --filter PlaylistDetailViewModelTests` — 56 passed
- `swift test --filter 'AuthServiceTests|AccountServiceSessionExpirationTests'` — 23 passed
- `swiftlint --strict`
- `swiftformat --lint .`
- final autoreview panel: Codex GPT-5.6 Sol max and Claude Opus 4.8 max — 0 actionable findings

No UI tests were run.