### PR TITLE
Fix: make WebExtension content scripts actually run in playback WebViews

### DIFF
--- a/Sources/Kaset/Services/ExtensionsManager.swift
+++ b/Sources/Kaset/Services/ExtensionsManager.swift
@@ -71,7 +71,7 @@ final class ExtensionsManager {
             .appendingPathComponent("extensions.json")
     }
 
-    private var managedExtensionsDirectoryURL: URL? {
+    var managedExtensionsDirectoryURL: URL? {
         self.persistenceURL?
             .deletingLastPathComponent()
             .appendingPathComponent("ManagedExtensions", isDirectory: true)

--- a/Sources/Kaset/Services/WebKit/ExtensionContentScriptInjector.swift
+++ b/Sources/Kaset/Services/WebKit/ExtensionContentScriptInjector.swift
@@ -1,0 +1,222 @@
+import Foundation
+import WebKit
+
+// MARK: - ExtensionContentScriptInjector
+
+/// Injects user-installed WebExtension `content_scripts` and stylesheets into
+/// Kaset's playback WebViews.
+///
+/// Kaset's player WebViews are long-lived surfaces that load a single origin
+/// each (`music.youtube.com` for the music player, `www.youtube.com` for the
+/// video player). Apple's `WKWebExtensionController` content-script injection
+/// relies on a full browser tab/window model that is not exercised by these
+/// dedicated WebViews on current macOS releases, so content scripts do not run
+/// through the controller. To make extensions actually affect playback, we read
+/// each enabled extension's `content_scripts` from disk and add them as
+/// `WKUserScript`s to the WebView's `WKUserContentController` — the mechanism
+/// WebKit reliably supports for manually managed WebViews.
+@MainActor
+enum ExtensionContentScriptInjector {
+
+    /// The origin a given hosted WebView role loads.
+    private static func originHost(for role: WebExtensionHostedWebViewRole) -> String {
+        switch role {
+        case .musicPlayer:
+            "music.youtube.com"
+        case .youtubeWatch:
+            "www.youtube.com"
+        }
+    }
+
+    /// Builds the on-disk URL for an enabled managed extension.
+    private static func resourceURL(for ext: ManagedExtension) -> URL? {
+        guard let base = ExtensionsManager.shared.managedExtensionsDirectoryURL else { return nil }
+        return base.appendingPathComponent(ext.relativePath, isDirectory: true)
+    }
+
+    /// Returns `WKUserScript`s for every enabled extension whose content scripts
+    /// target the given WebView role. Each script is wrapped so it only runs on
+    /// pages matching the extension's `matches` globs.
+    static func userScripts(for role: WebExtensionHostedWebViewRole) -> [WKUserScript] {
+        var result: [WKUserScript] = []
+        let host = Self.originHost(for: role)
+
+        for ext in ExtensionsManager.shared.extensions where ext.isEnabled {
+            guard let base = Self.resourceURL(for: ext),
+                  let manifest = Self.loadManifest(in: base),
+                  let contentScripts = manifest["content_scripts"] as? [[String: Any]]
+            else { continue }
+
+            for entry in contentScripts {
+                guard let matches = entry["matches"] as? [String],
+                      Self.matchesTargetHost(matches, host: host) else { continue }
+
+                let runAt = (entry["run_at"] as? String) ?? "document_idle"
+                let injectionTime: WKUserScriptInjectionTime = switch runAt {
+                case "document_start":
+                    .atDocumentStart
+                default:
+                    .atDocumentEnd
+                }
+
+                guard let jsFiles = entry["js"] as? [String] else { continue }
+
+                for file in jsFiles {
+                    let fileURL = base.appendingPathComponent(file)
+                    guard let source = try? String(contentsOf: fileURL, encoding: .utf8) else { continue }
+                    let wrapped = Self.wrap(source: source, matches: matches)
+                    result.append(WKUserScript(
+                        source: wrapped,
+                        injectionTime: injectionTime,
+                        forMainFrameOnly: true
+                    ))
+                }
+            }
+        }
+
+        return result
+    }
+
+    /// Returns `WKUserScript`s that inject each extension's stylesheet content as
+    /// a `<style>` element, scoped to the WebView role's origin.
+    static func styleSheets(for role: WebExtensionHostedWebViewRole) -> [WKUserScript] {
+        var result: [WKUserScript] = []
+        let host = Self.originHost(for: role)
+
+        for ext in ExtensionsManager.shared.extensions where ext.isEnabled {
+            guard let base = Self.resourceURL(for: ext),
+                  let manifest = Self.loadManifest(in: base),
+                  let contentScripts = manifest["content_scripts"] as? [[String: Any]]
+            else { continue }
+
+            for entry in contentScripts {
+                guard let matches = entry["matches"] as? [String],
+                      Self.matchesTargetHost(matches, host: host),
+                      let cssFiles = entry["css"] as? [String]
+                else { continue }
+
+                for file in cssFiles {
+                    let fileURL = base.appendingPathComponent(file)
+                    guard let css = try? String(contentsOf: fileURL, encoding: .utf8) else { continue }
+                    // JSON-encode so arbitrary CSS (quotes, newlines) is safe to
+                    // embed inside a JavaScript string literal.
+                    let encodedCSS = (try? JSONSerialization.data(withJSONObject: [css]))
+                        .flatMap { String(data: $0, encoding: .utf8) }
+                        .map { String($0.dropFirst().dropLast()) } // strip the surrounding [ ]
+                        ?? "\(css)"
+                    let regex = Self.cssMatchRegex(for: matches)
+                    let source = """
+                    (function(){
+                      if (!location.href.match(/\(regex)/)) return;
+                      var s = document.createElement('style');
+                      s.textContent = "\(encodedCSS)";
+                      (document.head || document.documentElement).appendChild(s);
+                    })();
+                    """
+                    result.append(WKUserScript(
+                        source: source,
+                        injectionTime: .atDocumentEnd,
+                        forMainFrameOnly: true
+                    ))
+                }
+            }
+        }
+
+        return result
+    }
+
+    // MARK: - Helpers
+
+    private static func loadManifest(in base: URL) -> [String: Any]? {
+        let url = base.appendingPathComponent("manifest.json")
+        guard let data = try? Data(contentsOf: url),
+              let manifest = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        return manifest
+    }
+
+    /// Whether any of the manifest match globs targets the given host. A glob
+    /// such as `https://music.youtube.com/*` or `*://*.youtube.com/*` matches
+    /// when its host (ignoring leading wildcards) is contained in `host`.
+    /// `<all_urls>` always matches.
+    private static func matchesTargetHost(_ matches: [String], host: String) -> Bool {
+        matches.contains { Self.matchTargetsHost($0, host: host) }
+    }
+
+    private static func matchTargetsHost(_ match: String, host: String) -> Bool {
+        if match == "<all_urls>" { return true }
+
+        // Strip scheme and path, keep host portion.
+        var remainder = match
+        if let schemeEnd = remainder.firstIndex(of: ":") {
+            remainder = String(remainder[remainder.index(after: schemeEnd)...])
+        }
+        remainder = remainder.replacingOccurrences(of: "//", with: "")
+        // Drop path component.
+        if let slash = remainder.firstIndex(of: "/") {
+            remainder = String(remainder[..<slash])
+        }
+        remainder = remainder.trimmingCharacters(in: .whitespaces)
+        if remainder.isEmpty { return true }
+        // Handle leading wildcard host like `*.youtube.com`.
+        if remainder.hasPrefix("*.") {
+            let suffix = String(remainder.dropFirst(2))
+            return host == suffix || host.hasSuffix("." + suffix) || host.hasSuffix(suffix)
+        }
+        return remainder == host || remainder == "*"
+    }
+
+    /// Wraps extension JS so it only executes on pages whose URL matches one of
+    /// the manifest match globs. Keeps multiple extensions isolated and avoids
+    /// running a music-extension script on the wrong surface.
+    private static func wrap(source: String, matches: [String]) -> String {
+        let regex = Self.cssMatchRegex(for: matches)
+        return """
+        (function(){
+          if (!location.href.match(/\(regex)/)) return;
+          \(source)
+        })();
+        """
+    }
+
+    /// Builds a JS regex source string from manifest match globs.
+    private static func cssMatchRegex(for matches: [String]) -> String {
+        let alternatives = matches.compactMap { Self.globToRegex($0) }
+        if alternatives.isEmpty { return "$.^" } // never matches
+        return alternatives.joined(separator: "|")
+    }
+
+    /// Converts a single MV3 match pattern to a JS regex source string.
+    private static func globToRegex(_ pattern: String) -> String? {
+        if pattern == "<all_urls>" { return ".*" }
+
+        // Scheme
+        var p = pattern
+        var scheme = "https?"
+        if p.hasPrefix("*://") {
+            p = String(p.dropFirst(4))
+        } else if let range = p.range(of: "://") {
+            scheme = String(p[..<range.lowerBound])
+            p = String(p[range.upperBound...])
+            scheme = scheme == "*" ? "https?" : NSRegularExpression.escapedPattern(for: scheme)
+        }
+        // Host + path
+        guard let slashIndex = p.firstIndex(of: "/") else { return nil }
+        var host = String(p[..<slashIndex])
+        let path = String(p[slashIndex...])
+
+        if host == "*" {
+            host = "[^/]+"
+        } else if host.hasPrefix("*.") {
+            host = "(?:[^/]+\\.)?" + NSRegularExpression.escapedPattern(for: String(host.dropFirst(2)))
+        } else {
+            host = NSRegularExpression.escapedPattern(for: host)
+        }
+
+        let pathRegex = path
+            .replacingOccurrences(of: ".", with: "\\.")
+            .replacingOccurrences(of: "*", with: ".*")
+
+        return "^(?:\(scheme)://)\(host)\(pathRegex)$"
+    }
+}

--- a/Sources/Kaset/Views/MiniPlayerWebView.swift
+++ b/Sources/Kaset/Views/MiniPlayerWebView.swift
@@ -686,6 +686,16 @@ final class SingletonPlayerWebView {
             forMainFrameOnly: true
         )
         contentController.addUserScript(script)
+
+        // Inject user-installed extension content scripts/styles so they affect
+        // the music player surface (WebKit's WKWebExtensionController does not
+        // inject content into these dedicated WebViews on current macOS).
+        for extScript in ExtensionContentScriptInjector.userScripts(for: .musicPlayer) {
+            contentController.addUserScript(extScript)
+        }
+        for extStyle in ExtensionContentScriptInjector.styleSheets(for: .musicPlayer) {
+            contentController.addUserScript(extStyle)
+        }
     }
 
     func refreshInstalledUserScripts() {

--- a/Sources/Kaset/Views/YouTube/YouTubeWatchWebView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeWatchWebView.swift
@@ -895,5 +895,15 @@ extension YouTubeWatchWebView {
             forMainFrameOnly: true
         )
         contentController.addUserScript(extraction)
+
+        // Inject user-installed extension content scripts/styles so they affect
+        // the video player surface (WebKit's WKWebExtensionController does not
+        // inject content into these dedicated WebViews on current macOS).
+        for extScript in ExtensionContentScriptInjector.userScripts(for: .youtubeWatch) {
+            contentController.addUserScript(extScript)
+        }
+        for extStyle in ExtensionContentScriptInjector.styleSheets(for: .youtubeWatch) {
+            contentController.addUserScript(extStyle)
+        }
     }
 }

--- a/Tests/KasetTests/ExtensionContentScriptInjectorTests.swift
+++ b/Tests/KasetTests/ExtensionContentScriptInjectorTests.swift
@@ -1,0 +1,183 @@
+import Foundation
+import Testing
+import WebKit
+@testable import Kaset
+
+/// Tests for `ExtensionContentScriptInjector` — the mechanism that actually
+/// runs user-installed WebExtension content scripts inside Kaset's playback
+/// WebViews (WebKit's WKWebExtensionController does not inject content into
+/// these dedicated WebViews on current macOS).
+@Suite(.serialized, .tags(.service))
+@MainActor
+struct ExtensionContentScriptInjectorTests {
+
+    /// Writes an extension source folder and registers it with the shared
+    /// `ExtensionsManager` via its public `addExtension(at:)` API.
+    private func installExtension(named name: String, manifest: [String: Any], files: [String: String]) throws -> String {
+        let source = FileManager.default.temporaryDirectory
+            .appendingPathComponent("kaset-ext-src-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+        let manifestData = try JSONSerialization.data(withJSONObject: manifest)
+        try manifestData.write(to: source.appendingPathComponent("manifest.json"))
+        for (file, contents) in files {
+            try contents.write(to: source.appendingPathComponent(file), atomically: true, encoding: .utf8)
+        }
+
+        try ExtensionsManager.shared.addExtension(at: source)
+        return name
+    }
+
+    private func removeExtension(_ name: String) {
+        let manager = ExtensionsManager.shared
+        if let ext = manager.extensions.first(where: { $0.name == name }) {
+            manager.removeExtension(id: ext.id)
+        }
+    }
+
+    @Test("Produces a content script for a music.youtube.com extension")
+    func buildsMusicContentScript() throws {
+        let id = try self.installExtension(
+            named: "MusicExt",
+            manifest: [
+                "manifest_version": 3,
+                "name": "MusicExt",
+                "version": "1.0.0",
+                "content_scripts": [
+                    [
+                        "matches": ["https://music.youtube.com/*"],
+                        "js": ["content.js"],
+                        "run_at": "document_start",
+                    ],
+                ],
+            ],
+            files: ["content.js": "window.__musicExtRan = true;"]
+        )
+        defer { self.removeExtension(id) }
+
+        let scripts = ExtensionContentScriptInjector.userScripts(for: .musicPlayer)
+        #expect(scripts.count == 1)
+        #expect(scripts.first?.injectionTime == .atDocumentStart)
+        #expect((scripts.first?.source ?? "").contains("window.__musicExtRan = true;"))
+    }
+
+    @Test("Does not surface a music extension in the video player")
+    func scopesMusicScriptToMusicPlayer() throws {
+        let id = try self.installExtension(
+            named: "MusicExt",
+            manifest: [
+                "manifest_version": 3,
+                "name": "MusicExt",
+                "version": "1.0.0",
+                "content_scripts": [
+                    ["matches": ["https://music.youtube.com/*"], "js": ["content.js"]],
+                ],
+            ],
+            files: ["content.js": "window.__musicExtRan = true;"]
+        )
+        defer { self.removeExtension(id) }
+
+        #expect(ExtensionContentScriptInjector.userScripts(for: .youtubeWatch).isEmpty)
+    }
+
+    @Test("Builds a stylesheet script for a youtube.com extension")
+    func buildsStyleSheet() throws {
+        let id = try self.installExtension(
+            named: "CssExt",
+            manifest: [
+                "manifest_version": 3,
+                "name": "CssExt",
+                "version": "1.0.0",
+                "content_scripts": [
+                    [
+                        "matches": ["*://*.youtube.com/*"],
+                        "css": ["style.css"],
+                    ],
+                ],
+            ],
+            files: ["style.css": "body { color: red; }"]
+        )
+        defer { self.removeExtension(id) }
+
+        let styles = ExtensionContentScriptInjector.styleSheets(for: .youtubeWatch)
+        #expect(styles.count == 1)
+        #expect((styles.first?.source ?? "").contains("body { color: red; }"))
+    }
+
+    @Test("Ignores disabled extensions")
+    func skipsDisabledExtensions() throws {
+        let name = try self.installExtension(
+            named: "DisabledExt",
+            manifest: [
+                "manifest_version": 3, "name": "DisabledExt", "version": "1.0.0",
+                "content_scripts": [["matches": ["https://music.youtube.com/*"], "js": ["c.js"]]],
+            ],
+            files: ["c.js": "window.x=1;"]
+        )
+        defer { self.removeExtension(name) }
+
+        // Disable it via the public toggle, then it should no longer contribute scripts.
+        if let ext = ExtensionsManager.shared.extensions.first(where: { $0.name == name }) {
+            ExtensionsManager.shared.toggleExtension(id: ext.id)
+        }
+        #expect(ExtensionContentScriptInjector.userScripts(for: .musicPlayer).isEmpty)
+    }
+
+    /// End-to-end: the generated content script actually runs inside a WebView
+    /// that loads the matching origin (this is what WKWebExtensionController
+    /// fails to do on current macOS).
+    @Test("Injected content script runs in a matching WebView")
+    func scriptRunsInWebView() async throws {
+        let id = try self.installExtension(
+            named: "RunExt",
+            manifest: [
+                "manifest_version": 3,
+                "name": "RunExt",
+                "version": "1.0.0",
+                "content_scripts": [
+                    ["matches": ["<all_urls>"], "js": ["c.js"], "run_at": "document_start"],
+                ],
+            ],
+            files: ["c.js": "document.documentElement.setAttribute('data-kaset-ext', 'ran');"]
+        )
+        defer { self.removeExtension(id) }
+
+        let scripts = ExtensionContentScriptInjector.userScripts(for: .musicPlayer)
+        #expect(!scripts.isEmpty)
+
+        let config = WKWebViewConfiguration()
+        config.websiteDataStore = .nonPersistent()
+        let controller = config.userContentController
+        for script in scripts { controller.addUserScript(script) }
+
+        let webView = WKWebView(frame: CGRect(x: 0, y: 0, width: 320, height: 200), configuration: config)
+        let window = NSWindow(contentRect: CGRect(x: 0, y: 0, width: 320, height: 200), styleMask: .titled, backing: .buffered, defer: false)
+        window.contentView = webView
+
+        let loaded = self.load(html: "<!doctype html><html><head></head><body>hi</body></html>", in: webView)
+        _ = await loaded.value
+
+        let ran = try? await webView.evaluateJavaScript("document.documentElement.getAttribute('data-kaset-ext')") as? String
+        #expect(ran == "ran")
+    }
+
+    private func load(html: String, in webView: WKWebView) -> Task<Void, Never> {
+        Task {
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                let delegate = LoadAwaitDelegate { continuation.resume() }
+                webView.navigationDelegate = delegate
+                webView.loadHTMLString(html, baseURL: URL(string: "https://music.youtube.com/"))
+                // Retain the delegate until the load completes.
+                DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
+                    withExtendedLifetime(delegate) {}
+                }
+            }
+        }
+    }
+}
+
+private final class LoadAwaitDelegate: NSObject, WKNavigationDelegate {
+    private let onLoad: () -> Void
+    init(onLoad: @escaping () -> Void) { self.onLoad = onLoad }
+    func webView(_: WKWebView, didFinish _: WKNavigation!) { self.onLoad() }
+    func webView(_: WKWebView, didFail _: WKNavigation!, withError _: Error) { self.onLoad() }
+}

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -84,6 +84,7 @@ Click the **trash** icon next to any extension, then restart Kaset.
 - When you add an extension, Kaset copies that folder into `~/Library/Application Support/Kaset/ManagedExtensions/`.
 - Kaset loads enabled extensions when the app starts.
 - Extensions run inside Kaset's YouTube and YouTube Music web players.
+- Content scripts and stylesheets are injected into the playback WebViews via `WKUserScript`/`WKUserContentController` (scoped to each extension's `matches`), because WebKit's `WKWebExtensionController` does not deliver content-script injection into these dedicated, single-origin WebViews on current macOS releases. Manifest V3 `content_scripts` (`js`/`css`, `run_at`) and `<all_urls>` are supported.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Extensions were loaded via `WKWebExtensionController` and exposed to WebKit through a hand-built `WKWebExtensionTab`/`WKWebExtensionWindow` model, but content scripts and stylesheets **never actually executed** inside Kaset's playback WebViews on current macOS (reproduced on macOS 26.5.2: `hasInjectedContentForURL` returns `true` and all permissions are granted, yet the content script does not run).

This adds a real injection path: each enabled extension's `content_scripts` (`js`/`css`, `run_at`, and `<all_urls>`) are read from disk and injected into the player WebViews' `WKUserContentController` via `WKUserScript` — the mechanism WebKit reliably supports for dedicated, single-origin WebViews.

## Changes

- **`ExtensionContentScriptInjector.swift`** (new): builds `WKUserScript`s from enabled extensions' `content_scripts`, scoped per WebView role (`musicPlayer` → `music.youtube.com`, `youtubeWatch` → `www.youtube.com`), with `matches`/`<all_urls>` gating and CSS injected as a `<style>` element.
- **`MiniPlayerWebView` / `YouTubeWatchWebView`**: call the injector from `installUserScripts` after Kaset's own scripts.
- **`ExtensionsManager`**: `managedExtensionsDirectoryURL` made `internal` so the injector can resolve copied extension folders.
- **`ExtensionContentScriptInjectorTests.swift`** (new): 5 tests including an end-to-end test proving the content script executes in a matching WebView.

## Test plan

- `swift test --filter ExtensionContentScriptInjectorTests` — all pass.
- `swift test --filter ExtensionsManagerTests` — no regression.
- `swift build --target Kaset` — clean (strict concurrency enabled).

Fixes the reported issue that extensions "can't run like they're supposed to."