### PR TITLE
fix(search): preserve semantic results and pagination

### DIFF
--- a/Sources/APIExplorer/SearchAudit.swift
+++ b/Sources/APIExplorer/SearchAudit.swift
@@ -1,0 +1,1134 @@
+import Foundation
+
+// MARK: - SearchFilterProbe
+
+struct SearchFilterProbe: Hashable {
+    let label: String
+    let query: String
+    let params: String
+}
+
+let kasetSearchFilterLabels: Set<String> = [
+    "Albums", "Artists", "Community playlists", "Episodes", "Featured playlists", "Playlists",
+    "Podcasts", "Profiles", "Songs", "Videos",
+]
+
+// MARK: - SearchAuditContext
+
+enum SearchAuditContext {
+    case automatic
+    case firstPage
+    case continuation
+}
+
+func terminalSafe(_ value: String) -> String {
+    var output = ""
+    output.reserveCapacity(value.count)
+    for scalar in value.unicodeScalars {
+        if CharacterSet.controlCharacters.contains(scalar) {
+            output += String(format: "\\u{%04X}", scalar.value)
+        } else {
+            output.unicodeScalars.append(scalar)
+        }
+    }
+    return output
+}
+
+private func collectRenderers(
+    named key: String,
+    in value: Any,
+    results: inout [[String: Any]]
+) {
+    if let dictionary = value as? [String: Any] {
+        if let renderer = dictionary[key] as? [String: Any] {
+            results.append(renderer)
+        }
+
+        for nestedKey in dictionary.keys.sorted() {
+            if let nestedValue = dictionary[nestedKey] {
+                collectRenderers(named: key, in: nestedValue, results: &results)
+            }
+        }
+    } else if let array = value as? [Any] {
+        for item in array {
+            collectRenderers(named: key, in: item, results: &results)
+        }
+    }
+}
+
+private func renderers(named key: String, in value: Any) -> [[String: Any]] {
+    var results: [[String: Any]] = []
+    collectRenderers(named: key, in: value, results: &results)
+    return results
+}
+
+func searchFilterProbes(from data: [String: Any]) -> [SearchFilterProbe] {
+    let chips = renderers(named: "chipCloudChipRenderer", in: data)
+    var probes: [SearchFilterProbe] = []
+    var seen: Set<SearchFilterProbe> = []
+
+    for chip in chips {
+        guard let rawLabel = joinedRunsText(chip["text"] as? [String: Any]),
+              let navigationEndpoint = chip["navigationEndpoint"] as? [String: Any],
+              let searchEndpoint = navigationEndpoint["searchEndpoint"] as? [String: Any],
+              let query = searchEndpoint["query"] as? String,
+              let params = searchEndpoint["params"] as? String
+        else {
+            continue
+        }
+
+        let probe = SearchFilterProbe(label: terminalSafe(rawLabel), query: query, params: params)
+        if seen.insert(probe).inserted {
+            probes.append(probe)
+        }
+    }
+
+    return probes
+}
+
+private func firstRun(in text: Any?) -> [String: Any]? {
+    guard let text = text as? [String: Any],
+          let runs = text["runs"] as? [[String: Any]]
+    else {
+        return nil
+    }
+    return runs.first
+}
+
+private func firstFlexColumnRun(in renderer: [String: Any], index: Int) -> [String: Any]? {
+    guard let flexColumns = renderer["flexColumns"] as? [[String: Any]],
+          flexColumns.indices.contains(index),
+          let columnRenderer = flexColumns[index]["musicResponsiveListItemFlexColumnRenderer"] as? [String: Any]
+    else {
+        return nil
+    }
+    return firstRun(in: columnRenderer["text"])
+}
+
+private func searchRowTitle(_ renderer: [String: Any]) -> String {
+    terminalSafe((firstFlexColumnRun(in: renderer, index: 0)?["text"] as? String) ?? "Untitled")
+}
+
+private func searchRowContentType(_ renderer: [String: Any]) -> String {
+    guard let run = firstFlexColumnRun(in: renderer, index: 1),
+          let rawCandidate = run["text"] as? String
+    else {
+        return "Unlabeled"
+    }
+    let candidate = terminalSafe(rawCandidate)
+
+    let knownTypes: Set = [
+        "Album", "Artist", "Audiobook", "Episode", "Playlist", "Podcast", "Profile", "Song", "Video",
+    ]
+    if candidate == "Single" || candidate == "EP" {
+        return "Album"
+    }
+    if knownTypes.contains(candidate) {
+        return candidate
+    }
+    if run["navigationEndpoint"] != nil {
+        return "Unlabeled"
+    }
+    return "Unknown(\(candidate))"
+}
+
+private func watchVideoId(in endpoint: [String: Any]?) -> String? {
+    guard let endpoint,
+          let watchEndpoint = endpoint["watchEndpoint"] as? [String: Any],
+          let videoId = watchEndpoint["videoId"] as? String,
+          !videoId.isEmpty
+    else {
+        return nil
+    }
+    return videoId
+}
+
+private func musicVideoType(in endpoint: [String: Any]?) -> String? {
+    guard let endpoint,
+          let watchEndpoint = endpoint["watchEndpoint"] as? [String: Any],
+          let configs = watchEndpoint["watchEndpointMusicSupportedConfigs"] as? [String: Any],
+          let musicConfig = configs["watchEndpointMusicConfig"] as? [String: Any]
+    else {
+        return nil
+    }
+    return (musicConfig["musicVideoType"] as? String).map(terminalSafe)
+}
+
+private func browseEndpoint(in endpoint: [String: Any]?) -> [String: Any]? {
+    endpoint?["browseEndpoint"] as? [String: Any]
+}
+
+private func innertubeEndpoint(in value: Any?) -> [String: Any]? {
+    guard let dictionary = value as? [String: Any] else { return nil }
+    if let command = dictionary["innertubeCommand"] as? [String: Any] {
+        return command
+    }
+    return dictionary
+}
+
+private func playNavigationEndpoint(in overlay: Any?) -> [String: Any]? {
+    guard let overlay = overlay as? [String: Any],
+          let thumbnailOverlay = overlay["musicItemThumbnailOverlayRenderer"] as? [String: Any],
+          let content = thumbnailOverlay["content"] as? [String: Any],
+          let playButton = content["musicPlayButtonRenderer"] as? [String: Any]
+    else {
+        return nil
+    }
+    return playButton["playNavigationEndpoint"] as? [String: Any]
+}
+
+private func pageType(in browseEndpoint: [String: Any]?) -> String? {
+    guard let browseEndpoint,
+          let configs = browseEndpoint["browseEndpointContextSupportedConfigs"] as? [String: Any],
+          let musicConfig = configs["browseEndpointContextMusicConfig"] as? [String: Any]
+    else {
+        return nil
+    }
+    return (musicConfig["pageType"] as? String).map(terminalSafe)
+}
+
+private func searchRowVideoSources(_ renderer: [String: Any]) -> [(label: String, videoId: String)] {
+    var sources: [(label: String, videoId: String)] = []
+
+    if let playlistItemData = renderer["playlistItemData"] as? [String: Any],
+       let videoId = playlistItemData["videoId"] as? String,
+       !videoId.isEmpty
+    {
+        sources.append(("playlistItemData", videoId))
+    }
+
+    if let videoId = watchVideoId(in: renderer["navigationEndpoint"] as? [String: Any]) {
+        sources.append(("rowNavigation", videoId))
+    }
+
+    if let titleRun = firstFlexColumnRun(in: renderer, index: 0),
+       let videoId = watchVideoId(in: titleRun["navigationEndpoint"] as? [String: Any])
+    {
+        sources.append(("titleRun", videoId))
+    }
+
+    if let overlay = renderer["overlay"] as? [String: Any],
+       let thumbnailOverlay = overlay["musicItemThumbnailOverlayRenderer"] as? [String: Any],
+       let content = thumbnailOverlay["content"] as? [String: Any],
+       let playButton = content["musicPlayButtonRenderer"] as? [String: Any],
+       let videoId = watchVideoId(in: playButton["playNavigationEndpoint"] as? [String: Any])
+    {
+        sources.append(("overlay", videoId))
+    }
+
+    return sources
+}
+
+private func searchRowBrowseSources(_ renderer: [String: Any]) -> [(label: String, endpoint: [String: Any])] {
+    var sources: [(label: String, endpoint: [String: Any])] = []
+
+    if let endpoint = browseEndpoint(in: renderer["navigationEndpoint"] as? [String: Any]) {
+        sources.append(("rowNavigation", endpoint))
+    }
+
+    if let titleRun = firstFlexColumnRun(in: renderer, index: 0),
+       let endpoint = browseEndpoint(in: titleRun["navigationEndpoint"] as? [String: Any])
+    {
+        sources.append(("titleRun", endpoint))
+    }
+
+    return sources
+}
+
+private func searchRowMusicVideoTypes(_ renderer: [String: Any]) -> [String] {
+    var types: [String] = []
+
+    if let type = musicVideoType(in: renderer["navigationEndpoint"] as? [String: Any]) {
+        types.append(type)
+    }
+
+    if let titleRun = firstFlexColumnRun(in: renderer, index: 0),
+       let type = musicVideoType(in: titleRun["navigationEndpoint"] as? [String: Any])
+    {
+        types.append(type)
+    }
+
+    if let overlay = renderer["overlay"] as? [String: Any],
+       let thumbnailOverlay = overlay["musicItemThumbnailOverlayRenderer"] as? [String: Any],
+       let content = thumbnailOverlay["content"] as? [String: Any],
+       let playButton = content["musicPlayButtonRenderer"] as? [String: Any],
+       let type = musicVideoType(in: playButton["playNavigationEndpoint"] as? [String: Any])
+    {
+        types.append(type)
+    }
+
+    return Array(Set(types)).sorted()
+}
+
+private func searchCardEndpointSources(
+    _ card: [String: Any]
+) -> [(label: String, endpoint: [String: Any])] {
+    var sources: [(label: String, endpoint: [String: Any])] = []
+
+    if let titleRun = firstRun(in: card["title"]),
+       let endpoint = innertubeEndpoint(in: titleRun["navigationEndpoint"])
+    {
+        sources.append(("titleRun", endpoint))
+    }
+    if let endpoint = innertubeEndpoint(in: card["navigationEndpoint"]) {
+        sources.append(("cardNavigation", endpoint))
+    }
+    if let endpoint = innertubeEndpoint(in: card["onTap"]) {
+        sources.append(("onTap", endpoint))
+    }
+    if let endpoint = playNavigationEndpoint(in: card["thumbnailOverlay"]) {
+        sources.append(("thumbnailOverlay", endpoint))
+    }
+    if let endpoint = playNavigationEndpoint(in: card["overlay"]) {
+        sources.append(("overlay", endpoint))
+    }
+
+    return sources
+}
+
+private func searchCardVideoSources(
+    _ card: [String: Any]
+) -> [(label: String, endpoint: [String: Any])] {
+    searchCardEndpointSources(card).filter { watchVideoId(in: $0.endpoint) != nil }
+}
+
+private func searchCardBrowseSources(
+    _ card: [String: Any]
+) -> [(label: String, endpoint: [String: Any])] {
+    searchCardEndpointSources(card).filter { browseEndpoint(in: $0.endpoint) != nil }
+}
+
+private func continuationCount(in renderer: [String: Any]) -> Int {
+    (renderer["continuations"] as? [[String: Any]])?.count ?? 0
+}
+
+func firstSearchContinuationValue(in data: [String: Any]) -> String? {
+    let continuationRenderers =
+        renderers(named: "musicShelfRenderer", in: data)
+            + renderers(named: "musicShelfContinuation", in: data)
+            + renderers(named: "sectionListRenderer", in: data)
+
+    for renderer in continuationRenderers {
+        guard let continuations = renderer["continuations"] as? [[String: Any]] else {
+            continue
+        }
+        for continuation in continuations {
+            for dataKey in ["nextContinuationData", "reloadContinuationData"] {
+                if let continuationData = continuation[dataKey] as? [String: Any],
+                   let continuationValue = continuationData["continuation"] as? String,
+                   !continuationValue.isEmpty
+                {
+                    return continuationValue
+                }
+            }
+        }
+    }
+
+    for item in renderers(named: "continuationItemRenderer", in: data) {
+        guard let endpoint = item["continuationEndpoint"] as? [String: Any],
+              let command = endpoint["continuationCommand"] as? [String: Any],
+              let continuationValue = command["token"] as? String,
+              !continuationValue.isEmpty
+        else {
+            continue
+        }
+        return continuationValue
+    }
+
+    return nil
+}
+
+func searchContinuationActionGroups(
+    in data: [String: Any]
+) -> [(envelope: String, command: String, items: [[String: Any]])] {
+    var groups: [(envelope: String, command: String, items: [[String: Any]])] = []
+    for envelopeKey in [
+        "onResponseReceivedCommands",
+        "onResponseReceivedActions",
+        "onResponseReceivedEndpoints",
+    ] {
+        guard let actions = data[envelopeKey] as? [[String: Any]] else { continue }
+        for action in actions {
+            for commandKey in [
+                "appendContinuationItemsAction",
+                "reloadContinuationItemsCommand",
+            ] {
+                guard let command = action[commandKey] as? [String: Any],
+                      let items = command["continuationItems"] as? [[String: Any]]
+                else {
+                    continue
+                }
+                groups.append((envelopeKey, commandKey, items))
+            }
+        }
+    }
+    return groups
+}
+
+private func hasMusicSearchContinuationEnvelope(_ data: [String: Any]) -> Bool {
+    if let continuationContents = data["continuationContents"] as? [String: Any],
+       continuationContents["musicShelfContinuation"] is [String: Any]
+    {
+        return true
+    }
+    return !searchContinuationActionGroups(in: data).isEmpty
+}
+
+private func formattedCounts(_ counts: [String: Int]) -> String {
+    guard !counts.isEmpty else { return "none" }
+    return counts.sorted { lhs, rhs in
+        lhs.value != rhs.value ? lhs.value > rhs.value : lhs.key < rhs.key
+    }.map { "\($0.key)=\($0.value)" }.joined(separator: ", ")
+}
+
+// MARK: - CurrentSearchParserCoverage
+
+private struct CurrentSearchParserCoverage {
+    var parsedTypes: [String: Int] = [:]
+    var ignoredSections: [String: Int] = [:]
+    var droppedCards = 0
+    var droppedRows = 0
+    var rootStructureSupported = true
+}
+
+private func currentContentKind(fromLabel label: String) -> String? {
+    switch label.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+    case "song": "song"
+    case "video": "video"
+    case "album", "single", "ep": "album"
+    case "audiobook": "audiobook"
+    case "artist": "artist"
+    case "profile": "profile"
+    case "playlist": "playlist"
+    case "podcast": "podcastShow"
+    case "episode", "podcast episode": "podcastEpisode"
+    default: nil
+    }
+}
+
+private func currentContentKind(in renderer: [String: Any]) -> String? {
+    var textContainers: [[String: Any]] = []
+
+    if let flexColumns = renderer["flexColumns"] as? [[String: Any]],
+       flexColumns.indices.contains(1),
+       let column = flexColumns[1]["musicResponsiveListItemFlexColumnRenderer"] as? [String: Any],
+       let text = column["text"] as? [String: Any]
+    {
+        textContainers.append(text)
+    }
+
+    for key in ["subtitle", "secondSubtitle"] {
+        if let text = renderer[key] as? [String: Any] {
+            textContainers.append(text)
+        }
+    }
+
+    for container in textContainers {
+        guard let runs = container["runs"] as? [[String: Any]] else { continue }
+        for run in runs {
+            guard let text = run["text"] as? String else { continue }
+            let components = text
+                .components(separatedBy: "•")
+                .flatMap { $0.components(separatedBy: "·") }
+            for component in components {
+                if let kind = currentContentKind(fromLabel: component) {
+                    return kind
+                }
+            }
+        }
+    }
+
+    return nil
+}
+
+private func currentTitleRun(in renderer: [String: Any]) -> [String: Any]? {
+    firstFlexColumnRun(in: renderer, index: 0) ?? firstRun(in: renderer["title"])
+}
+
+private func appendCurrentEndpoint(_ value: Any?, to endpoints: inout [[String: Any]]) {
+    guard let endpoint = innertubeEndpoint(in: value) else { return }
+    endpoints.append(endpoint)
+}
+
+private func currentEndpointCandidates(from renderer: [String: Any]) -> [[String: Any]] {
+    var endpoints: [[String: Any]] = []
+    appendCurrentEndpoint(renderer["navigationEndpoint"], to: &endpoints)
+    appendCurrentEndpoint(currentTitleRun(in: renderer)?["navigationEndpoint"], to: &endpoints)
+    appendCurrentEndpoint(renderer["onTap"], to: &endpoints)
+    appendCurrentEndpoint(playNavigationEndpoint(in: renderer["thumbnailOverlay"]), to: &endpoints)
+    appendCurrentEndpoint(playNavigationEndpoint(in: renderer["overlay"]), to: &endpoints)
+    return endpoints
+}
+
+private func currentBrowseDisposition(
+    _ browse: [String: Any],
+    contentKind: String?
+) -> String? {
+    guard let browseId = browse["browseId"] as? String else { return nil }
+    let type = pageType(in: browse)
+
+    switch type {
+    case "MUSIC_PAGE_TYPE_ALBUM":
+        return "album"
+    case "MUSIC_PAGE_TYPE_AUDIOBOOK":
+        return "audiobook"
+    case "MUSIC_PAGE_TYPE_ARTIST", "MUSIC_PAGE_TYPE_LIBRARY_ARTIST":
+        return "artist"
+    case "MUSIC_PAGE_TYPE_USER_CHANNEL":
+        return "profile"
+    case "MUSIC_PAGE_TYPE_PLAYLIST":
+        return "playlist"
+    case "MUSIC_PAGE_TYPE_PODCAST_SHOW_DETAIL_PAGE":
+        return "podcastShow"
+    default:
+        break
+    }
+
+    if browseId.hasPrefix("MPSPP") {
+        return "podcastShow"
+    }
+    if browseId.hasPrefix("MPED") || contentKind == "podcastEpisode" {
+        return "podcastEpisode"
+    }
+    if browseId.hasPrefix("MPRE") || browseId.hasPrefix("OLAK") {
+        return contentKind == "audiobook" ? "audiobook" : "album"
+    }
+    if browseId.hasPrefix("VL") || browseId.hasPrefix("PL") {
+        return "playlist"
+    }
+    if browseId.hasPrefix("UC") || browseId.hasPrefix("MPLAUC") {
+        return contentKind == "profile" ? "profile" : "artist"
+    }
+    return nil
+}
+
+private func currentItemDisposition(_ renderer: [String: Any]) -> String? {
+    let contentKind = currentContentKind(in: renderer)
+    let endpoints = currentEndpointCandidates(from: renderer)
+    var hasPodcastEpisodeBrowseDestination = false
+
+    for endpoint in endpoints {
+        guard let browse = browseEndpoint(in: endpoint),
+              let disposition = currentBrowseDisposition(browse, contentKind: contentKind)
+        else {
+            continue
+        }
+
+        if disposition == "podcastEpisode" {
+            hasPodcastEpisodeBrowseDestination = true
+            continue
+        }
+        return disposition
+    }
+
+    let playlistVideoId = (renderer["playlistItemData"] as? [String: Any])?["videoId"] as? String
+    let hasPlayableDestination = playlistVideoId?.isEmpty == false
+        || endpoints.contains { watchVideoId(in: $0) != nil }
+    guard hasPlayableDestination else { return nil }
+
+    let videoTypes = Set(endpoints.compactMap { musicVideoType(in: $0) })
+    if hasPodcastEpisodeBrowseDestination
+        || contentKind == "podcastEpisode"
+        || videoTypes.contains("MUSIC_VIDEO_TYPE_PODCAST_EPISODE")
+    {
+        return "podcastEpisode"
+    }
+
+    if contentKind == "video"
+        || !videoTypes.isDisjoint(with: [
+            "MUSIC_VIDEO_TYPE_OMV",
+            "MUSIC_VIDEO_TYPE_UGC",
+            "MUSIC_VIDEO_TYPE_OFFICIAL_SOURCE_MUSIC",
+        ])
+    {
+        return "video"
+    }
+    return "song"
+}
+
+private func recordCurrentSearchContainer(
+    _ container: [String: Any],
+    coverage: inout CurrentSearchParserCoverage
+) {
+    if let card = container["musicCardShelfRenderer"] as? [String: Any] {
+        if let disposition = currentItemDisposition(card) {
+            coverage.parsedTypes[disposition, default: 0] += 1
+        } else {
+            coverage.droppedCards += 1
+        }
+        for content in card["contents"] as? [[String: Any]] ?? [] {
+            recordCurrentSearchContainer(content, coverage: &coverage)
+        }
+        return
+    }
+
+    if let shelf = container["musicShelfRenderer"] as? [String: Any] {
+        for content in shelf["contents"] as? [[String: Any]] ?? [] {
+            recordCurrentSearchContainer(content, coverage: &coverage)
+        }
+        return
+    }
+
+    if let itemSection = container["itemSectionRenderer"] as? [String: Any] {
+        for content in itemSection["contents"] as? [[String: Any]] ?? [] {
+            recordCurrentSearchContainer(content, coverage: &coverage)
+        }
+        return
+    }
+
+    for rendererKey in [
+        "musicResponsiveListItemRenderer",
+        "musicTwoRowItemRenderer",
+        "musicMultiRowListItemRenderer",
+    ] {
+        guard let renderer = container[rendererKey] as? [String: Any] else { continue }
+        if let disposition = currentItemDisposition(renderer) {
+            coverage.parsedTypes[disposition, default: 0] += 1
+        } else {
+            coverage.droppedRows += 1
+        }
+        return
+    }
+
+    if container["continuationItemRenderer"] != nil {
+        return
+    }
+
+    let nestedResultCount = renderers(named: "musicResponsiveListItemRenderer", in: container).count
+        + renderers(named: "musicTwoRowItemRenderer", in: container).count
+        + renderers(named: "musicMultiRowListItemRenderer", in: container).count
+        + renderers(named: "musicCardShelfRenderer", in: container).count
+    guard nestedResultCount > 0 else { return }
+
+    let sectionType = terminalSafe(container.keys.min() ?? "unknown")
+    coverage.ignoredSections[sectionType, default: 0] += 1
+    coverage.droppedRows += nestedResultCount
+}
+
+private func currentSearchParserCoverage(_ data: [String: Any]) -> CurrentSearchParserCoverage? {
+    var coverage = CurrentSearchParserCoverage()
+    var recognizedContinuation = false
+
+    if let continuationContents = data["continuationContents"] as? [String: Any],
+       let shelf = continuationContents["musicShelfContinuation"] as? [String: Any]
+    {
+        recognizedContinuation = true
+        for content in shelf["contents"] as? [[String: Any]] ?? [] {
+            recordCurrentSearchContainer(content, coverage: &coverage)
+        }
+    }
+
+    let actionGroups = searchContinuationActionGroups(in: data)
+    if !actionGroups.isEmpty {
+        recognizedContinuation = true
+        for group in actionGroups {
+            for content in group.items {
+                recordCurrentSearchContainer(content, coverage: &coverage)
+            }
+        }
+    }
+
+    if recognizedContinuation {
+        return coverage
+    }
+
+    guard let contents = data["contents"] as? [String: Any] else { return nil }
+
+    var sectionLists: [[String: Any]] = []
+    if let directSectionList = contents["sectionListRenderer"] as? [String: Any] {
+        sectionLists.append(directSectionList)
+    }
+    if let tabbed = contents["tabbedSearchResultsRenderer"] as? [String: Any],
+       let tabs = tabbed["tabs"] as? [[String: Any]]
+    {
+        for tab in tabs {
+            guard let tabRenderer = tab["tabRenderer"] as? [String: Any],
+                  let content = tabRenderer["content"] as? [String: Any],
+                  let sectionList = content["sectionListRenderer"] as? [String: Any]
+            else {
+                continue
+            }
+            sectionLists.append(sectionList)
+        }
+    }
+
+    guard !sectionLists.isEmpty else {
+        coverage.rootStructureSupported = false
+        return coverage
+    }
+
+    for sectionList in sectionLists {
+        for content in sectionList["contents"] as? [[String: Any]] ?? [] {
+            recordCurrentSearchContainer(content, coverage: &coverage)
+        }
+    }
+    return coverage
+}
+
+// MARK: - BoundedSearchAuditRenderers
+
+private struct BoundedSearchAuditRenderers {
+    var itemSections: [[String: Any]] = []
+    var cardShelves: [[String: Any]] = []
+    var musicShelves: [[String: Any]] = []
+    var shelfContinuations: [[String: Any]] = []
+    var rows: [[String: Any]] = []
+    var twoRowItems: [[String: Any]] = []
+    var multiRowItems: [[String: Any]] = []
+    var messageCount = 0
+}
+
+private func appendBoundedSearchAuditContainer(
+    _ container: [String: Any],
+    to renderers: inout BoundedSearchAuditRenderers
+) {
+    if let card = container["musicCardShelfRenderer"] as? [String: Any] {
+        renderers.cardShelves.append(card)
+        for content in card["contents"] as? [[String: Any]] ?? [] {
+            appendBoundedSearchAuditContainer(content, to: &renderers)
+        }
+        return
+    }
+
+    if let shelf = container["musicShelfRenderer"] as? [String: Any] {
+        renderers.musicShelves.append(shelf)
+        for content in shelf["contents"] as? [[String: Any]] ?? [] {
+            appendBoundedSearchAuditContainer(content, to: &renderers)
+        }
+        return
+    }
+
+    if let itemSection = container["itemSectionRenderer"] as? [String: Any] {
+        renderers.itemSections.append(itemSection)
+        for content in itemSection["contents"] as? [[String: Any]] ?? [] {
+            appendBoundedSearchAuditContainer(content, to: &renderers)
+        }
+        return
+    }
+
+    if let row = container["musicResponsiveListItemRenderer"] as? [String: Any] {
+        renderers.rows.append(row)
+        return
+    }
+    if let item = container["musicTwoRowItemRenderer"] as? [String: Any] {
+        renderers.twoRowItems.append(item)
+        return
+    }
+    if let item = container["musicMultiRowListItemRenderer"] as? [String: Any] {
+        renderers.multiRowItems.append(item)
+        return
+    }
+    if container["musicMessageRenderer"] != nil || container["messageRenderer"] != nil {
+        renderers.messageCount += 1
+    }
+}
+
+private func boundedSearchAuditRenderers(in data: [String: Any]) -> BoundedSearchAuditRenderers {
+    var renderers = BoundedSearchAuditRenderers()
+
+    if let continuationContents = data["continuationContents"] as? [String: Any],
+       let shelf = continuationContents["musicShelfContinuation"] as? [String: Any]
+    {
+        renderers.shelfContinuations.append(shelf)
+        for content in shelf["contents"] as? [[String: Any]] ?? [] {
+            appendBoundedSearchAuditContainer(content, to: &renderers)
+        }
+    }
+
+    for group in searchContinuationActionGroups(in: data) {
+        for content in group.items {
+            appendBoundedSearchAuditContainer(content, to: &renderers)
+        }
+    }
+
+    guard let contents = data["contents"] as? [String: Any] else {
+        return renderers
+    }
+
+    var sectionLists: [[String: Any]] = []
+    if let directSectionList = contents["sectionListRenderer"] as? [String: Any] {
+        sectionLists.append(directSectionList)
+    }
+    if let tabbed = contents["tabbedSearchResultsRenderer"] as? [String: Any],
+       let tabs = tabbed["tabs"] as? [[String: Any]]
+    {
+        for tab in tabs {
+            guard let tabRenderer = tab["tabRenderer"] as? [String: Any],
+                  let content = tabRenderer["content"] as? [String: Any],
+                  let sectionList = content["sectionListRenderer"] as? [String: Any]
+            else {
+                continue
+            }
+            sectionLists.append(sectionList)
+        }
+    }
+
+    for sectionList in sectionLists {
+        for content in sectionList["contents"] as? [[String: Any]] ?? [] {
+            appendBoundedSearchAuditContainer(content, to: &renderers)
+        }
+    }
+    return renderers
+}
+
+private func boundedContainerContainsResult(_ container: [String: Any]) -> Bool {
+    if container["musicCardShelfRenderer"] != nil
+        || container["musicShelfRenderer"] != nil
+        || container["musicResponsiveListItemRenderer"] != nil
+        || container["musicTwoRowItemRenderer"] != nil
+        || container["musicMultiRowListItemRenderer"] != nil
+    {
+        return true
+    }
+    guard let section = container["itemSectionRenderer"] as? [String: Any] else {
+        return false
+    }
+    return (section["contents"] as? [[String: Any]] ?? []).contains(where: boundedContainerContainsResult)
+}
+
+// MARK: - SearchAuditSnapshot
+
+private struct SearchAuditSnapshot {
+    let tabbedSearchCount: Int
+    let itemSections: [[String: Any]]
+    let cardShelves: [[String: Any]]
+    let musicShelves: [[String: Any]]
+    let shelfContinuations: [[String: Any]]
+    let rows: [[String: Any]]
+    let twoRowItems: [[String: Any]]
+    let multiRowItems: [[String: Any]]
+    let messageCount: Int
+    let chips: [SearchFilterProbe]
+    let hasMusicHeader: Bool
+    let hasDirectSectionList: Bool
+    let hasContinuationEnvelope: Bool
+
+    init(data: [String: Any]) {
+        let boundedRenderers = boundedSearchAuditRenderers(in: data)
+        let contents = data["contents"] as? [String: Any]
+        self.tabbedSearchCount = contents?["tabbedSearchResultsRenderer"] == nil ? 0 : 1
+        self.itemSections = boundedRenderers.itemSections
+        self.cardShelves = boundedRenderers.cardShelves
+        self.musicShelves = boundedRenderers.musicShelves
+        self.shelfContinuations = boundedRenderers.shelfContinuations
+        self.rows = boundedRenderers.rows
+        self.twoRowItems = boundedRenderers.twoRowItems
+        self.multiRowItems = boundedRenderers.multiRowItems
+        self.messageCount = boundedRenderers.messageCount
+        self.chips = searchFilterProbes(from: data)
+        self.hasMusicHeader = !renderers(named: "musicHeaderRenderer", in: data).isEmpty
+        self.hasDirectSectionList = contents?["sectionListRenderer"] != nil
+        self.hasContinuationEnvelope = hasMusicSearchContinuationEnvelope(data)
+    }
+
+    func isRecognized(in context: SearchAuditContext) -> Bool {
+        switch context {
+        case .automatic:
+            self.tabbedSearchCount > 0
+                || (self.hasDirectSectionList && self.hasMusicHeader && !self.chips.isEmpty)
+        case .firstPage:
+            self.tabbedSearchCount > 0 || self.hasDirectSectionList
+        case .continuation:
+            self.hasContinuationEnvelope
+        }
+    }
+
+    var cardNestedItemCount: Int {
+        self.cardShelves.reduce(0) { count, card in
+            count + ((card["contents"] as? [[String: Any]])?.count ?? 0)
+        }
+    }
+
+    var resultItemSectionCount: Int {
+        self.itemSections.count { section in
+            (section["contents"] as? [[String: Any]] ?? []).contains(where: boundedContainerContainsResult)
+        }
+    }
+}
+
+// MARK: - SearchRowAuditStats
+
+private struct SearchRowAuditStats {
+    var contentTypes: [String: Int] = [:]
+    var videoSourceCounts: [String: Int] = [:]
+    var musicVideoTypeCounts: [String: Int] = [:]
+    var browseSourceCounts: [String: Int] = [:]
+    var browsePageTypes: [String: Int] = [:]
+    var unaddressableRows = 0
+    var overlayOnlyRows = 0
+}
+
+private func makeSearchRowAuditStats(_ rows: [[String: Any]]) -> SearchRowAuditStats {
+    var stats = SearchRowAuditStats()
+    for row in rows {
+        stats.contentTypes[searchRowContentType(row), default: 0] += 1
+        let videoSources = searchRowVideoSources(row)
+        let browseSources = searchRowBrowseSources(row)
+
+        for source in videoSources {
+            stats.videoSourceCounts[source.label, default: 0] += 1
+        }
+        for type in searchRowMusicVideoTypes(row) {
+            stats.musicVideoTypeCounts[type, default: 0] += 1
+        }
+        for source in browseSources {
+            stats.browseSourceCounts[source.label, default: 0] += 1
+        }
+        let rowPageTypes = Set(browseSources.map { pageType(in: $0.endpoint) ?? "unknown" })
+        for type in rowPageTypes {
+            stats.browsePageTypes[type, default: 0] += 1
+        }
+
+        if videoSources.isEmpty, browseSources.isEmpty {
+            stats.unaddressableRows += 1
+        }
+        if videoSources.map(\.label) == ["overlay"] {
+            stats.overlayOnlyRows += 1
+        }
+    }
+    return stats
+}
+
+// MARK: - SearchCardAuditStats
+
+private struct SearchCardAuditStats {
+    var watchEndpoints = 0
+    var browseEndpoints = 0
+    var unknownEndpoints = 0
+    var musicVideoTypeCounts: [String: Int] = [:]
+    var videoSourceCounts: [String: Int] = [:]
+    var browseSourceCounts: [String: Int] = [:]
+}
+
+private func makeSearchCardAuditStats(_ cards: [[String: Any]]) -> SearchCardAuditStats {
+    var stats = SearchCardAuditStats()
+    for card in cards {
+        let videoSources = searchCardVideoSources(card)
+        let browseSources = searchCardBrowseSources(card)
+
+        if videoSources.isEmpty, browseSources.isEmpty {
+            stats.unknownEndpoints += 1
+            continue
+        }
+        if !videoSources.isEmpty {
+            stats.watchEndpoints += 1
+        }
+        if !browseSources.isEmpty {
+            stats.browseEndpoints += 1
+        }
+        for source in videoSources {
+            stats.videoSourceCounts[source.label, default: 0] += 1
+        }
+        for source in browseSources {
+            stats.browseSourceCounts[source.label, default: 0] += 1
+        }
+        for type in Set(videoSources.compactMap { musicVideoType(in: $0.endpoint) }) where !type.isEmpty {
+            stats.musicVideoTypeCounts[type, default: 0] += 1
+        }
+    }
+    return stats
+}
+
+// MARK: - SearchContinuationAuditStats
+
+private struct SearchContinuationAuditStats {
+    let sectionListContinuationCount: Int
+    let shelfContinuationCount: Int
+    let nextShelfContinuationCount: Int
+    let continuationItems: Int
+    let hasFollowableContinuation: Bool
+}
+
+private func makeSearchContinuationAuditStats(
+    _ data: [String: Any],
+    snapshot: SearchAuditSnapshot
+) -> SearchContinuationAuditStats {
+    let sectionLists = renderers(named: "sectionListRenderer", in: data)
+    return SearchContinuationAuditStats(
+        sectionListContinuationCount: sectionLists.reduce(0) { $0 + continuationCount(in: $1) },
+        shelfContinuationCount: snapshot.musicShelves.reduce(0) { $0 + continuationCount(in: $1) },
+        nextShelfContinuationCount: snapshot.shelfContinuations.reduce(0) { $0 + continuationCount(in: $1) },
+        continuationItems: renderers(named: "continuationItemRenderer", in: data).count,
+        hasFollowableContinuation: firstSearchContinuationValue(in: data) != nil
+    )
+}
+
+private func formatSearchAuditOverview(
+    data: [String: Any],
+    snapshot: SearchAuditSnapshot,
+    rows: SearchRowAuditStats,
+    cards: SearchCardAuditStats,
+    continuations: SearchContinuationAuditStats
+) -> String {
+    var output = "\n🔎 Search response audit:\n"
+    output += "  • Layout: tabbed=\(snapshot.tabbedSearchCount), item sections=\(snapshot.itemSections.count), card shelves=\(snapshot.cardShelves.count), music shelves=\(snapshot.musicShelves.count), shelf continuations=\(snapshot.shelfContinuations.count)\n"
+    if snapshot.cardNestedItemCount > 0 {
+        output += "  • Nested top-card items: \(snapshot.cardNestedItemCount)\n"
+    }
+    if !snapshot.twoRowItems.isEmpty || !snapshot.multiRowItems.isEmpty {
+        output += "  • Other search items: two-row=\(snapshot.twoRowItems.count), multi-row=\(snapshot.multiRowItems.count)\n"
+    }
+    if snapshot.messageCount > 0 {
+        output += "  • Message renderers: \(snapshot.messageCount)\n"
+    }
+    output += "  • Responsive rows: \(snapshot.rows.count) (\(formattedCounts(rows.contentTypes)))\n"
+    output += "  • Video ID paths: \(formattedCounts(rows.videoSourceCounts))\n"
+    if !rows.musicVideoTypeCounts.isEmpty {
+        output += "  • Row music video types: \(formattedCounts(rows.musicVideoTypeCounts))\n"
+    }
+    output += "  • Browse paths: \(formattedCounts(rows.browseSourceCounts))\n"
+    if !rows.browsePageTypes.isEmpty {
+        output += "  • Browse page types: \(formattedCounts(rows.browsePageTypes))\n"
+    }
+    output += "  • Top cards: watch=\(cards.watchEndpoints), browse=\(cards.browseEndpoints), unknown=\(cards.unknownEndpoints)\n"
+    if !cards.videoSourceCounts.isEmpty {
+        output += "  • Top-card video paths: \(formattedCounts(cards.videoSourceCounts))\n"
+    }
+    if !cards.browseSourceCounts.isEmpty {
+        output += "  • Top-card browse paths: \(formattedCounts(cards.browseSourceCounts))\n"
+    }
+    if !cards.musicVideoTypeCounts.isEmpty {
+        output += "  • Top-card music video types: \(formattedCounts(cards.musicVideoTypeCounts))\n"
+    }
+    output += "  • Continuations: section list=\(continuations.sectionListContinuationCount), music shelf=\(continuations.shelfContinuationCount), shelf continuation=\(continuations.nextShelfContinuationCount), continuation items=\(continuations.continuationItems), followable=\(continuations.hasFollowableContinuation ? "yes" : "no")\n"
+    if !snapshot.chips.isEmpty {
+        output += "  • Live filter chips: \(snapshot.chips.map(\.label).joined(separator: ", "))\n"
+    }
+    return output + formatCurrentMixedParserCoverage(data)
+}
+
+private func formatCurrentMixedParserCoverage(_ data: [String: Any]) -> String {
+    guard let coverage = currentSearchParserCoverage(data) else { return "" }
+    if !coverage.rootStructureSupported {
+        return "  • Current Kaset parser reachability: unsupported response root\n"
+    }
+    let parsedCount = coverage.parsedTypes.values.reduce(0, +)
+    var output = "  • Current Kaset parser reachability: supported=\(parsedCount) (\(formattedCounts(coverage.parsedTypes))), unhandled cards=\(coverage.droppedCards), unhandled result rows=\(coverage.droppedRows)\n"
+    if !coverage.ignoredSections.isEmpty {
+        output += "  • Current Kaset ignored sections: \(formattedCounts(coverage.ignoredSections))\n"
+    }
+    return output
+}
+
+private func searchAuditWarnings(
+    snapshot: SearchAuditSnapshot,
+    rows: SearchRowAuditStats,
+    cards: SearchCardAuditStats,
+    continuations: SearchContinuationAuditStats
+) -> [String] {
+    var warnings: [String] = []
+    if snapshot.resultItemSectionCount > 0 {
+        warnings.append("result rows are nested in \(snapshot.resultItemSectionCount) itemSectionRenderer wrapper(s)")
+    }
+    if cards.watchEndpoints > 0 {
+        warnings.append("top cards use watchEndpoint")
+    }
+    if rows.overlayOnlyRows > 0 {
+        warnings.append("\(rows.overlayOnlyRows) row(s) expose a video ID only through the overlay")
+    }
+    if continuations.shelfContinuationCount > 0, continuations.sectionListContinuationCount == 0 {
+        warnings.append("first-page continuation token is stored on musicShelfRenderer")
+    }
+    if rows.unaddressableRows > 0 {
+        warnings.append("\(rows.unaddressableRows) row(s) have no recognized watch or browse destination")
+    }
+    if !snapshot.twoRowItems.isEmpty || !snapshot.multiRowItems.isEmpty {
+        warnings.append("search includes non-responsive item renderers that need separate parsing")
+    }
+    if snapshot.cardNestedItemCount > 0 {
+        warnings.append("top cards contain \(snapshot.cardNestedItemCount) nested item(s)")
+    }
+    return warnings
+}
+
+private func formatSearchRowSamples(_ rows: [[String: Any]], limit: Int) -> String {
+    guard limit > 0, !rows.isEmpty else { return "" }
+    var output = "  • Sample rows:\n"
+    for row in rows.prefix(limit) {
+        let type = searchRowContentType(row)
+        let title = searchRowTitle(row)
+        let videoSources = searchRowVideoSources(row)
+        let browseSources = searchRowBrowseSources(row)
+        let destination = if !videoSources.isEmpty {
+            "video via \(videoSources.map(\.label).joined(separator: "+"))"
+        } else if let browseSource = browseSources.first {
+            "browse via \(browseSource.label) (\(pageType(in: browseSource.endpoint) ?? "unknown"))"
+        } else {
+            "no destination"
+        }
+        output += "    - [\(type)] \(title) — \(destination)\n"
+    }
+    if rows.count > limit {
+        output += "    - … and \(rows.count - limit) more\n"
+    }
+    return output
+}
+
+private func formatSearchCardSamples(_ cards: [[String: Any]], limit: Int) -> String {
+    guard limit > 0, !cards.isEmpty else { return "" }
+    var output = "  • Top-card samples:\n"
+    for card in cards.prefix(limit) {
+        let title = terminalSafe(joinedRunsText(card["title"] as? [String: Any]) ?? "Untitled")
+        let subtitle = joinedRunsText(card["subtitle"] as? [String: Any]).map(terminalSafe)
+        let videoSources = searchCardVideoSources(card)
+        let browseSources = searchCardBrowseSources(card)
+        let destination: String
+        if !videoSources.isEmpty {
+            let types = Set(videoSources.compactMap { musicVideoType(in: $0.endpoint) }).sorted()
+            let typeSummary = types.isEmpty ? "unknown type" : types.joined(separator: "+")
+            destination = "watch via \(videoSources.map(\.label).joined(separator: "+")) (\(typeSummary))"
+        } else if let source = browseSources.first,
+                  let browse = browseEndpoint(in: source.endpoint)
+        {
+            destination = "browse via \(source.label) (\(pageType(in: browse) ?? "unknown type"))"
+        } else {
+            destination = "no recognized destination"
+        }
+        output += "    - \(title) — \(destination)\(subtitle.map { " — \($0)" } ?? "")\n"
+    }
+    return output
+}
+
+func isSuccessfulAPIResponse(statusCode: Int, data: [String: Any]) -> Bool {
+    (200 ... 299).contains(statusCode) && data["error"] == nil
+}
+
+func apiFailureDescription(statusCode: Int, data: [String: Any]) -> String {
+    guard let error = data["error"] as? [String: Any] else {
+        return "HTTP \(statusCode)"
+    }
+    let code = terminalSafe(error["code"].map(String.init(describing:)) ?? "unknown")
+    let message = terminalSafe(error["message"] as? String ?? "Unknown API error")
+    return "HTTP \(statusCode), API \(code): \(message)"
+}
+
+func searchResponseAuditSummary(
+    _ data: [String: Any],
+    sampleLimit: Int = 6,
+    context: SearchAuditContext = .automatic
+) -> String {
+    let snapshot = SearchAuditSnapshot(data: data)
+    guard snapshot.isRecognized(in: context) else { return "" }
+
+    let rowStats = makeSearchRowAuditStats(snapshot.rows)
+    let cardStats = makeSearchCardAuditStats(snapshot.cardShelves)
+    let continuationStats = makeSearchContinuationAuditStats(data, snapshot: snapshot)
+    var output = formatSearchAuditOverview(
+        data: data,
+        snapshot: snapshot,
+        rows: rowStats,
+        cards: cardStats,
+        continuations: continuationStats
+    )
+    for warning in searchAuditWarnings(
+        snapshot: snapshot,
+        rows: rowStats,
+        cards: cardStats,
+        continuations: continuationStats
+    ) {
+        output += "  ⚠️ \(warning)\n"
+    }
+    output += formatSearchRowSamples(snapshot.rows, limit: sampleLimit)
+    output += formatSearchCardSamples(snapshot.cardShelves, limit: sampleLimit)
+    return output
+}

--- a/Sources/APIExplorer/main.swift
+++ b/Sources/APIExplorer/main.swift
@@ -12,15 +12,17 @@
 //  Commands:
 //    browse <browseId> [params]    - Explore a browse endpoint
 //    action <endpoint> <body>      - Explore an action endpoint (body as JSON)
-//    continuation <token> [ep]     - Explore a continuation (ep: browse or next)
+//    search-audit <query>          - Audit live YouTube Music search shapes and filters
+//    continuation <token> [ep]     - Explore a continuation (ep: browse, search, or next)
 //    analyze-file <path>           - Safely summarize a saved JSON response
 //    list                          - List all known endpoints
 //    auth                          - Check authentication status
 //    help                          - Show this help message
 //
 //  Options:
-//    -v, --verbose                 - Show full raw JSON response (not truncated)
+//    -v, --verbose                 - Show raw JSON, or expanded search-audit samples
 //    -o, --output <file>           - Save raw JSON response to a file
+//    --client-version <version>    - Override the resolved InnerTube client version
 //    --youtube, --yt               - Target regular YouTube (www.youtube.com, WEB client)
 //                                    instead of YouTube Music
 //    --no-auth, --guest            - Force unauthenticated requests even if Kaset cookies exist
@@ -52,6 +54,7 @@ let origin = "https://music.youtube.com"
 /// instead of YouTube Music (music.youtube.com, WEB_REMIX client). Set via --youtube.
 nonisolated(unsafe) var youtubeMode = false
 nonisolated(unsafe) var cachedClientVersion: String?
+nonisolated(unsafe) var clientVersionWasForced = false
 nonisolated(unsafe) var forceUnauthenticatedRequests = false
 
 // Active request configuration. Defaults to YouTube Music (the constants
@@ -199,6 +202,18 @@ func computeSAPISIDHASH(sapisid: String) -> String {
 
 // MARK: - API Key Resolution
 
+private func webClientConfigurationRequest(timeout: TimeInterval? = nil) -> URLRequest {
+    var request = URLRequest(url: activeWebClientURL)
+    if let timeout {
+        request.timeoutInterval = timeout
+    }
+    request.setValue(
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
+        forHTTPHeaderField: "User-Agent"
+    )
+    return request
+}
+
 func resolveAPIKey() async throws -> String {
     if let cachedAPIKey {
         return cachedAPIKey
@@ -212,11 +227,7 @@ func resolveAPIKey() async throws -> String {
         return trimmed
     }
 
-    var request = URLRequest(url: activeWebClientURL)
-    request.setValue(
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
-        forHTTPHeaderField: "User-Agent"
-    )
+    let request = webClientConfigurationRequest()
     let (data, response) = try await URLSession.shared.data(for: request)
     if let httpResponse = response as? HTTPURLResponse,
        !(200 ... 399).contains(httpResponse.statusCode)
@@ -240,12 +251,34 @@ func resolveAPIKey() async throws -> String {
 
     // Opportunistically capture the live client version so requests
     // match what the web client currently sends.
-    if let version = extractInnertubeClientVersion(from: html) {
+    if cachedClientVersion == nil,
+       let version = extractInnertubeClientVersion(from: html)
+    {
         cachedClientVersion = version
     }
 
     cachedAPIKey = key
     return key
+}
+
+/// Resolves only the live client version when the API key came from an explicit
+/// environment override. Failure is non-fatal: callers can still use the
+/// configured fallback, and search-audit labels that source explicitly.
+func resolveLiveClientVersionIfNeeded() async {
+    guard cachedClientVersion == nil else { return }
+
+    let request = webClientConfigurationRequest(timeout: 5)
+
+    guard let (data, response) = try? await URLSession.shared.data(for: request),
+          let httpResponse = response as? HTTPURLResponse,
+          (200 ... 399).contains(httpResponse.statusCode),
+          let html = String(data: data, encoding: .utf8),
+          let version = extractInnertubeClientVersion(from: html)
+    else {
+        return
+    }
+
+    cachedClientVersion = version
 }
 
 func extractInnertubeAPIKey(from html: String) -> String? {
@@ -337,6 +370,11 @@ func buildHeaders(authenticated: Bool = false, authUserIndex: Int? = nil) -> [St
     return headers
 }
 
+func hasUsableAuthMaterial() -> Bool {
+    guard let cookies = loadCookiesFromAppBackup() else { return false }
+    return getSAPISID(from: cookies) != nil && buildCookieHeader(from: cookies) != nil
+}
+
 // MARK: - API Request
 
 func makeRequest(endpoint: String, body: [String: Any], authenticated: Bool = false) async throws
@@ -386,7 +424,7 @@ func makeRequest(endpoint: String, body: [String: Any], authenticated: Bool = fa
 
 // MARK: - Response Analysis
 
-private func joinedRunsText(_ data: [String: Any]?) -> String? {
+func joinedRunsText(_ data: [String: Any]?) -> String? {
     guard let data,
           let runs = data["runs"] as? [[String: Any]]
     else {
@@ -936,7 +974,11 @@ private func libraryFeedbackProbeSummary(_ data: [String: Any]) -> String {
     return output
 }
 
-func analyzeResponse(_ data: [String: Any], verbose: Bool = false) -> String {
+func analyzeResponse(
+    _ data: [String: Any],
+    verbose: Bool = false,
+    searchAuditContext: SearchAuditContext = .automatic
+) -> String {
     var output = ""
 
     // Top-level keys
@@ -1025,6 +1067,13 @@ func analyzeResponse(_ data: [String: Any], verbose: Bool = false) -> String {
     output += chapterProbeSummary(data)
 
     output += libraryFeedbackProbeSummary(data)
+
+    if !youtubeMode {
+        output += searchResponseAuditSummary(
+            data,
+            context: searchAuditContext
+        )
+    }
 
     output += rendererHistogram(data)
 
@@ -1211,7 +1260,11 @@ func exploreAction(
 
         print("✅ HTTP \(statusCode)")
         print()
-        print(analyzeResponse(data, verbose: verbose))
+        print(analyzeResponse(
+            data,
+            verbose: verbose,
+            searchAuditContext: endpoint == "search" && !youtubeMode ? .firstPage : .automatic
+        ))
 
         if verbose {
             print("\n📄 Raw response (pretty-printed):")
@@ -1238,20 +1291,155 @@ func exploreAction(
     }
 }
 
+// swiftlint:disable no_print
+private func auditSearchFilter(
+    _ probe: SearchFilterProbe,
+    authenticated: Bool,
+    verbose: Bool
+) async {
+    do {
+        let (filterResponse, filterStatus) = try await makeRequest(
+            endpoint: "search",
+            body: [
+                "query": probe.query,
+                "params": probe.params,
+            ],
+            authenticated: authenticated
+        )
+        print("\n══ \(probe.label) — HTTP \(filterStatus) ══")
+        guard isSuccessfulAPIResponse(statusCode: filterStatus, data: filterResponse) else {
+            print("  ❌ Filter probe failed: \(apiFailureDescription(statusCode: filterStatus, data: filterResponse))")
+            return
+        }
+        if verbose {
+            print("   Params: \(terminalSafe(probe.params))")
+        }
+        let filterSummary = searchResponseAuditSummary(
+            filterResponse,
+            sampleLimit: verbose ? 12 : 4,
+            context: .firstPage
+        )
+        print(filterSummary.isEmpty ? "  ⚠️ No recognized YouTube Music search shape" : filterSummary)
+        if probe.label == "Podcasts" {
+            print("  • Kaset uses a dedicated podcast-show parser for this filter.")
+        }
+
+        guard let continuationValue = firstSearchContinuationValue(in: filterResponse) else {
+            print("  • Continuation probe: none offered")
+            return
+        }
+
+        let (continuationResponse, continuationStatus) = try await makeRequest(
+            endpoint: "search",
+            body: ["continuation": continuationValue],
+            authenticated: authenticated
+        )
+        print("  • Continuation probe via /search: HTTP \(continuationStatus)")
+        guard isSuccessfulAPIResponse(
+            statusCode: continuationStatus,
+            data: continuationResponse
+        ) else {
+            print("  ❌ Continuation probe failed: \(apiFailureDescription(statusCode: continuationStatus, data: continuationResponse))")
+            return
+        }
+        let continuationSummary = searchResponseAuditSummary(
+            continuationResponse,
+            sampleLimit: verbose ? 8 : 2,
+            context: .continuation
+        )
+        print(continuationSummary.isEmpty
+            ? "  ⚠️ Unrecognized search continuation response shape"
+            : continuationSummary)
+    } catch {
+        print("  ❌ \(probe.label) probe failed: \(error.localizedDescription)")
+    }
+}
+
+/// Audits the live YouTube Music search response, every filter chip returned by the
+/// service, and the first continuation page for each filter that offers one.
+func auditSearch(_ query: String, verbose: Bool = false) async {
+    guard !youtubeMode else {
+        print("❌ search-audit currently supports YouTube Music mode only")
+        print("   Use 'action search' for regular YouTube response inspection.")
+        return
+    }
+
+    let authenticated = !forceUnauthenticatedRequests && hasUsableAuthMaterial()
+    let mode = authenticated ? "cookie auth requested (validity unverified)" : "guest"
+    print("🔬 Auditing YouTube Music search")
+    print("   Query: \(terminalSafe(query))")
+    print("   Session: \(mode)")
+    print()
+
+    do {
+        if ProcessInfo.processInfo.environment[apiKeyEnvironmentVariable]?.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        ).isEmpty == false {
+            await resolveLiveClientVersionIfNeeded()
+        }
+        let (baseResponse, baseStatus) = try await makeRequest(
+            endpoint: "search",
+            body: ["query": query],
+            authenticated: authenticated
+        )
+        let versionSource = if clientVersionWasForced {
+            "override"
+        } else if cachedClientVersion != nil {
+            "live"
+        } else {
+            "fallback"
+        }
+        print("   Client version: \(terminalSafe(cachedClientVersion ?? activeFallbackClientVersion)) (\(versionSource))")
+        print("══ Unfiltered search — HTTP \(baseStatus) ══")
+        guard isSuccessfulAPIResponse(statusCode: baseStatus, data: baseResponse) else {
+            print("  ❌ Unfiltered probe failed: \(apiFailureDescription(statusCode: baseStatus, data: baseResponse))")
+            return
+        }
+        let baseSummary = searchResponseAuditSummary(
+            baseResponse,
+            sampleLimit: verbose ? 20 : 8,
+            context: .firstPage
+        )
+        print(baseSummary.isEmpty ? "  ⚠️ No recognized YouTube Music search shape" : baseSummary)
+
+        let probes = searchFilterProbes(from: baseResponse)
+        guard !probes.isEmpty else {
+            print("\n⚠️ The unfiltered response exposed no navigable filter chips.")
+            return
+        }
+
+        print("\n🧭 Probing \(probes.count) live filter chip(s): \(probes.map(\.label).joined(separator: ", "))")
+        let unsupportedLabels = probes.map(\.label).filter { !kasetSearchFilterLabels.contains($0) }
+        if !unsupportedLabels.isEmpty {
+            print("   Filter chips without a dedicated Kaset filter: \(unsupportedLabels.joined(separator: ", "))")
+        }
+
+        for probe in probes {
+            await auditSearchFilter(probe, authenticated: authenticated, verbose: verbose)
+        }
+    } catch {
+        print("❌ Search audit failed: \(error.localizedDescription)")
+    }
+}
+
+// swiftlint:enable no_print
+
 /// Explores a continuation request to fetch more items.
 /// - Parameters:
 ///   - token: The continuation token
-///   - endpoint: The endpoint to use ("browse" for home/library, "next" for mix queues)
+///   - endpoint: The endpoint to use ("browse" for home/library, "search" for search, "next" for mix queues)
 func exploreContinuation(
     _ token: String, endpoint: String = "browse", verbose: Bool = false, outputFile: String? = nil
 ) async {
     print("🔄 Exploring continuation request")
-    print("   Token: \(token.prefix(50))...")
+    print("   Token: present (value hidden)")
     print("   Endpoint: \(endpoint)")
     print()
 
     var body: [String: Any] = ["continuation": token]
-
+    // Preserve the caller's requested session mode: cookies are used when they
+    // are available, while --guest/--no-auth forces a signed-out continuation.
+    let authenticated = !forceUnauthenticatedRequests && hasUsableAuthMaterial()
     // For "next" endpoint continuations (mix queues), add required parameters
     if endpoint == "next" {
         body["enablePersistentPlaylistPanel"] = true
@@ -1259,9 +1447,8 @@ func exploreContinuation(
     }
 
     do {
-        // Always authenticate for continuations
         let (data, statusCode) = try await makeRequest(
-            endpoint: endpoint, body: body, authenticated: true
+            endpoint: endpoint, body: body, authenticated: authenticated
         )
 
         if statusCode == 401 || statusCode == 403 {
@@ -1271,7 +1458,11 @@ func exploreContinuation(
 
         print("✅ HTTP \(statusCode)")
         print()
-        print(analyzeResponse(data, verbose: verbose))
+        print(analyzeResponse(
+            data,
+            verbose: verbose,
+            searchAuditContext: endpoint == "search" && !youtubeMode ? .continuation : .automatic
+        ))
 
         // Analyze continuation-specific structure
         print("\n📊 Continuation Analysis:")
@@ -1308,19 +1499,18 @@ func exploreContinuation(
                     }
                 }
             }
-        } else if let actions = data["onResponseReceivedActions"] as? [[String: Any]] {
-            print("   Found onResponseReceivedActions (2025 format)")
-            for (idx, action) in actions.enumerated() {
-                print("   └─ Action \(idx) keys: \(Array(action.keys))")
-                if let appendAction = action["appendContinuationItemsAction"] as? [String: Any],
-                   let items = appendAction["continuationItems"] as? [[String: Any]]
-                {
-                    print("      └─ continuationItems: \(items.count) items")
-                }
-            }
         } else {
-            print("   ⚠️ No recognized continuation format found")
-            print("   Top-level keys: \(Array(data.keys))")
+            let actionGroups = searchContinuationActionGroups(in: data)
+            if !actionGroups.isEmpty {
+                print("   Found action-envelope continuation format")
+                for (index, group) in actionGroups.enumerated() {
+                    print("   └─ Group \(index): \(group.envelope).\(group.command)")
+                    print("      └─ continuationItems: \(group.items.count) items")
+                }
+            } else {
+                print("   ⚠️ No recognized continuation format found")
+                print("   Top-level keys: \(Array(data.keys))")
+            }
         }
 
         if verbose {
@@ -2274,7 +2464,8 @@ func showHelp() {
         Commands:
           browse <browseId> [params]     Explore a browse endpoint
           action <endpoint> <body>       Explore an action endpoint (body as JSON)
-          continuation <token> [ep]      Explore a continuation (ep: 'browse' or 'next')
+          search-audit <query>           Audit live Music search shapes, filters, and continuations
+          continuation <token> [ep]      Explore a continuation (ep: 'browse', 'search', or 'next')
           analyze-file <path>            Safely summarize a saved JSON response
           list                           List all known endpoints
           auth                           Check authentication status
@@ -2289,10 +2480,11 @@ func showHelp() {
           help                           Show this help message
 
         Options:
-          -v, --verbose                  Show full raw JSON response (not truncated)
+          -v, --verbose                  Show raw JSON; expand samples/params for search-audit
           -o, --output <file>            Save raw JSON response to a file
           --authuser N                   Use Google account at index N (for multi-account)
           --brand <ID>                   Use brand account ID (21-digit number)
+          --client-version <version>     Override the resolved InnerTube client version
           --youtube, --yt                Target regular YouTube (www.youtube.com, WEB client)
                                          instead of YouTube Music
           --no-auth, --guest             Force signed-out requests even if Kaset cookies exist
@@ -2329,8 +2521,12 @@ func showHelp() {
           swift run api-explorer action player '{"videoId":"dQw4w9WgXcQ"}'
           swift run api-explorer action next '{"playlistId":"RDEM...","videoId":"abc123"}'
 
+          # Deeply audit YouTube Music search response coverage
+          swift run api-explorer --guest search-audit "ambient electronic mix"
+
           # Continuation (for pagination / infinite mix)
           swift run api-explorer continuation <token>           # browse endpoint (default)
+          swift run api-explorer --guest continuation <token> search # guest filtered search results
           swift run api-explorer continuation <token> next      # next endpoint (for mix queues)
 
           # Safely inspect a saved response without printing raw token values
@@ -2402,6 +2598,26 @@ func runMain() async {
         }
     }
 
+    // Parse client version override. Keeping it in cachedClientVersion prevents
+    // live web configuration discovery from replacing the explicit probe value.
+    for (index, arg) in args.enumerated() {
+        guard arg == "--client-version" else { continue }
+        guard index + 1 < args.count else {
+            print("❌ --client-version requires a value")
+            return
+        }
+
+        let value = args[index + 1].trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty, !value.hasPrefix("-") else {
+            print("❌ Invalid --client-version value: provide a version such as 1.20231204.01.00")
+            return
+        }
+
+        cachedClientVersion = value
+        clientVersionWasForced = true
+        break
+    }
+
     // Parse YouTube mode option (target www.youtube.com / WEB client)
     if args.contains("--youtube") || args.contains("--yt") {
         activateYouTubeMode()
@@ -2428,7 +2644,9 @@ func runMain() async {
         {
             continue
         }
-        if arg == "-o" || arg == "--output" || arg == "--authuser" || arg == "--brand" {
+        if arg == "-o" || arg == "--output" || arg == "--authuser" || arg == "--brand"
+            || arg == "--client-version"
+        {
             skipNext = true
             continue
         }
@@ -2460,10 +2678,21 @@ func runMain() async {
         let bodyJson = filteredArgs[2]
         await exploreAction(endpoint, bodyJson: bodyJson, verbose: verbose, outputFile: outputFile)
 
+    case "search-audit":
+        guard filteredArgs.count >= 2 else {
+            print("❌ Usage: search-audit <query>")
+            print("   Example: search-audit \"ambient electronic mix\"")
+            return
+        }
+        if outputFile != nil {
+            print("⚠️ --output is ignored by search-audit; use 'action search' to save raw JSON")
+        }
+        await auditSearch(filteredArgs[1], verbose: verbose)
+
     case "continuation":
         guard filteredArgs.count >= 2 else {
             print("❌ Usage: continuation <token> [endpoint]")
-            print("   endpoint: 'browse' (default) for home/library, 'next' for mix queues")
+            print("   endpoint: 'browse' (default), 'search' for search, or 'next' for mix queues")
             print("   Get the token from a browse response's continuationItemRenderer or")
             print("   from a next response's nextRadioContinuationData.continuation")
             return

--- a/Sources/Kaset/Models/MusicVideoType.swift
+++ b/Sources/Kaset/Models/MusicVideoType.swift
@@ -22,6 +22,9 @@ enum MusicVideoType: String, Codable {
     /// User Generated Content - Fan-made or unofficial videos.
     case ugc = "MUSIC_VIDEO_TYPE_UGC"
 
+    /// Official-source music video exposed by current Videos search results.
+    case officialSourceMusic = "MUSIC_VIDEO_TYPE_OFFICIAL_SOURCE_MUSIC"
+
     /// Podcast Episode - Audio podcast content.
     case podcastEpisode = "MUSIC_VIDEO_TYPE_PODCAST_EPISODE"
 
@@ -31,12 +34,23 @@ enum MusicVideoType: String, Codable {
         self == .omv
     }
 
+    /// Whether search should present the item as a video result.
+    var isSearchVideo: Bool {
+        switch self {
+        case .omv, .ugc, .officialSourceMusic:
+            true
+        case .atv, .podcastEpisode:
+            false
+        }
+    }
+
     /// Human-readable description of the video type.
     var displayName: String {
         switch self {
         case .omv: "Official Music Video"
         case .atv: "Audio Track"
         case .ugc: "User Generated"
+        case .officialSourceMusic: "Official Source Music"
         case .podcastEpisode: "Podcast Episode"
         }
     }

--- a/Sources/Kaset/Models/Podcast.swift
+++ b/Sources/Kaset/Models/Podcast.swift
@@ -49,6 +49,22 @@ struct PodcastEpisode: Identifiable, Hashable {
         }
         return self.duration
     }
+
+    /// Queue-compatible representation used by search and podcast playback.
+    var playbackSong: Song {
+        Song(
+            id: self.id,
+            title: self.title,
+            artists: self.showTitle.map {
+                [Artist.inline(name: $0, namespace: "podcast-show")]
+            } ?? [],
+            album: nil,
+            duration: self.durationSeconds.map(TimeInterval.init),
+            thumbnailURL: self.thumbnailURL,
+            videoId: self.id,
+            musicVideoType: .podcastEpisode
+        )
+    }
 }
 
 // MARK: - PodcastSection

--- a/Sources/Kaset/Models/SearchResponse.swift
+++ b/Sources/Kaset/Models/SearchResponse.swift
@@ -3,29 +3,86 @@ import Foundation
 // MARK: - SearchResponse
 
 /// Response from a YouTube Music search query.
+///
+/// `items` is the canonical representation so mixed search preserves YouTube
+/// Music's server ranking. Typed collections are projections used by filters and
+/// compatibility call sites.
 struct SearchResponse {
-    let songs: [Song]
-    let albums: [Album]
-    let artists: [Artist]
-    let playlists: [Playlist]
-    let podcastShows: [PodcastShow]
-    /// Continuation token for loading more results (only present for filtered searches).
+    let items: [SearchResultItem]
+    /// Continuation value for loading more results (only present for filtered searches).
     let continuationToken: String?
 
-    /// All results as a flat array of items.
+    /// All results in server-provided order.
     var allItems: [SearchResultItem] {
-        var items: [SearchResultItem] = []
-        items.append(contentsOf: self.songs.map { .song($0) })
-        items.append(contentsOf: self.albums.map { .album($0) })
-        items.append(contentsOf: self.artists.map { .artist($0) })
-        items.append(contentsOf: self.playlists.map { .playlist($0) })
-        items.append(contentsOf: self.podcastShows.map { .podcastShow($0) })
-        return items
+        self.items
+    }
+
+    var songs: [Song] {
+        self.items.compactMap { item in
+            guard case let .song(song) = item else { return nil }
+            return song
+        }
+    }
+
+    var videos: [Song] {
+        self.items.compactMap { item in
+            guard case let .video(video) = item else { return nil }
+            return video
+        }
+    }
+
+    var albums: [Album] {
+        self.items.compactMap { item in
+            guard case let .album(album) = item else { return nil }
+            return album
+        }
+    }
+
+    var audiobooks: [Album] {
+        self.items.compactMap { item in
+            guard case let .audiobook(audiobook) = item else { return nil }
+            return audiobook
+        }
+    }
+
+    var artists: [Artist] {
+        self.items.compactMap { item in
+            guard case let .artist(artist) = item else { return nil }
+            return artist
+        }
+    }
+
+    var profiles: [Artist] {
+        self.items.compactMap { item in
+            guard case let .profile(profile) = item else { return nil }
+            return profile
+        }
+    }
+
+    var playlists: [Playlist] {
+        self.items.compactMap { item in
+            guard case let .playlist(playlist) = item else { return nil }
+            return playlist
+        }
+    }
+
+    var podcastShows: [PodcastShow] {
+        self.items.compactMap { item in
+            guard case let .podcastShow(show) = item else { return nil }
+            return show
+        }
+    }
+
+    var podcastEpisodes: [PodcastEpisode] {
+        self.items.compactMap { item in
+            guard case let .podcastEpisode(episode) = item else { return nil }
+            return episode
+        }
     }
 
     /// Whether the search returned any results.
     var isEmpty: Bool {
-        self.songs.isEmpty && self.albums.isEmpty && self.artists.isEmpty && self.playlists.isEmpty && self.podcastShows.isEmpty
+        self.items.isEmpty
     }
 
     /// Whether more results are available to load.
@@ -33,99 +90,132 @@ struct SearchResponse {
         self.continuationToken != nil
     }
 
-    static let empty = SearchResponse(songs: [], albums: [], artists: [], playlists: [], podcastShows: [], continuationToken: nil)
+    static let empty = SearchResponse(items: [], continuationToken: nil)
 
-    /// Creates a SearchResponse without continuation token (backward compatibility).
-    init(songs: [Song], albums: [Album], artists: [Artist], playlists: [Playlist]) {
-        self.songs = songs
-        self.albums = albums
-        self.artists = artists
-        self.playlists = playlists
-        self.podcastShows = []
-        self.continuationToken = nil
+    init(items: [SearchResultItem], continuationToken value: String? = nil) {
+        self.items = items
+        self.continuationToken = value
     }
 
-    /// Creates a SearchResponse with optional continuation token (backward compatibility).
-    init(songs: [Song], albums: [Album], artists: [Artist], playlists: [Playlist], continuationToken: String?) {
-        self.songs = songs
-        self.albums = albums
-        self.artists = artists
-        self.playlists = playlists
-        self.podcastShows = []
-        self.continuationToken = continuationToken
-    }
-
-    /// Creates a SearchResponse with podcast shows and optional continuation token.
+    /// Compatibility initializer for category-specific callers and tests.
+    /// Mixed API parsing should use `init(items:continuationToken:)` instead.
     init(
-        songs: [Song],
-        albums: [Album],
-        artists: [Artist],
-        playlists: [Playlist],
-        podcastShows: [PodcastShow],
-        continuationToken: String?
+        songs: [Song] = [],
+        videos: [Song] = [],
+        albums: [Album] = [],
+        audiobooks: [Album] = [],
+        artists: [Artist] = [],
+        profiles: [Artist] = [],
+        playlists: [Playlist] = [],
+        podcastShows: [PodcastShow] = [],
+        podcastEpisodes: [PodcastEpisode] = [],
+        continuationToken value: String? = nil
     ) {
-        self.songs = songs
-        self.albums = albums
-        self.artists = artists
-        self.playlists = playlists
-        self.podcastShows = podcastShows
-        self.continuationToken = continuationToken
+        var items: [SearchResultItem] = []
+        items.reserveCapacity(
+            songs.count + videos.count + albums.count + audiobooks.count + artists.count
+                + profiles.count + playlists.count + podcastShows.count + podcastEpisodes.count
+        )
+        items.append(contentsOf: songs.map(SearchResultItem.song))
+        items.append(contentsOf: videos.map(SearchResultItem.video))
+        items.append(contentsOf: albums.map(SearchResultItem.album))
+        items.append(contentsOf: audiobooks.map(SearchResultItem.audiobook))
+        items.append(contentsOf: artists.map { artist in
+            artist.profileKind == .profile ? .profile(artist) : .artist(artist)
+        })
+        items.append(contentsOf: profiles.map(SearchResultItem.profile))
+        items.append(contentsOf: playlists.map(SearchResultItem.playlist))
+        items.append(contentsOf: podcastShows.map(SearchResultItem.podcastShow))
+        items.append(contentsOf: podcastEpisodes.map(SearchResultItem.podcastEpisode))
+
+        self.init(items: items, continuationToken: value)
     }
 }
 
 // MARK: - SearchResultItem
 
-/// A search result item (can be any content type).
-enum SearchResultItem: Identifiable {
+/// A semantically typed YouTube Music search result.
+enum SearchResultItem: Identifiable, Hashable {
     case song(Song)
+    case video(Song)
     case album(Album)
+    case audiobook(Album)
     case artist(Artist)
+    case profile(Artist)
     case playlist(Playlist)
     case podcastShow(PodcastShow)
+    case podcastEpisode(PodcastEpisode)
 
     var id: String {
         switch self {
         case let .song(song):
             "song-\(song.id)"
+        case let .video(video):
+            "video-\(video.id)"
         case let .album(album):
             "album-\(album.id)"
+        case let .audiobook(audiobook):
+            "audiobook-\(audiobook.id)"
         case let .artist(artist):
             "artist-\(artist.id)"
+        case let .profile(profile):
+            "profile-\(profile.id)"
         case let .playlist(playlist):
             "playlist-\(playlist.id)"
         case let .podcastShow(show):
             "podcast-\(show.id)"
+        case let .podcastEpisode(episode):
+            "episode-\(episode.id)"
+        }
+    }
+
+    /// Cross-type identity used to deduplicate the same destination while
+    /// preserving the first server-ranked occurrence.
+    var contentIdentity: String {
+        switch self {
+        case let .song(song), let .video(song):
+            "video:\(song.videoId)"
+        case let .podcastEpisode(episode):
+            "video:\(episode.id)"
+        case let .album(album), let .audiobook(album):
+            "album:\(album.id)"
+        case let .artist(artist), let .profile(artist):
+            "artist:\(artist.id)"
+        case let .playlist(playlist):
+            "playlist:\(LibraryContentIdentity.playlistKey(for: playlist))"
+        case let .podcastShow(show):
+            "podcast:\(show.id)"
         }
     }
 
     var title: String {
         switch self {
-        case let .song(song):
+        case let .song(song), let .video(song):
             song.title
-        case let .album(album):
+        case let .album(album), let .audiobook(album):
             album.title
-        case let .artist(artist):
+        case let .artist(artist), let .profile(artist):
             artist.name
         case let .playlist(playlist):
             playlist.title
         case let .podcastShow(show):
             show.title
+        case let .podcastEpisode(episode):
+            episode.title
         }
     }
 
     var subtitle: String? {
         switch self {
-        case let .song(song):
+        case let .song(song), let .video(song):
             let display = song.artistsDisplay
             return display.isEmpty ? nil : display
-        case let .album(album):
+        case let .album(album), let .audiobook(album):
             let display = album.artistsDisplay
             return display.isEmpty ? nil : display
-        case .artist:
-            // No additional subtitle needed - resultType already shows "Artist"
-            return nil
+        case let .artist(artist), let .profile(artist):
+            return artist.subtitle
         case let .playlist(playlist):
-            // Strip "Playlist • " prefix since resultType already shows "Playlist"
             guard let authorName = playlist.author?.name else { return nil }
             let stripped = authorName
                 .replacingOccurrences(of: "Playlist • ", with: "")
@@ -133,46 +223,84 @@ enum SearchResultItem: Identifiable {
             return stripped.isEmpty ? nil : stripped
         case let .podcastShow(show):
             return show.author
+        case let .podcastEpisode(episode):
+            let components = [episode.publishedDate, episode.showTitle]
+                .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+            return components.isEmpty ? nil : components.joined(separator: " • ")
         }
     }
 
     var thumbnailURL: URL? {
         switch self {
-        case let .song(song):
+        case let .song(song), let .video(song):
             song.thumbnailURL
-        case let .album(album):
+        case let .album(album), let .audiobook(album):
             album.thumbnailURL
-        case let .artist(artist):
+        case let .artist(artist), let .profile(artist):
             artist.thumbnailURL
         case let .playlist(playlist):
             playlist.thumbnailURL
         case let .podcastShow(show):
             show.thumbnailURL
+        case let .podcastEpisode(episode):
+            episode.thumbnailURL
         }
     }
 
     var resultType: String {
         switch self {
         case .song:
-            "Song"
+            String(localized: "Song")
+        case .video:
+            String(localized: "Video")
         case .album:
-            "Album"
+            String(localized: "Album")
+        case .audiobook:
+            String(localized: "Audiobook")
         case .artist:
-            "Artist"
+            String(localized: "Artist")
+        case .profile:
+            String(localized: "Profile")
         case .playlist:
-            "Playlist"
+            String(localized: "Playlist")
         case .podcastShow:
-            "Podcast"
+            String(localized: "Podcast")
+        case .podcastEpisode:
+            String(localized: "Episode")
         }
     }
 
-    /// Returns the video ID if this item is directly playable.
+    /// Returns the playable video ID, when the result is directly playable.
     var videoId: String? {
         switch self {
-        case let .song(song):
+        case let .song(song), let .video(song):
             song.videoId
+        case let .podcastEpisode(episode):
+            episode.id
         default:
             nil
+        }
+    }
+
+    /// Song payload used by shared playback, queue, favorite, and share actions.
+    var songPayload: Song? {
+        switch self {
+        case let .song(song), let .video(song):
+            song
+        case let .podcastEpisode(episode):
+            episode.playbackSong
+        default:
+            nil
+        }
+    }
+
+    var usesCircularThumbnail: Bool {
+        switch self {
+        case .artist, .profile:
+            true
+        default:
+            false
         }
     }
 }

--- a/Sources/Kaset/Resources/Localizable.xcstrings
+++ b/Sources/Kaset/Resources/Localizable.xcstrings
@@ -46488,6 +46488,622 @@
           }
         }
       }
+    },
+    "Profiles": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الملفات الشخصية"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Profile"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Perfiles"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Profils"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Profil"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Profili"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "프로필"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Profielen"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Profile"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Perfis"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Профили"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Profiler"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Profiller"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Профілі"
+          }
+        }
+      }
+    },
+    "View Profile": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "عرض الملف الشخصي"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Profil anzeigen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ver perfil"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voir le profil"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lihat Profil"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Visualizza profilo"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "프로필 보기"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Profiel bekijken"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zobacz profil"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ver perfil"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть профиль"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Visa profil"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Profili Görüntüle"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Переглянути профіль"
+          }
+        }
+      }
+    },
+    "Audiobook": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "كتاب صوتي"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hörbuch"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audiolibro"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Livre audio"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Buku audio"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audiolibro"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오디오북"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Luisterboek"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audiobook"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Audiolivro"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Аудиокнига"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ljudbok"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sesli Kitap"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Аудіокнига"
+          }
+        }
+      }
+    },
+    "View Audiobook": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "عرض الكتاب الصوتي"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hörbuch anzeigen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ver audiolibro"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Voir le livre audio"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lihat Buku Audio"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Visualizza audiolibro"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오디오북 보기"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Luisterboek bekijken"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zobacz audiobook"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ver audiolivro"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть аудиокнигу"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Visa ljudbok"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sesli Kitabı Görüntüle"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Переглянути аудіокнигу"
+          }
+        }
+      }
+    },
+    "Song": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أغنية"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Titel"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Canción"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Morceau"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Lagu"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brano"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "노래"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nummer"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utwór"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Música"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Трек"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Låt"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Şarkı"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Пісня"
+          }
+        }
+      }
+    },
+    "Podcast": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "بودكاست"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Podcast"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Podcast"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Podcast"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Podcast"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Podcast"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "팟캐스트"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Podcast"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Podcast"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Podcast"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подкаст"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Podd"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Podcast"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Подкаст"
+          }
+        }
+      }
+    },
+    "Episode": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "حلقة"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Folge"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Episodio"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Épisode"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Episode"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Episodio"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "에피소드"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aflevering"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odcinek"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Episódio"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Выпуск"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Avsnitt"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bölüm"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Епізод"
+          }
+        }
+      }
     }
   },
   "version": "1.1"

--- a/Sources/Kaset/Resources/ar.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/ar.lproj/Localizable.strings
@@ -525,3 +525,10 @@
 "e.g., Remove slow songs, reorder by energy..." = "مثال: أزل الأغاني البطيئة، أعد الترتيب حسب الحيوية...";
 "songs" = "أغانٍ";
 "tracks" = "مقطوعات";
+"Profiles" = "الملفات الشخصية";
+"View Profile" = "عرض الملف الشخصي";
+"Audiobook" = "كتاب صوتي";
+"View Audiobook" = "عرض الكتاب الصوتي";
+"Song" = "أغنية";
+"Podcast" = "بودكاست";
+"Episode" = "حلقة";

--- a/Sources/Kaset/Resources/de.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/de.lproj/Localizable.strings
@@ -525,3 +525,10 @@
 "e.g., Remove slow songs, reorder by energy..." = "z. B. langsame Titel entfernen, nach Energie neu anordnen…";
 "songs" = "Titeln";
 "tracks" = "Titel";
+"Profiles" = "Profile";
+"View Profile" = "Profil anzeigen";
+"Audiobook" = "Hörbuch";
+"View Audiobook" = "Hörbuch anzeigen";
+"Song" = "Titel";
+"Podcast" = "Podcast";
+"Episode" = "Folge";

--- a/Sources/Kaset/Resources/en.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/en.lproj/Localizable.strings
@@ -1,2 +1,9 @@
 "%@ %@" = "%1$@ %2$@";
 "%@, %@, %@" = "%1$@, %2$@, %3$@";
+"Profiles" = "Profiles";
+"View Profile" = "View Profile";
+"Audiobook" = "Audiobook";
+"View Audiobook" = "View Audiobook";
+"Song" = "Song";
+"Podcast" = "Podcast";
+"Episode" = "Episode";

--- a/Sources/Kaset/Resources/es.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/es.lproj/Localizable.strings
@@ -525,3 +525,10 @@
 "e.g., Remove slow songs, reorder by energy..." = "p. ej., quitar canciones lentas, reordenar por energía…";
 "songs" = "canciones";
 "tracks" = "pistas";
+"Profiles" = "Perfiles";
+"View Profile" = "Ver perfil";
+"Audiobook" = "Audiolibro";
+"View Audiobook" = "Ver audiolibro";
+"Song" = "Canción";
+"Podcast" = "Podcast";
+"Episode" = "Episodio";

--- a/Sources/Kaset/Resources/fr.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/fr.lproj/Localizable.strings
@@ -525,3 +525,10 @@
 "e.g., Remove slow songs, reorder by energy..." = "p. ex. Supprimer les morceaux lents, réorganiser par énergie...";
 "songs" = "morceaux";
 "tracks" = "titres";
+"Profiles" = "Profils";
+"View Profile" = "Voir le profil";
+"Audiobook" = "Livre audio";
+"View Audiobook" = "Voir le livre audio";
+"Song" = "Morceau";
+"Podcast" = "Podcast";
+"Episode" = "Épisode";

--- a/Sources/Kaset/Resources/id.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/id.lproj/Localizable.strings
@@ -525,3 +525,10 @@
 "e.g., Remove slow songs, reorder by energy..." = "mis. Hapus lagu lambat, urutkan ulang berdasarkan energi...";
 "songs" = "lagu";
 "tracks" = "trek";
+"Profiles" = "Profil";
+"View Profile" = "Lihat Profil";
+"Audiobook" = "Buku audio";
+"View Audiobook" = "Lihat Buku Audio";
+"Song" = "Lagu";
+"Podcast" = "Podcast";
+"Episode" = "Episode";

--- a/Sources/Kaset/Resources/it.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/it.lproj/Localizable.strings
@@ -525,3 +525,10 @@
 "e.g., Remove slow songs, reorder by energy..." = "ad es. rimuovi i brani lenti, riordina per energia…";
 "songs" = "brani";
 "tracks" = "brani";
+"Profiles" = "Profili";
+"View Profile" = "Visualizza profilo";
+"Audiobook" = "Audiolibro";
+"View Audiobook" = "Visualizza audiolibro";
+"Song" = "Brano";
+"Podcast" = "Podcast";
+"Episode" = "Episodio";

--- a/Sources/Kaset/Resources/ko.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/ko.lproj/Localizable.strings
@@ -525,3 +525,10 @@
 "e.g., Remove slow songs, reorder by energy..." = "예: 느린 곡 제거, 에너지순으로 재정렬...";
 "songs" = "곡";
 "tracks" = "트랙";
+"Profiles" = "프로필";
+"View Profile" = "프로필 보기";
+"Audiobook" = "오디오북";
+"View Audiobook" = "오디오북 보기";
+"Song" = "노래";
+"Podcast" = "팟캐스트";
+"Episode" = "에피소드";

--- a/Sources/Kaset/Resources/nl.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/nl.lproj/Localizable.strings
@@ -525,3 +525,10 @@
 "e.g., Remove slow songs, reorder by energy..." = "bijv. langzame nummers verwijderen, opnieuw ordenen op energie…";
 "songs" = "nummers";
 "tracks" = "nummers";
+"Profiles" = "Profielen";
+"View Profile" = "Profiel bekijken";
+"Audiobook" = "Luisterboek";
+"View Audiobook" = "Luisterboek bekijken";
+"Song" = "Nummer";
+"Podcast" = "Podcast";
+"Episode" = "Aflevering";

--- a/Sources/Kaset/Resources/pl.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/pl.lproj/Localizable.strings
@@ -525,3 +525,10 @@
 "e.g., Remove slow songs, reorder by energy..." = "np. usuń wolne utwory, zmień kolejność według energii…";
 "songs" = "utworów";
 "tracks" = "utworami";
+"Profiles" = "Profile";
+"View Profile" = "Zobacz profil";
+"Audiobook" = "Audiobook";
+"View Audiobook" = "Zobacz audiobook";
+"Song" = "Utwór";
+"Podcast" = "Podcast";
+"Episode" = "Odcinek";

--- a/Sources/Kaset/Resources/pt.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/pt.lproj/Localizable.strings
@@ -525,3 +525,10 @@
 "e.g., Remove slow songs, reorder by energy..." = "por exemplo, remover músicas lentas, reordenar por energia…";
 "songs" = "músicas";
 "tracks" = "faixas";
+"Profiles" = "Perfis";
+"View Profile" = "Ver perfil";
+"Audiobook" = "Audiolivro";
+"View Audiobook" = "Ver audiolivro";
+"Song" = "Música";
+"Podcast" = "Podcast";
+"Episode" = "Episódio";

--- a/Sources/Kaset/Resources/ru.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/ru.lproj/Localizable.strings
@@ -525,3 +525,10 @@
 "e.g., Remove slow songs, reorder by energy..." = "например, убрать медленные треки, перестроить по энергии…";
 "songs" = "треков";
 "tracks" = "треков";
+"Profiles" = "Профили";
+"View Profile" = "Открыть профиль";
+"Audiobook" = "Аудиокнига";
+"View Audiobook" = "Открыть аудиокнигу";
+"Song" = "Трек";
+"Podcast" = "Подкаст";
+"Episode" = "Выпуск";

--- a/Sources/Kaset/Resources/sv.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/sv.lproj/Localizable.strings
@@ -525,3 +525,10 @@
 "e.g., Remove slow songs, reorder by energy..." = "t.ex. ta bort långsamma låtar, ordna om efter energi…";
 "songs" = "låtar";
 "tracks" = "spår";
+"Profiles" = "Profiler";
+"View Profile" = "Visa profil";
+"Audiobook" = "Ljudbok";
+"View Audiobook" = "Visa ljudbok";
+"Song" = "Låt";
+"Podcast" = "Podd";
+"Episode" = "Avsnitt";

--- a/Sources/Kaset/Resources/tr.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/tr.lproj/Localizable.strings
@@ -525,3 +525,10 @@
 "e.g., Remove slow songs, reorder by energy..." = "örn. Yavaş şarkıları kaldır, enerjiye göre yeniden sırala...";
 "songs" = "şarkı";
 "tracks" = "parça";
+"Profiles" = "Profiller";
+"View Profile" = "Profili Görüntüle";
+"Audiobook" = "Sesli Kitap";
+"View Audiobook" = "Sesli Kitabı Görüntüle";
+"Song" = "Şarkı";
+"Podcast" = "Podcast";
+"Episode" = "Bölüm";

--- a/Sources/Kaset/Resources/uk.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/uk.lproj/Localizable.strings
@@ -525,3 +525,10 @@
 "e.g., Remove slow songs, reorder by energy..." = "напр., прибрати повільні пісні, змінити порядок за енергією...";
 "songs" = "пісень";
 "tracks" = "треків";
+"Profiles" = "Профілі";
+"View Profile" = "Переглянути профіль";
+"Audiobook" = "Аудіокнига";
+"View Audiobook" = "Переглянути аудіокнигу";
+"Song" = "Пісня";
+"Podcast" = "Подкаст";
+"Episode" = "Епізод";

--- a/Sources/Kaset/Services/API/MockUITestYTMusicClient+DefaultData.swift
+++ b/Sources/Kaset/Services/API/MockUITestYTMusicClient+DefaultData.swift
@@ -1,0 +1,145 @@
+import Foundation
+
+// MARK: - Mock UI-Test Default Data
+
+extension MockUITestYTMusicClient {
+    // MARK: - Default Data
+
+    static func defaultHomeSections() -> [HomeSection] {
+        [
+            HomeSection(
+                id: "quick-picks",
+                title: "Quick picks",
+                items: self.defaultSongs(count: 8).map { .song($0) }
+            ),
+            HomeSection(
+                id: "listen-again",
+                title: "Listen again",
+                items: self.defaultSongs(count: 6).map { .song($0) }
+            ),
+            HomeSection(
+                id: "recommended",
+                title: "Recommended",
+                items: self.defaultSongs(count: 10).map { .song($0) }
+            ),
+        ]
+    }
+
+    static func defaultSearchResults() -> SearchResponse {
+        let podcastShow = PodcastShow(
+            id: "MPSPPMockSearchShow",
+            title: "Search Podcast",
+            author: "Podcast Host",
+            description: "A representative podcast search result",
+            thumbnailURL: nil,
+            episodeCount: 24
+        )
+
+        return SearchResponse(
+            songs: self.defaultSongs(count: 5),
+            videos: [
+                Song(
+                    id: "search-video-result",
+                    title: "Search Video",
+                    artists: [Artist(id: "UCSearchVideoArtist", name: "Video Artist")],
+                    thumbnailURL: nil,
+                    videoId: "search-video-result",
+                    hasVideo: true,
+                    musicVideoType: .omv
+                ),
+            ],
+            albums: self.defaultAlbums(count: 2),
+            audiobooks: [
+                Album(
+                    id: "MPREbMockAudiobook",
+                    title: "Search Audiobook",
+                    artists: [Artist.inline(name: "Audiobook Author", namespace: "mock-search-audiobook")],
+                    thumbnailURL: nil,
+                    year: "2026",
+                    trackCount: 18
+                ),
+            ],
+            artists: [
+                Artist(id: "artist-1", name: "Search Artist 1", thumbnailURL: nil),
+                Artist(id: "artist-2", name: "Search Artist 2", thumbnailURL: nil),
+            ],
+            profiles: [
+                Artist(
+                    id: "UCMockSearchProfile",
+                    name: "Search Profile",
+                    thumbnailURL: nil,
+                    subtitle: "@searchprofile",
+                    profileKind: .profile
+                ),
+            ],
+            playlists: self.defaultPlaylists(),
+            podcastShows: [podcastShow],
+            podcastEpisodes: [
+                PodcastEpisode(
+                    id: "mock-search-episode",
+                    title: "Search Podcast Episode",
+                    showTitle: podcastShow.title,
+                    showBrowseId: podcastShow.id,
+                    description: "A representative podcast episode search result",
+                    thumbnailURL: nil,
+                    publishedDate: "Jul 19, 2026",
+                    duration: "32 min",
+                    durationSeconds: 1920,
+                    playbackProgress: 0,
+                    isPlayed: false
+                ),
+            ]
+        )
+    }
+
+    static func defaultPlaylists() -> [Playlist] {
+        (0 ..< 5).map { index in
+            Playlist(
+                id: "playlist-\(index)",
+                title: "My Playlist \(index + 1)",
+                description: "A great playlist",
+                thumbnailURL: nil,
+                trackCount: 10 + index * 5,
+                author: Artist.inline(name: "Test User", namespace: "playlist-author")
+            )
+        }
+    }
+
+    static func defaultLikedSongs() -> [Song] {
+        self.defaultSongs(count: 20)
+    }
+
+    static func defaultSongs(count: Int) -> [Song] {
+        (0 ..< count).map { index in
+            Song(
+                id: "song-\(index)",
+                title: "Test Song \(index + 1)",
+                artists: [Artist(id: "artist-\(index % 3)", name: "Artist \(index % 3 + 1)")],
+                album: Album(
+                    id: "album-\(index % 5)",
+                    title: "Album \(index % 5 + 1)",
+                    artists: nil,
+                    thumbnailURL: nil,
+                    year: "2024",
+                    trackCount: 12
+                ),
+                duration: TimeInterval(180 + index * 10),
+                thumbnailURL: nil,
+                videoId: "video-\(index)"
+            )
+        }
+    }
+
+    static func defaultAlbums(count: Int) -> [Album] {
+        (0 ..< count).map { index in
+            Album(
+                id: "album-\(index)",
+                title: "Test Album \(index + 1)",
+                artists: [Artist(id: "artist-\(index)", name: "Album Artist \(index + 1)")],
+                thumbnailURL: nil,
+                year: "2024",
+                trackCount: 10 + index
+            )
+        }
+    }
+}

--- a/Sources/Kaset/Services/API/MockUITestYTMusicClient+SearchFixtures.swift
+++ b/Sources/Kaset/Services/API/MockUITestYTMusicClient+SearchFixtures.swift
@@ -1,0 +1,277 @@
+import Foundation
+
+// MARK: - Mock UI-Test Search Fixtures
+
+extension MockUITestYTMusicClient {
+    static func parseSearchResults() -> SearchResponse? {
+        guard let jsonString = UITestConfig.environmentValue(for: UITestConfig.mockSearchResultsKey),
+              let data = jsonString.data(using: .utf8),
+              let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            return nil
+        }
+
+        let continuationToken = dict["continuationToken"] as? String
+
+        if let itemDictionaries = dict["items"] as? [[String: Any]] {
+            return SearchResponse(
+                items: itemDictionaries.compactMap(Self.parseSearchItem),
+                continuationToken: continuationToken
+            )
+        }
+
+        return SearchResponse(
+            songs: Self.parseSearchArray(dict["songs"]) {
+                Self.parseSearchSong($0)
+            },
+            videos: Self.parseSearchArray(dict["videos"]) {
+                Self.parseSearchSong($0, defaultMusicVideoType: .omv)
+            },
+            albums: Self.parseSearchArray(dict["albums"], using: Self.parseSearchAlbum),
+            audiobooks: Self.parseSearchArray(dict["audiobooks"], using: Self.parseSearchAlbum),
+            artists: Self.parseSearchArray(dict["artists"]) {
+                Self.parseSearchArtist($0, profileKind: .artist)
+            },
+            profiles: Self.parseSearchArray(dict["profiles"]) {
+                Self.parseSearchArtist($0, profileKind: .profile)
+            },
+            playlists: Self.parseSearchArray(dict["playlists"], using: Self.parseSearchPlaylist),
+            podcastShows: Self.parseSearchArray(dict["podcastShows"], using: Self.parseSearchPodcastShow),
+            podcastEpisodes: Self.parseSearchArray(dict["podcastEpisodes"], using: Self.parseSearchPodcastEpisode),
+            continuationToken: continuationToken
+        )
+    }
+
+    static func parseSearchArray<Value>(
+        _ value: Any?,
+        using transform: ([String: Any]) -> Value?
+    ) -> [Value] {
+        (value as? [[String: Any]])?.compactMap(transform) ?? []
+    }
+
+    static func parseSearchItem(_ dict: [String: Any]) -> SearchResultItem? {
+        guard let rawType = dict["type"] as? String else {
+            return nil
+        }
+
+        let type = rawType.lowercased().filter { $0.isLetter || $0.isNumber }
+        switch type {
+        case "song", "songs":
+            return Self.parseSearchSong(dict).map(SearchResultItem.song)
+        case "video", "videos":
+            return Self.parseSearchSong(dict, defaultMusicVideoType: .omv).map(SearchResultItem.video)
+        case "album", "albums":
+            return Self.parseSearchAlbum(dict).map(SearchResultItem.album)
+        case "audiobook", "audiobooks":
+            return Self.parseSearchAlbum(dict).map(SearchResultItem.audiobook)
+        case "artist", "artists":
+            return Self.parseSearchArtist(dict, profileKind: .artist).map(SearchResultItem.artist)
+        case "profile", "profiles":
+            return Self.parseSearchArtist(dict, profileKind: .profile).map(SearchResultItem.profile)
+        case "playlist", "playlists":
+            return Self.parseSearchPlaylist(dict).map(SearchResultItem.playlist)
+        case "podcast", "podcastshow", "podcastshows", "show":
+            return Self.parseSearchPodcastShow(dict).map(SearchResultItem.podcastShow)
+        case "episode", "podcastepisode", "podcastepisodes":
+            return Self.parseSearchPodcastEpisode(dict).map(SearchResultItem.podcastEpisode)
+        default:
+            return nil
+        }
+    }
+
+    static func parseSearchSong(
+        _ dict: [String: Any],
+        defaultMusicVideoType: MusicVideoType? = nil
+    ) -> Song? {
+        guard let id = dict["id"] as? String,
+              let title = dict["title"] as? String,
+              let videoId = dict["videoId"] as? String
+        else {
+            return nil
+        }
+
+        let artistNames = Self.parseArtistNames(from: dict)
+        let artists = artistNames.enumerated().map { index, name in
+            Artist(id: "mock-search-artist-\(index)", name: name)
+        }
+        let primaryArtist = artistNames.first ?? "Unknown"
+        let album: Album? = if let albumDict = dict["album"] as? [String: Any] {
+            Self.parseSearchAlbum(albumDict)
+        } else if let albumId = dict["albumId"] as? String,
+                  let albumTitle = dict["albumTitle"] as? String
+        {
+            Album(
+                id: albumId,
+                title: albumTitle,
+                artists: [Artist.inline(name: primaryArtist, namespace: "mock-search-album")],
+                thumbnailURL: nil,
+                year: nil,
+                trackCount: nil
+            )
+        } else {
+            nil
+        }
+        let musicVideoType = (dict["musicVideoType"] as? String).flatMap(MusicVideoType.init(rawValue:))
+            ?? defaultMusicVideoType
+
+        return Song(
+            id: id,
+            title: title,
+            artists: artists.isEmpty ? [Artist(id: "mock", name: "Unknown")] : artists,
+            album: album,
+            duration: Self.parseTimeInterval(dict["duration"]),
+            thumbnailURL: Self.parseURL(dict["thumbnailURL"]),
+            videoId: videoId,
+            isPlayable: dict["isPlayable"] as? Bool ?? true,
+            hasVideo: dict["hasVideo"] as? Bool ?? defaultMusicVideoType.map { _ in true },
+            musicVideoType: musicVideoType,
+            isExplicit: dict["isExplicit"] as? Bool
+        )
+    }
+
+    static func parseSearchAlbum(_ dict: [String: Any]) -> Album? {
+        guard let id = dict["id"] as? String,
+              let title = dict["title"] as? String
+        else {
+            return nil
+        }
+
+        let artistNames = Self.parseArtistNames(from: dict)
+        let artists = artistNames.isEmpty ? nil : artistNames.map {
+            Artist.inline(name: $0, namespace: "mock-search-album")
+        }
+
+        return Album(
+            id: id,
+            title: title,
+            artists: artists,
+            thumbnailURL: Self.parseURL(dict["thumbnailURL"]),
+            year: dict["year"] as? String,
+            trackCount: Self.parseInt(dict["trackCount"])
+        )
+    }
+
+    static func parseSearchArtist(
+        _ dict: [String: Any],
+        profileKind: ArtistProfileKind
+    ) -> Artist? {
+        guard let id = dict["id"] as? String,
+              let name = dict["name"] as? String ?? dict["title"] as? String
+        else {
+            return nil
+        }
+
+        return Artist(
+            id: id,
+            name: name,
+            thumbnailURL: Self.parseURL(dict["thumbnailURL"]),
+            subtitle: dict["subtitle"] as? String,
+            profileKind: profileKind
+        )
+    }
+
+    static func parseSearchPlaylist(_ dict: [String: Any]) -> Playlist? {
+        guard let id = dict["id"] as? String,
+              let title = dict["title"] as? String
+        else {
+            return nil
+        }
+
+        return Playlist(
+            id: id,
+            title: title,
+            description: dict["description"] as? String,
+            thumbnailURL: Self.parseURL(dict["thumbnailURL"]),
+            trackCount: Self.parseInt(dict["trackCount"]),
+            author: (dict["author"] as? String).map {
+                Artist.inline(name: $0, namespace: "mock-search-playlist-author")
+            },
+            canDelete: dict["canDelete"] as? Bool ?? false
+        )
+    }
+
+    static func parseSearchPodcastShow(_ dict: [String: Any]) -> PodcastShow? {
+        guard let id = dict["id"] as? String,
+              let title = dict["title"] as? String
+        else {
+            return nil
+        }
+
+        return PodcastShow(
+            id: id,
+            title: title,
+            author: dict["author"] as? String,
+            description: dict["description"] as? String,
+            thumbnailURL: Self.parseURL(dict["thumbnailURL"]),
+            episodeCount: Self.parseInt(dict["episodeCount"])
+        )
+    }
+
+    static func parseSearchPodcastEpisode(_ dict: [String: Any]) -> PodcastEpisode? {
+        guard let id = dict["id"] as? String,
+              let title = dict["title"] as? String
+        else {
+            return nil
+        }
+
+        return PodcastEpisode(
+            id: id,
+            title: title,
+            showTitle: dict["showTitle"] as? String,
+            showBrowseId: dict["showBrowseId"] as? String,
+            description: dict["description"] as? String,
+            thumbnailURL: Self.parseURL(dict["thumbnailURL"]),
+            publishedDate: dict["publishedDate"] as? String,
+            duration: dict["duration"] as? String,
+            durationSeconds: Self.parseInt(dict["durationSeconds"]),
+            playbackProgress: Self.parseDouble(dict["playbackProgress"]) ?? 0,
+            isPlayed: dict["isPlayed"] as? Bool ?? false
+        )
+    }
+
+    static func parseArtistNames(from dict: [String: Any]) -> [String] {
+        if let artists = dict["artists"] as? [String] {
+            return artists
+        }
+
+        if let artists = dict["artists"] as? [[String: Any]] {
+            return artists.compactMap { $0["name"] as? String }
+        }
+
+        return (dict["artist"] as? String).map { [$0] } ?? []
+    }
+
+    static func parseURL(_ value: Any?) -> URL? {
+        (value as? String).flatMap(URL.init(string:))
+    }
+
+    static func parseInt(_ value: Any?) -> Int? {
+        if let value = value as? Int {
+            return value
+        }
+        if let value = value as? NSNumber {
+            return value.intValue
+        }
+        if let value = value as? String {
+            return Int(value)
+        }
+        return nil
+    }
+
+    static func parseDouble(_ value: Any?) -> Double? {
+        if let value = value as? Double {
+            return value
+        }
+        if let value = value as? NSNumber {
+            return value.doubleValue
+        }
+        if let value = value as? String {
+            return Double(value)
+        }
+        return nil
+    }
+
+    static func parseTimeInterval(_ value: Any?) -> TimeInterval? {
+        self.parseDouble(value)
+    }
+}

--- a/Sources/Kaset/Services/API/MockUITestYTMusicClient.swift
+++ b/Sources/Kaset/Services/API/MockUITestYTMusicClient.swift
@@ -173,11 +173,17 @@ final class MockUITestYTMusicClient: YTMusicClientProtocol {
         )
     }
 
+    func searchVideos(query _: String) async throws -> SearchResponse {
+        try? await Task.sleep(for: .milliseconds(100))
+        return SearchResponse(videos: self.searchResults.videos)
+    }
+
     func searchAlbums(query _: String) async throws -> SearchResponse {
         try? await Task.sleep(for: .milliseconds(100))
         return SearchResponse(
             songs: [],
             albums: self.searchResults.albums,
+            audiobooks: self.searchResults.audiobooks,
             artists: [],
             playlists: [],
             continuationToken: nil
@@ -193,6 +199,11 @@ final class MockUITestYTMusicClient: YTMusicClientProtocol {
             playlists: [],
             continuationToken: nil
         )
+    }
+
+    func searchProfiles(query _: String) async throws -> SearchResponse {
+        try? await Task.sleep(for: .milliseconds(100))
+        return SearchResponse(profiles: self.searchResults.profiles)
     }
 
     func searchPlaylists(query _: String) async throws -> SearchResponse {
@@ -230,26 +241,16 @@ final class MockUITestYTMusicClient: YTMusicClientProtocol {
 
     func searchPodcasts(query _: String) async throws -> SearchResponse {
         try? await Task.sleep(for: .milliseconds(100))
-        return SearchResponse(
-            songs: [],
-            albums: [],
-            artists: [],
-            playlists: [],
-            podcastShows: [],
-            continuationToken: nil
-        )
+        return SearchResponse(podcastShows: self.searchResults.podcastShows)
     }
 
-    func getSearchContinuation() async throws -> SearchResponse? {
-        nil
+    func searchEpisodes(query _: String) async throws -> SearchResponse {
+        try? await Task.sleep(for: .milliseconds(100))
+        return SearchResponse(podcastEpisodes: self.searchResults.podcastEpisodes)
     }
 
-    var hasMoreSearchResults: Bool {
-        false
-    }
-
-    func clearSearchContinuation() {
-        // No-op for mock
+    func getSearchContinuation(token _: String) async throws -> SearchResponse {
+        .empty
     }
 
     func getSearchSuggestions(query: String) async throws -> [SearchSuggestion] {
@@ -563,48 +564,6 @@ final class MockUITestYTMusicClient: YTMusicClientProtocol {
         }
     }
 
-    private static func parseSearchResults() -> SearchResponse? {
-        guard let jsonString = UITestConfig.environmentValue(for: UITestConfig.mockSearchResultsKey),
-              let data = jsonString.data(using: .utf8),
-              let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
-        else {
-            return nil
-        }
-
-        let songs = (dict["songs"] as? [[String: Any]])?.compactMap { songDict -> Song? in
-            guard let id = songDict["id"] as? String,
-                  let title = songDict["title"] as? String,
-                  let videoId = songDict["videoId"] as? String
-            else {
-                return nil
-            }
-            let artist = songDict["artist"] as? String ?? "Unknown"
-            let album: Album? = if let albumId = songDict["albumId"] as? String,
-                                   let albumTitle = songDict["albumTitle"] as? String
-            {
-                Album(
-                    id: albumId,
-                    title: albumTitle,
-                    artists: [Artist.inline(name: artist, namespace: "mock-search-album")],
-                    thumbnailURL: nil,
-                    year: nil,
-                    trackCount: nil
-                )
-            } else {
-                nil
-            }
-            return Song(
-                id: id,
-                title: title,
-                artists: [Artist(id: "mock", name: artist)],
-                album: album,
-                videoId: videoId
-            )
-        } ?? []
-
-        return SearchResponse(songs: songs, albums: [], artists: [], playlists: [])
-    }
-
     private static func parsePlaylists() -> [Playlist]? {
         guard let jsonString = UITestConfig.environmentValue(for: UITestConfig.mockPlaylistsKey),
               let data = jsonString.data(using: .utf8),
@@ -658,91 +617,6 @@ final class MockUITestYTMusicClient: YTMusicClientProtocol {
                 brandId: brandId,
                 thumbnailURL: thumbnailURL,
                 isSelected: isSelected
-            )
-        }
-    }
-
-    // MARK: - Default Data
-
-    private static func defaultHomeSections() -> [HomeSection] {
-        [
-            HomeSection(
-                id: "quick-picks",
-                title: "Quick picks",
-                items: self.defaultSongs(count: 8).map { .song($0) }
-            ),
-            HomeSection(
-                id: "listen-again",
-                title: "Listen again",
-                items: self.defaultSongs(count: 6).map { .song($0) }
-            ),
-            HomeSection(
-                id: "recommended",
-                title: "Recommended",
-                items: self.defaultSongs(count: 10).map { .song($0) }
-            ),
-        ]
-    }
-
-    private static func defaultSearchResults() -> SearchResponse {
-        SearchResponse(
-            songs: self.defaultSongs(count: 5),
-            albums: self.defaultAlbums(count: 2),
-            artists: [
-                Artist(id: "artist-1", name: "Search Artist 1", thumbnailURL: nil),
-                Artist(id: "artist-2", name: "Search Artist 2", thumbnailURL: nil),
-            ],
-            playlists: self.defaultPlaylists()
-        )
-    }
-
-    private static func defaultPlaylists() -> [Playlist] {
-        (0 ..< 5).map { index in
-            Playlist(
-                id: "playlist-\(index)",
-                title: "My Playlist \(index + 1)",
-                description: "A great playlist",
-                thumbnailURL: nil,
-                trackCount: 10 + index * 5,
-                author: Artist.inline(name: "Test User", namespace: "playlist-author")
-            )
-        }
-    }
-
-    private static func defaultLikedSongs() -> [Song] {
-        self.defaultSongs(count: 20)
-    }
-
-    private static func defaultSongs(count: Int) -> [Song] {
-        (0 ..< count).map { index in
-            Song(
-                id: "song-\(index)",
-                title: "Test Song \(index + 1)",
-                artists: [Artist(id: "artist-\(index % 3)", name: "Artist \(index % 3 + 1)")],
-                album: Album(
-                    id: "album-\(index % 5)",
-                    title: "Album \(index % 5 + 1)",
-                    artists: nil,
-                    thumbnailURL: nil,
-                    year: "2024",
-                    trackCount: 12
-                ),
-                duration: TimeInterval(180 + index * 10),
-                thumbnailURL: nil,
-                videoId: "video-\(index)"
-            )
-        }
-    }
-
-    private static func defaultAlbums(count: Int) -> [Album] {
-        (0 ..< count).map { index in
-            Album(
-                id: "album-\(index)",
-                title: "Test Album \(index + 1)",
-                artists: [Artist(id: "artist-\(index)", name: "Album Artist \(index + 1)")],
-                thumbnailURL: nil,
-                year: "2024",
-                trackCount: 10 + index
             )
         }
     }

--- a/Sources/Kaset/Services/API/Parsers/ParsingHelpers.swift
+++ b/Sources/Kaset/Services/API/Parsers/ParsingHelpers.swift
@@ -690,15 +690,17 @@ enum ParsingHelpers {
 
     /// Known content type keywords that should not be treated as artist names.
     private static let contentTypeKeywords: Set<String> = [
-        "Song", "Video", "Album", "Playlist", "Artist", "Episode", "Podcast",
+        "album", "artist", "audiobook", "ep", "episode", "playlist", "podcast",
+        "podcast episode", "profile", "single", "song", "video",
     ]
 
     private static func isArtistSeparator(_ text: String) -> Bool {
-        text == " • " || text == " & " || text == ", " || text == "•" || text == "&" || text == ","
+        text == " • " || text == " · " || text == " & " || text == ", "
+            || text == "•" || text == "·" || text == "&" || text == ","
     }
 
     private static func isMetadataText(_ text: String) -> Bool {
-        if self.contentTypeKeywords.contains(text) {
+        if self.contentTypeKeywords.contains(text.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()) {
             return true
         }
 

--- a/Sources/Kaset/Services/API/Parsers/SearchResponseParser+Support.swift
+++ b/Sources/Kaset/Services/API/Parsers/SearchResponseParser+Support.swift
@@ -1,0 +1,138 @@
+import Foundation
+
+// MARK: - SearchResponseParser Support
+
+extension SearchResponseParser {
+    static func splitMetadataText(_ text: String) -> [String] {
+        text.replacingOccurrences(of: "·", with: "•")
+            .split(separator: "•", omittingEmptySubsequences: true)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    static func descriptionText(from renderer: [String: Any]) -> String? {
+        guard let description = renderer["description"] as? [String: Any],
+              let runs = description["runs"] as? [[String: Any]]
+        else {
+            return nil
+        }
+        let text = ParsingHelpers.joinedRunText(runs).trimmingCharacters(in: .whitespacesAndNewlines)
+        return text.isEmpty ? nil : text
+    }
+
+    static func isYear(_ text: String) -> Bool {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count == 4,
+              trimmed.allSatisfy(\.isNumber),
+              let year = Int(trimmed)
+        else {
+            return false
+        }
+        return (1900 ... 2100).contains(year)
+    }
+
+    static func looksLikeDuration(_ text: String) -> Bool {
+        if ParsingHelpers.parseDuration(text) != nil {
+            return true
+        }
+        let lowercased = text.lowercased()
+        return lowercased.contains(" min")
+            || lowercased.contains(" minute")
+            || lowercased.contains(" hour")
+            || lowercased.contains(" sec")
+    }
+
+    static func durationSeconds(_ text: String) -> TimeInterval? {
+        if let seconds = ParsingHelpers.parseDuration(text) {
+            return seconds
+        }
+
+        let lowercased = text.lowercased()
+        let number = lowercased.split(whereSeparator: { !$0.isNumber }).first.flatMap { Double($0) }
+        guard let number else {
+            return nil
+        }
+        if lowercased.contains("hour") {
+            return number * 3600
+        }
+        if lowercased.contains("min") {
+            return number * 60
+        }
+        if lowercased.contains("sec") {
+            return number
+        }
+        return nil
+    }
+
+    static func looksLikePublishedDate(_ text: String) -> Bool {
+        let lowercased = text.lowercased()
+        if lowercased.contains(" ago") {
+            return true
+        }
+        if text.range(of: #"\b(19|20)\d{2}\b"#, options: .regularExpression) != nil {
+            return true
+        }
+        let monthPrefixes = [
+            "jan", "feb", "mar", "apr", "may", "jun",
+            "jul", "aug", "sep", "oct", "nov", "dec",
+        ]
+        return monthPrefixes.contains { lowercased.hasPrefix($0) }
+    }
+
+    static func looksLikeCount(_ text: String) -> Bool {
+        let lowercased = text.lowercased()
+        return lowercased.contains("subscriber")
+            || lowercased.contains("view")
+            || lowercased.contains("play")
+            || lowercased.contains("episode")
+            || lowercased.contains("song")
+            || lowercased.contains("track")
+    }
+
+    static func playbackProgress(from renderer: [String: Any]) -> Double {
+        guard let rawProgress = renderer["playbackProgress"] as? Double else {
+            return 0
+        }
+        if rawProgress > 1 {
+            return min(rawProgress / 100, 1)
+        }
+        return max(0, min(rawProgress, 1))
+    }
+
+    static func extractContinuationToken(from renderer: [String: Any]) -> String? {
+        if let continuations = renderer["continuations"] as? [[String: Any]] {
+            for continuation in continuations {
+                for key in ["nextContinuationData", "reloadContinuationData"] {
+                    guard let continuationData = continuation[key] as? [String: Any],
+                          let token = continuationData["continuation"] as? String,
+                          !token.isEmpty
+                    else {
+                        continue
+                    }
+                    return token
+                }
+            }
+        }
+
+        if let contents = renderer["contents"] as? [[String: Any]] {
+            for content in contents {
+                if let token = Self.extractContinuationToken(fromContinuationItem: content) {
+                    return token
+                }
+            }
+        }
+        return nil
+    }
+
+    static func extractContinuationToken(fromContinuationItem item: [String: Any]) -> String? {
+        guard let renderer = item["continuationItemRenderer"] as? [String: Any],
+              let endpoint = renderer["continuationEndpoint"] as? [String: Any],
+              let command = endpoint["continuationCommand"] as? [String: Any],
+              let token = command["token"] as? String,
+              !token.isEmpty
+        else {
+            return nil
+        }
+        return token
+    }
+}

--- a/Sources/Kaset/Services/API/Parsers/SearchResponseParser+Support.swift
+++ b/Sources/Kaset/Services/API/Parsers/SearchResponseParser+Support.swift
@@ -31,62 +31,192 @@ extension SearchResponseParser {
         return (1900 ... 2100).contains(year)
     }
 
-    static func looksLikeDuration(_ text: String) -> Bool {
-        if ParsingHelpers.parseDuration(text) != nil {
-            return true
+    private static let durationUnitSeconds: [String: TimeInterval] = {
+        var units: [String: TimeInterval] = [:]
+        for unit in [
+            "s", "sec", "secs", "second", "seconds", "ثانية", "ثوان", "ثواني",
+            "sek", "sekunde", "sekunden", "seg", "segundo", "segundos", "seconde",
+            "secondes", "detik", "secondo", "secondi", "초", "seconden", "sekunda",
+            "sekundy", "sekund", "segundos", "сек", "секунда", "секунды", "секунд",
+            "sekund", "sekunder", "sn", "saniye", "секунда", "секунди", "секунд",
+        ] {
+            units[unit] = 1
         }
-        let lowercased = text.lowercased()
-        return lowercased.contains(" min")
-            || lowercased.contains(" minute")
-            || lowercased.contains(" hour")
-            || lowercased.contains(" sec")
+        for unit in [
+            "m", "min", "mins", "minute", "minutes", "دقيقة", "دقائق", "minuten",
+            "minuto", "minutos", "menit", "minuti", "분", "minuut", "minuten",
+            "minuta", "minuty", "minut", "мин", "минута", "минуты", "минут", "minut",
+            "minuter", "dk", "dakika", "хв", "хвилина", "хвилини", "хвилин",
+        ] {
+            units[unit] = 60
+        }
+        for unit in [
+            "h", "hr", "hrs", "hour", "hours", "ساعة", "ساعات", "std", "stunde",
+            "stunden", "hora", "horas", "heure", "heures", "jam", "ora", "ore",
+            "시간", "uur", "uren", "godzina", "godziny", "godzin", "час", "часа",
+            "часов", "timme", "timmar", "saat", "год", "година", "години", "годин",
+        ] {
+            units[unit] = 3600
+        }
+        return units
+    }()
+
+    private static let relativeDatePrefixes = [
+        "منذ ", "قبل ", "vor ", "hace ", "il y a ", "há ",
+    ]
+
+    private static let relativeDateSuffixes = [
+        " ago", " lalu", " fa", " 전", " geleden", " temu", " назад", " sedan",
+        " önce", " тому",
+    ]
+
+    private static let monthNames: Set<String> = [
+        "jan", "january", "يناير", "januar", "enero", "janvier", "januari", "gennaio",
+        "feb", "february", "فبراير", "februar", "febrero", "février", "fevrier", "februari", "febbraio",
+        "mar", "march", "مارس", "märz", "maerz", "marzo", "mars", "maret", "marzec", "março", "março",
+        "apr", "april", "أبريل", "ابريل", "abril", "avril", "aprile", "kwiecień", "kwiecien", "апрель", "квітень",
+        "may", "مايو", "mai", "mayo", "mei", "maggio", "maj", "май", "mayıs", "mayis", "травень",
+        "jun", "june", "يونيو", "juni", "junio", "juin", "giugno", "czerwiec", "junho", "июнь", "haziran", "червень",
+        "jul", "july", "يوليو", "juli", "julio", "juillet", "luglio", "lipiec", "julho", "июль", "temmuz", "липень",
+        "aug", "august", "أغسطس", "اغسطس", "agosto", "août", "aout", "agustus", "augustus", "sierpień", "sierpien", "август", "augusti", "ağustos", "agustos", "серпень",
+        "sep", "sept", "september", "سبتمبر", "septiembre", "septembre", "settembre", "wrzesień", "wrzesien", "setembro", "сентябрь", "eylül", "eylul", "вересень",
+        "oct", "okt", "october", "أكتوبر", "اكتوبر", "oktober", "octubre", "octobre", "ottobre", "październik", "pazdziernik", "outubro", "октябрь", "ekim", "жовтень",
+        "nov", "november", "نوفمبر", "noviembre", "novembre", "listopad", "ноябрь", "kasım", "kasim", "листопад",
+        "dec", "dez", "december", "ديسمبر", "diciembre", "décembre", "decembre", "desember", "dicembre", "grudzień", "grudzien", "dezembro", "декабрь", "aralık", "aralik", "грудень",
+        "maart",
+        "stycznia", "lutego", "marca", "kwietnia", "maja", "czerwca", "lipca", "sierpnia", "września", "wrzesnia", "października", "pazdziernika", "listopada", "grudnia",
+        "января", "февраля", "марта", "апреля", "мая", "июня", "июля", "августа", "сентября", "октября", "ноября", "декабря",
+        "січня", "лютого", "березня", "квітня", "травня", "червня", "липня", "серпня", "вересня", "жовтня", "листопада", "грудня",
+    ]
+
+    static func looksLikeDuration(_ text: String) -> Bool {
+        self.durationSeconds(text) != nil
     }
 
     static func durationSeconds(_ text: String) -> TimeInterval? {
         if let seconds = ParsingHelpers.parseDuration(text) {
             return seconds
         }
-
-        let lowercased = text.lowercased()
-        let number = lowercased.split(whereSeparator: { !$0.isNumber }).first.flatMap { Double($0) }
-        guard let number else {
+        guard let (number, unit) = Self.leadingNumberAndUnit(in: text),
+              let multiplier = Self.durationUnitSeconds[unit]
+        else {
             return nil
         }
-        if lowercased.contains("hour") {
-            return number * 3600
-        }
-        if lowercased.contains("min") {
-            return number * 60
-        }
-        if lowercased.contains("sec") {
-            return number
-        }
-        return nil
+        return number * multiplier
     }
 
     static func looksLikePublishedDate(_ text: String) -> Bool {
-        let lowercased = text.lowercased()
-        if lowercased.contains(" ago") {
+        let normalized = text.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard Self.containsNumber(normalized) else { return false }
+
+        if Self.relativeDatePrefixes.contains(where: normalized.hasPrefix)
+            || Self.relativeDateSuffixes.contains(where: normalized.hasSuffix)
+        {
             return true
         }
-        if text.range(of: #"\b(19|20)\d{2}\b"#, options: .regularExpression) != nil {
+        if Self.containsFourDigitYear(normalized) {
             return true
         }
-        let monthPrefixes = [
-            "jan", "feb", "mar", "apr", "may", "jun",
-            "jul", "aug", "sep", "oct", "nov", "dec",
-        ]
-        return monthPrefixes.contains { lowercased.hasPrefix($0) }
+        if normalized.range(
+            of: #"^\s*\d{1,4}[./-]\d{1,2}(?:[./-]\d{1,4})?\s*$"#,
+            options: .regularExpression
+        ) != nil {
+            return true
+        }
+        if normalized.contains("월"), normalized.contains("일") {
+            return true
+        }
+
+        let words = Set(normalized.split(whereSeparator: { !$0.isLetter }).map(String.init))
+        return !words.isDisjoint(with: Self.monthNames)
     }
 
     static func looksLikeCount(_ text: String) -> Bool {
-        let lowercased = text.lowercased()
-        return lowercased.contains("subscriber")
-            || lowercased.contains("view")
-            || lowercased.contains("play")
-            || lowercased.contains("episode")
-            || lowercased.contains("song")
-            || lowercased.contains("track")
+        self.hasLocalizedCountUnit(text)
+    }
+
+    private static func leadingNumberAndUnit(in text: String) -> (Double, String)? {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        var numberText = ""
+        var sawDigit = false
+        var sawDecimalSeparator = false
+        var index = trimmed.startIndex
+
+        while index < trimmed.endIndex {
+            let character = trimmed[index]
+            if let value = character.wholeNumberValue {
+                numberText.append(String(value))
+                sawDigit = true
+            } else if sawDigit,
+                      !sawDecimalSeparator,
+                      character == "." || character == "," || character == "٫"
+            {
+                numberText.append(".")
+                sawDecimalSeparator = true
+            } else if !sawDigit, character.isWhitespace {
+                // Permit leading whitespace already preserved by unusual Unicode spacing.
+            } else {
+                break
+            }
+            index = trimmed.index(after: index)
+        }
+
+        guard sawDigit, let number = Double(numberText) else { return nil }
+        let unit = String(trimmed[index...])
+            .trimmingCharacters(in: .whitespacesAndNewlines.union(.punctuationCharacters))
+            .lowercased()
+        guard !unit.isEmpty else { return nil }
+        return (number, unit)
+    }
+
+    private static func containsNumber(_ text: String) -> Bool {
+        text.contains { $0.wholeNumberValue != nil }
+    }
+
+    private static func containsFourDigitYear(_ text: String) -> Bool {
+        var digits = ""
+        func isYear(_ value: String) -> Bool {
+            value.count == 4 && Int(value).map { (1900 ... 2100).contains($0) } == true
+        }
+
+        for character in text {
+            if let value = character.wholeNumberValue {
+                digits.append(String(value))
+            } else {
+                if isYear(digits) {
+                    return true
+                }
+                digits.removeAll(keepingCapacity: true)
+            }
+        }
+        return isYear(digits)
+    }
+
+    private static let countMetadataUnits: Set<String> = [
+        "subscriber", "subscribers", "view", "views", "play", "plays", "episode", "episodes", "song", "songs",
+        "track", "tracks", "حلقة", "الحلقات", "أغنية", "أغاني", "أغانٍ", "مقطوعات", "folge", "folgen",
+        "titel", "titeln", "episodio", "episodios", "canción", "canciones", "pista", "pistas", "épisode",
+        "épisodes", "morceau", "morceaux", "titre", "titres", "lagu", "trek", "episodi", "brano", "brani",
+        "에피소드", "노래", "곡", "트랙", "aflevering", "afleveringen", "nummer", "nummers", "odcinek",
+        "odcinki", "utwór", "utwory", "utworów", "utworami", "episódio", "episódios", "música", "músicas",
+        "faixa", "faixas", "выпуск", "выпуски", "трек", "треки", "треков", "avsnitt", "låt", "låtar",
+        "spår", "bölüm", "bölümler", "şarkı", "şarkılar", "parça", "епізод", "епізоди", "пісня",
+        "пісні", "пісень", "треків",
+    ]
+
+    static func hasLocalizedCountUnit(_ text: String) -> Bool {
+        let normalized = text
+            .replacingOccurrences(of: "\u{00A0}", with: " ")
+            .replacingOccurrences(of: "\u{202F}", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        guard normalized.contains(where: \.isNumber),
+              let unit = normalized.split(whereSeparator: { character in
+                  character.isWhitespace || character.isNumber || character == "." || character == ","
+              }).last.map(String.init)
+        else { return false }
+        return Self.countMetadataUnits.contains(unit)
+            || ["выпуск", "odcin", "епізод"].contains { unit.hasPrefix($0) }
     }
 
     static func playbackProgress(from renderer: [String: Any]) -> Double {

--- a/Sources/Kaset/Services/API/Parsers/SearchResponseParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/SearchResponseParser.swift
@@ -1,506 +1,896 @@
 import Foundation
 
-/// Parser for search responses from YouTube Music API.
+// MARK: - SearchResponseParser
+
 enum SearchResponseParser {
     private static let logger = DiagnosticsLogger.api
 
-    /// Parses a search response.
-    static func parse(_ data: [String: Any]) -> SearchResponse {
-        var songs: [Song] = []
-        var albums: [Album] = []
-        var artists: [Artist] = []
-        var playlists: [Playlist] = []
-
-        // Navigate to contents
-        guard let contents = data["contents"] as? [String: Any],
-              let tabbedSearchResults = contents["tabbedSearchResultsRenderer"] as? [String: Any],
-              let tabs = tabbedSearchResults["tabs"] as? [[String: Any]],
-              let firstTab = tabs.first,
-              let tabRenderer = firstTab["tabRenderer"] as? [String: Any],
-              let tabContent = tabRenderer["content"] as? [String: Any],
-              let sectionListRenderer = tabContent["sectionListRenderer"] as? [String: Any],
-              let sectionContents = sectionListRenderer["contents"] as? [[String: Any]]
-        else {
-            Self.logger.debug("SearchResponseParser: Failed to parse response structure. Top keys: \(data.keys.sorted())")
-            return SearchResponse.empty
-        }
-
-        for sectionData in sectionContents {
-            // Parse musicCardShelfRenderer (Top Result section)
-            if let cardShelfRenderer = sectionData["musicCardShelfRenderer"] as? [String: Any] {
-                if let item = parseCardShelfRenderer(cardShelfRenderer) {
-                    Self.appendItem(item, songs: &songs, albums: &albums, artists: &artists, playlists: &playlists)
-                }
-            }
-
-            // Parse musicShelfRenderer (regular results)
-            if let shelfRenderer = sectionData["musicShelfRenderer"] as? [String: Any],
-               let shelfContents = shelfRenderer["contents"] as? [[String: Any]]
-            {
-                songs.reserveCapacity(songs.count + shelfContents.count)
-                for itemData in shelfContents {
-                    if let item = parseSearchResultItem(itemData) {
-                        Self.appendItem(item, songs: &songs, albums: &albums, artists: &artists, playlists: &playlists)
-                    }
-                }
-            }
-        }
-
-        return SearchResponse(songs: songs, albums: albums, artists: artists, playlists: playlists)
+    private enum ContentKind {
+        case song
+        case video
+        case album
+        case audiobook
+        case artist
+        case profile
+        case playlist
+        case podcastShow
+        case podcastEpisode
     }
 
-    /// Helper to append a search result item to the appropriate array.
-    private static func appendItem(
-        _ item: SearchResultItem,
-        songs: inout [Song],
-        albums: inout [Album],
-        artists: inout [Artist],
-        playlists: inout [Playlist]
-    ) {
-        switch item {
-        case let .song(song):
-            songs.append(song)
-        case let .album(album):
-            albums.append(album)
-        case let .artist(artist):
-            artists.append(artist)
-        case let .playlist(playlist):
-            playlists.append(playlist)
-        case .podcastShow:
-            // Podcast shows not parsed in general search
-            break
-        }
+    private enum BrowseKind {
+        case album
+        case audiobook
+        case artist
+        case profile
+        case playlist
+        case podcastShow
+        case podcastEpisode
     }
 
-    /// Parses a filtered songs-only search response.
-    /// Filtered searches have a simpler structure without tabs.
-    static func parseSongsOnly(_ data: [String: Any]) -> [Song] {
-        var songs: [Song] = []
-
-        // Filtered search has a simpler structure - no tabs
-        guard let contents = data["contents"] as? [String: Any],
-              let sectionListRenderer = contents["sectionListRenderer"] as? [String: Any],
-              let sectionContents = sectionListRenderer["contents"] as? [[String: Any]]
-        else {
-            // Try tabbed structure as fallback
-            let response = self.parse(data)
-            return response.songs
-        }
-
-        for sectionData in sectionContents {
-            if let shelfRenderer = sectionData["musicShelfRenderer"] as? [String: Any],
-               let shelfContents = shelfRenderer["contents"] as? [[String: Any]]
-            {
-                songs.reserveCapacity(songs.count + shelfContents.count)
-                for itemData in shelfContents {
-                    if let item = parseSearchResultItem(itemData),
-                       case let .song(song) = item
-                    {
-                        songs.append(song)
-                    }
-                }
-            }
-        }
-
-        return songs
+    private struct PlayableDestination {
+        let videoId: String
+        let musicVideoType: MusicVideoType?
     }
 
-    // MARK: - Item Parsing
-
-    /// Parses a musicCardShelfRenderer (Top Result section).
-    /// This renderer contains a single prominent result with title, subtitle, and browse endpoint.
-    private static func parseCardShelfRenderer(_ data: [String: Any]) -> SearchResultItem? {
-        // Extract title and navigation from the title runs
-        guard let titleData = data["title"] as? [String: Any],
-              let runs = titleData["runs"] as? [[String: Any]],
-              let firstRun = runs.first,
-              let title = firstRun["text"] as? String,
-              let navigationEndpoint = firstRun["navigationEndpoint"] as? [String: Any],
-              let browseEndpoint = navigationEndpoint["browseEndpoint"] as? [String: Any],
-              let browseId = browseEndpoint["browseId"] as? String
-        else {
-            return nil
-        }
-
-        // Extract thumbnail
-        let thumbnailURL = ParsingHelpers.extractThumbnailURL(from: data)
-
-        // Extract subtitle
-        var subtitle: String?
-        if let subtitleData = data["subtitle"] as? [String: Any],
-           let subtitleRuns = subtitleData["runs"] as? [[String: Any]]
-        {
-            subtitle = ParsingHelpers.joinedRunText(subtitleRuns)
-        }
-
-        let pageType = ParsingHelpers.extractPageType(from: browseEndpoint)
-        return self.createItemFromBrowseEndpoint(
-            browseId: browseId,
-            pageType: pageType,
-            title: title,
-            thumbnailURL: thumbnailURL,
-            subtitle: subtitle
-        )
-    }
-
-    private static func parseSearchResultItem(_ data: [String: Any]) -> SearchResultItem? {
-        guard let responsiveRenderer = data["musicResponsiveListItemRenderer"] as? [String: Any] else {
-            return nil
-        }
-
-        // Try to get videoId for songs
-        if let playlistItemData = responsiveRenderer["playlistItemData"] as? [String: Any],
-           let videoId = playlistItemData["videoId"] as? String
-        {
-            return self.parseSongFromResponsiveRenderer(responsiveRenderer, videoId: videoId)
-        }
-
-        // Check navigation endpoint for other types
-        if let navigationEndpoint = responsiveRenderer["navigationEndpoint"] as? [String: Any],
-           let browseEndpoint = navigationEndpoint["browseEndpoint"] as? [String: Any],
-           let browseId = browseEndpoint["browseId"] as? String
-        {
-            let thumbnailURL = ParsingHelpers.extractThumbnailURL(from: responsiveRenderer)
-            let title = ParsingHelpers.extractTitleFromFlexColumns(responsiveRenderer) ?? "Unknown"
-            let subtitle = ParsingHelpers.extractSubtitleFromFlexColumns(responsiveRenderer)
-
-            let pageType = ParsingHelpers.extractPageType(from: browseEndpoint)
-            return self.createItemFromBrowseEndpoint(
-                browseId: browseId,
-                pageType: pageType,
-                title: title,
-                thumbnailURL: thumbnailURL,
-                subtitle: subtitle
-            )
-        }
-
-        return nil
-    }
-
-    // MARK: - Helpers
-
-    private static func createItemFromBrowseEndpoint(
-        browseId: String,
-        pageType: String?,
-        title: String,
-        thumbnailURL: URL?,
-        subtitle: String?
-    ) -> SearchResultItem? {
-        if pageType == "MUSIC_PAGE_TYPE_ALBUM" || browseId.hasPrefix("MPRE") || browseId.hasPrefix("OLAK") {
-            let album = Album(
-                id: browseId,
-                title: title,
-                artists: nil,
-                thumbnailURL: thumbnailURL,
-                year: nil,
-                trackCount: nil
-            )
-            return .album(album)
-        }
-
-        if ParsingHelpers.isArtistPageType(pageType) || Artist.isNavigableId(browseId) {
-            let artist = Artist(
-                id: browseId,
-                name: title,
-                thumbnailURL: thumbnailURL,
-                profileKind: Artist.profileKind(forPageType: pageType)
-            )
-            return .artist(artist)
-        }
-
-        if pageType == "MUSIC_PAGE_TYPE_PLAYLIST" || browseId.hasPrefix("VL") || browseId.hasPrefix("PL") {
-            let playlist = Playlist(
-                id: browseId,
-                title: title,
-                description: nil,
-                thumbnailURL: thumbnailURL,
-                trackCount: nil,
-                author: subtitle.map { Artist.inline(name: $0, namespace: "playlist-author") }
-            )
-            return .playlist(playlist)
-        }
-
-        return nil
-    }
-
-    private static func parseSongFromResponsiveRenderer(
-        _ data: [String: Any],
-        videoId: String
-    ) -> SearchResultItem? {
-        let thumbnailURL = ParsingHelpers.extractThumbnailURL(from: data)
-        let title = ParsingHelpers.extractTitleFromFlexColumns(data) ?? "Unknown"
-        let artists = ParsingHelpers.extractArtistsFromFlexColumns(data)
-        let album = ParsingHelpers.extractAlbumFromFlexColumns(data)
-
-        let isExplicit = ParsingHelpers.extractIsExplicit(from: data)
-        let song = Song(
-            id: videoId,
-            title: title,
-            artists: artists,
-            album: album,
-            duration: nil,
-            thumbnailURL: thumbnailURL,
-            videoId: videoId,
-            isExplicit: isExplicit
-        )
-        return .song(song)
-    }
-
-    // MARK: - Filtered Search Parsing
-
-    /// Extracts the continuation token from a filtered search response.
-    private static func extractContinuationToken(from sectionListRenderer: [String: Any]) -> String? {
-        // Check for continuations array
-        if let continuations = sectionListRenderer["continuations"] as? [[String: Any]],
-           let firstContinuation = continuations.first,
-           let nextContinuationData = firstContinuation["nextContinuationData"] as? [String: Any],
-           let token = nextContinuationData["continuation"] as? String
-        {
-            return token
-        }
-        return nil
-    }
-
-    /// Helper to get sectionListRenderer from filtered search response.
-    private static func getSectionListRenderer(from data: [String: Any]) -> [String: Any]? {
-        // Try filtered search structure first (no tabs)
-        if let contents = data["contents"] as? [String: Any],
-           let sectionListRenderer = contents["sectionListRenderer"] as? [String: Any]
-        {
-            return sectionListRenderer
-        }
-
-        // Try tabbed structure as fallback
-        if let contents = data["contents"] as? [String: Any],
-           let tabbedSearchResults = contents["tabbedSearchResultsRenderer"] as? [String: Any],
-           let tabs = tabbedSearchResults["tabs"] as? [[String: Any]],
-           let firstTab = tabs.first,
-           let tabRenderer = firstTab["tabRenderer"] as? [String: Any],
-           let tabContent = tabRenderer["content"] as? [String: Any],
-           let sectionListRenderer = tabContent["sectionListRenderer"] as? [String: Any]
-        {
-            return sectionListRenderer
-        }
-
-        return nil
-    }
-
-    /// Parses albums from a filtered search response with continuation token.
-    static func parseAlbumsOnly(_ data: [String: Any]) -> ([Album], String?) {
-        var albums: [Album] = []
-
-        guard let sectionListRenderer = getSectionListRenderer(from: data),
-              let sectionContents = sectionListRenderer["contents"] as? [[String: Any]]
-        else {
-            return ([], nil)
-        }
-
-        for sectionData in sectionContents {
-            if let shelfRenderer = sectionData["musicShelfRenderer"] as? [String: Any],
-               let shelfContents = shelfRenderer["contents"] as? [[String: Any]]
-            {
-                albums.reserveCapacity(albums.count + shelfContents.count)
-                for itemData in shelfContents {
-                    if let item = parseSearchResultItem(itemData),
-                       case let .album(album) = item
-                    {
-                        albums.append(album)
-                    }
-                }
-            }
-        }
-
-        let token = Self.extractContinuationToken(from: sectionListRenderer)
-        return (albums, token)
-    }
-
-    /// Parses artists from a filtered search response with continuation token.
-    static func parseArtistsOnly(_ data: [String: Any]) -> ([Artist], String?) {
-        var artists: [Artist] = []
-
-        guard let sectionListRenderer = getSectionListRenderer(from: data),
-              let sectionContents = sectionListRenderer["contents"] as? [[String: Any]]
-        else {
-            return ([], nil)
-        }
-
-        for sectionData in sectionContents {
-            if let shelfRenderer = sectionData["musicShelfRenderer"] as? [String: Any],
-               let shelfContents = shelfRenderer["contents"] as? [[String: Any]]
-            {
-                artists.reserveCapacity(artists.count + shelfContents.count)
-                for itemData in shelfContents {
-                    if let item = parseSearchResultItem(itemData),
-                       case let .artist(artist) = item
-                    {
-                        artists.append(artist)
-                    }
-                }
-            }
-        }
-
-        let token = Self.extractContinuationToken(from: sectionListRenderer)
-        return (artists, token)
-    }
-
-    /// Parses playlists from a filtered search response with continuation token.
-    static func parsePlaylistsOnly(_ data: [String: Any]) -> ([Playlist], String?) {
-        var playlists: [Playlist] = []
-
-        guard let sectionListRenderer = getSectionListRenderer(from: data),
-              let sectionContents = sectionListRenderer["contents"] as? [[String: Any]]
-        else {
-            return ([], nil)
-        }
-
-        for sectionData in sectionContents {
-            if let shelfRenderer = sectionData["musicShelfRenderer"] as? [String: Any],
-               let shelfContents = shelfRenderer["contents"] as? [[String: Any]]
-            {
-                playlists.reserveCapacity(playlists.count + shelfContents.count)
-                for itemData in shelfContents {
-                    if let item = parseSearchResultItem(itemData),
-                       case let .playlist(playlist) = item
-                    {
-                        playlists.append(playlist)
-                    }
-                }
-            }
-        }
-
-        let token = Self.extractContinuationToken(from: sectionListRenderer)
-        return (playlists, token)
-    }
-
-    /// Parses podcasts from a filtered search response with continuation token.
-    static func parsePodcastsOnly(_ data: [String: Any]) -> ([PodcastShow], String?) {
-        var podcasts: [PodcastShow] = []
-
-        guard let sectionListRenderer = getSectionListRenderer(from: data),
-              let sectionContents = sectionListRenderer["contents"] as? [[String: Any]]
-        else {
-            return ([], nil)
-        }
-
-        for sectionData in sectionContents {
-            if let shelfRenderer = sectionData["musicShelfRenderer"] as? [String: Any],
-               let shelfContents = shelfRenderer["contents"] as? [[String: Any]]
-            {
-                podcasts.reserveCapacity(podcasts.count + shelfContents.count)
-                for itemData in shelfContents {
-                    if let show = Self.parsePodcastShowFromSearchResult(itemData) {
-                        podcasts.append(show)
-                    }
-                }
-            }
-        }
-
-        let token = Self.extractContinuationToken(from: sectionListRenderer)
-        return (podcasts, token)
-    }
-
-    /// Parses a podcast show from a search result item.
-    private static func parsePodcastShowFromSearchResult(_ data: [String: Any]) -> PodcastShow? {
-        guard let responsiveRenderer = data["musicResponsiveListItemRenderer"] as? [String: Any] else {
-            return nil
-        }
-
-        // Check navigation endpoint for browse ID
-        guard let navigationEndpoint = responsiveRenderer["navigationEndpoint"] as? [String: Any],
-              let browseEndpoint = navigationEndpoint["browseEndpoint"] as? [String: Any],
-              let browseId = browseEndpoint["browseId"] as? String,
-              browseId.hasPrefix("MPSPP")
-        else {
-            return nil
-        }
-
-        let thumbnailURL = ParsingHelpers.extractThumbnailURL(from: responsiveRenderer)
-        let title = ParsingHelpers.extractTitleFromFlexColumns(responsiveRenderer) ?? "Unknown Podcast"
-        let author = ParsingHelpers.extractSubtitleFromFlexColumns(responsiveRenderer)
-
-        return PodcastShow(
-            id: browseId,
-            title: title,
-            author: author,
-            description: nil,
-            thumbnailURL: thumbnailURL,
-            episodeCount: nil
-        )
-    }
-
-    /// Parses songs from a filtered search response with continuation token.
-    static func parseSongsWithContinuation(_ data: [String: Any]) -> ([Song], String?) {
-        var songs: [Song] = []
-
-        guard let sectionListRenderer = getSectionListRenderer(from: data),
-              let sectionContents = sectionListRenderer["contents"] as? [[String: Any]]
-        else {
-            return ([], nil)
-        }
-
-        for sectionData in sectionContents {
-            if let shelfRenderer = sectionData["musicShelfRenderer"] as? [String: Any],
-               let shelfContents = shelfRenderer["contents"] as? [[String: Any]]
-            {
-                songs.reserveCapacity(songs.count + shelfContents.count)
-                for itemData in shelfContents {
-                    if let item = parseSearchResultItem(itemData),
-                       case let .song(song) = item
-                    {
-                        songs.append(song)
-                    }
-                }
-            }
-        }
-
-        let token = Self.extractContinuationToken(from: sectionListRenderer)
-        return (songs, token)
-    }
-
-    /// Parses a search continuation response.
-    /// Returns a SearchResponse with all item types and optional continuation token.
-    static func parseContinuation(_ data: [String: Any]) -> SearchResponse {
-        var songs: [Song] = []
-        var albums: [Album] = []
-        var artists: [Artist] = []
-        var playlists: [Playlist] = []
-        var podcastShows: [PodcastShow] = []
+    private struct ParseAccumulator {
+        var items: [SearchResultItem] = []
+        var seenContentIdentities: Set<String> = []
         var continuationToken: String?
 
-        // Continuation responses have a different structure
-        if let continuationContents = data["continuationContents"] as? [String: Any],
-           let musicShelfContinuation = continuationContents["musicShelfContinuation"] as? [String: Any]
-        {
-            // Parse items
-            if let contents = musicShelfContinuation["contents"] as? [[String: Any]] {
-                songs.reserveCapacity(contents.count)
-                for itemData in contents {
-                    // Try to parse as podcast show first (for podcast search continuation)
-                    if let show = Self.parsePodcastShowFromSearchResult(itemData) {
-                        podcastShows.append(show)
-                    } else if let item = parseSearchResultItem(itemData) {
-                        Self.appendItem(item, songs: &songs, albums: &albums, artists: &artists, playlists: &playlists)
-                    }
-                }
+        mutating func append(_ item: SearchResultItem) {
+            guard self.seenContentIdentities.insert(item.contentIdentity).inserted else {
+                return
             }
+            self.items.append(item)
+        }
 
-            // Extract next continuation token
-            if let continuations = musicShelfContinuation["continuations"] as? [[String: Any]],
-               let firstContinuation = continuations.first,
-               let nextContinuationData = firstContinuation["nextContinuationData"] as? [String: Any],
-               let token = nextContinuationData["continuation"] as? String
-            {
-                continuationToken = token
+        mutating func captureContinuation(_ token: String?) {
+            guard self.continuationToken == nil,
+                  let token = token?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !token.isEmpty
+            else {
+                return
+            }
+            self.continuationToken = token
+        }
+    }
+
+    static func parse(_ data: [String: Any]) -> SearchResponse {
+        let sectionLists = Self.firstPageSectionLists(from: data)
+        guard !sectionLists.isEmpty else {
+            Self.logger.debug("SearchResponseParser: Failed to find a search section list. Top keys: \(data.keys.sorted())")
+            return .empty
+        }
+
+        var accumulator = ParseAccumulator()
+        for sectionList in sectionLists {
+            Self.parseSectionList(sectionList, into: &accumulator)
+        }
+
+        return SearchResponse(
+            items: accumulator.items,
+            continuationToken: accumulator.continuationToken
+        )
+    }
+
+    static func parseSongsOnly(_ data: [String: Any]) -> [Song] {
+        self.parse(data).songs
+    }
+
+    static func parseAlbumsOnly(_ data: [String: Any]) -> ([Album], String?) {
+        let response = Self.parse(data)
+        return (response.albums, response.continuationToken)
+    }
+
+    static func parseArtistsOnly(_ data: [String: Any]) -> ([Artist], String?) {
+        let response = Self.parse(data)
+        return (response.artists, response.continuationToken)
+    }
+
+    static func parsePlaylistsOnly(_ data: [String: Any]) -> ([Playlist], String?) {
+        let response = Self.parse(data)
+        return (response.playlists, response.continuationToken)
+    }
+
+    static func parsePodcastsOnly(_ data: [String: Any]) -> ([PodcastShow], String?) {
+        let response = Self.parse(data)
+        return (response.podcastShows, response.continuationToken)
+    }
+
+    static func parseSongsWithContinuation(_ data: [String: Any]) -> ([Song], String?) {
+        let response = Self.parse(data)
+        return (response.songs, response.continuationToken)
+    }
+
+    static func parseContinuation(_ data: [String: Any]) -> SearchResponse {
+        var accumulator = ParseAccumulator()
+
+        if let continuationContents = data["continuationContents"] as? [String: Any],
+           let shelf = continuationContents["musicShelfContinuation"] as? [String: Any]
+        {
+            Self.parseMusicShelf(shelf, into: &accumulator)
+        }
+
+        for items in Self.continuationActionItemGroups(from: data) {
+            accumulator.items.reserveCapacity(accumulator.items.count + items.count)
+            for item in items {
+                Self.parseContainer(item, into: &accumulator)
             }
         }
 
         return SearchResponse(
-            songs: songs,
-            albums: albums,
-            artists: artists,
-            playlists: playlists,
-            podcastShows: podcastShows,
-            continuationToken: continuationToken
+            items: accumulator.items,
+            continuationToken: accumulator.continuationToken
         )
+    }
+}
+
+private extension SearchResponseParser {
+    private static func firstPageSectionLists(from data: [String: Any]) -> [[String: Any]] {
+        guard let contents = data["contents"] as? [String: Any] else {
+            return []
+        }
+
+        if let directSectionList = contents["sectionListRenderer"] as? [String: Any] {
+            return [directSectionList]
+        }
+
+        guard let tabbed = contents["tabbedSearchResultsRenderer"] as? [String: Any],
+              let tabs = tabbed["tabs"] as? [[String: Any]]
+        else {
+            return []
+        }
+
+        var sectionLists: [[String: Any]] = []
+        sectionLists.reserveCapacity(tabs.count)
+        for tab in tabs {
+            guard let tabRenderer = tab["tabRenderer"] as? [String: Any],
+                  let content = tabRenderer["content"] as? [String: Any],
+                  let sectionList = content["sectionListRenderer"] as? [String: Any]
+            else {
+                continue
+            }
+            sectionLists.append(sectionList)
+        }
+        return sectionLists
+    }
+
+    private static func parseSectionList(
+        _ sectionList: [String: Any],
+        into accumulator: inout ParseAccumulator
+    ) {
+        if let contents = sectionList["contents"] as? [[String: Any]] {
+            accumulator.items.reserveCapacity(accumulator.items.count + contents.count)
+            for content in contents {
+                self.parseContainer(content, into: &accumulator)
+            }
+        }
+
+        accumulator.captureContinuation(Self.extractContinuationToken(from: sectionList))
+    }
+
+    private static func parseContainer(
+        _ container: [String: Any],
+        into accumulator: inout ParseAccumulator
+    ) {
+        if let card = container["musicCardShelfRenderer"] as? [String: Any] {
+            self.parseCardShelf(card, into: &accumulator)
+            return
+        }
+
+        if let shelf = container["musicShelfRenderer"] as? [String: Any] {
+            Self.parseMusicShelf(shelf, into: &accumulator)
+            return
+        }
+
+        if let itemSection = container["itemSectionRenderer"] as? [String: Any] {
+            Self.parseItemSection(itemSection, into: &accumulator)
+            return
+        }
+
+        if let renderer = container["musicResponsiveListItemRenderer"] as? [String: Any],
+           let item = Self.parseResponsiveListItem(renderer)
+        {
+            accumulator.append(item)
+            return
+        }
+
+        if let renderer = container["musicTwoRowItemRenderer"] as? [String: Any],
+           let item = Self.parseTwoRowItem(renderer)
+        {
+            accumulator.append(item)
+            return
+        }
+
+        if let renderer = container["musicMultiRowListItemRenderer"] as? [String: Any],
+           let item = Self.parseMultiRowItem(renderer)
+        {
+            accumulator.append(item)
+            return
+        }
+
+        accumulator.captureContinuation(Self.extractContinuationToken(fromContinuationItem: container))
+    }
+
+    private static func parseCardShelf(
+        _ card: [String: Any],
+        into accumulator: inout ParseAccumulator
+    ) {
+        let endpoints = Self.cardEndpointCandidates(from: card)
+        if let item = Self.parseItemRenderer(card, endpointCandidates: endpoints) {
+            accumulator.append(item)
+        }
+
+        if let contents = card["contents"] as? [[String: Any]] {
+            for content in contents {
+                Self.parseContainer(content, into: &accumulator)
+            }
+        }
+
+        accumulator.captureContinuation(Self.extractContinuationToken(from: card))
+    }
+
+    private static func parseMusicShelf(
+        _ shelf: [String: Any],
+        into accumulator: inout ParseAccumulator
+    ) {
+        accumulator.captureContinuation(self.extractContinuationToken(from: shelf))
+
+        guard let contents = shelf["contents"] as? [[String: Any]] else {
+            return
+        }
+        accumulator.items.reserveCapacity(accumulator.items.count + contents.count)
+        for content in contents {
+            Self.parseContainer(content, into: &accumulator)
+        }
+    }
+
+    private static func continuationActionItemGroups(
+        from data: [String: Any]
+    ) -> [[[String: Any]]] {
+        var groups: [[[String: Any]]] = []
+        for envelopeKey in [
+            "onResponseReceivedCommands",
+            "onResponseReceivedActions",
+            "onResponseReceivedEndpoints",
+        ] {
+            guard let actions = data[envelopeKey] as? [[String: Any]] else {
+                continue
+            }
+            for action in actions {
+                for commandKey in [
+                    "appendContinuationItemsAction",
+                    "reloadContinuationItemsCommand",
+                ] {
+                    guard let command = action[commandKey] as? [String: Any],
+                          let items = command["continuationItems"] as? [[String: Any]]
+                    else {
+                        continue
+                    }
+                    groups.append(items)
+                }
+            }
+        }
+        return groups
+    }
+
+    private static func parseItemSection(
+        _ itemSection: [String: Any],
+        into accumulator: inout ParseAccumulator
+    ) {
+        guard let contents = itemSection["contents"] as? [[String: Any]] else {
+            return
+        }
+        accumulator.items.reserveCapacity(accumulator.items.count + contents.count)
+        for content in contents {
+            Self.parseContainer(content, into: &accumulator)
+        }
+    }
+
+    private static func parseResponsiveListItem(_ renderer: [String: Any]) -> SearchResultItem? {
+        self.parseItemRenderer(
+            renderer,
+            endpointCandidates: self.responsiveEndpointCandidates(from: renderer)
+        )
+    }
+
+    private static func parseTwoRowItem(_ renderer: [String: Any]) -> SearchResultItem? {
+        self.parseItemRenderer(
+            renderer,
+            endpointCandidates: self.directItemEndpointCandidates(from: renderer)
+        )
+    }
+
+    private static func parseMultiRowItem(_ renderer: [String: Any]) -> SearchResultItem? {
+        self.parseItemRenderer(
+            renderer,
+            endpointCandidates: self.multiRowEndpointCandidates(from: renderer)
+        )
+    }
+
+    private static func parseItemRenderer(
+        _ renderer: [String: Any],
+        endpointCandidates: [[String: Any]]
+    ) -> SearchResultItem? {
+        let title = Self.itemTitle(from: renderer) ?? "Unknown"
+        let thumbnailURL = ParsingHelpers.extractThumbnailURL(from: renderer)
+        let contentKind = Self.contentKind(from: renderer)
+
+        var episodeBrowseId: String?
+        for endpoint in endpointCandidates {
+            guard let browseEndpoint = endpoint["browseEndpoint"] as? [String: Any],
+                  let browseId = browseEndpoint["browseId"] as? String,
+                  let browseKind = Self.browseKind(
+                      browseId: browseId,
+                      pageType: ParsingHelpers.extractPageType(from: browseEndpoint),
+                      contentKind: contentKind
+                  )
+            else {
+                continue
+            }
+
+            if browseKind == .podcastEpisode {
+                episodeBrowseId = episodeBrowseId ?? browseId
+                continue
+            }
+
+            return Self.makeBrowseItem(
+                kind: browseKind,
+                browseId: browseId,
+                title: title,
+                thumbnailURL: thumbnailURL,
+                renderer: renderer
+            )
+        }
+
+        for endpoint in endpointCandidates {
+            let watchPlaylistId = (endpoint["watchPlaylistEndpoint"] as? [String: Any])?["playlistId"] as? String
+            let contextualPlaylistId = contentKind == .playlist
+                ? (endpoint["watchEndpoint"] as? [String: Any])?["playlistId"] as? String
+                : nil
+            if let playlistId = watchPlaylistId ?? contextualPlaylistId,
+               playlistId.hasPrefix("VL") || playlistId.hasPrefix("PL")
+               || playlistId.hasPrefix("VM") || playlistId.hasPrefix("RD")
+            {
+                return Self.makeBrowseItem(kind: .playlist, browseId: playlistId, title: title, thumbnailURL: thumbnailURL, renderer: renderer)
+            }
+        }
+
+        guard let playable = Self.playableDestination(
+            from: renderer,
+            endpointCandidates: endpointCandidates
+        ) else {
+            return nil
+        }
+
+        if episodeBrowseId != nil
+            || contentKind == .podcastEpisode
+            || playable.musicVideoType == .podcastEpisode
+        {
+            return .podcastEpisode(Self.makePodcastEpisode(
+                renderer: renderer,
+                title: title,
+                thumbnailURL: thumbnailURL,
+                videoId: playable.videoId
+            ))
+        }
+
+        let isVideo = contentKind == .video || Self.isVideoResult(playable.musicVideoType)
+        let song = Self.makeSong(
+            renderer: renderer,
+            title: title,
+            thumbnailURL: thumbnailURL,
+            destination: playable
+        )
+        return isVideo ? .video(song) : .song(song)
+    }
+
+    private static func makeBrowseItem(
+        kind: BrowseKind,
+        browseId: String,
+        title: String,
+        thumbnailURL: URL?,
+        renderer: [String: Any]
+    ) -> SearchResultItem? {
+        switch kind {
+        case .album, .audiobook:
+            let artists = Self.itemArtists(from: renderer, allowPlainTextFallback: false)
+            let album = Album(
+                id: browseId,
+                title: title,
+                artists: artists.isEmpty ? nil : artists,
+                thumbnailURL: thumbnailURL,
+                year: Self.metadataComponents(from: renderer).first(where: Self.isYear),
+                trackCount: nil
+            )
+            return kind == .audiobook ? .audiobook(album) : .album(album)
+
+        case .artist, .profile:
+            let profileKind: ArtistProfileKind = kind == .profile ? .profile : .artist
+            let artist = Artist(
+                id: browseId,
+                name: title,
+                thumbnailURL: thumbnailURL,
+                subtitle: Self.semanticSubtitle(from: renderer),
+                profileKind: profileKind
+            )
+            return kind == .profile ? .profile(artist) : .artist(artist)
+
+        case .playlist:
+            let subtitleRuns = Self.metadataRuns(from: renderer)
+            let author = ParsingHelpers.extractFirstNavigableArtist(from: subtitleRuns)
+                ?? Self.fallbackCreatorName(from: renderer).map {
+                    Artist.inline(name: $0, namespace: "playlist-author")
+                }
+            let songCount = Self.songCount(from: renderer)
+            return .playlist(Playlist(
+                id: browseId,
+                title: title,
+                description: nil,
+                thumbnailURL: thumbnailURL,
+                trackCount: songCount,
+                author: author
+            ))
+
+        case .podcastShow:
+            return .podcastShow(PodcastShow(
+                id: browseId,
+                title: title,
+                author: self.fallbackCreatorName(from: renderer),
+                description: self.descriptionText(from: renderer),
+                thumbnailURL: thumbnailURL,
+                episodeCount: nil
+            ))
+
+        case .podcastEpisode:
+            return nil
+        }
+    }
+
+    private static func makeSong(
+        renderer: [String: Any],
+        title: String,
+        thumbnailURL: URL?,
+        destination: PlayableDestination
+    ) -> Song {
+        let musicVideoType = destination.musicVideoType
+        return Song(
+            id: destination.videoId,
+            title: title,
+            artists: Self.itemArtists(from: renderer, allowPlainTextFallback: true),
+            album: ParsingHelpers.extractAlbumFromFlexColumns(renderer),
+            duration: ParsingHelpers.extractDurationFromFlexColumns(renderer),
+            thumbnailURL: thumbnailURL,
+            videoId: destination.videoId,
+            isPlayable: ParsingHelpers.isPlayableMusicItem(from: renderer),
+            hasVideo: musicVideoType?.hasVideoContent,
+            musicVideoType: musicVideoType,
+            isExplicit: ParsingHelpers.extractIsExplicit(from: renderer)
+        )
+    }
+
+    private static func makePodcastEpisode(
+        renderer: [String: Any],
+        title: String,
+        thumbnailURL: URL?,
+        videoId: String
+    ) -> PodcastEpisode {
+        let metadataRuns = Self.metadataRuns(from: renderer)
+        let showRun = metadataRuns.first { run in
+            guard let endpoint = Self.unwrapEndpoint(run["navigationEndpoint"]),
+                  let browseEndpoint = endpoint["browseEndpoint"] as? [String: Any],
+                  let browseId = browseEndpoint["browseId"] as? String
+            else {
+                return false
+            }
+            return browseId.hasPrefix("MPSPP")
+        }
+        let showTitle = (showRun?["text"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let showBrowseId = showRun
+            .flatMap { Self.unwrapEndpoint($0["navigationEndpoint"]) }
+            .flatMap { $0["browseEndpoint"] as? [String: Any] }
+            .flatMap { $0["browseId"] as? String }
+
+        let components = Self.metadataComponents(from: renderer)
+        let publishedDate = components.first(where: Self.looksLikePublishedDate)
+        let durationText = components.first { component in
+            component != publishedDate && Self.looksLikeDuration(component)
+        }
+        let durationSeconds = ParsingHelpers.extractDurationFromFlexColumns(renderer)
+            ?? durationText.flatMap(Self.durationSeconds)
+        let fallbackShowTitle = components.first { component in
+            component != durationText
+                && component != publishedDate
+                && !Self.looksLikeCount(component)
+        }
+
+        let progress = Self.playbackProgress(from: renderer)
+        return PodcastEpisode(
+            id: videoId,
+            title: title,
+            showTitle: showTitle ?? fallbackShowTitle,
+            showBrowseId: showBrowseId,
+            description: Self.descriptionText(from: renderer),
+            thumbnailURL: thumbnailURL,
+            publishedDate: publishedDate,
+            duration: durationText,
+            durationSeconds: durationSeconds.map(Int.init),
+            playbackProgress: progress,
+            isPlayed: (renderer["isPlayed"] as? Bool) ?? (progress >= 1)
+        )
+    }
+}
+
+private extension SearchResponseParser {
+    private static func responsiveEndpointCandidates(from renderer: [String: Any]) -> [[String: Any]] {
+        var endpoints: [[String: Any]] = []
+        Self.appendEndpoint(renderer["navigationEndpoint"], to: &endpoints)
+        Self.appendEndpoint(Self.titleRun(from: renderer)?["navigationEndpoint"], to: &endpoints)
+        Self.appendEndpoint(renderer["onTap"], to: &endpoints)
+        Self.appendEndpoint(Self.playEndpoint(from: renderer["overlay"]), to: &endpoints)
+        return endpoints
+    }
+
+    private static func directItemEndpointCandidates(from renderer: [String: Any]) -> [[String: Any]] {
+        var endpoints: [[String: Any]] = []
+        Self.appendEndpoint(renderer["navigationEndpoint"], to: &endpoints)
+        Self.appendEndpoint(Self.titleRun(from: renderer)?["navigationEndpoint"], to: &endpoints)
+        Self.appendEndpoint(renderer["onTap"], to: &endpoints)
+        Self.appendEndpoint(Self.playEndpoint(from: renderer["thumbnailOverlay"]), to: &endpoints)
+        Self.appendEndpoint(Self.playEndpoint(from: renderer["overlay"]), to: &endpoints)
+        return endpoints
+    }
+
+    private static func multiRowEndpointCandidates(from renderer: [String: Any]) -> [[String: Any]] {
+        var endpoints: [[String: Any]] = []
+        Self.appendEndpoint(renderer["onTap"], to: &endpoints)
+        Self.appendEndpoint(renderer["navigationEndpoint"], to: &endpoints)
+        Self.appendEndpoint(Self.titleRun(from: renderer)?["navigationEndpoint"], to: &endpoints)
+        Self.appendEndpoint(Self.playEndpoint(from: renderer["overlay"]), to: &endpoints)
+        return endpoints
+    }
+
+    private static func cardEndpointCandidates(from card: [String: Any]) -> [[String: Any]] {
+        var endpoints: [[String: Any]] = []
+        Self.appendEndpoint(Self.titleRun(from: card)?["navigationEndpoint"], to: &endpoints)
+        Self.appendEndpoint(card["navigationEndpoint"], to: &endpoints)
+        Self.appendEndpoint(card["onTap"], to: &endpoints)
+        Self.appendEndpoint(Self.playEndpoint(from: card["thumbnailOverlay"]), to: &endpoints)
+        Self.appendEndpoint(Self.playEndpoint(from: card["overlay"]), to: &endpoints)
+        return endpoints
+    }
+
+    private static func appendEndpoint(_ value: Any?, to endpoints: inout [[String: Any]]) {
+        guard let endpoint = unwrapEndpoint(value) else {
+            return
+        }
+        endpoints.append(endpoint)
+    }
+
+    private static func unwrapEndpoint(_ value: Any?) -> [String: Any]? {
+        guard let endpoint = value as? [String: Any] else {
+            return nil
+        }
+        return (endpoint["innertubeCommand"] as? [String: Any]) ?? endpoint
+    }
+
+    private static func playEndpoint(from overlayValue: Any?) -> [String: Any]? {
+        guard let overlay = overlayValue as? [String: Any],
+              let thumbnailOverlay = overlay["musicItemThumbnailOverlayRenderer"] as? [String: Any],
+              let content = thumbnailOverlay["content"] as? [String: Any],
+              let playButton = content["musicPlayButtonRenderer"] as? [String: Any]
+        else {
+            return nil
+        }
+        return Self.unwrapEndpoint(playButton["playNavigationEndpoint"])
+    }
+
+    private static func playableDestination(
+        from renderer: [String: Any],
+        endpointCandidates: [[String: Any]]
+    ) -> PlayableDestination? {
+        let musicVideoType = Self.firstMusicVideoType(
+            from: renderer,
+            endpointCandidates: endpointCandidates
+        )
+
+        if let playlistItemData = renderer["playlistItemData"] as? [String: Any],
+           let videoId = playlistItemData["videoId"] as? String,
+           !videoId.isEmpty
+        {
+            return PlayableDestination(videoId: videoId, musicVideoType: musicVideoType)
+        }
+
+        for endpoint in endpointCandidates {
+            let wrapper = ["navigationEndpoint": endpoint]
+            guard let videoId = ParsingHelpers.extractVideoId(from: wrapper),
+                  !videoId.isEmpty
+            else {
+                continue
+            }
+            let endpointType = ParsingHelpers.extractMusicVideoType(from: wrapper) ?? musicVideoType
+            return PlayableDestination(videoId: videoId, musicVideoType: endpointType)
+        }
+
+        return nil
+    }
+
+    private static func firstMusicVideoType(
+        from renderer: [String: Any],
+        endpointCandidates: [[String: Any]]
+    ) -> MusicVideoType? {
+        if let type = ParsingHelpers.extractMusicVideoType(from: renderer) {
+            return type
+        }
+
+        for endpoint in endpointCandidates {
+            if let type = ParsingHelpers.extractMusicVideoType(from: ["navigationEndpoint": endpoint]) {
+                return type
+            }
+        }
+        return nil
+    }
+
+    private static func contentKind(from renderer: [String: Any]) -> ContentKind? {
+        for run in self.metadataRuns(from: renderer) {
+            guard let text = run["text"] as? String else {
+                continue
+            }
+            for component in Self.splitMetadataText(text) {
+                if let kind = Self.contentKind(fromLabel: component) {
+                    return kind
+                }
+            }
+        }
+        return nil
+    }
+
+    private static func contentKind(fromLabel label: String) -> ContentKind? {
+        switch label.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "song", "أغنية", "titel", "canción", "morceau", "lagu", "brano", "노래",
+             "nummer", "utwór", "música", "трек", "låt", "şarkı", "пісня":
+            .song
+        case "video", "فيديو", "vídeo", "vidéo", "동영상", "wideo", "видео", "відео":
+            .video
+        case "album", "single", "ep", "ألبوم", "álbum", "앨범", "альбом", "albüm":
+            .album
+        case "audiobook", "كتاب صوتي", "hörbuch", "audiolibro", "livre audio", "buku audio",
+             "오디오북", "luisterboek", "аудиокнига", "ljudbok", "sesli kitap", "аудіокнига":
+            .audiobook
+        case "artist", "فنان", "interpret", "artista", "artiste", "artis", "아티스트",
+             "artiest", "artysta", "исполнитель", "sanatçı", "виконавець":
+            .artist
+        case "profile", "الملف الشخصي", "profil", "perfil", "profilo", "프로필", "profiel",
+             "профиль", "профіль":
+            .profile
+        case "playlist", "قائمة تشغيل", "lista de reproducción", "daftar putar", "재생목록",
+             "afspeellijst", "playlista", "lista de reprodução", "плейлист", "spellista", "çalma listesi":
+            .playlist
+        case "podcast", "بودكاست", "팟캐스트", "подкаст", "podd":
+            .podcastShow
+        case "episode", "podcast episode", "حلقة", "folge", "episodio", "épisode", "에피소드",
+             "aflevering", "odcinek", "episódio", "выпуск", "avsnitt", "bölüm", "епізод":
+            .podcastEpisode
+        default:
+            nil
+        }
+    }
+
+    private static func browseKind(
+        browseId: String,
+        pageType: String?,
+        contentKind: ContentKind?
+    ) -> BrowseKind? {
+        switch pageType {
+        case "MUSIC_PAGE_TYPE_ALBUM":
+            return .album
+        case "MUSIC_PAGE_TYPE_AUDIOBOOK":
+            return .audiobook
+        case "MUSIC_PAGE_TYPE_ARTIST", "MUSIC_PAGE_TYPE_LIBRARY_ARTIST":
+            return .artist
+        case "MUSIC_PAGE_TYPE_USER_CHANNEL":
+            return .profile
+        case "MUSIC_PAGE_TYPE_PLAYLIST":
+            return .playlist
+        case "MUSIC_PAGE_TYPE_PODCAST_SHOW_DETAIL_PAGE":
+            return .podcastShow
+        default:
+            break
+        }
+
+        if browseId.hasPrefix("MPSPP") {
+            return .podcastShow
+        }
+        if browseId.hasPrefix("MPED") || contentKind == .podcastEpisode {
+            return .podcastEpisode
+        }
+        if browseId.hasPrefix("MPRE") || browseId.hasPrefix("OLAK") {
+            return contentKind == .audiobook ? .audiobook : .album
+        }
+        if browseId.hasPrefix("VL") || browseId.hasPrefix("PL")
+            || browseId.hasPrefix("VM") || browseId.hasPrefix("RD")
+        {
+            return .playlist
+        }
+        if Artist.isNavigableId(browseId) {
+            return contentKind == .profile ? .profile : .artist
+        }
+        return nil
+    }
+
+    private static func isVideoResult(_ musicVideoType: MusicVideoType?) -> Bool {
+        switch musicVideoType {
+        case .omv, .ugc, .officialSourceMusic:
+            true
+        case .atv, .podcastEpisode, nil:
+            false
+        }
+    }
+
+    private static func itemTitle(from renderer: [String: Any]) -> String? {
+        ParsingHelpers.extractTitleFromFlexColumns(renderer)
+            ?? ParsingHelpers.extractTitle(from: renderer)
+    }
+
+    private static func titleRun(from renderer: [String: Any]) -> [String: Any]? {
+        if let flexColumns = renderer["flexColumns"] as? [[String: Any]],
+           let firstColumn = flexColumns.first,
+           let columnRenderer = firstColumn["musicResponsiveListItemFlexColumnRenderer"] as? [String: Any],
+           let text = columnRenderer["text"] as? [String: Any],
+           let runs = text["runs"] as? [[String: Any]]
+        {
+            return runs.first
+        }
+
+        if let title = renderer["title"] as? [String: Any],
+           let runs = title["runs"] as? [[String: Any]]
+        {
+            return runs.first
+        }
+        return nil
+    }
+
+    private static func metadataRuns(from renderer: [String: Any]) -> [[String: Any]] {
+        if let flexColumns = renderer["flexColumns"] as? [[String: Any]] {
+            var runs: [[String: Any]] = []
+            for column in flexColumns.dropFirst() {
+                guard let columnRenderer = column["musicResponsiveListItemFlexColumnRenderer"] as? [String: Any],
+                      let text = columnRenderer["text"] as? [String: Any],
+                      let columnRuns = text["runs"] as? [[String: Any]]
+                else { continue }
+                runs.append(contentsOf: columnRuns)
+            }
+            if !runs.isEmpty {
+                return runs
+            }
+        }
+
+        var runs: [[String: Any]] = []
+        for key in ["subtitle", "secondSubtitle"] {
+            guard let subtitle = renderer[key] as? [String: Any],
+                  let subtitleRuns = subtitle["runs"] as? [[String: Any]]
+            else {
+                continue
+            }
+            runs.append(contentsOf: subtitleRuns)
+        }
+        return runs
+    }
+
+    private static func metadataComponents(from renderer: [String: Any]) -> [String] {
+        var components: [String] = []
+        for run in Self.metadataRuns(from: renderer) {
+            guard let text = run["text"] as? String else {
+                continue
+            }
+            for component in Self.splitMetadataText(text)
+                where Self.contentKind(fromLabel: component) == nil
+            {
+                components.append(component)
+            }
+        }
+        return components
+    }
+
+    private static func semanticSubtitle(from renderer: [String: Any]) -> String? {
+        let components = Self.metadataComponents(from: renderer)
+        return components.isEmpty ? nil : components.joined(separator: " • ")
+    }
+
+    private static func itemArtists(
+        from renderer: [String: Any],
+        allowPlainTextFallback: Bool
+    ) -> [Artist] {
+        if renderer["flexColumns"] != nil {
+            let artists = ParsingHelpers.extractArtistsFromFlexColumns(renderer).filter { artist in
+                artist.hasNavigableId || Self.contentKind(fromLabel: artist.name) == nil
+            }
+            if !artists.isEmpty {
+                return artists
+            }
+        }
+
+        let runs = Self.metadataRuns(from: renderer)
+        var artists: [Artist] = []
+        for run in runs {
+            guard let name = (run["text"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !name.isEmpty,
+                  let endpoint = Self.unwrapEndpoint(run["navigationEndpoint"]),
+                  let browseEndpoint = endpoint["browseEndpoint"] as? [String: Any],
+                  let artist = ParsingHelpers.extractArtist(from: browseEndpoint, name: name)
+            else {
+                continue
+            }
+            artists.append(artist)
+        }
+        if !artists.isEmpty || !allowPlainTextFallback {
+            return artists
+        }
+
+        guard let fallbackName = Self.metadataComponents(from: renderer).first(where: { component in
+            !Self.isNonArtistMetadata(component)
+        }) else {
+            return []
+        }
+        return [Artist.inline(name: fallbackName, namespace: "search-artist")]
+    }
+
+    private static let countMetadataUnits: Set<String> = [
+        "subscriber", "subscribers", "view", "views", "play", "plays", "episode", "episodes", "song", "songs",
+        "track", "tracks", "حلقة", "الحلقات", "أغنية", "أغاني", "أغانٍ", "مقطوعات", "folge", "folgen",
+        "titel", "titeln", "episodio", "episodios", "canción", "canciones", "pista", "pistas", "épisode",
+        "épisodes", "morceau", "morceaux", "titre", "titres", "lagu", "trek", "episodi", "brano", "brani",
+        "에피소드", "노래", "곡", "트랙", "aflevering", "afleveringen", "nummer", "nummers", "odcinek",
+        "odcinki", "utwór", "utwory", "utworów", "utworami", "episódio", "episódios", "música", "músicas",
+        "faixa", "faixas", "выпуск", "выпуски", "трек", "треки", "треков", "avsnitt", "låt", "låtar",
+        "spår", "bölüm", "bölümler", "şarkı", "şarkılar", "parça", "епізод", "епізоди", "пісня",
+        "пісні", "пісень", "треків",
+    ]
+
+    private static func hasLocalizedCountUnit(_ text: String) -> Bool {
+        let normalized = text
+            .replacingOccurrences(of: "\u{00A0}", with: " ")
+            .replacingOccurrences(of: "\u{202F}", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        guard normalized.contains(where: \.isNumber),
+              let unit = normalized.split(whereSeparator: { character in
+                  character.isWhitespace || character.isNumber || character == "." || character == ","
+              }).last.map(String.init)
+        else { return false }
+        return Self.countMetadataUnits.contains(unit)
+            || ["выпуск", "odcin", "епізод"].contains { unit.hasPrefix($0) }
+    }
+
+    private static func fallbackCreatorName(from renderer: [String: Any]) -> String? {
+        self.metadataComponents(from: renderer).first { component in
+            !Self.isNonArtistMetadata(component)
+        }
+    }
+
+    private static func isNonArtistMetadata(_ text: String) -> Bool {
+        if self.contentKind(fromLabel: text) != nil {
+            return true
+        }
+        if ParsingHelpers.parseDuration(text) != nil || self.hasLocalizedCountUnit(text) {
+            return true
+        }
+
+        let patterns = [
+            #"^\s*\d+(?:[.,]\d+)?\s*(?:seconds?|secs?|minutes?|mins?|hours?|hrs?)\s*$"#,
+            #"^\s*\d+\s*(?:seconds?|secs?|minutes?|mins?|hours?|hrs?|days?|weeks?|months?|years?|[smhdwy])\s+ago\s*$"#,
+            #"^\s*(?:jan(?:uary)?|feb(?:ruary)?|mar(?:ch)?|apr(?:il)?|may|jun(?:e)?|jul(?:y)?|aug(?:ust)?|sep(?:tember)?|oct(?:ober)?|nov(?:ember)?|dec(?:ember)?)\.?\s+\d{1,2}(?:,\s*\d{4})?\s*$"#,
+            #"^\s*(?:\d{4}|\d{4}-\d{1,2}-\d{1,2})\s*$"#,
+        ]
+        return patterns.contains { pattern in
+            text.range(of: pattern, options: [.regularExpression, .caseInsensitive]) != nil
+        }
+    }
+
+    private static func songCount(from renderer: [String: Any]) -> Int? {
+        if renderer["flexColumns"] != nil {
+            return ParsingHelpers.extractSongCountFromFlexColumns(renderer)
+        }
+        return ParsingHelpers.extractSongCountFromSubtitle(from: renderer)
     }
 }

--- a/Sources/Kaset/Services/API/Parsers/SearchResponseParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/SearchResponseParser.swift
@@ -835,33 +835,6 @@ private extension SearchResponseParser {
         return [Artist.inline(name: fallbackName, namespace: "search-artist")]
     }
 
-    private static let countMetadataUnits: Set<String> = [
-        "subscriber", "subscribers", "view", "views", "play", "plays", "episode", "episodes", "song", "songs",
-        "track", "tracks", "حلقة", "الحلقات", "أغنية", "أغاني", "أغانٍ", "مقطوعات", "folge", "folgen",
-        "titel", "titeln", "episodio", "episodios", "canción", "canciones", "pista", "pistas", "épisode",
-        "épisodes", "morceau", "morceaux", "titre", "titres", "lagu", "trek", "episodi", "brano", "brani",
-        "에피소드", "노래", "곡", "트랙", "aflevering", "afleveringen", "nummer", "nummers", "odcinek",
-        "odcinki", "utwór", "utwory", "utworów", "utworami", "episódio", "episódios", "música", "músicas",
-        "faixa", "faixas", "выпуск", "выпуски", "трек", "треки", "треков", "avsnitt", "låt", "låtar",
-        "spår", "bölüm", "bölümler", "şarkı", "şarkılar", "parça", "епізод", "епізоди", "пісня",
-        "пісні", "пісень", "треків",
-    ]
-
-    private static func hasLocalizedCountUnit(_ text: String) -> Bool {
-        let normalized = text
-            .replacingOccurrences(of: "\u{00A0}", with: " ")
-            .replacingOccurrences(of: "\u{202F}", with: " ")
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .lowercased()
-        guard normalized.contains(where: \.isNumber),
-              let unit = normalized.split(whereSeparator: { character in
-                  character.isWhitespace || character.isNumber || character == "." || character == ","
-              }).last.map(String.init)
-        else { return false }
-        return Self.countMetadataUnits.contains(unit)
-            || ["выпуск", "odcin", "епізод"].contains { unit.hasPrefix($0) }
-    }
-
     private static func fallbackCreatorName(from renderer: [String: Any]) -> String? {
         self.metadataComponents(from: renderer).first { component in
             !Self.isNonArtistMetadata(component)

--- a/Sources/Kaset/Services/API/YTMusicClient.swift
+++ b/Sources/Kaset/Services/API/YTMusicClient.swift
@@ -426,7 +426,7 @@ final class YTMusicClient: YTMusicClientProtocol {
 
         let data = try await request("search", body: body, ttl: APICache.TTL.search)
         let response = SearchResponseParser.parse(data)
-        self.logger.info("Search found \(response.songs.count) songs, \(response.albums.count) albums, \(response.artists.count) artists, \(response.playlists.count) playlists")
+        self.logger.info("Search found \(response.allItems.count) ordered results")
         return response
     }
 
@@ -434,13 +434,9 @@ final class YTMusicClient: YTMusicClientProtocol {
     func searchSongs(query: String) async throws -> [Song] {
         self.logger.info("Searching songs only for: \(query)")
 
-        // YouTube Music API params for songs filter
-        // Derived from: EgWKAQ (filtered) + II (songs) + AWoMEA4QChADEAQQCRAF (no spelling correction)
-        let songsFilterParams = "EgWKAQIIAWoMEA4QChADEAQQCRAF"
-
         let body: [String: Any] = [
             "query": query,
-            "params": songsFilterParams,
+            "params": SearchFilterParams.songs,
         ]
 
         let data = try await request("search", body: body, ttl: APICache.TTL.search)
@@ -455,8 +451,10 @@ final class YTMusicClient: YTMusicClientProtocol {
     /// Pattern: EgWKAQ (base) + filter code + AWoMEA4QChADEAQQCRAF (no spelling correction)
     private enum SearchFilterParams {
         static let songs = "EgWKAQIIAWoMEA4QChADEAQQCRAF"
+        static let videos = "EgWKAQIQAWoMEA4QChADEAQQCRAF"
         static let albums = "EgWKAQIYAWoMEA4QChADEAQQCRAF"
         static let artists = "EgWKAQIgAWoMEA4QChADEAQQCRAF"
+        static let profiles = "EgWKAQJYAWoMEA4QChADEAQQCRAF"
         static let playlists = "EgWKAQIoAWoMEA4QChADEAQQCRAF"
         /// Featured playlists (first-party YouTube Music curated playlists)
         static let featuredPlaylists = "EgeKAQQoADgBagwQDhAKEAMQBBAJEAU="
@@ -464,14 +462,23 @@ final class YTMusicClient: YTMusicClientProtocol {
         static let communityPlaylists = "EgeKAQQoAEABagwQDhAKEAMQBBAJEAU="
         /// Podcasts (podcast shows)
         static let podcasts = "EgWKAQJQAWoQEBAQCRAEEAMQBRAKEBUQEQ%3D%3D"
+        static let episodes = "EgWKAQJIAWoMEA4QChADEAQQCRAF"
     }
 
-    /// Continuation token for filtered search pagination.
-    private var searchContinuationToken: String?
+    /// Searches for videos only (filtered search with pagination).
+    func searchVideos(query: String) async throws -> SearchResponse {
+        self.logger.info("Searching videos only for: \(query)")
 
-    /// Whether more search results are available to load.
-    var hasMoreSearchResults: Bool {
-        self.searchContinuationToken != nil
+        let body: [String: Any] = [
+            "query": query,
+            "params": SearchFilterParams.videos,
+        ]
+
+        let data = try await request("search", body: body, ttl: APICache.TTL.search)
+        let response = SearchResponseParser.parse(data)
+
+        self.logger.info("Videos search found \(response.videos.count) videos, hasMore: \(response.hasMore)")
+        return response
     }
 
     /// Searches for albums only (filtered search with pagination).
@@ -483,15 +490,10 @@ final class YTMusicClient: YTMusicClientProtocol {
             "params": SearchFilterParams.albums,
         ]
 
-        let generation = self.continuationGeneration
         let data = try await request("search", body: body, ttl: APICache.TTL.search)
-        let (albums, token) = SearchResponseParser.parseAlbumsOnly(data)
-        if generation == self.continuationGeneration {
-            self.searchContinuationToken = token
-        }
-
-        self.logger.info("Albums search found \(albums.count) albums, hasMore: \(token != nil)")
-        return SearchResponse(songs: [], albums: albums, artists: [], playlists: [], continuationToken: token)
+        let response = SearchResponseParser.parse(data)
+        self.logger.info("Albums search found \(response.albums.count) albums and \(response.audiobooks.count) audiobooks, hasMore: \(response.hasMore)")
+        return response
     }
 
     /// Searches for artists only (filtered search with pagination).
@@ -503,15 +505,26 @@ final class YTMusicClient: YTMusicClientProtocol {
             "params": SearchFilterParams.artists,
         ]
 
-        let generation = self.continuationGeneration
         let data = try await request("search", body: body, ttl: APICache.TTL.search)
-        let (artists, token) = SearchResponseParser.parseArtistsOnly(data)
-        if generation == self.continuationGeneration {
-            self.searchContinuationToken = token
-        }
+        let response = SearchResponseParser.parse(data)
+        self.logger.info("Artists search found \(response.artists.count) artists, hasMore: \(response.hasMore)")
+        return response
+    }
 
-        self.logger.info("Artists search found \(artists.count) artists, hasMore: \(token != nil)")
-        return SearchResponse(songs: [], albums: [], artists: artists, playlists: [], continuationToken: token)
+    /// Searches for profiles only (filtered search with pagination).
+    func searchProfiles(query: String) async throws -> SearchResponse {
+        self.logger.info("Searching profiles only for: \(query)")
+
+        let body: [String: Any] = [
+            "query": query,
+            "params": SearchFilterParams.profiles,
+        ]
+
+        let data = try await request("search", body: body, ttl: APICache.TTL.search)
+        let response = SearchResponseParser.parse(data)
+
+        self.logger.info("Profiles search found \(response.profiles.count) profiles, hasMore: \(response.hasMore)")
+        return response
     }
 
     /// Searches for playlists only (filtered search with pagination).
@@ -523,15 +536,10 @@ final class YTMusicClient: YTMusicClientProtocol {
             "params": SearchFilterParams.playlists,
         ]
 
-        let generation = self.continuationGeneration
         let data = try await request("search", body: body, ttl: APICache.TTL.search)
-        let (playlists, token) = SearchResponseParser.parsePlaylistsOnly(data)
-        if generation == self.continuationGeneration {
-            self.searchContinuationToken = token
-        }
-
-        self.logger.info("Playlists search found \(playlists.count) playlists, hasMore: \(token != nil)")
-        return SearchResponse(songs: [], albums: [], artists: [], playlists: playlists, continuationToken: token)
+        let response = SearchResponseParser.parse(data)
+        self.logger.info("Playlists search found \(response.playlists.count) playlists, hasMore: \(response.hasMore)")
+        return response
     }
 
     /// Searches for featured playlists only (YouTube Music curated playlists).
@@ -543,15 +551,10 @@ final class YTMusicClient: YTMusicClientProtocol {
             "params": SearchFilterParams.featuredPlaylists,
         ]
 
-        let generation = self.continuationGeneration
         let data = try await request("search", body: body, ttl: APICache.TTL.search)
-        let (playlists, token) = SearchResponseParser.parsePlaylistsOnly(data)
-        if generation == self.continuationGeneration {
-            self.searchContinuationToken = token
-        }
-
-        self.logger.info("Featured playlists search found \(playlists.count) playlists, hasMore: \(token != nil)")
-        return SearchResponse(songs: [], albums: [], artists: [], playlists: playlists, continuationToken: token)
+        let response = SearchResponseParser.parse(data)
+        self.logger.info("Featured playlists search found \(response.playlists.count) playlists, hasMore: \(response.hasMore)")
+        return response
     }
 
     /// Searches for community playlists only (user-created playlists).
@@ -563,15 +566,10 @@ final class YTMusicClient: YTMusicClientProtocol {
             "params": SearchFilterParams.communityPlaylists,
         ]
 
-        let generation = self.continuationGeneration
         let data = try await request("search", body: body, ttl: APICache.TTL.search)
-        let (playlists, token) = SearchResponseParser.parsePlaylistsOnly(data)
-        if generation == self.continuationGeneration {
-            self.searchContinuationToken = token
-        }
-
-        self.logger.info("Community playlists search found \(playlists.count) playlists, hasMore: \(token != nil)")
-        return SearchResponse(songs: [], albums: [], artists: [], playlists: playlists, continuationToken: token)
+        let response = SearchResponseParser.parse(data)
+        self.logger.info("Community playlists search found \(response.playlists.count) playlists, hasMore: \(response.hasMore)")
+        return response
     }
 
     /// Searches for podcasts only (podcast shows).
@@ -583,22 +581,10 @@ final class YTMusicClient: YTMusicClientProtocol {
             "params": SearchFilterParams.podcasts,
         ]
 
-        let generation = self.continuationGeneration
         let data = try await request("search", body: body, ttl: APICache.TTL.search)
-        let (podcastShows, token) = SearchResponseParser.parsePodcastsOnly(data)
-        if generation == self.continuationGeneration {
-            self.searchContinuationToken = token
-        }
-
-        self.logger.info("Podcasts search found \(podcastShows.count) shows, hasMore: \(token != nil)")
-        return SearchResponse(
-            songs: [],
-            albums: [],
-            artists: [],
-            playlists: [],
-            podcastShows: podcastShows,
-            continuationToken: token
-        )
+        let response = SearchResponseParser.parse(data)
+        self.logger.info("Podcasts search found \(response.podcastShows.count) shows, hasMore: \(response.hasMore)")
+        return response
     }
 
     /// Searches for songs only with pagination support.
@@ -610,58 +596,54 @@ final class YTMusicClient: YTMusicClientProtocol {
             "params": SearchFilterParams.songs,
         ]
 
-        let generation = self.continuationGeneration
         let data = try await request("search", body: body, ttl: APICache.TTL.search)
-        let (songs, token) = SearchResponseParser.parseSongsWithContinuation(data)
-        if generation == self.continuationGeneration {
-            self.searchContinuationToken = token
-        }
-
-        self.logger.info("Songs search found \(songs.count) songs, hasMore: \(token != nil)")
-        return SearchResponse(songs: songs, albums: [], artists: [], playlists: [], continuationToken: token)
+        let response = SearchResponseParser.parse(data)
+        self.logger.info("Songs search found \(response.songs.count) songs, hasMore: \(response.hasMore)")
+        return response
     }
 
-    /// Fetches the next batch of search results via continuation.
-    /// Returns nil if no more results are available.
-    func getSearchContinuation() async throws -> SearchResponse? {
-        guard let token = searchContinuationToken else {
-            self.logger.debug("No search continuation token available")
-            return nil
-        }
+    /// Searches for podcast episodes only (filtered search with pagination).
+    func searchEpisodes(query: String) async throws -> SearchResponse {
+        self.logger.info("Searching podcast episodes only for: \(query)")
 
+        let body: [String: Any] = [
+            "query": query,
+            "params": SearchFilterParams.episodes,
+        ]
+
+        let data = try await request("search", body: body, ttl: APICache.TTL.search)
+        let response = SearchResponseParser.parse(data)
+
+        self.logger.info("Episodes search found \(response.podcastEpisodes.count) episodes, hasMore: \(response.hasMore)")
+        return response
+    }
+
+    /// Fetches the next batch of search results for an explicit continuation value.
+    func getSearchContinuation(token: String) async throws -> SearchResponse {
         self.logger.info("Fetching search continuation")
         let generation = self.continuationGeneration
 
-        do {
-            let continuationData = try await requestContinuation(token, ttl: APICache.TTL.search)
-            let response = SearchResponseParser.parseContinuation(continuationData)
-            guard generation == self.continuationGeneration else {
-                self.logger.info("Discarding stale search continuation after session reset")
-                return nil
-            }
-            self.searchContinuationToken = response.continuationToken
-
-            self.logger.info("Search continuation loaded: \(response.allItems.count) items, hasMore: \(response.hasMore)")
-            return response
-        } catch {
-            self.logger.warning("Failed to fetch search continuation: \(error.localizedDescription)")
-            self.searchContinuationToken = nil
-            throw error
+        let body: [String: Any] = [
+            "continuation": token,
+        ]
+        let continuationData = try await request("search", body: body, ttl: APICache.TTL.search)
+        guard generation == self.continuationGeneration else {
+            self.logger.info("Discarding stale search continuation after session reset")
+            throw CancellationError()
         }
-    }
+        let response = SearchResponseParser.parseContinuation(continuationData)
 
-    /// Clears the search continuation token.
-    func clearSearchContinuation() {
-        self.searchContinuationToken = nil
+        self.logger.info("Search continuation loaded: \(response.allItems.count) items, hasMore: \(response.hasMore)")
+        return response
     }
 
     /// Clears cached continuation/session state when switching accounts.
     func resetSessionStateForAccountSwitch() {
         self.logger.info("Resetting client session state for account switch")
         self.continuationGeneration &+= 1
+        APICache.shared.invalidateAll()
         self.continuationTokens.removeAll()
         self.personalizedRecommendationsContinuationToken = nil
-        self.searchContinuationToken = nil
         self.likedSongsContinuationToken = nil
     }
 
@@ -1855,6 +1837,10 @@ final class YTMusicClient: YTMusicClientProtocol {
         ttl: TimeInterval? = nil,
         authPolicy explicitAuthPolicy: RequestAuthPolicy? = nil
     ) async throws -> [String: Any] {
+        // Account and guest-mode transitions invalidate the shared API cache.
+        // Capture its generation before any auth/network await so stale responses
+        // cannot repopulate the cache after a session reset.
+        let cacheGeneration = APICache.shared.generation
         let authPolicy = explicitAuthPolicy ?? self.authPolicy(forEndpoint: endpoint, body: body)
         let requestAuth = try await self.buildRequestHeaders(authPolicy: authPolicy)
 
@@ -1882,8 +1868,11 @@ final class YTMusicClient: YTMusicClientProtocol {
             )
         }
 
-        // Cache response if TTL specified.
-        if let ttl {
+        // Cache only if no account/guest transition happened while the
+        // request was in flight. YTMusicClient and APICache are both
+        // @MainActor, so this comparison and the synchronous set below are
+        // atomic relative to invalidateAll().
+        if let ttl, cacheGeneration == APICache.shared.generation {
             APICache.shared.set(key: cacheKey, data: json, ttl: ttl)
         }
 

--- a/Sources/Kaset/Services/Protocols.swift
+++ b/Sources/Kaset/Services/Protocols.swift
@@ -135,11 +135,17 @@ protocol YTMusicClientProtocol: Sendable {
     /// Searches for songs only with pagination support.
     func searchSongsWithPagination(query: String) async throws -> SearchResponse
 
+    /// Searches for videos only (filtered search with pagination).
+    func searchVideos(query: String) async throws -> SearchResponse
+
     /// Searches for albums only (filtered search with pagination).
     func searchAlbums(query: String) async throws -> SearchResponse
 
     /// Searches for artists only (filtered search with pagination).
     func searchArtists(query: String) async throws -> SearchResponse
+
+    /// Searches for profiles only (filtered search with pagination).
+    func searchProfiles(query: String) async throws -> SearchResponse
 
     /// Searches for playlists only (filtered search with pagination).
     func searchPlaylists(query: String) async throws -> SearchResponse
@@ -153,15 +159,11 @@ protocol YTMusicClientProtocol: Sendable {
     /// Searches for podcasts only (podcast shows).
     func searchPodcasts(query: String) async throws -> SearchResponse
 
-    /// Fetches the next batch of search results via continuation.
-    /// Returns nil if no more results are available.
-    func getSearchContinuation() async throws -> SearchResponse?
+    /// Searches for podcast episodes only (filtered search with pagination).
+    func searchEpisodes(query: String) async throws -> SearchResponse
 
-    /// Whether more search results are available to load.
-    var hasMoreSearchResults: Bool { get }
-
-    /// Clears the search continuation token.
-    func clearSearchContinuation()
+    /// Fetches the next batch of search results for an explicit continuation value.
+    func getSearchContinuation(token: String) async throws -> SearchResponse
 
     /// Clears cached continuation/session state when switching accounts.
     func resetSessionStateForAccountSwitch()

--- a/Sources/Kaset/ViewModels/SearchViewModel.swift
+++ b/Sources/Kaset/ViewModels/SearchViewModel.swift
@@ -12,6 +12,9 @@ final class SearchViewModel {
     /// Current search query.
     var query: String = "" {
         didSet {
+            if oldValue != self.query {
+                self.resultGeneration &+= 1
+            }
             self.searchTask?.cancel()
             self.suggestionsTask?.cancel()
             self.allSearchEnrichmentID = nil
@@ -24,12 +27,10 @@ final class SearchViewModel {
                 self.loadingState = .idle
                 self.lastSearchedQuery = nil
                 self.suppressedSuggestionsQuery = nil
-                self.client.clearSearchContinuation()
             } else if self.query != self.lastSearchedQuery {
                 // Clear results when query changes from what was searched
                 self.results = .empty
                 self.loadingState = .idle
-                self.client.clearSearchContinuation()
             }
         }
     }
@@ -94,18 +95,21 @@ final class SearchViewModel {
     var hasMoreResults: Bool {
         // For "All" filter, we don't support pagination (mixed results)
         guard self.selectedFilter != .all else { return false }
-        return self.client.hasMoreSearchResults
+        return self.results.hasMore
     }
 
     /// Available filters.
     enum SearchFilter: String, CaseIterable, Identifiable {
         case all = "All"
         case songs = "Songs"
+        case videos = "Videos"
         case albums = "Albums"
         case artists = "Artists"
+        case profiles = "Profiles"
         case featuredPlaylists = "Featured playlists"
         case communityPlaylists = "Community playlists"
         case podcasts = "Podcasts"
+        case episodes = "Episodes"
 
         var id: String {
             rawValue
@@ -117,16 +121,22 @@ final class SearchViewModel {
                 String(localized: "All")
             case .songs:
                 String(localized: "Songs")
+            case .videos:
+                String(localized: "Videos")
             case .albums:
                 String(localized: "Albums")
             case .artists:
                 String(localized: "Artists")
+            case .profiles:
+                String(localized: "Profiles")
             case .featuredPlaylists:
                 String(localized: "Featured playlists")
             case .communityPlaylists:
                 String(localized: "Community playlists")
             case .podcasts:
                 String(localized: "Podcasts")
+            case .episodes:
+                String(localized: "Episodes")
             }
         }
     }
@@ -138,14 +148,27 @@ final class SearchViewModel {
             self.results.allItems
         case .songs:
             self.results.songs.map { .song($0) }
+        case .videos:
+            self.results.videos.map { .video($0) }
         case .albums:
-            self.results.albums.map { .album($0) }
+            self.results.allItems.filter { item in
+                switch item {
+                case .album, .audiobook:
+                    true
+                default:
+                    false
+                }
+            }
         case .artists:
             self.results.artists.map { .artist($0) }
+        case .profiles:
+            self.results.profiles.map { .profile($0) }
         case .featuredPlaylists, .communityPlaylists:
             self.results.playlists.map { .playlist($0) }
         case .podcasts:
             self.results.podcastShows.map { .podcastShow($0) }
+        case .episodes:
+            self.results.podcastEpisodes.map { .podcastEpisode($0) }
         }
     }
 
@@ -156,6 +179,7 @@ final class SearchViewModel {
     /// nonisolated(unsafe) required for deinit access; Swift 6.2 warning is expected.
     @ObservationIgnored private var searchTask: Task<Void, Never>?
     @ObservationIgnored private var suggestionsTask: Task<Void, Never>?
+    @ObservationIgnored private var resultGeneration: UInt = 0
     @ObservationIgnored private var suppressedSuggestionsQuery: String?
     // swiftformat:enable modifierOrder
 
@@ -165,9 +189,7 @@ final class SearchViewModel {
     }
 
     /// Non-nil while an All-filter search has published its mixed first paint
-    /// but is still awaiting dedicated category requests. Filter chips stay
-    /// hidden during this window because those category calls can still update
-    /// the shared client continuation token.
+    /// but is still awaiting dedicated category requests.
     private var allSearchEnrichmentID: UUID?
 
     init(client: any YTMusicClientProtocol) {
@@ -233,12 +255,12 @@ final class SearchViewModel {
 
     /// Performs a search with debounce.
     func search() {
+        self.resultGeneration &+= 1
         self.searchTask?.cancel()
         self.suggestionsTask?.cancel()
         self.allSearchEnrichmentID = nil
         self.suggestions = []
         self.suppressedSuggestionsQuery = self.query
-        self.client.clearSearchContinuation()
 
         guard !self.query.isEmpty else {
             self.results = .empty
@@ -258,12 +280,12 @@ final class SearchViewModel {
 
     /// Performs a search immediately without debounce.
     func searchImmediately() {
+        self.resultGeneration &+= 1
         self.searchTask?.cancel()
         self.suggestionsTask?.cancel()
         self.allSearchEnrichmentID = nil
         self.suggestions = []
         self.suppressedSuggestionsQuery = self.query
-        self.client.clearSearchContinuation()
 
         guard !self.query.isEmpty else {
             self.results = .empty
@@ -278,9 +300,9 @@ final class SearchViewModel {
 
     /// Performs a search with the current filter (no debounce, called when filter changes).
     private func searchWithFilter() {
+        self.resultGeneration &+= 1
         self.searchTask?.cancel()
         self.allSearchEnrichmentID = nil
-        self.client.clearSearchContinuation()
 
         guard !self.query.isEmpty else {
             self.results = .empty
@@ -313,26 +335,10 @@ final class SearchViewModel {
         self.logger.info("Searching for: \(currentQuery) with filter: \(currentFilter.rawValue)")
 
         do {
-            let searchResults: SearchResponse
-
-                // Use filtered search for specific filters to get more results
-                = switch currentFilter
-            {
-            case .all:
-                try await self.searchAll(query: currentQuery, filter: currentFilter)
-            case .songs:
-                try await self.client.searchSongsWithPagination(query: currentQuery)
-            case .albums:
-                try await self.client.searchAlbums(query: currentQuery)
-            case .artists:
-                try await self.client.searchArtists(query: currentQuery)
-            case .featuredPlaylists:
-                try await self.client.searchFeaturedPlaylists(query: currentQuery)
-            case .communityPlaylists:
-                try await self.client.searchCommunityPlaylists(query: currentQuery)
-            case .podcasts:
-                try await self.client.searchPodcasts(query: currentQuery)
-            }
+            let searchResults = try await self.executeSearch(
+                query: currentQuery,
+                filter: currentFilter
+            )
 
             // Check cancellation and query change before updating results
             // This handles the race condition where query changed during the request
@@ -349,6 +355,32 @@ final class SearchViewModel {
                 self.logger.error("Search failed: \(error.localizedDescription)")
                 self.loadingState = .error(LoadingError(from: error))
             }
+        }
+    }
+
+    /// Routes one query to the endpoint owned by the selected filter.
+    private func executeSearch(query: String, filter: SearchFilter) async throws -> SearchResponse {
+        switch filter {
+        case .all:
+            try await self.searchAll(query: query, filter: filter)
+        case .songs:
+            try await self.client.searchSongsWithPagination(query: query)
+        case .videos:
+            try await self.client.searchVideos(query: query)
+        case .albums:
+            try await self.client.searchAlbums(query: query)
+        case .artists:
+            try await self.client.searchArtists(query: query)
+        case .profiles:
+            try await self.client.searchProfiles(query: query)
+        case .featuredPlaylists:
+            try await self.client.searchFeaturedPlaylists(query: query)
+        case .communityPlaylists:
+            try await self.client.searchCommunityPlaylists(query: query)
+        case .podcasts:
+            try await self.client.searchPodcasts(query: query)
+        case .episodes:
+            try await self.client.searchEpisodes(query: query)
         }
     }
 
@@ -397,11 +429,17 @@ final class SearchViewModel {
         async let songResults = self.attemptSearch(label: "songs search") {
             try await self.client.searchSongsWithPagination(query: query)
         }
+        async let videoResults = self.attemptSearch(label: "videos search") {
+            try await self.client.searchVideos(query: query)
+        }
         async let albumResults = self.attemptSearch(label: "albums search") {
             try await self.client.searchAlbums(query: query)
         }
         async let artistResults = self.attemptSearch(label: "artists search") {
             try await self.client.searchArtists(query: query)
+        }
+        async let profileResults = self.attemptSearch(label: "profiles search") {
+            try await self.client.searchProfiles(query: query)
         }
         async let featuredPlaylistResults = self.attemptSearch(label: "featured playlists search") {
             try await self.client.searchFeaturedPlaylists(query: query)
@@ -412,14 +450,20 @@ final class SearchViewModel {
         async let podcastResults = self.attemptSearch(label: "podcasts search") {
             try await self.client.searchPodcasts(query: query)
         }
+        async let episodeResults = self.attemptSearch(label: "episodes search") {
+            try await self.client.searchEpisodes(query: query)
+        }
 
         let attempts = await [
             songResults,
+            videoResults,
             albumResults,
             artistResults,
+            profileResults,
             featuredPlaylistResults,
             communityPlaylistResults,
             podcastResults,
+            episodeResults,
         ]
 
         if let authError = attempts.compactMap(\.error).compactMap(Self.authenticationError).first {
@@ -459,44 +503,16 @@ final class SearchViewModel {
 
     /// Combines multiple search responses while keeping the first occurrence of each item.
     private static func mergeSearchResponses(_ responses: [SearchResponse]) -> SearchResponse {
-        var songs: [Song] = []
-        var albums: [Album] = []
-        var artists: [Artist] = []
-        var playlists: [Playlist] = []
-        var podcastShows: [PodcastShow] = []
-
-        var seenSongIDs: Set<String> = []
-        var seenAlbumIDs: Set<String> = []
-        var seenArtistIDs: Set<String> = []
-        var seenPlaylistIDs: Set<String> = []
-        var seenPodcastIDs: Set<String> = []
+        var items: [SearchResultItem] = []
+        var seenContent: Set<String> = []
 
         for response in responses {
-            for song in response.songs where seenSongIDs.insert(song.id).inserted {
-                songs.append(song)
-            }
-            for album in response.albums where seenAlbumIDs.insert(album.id).inserted {
-                albums.append(album)
-            }
-            for artist in response.artists where seenArtistIDs.insert(artist.id).inserted {
-                artists.append(artist)
-            }
-            for playlist in response.playlists where seenPlaylistIDs.insert(playlist.id).inserted {
-                playlists.append(playlist)
-            }
-            for podcastShow in response.podcastShows where seenPodcastIDs.insert(podcastShow.id).inserted {
-                podcastShows.append(podcastShow)
+            for item in response.allItems where seenContent.insert(item.contentIdentity).inserted {
+                items.append(item)
             }
         }
 
-        return SearchResponse(
-            songs: songs,
-            albums: albums,
-            artists: artists,
-            playlists: playlists,
-            podcastShows: podcastShows,
-            continuationToken: nil
-        )
+        return SearchResponse(items: items, continuationToken: nil)
     }
 
     /// Loads more search results via continuation.
@@ -505,37 +521,69 @@ final class SearchViewModel {
         guard self.selectedFilter != .all else { return }
         guard self.loadingState == .loaded else { return }
         guard self.hasMoreResults else { return }
+        guard let continuationToken = self.results.continuationToken else { return }
+
+        let generation = self.resultGeneration
+        let currentQuery = self.query
+        let currentFilter = self.selectedFilter
+        let baseResults = self.results
 
         self.loadingState = .loadingMore
         self.logger.info("Loading more search results")
 
         do {
-            guard let continuation = try await client.getSearchContinuation() else {
-                self.loadingState = .loaded
+            let continuation = try await self.client.getSearchContinuation(token: continuationToken)
+
+            guard self.isCurrentPagination(
+                query: currentQuery,
+                filter: currentFilter,
+                token: continuationToken,
+                generation: generation
+            ) else {
+                self.logger.debug("Search continuation discarded: query/filter/results changed")
                 return
             }
 
-            // Merge continuation results with existing results
-            let mergedResults = SearchResponse(
-                songs: self.results.songs + continuation.songs,
-                albums: self.results.albums + continuation.albums,
-                artists: self.results.artists + continuation.artists,
-                playlists: self.results.playlists + continuation.playlists,
-                podcastShows: self.results.podcastShows + continuation.podcastShows,
+            let mergedResults = Self.mergeSearchResponses([baseResults, continuation])
+            let paginatedResults = SearchResponse(
+                items: mergedResults.allItems,
                 continuationToken: continuation.continuationToken
             )
 
-            self.results = mergedResults
+            self.results = paginatedResults
             self.loadingState = .loaded
-            self.logger.info("Loaded more results: now \(mergedResults.allItems.count) total, hasMore: \(mergedResults.hasMore)")
+            self.logger.info("Loaded more results: now \(paginatedResults.allItems.count) total, hasMore: \(paginatedResults.hasMore)")
         } catch {
+            guard self.isCurrentPagination(
+                query: currentQuery,
+                filter: currentFilter,
+                token: continuationToken,
+                generation: generation
+            ) else {
+                return
+            }
             self.logger.error("Failed to load more: \(error.localizedDescription)")
             self.loadingState = .loaded // Revert to loaded state to allow retry
         }
     }
 
+    private func isCurrentPagination(
+        query: String,
+        filter: SearchFilter,
+        token: String,
+        generation: UInt
+    ) -> Bool {
+        !Task.isCancelled
+            && self.resultGeneration == generation
+            && self.query == query
+            && self.selectedFilter == filter
+            && self.results.continuationToken == token
+            && self.loadingState == .loadingMore
+    }
+
     /// Clears search results.
     func clear() {
+        self.resultGeneration &+= 1
         self.searchTask?.cancel()
         self.suggestionsTask?.cancel()
         self.query = ""
@@ -546,6 +594,5 @@ final class SearchViewModel {
         self.suppressedSuggestionsQuery = nil
         self.allSearchEnrichmentID = nil
         self.loadingState = .idle
-        self.client.clearSearchContinuation()
     }
 }

--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -267,6 +267,7 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
         }
         .onChange(of: self.accountService.currentAccount?.id) { _, newAccountId in
             self.playerService.resetTrackStatus()
+            self.searchViewModel?.clear()
             self.podcastsViewModel?.configure(
                 availabilityService: self.podcastsAvailability,
                 accountId: newAccountId

--- a/Sources/Kaset/Views/PodcastsView.swift
+++ b/Sources/Kaset/Views/PodcastsView.swift
@@ -467,23 +467,10 @@ struct PodcastShowView: View {
 
     /// Plays an episode and queues the remaining episodes from the show.
     private func playEpisodeInQueue(at index: Int) {
-        let songs = self.episodes.map { self.episodeToSong($0) }
+        let songs = self.episodes.map(\.playbackSong)
         Task {
             await self.playerService.playQueue(songs, startingAt: index)
         }
-    }
-
-    /// Converts a podcast episode to a Song for playback.
-    private func episodeToSong(_ episode: PodcastEpisode) -> Song {
-        Song(
-            id: episode.id,
-            title: episode.title,
-            artists: episode.showTitle.map { [Artist(id: "podcast", name: $0)] } ?? [],
-            album: nil,
-            duration: episode.durationSeconds.map { TimeInterval($0) },
-            thumbnailURL: episode.thumbnailURL,
-            videoId: episode.id
-        )
     }
 
     private func toggleSubscription() async {
@@ -677,23 +664,10 @@ struct AllEpisodesView: View {
 
     /// Plays an episode and queues the remaining episodes.
     private func playEpisodeInQueue(at index: Int) {
-        let songs = self.episodes.map { self.episodeToSong($0) }
+        let songs = self.episodes.map(\.playbackSong)
         Task {
             await self.playerService.playQueue(songs, startingAt: index)
         }
-    }
-
-    /// Converts a podcast episode to a Song for playback.
-    private func episodeToSong(_ episode: PodcastEpisode) -> Song {
-        Song(
-            id: episode.id,
-            title: episode.title,
-            artists: episode.showTitle.map { [Artist(id: "podcast", name: $0)] } ?? [],
-            album: nil,
-            duration: episode.durationSeconds.map { TimeInterval($0) },
-            thumbnailURL: episode.thumbnailURL,
-            videoId: episode.id
-        )
     }
 }
 

--- a/Sources/Kaset/Views/SearchView.swift
+++ b/Sources/Kaset/Views/SearchView.swift
@@ -248,9 +248,9 @@ struct SearchView: View {
             switch self.viewModel.loadingState {
             case .idle:
                 self.emptyStateView
-            case .loading, .loadingMore:
+            case .loading:
                 LoadingView(String(localized: "Searching..."))
-            case .loaded:
+            case .loaded, .loadingMore:
                 if self.viewModel.filteredItems.isEmpty {
                     self.noResultsView
                 } else {
@@ -367,7 +367,7 @@ struct SearchView: View {
                             }
                     }
                     .frame(width: 48, height: 48)
-                    .clipShape(.rect(cornerRadius: item.isArtist ? 24 : 6))
+                    .clipShape(.rect(cornerRadius: item.usesCircularThumbnail ? 24 : 6))
 
                     // Info
                     VStack(alignment: .leading, spacing: 2) {
@@ -375,7 +375,7 @@ struct SearchView: View {
                             Text(item.title)
                                 .font(.system(size: 14))
                                 .lineLimit(1)
-                            if case let .song(song) = item, song.isExplicit == true {
+                            if let song = self.songResultPayload(for: item), song.isExplicit == true {
                                 ExplicitBadge()
                             }
                         }
@@ -401,7 +401,7 @@ struct SearchView: View {
                     Spacer()
 
                     // Favorite toggle for songs
-                    if case let .song(song) = item {
+                    if let song = self.songResultPayload(for: item) {
                         LikeButton(song: song, isRowHovered: isHovered, allowsActions: self.authService.hasPersonalAccount)
                     }
 
@@ -427,16 +427,20 @@ struct SearchView: View {
     @ViewBuilder
     private func contextMenuItems(for item: SearchResultItem) -> some View {
         switch item {
-        case let .song(song):
+        case let .song(song), let .video(song):
             self.songContextMenu(song)
         case let .album(album):
             self.albumContextMenu(album)
-        case let .artist(artist):
+        case let .audiobook(audiobook):
+            self.albumContextMenu(audiobook, isAudiobook: true)
+        case let .artist(artist), let .profile(artist):
             self.artistContextMenu(artist)
         case let .playlist(playlist):
             self.playlistContextMenu(playlist)
         case let .podcastShow(show):
             self.podcastShowContextMenu(show)
+        case let .podcastEpisode(episode):
+            self.podcastEpisodeContextMenu(episode)
         }
     }
 
@@ -510,7 +514,10 @@ struct SearchView: View {
     }
 
     @ViewBuilder
-    private func albumContextMenu(_ album: Album) -> some View {
+    private func albumContextMenu(_ album: Album, isAudiobook: Bool = false) -> some View {
+        let viewTitle = isAudiobook ? String(localized: "View Audiobook") : String(localized: "View Album")
+        let icon = isAudiobook ? "books.vertical" : "square.stack"
+
         Button {
             let playlist = Playlist(
                 id: album.id,
@@ -522,12 +529,12 @@ struct SearchView: View {
             )
             self.navigationPath.append(playlist)
         } label: {
-            Label(String(localized: "View Album"), systemImage: "square.stack")
+            Label(viewTitle, systemImage: icon)
         }
 
         Divider()
 
-        // Play / Play Next / Add to Queue for albums
+        // Play / Play Next / Add to Queue for albums and audiobooks
         Button {
             SongActionsHelper.playAlbum(
                 album,
@@ -570,7 +577,12 @@ struct SearchView: View {
         Button {
             self.navigationPath.append(artist)
         } label: {
-            Label(String(localized: "View Artist"), systemImage: "person")
+            Label(
+                artist.profileKind == .profile
+                    ? String(localized: "View Profile")
+                    : String(localized: "View Artist"),
+                systemImage: artist.profileKind == .profile ? "person.crop.circle" : "person"
+            )
         }
 
         Divider()
@@ -626,33 +638,78 @@ struct SearchView: View {
         FavoritesContextMenu.menuItem(for: show, manager: self.favoritesManager)
     }
 
+    @ViewBuilder
+    private func podcastEpisodeContextMenu(_ episode: PodcastEpisode) -> some View {
+        let song = episode.playbackSong
+        Button {
+            Task { await self.playerService.play(song: song) }
+        } label: {
+            Label(String(localized: "Play"), systemImage: "play.fill")
+        }
+
+        Divider()
+
+        AddToQueueContextMenu(song: song, playerService: self.playerService)
+
+        Divider()
+
+        ShareContextMenu.menuItem(for: song)
+
+        if let showBrowseId = episode.showBrowseId,
+           let showTitle = episode.showTitle
+        {
+            Divider()
+
+            Button {
+                self.navigationPath.append(PodcastShow(
+                    id: showBrowseId,
+                    title: showTitle,
+                    author: nil,
+                    description: nil,
+                    thumbnailURL: episode.thumbnailURL,
+                    episodeCount: nil
+                ))
+            } label: {
+                Label(String(localized: "View Podcast"), systemImage: "mic.fill")
+            }
+        }
+    }
+
     // MARK: - Helpers
 
     private func iconForItem(_ item: SearchResultItem) -> String {
         switch item {
         case .song:
             "music.note"
+        case .video:
+            "play.rectangle"
         case .album:
             "square.stack"
+        case .audiobook:
+            "books.vertical"
         case .artist:
             "person"
+        case .profile:
+            "person.crop.circle"
         case .playlist:
             "music.note.list"
         case .podcastShow:
             "mic.fill"
+        case .podcastEpisode:
+            "mic.badge.plus"
         }
     }
 
     private func handleItemTap(_ item: SearchResultItem) {
         switch item {
-        case let .song(song):
+        case let .song(song), let .video(song):
             // Play the song and fetch similar songs (radio queue) in the background
             Task {
                 await self.playerService.playWithRadio(song: song)
             }
-        case let .artist(artist):
+        case let .artist(artist), let .profile(artist):
             self.navigationPath.append(artist)
-        case let .album(album):
+        case let .album(album), let .audiobook(album):
             // Navigate as playlist for now
             let playlist = Playlist(
                 id: album.id,
@@ -667,16 +724,20 @@ struct SearchView: View {
             self.navigationPath.append(playlist)
         case let .podcastShow(show):
             self.navigationPath.append(show)
+        case let .podcastEpisode(episode):
+            Task {
+                await self.playerService.play(song: episode.playbackSong)
+            }
         }
     }
-}
 
-extension SearchResultItem {
-    var isArtist: Bool {
-        if case .artist = self {
-            return true
+    private func songResultPayload(for item: SearchResultItem) -> Song? {
+        switch item {
+        case let .song(song), let .video(song):
+            song
+        default:
+            nil
         }
-        return false
     }
 }
 

--- a/Sources/Kaset/Views/SharedViews/FavoritesContextMenu.swift
+++ b/Sources/Kaset/Views/SharedViews/FavoritesContextMenu.swift
@@ -64,16 +64,18 @@ enum FavoritesContextMenu {
     @ViewBuilder
     static func menuItem(for item: SearchResultItem, manager: FavoritesManager) -> some View {
         switch item {
-        case let .song(song):
+        case let .song(song), let .video(song):
             Self.menuItem(for: song, manager: manager)
-        case let .album(album):
+        case let .album(album), let .audiobook(album):
             Self.menuItem(for: album, manager: manager)
         case let .playlist(playlist):
             Self.menuItem(for: playlist, manager: manager)
-        case let .artist(artist):
+        case let .artist(artist), let .profile(artist):
             Self.menuItem(for: artist, manager: manager)
         case let .podcastShow(show):
             Self.menuItem(for: show, manager: manager)
+        case .podcastEpisode:
+            EmptyView()
         }
     }
 }

--- a/Sources/Kaset/Views/SharedViews/ShareContextMenu.swift
+++ b/Sources/Kaset/Views/SharedViews/ShareContextMenu.swift
@@ -125,16 +125,18 @@ enum ShareContextMenu {
     @ViewBuilder
     static func menuItem(for item: SearchResultItem) -> some View {
         switch item {
-        case let .song(song):
+        case let .song(song), let .video(song):
             Self.menuItem(for: song)
-        case let .album(album):
+        case let .album(album), let .audiobook(album):
             Self.menuItem(for: album)
         case let .playlist(playlist):
             Self.menuItem(for: playlist)
-        case let .artist(artist):
+        case let .artist(artist), let .profile(artist):
             Self.menuItem(for: artist)
         case let .podcastShow(show):
             Self.menuItem(for: show)
+        case let .podcastEpisode(episode):
+            Self.menuItem(for: episode.playbackSong)
         }
     }
 

--- a/Tests/KasetTests/Fixtures/search_direct_item_section.json
+++ b/Tests/KasetTests/Fixtures/search_direct_item_section.json
@@ -1,0 +1,125 @@
+{
+  "contents": {
+    "sectionListRenderer": {
+      "contents": [
+        {
+          "itemSectionRenderer": {
+            "contents": [
+              {
+                "musicResponsiveListItemRenderer": {
+                  "playlistItemData": {
+                    "videoId": "direct-song-video"
+                  },
+                  "flexColumns": [
+                    {
+                      "musicResponsiveListItemFlexColumnRenderer": {
+                        "text": {
+                          "runs": [
+                            {
+                              "text": "Direct Song"
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "musicResponsiveListItemFlexColumnRenderer": {
+                        "text": {
+                          "runs": [
+                            {
+                              "text": "Song"
+                            },
+                            {
+                              "text": " • "
+                            },
+                            {
+                              "text": "Fixture Artist",
+                              "navigationEndpoint": {
+                                "browseEndpoint": {
+                                  "browseId": "UCfixture-artist",
+                                  "browseEndpointContextSupportedConfigs": {
+                                    "browseEndpointContextMusicConfig": {
+                                      "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ],
+                  "navigationEndpoint": {
+                    "watchEndpoint": {
+                      "videoId": "direct-song-video",
+                      "watchEndpointMusicSupportedConfigs": {
+                        "watchEndpointMusicConfig": {
+                          "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "musicResponsiveListItemRenderer": {
+                  "navigationEndpoint": {
+                    "browseEndpoint": {
+                      "browseId": "MPREdirect-album",
+                      "browseEndpointContextSupportedConfigs": {
+                        "browseEndpointContextMusicConfig": {
+                          "pageType": "MUSIC_PAGE_TYPE_ALBUM"
+                        }
+                      }
+                    }
+                  },
+                  "flexColumns": [
+                    {
+                      "musicResponsiveListItemFlexColumnRenderer": {
+                        "text": {
+                          "runs": [
+                            {
+                              "text": "Direct Album"
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "musicResponsiveListItemFlexColumnRenderer": {
+                        "text": {
+                          "runs": [
+                            {
+                              "text": "Album"
+                            },
+                            {
+                              "text": " • "
+                            },
+                            {
+                              "text": "Fixture Artist",
+                              "navigationEndpoint": {
+                                "browseEndpoint": {
+                                  "browseId": "UCfixture-artist",
+                                  "browseEndpointContextSupportedConfigs": {
+                                    "browseEndpointContextMusicConfig": {
+                                      "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Tests/KasetTests/Fixtures/search_later_flex_columns.json
+++ b/Tests/KasetTests/Fixtures/search_later_flex_columns.json
@@ -1,0 +1,52 @@
+{
+  "contents": {
+    "sectionListRenderer": {
+      "contents": [
+        {
+          "musicResponsiveListItemRenderer": {
+            "navigationEndpoint": {
+              "browseEndpoint": {
+                "browseId": "MPREthird-column"
+              }
+            },
+            "flexColumns": [
+              {
+                "musicResponsiveListItemFlexColumnRenderer": {
+                  "text": {
+                    "runs": [
+                      {
+                        "text": "Third Column Album"
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "musicResponsiveListItemFlexColumnRenderer": {
+                  "text": {
+                    "runs": [
+                      {
+                        "text": "Album"
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "musicResponsiveListItemFlexColumnRenderer": {
+                  "text": {
+                    "runs": [
+                      {
+                        "text": "2026"
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Tests/KasetTests/Fixtures/search_music_shelf_continuation.json
+++ b/Tests/KasetTests/Fixtures/search_music_shelf_continuation.json
@@ -1,0 +1,146 @@
+{
+  "continuationContents": {
+    "musicShelfContinuation": {
+      "contents": [
+        {
+          "musicResponsiveListItemRenderer": {
+            "playlistItemData": {
+              "videoId": "continuation-song"
+            },
+            "navigationEndpoint": {
+              "watchEndpoint": {
+                "videoId": "continuation-song",
+                "watchEndpointMusicSupportedConfigs": {
+                  "watchEndpointMusicConfig": {
+                    "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                  }
+                }
+              }
+            },
+            "flexColumns": [
+              {
+                "musicResponsiveListItemFlexColumnRenderer": {
+                  "text": {
+                    "runs": [
+                      {
+                        "text": "Continuation Song"
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "musicResponsiveListItemFlexColumnRenderer": {
+                  "text": {
+                    "runs": [
+                      {
+                        "text": "Song"
+                      },
+                      {
+                        "text": " • "
+                      },
+                      {
+                        "text": "Continuation Artist"
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "musicResponsiveListItemRenderer": {
+            "navigationEndpoint": {
+              "browseEndpoint": {
+                "browseId": "UCcontinuation-profile",
+                "browseEndpointContextSupportedConfigs": {
+                  "browseEndpointContextMusicConfig": {
+                    "pageType": "MUSIC_PAGE_TYPE_USER_CHANNEL"
+                  }
+                }
+              }
+            },
+            "flexColumns": [
+              {
+                "musicResponsiveListItemFlexColumnRenderer": {
+                  "text": {
+                    "runs": [
+                      {
+                        "text": "Continuation Profile"
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "musicResponsiveListItemFlexColumnRenderer": {
+                  "text": {
+                    "runs": [
+                      {
+                        "text": "Profile"
+                      },
+                      {
+                        "text": " • "
+                      },
+                      {
+                        "text": "900 subscribers"
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "musicResponsiveListItemRenderer": {
+            "navigationEndpoint": {
+              "watchEndpoint": {
+                "videoId": "continuation-song",
+                "watchEndpointMusicSupportedConfigs": {
+                  "watchEndpointMusicConfig": {
+                    "musicVideoType": "MUSIC_VIDEO_TYPE_OMV"
+                  }
+                }
+              }
+            },
+            "flexColumns": [
+              {
+                "musicResponsiveListItemFlexColumnRenderer": {
+                  "text": {
+                    "runs": [
+                      {
+                        "text": "Duplicate Continuation Video"
+                      }
+                    ]
+                  }
+                }
+              },
+              {
+                "musicResponsiveListItemFlexColumnRenderer": {
+                  "text": {
+                    "runs": [
+                      {
+                        "text": "Video"
+                      }
+                    ]
+                  }
+                }
+              }
+            ]
+          }
+        },
+        {
+          "continuationItemRenderer": {
+            "continuationEndpoint": {
+              "continuationCommand": {
+                "token": "sanitized-continuation-item-token"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Tests/KasetTests/Fixtures/search_playlist_watch_endpoints.json
+++ b/Tests/KasetTests/Fixtures/search_playlist_watch_endpoints.json
@@ -1,0 +1,83 @@
+{
+  "contents": {
+    "sectionListRenderer": {
+      "contents": [
+        {
+          "musicCardShelfRenderer": {
+            "title": {
+              "runs": [
+                {
+                  "text": "Radio Watch"
+                }
+              ]
+            },
+            "subtitle": {
+              "runs": [
+                {
+                  "text": "Playlist"
+                }
+              ]
+            },
+            "onTap": {
+              "watchEndpoint": {
+                "videoId": "radio-preview",
+                "playlistId": "RDradio-watch"
+              }
+            }
+          }
+        },
+        {
+          "musicCardShelfRenderer": {
+            "title": {
+              "runs": [
+                {
+                  "text": "Playlist Action"
+                }
+              ]
+            },
+            "subtitle": {
+              "runs": [
+                {
+                  "text": "Playlist"
+                }
+              ]
+            },
+            "navigationEndpoint": {
+              "watchPlaylistEndpoint": {
+                "playlistId": "VMplaylist-action"
+              }
+            }
+          }
+        },
+        {
+          "musicCardShelfRenderer": {
+            "title": {
+              "runs": [
+                {
+                  "text": "Canonical Album",
+                  "navigationEndpoint": {
+                    "watchPlaylistEndpoint": {
+                      "playlistId": "VMalbum-context"
+                    }
+                  }
+                }
+              ]
+            },
+            "subtitle": {
+              "runs": [
+                {
+                  "text": "Album"
+                }
+              ]
+            },
+            "navigationEndpoint": {
+              "browseEndpoint": {
+                "browseId": "MPREcanonical-album"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Tests/KasetTests/Fixtures/search_tabbed_mixed.json
+++ b/Tests/KasetTests/Fixtures/search_tabbed_mixed.json
@@ -1,0 +1,413 @@
+{
+  "contents": {
+    "tabbedSearchResultsRenderer": {
+      "tabs": [
+        {
+          "tabRenderer": {
+            "content": {
+              "sectionListRenderer": {
+                "contents": [
+                  {
+                    "musicCardShelfRenderer": {
+                      "title": {
+                        "runs": [
+                          {
+                            "text": "Top Profile",
+                            "navigationEndpoint": {
+                              "browseEndpoint": {
+                                "browseId": "UCtop-profile",
+                                "browseEndpointContextSupportedConfigs": {
+                                  "browseEndpointContextMusicConfig": {
+                                    "pageType": "MUSIC_PAGE_TYPE_USER_CHANNEL"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      },
+                      "subtitle": {
+                        "runs": [
+                          {
+                            "text": "Profile"
+                          },
+                          {
+                            "text": " • "
+                          },
+                          {
+                            "text": "42K subscribers"
+                          }
+                        ]
+                      },
+                      "thumbnail": {
+                        "musicThumbnailRenderer": {
+                          "thumbnail": {
+                            "thumbnails": [
+                              {
+                                "url": "https://example.invalid/top-profile.jpg"
+                              }
+                            ]
+                          }
+                        }
+                      },
+                      "onTap": {
+                        "innertubeCommand": {
+                          "watchEndpoint": {
+                            "videoId": "top-profile-play-action",
+                            "watchEndpointMusicSupportedConfigs": {
+                              "watchEndpointMusicConfig": {
+                                "musicVideoType": "MUSIC_VIDEO_TYPE_OMV"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "thumbnailOverlay": {
+                        "musicItemThumbnailOverlayRenderer": {
+                          "content": {
+                            "musicPlayButtonRenderer": {
+                              "playNavigationEndpoint": {
+                                "watchEndpoint": {
+                                  "videoId": "top-profile-overlay-action",
+                                  "watchEndpointMusicSupportedConfigs": {
+                                    "watchEndpointMusicConfig": {
+                                      "musicVideoType": "MUSIC_VIDEO_TYPE_OMV"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      },
+                      "contents": [
+                        {
+                          "musicResponsiveListItemRenderer": {
+                            "navigationEndpoint": {
+                              "watchEndpoint": {
+                                "videoId": "official-source-video",
+                                "watchEndpointMusicSupportedConfigs": {
+                                  "watchEndpointMusicConfig": {
+                                    "musicVideoType": "MUSIC_VIDEO_TYPE_OFFICIAL_SOURCE_MUSIC"
+                                  }
+                                }
+                              }
+                            },
+                            "flexColumns": [
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "Official Source Video"
+                                      }
+                                    ]
+                                  }
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "Video"
+                                      },
+                                      {
+                                        "text": " • "
+                                      },
+                                      {
+                                        "text": "Fixture Artist",
+                                        "navigationEndpoint": {
+                                          "browseEndpoint": {
+                                            "browseId": "UCfixture-video-artist",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_ARTIST"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              }
+                            ],
+                            "menu": {
+                              "menuRenderer": {
+                                "items": [
+                                  {
+                                    "musicResponsiveListItemRenderer": {
+                                      "playlistItemData": {
+                                        "videoId": "menu-only-video"
+                                      },
+                                      "flexColumns": [
+                                        {
+                                          "musicResponsiveListItemFlexColumnRenderer": {
+                                            "text": {
+                                              "runs": [
+                                                {
+                                                  "text": "Must Not Parse"
+                                                }
+                                              ]
+                                            }
+                                          }
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "itemSectionRenderer": {
+                      "contents": [
+                        {
+                          "musicResponsiveListItemRenderer": {
+                            "navigationEndpoint": {
+                              "browseEndpoint": {
+                                "browseId": "MPSPPfixture-show",
+                                "browseEndpointContextSupportedConfigs": {
+                                  "browseEndpointContextMusicConfig": {
+                                    "pageType": "MUSIC_PAGE_TYPE_PODCAST_SHOW_DETAIL_PAGE"
+                                  }
+                                }
+                              }
+                            },
+                            "flexColumns": [
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "Fixture Podcast"
+                                      }
+                                    ]
+                                  }
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "Podcast"
+                                      },
+                                      {
+                                        "text": " • "
+                                      },
+                                      {
+                                        "text": "Fixture Network"
+                                      }
+                                    ]
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "musicResponsiveListItemRenderer": {
+                            "navigationEndpoint": {
+                              "watchEndpoint": {
+                                "videoId": "fixture-episode-video",
+                                "watchEndpointMusicSupportedConfigs": {
+                                  "watchEndpointMusicConfig": {
+                                    "musicVideoType": "MUSIC_VIDEO_TYPE_PODCAST_EPISODE"
+                                  }
+                                }
+                              }
+                            },
+                            "flexColumns": [
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "Fixture Episode",
+                                        "navigationEndpoint": {
+                                          "browseEndpoint": {
+                                            "browseId": "MPEDfixture-episode"
+                                          }
+                                        }
+                                      }
+                                    ]
+                                  }
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "Episode"
+                                      },
+                                      {
+                                        "text": " • "
+                                      },
+                                      {
+                                        "text": "Fixture Podcast",
+                                        "navigationEndpoint": {
+                                          "browseEndpoint": {
+                                            "browseId": "MPSPPfixture-show",
+                                            "browseEndpointContextSupportedConfigs": {
+                                              "browseEndpointContextMusicConfig": {
+                                                "pageType": "MUSIC_PAGE_TYPE_PODCAST_SHOW_DETAIL_PAGE"
+                                              }
+                                            }
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "text": " • "
+                                      },
+                                      {
+                                        "text": "Jul 18, 2026"
+                                      },
+                                      {
+                                        "text": " • "
+                                      },
+                                      {
+                                        "text": "42:10"
+                                      }
+                                    ]
+                                  }
+                                }
+                              }
+                            ],
+                            "description": {
+                              "runs": [
+                                {
+                                  "text": "Sanitized episode description."
+                                }
+                              ]
+                            }
+                          }
+                        },
+                        {
+                          "musicResponsiveListItemRenderer": {
+                            "playlistItemData": {
+                              "videoId": "official-source-video"
+                            },
+                            "navigationEndpoint": {
+                              "watchEndpoint": {
+                                "videoId": "official-source-video",
+                                "watchEndpointMusicSupportedConfigs": {
+                                  "watchEndpointMusicConfig": {
+                                    "musicVideoType": "MUSIC_VIDEO_TYPE_ATV"
+                                  }
+                                }
+                              }
+                            },
+                            "flexColumns": [
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "Duplicate Audio Form"
+                                      }
+                                    ]
+                                  }
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "Song"
+                                      },
+                                      {
+                                        "text": " • "
+                                      },
+                                      {
+                                        "text": "Fixture Artist"
+                                      }
+                                    ]
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "musicShelfRenderer": {
+                      "contents": [
+                        {
+                          "musicResponsiveListItemRenderer": {
+                            "navigationEndpoint": {
+                              "browseEndpoint": {
+                                "browseId": "VLfixture-playlist",
+                                "browseEndpointContextSupportedConfigs": {
+                                  "browseEndpointContextMusicConfig": {
+                                    "pageType": "MUSIC_PAGE_TYPE_PLAYLIST"
+                                  }
+                                }
+                              }
+                            },
+                            "flexColumns": [
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "Fixture Playlist"
+                                      }
+                                    ]
+                                  }
+                                }
+                              },
+                              {
+                                "musicResponsiveListItemFlexColumnRenderer": {
+                                  "text": {
+                                    "runs": [
+                                      {
+                                        "text": "Playlist"
+                                      },
+                                      {
+                                        "text": " • "
+                                      },
+                                      {
+                                        "text": "Fixture Curator"
+                                      },
+                                      {
+                                        "text": " • "
+                                      },
+                                      {
+                                        "text": "12 songs"
+                                      }
+                                    ]
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ],
+                      "continuations": [
+                        {
+                          "nextContinuationData": {
+                            "continuation": "sanitized-next-page-token"
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Tests/KasetTests/Fixtures/search_top_result_watch_endpoints.json
+++ b/Tests/KasetTests/Fixtures/search_top_result_watch_endpoints.json
@@ -1,0 +1,120 @@
+{
+  "contents": {
+    "sectionListRenderer": {
+      "contents": [
+        {
+          "musicCardShelfRenderer": {
+            "title": {
+              "runs": [
+                {
+                  "text": "Title Endpoint Video",
+                  "navigationEndpoint": {
+                    "watchEndpoint": {
+                      "videoId": "title-endpoint-video",
+                      "watchEndpointMusicSupportedConfigs": {
+                        "watchEndpointMusicConfig": {
+                          "musicVideoType": "MUSIC_VIDEO_TYPE_OMV"
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            "subtitle": {
+              "runs": [
+                {
+                  "text": "Video"
+                },
+                {
+                  "text": " • "
+                },
+                {
+                  "text": "Fixture Artist"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "musicCardShelfRenderer": {
+            "title": {
+              "runs": [
+                {
+                  "text": "On Tap Video"
+                }
+              ]
+            },
+            "subtitle": {
+              "runs": [
+                {
+                  "text": "Video"
+                },
+                {
+                  "text": " • "
+                },
+                {
+                  "text": "Fixture Creator"
+                }
+              ]
+            },
+            "onTap": {
+              "innertubeCommand": {
+                "watchEndpoint": {
+                  "videoId": "on-tap-video",
+                  "watchEndpointMusicSupportedConfigs": {
+                    "watchEndpointMusicConfig": {
+                      "musicVideoType": "MUSIC_VIDEO_TYPE_UGC"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "musicCardShelfRenderer": {
+            "title": {
+              "runs": [
+                {
+                  "text": "Thumbnail Overlay Video"
+                }
+              ]
+            },
+            "subtitle": {
+              "runs": [
+                {
+                  "text": "Video"
+                },
+                {
+                  "text": " • "
+                },
+                {
+                  "text": "Fixture Label"
+                }
+              ]
+            },
+            "thumbnailOverlay": {
+              "musicItemThumbnailOverlayRenderer": {
+                "content": {
+                  "musicPlayButtonRenderer": {
+                    "playNavigationEndpoint": {
+                      "watchEndpoint": {
+                        "videoId": "thumbnail-overlay-video",
+                        "watchEndpointMusicSupportedConfigs": {
+                          "watchEndpointMusicConfig": {
+                            "musicVideoType": "MUSIC_VIDEO_TYPE_OFFICIAL_SOURCE_MUSIC"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Tests/KasetTests/GuestModeAPIClientTests.swift
+++ b/Tests/KasetTests/GuestModeAPIClientTests.swift
@@ -207,6 +207,56 @@ struct GuestModeAPIClientTests {
         #expect(requestCount == 0)
     }
 
+    @Test("YouTube Music filtered search and continuation remain public in logged-in guest mode")
+    @MainActor
+    func youTubeMusicFilteredSearchRemainsPublicInLoggedInGuestMode() async throws {
+        APICache.shared.invalidateAll()
+        let webKitManager = WebKitManager.makeTestInstance()
+        let authService = AuthService(webKitManager: webKitManager)
+        authService.completeLogin(sapisid: "test-sapisid")
+        authService.enterGuestMode()
+
+        let session = MockURLProtocol.makeMockSession()
+        nonisolated(unsafe) var apiRequestCount = 0
+        MockURLProtocol.setRequestHandler(for: session) { request in
+            apiRequestCount += 1
+            #expect(request.url?.host == "music.youtube.com")
+            #expect(request.url?.path == "/youtubei/v1/search")
+            let authHeader = ["Author", "ization"].joined()
+            let cookieHeader = ["Coo", "kie"].joined()
+            #expect(request.value(forHTTPHeaderField: authHeader) == nil)
+            #expect(request.value(forHTTPHeaderField: cookieHeader) == nil)
+            #expect(request.httpShouldHandleCookies == false)
+
+            let data = try JSONSerialization.data(withJSONObject: [:])
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, data)
+        }
+        defer { MockURLProtocol.reset(session: session) }
+
+        let resolver = YTMusicAPIKeyResolver(session: session, environment: { name in
+            name == YTMusicAPIKeyResolver.environmentVariable ? "mock-token" : nil
+        })
+        let client = YTMusicClient(
+            authService: authService,
+            webKitManager: webKitManager,
+            session: session,
+            apiKeyResolver: resolver
+        )
+
+        _ = try await client.searchVideos(query: "swift videos")
+        _ = try await client.searchProfiles(query: "swift profiles")
+        _ = try await client.searchEpisodes(query: "swift episodes")
+        _ = try await client.getSearchContinuation(token: "guest-mode-search-continuation")
+
+        #expect(apiRequestCount == 4)
+    }
+
     @Test("YouTube Music public requests omit auth headers in logged-in guest mode")
     @MainActor
     func youTubeMusicPublicRequestsOmitAuthHeadersInLoggedInGuestMode() async throws {

--- a/Tests/KasetTests/Helpers/MockYTMusicClient.swift
+++ b/Tests/KasetTests/Helpers/MockYTMusicClient.swift
@@ -1290,6 +1290,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.completedSearchEndpoints = []
         self.getSearchContinuationTokens = []
         self.beforeSearchReturn = nil
+        self.beforeSearchContinuationReturn = nil
         self.beforeGetSongReturn = nil
         self.beforeGetPlaylistReturn = nil
         self.beforePlaylistContinuationReturn = nil

--- a/Tests/KasetTests/Helpers/MockYTMusicClient.swift
+++ b/Tests/KasetTests/Helpers/MockYTMusicClient.swift
@@ -9,12 +9,15 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         case mixed
         case songs
         case songsWithPagination
+        case videos
         case albums
         case artists
+        case profiles
         case playlists
         case featuredPlaylists
         case communityPlaylists
         case podcasts
+        case episodes
     }
 
     private static func playlistContinuationToken(playlistId: String, index: Int) -> String {
@@ -52,13 +55,16 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     var searchResponse: SearchResponse = .empty
     var mixedSearchResponse: SearchResponse?
     var songsSearchResponse: SearchResponse?
+    var videosSearchResponse: SearchResponse?
     var albumsSearchResponse: SearchResponse?
     var artistsSearchResponse: SearchResponse?
+    var profilesSearchResponse: SearchResponse?
     var playlistsSearchResponse: SearchResponse?
     var featuredPlaylistsSearchResponse: SearchResponse?
     var communityPlaylistsSearchResponse: SearchResponse?
     var podcastsSearchResponse: SearchResponse?
-    var searchContinuationResponses: [SearchResponse] = []
+    var episodesSearchResponse: SearchResponse?
+    var searchContinuationResponses: [String: SearchResponse] = [:]
     var searchSuggestions: [SearchSuggestion] = []
     var libraryPlaylists: [Playlist] = []
     var libraryArtists: [Artist] = []
@@ -163,12 +169,6 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self._likedSongsContinuationIndex < self.likedSongsContinuationSongs.count
     }
 
-    private var _searchContinuationIndex = 0
-
-    var hasMoreSearchResults: Bool {
-        self._searchContinuationIndex < self.searchContinuationResponses.count
-    }
-
     // MARK: - Call Tracking
 
     private(set) var getHomeCalled = false
@@ -194,8 +194,10 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     private(set) var searchCalled = false
     private(set) var searchQueries: [String] = []
     private(set) var completedSearchEndpoints: [SearchEndpoint] = []
+    private(set) var getSearchContinuationTokens: [String] = []
 
     var beforeSearchReturn: (@Sendable (String, SearchEndpoint) async -> Void)?
+    var beforeSearchContinuationReturn: (@Sendable (String) async -> Void)?
     var beforeGetSongReturn: (@Sendable (String) async -> Void)?
     var beforeGetPlaylistReturn: (@Sendable (String) async -> Void)?
     var beforePlaylistContinuationReturn: (@Sendable (String) async -> Void)?
@@ -522,7 +524,6 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     func search(query: String) async throws -> SearchResponse {
         self.searchCalled = true
         self.searchQueries.append(query)
-        self._searchContinuationIndex = 0
         await self.waitBeforeSearchReturn(query: query, endpoint: .mixed)
         defer { self.completedSearchEndpoints.append(.mixed) }
         if let error = shouldThrowError {
@@ -545,158 +546,163 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     func searchSongsWithPagination(query: String) async throws -> SearchResponse {
         self.searchCalled = true
         self.searchQueries.append(query)
-        self._searchContinuationIndex = 0
         await self.waitBeforeSearchReturn(query: query, endpoint: .songsWithPagination)
         defer { self.completedSearchEndpoints.append(.songsWithPagination) }
         if let error = shouldThrowError {
             throw error
         }
-        let hasMore = !self.searchContinuationResponses.isEmpty
         let response = self.songsSearchResponse ?? self.searchResponse
         return SearchResponse(
             songs: response.songs,
-            albums: [],
-            artists: [],
-            playlists: [],
-            continuationToken: hasMore ? "mock-token" : nil
+            continuationToken: response.continuationToken
+        )
+    }
+
+    func searchVideos(query: String) async throws -> SearchResponse {
+        self.searchCalled = true
+        self.searchQueries.append(query)
+        await self.waitBeforeSearchReturn(query: query, endpoint: .videos)
+        defer { self.completedSearchEndpoints.append(.videos) }
+        if let error = shouldThrowError {
+            throw error
+        }
+        let response = self.videosSearchResponse ?? self.searchResponse
+        return SearchResponse(
+            videos: response.videos,
+            continuationToken: response.continuationToken
         )
     }
 
     func searchAlbums(query: String) async throws -> SearchResponse {
         self.searchCalled = true
         self.searchQueries.append(query)
-        self._searchContinuationIndex = 0
         await self.waitBeforeSearchReturn(query: query, endpoint: .albums)
         defer { self.completedSearchEndpoints.append(.albums) }
         if let error = shouldThrowError {
             throw error
         }
-        let hasMore = !self.searchContinuationResponses.isEmpty
         let response = self.albumsSearchResponse ?? self.searchResponse
         return SearchResponse(
-            songs: [],
             albums: response.albums,
-            artists: [],
-            playlists: [],
-            continuationToken: hasMore ? "mock-token" : nil
+            audiobooks: response.audiobooks,
+            continuationToken: response.continuationToken
         )
     }
 
     func searchArtists(query: String) async throws -> SearchResponse {
         self.searchCalled = true
         self.searchQueries.append(query)
-        self._searchContinuationIndex = 0
         await self.waitBeforeSearchReturn(query: query, endpoint: .artists)
         defer { self.completedSearchEndpoints.append(.artists) }
         if let error = shouldThrowError {
             throw error
         }
-        let hasMore = !self.searchContinuationResponses.isEmpty
         let response = self.artistsSearchResponse ?? self.searchResponse
         return SearchResponse(
-            songs: [],
-            albums: [],
             artists: response.artists,
-            playlists: [],
-            continuationToken: hasMore ? "mock-token" : nil
+            continuationToken: response.continuationToken
+        )
+    }
+
+    func searchProfiles(query: String) async throws -> SearchResponse {
+        self.searchCalled = true
+        self.searchQueries.append(query)
+        await self.waitBeforeSearchReturn(query: query, endpoint: .profiles)
+        defer { self.completedSearchEndpoints.append(.profiles) }
+        if let error = shouldThrowError {
+            throw error
+        }
+        let response = self.profilesSearchResponse ?? self.searchResponse
+        return SearchResponse(
+            profiles: response.profiles,
+            continuationToken: response.continuationToken
         )
     }
 
     func searchPlaylists(query: String) async throws -> SearchResponse {
         self.searchCalled = true
         self.searchQueries.append(query)
-        self._searchContinuationIndex = 0
         await self.waitBeforeSearchReturn(query: query, endpoint: .playlists)
         defer { self.completedSearchEndpoints.append(.playlists) }
         if let error = shouldThrowError {
             throw error
         }
-        let hasMore = !self.searchContinuationResponses.isEmpty
         let response = self.playlistsSearchResponse ?? self.searchResponse
         return SearchResponse(
-            songs: [],
-            albums: [],
-            artists: [],
             playlists: response.playlists,
-            continuationToken: hasMore ? "mock-token" : nil
+            continuationToken: response.continuationToken
         )
     }
 
     func searchFeaturedPlaylists(query: String) async throws -> SearchResponse {
         self.searchCalled = true
         self.searchQueries.append(query)
-        self._searchContinuationIndex = 0
         await self.waitBeforeSearchReturn(query: query, endpoint: .featuredPlaylists)
         defer { self.completedSearchEndpoints.append(.featuredPlaylists) }
         if let error = shouldThrowError {
             throw error
         }
-        let hasMore = !self.searchContinuationResponses.isEmpty
         let response = self.featuredPlaylistsSearchResponse ?? self.searchResponse
         return SearchResponse(
-            songs: [],
-            albums: [],
-            artists: [],
             playlists: response.playlists,
-            continuationToken: hasMore ? "mock-token" : nil
+            continuationToken: response.continuationToken
         )
     }
 
     func searchCommunityPlaylists(query: String) async throws -> SearchResponse {
         self.searchCalled = true
         self.searchQueries.append(query)
-        self._searchContinuationIndex = 0
         await self.waitBeforeSearchReturn(query: query, endpoint: .communityPlaylists)
         defer { self.completedSearchEndpoints.append(.communityPlaylists) }
         if let error = shouldThrowError {
             throw error
         }
-        let hasMore = !self.searchContinuationResponses.isEmpty
         let response = self.communityPlaylistsSearchResponse ?? self.searchResponse
         return SearchResponse(
-            songs: [],
-            albums: [],
-            artists: [],
             playlists: response.playlists,
-            continuationToken: hasMore ? "mock-token" : nil
+            continuationToken: response.continuationToken
         )
     }
 
     func searchPodcasts(query: String) async throws -> SearchResponse {
         self.searchCalled = true
         self.searchQueries.append(query)
-        self._searchContinuationIndex = 0
         await self.waitBeforeSearchReturn(query: query, endpoint: .podcasts)
         defer { self.completedSearchEndpoints.append(.podcasts) }
         if let error = shouldThrowError {
             throw error
         }
-        let hasMore = !self.searchContinuationResponses.isEmpty
         let response = self.podcastsSearchResponse ?? self.searchResponse
         return SearchResponse(
-            songs: [],
-            albums: [],
-            artists: [],
-            playlists: response.playlists,
             podcastShows: response.podcastShows,
-            continuationToken: hasMore ? "mock-token" : nil
+            continuationToken: response.continuationToken
         )
     }
 
-    func getSearchContinuation() async throws -> SearchResponse? {
+    func searchEpisodes(query: String) async throws -> SearchResponse {
+        self.searchCalled = true
+        self.searchQueries.append(query)
+        await self.waitBeforeSearchReturn(query: query, endpoint: .episodes)
+        defer { self.completedSearchEndpoints.append(.episodes) }
         if let error = shouldThrowError {
             throw error
         }
-        guard self._searchContinuationIndex < self.searchContinuationResponses.count else {
-            return nil
-        }
-        let response = self.searchContinuationResponses[self._searchContinuationIndex]
-        self._searchContinuationIndex += 1
-        return response
+        let response = self.episodesSearchResponse ?? self.searchResponse
+        return SearchResponse(
+            podcastEpisodes: response.podcastEpisodes,
+            continuationToken: response.continuationToken
+        )
     }
 
-    func clearSearchContinuation() {
-        self._searchContinuationIndex = 0
+    func getSearchContinuation(token: String) async throws -> SearchResponse {
+        self.getSearchContinuationTokens.append(token)
+        if let beforeSearchContinuationReturn {
+            await beforeSearchContinuationReturn(token)
+        }
+        if let error = shouldThrowError {
+            throw error
+        }
+        return self.searchContinuationResponses[token] ?? .empty
     }
 
     func resetSessionStateForAccountSwitch() {
@@ -710,7 +716,6 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self._historyContinuationIndex = 0
         self._podcastsContinuationIndex = 0
         self._likedSongsContinuationIndex = 0
-        self._searchContinuationIndex = 0
     }
 
     func getSearchSuggestions(query: String) async throws -> [SearchSuggestion] {
@@ -1283,6 +1288,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.searchCalled = false
         self.searchQueries = []
         self.completedSearchEndpoints = []
+        self.getSearchContinuationTokens = []
         self.beforeSearchReturn = nil
         self.beforeGetSongReturn = nil
         self.beforeGetPlaylistReturn = nil

--- a/Tests/KasetTests/MockUITestYTMusicClientSearchTests.swift
+++ b/Tests/KasetTests/MockUITestYTMusicClientSearchTests.swift
@@ -1,0 +1,211 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+@Suite("Mock UI-test YouTube Music search configuration", .serialized)
+struct MockUITestYTMusicClientSearchTests {
+    @Test("Legacy grouped search schema supports every semantic family")
+    @MainActor
+    func groupedSchemaSupportsEverySemanticFamily() async throws {
+        let payload: [String: Any] = [
+            "songs": [[
+                "id": "song-1",
+                "title": "Configured Song",
+                "artist": "Song Artist",
+                "videoId": "song-video-1",
+                "albumId": "MPREbConfiguredAlbum",
+                "albumTitle": "Configured Song Album",
+            ]],
+            "videos": [[
+                "id": "video-1",
+                "title": "Configured Video",
+                "artist": "Video Artist",
+                "videoId": "video-id-1",
+                "musicVideoType": "MUSIC_VIDEO_TYPE_OMV",
+            ]],
+            "albums": [[
+                "id": "MPREbAlbum1",
+                "title": "Configured Album",
+                "artist": "Album Artist",
+                "year": "2026",
+                "trackCount": 12,
+            ]],
+            "audiobooks": [[
+                "id": "MPREbAudiobook1",
+                "title": "Configured Audiobook",
+                "artist": "Audiobook Author",
+                "year": "2025",
+            ]],
+            "artists": [[
+                "id": "UCArtist1",
+                "name": "Configured Artist",
+                "subtitle": "Artist subtitle",
+            ]],
+            "profiles": [[
+                "id": "UCProfile1",
+                "name": "Configured Profile",
+                "subtitle": "Profile subtitle",
+            ]],
+            "playlists": [[
+                "id": "VLPlaylist1",
+                "title": "Configured Playlist",
+                "description": "Playlist description",
+                "trackCount": 24,
+                "author": "Playlist Author",
+            ]],
+            "podcastShows": [[
+                "id": "MPSPPShow1",
+                "title": "Configured Podcast",
+                "author": "Podcast Host",
+                "description": "Show description",
+                "episodeCount": 40,
+            ]],
+            "podcastEpisodes": [[
+                "id": "episode-video-1",
+                "title": "Configured Episode",
+                "showTitle": "Configured Podcast",
+                "showBrowseId": "MPSPPShow1",
+                "publishedDate": "Jul 19, 2026",
+                "duration": "42 min",
+                "durationSeconds": 2520,
+                "playbackProgress": 0.25,
+                "isPlayed": false,
+            ]],
+        ]
+
+        try await self.withMockSearchResults(payload) { client in
+            let response = try await client.search(query: "configured")
+
+            #expect(response.songs.map(\.title) == ["Configured Song"])
+            #expect(response.songs.first?.album?.title == "Configured Song Album")
+            #expect(response.videos.map(\.title) == ["Configured Video"])
+            #expect(response.videos.first?.musicVideoType == .omv)
+            #expect(response.albums.map(\.title) == ["Configured Album"])
+            #expect(response.audiobooks.map(\.title) == ["Configured Audiobook"])
+            #expect(response.artists.map(\.name) == ["Configured Artist"])
+            #expect(response.profiles.map(\.name) == ["Configured Profile"])
+            #expect(response.profiles.first?.profileKind == .profile)
+            #expect(response.playlists.map(\.title) == ["Configured Playlist"])
+            #expect(response.podcastShows.map(\.title) == ["Configured Podcast"])
+            #expect(response.podcastEpisodes.map(\.title) == ["Configured Episode"])
+        }
+    }
+
+    @Test("Explicit items preserve mixed semantic order")
+    @MainActor
+    func explicitItemsPreserveMixedSemanticOrder() async throws {
+        let payload: [String: Any] = [
+            "items": [
+                [
+                    "type": "profile",
+                    "id": "UCProfileFirst",
+                    "name": "First Profile",
+                ],
+                [
+                    "type": "podcastEpisode",
+                    "id": "episode-second",
+                    "title": "Second Episode",
+                    "showTitle": "Ordered Show",
+                ],
+                [
+                    "type": "video",
+                    "id": "video-third",
+                    "title": "Third Video",
+                    "artist": "Ordered Artist",
+                    "videoId": "video-third",
+                ],
+                [
+                    "type": "audiobook",
+                    "id": "MPREbFourth",
+                    "title": "Fourth Audiobook",
+                    "artist": "Ordered Author",
+                ],
+                [
+                    "type": "song",
+                    "id": "song-fifth",
+                    "title": "Fifth Song",
+                    "artist": "Ordered Artist",
+                    "videoId": "song-fifth",
+                ],
+            ],
+            "songs": [[
+                "id": "grouped-song",
+                "title": "Grouped Song Should Not Be Appended",
+                "artist": "Grouped Artist",
+                "videoId": "grouped-song",
+            ]],
+        ]
+
+        try await self.withMockSearchResults(payload) { client in
+            let response = try await client.search(query: "ordered")
+
+            #expect(response.allItems.map(\.title) == [
+                "First Profile",
+                "Second Episode",
+                "Third Video",
+                "Fourth Audiobook",
+                "Fifth Song",
+            ])
+            #expect(response.songs.map(\.title) == ["Fifth Song"])
+        }
+    }
+
+    @Test("Default search data covers every semantic family")
+    @MainActor
+    func defaultSearchDataCoversEverySemanticFamily() async throws {
+        try await self.withoutConfiguredMockSearchResults { client in
+            let response = try await client.search(query: "default")
+
+            #expect(!response.songs.isEmpty)
+            #expect(!response.videos.isEmpty)
+            #expect(!response.albums.isEmpty)
+            #expect(!response.audiobooks.isEmpty)
+            #expect(!response.artists.isEmpty)
+            #expect(!response.profiles.isEmpty)
+            #expect(!response.playlists.isEmpty)
+            #expect(!response.podcastShows.isEmpty)
+            #expect(!response.podcastEpisodes.isEmpty)
+        }
+    }
+
+    @MainActor
+    private func withMockSearchResults(
+        _ payload: [String: Any],
+        operation: @MainActor (MockUITestYTMusicClient) async throws -> Void
+    ) async throws {
+        let data = try JSONSerialization.data(withJSONObject: payload)
+        let json = try #require(String(data: data, encoding: .utf8))
+        try await self.withEnvironmentValue(json, operation: operation)
+    }
+
+    @MainActor
+    private func withoutConfiguredMockSearchResults(
+        operation: @MainActor (MockUITestYTMusicClient) async throws -> Void
+    ) async throws {
+        try await self.withEnvironmentValue(nil, operation: operation)
+    }
+
+    @MainActor
+    private func withEnvironmentValue(
+        _ value: String?,
+        operation: @MainActor (MockUITestYTMusicClient) async throws -> Void
+    ) async throws {
+        let key = UITestConfig.mockSearchResultsKey
+        let previousValue = ProcessInfo.processInfo.environment[key]
+        defer {
+            if let previousValue {
+                setenv(key, previousValue, 1)
+            } else {
+                unsetenv(key)
+            }
+        }
+
+        if let value {
+            setenv(key, value, 1)
+        } else {
+            unsetenv(key)
+        }
+
+        try await operation(MockUITestYTMusicClient())
+    }
+}

--- a/Tests/KasetTests/ParsingHelpersTests.swift
+++ b/Tests/KasetTests/ParsingHelpersTests.swift
@@ -366,6 +366,65 @@ struct ParsingHelpersTests {
         #expect(artists.allSatisfy { !$0.hasNavigableId })
     }
 
+    @Test(
+        "Content type labels are not treated as plain artist names",
+        arguments: ["Audiobook", "Single", "EP", "Profile", "Podcast Episode"]
+    )
+    func contentTypeLabelsAreNotPlainArtists(label: String) {
+        let data: [String: Any] = [
+            "flexColumns": [
+                [
+                    "musicResponsiveListItemFlexColumnRenderer": [
+                        "text": ["runs": [["text": "Fixture Result"]]],
+                    ],
+                ],
+                [
+                    "musicResponsiveListItemFlexColumnRenderer": [
+                        "text": [
+                            "runs": [
+                                ["text": label],
+                                ["text": " • "],
+                                ["text": "Fixture Creator"],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]
+
+        let artists = ParsingHelpers.extractArtistsFromFlexColumns(data)
+
+        #expect(artists.map(\.name) == ["Fixture Creator"])
+    }
+
+    @Test("Middle-dot separators are excluded from plain artist fallback")
+    func middleDotSeparatorsAreNotArtists() {
+        let data: [String: Any] = [
+            "flexColumns": [
+                [
+                    "musicResponsiveListItemFlexColumnRenderer": [
+                        "text": ["runs": [["text": "Fixture Video"]]],
+                    ],
+                ],
+                [
+                    "musicResponsiveListItemFlexColumnRenderer": [
+                        "text": [
+                            "runs": [
+                                ["text": "Video"],
+                                ["text": " · "],
+                                ["text": "Fixture Creator"],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]
+
+        let artists = ParsingHelpers.extractArtistsFromFlexColumns(data)
+
+        #expect(artists.map(\.name) == ["Fixture Creator"])
+    }
+
     // MARK: - Video ID Extraction
 
     @Test("Extract video ID from playlistItemData")

--- a/Tests/KasetTests/SearchResponseParserTestFixtures.swift
+++ b/Tests/KasetTests/SearchResponseParserTestFixtures.swift
@@ -264,8 +264,20 @@ extension SearchResponseParserTests {
         ]
     }
 
-    static func makeRelativeDateEpisodeData() -> [String: Any] {
-        [
+    static func makeRelativeDateEpisodeData(
+        showTitle: String = "Fixture Podcast",
+        showBrowseId: String? = "MPSPPrelative-date",
+        publishedDate: String = "2 hours ago",
+        duration: String = "36 min"
+    ) -> [String: Any] {
+        var showRun: [String: Any] = ["text": showTitle]
+        if let showBrowseId {
+            showRun["navigationEndpoint"] = [
+                "browseEndpoint": ["browseId": showBrowseId],
+            ]
+        }
+
+        return [
             "contents": [
                 "sectionListRenderer": [
                     "contents": [[
@@ -303,18 +315,11 @@ extension SearchResponseParserTests {
                                                     "runs": [
                                                         ["text": "Episode"],
                                                         ["text": " • "],
-                                                        [
-                                                            "text": "Fixture Podcast",
-                                                            "navigationEndpoint": [
-                                                                "browseEndpoint": [
-                                                                    "browseId": "MPSPPrelative-date",
-                                                                ],
-                                                            ],
-                                                        ],
+                                                        showRun,
                                                         ["text": " • "],
-                                                        ["text": "2 hours ago"],
+                                                        ["text": publishedDate],
                                                         ["text": " • "],
-                                                        ["text": "36 min"],
+                                                        ["text": duration],
                                                     ],
                                                 ],
                                             ],

--- a/Tests/KasetTests/SearchResponseParserTestFixtures.swift
+++ b/Tests/KasetTests/SearchResponseParserTestFixtures.swift
@@ -1,0 +1,454 @@
+import Foundation
+
+// MARK: - Search Response Parser Test Fixtures
+
+extension SearchResponseParserTests {
+    static func loadFixture(_ name: String) throws -> [String: Any] {
+        guard let url = Bundle.module.url(forResource: name, withExtension: "json") else {
+            throw FixtureError.notFound(name)
+        }
+        let raw = try Data(contentsOf: url)
+        guard let fixture = try JSONSerialization.jsonObject(with: raw) as? [String: Any] else {
+            throw FixtureError.invalidJSON(name)
+        }
+        return fixture
+    }
+
+    enum FixtureError: Error { case notFound(String), invalidJSON(String) }
+
+    static func makeLocalizedSemanticData() -> [String: Any] {
+        [
+            "contents": [
+                "sectionListRenderer": [
+                    "contents": [
+                        [
+                            "musicCardShelfRenderer": [
+                                "title": [
+                                    "runs": [["text": "Vídeo localizado"]],
+                                ],
+                                "subtitle": [
+                                    "runs": [
+                                        ["text": "Vídeo"],
+                                        ["text": " • "],
+                                        ["text": "Banda Ejemplo"],
+                                    ],
+                                ],
+                                "onTap": [
+                                    "watchEndpoint": [
+                                        "videoId": "localized-video",
+                                    ],
+                                ],
+                            ],
+                        ],
+                        [
+                            "musicResponsiveListItemRenderer": [
+                                "navigationEndpoint": [
+                                    "browseEndpoint": [
+                                        "browseId": "MPSPPlocalized-show",
+                                    ],
+                                ],
+                                "flexColumns": [
+                                    [
+                                        "musicResponsiveListItemFlexColumnRenderer": [
+                                            "text": [
+                                                "runs": [["text": "Localized Podcast"]],
+                                            ],
+                                        ],
+                                    ],
+                                    [
+                                        "musicResponsiveListItemFlexColumnRenderer": [
+                                            "text": [
+                                                "runs": [
+                                                    ["text": "Подкаст"],
+                                                    ["text": " • "],
+                                                    ["text": "Fixture Network"],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]
+    }
+
+    static func makeCountOnlyCreatorData(
+        playlistLabel: String = "Playlist",
+        songCount: String = "12 songs",
+        podcastLabel: String = "Podcast",
+        episodeCount: String = "12 episodes"
+    ) -> [String: Any] {
+        [
+            "contents": [
+                "sectionListRenderer": [
+                    "contents": [[
+                        "itemSectionRenderer": [
+                            "contents": [
+                                [
+                                    "musicResponsiveListItemRenderer": [
+                                        "navigationEndpoint": [
+                                            "browseEndpoint": [
+                                                "browseId": "PLcount-only",
+                                            ],
+                                        ],
+                                        "flexColumns": [
+                                            [
+                                                "musicResponsiveListItemFlexColumnRenderer": [
+                                                    "text": [
+                                                        "runs": [["text": "Count-only Playlist"]],
+                                                    ],
+                                                ],
+                                            ],
+                                            [
+                                                "musicResponsiveListItemFlexColumnRenderer": [
+                                                    "text": [
+                                                        "runs": [
+                                                            ["text": playlistLabel],
+                                                            ["text": " • "],
+                                                            ["text": songCount],
+                                                        ],
+                                                    ],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                                [
+                                    "musicResponsiveListItemRenderer": [
+                                        "navigationEndpoint": [
+                                            "browseEndpoint": [
+                                                "browseId": "MPSPPcount-only",
+                                            ],
+                                        ],
+                                        "flexColumns": [
+                                            [
+                                                "musicResponsiveListItemFlexColumnRenderer": [
+                                                    "text": [
+                                                        "runs": [["text": "Count-only Podcast"]],
+                                                    ],
+                                                ],
+                                            ],
+                                            [
+                                                "musicResponsiveListItemFlexColumnRenderer": [
+                                                    "text": [
+                                                        "runs": [
+                                                            ["text": podcastLabel],
+                                                            ["text": " • "],
+                                                            ["text": episodeCount],
+                                                        ],
+                                                    ],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ]],
+                ],
+            ],
+        ]
+    }
+
+    static func makeRadioBrowseData(browseIds: [String]) -> [String: Any] {
+        [
+            "contents": [
+                "sectionListRenderer": [
+                    "contents": [[
+                        "itemSectionRenderer": [
+                            "contents": browseIds.enumerated().map { index, browseId in
+                                [
+                                    "musicResponsiveListItemRenderer": [
+                                        "navigationEndpoint": [
+                                            "browseEndpoint": [
+                                                "browseId": browseId,
+                                            ],
+                                        ],
+                                        "flexColumns": [
+                                            [
+                                                "musicResponsiveListItemFlexColumnRenderer": [
+                                                    "text": [
+                                                        "runs": [["text": "Radio \(index)"]],
+                                                    ],
+                                                ],
+                                            ],
+                                            [
+                                                "musicResponsiveListItemFlexColumnRenderer": [
+                                                    "text": [
+                                                        "runs": [["text": "Playlist"]],
+                                                    ],
+                                                ],
+                                            ],
+                                        ],
+                                        "overlay": [
+                                            "musicItemThumbnailOverlayRenderer": [
+                                                "content": [
+                                                    "musicPlayButtonRenderer": [
+                                                        "playNavigationEndpoint": [
+                                                            "watchEndpoint": [
+                                                                "videoId": "radio-preview-\(index)",
+                                                                "watchEndpointMusicSupportedConfigs": [
+                                                                    "watchEndpointMusicConfig": [
+                                                                        "musicVideoType": "MUSIC_VIDEO_TYPE_UGC",
+                                                                    ],
+                                                                ],
+                                                            ],
+                                                        ],
+                                                    ],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ]
+                            },
+                        ],
+                    ]],
+                ],
+            ],
+        ]
+    }
+
+    static func makeSecondSubtitleVideoData() -> [String: Any] {
+        [
+            "contents": [
+                "sectionListRenderer": [
+                    "contents": [[
+                        "itemSectionRenderer": [
+                            "contents": [[
+                                "musicMultiRowListItemRenderer": [
+                                    "title": ["runs": [["text": "Second Subtitle Video"]]],
+                                    "subtitle": ["runs": [["text": "Fixture Creator"]]],
+                                    "secondSubtitle": ["runs": [["text": "Video"]]],
+                                    "onTap": [
+                                        "watchEndpoint": ["videoId": "second-subtitle-video"],
+                                    ],
+                                ],
+                            ]],
+                        ],
+                    ]],
+                ],
+            ],
+        ]
+    }
+
+    static func makeUntypedVideoCardData(artists: [String]) -> [String: Any] {
+        [
+            "contents": [
+                "sectionListRenderer": [
+                    "contents": artists.enumerated().map { index, artist in
+                        [
+                            "musicCardShelfRenderer": [
+                                "title": [
+                                    "runs": [["text": "Video \(index)"]],
+                                ],
+                                "subtitle": [
+                                    "runs": [
+                                        ["text": "Video"],
+                                        ["text": " • "],
+                                        ["text": artist],
+                                    ],
+                                ],
+                                "onTap": [
+                                    "watchEndpoint": [
+                                        "videoId": "untyped-video-\(index)",
+                                    ],
+                                ],
+                            ],
+                        ]
+                    },
+                ],
+            ],
+        ]
+    }
+
+    static func makeRelativeDateEpisodeData() -> [String: Any] {
+        [
+            "contents": [
+                "sectionListRenderer": [
+                    "contents": [[
+                        "itemSectionRenderer": [
+                            "contents": [[
+                                "musicResponsiveListItemRenderer": [
+                                    "navigationEndpoint": [
+                                        "watchEndpoint": [
+                                            "videoId": "relative-date-episode",
+                                            "watchEndpointMusicSupportedConfigs": [
+                                                "watchEndpointMusicConfig": [
+                                                    "musicVideoType": "MUSIC_VIDEO_TYPE_PODCAST_EPISODE",
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                    "flexColumns": [
+                                        [
+                                            "musicResponsiveListItemFlexColumnRenderer": [
+                                                "text": [
+                                                    "runs": [[
+                                                        "text": "Relative Date Episode",
+                                                        "navigationEndpoint": [
+                                                            "browseEndpoint": [
+                                                                "browseId": "MPEDrelative-date",
+                                                            ],
+                                                        ],
+                                                    ]],
+                                                ],
+                                            ],
+                                        ],
+                                        [
+                                            "musicResponsiveListItemFlexColumnRenderer": [
+                                                "text": [
+                                                    "runs": [
+                                                        ["text": "Episode"],
+                                                        ["text": " • "],
+                                                        [
+                                                            "text": "Fixture Podcast",
+                                                            "navigationEndpoint": [
+                                                                "browseEndpoint": [
+                                                                    "browseId": "MPSPPrelative-date",
+                                                                ],
+                                                            ],
+                                                        ],
+                                                        ["text": " • "],
+                                                        ["text": "2 hours ago"],
+                                                        ["text": " • "],
+                                                        ["text": "36 min"],
+                                                    ],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ]],
+                        ],
+                    ]],
+                ],
+            ],
+        ]
+    }
+
+    static func makeContinuationCarrierData(_ continuation: [String: Any]) -> [String: Any] {
+        [
+            "contents": [
+                "sectionListRenderer": [
+                    "contents": [[
+                        "musicShelfRenderer": [
+                            "contents": [],
+                            "continuations": [continuation],
+                        ],
+                    ]],
+                ],
+            ],
+        ]
+    }
+
+    static func makeContinuationItemData(token: String) -> [String: Any] {
+        [
+            "contents": [
+                "sectionListRenderer": [
+                    "contents": [[
+                        "musicShelfRenderer": [
+                            "contents": [[
+                                "continuationItemRenderer": [
+                                    "continuationEndpoint": [
+                                        "continuationCommand": [
+                                            "token": token,
+                                        ],
+                                    ],
+                                ],
+                            ]],
+                        ],
+                    ]],
+                ],
+            ],
+        ]
+    }
+
+    func makeSearchResponseData(songs: Int, albums: Int, artists: Int, playlists: Int) -> [String: Any] {
+        var contents: [[String: Any]] = []
+
+        if songs > 0 {
+            contents.append(["musicShelfRenderer": ["contents": self.makeSongItems(count: songs)]])
+        }
+        if albums > 0 {
+            contents.append(["musicShelfRenderer": ["contents": self.makeAlbumItems(count: albums)]])
+        }
+        if artists > 0 {
+            contents.append(["musicShelfRenderer": ["contents": self.makeArtistItems(count: artists)]])
+        }
+        if playlists > 0 {
+            contents.append(["musicShelfRenderer": ["contents": self.makePlaylistItems(count: playlists)]])
+        }
+
+        return [
+            "contents": [
+                "tabbedSearchResultsRenderer": [
+                    "tabs": [[
+                        "tabRenderer": [
+                            "content": [
+                                "sectionListRenderer": [
+                                    "contents": contents,
+                                ],
+                            ],
+                        ],
+                    ]],
+                ],
+            ],
+        ]
+    }
+
+    func makeSongItems(count: Int) -> [[String: Any]] {
+        (0 ..< count).map { i in
+            [
+                "musicResponsiveListItemRenderer": [
+                    "playlistItemData": ["videoId": "video\(i)"],
+                    "flexColumns": [
+                        ["musicResponsiveListItemFlexColumnRenderer": ["text": ["runs": [["text": "Song \(i)"]]]]],
+                        ["musicResponsiveListItemFlexColumnRenderer": ["text": ["runs": [["text": "Artist"]]]]],
+                    ],
+                ],
+            ]
+        }
+    }
+
+    func makeAlbumItems(count: Int) -> [[String: Any]] {
+        (0 ..< count).map { i in
+            [
+                "musicResponsiveListItemRenderer": [
+                    "navigationEndpoint": ["browseEndpoint": ["browseId": "MPRE\(i)"]],
+                    "flexColumns": [
+                        ["musicResponsiveListItemFlexColumnRenderer": ["text": ["runs": [["text": "Album \(i)"]]]]],
+                    ],
+                ],
+            ]
+        }
+    }
+
+    func makeArtistItems(count: Int) -> [[String: Any]] {
+        (0 ..< count).map { i in
+            [
+                "musicResponsiveListItemRenderer": [
+                    "navigationEndpoint": ["browseEndpoint": ["browseId": "UC\(i)"]],
+                    "flexColumns": [
+                        ["musicResponsiveListItemFlexColumnRenderer": ["text": ["runs": [["text": "Artist \(i)"]]]]],
+                    ],
+                ],
+            ]
+        }
+    }
+
+    func makePlaylistItems(count: Int) -> [[String: Any]] {
+        (0 ..< count).map { i in
+            [
+                "musicResponsiveListItemRenderer": [
+                    "navigationEndpoint": ["browseEndpoint": ["browseId": "VL\(i)"]],
+                    "flexColumns": [
+                        ["musicResponsiveListItemFlexColumnRenderer": ["text": ["runs": [["text": "Playlist \(i)"]]]]],
+                    ],
+                ],
+            ]
+        }
+    }
+}

--- a/Tests/KasetTests/SearchResponseParserTests.swift
+++ b/Tests/KasetTests/SearchResponseParserTests.swift
@@ -2,9 +2,339 @@ import Foundation
 import Testing
 @testable import Kaset
 
-/// Tests for the SearchResponseParser.
+// MARK: - SearchResponseParserTests
+
 @Suite(.tags(.parser))
 struct SearchResponseParserTests {
+    @Test("Direct item-section search roots preserve server order")
+    func directItemSectionRootPreservesServerOrder() throws {
+        let data = try Self.loadFixture("search_direct_item_section")
+
+        let response = SearchResponseParser.parse(data)
+
+        #expect(response.allItems.map(\.id) == [
+            "song-direct-song-video",
+            "album-MPREdirect-album",
+        ])
+    }
+
+    @Test("Tabbed mixed search preserves order and first-occurrence identity")
+    func tabbedMixedSearchPreservesOrderAndDeduplicates() throws {
+        let data = try Self.loadFixture("search_tabbed_mixed")
+
+        let response = SearchResponseParser.parse(data)
+
+        #expect(response.allItems.map(\.id) == [
+            "profile-UCtop-profile",
+            "video-official-source-video",
+            "podcast-MPSPPfixture-show",
+            "episode-fixture-episode-video",
+            "playlist-VLfixture-playlist",
+        ])
+        #expect(response.videos.first?.title == "Official Source Video")
+        #expect(!response.allItems.contains { $0.videoId == "menu-only-video" })
+    }
+
+    @Test("Top Result browse semantics win and nested official-source video parses")
+    func topResultBrowseSemanticsWinOverWatchFallbacks() throws {
+        let data = try Self.loadFixture("search_tabbed_mixed")
+
+        let response = SearchResponseParser.parse(data)
+
+        let profile = try #require(response.profiles.first)
+        #expect(profile.id == "UCtop-profile")
+        #expect(profile.subtitle == "42K subscribers")
+
+        let video = try #require(response.videos.first)
+        #expect(video.videoId == "official-source-video")
+        #expect(video.musicVideoType == .officialSourceMusic)
+        #expect(video.hasVideo != true)
+    }
+
+    @Test("Mixed search parses podcast shows and episodes")
+    func mixedSearchParsesPodcastShowsAndEpisodes() throws {
+        let data = try Self.loadFixture("search_tabbed_mixed")
+
+        let response = SearchResponseParser.parse(data)
+
+        let show = try #require(response.podcastShows.first)
+        #expect(show.id == "MPSPPfixture-show")
+        #expect(show.author == "Fixture Network")
+
+        let episode = try #require(response.podcastEpisodes.first)
+        #expect(episode.id == "fixture-episode-video")
+        #expect(episode.showTitle == "Fixture Podcast")
+        #expect(episode.showBrowseId == "MPSPPfixture-show")
+        #expect(episode.publishedDate == "Jul 18, 2026")
+        #expect(episode.duration == "42:10")
+        #expect(episode.durationSeconds == 2530)
+    }
+
+    @Test("First-page search reads shelf-level next continuation")
+    func firstPageReadsShelfNextContinuation() throws {
+        let data = try Self.loadFixture("search_tabbed_mixed")
+
+        let response = SearchResponseParser.parse(data)
+
+        #expect(response.continuationToken == "sanitized-next-page-token")
+    }
+
+    @Test("Audiobook page types remain semantically distinct from albums")
+    func audiobookPageTypeParses() {
+        let data: [String: Any] = [
+            "contents": [
+                "sectionListRenderer": [
+                    "contents": [[
+                        "itemSectionRenderer": [
+                            "contents": [[
+                                "musicResponsiveListItemRenderer": [
+                                    "navigationEndpoint": [
+                                        "browseEndpoint": [
+                                            "browseId": "MPREb_audiobook",
+                                            "browseEndpointContextSupportedConfigs": [
+                                                "browseEndpointContextMusicConfig": [
+                                                    "pageType": "MUSIC_PAGE_TYPE_AUDIOBOOK",
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                    "flexColumns": [
+                                        [
+                                            "musicResponsiveListItemFlexColumnRenderer": [
+                                                "text": ["runs": [["text": "Fixture Audiobook"]]],
+                                            ],
+                                        ],
+                                        [
+                                            "musicResponsiveListItemFlexColumnRenderer": [
+                                                "text": ["runs": [
+                                                    ["text": "Audiobook"],
+                                                    ["text": " • "],
+                                                    ["text": "Fixture Narrator"],
+                                                ]],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ]],
+                        ],
+                    ]],
+                ],
+            ],
+        ]
+
+        let response = SearchResponseParser.parse(data)
+
+        #expect(response.allItems.map(\.id) == ["audiobook-MPREb_audiobook"])
+        #expect(response.audiobooks.map(\.title) == ["Fixture Audiobook"])
+        #expect(response.audiobooks.map(\.artistsDisplay) == ["Fixture Narrator"])
+        #expect(response.albums.isEmpty)
+    }
+
+    @Test("Top Result watch destinations parse from title, onTap, and thumbnail overlay")
+    func topResultWatchEndpointSourcesParse() throws {
+        let data = try Self.loadFixture("search_top_result_watch_endpoints")
+
+        let response = SearchResponseParser.parse(data)
+
+        #expect(response.videos.map(\.videoId) == [
+            "title-endpoint-video",
+            "on-tap-video",
+            "thumbnail-overlay-video",
+        ])
+        #expect(response.videos.map(\.musicVideoType) == [
+            .omv,
+            .ugc,
+            .officialSourceMusic,
+        ])
+    }
+
+    @Test("First-page shelves accept reload and continuation-item tokens")
+    func firstPageReadsAlternateShelfContinuationCarriers() {
+        let reloadResponse = SearchResponseParser.parse(Self.makeContinuationCarrierData(
+            ["reloadContinuationData": ["continuation": "sanitized-reload-token"]]
+        ))
+        let itemResponse = SearchResponseParser.parse(Self.makeContinuationItemData(
+            token: "sanitized-item-token"
+        ))
+
+        #expect(reloadResponse.continuationToken == "sanitized-reload-token")
+        #expect(itemResponse.continuationToken == "sanitized-item-token")
+    }
+
+    @Test("Music shelf continuations preserve order, identity, and next token")
+    func musicShelfContinuationParsesOrderedItems() throws {
+        let data = try Self.loadFixture("search_music_shelf_continuation")
+
+        let response = SearchResponseParser.parseContinuation(data)
+
+        #expect(response.allItems.map(\.id) == [
+            "song-continuation-song",
+            "profile-UCcontinuation-profile",
+        ])
+        #expect(response.songs.first?.title == "Continuation Song")
+        #expect(response.videos.isEmpty)
+        #expect(response.continuationToken == "sanitized-continuation-item-token")
+    }
+
+    @Test(
+        "Action-envelope continuations preserve order, identity, and next token",
+        arguments: [
+            ("onResponseReceivedActions", "appendContinuationItemsAction"),
+            ("onResponseReceivedCommands", "reloadContinuationItemsCommand"),
+            ("onResponseReceivedEndpoints", "appendContinuationItemsAction"),
+        ]
+    )
+    func actionEnvelopeContinuationParsesOrderedItems(
+        envelopeKey: String,
+        commandKey: String
+    ) throws {
+        let fixture = try Self.loadFixture("search_music_shelf_continuation")
+        let continuationContents = try #require(fixture["continuationContents"] as? [String: Any])
+        let shelf = try #require(continuationContents["musicShelfContinuation"] as? [String: Any])
+        let items = try #require(shelf["contents"] as? [[String: Any]])
+        let actions = items.map { item in
+            [commandKey: ["continuationItems": [item]]]
+        }
+
+        let response = SearchResponseParser.parseContinuation([envelopeKey: actions])
+
+        #expect(response.allItems.map(\.id) == [
+            "song-continuation-song",
+            "profile-UCcontinuation-profile",
+        ])
+        #expect(response.continuationToken == "sanitized-continuation-item-token")
+    }
+
+    @Test("Untyped video cards preserve semantic classification and plain artist names")
+    func untypedVideoCardsPreserveSemanticMetadata() {
+        let data = Self.makeUntypedVideoCardData(artists: [
+            "Coldplay",
+            "Maroon 5",
+            "The Midnight",
+        ])
+
+        let response = SearchResponseParser.parse(data)
+
+        #expect(response.videos.map(\.artistsDisplay) == [
+            "Coldplay",
+            "Maroon 5",
+            "The Midnight",
+        ])
+        #expect(response.videos.allSatisfy { $0.hasVideo != true })
+    }
+
+    @Test("Multi-row second subtitles contribute semantic metadata")
+    func multiRowSecondSubtitleParses() {
+        let response = SearchResponseParser.parse(Self.makeSecondSubtitleVideoData())
+
+        #expect(response.videos.map(\.videoId) == ["second-subtitle-video"])
+        #expect(response.videos.map(\.artistsDisplay) == ["Fixture Creator"])
+        #expect(response.songs.isEmpty)
+    }
+
+    @Test("Middle-dot metadata preserves semantic video and creator parsing")
+    func middleDotMetadataParses() {
+        let data: [String: Any] = [
+            "contents": [
+                "sectionListRenderer": [
+                    "contents": [[
+                        "musicCardShelfRenderer": [
+                            "title": ["runs": [["text": "Middle Dot Video"]]],
+                            "subtitle": ["runs": [["text": "Video · Fixture Creator"]]],
+                            "onTap": ["watchEndpoint": ["videoId": "middle-dot-video"]],
+                        ],
+                    ]],
+                ],
+            ],
+        ]
+
+        let response = SearchResponseParser.parse(data)
+
+        #expect(response.videos.map(\.videoId) == ["middle-dot-video"])
+        #expect(response.videos.map(\.artistsDisplay) == ["Fixture Creator"])
+    }
+
+    @Test("Relative podcast dates do not replace episode duration")
+    func relativePodcastDateDoesNotReplaceDuration() {
+        let response = SearchResponseParser.parse(Self.makeRelativeDateEpisodeData())
+
+        let episode = response.podcastEpisodes.first
+        #expect(episode?.publishedDate == "2 hours ago")
+        #expect(episode?.duration == "36 min")
+        #expect(episode?.durationSeconds == 2160)
+    }
+
+    @Test("Radio browse IDs remain playlists ahead of watch fallbacks")
+    func radioBrowseIdsPreservePlaylistSemantics() {
+        let response = SearchResponseParser.parse(Self.makeRadioBrowseData(
+            browseIds: ["RDfixture-radio", "VMfixture-mix"]
+        ))
+
+        #expect(response.playlists.map(\.id) == ["RDfixture-radio", "VMfixture-mix"])
+        #expect(response.videos.isEmpty)
+        #expect(response.songs.isEmpty)
+    }
+
+    @Test("Localized type labels preserve video and podcast semantics")
+    func localizedTypeLabelsPreserveSemantics() {
+        let response = SearchResponseParser.parse(Self.makeLocalizedSemanticData())
+
+        #expect(response.videos.map(\.videoId) == ["localized-video"])
+        #expect(response.videos.first?.artistsDisplay == "Banda Ejemplo")
+        #expect(response.podcastShows.first?.author == "Fixture Network")
+    }
+
+    @Test("Count-only subtitles do not create fallback authors")
+    func countOnlySubtitlesDoNotCreateAuthors() {
+        let response = SearchResponseParser.parse(Self.makeCountOnlyCreatorData())
+
+        #expect(response.playlists.first?.trackCount == 12)
+        #expect(response.playlists.first?.author == nil)
+        #expect(response.podcastShows.first?.author == nil)
+    }
+
+    @Test("Localized count-only subtitles do not create fallback authors")
+    func localizedCountOnlySubtitlesDoNotCreateAuthors() {
+        let response = SearchResponseParser.parse(Self.makeCountOnlyCreatorData(
+            playlistLabel: "Lista de reproducción",
+            songCount: "1,2 mil canciones",
+            podcastLabel: "Podcast",
+            episodeCount: "1 234 episodios"
+        ))
+
+        #expect(response.playlists.first?.author == nil)
+        #expect(response.podcastShows.first?.author == nil)
+
+        let inflectedResponse = SearchResponseParser.parse(Self.makeCountOnlyCreatorData(
+            playlistLabel: "Playlista",
+            songCount: "12 utworów",
+            podcastLabel: "Подкаст",
+            episodeCount: "12 выпусков"
+        ))
+        #expect(inflectedResponse.playlists.first?.author == nil)
+        #expect(inflectedResponse.podcastShows.first?.author == nil)
+    }
+
+    @Test("Playlist IDs in watch endpoints retain playlist semantics")
+    func playlistWatchEndpointsPreserveSemantics() throws {
+        let data = try Self.loadFixture("search_playlist_watch_endpoints")
+
+        let response = SearchResponseParser.parse(data)
+
+        #expect(response.playlists.map(\.id) == ["RDradio-watch", "VMplaylist-action"])
+        #expect(response.albums.map(\.id) == ["MPREcanonical-album"])
+        #expect(response.videos.isEmpty)
+    }
+
+    @Test("Later flex columns contribute ordered metadata")
+    func laterFlexColumnsContributeMetadata() throws {
+        let data = try Self.loadFixture("search_later_flex_columns")
+
+        let response = SearchResponseParser.parse(data)
+
+        #expect(response.albums.first?.year == "2026")
+    }
+
     @Test("Parse empty response returns empty results")
     func parseEmptyResponse() {
         let data: [String: Any] = [:]
@@ -178,92 +508,6 @@ struct SearchResponseParserTests {
         #expect(explicit?.isExplicit == true)
         #expect(clean?.isExplicit == false)
     }
-
-    // MARK: - Helpers
-
-    private func makeSearchResponseData(songs: Int, albums: Int, artists: Int, playlists: Int) -> [String: Any] {
-        var contents: [[String: Any]] = []
-
-        if songs > 0 {
-            contents.append(["musicShelfRenderer": ["contents": self.makeSongItems(count: songs)]])
-        }
-        if albums > 0 {
-            contents.append(["musicShelfRenderer": ["contents": self.makeAlbumItems(count: albums)]])
-        }
-        if artists > 0 {
-            contents.append(["musicShelfRenderer": ["contents": self.makeArtistItems(count: artists)]])
-        }
-        if playlists > 0 {
-            contents.append(["musicShelfRenderer": ["contents": self.makePlaylistItems(count: playlists)]])
-        }
-
-        return [
-            "contents": [
-                "tabbedSearchResultsRenderer": [
-                    "tabs": [[
-                        "tabRenderer": [
-                            "content": [
-                                "sectionListRenderer": [
-                                    "contents": contents,
-                                ],
-                            ],
-                        ],
-                    ]],
-                ],
-            ],
-        ]
-    }
-
-    private func makeSongItems(count: Int) -> [[String: Any]] {
-        (0 ..< count).map { i in
-            [
-                "musicResponsiveListItemRenderer": [
-                    "playlistItemData": ["videoId": "video\(i)"],
-                    "flexColumns": [
-                        ["musicResponsiveListItemFlexColumnRenderer": ["text": ["runs": [["text": "Song \(i)"]]]]],
-                        ["musicResponsiveListItemFlexColumnRenderer": ["text": ["runs": [["text": "Artist"]]]]],
-                    ],
-                ],
-            ]
-        }
-    }
-
-    private func makeAlbumItems(count: Int) -> [[String: Any]] {
-        (0 ..< count).map { i in
-            [
-                "musicResponsiveListItemRenderer": [
-                    "navigationEndpoint": ["browseEndpoint": ["browseId": "MPRE\(i)"]],
-                    "flexColumns": [
-                        ["musicResponsiveListItemFlexColumnRenderer": ["text": ["runs": [["text": "Album \(i)"]]]]],
-                    ],
-                ],
-            ]
-        }
-    }
-
-    private func makeArtistItems(count: Int) -> [[String: Any]] {
-        (0 ..< count).map { i in
-            [
-                "musicResponsiveListItemRenderer": [
-                    "navigationEndpoint": ["browseEndpoint": ["browseId": "UC\(i)"]],
-                    "flexColumns": [
-                        ["musicResponsiveListItemFlexColumnRenderer": ["text": ["runs": [["text": "Artist \(i)"]]]]],
-                    ],
-                ],
-            ]
-        }
-    }
-
-    private func makePlaylistItems(count: Int) -> [[String: Any]] {
-        (0 ..< count).map { i in
-            [
-                "musicResponsiveListItemRenderer": [
-                    "navigationEndpoint": ["browseEndpoint": ["browseId": "VL\(i)"]],
-                    "flexColumns": [
-                        ["musicResponsiveListItemFlexColumnRenderer": ["text": ["runs": [["text": "Playlist \(i)"]]]]],
-                    ],
-                ],
-            ]
-        }
-    }
 }
+
+private extension SearchResponseParserTests {}

--- a/Tests/KasetTests/SearchResponseParserTests.swift
+++ b/Tests/KasetTests/SearchResponseParserTests.swift
@@ -264,6 +264,47 @@ struct SearchResponseParserTests {
         #expect(episode?.durationSeconds == 2160)
     }
 
+    @Test(
+        "Localized episode dates and durations preserve metadata",
+        arguments: [
+            ("2시간 전", "36분", 2160),
+            ("vor 2 Stunden", "45 Min", 2700),
+            ("منذ ٣ ساعات", "٣٦ دقيقة", 2160),
+            ("19 lipca", "36 min", 2160),
+            ("19 июля", "36 мин.", 2160),
+            ("12 maart", "36 min", 2160),
+            ("12 aprile", "36 min", 2160),
+        ]
+    )
+    func localizedEpisodeMetadataParses(
+        publishedDate: String,
+        duration: String,
+        expectedSeconds: Int
+    ) {
+        let response = SearchResponseParser.parse(Self.makeRelativeDateEpisodeData(
+            publishedDate: publishedDate,
+            duration: duration
+        ))
+
+        let episode = response.podcastEpisodes.first
+        #expect(episode?.publishedDate == publishedDate)
+        #expect(episode?.duration == duration)
+        #expect(episode?.durationSeconds == expectedSeconds)
+    }
+
+    @Test(
+        "Fallback show names containing count words are preserved",
+        arguments: ["Song Exploder", "Gameplay"]
+    )
+    func countWordsWithoutNumbersRemainShowNames(showTitle: String) {
+        let response = SearchResponseParser.parse(Self.makeRelativeDateEpisodeData(
+            showTitle: showTitle,
+            showBrowseId: nil
+        ))
+
+        #expect(response.podcastEpisodes.first?.showTitle == showTitle)
+    }
+
     @Test("Radio browse IDs remain playlists ahead of watch fallbacks")
     func radioBrowseIdsPreservePlaylistSemantics() {
         let response = SearchResponseParser.parse(Self.makeRadioBrowseData(

--- a/Tests/KasetTests/SearchResponseTests.swift
+++ b/Tests/KasetTests/SearchResponseTests.swift
@@ -12,6 +12,7 @@ struct SearchResponseTests {
         arguments: [
             ("song", "s1", "song-s1"),
             ("album", "a1", "album-a1"),
+            ("audiobook", "ab1", "audiobook-ab1"),
             ("artist", "ar1", "artist-ar1"),
             ("playlist", "p1", "playlist-p1"),
         ]
@@ -23,6 +24,8 @@ struct SearchResponseTests {
             item = .song(Song(id: id, title: "Song", artists: [], album: nil, duration: nil, thumbnailURL: nil, videoId: id))
         case "album":
             item = .album(Album(id: id, title: "Album", artists: nil, thumbnailURL: nil, year: nil, trackCount: nil))
+        case "audiobook":
+            item = .audiobook(Album(id: id, title: "Audiobook", artists: nil, thumbnailURL: nil, year: nil, trackCount: nil))
         case "artist":
             item = .artist(Artist(id: id, name: "Artist"))
         case "playlist":
@@ -32,6 +35,31 @@ struct SearchResponseTests {
             return
         }
         #expect(item.id == expectedId)
+    }
+
+    @Test("Playlist browse aliases share one content identity")
+    func playlistAliasesShareContentIdentity() {
+        let browsePlaylist = Playlist(
+            id: "VLPLfixture",
+            title: "Fixture",
+            description: nil,
+            thumbnailURL: nil,
+            trackCount: nil,
+            author: nil
+        )
+        let rawPlaylist = Playlist(
+            id: "PLfixture",
+            title: "Fixture",
+            description: nil,
+            thumbnailURL: nil,
+            trackCount: nil,
+            author: nil
+        )
+
+        #expect(
+            SearchResultItem.playlist(browsePlaylist).contentIdentity
+                == SearchResultItem.playlist(rawPlaylist).contentIdentity
+        )
     }
 
     // MARK: - SearchResultItem Title Tests
@@ -169,7 +197,69 @@ struct SearchResponseTests {
         #expect(SearchResultItem.playlist(playlist).videoId == nil)
     }
 
+    @Test("Video, profile, and podcast episode results expose semantic metadata")
+    func semanticResultMetadata() {
+        let video = Song(
+            id: "video",
+            title: "Video",
+            artists: [Artist(id: "artist", name: "Artist")],
+            videoId: "video",
+            musicVideoType: .omv
+        )
+        let profile = Artist(id: "UCprofile", name: "Profile", profileKind: .profile)
+        let episode = PodcastEpisode(
+            id: "episode",
+            title: "Episode",
+            showTitle: "Show",
+            showBrowseId: "MPSPPshow",
+            description: nil,
+            thumbnailURL: nil,
+            publishedDate: "Jul 19, 2026",
+            duration: nil,
+            durationSeconds: nil,
+            playbackProgress: 0,
+            isPlayed: false
+        )
+
+        let videoItem = SearchResultItem.video(video)
+        #expect(videoItem.resultType == "Video")
+        #expect(videoItem.videoId == "video")
+        #expect(videoItem.songPayload == video)
+
+        let profileItem = SearchResultItem.profile(profile)
+        #expect(profileItem.resultType == "Profile")
+        #expect(profileItem.usesCircularThumbnail)
+
+        let episodeItem = SearchResultItem.podcastEpisode(episode)
+        #expect(episodeItem.resultType == "Episode")
+        #expect(episodeItem.videoId == "episode")
+        #expect(episodeItem.songPayload == episode.playbackSong)
+        #expect(episodeItem.subtitle == "Jul 19, 2026 • Show")
+    }
+
     // MARK: - SearchResponse Tests
+
+    @Test("Audiobook results preserve semantic type and album-compatible metadata")
+    func audiobookResultMetadata() {
+        let narrator = Artist(id: "narrator", name: "Fixture Narrator")
+        let audiobook = Album(
+            id: "MPREb_audiobook",
+            title: "Fixture Audiobook",
+            artists: [narrator],
+            thumbnailURL: URL(string: "https://example.com/audiobook.jpg"),
+            year: "2026",
+            trackCount: 20
+        )
+        let item = SearchResultItem.audiobook(audiobook)
+        let response = SearchResponse(audiobooks: [audiobook])
+
+        #expect(item.id == "audiobook-MPREb_audiobook")
+        #expect(item.title == "Fixture Audiobook")
+        #expect(item.subtitle == "Fixture Narrator")
+        #expect(item.resultType == String(localized: "Audiobook"))
+        #expect(response.audiobooks.map(\.id) == ["MPREb_audiobook"])
+        #expect(response.albums.isEmpty)
+    }
 
     @Test("SearchResponse empty")
     func searchResponseEmpty() {
@@ -244,5 +334,49 @@ struct SearchResponseTests {
         let response = SearchResponse(songs: [song1, song2], albums: [album], artists: [], playlists: [])
 
         #expect(response.allItems.count == 3)
+    }
+
+    @Test("Ordered SearchResponse preserves server ranking and semantic projections")
+    func orderedSearchResponsePreservesRanking() {
+        let song = Song(id: "song", title: "Song", artists: [], videoId: "song")
+        let video = Song(
+            id: "video",
+            title: "Video",
+            artists: [],
+            videoId: "video",
+            musicVideoType: .ugc
+        )
+        let profile = Artist(id: "UCprofile", name: "Profile", profileKind: .profile)
+        let artist = Artist(id: "UCartist", name: "Artist", profileKind: .artist)
+        let episode = PodcastEpisode(
+            id: "episode",
+            title: "Episode",
+            showTitle: "Show",
+            showBrowseId: "MPSPPshow",
+            description: nil,
+            thumbnailURL: nil,
+            publishedDate: nil,
+            duration: nil,
+            durationSeconds: nil,
+            playbackProgress: 0,
+            isPlayed: false
+        )
+        let items: [SearchResultItem] = [
+            .profile(profile),
+            .video(video),
+            .podcastEpisode(episode),
+            .artist(artist),
+            .song(song),
+        ]
+
+        let response = SearchResponse(items: items, continuationToken: "next")
+
+        #expect(response.allItems.map(\.id) == items.map(\.id))
+        #expect(response.songs.map(\.id) == ["song"])
+        #expect(response.videos.map(\.id) == ["video"])
+        #expect(response.artists.map(\.id) == ["UCartist"])
+        #expect(response.profiles.map(\.id) == ["UCprofile"])
+        #expect(response.podcastEpisodes.map(\.id) == ["episode"])
+        #expect(response.continuationToken == "next")
     }
 }

--- a/Tests/KasetTests/SearchViewModelTests.swift
+++ b/Tests/KasetTests/SearchViewModelTests.swift
@@ -128,6 +128,77 @@ struct SearchViewModelTests {
         #expect(filters.contains(.podcasts))
     }
 
+    @Test("Video, profile, and episode filters are available")
+    func newSemanticFiltersAreAvailable() {
+        let filters = SearchViewModel.SearchFilter.allCases
+        #expect(filters.contains(.videos))
+        #expect(filters.contains(.profiles))
+        #expect(filters.contains(.episodes))
+        #expect(SearchViewModel.SearchFilter.videos.displayName == String(localized: "Videos"))
+        #expect(SearchViewModel.SearchFilter.profiles.displayName == String(localized: "Profiles"))
+        #expect(SearchViewModel.SearchFilter.episodes.displayName == String(localized: "Episodes"))
+    }
+
+    @Test(
+        "New semantic filters route to their dedicated endpoints",
+        arguments: [
+            (SearchViewModel.SearchFilter.videos, MockYTMusicClient.SearchEndpoint.videos),
+            (SearchViewModel.SearchFilter.profiles, MockYTMusicClient.SearchEndpoint.profiles),
+            (SearchViewModel.SearchFilter.episodes, MockYTMusicClient.SearchEndpoint.episodes),
+        ]
+    )
+    func newSemanticFiltersRoute(
+        filter: SearchViewModel.SearchFilter,
+        endpoint: MockYTMusicClient.SearchEndpoint
+    ) async {
+        self.viewModel.query = "semantic"
+        self.viewModel.selectedFilter = filter
+
+        await self.waitUntil(
+            self.mockClient.completedSearchEndpoints.contains(endpoint),
+            description: "\(filter.rawValue) search endpoint"
+        )
+
+        #expect(self.viewModel.loadingState == .loaded)
+    }
+
+    @Test("Albums filter preserves audiobook semantics")
+    func albumsFilterIncludesAudiobooks() async {
+        let album = Album(
+            id: "MPREalbum",
+            title: "Album",
+            artists: nil,
+            thumbnailURL: nil,
+            year: nil,
+            trackCount: nil
+        )
+        let audiobook = Album(
+            id: "MPREb_audiobook",
+            title: "Audiobook",
+            artists: nil,
+            thumbnailURL: nil,
+            year: nil,
+            trackCount: nil
+        )
+        self.mockClient.albumsSearchResponse = SearchResponse(items: [
+            .album(album),
+            .audiobook(audiobook),
+        ])
+
+        self.viewModel.query = "spoken word"
+        self.viewModel.selectedFilter = .albums
+        self.viewModel.searchImmediately()
+        await self.waitUntil(
+            self.viewModel.filteredItems.count == 2,
+            description: "album and audiobook results"
+        )
+
+        #expect(self.viewModel.filteredItems.map(\.id) == [
+            "album-MPREalbum",
+            "audiobook-MPREb_audiobook",
+        ])
+    }
+
     @Test("Podcast filter has correct raw value")
     func podcastFilterRawValue() {
         #expect(SearchViewModel.SearchFilter.podcasts.rawValue == "Podcasts")
@@ -233,31 +304,74 @@ struct SearchViewModelTests {
             podcastShows: [TestFixtures.makePodcastShow()],
             continuationToken: nil
         )
+        let videosResponse = SearchResponse(videos: [Song(
+            id: "video",
+            title: "Video",
+            artists: [],
+            videoId: "video",
+            musicVideoType: .ugc
+        )])
+        let profilesResponse = SearchResponse(profiles: [Artist(
+            id: "UCprofile",
+            name: "Profile",
+            profileKind: .profile
+        )])
+        let episode = PodcastEpisode(
+            id: "episode",
+            title: "Episode",
+            showTitle: "Show",
+            showBrowseId: "MPSPPshow",
+            description: nil,
+            thumbnailURL: nil,
+            publishedDate: nil,
+            duration: nil,
+            durationSeconds: nil,
+            playbackProgress: 0,
+            isPlayed: false
+        )
+        let episodesResponse = SearchResponse(podcastEpisodes: [episode])
 
         self.mockClient.mixedSearchResponse = .empty
         self.mockClient.songsSearchResponse = songsResponse
+        self.mockClient.videosSearchResponse = videosResponse
         self.mockClient.albumsSearchResponse = albumsResponse
         self.mockClient.artistsSearchResponse = artistsResponse
+        self.mockClient.profilesSearchResponse = profilesResponse
         self.mockClient.featuredPlaylistsSearchResponse = playlistsResponse
         self.mockClient.communityPlaylistsSearchResponse = playlistsResponse
         self.mockClient.podcastsSearchResponse = podcastsResponse
+        self.mockClient.episodesSearchResponse = episodesResponse
 
         self.viewModel.query = "lofi"
         self.viewModel.selectedFilter = .all
         self.viewModel.searchImmediately()
         await self.waitUntil(
-            self.viewModel.filteredItems.count == 6,
+            self.viewModel.filteredItems.count == 9,
             description: "all-filter aggregate results"
         )
 
         #expect(self.viewModel.loadingState == .loaded)
-        #expect(self.viewModel.filteredItems.count == 6)
+        #expect(self.viewModel.filteredItems.count == 9)
+        #expect(self.viewModel.results.allItems.map(\.id) == [
+            "song-video-0",
+            "song-video-1",
+            "video-video",
+            "album-MPRE-search-0",
+            "artist-UC-search-0",
+            "profile-UCprofile",
+            "playlist-VL-search-0",
+            "podcast-MPSPPLXz2p9test123",
+            "episode-episode",
+        ])
         #expect(self.viewModel.results.songs.count == 2)
+        #expect(self.viewModel.results.videos.count == 1)
         #expect(self.viewModel.results.albums.count == 1)
         #expect(self.viewModel.results.artists.count == 1)
+        #expect(self.viewModel.results.profiles.count == 1)
         #expect(self.viewModel.results.playlists.count == 1)
         #expect(self.viewModel.results.podcastShows.count == 1)
-        #expect(self.mockClient.searchQueries.count == 7)
+        #expect(self.viewModel.results.podcastEpisodes.count == 1)
+        #expect(self.mockClient.searchQueries.count == 10)
     }
 
     @Test("All filter uses mixed response without category fanout when mixed has results")
@@ -364,6 +478,84 @@ struct SearchViewModelTests {
         #expect(error.title == "Connection Error")
         #expect(error.isRetryable)
         #expect(self.viewModel.results.isEmpty)
-        #expect(self.mockClient.searchQueries.count == 7)
+        #expect(self.mockClient.searchQueries.count == 10)
+    }
+
+    @Test("Stale pagination cannot append into a newer search")
+    func stalePaginationCannotCorruptNewerSearch() async {
+        let continuationGate = AsyncGate()
+        let oldSong = TestFixtures.makeSong(id: "old", title: "Old")
+        let staleSong = TestFixtures.makeSong(id: "stale", title: "Stale")
+        let newSong = TestFixtures.makeSong(id: "new", title: "New")
+
+        self.mockClient.songsSearchResponse = SearchResponse(
+            songs: [oldSong],
+            continuationToken: "old-page-two"
+        )
+        self.mockClient.searchContinuationResponses["old-page-two"] = SearchResponse(
+            songs: [staleSong],
+            continuationToken: nil
+        )
+        self.mockClient.beforeSearchContinuationReturn = { token in
+            if token == "old-page-two" {
+                await continuationGate.wait()
+            }
+        }
+
+        self.viewModel.query = "old"
+        self.viewModel.selectedFilter = .songs
+        await self.waitUntil(
+            self.viewModel.loadingState == .loaded && self.viewModel.results.hasMore,
+            description: "old paginated search"
+        )
+
+        let paginationTask = Task { await self.viewModel.loadMore() }
+        await self.waitUntil(
+            self.mockClient.getSearchContinuationTokens == ["old-page-two"],
+            description: "stale continuation request"
+        )
+        #expect(self.viewModel.loadingState == .loadingMore)
+        #expect(self.viewModel.results.allItems.map(\.id) == ["song-old"])
+
+        self.mockClient.songsSearchResponse = SearchResponse(songs: [newSong])
+        self.viewModel.query = "new"
+        self.viewModel.searchImmediately()
+        await self.waitUntil(
+            self.viewModel.results.songs.map(\.id) == ["new"],
+            description: "new search results"
+        )
+
+        await continuationGate.open()
+        await paginationTask.value
+
+        #expect(self.viewModel.results.allItems.map(\.id) == ["song-new"])
+        #expect(self.viewModel.loadingState == .loaded)
+    }
+
+    @Test("Load more uses explicit continuation and preserves first occurrence order")
+    func loadMoreUsesExplicitContinuationAndDeduplicates() async {
+        let first = TestFixtures.makeSong(id: "first", title: "First")
+        let second = TestFixtures.makeSong(id: "second", title: "Second")
+        self.mockClient.songsSearchResponse = SearchResponse(
+            songs: [first],
+            continuationToken: "page-two"
+        )
+        self.mockClient.searchContinuationResponses["page-two"] = SearchResponse(
+            songs: [first, second],
+            continuationToken: nil
+        )
+
+        self.viewModel.query = "ordered"
+        self.viewModel.selectedFilter = .songs
+        await self.waitUntil(
+            self.viewModel.loadingState == .loaded && self.viewModel.results.hasMore,
+            description: "initial paginated search"
+        )
+
+        await self.viewModel.loadMore()
+
+        #expect(self.mockClient.getSearchContinuationTokens == ["page-two"])
+        #expect(self.viewModel.results.allItems.map(\.id) == ["song-first", "song-second"])
+        #expect(self.viewModel.results.hasMore == false)
     }
 }

--- a/Tests/KasetTests/SearchViewModelTests.swift
+++ b/Tests/KasetTests/SearchViewModelTests.swift
@@ -481,6 +481,16 @@ struct SearchViewModelTests {
         #expect(self.mockClient.searchQueries.count == 10)
     }
 
+    @Test("Mock reset clears the search continuation return hook")
+    func mockResetClearsSearchContinuationHook() {
+        self.mockClient.beforeSearchContinuationReturn = { _ in }
+
+        self.mockClient.reset()
+
+        #expect(self.mockClient.beforeSearchContinuationReturn == nil)
+        #expect(self.mockClient.getSearchContinuationTokens.isEmpty)
+    }
+
     @Test("Stale pagination cannot append into a newer search")
     func stalePaginationCannotCorruptNewerSearch() async {
         let continuationGate = AsyncGate()

--- a/Tests/KasetTests/SwiftTestingHelpers/TestStringConvertible.swift
+++ b/Tests/KasetTests/SwiftTestingHelpers/TestStringConvertible.swift
@@ -148,14 +148,22 @@ extension SearchResultItem: CustomTestStringConvertible {
         switch self {
         case let .song(song):
             "SearchResult[Song]: \(song.testDescription)"
+        case let .video(video):
+            "SearchResult[Video]: \(video.testDescription)"
         case let .album(album):
             "SearchResult[Album]: \(album.testDescription)"
+        case let .audiobook(audiobook):
+            "SearchResult[Audiobook]: \(audiobook.testDescription)"
         case let .artist(artist):
             "SearchResult[Artist]: \(artist.testDescription)"
+        case let .profile(profile):
+            "SearchResult[Profile]: \(profile.testDescription)"
         case let .playlist(playlist):
             "SearchResult[Playlist]: \(playlist.testDescription)"
         case let .podcastShow(show):
             "SearchResult[Podcast]: \(show.testDescription)"
+        case let .podcastEpisode(episode):
+            "SearchResult[Episode]: \(episode.title) [\(episode.id)]"
         }
     }
 }

--- a/Tests/KasetTests/YTMusicClientTests.swift
+++ b/Tests/KasetTests/YTMusicClientTests.swift
@@ -240,6 +240,248 @@ struct YTMusicClientTests {
     }
 }
 
+// MARK: - YTMusicClientSearchRequestTests
+
+@Suite(.serialized, .tags(.api))
+@MainActor
+struct YTMusicClientSearchRequestTests {
+    @Test("Filtered search and continuation route through search with exact parameters")
+    func filteredSearchAndContinuationRouting() async throws {
+        APICache.shared.invalidateAll()
+        let session = MockURLProtocol.makeMockSession()
+        let recorder = SearchRequestRecorder()
+
+        MockURLProtocol.setRequestHandler(for: session) { request in
+            let url = try #require(request.url)
+            let bodyData = try Self.requestBodyData(request)
+            let body = try #require(
+                JSONSerialization.jsonObject(with: bodyData) as? [String: Any]
+            )
+            recorder.append(SearchRequestRecord(
+                path: url.path,
+                query: body["query"] as? String,
+                params: body["params"] as? String,
+                continuation: body["continuation"] as? String,
+                hasBrowseId: body["browseId"] != nil
+            ))
+
+            let payload: [String: Any]
+            if body["continuation"] != nil {
+                payload = Self.continuationSearchPayload(continuation: "continuation-next")
+            } else {
+                let continuation = switch body["params"] as? String {
+                case "EgWKAQIQAWoMEA4QChADEAQQCRAF": "video-next"
+                case "EgWKAQJYAWoMEA4QChADEAQQCRAF": "profile-next"
+                case "EgWKAQJIAWoMEA4QChADEAQQCRAF": "episode-next"
+                default: "unexpected-next"
+                }
+                payload = Self.firstPageSearchPayload(continuation: continuation)
+            }
+            let data = try JSONSerialization.data(withJSONObject: payload)
+            let response = try #require(
+                HTTPURLResponse(
+                    url: url,
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "application/json"]
+                )
+            )
+            return (response, data)
+        }
+        defer { MockURLProtocol.reset(session: session) }
+
+        let client = self.makeClient(session: session)
+
+        let videos = try await client.searchVideos(query: "video query")
+        let profiles = try await client.searchProfiles(query: "profile query")
+        let episodes = try await client.searchEpisodes(query: "episode query")
+        let videoContinuation = try #require(videos.continuationToken)
+        let continuation = try await client.getSearchContinuation(token: videoContinuation)
+
+        #expect(videoContinuation == "video-next")
+        #expect(profiles.continuationToken == "profile-next")
+        #expect(episodes.continuationToken == "episode-next")
+        #expect(continuation.videos.map(\.videoId) == ["continued-video"])
+        #expect(continuation.continuationToken == "continuation-next")
+
+        let records = recorder.records
+        try #require(records.count == 4)
+        #expect(records.map(\.path) == Array(repeating: "/youtubei/v1/search", count: 4))
+        #expect(records.allSatisfy { !$0.hasBrowseId })
+        #expect(records[0] == SearchRequestRecord(
+            path: "/youtubei/v1/search",
+            query: "video query",
+            params: "EgWKAQIQAWoMEA4QChADEAQQCRAF",
+            continuation: nil,
+            hasBrowseId: false
+        ))
+        #expect(records[1] == SearchRequestRecord(
+            path: "/youtubei/v1/search",
+            query: "profile query",
+            params: "EgWKAQJYAWoMEA4QChADEAQQCRAF",
+            continuation: nil,
+            hasBrowseId: false
+        ))
+        #expect(records[2] == SearchRequestRecord(
+            path: "/youtubei/v1/search",
+            query: "episode query",
+            params: "EgWKAQJIAWoMEA4QChADEAQQCRAF",
+            continuation: nil,
+            hasBrowseId: false
+        ))
+        #expect(records[3] == SearchRequestRecord(
+            path: "/youtubei/v1/search",
+            query: nil,
+            params: nil,
+            continuation: "video-next",
+            hasBrowseId: false
+        ))
+    }
+
+    // swiftlint:disable:next modifier_order
+    private nonisolated static func firstPageSearchPayload(continuation: String) -> [String: Any] {
+        [
+            "contents": [
+                "tabbedSearchResultsRenderer": [
+                    "tabs": [[
+                        "tabRenderer": [
+                            "content": [
+                                "sectionListRenderer": [
+                                    "contents": [[
+                                        "musicShelfRenderer": [
+                                            "contents": [],
+                                            "continuations": [[
+                                                "nextContinuationData": [
+                                                    "continuation": continuation,
+                                                ],
+                                            ]],
+                                        ],
+                                    ]],
+                                ],
+                            ],
+                        ],
+                    ]],
+                ],
+            ],
+        ]
+    }
+
+    // swiftlint:disable:next modifier_order
+    private nonisolated static func continuationSearchPayload(continuation: String) -> [String: Any] {
+        [
+            "onResponseReceivedActions": [[
+                "appendContinuationItemsAction": [
+                    "continuationItems": [
+                        [
+                            "musicResponsiveListItemRenderer": [
+                                "playlistItemData": ["videoId": "continued-video"],
+                                "navigationEndpoint": [
+                                    "watchEndpoint": [
+                                        "videoId": "continued-video",
+                                        "watchEndpointMusicSupportedConfigs": [
+                                            "watchEndpointMusicConfig": [
+                                                "musicVideoType": "MUSIC_VIDEO_TYPE_UGC",
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                                "flexColumns": [
+                                    [
+                                        "musicResponsiveListItemFlexColumnRenderer": [
+                                            "text": ["runs": [["text": "Continued Video"]]],
+                                        ],
+                                    ],
+                                    [
+                                        "musicResponsiveListItemFlexColumnRenderer": [
+                                            "text": ["runs": [["text": "Video"]]],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                        [
+                            "continuationItemRenderer": [
+                                "continuationEndpoint": [
+                                    "continuationCommand": ["token": continuation],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ]],
+        ]
+    }
+
+    // URLSession may bridge `httpBody` to a stream before URLProtocol observes the request.
+    // swiftlint:disable:next modifier_order
+    private nonisolated static func requestBodyData(_ request: URLRequest) throws -> Data {
+        if let body = request.httpBody {
+            return body
+        }
+
+        guard let stream = request.httpBodyStream else {
+            throw YTMusicError.parseError(message: "Search request body was missing")
+        }
+
+        stream.open()
+        defer { stream.close() }
+
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while true {
+            let count = stream.read(&buffer, maxLength: buffer.count)
+            if count < 0 {
+                throw stream.streamError ?? YTMusicError.parseError(message: "Search request body could not be read")
+            }
+            if count == 0 {
+                return data
+            }
+            data.append(buffer, count: count)
+        }
+    }
+
+    private func makeClient(session: URLSession) -> YTMusicClient {
+        let webKitManager = WebKitManager.makeTestInstance()
+        let authService = AuthService(webKitManager: webKitManager)
+        let resolver = YTMusicAPIKeyResolver(session: session, environment: { name in
+            name == YTMusicAPIKeyResolver.environmentVariable ? "mock-token" : nil
+        })
+        return YTMusicClient(
+            authService: authService,
+            webKitManager: webKitManager,
+            session: session,
+            apiKeyResolver: resolver
+        )
+    }
+}
+
+// MARK: - SearchRequestRecord
+
+private struct SearchRequestRecord: Equatable, Sendable {
+    let path: String
+    let query: String?
+    let params: String?
+    let continuation: String?
+    let hasBrowseId: Bool
+}
+
+// MARK: - SearchRequestRecorder
+
+private final class SearchRequestRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedRecords: [SearchRequestRecord] = []
+
+    var records: [SearchRequestRecord] {
+        self.lock.withLock { self.storedRecords }
+    }
+
+    func append(_ record: SearchRequestRecord) {
+        self.lock.withLock {
+            self.storedRecords.append(record)
+        }
+    }
+}
+
 // MARK: - YTMusicAPIKeyResolverTests
 
 /// Tests for runtime resolution of the YouTube Music web client API key.
@@ -536,6 +778,62 @@ struct YTMusicClientContinuationResetTests {
         #expect(continuationRequestCount.count == 1)
     }
 
+    @Test("Stale search continuation is discarded after reset")
+    func staleSearchContinuationIsDiscardedAfterReset() async throws {
+        APICache.shared.invalidateAll()
+        let session = MockURLProtocol.makeMockSession()
+        let requestCount = LockedCounter()
+
+        MockURLProtocol.setRequestHandler(for: session) { request in
+            requestCount.increment()
+            Thread.sleep(forTimeInterval: 0.15)
+            let url = try #require(request.url)
+
+            let data = try JSONSerialization.data(
+                withJSONObject: Self.searchContinuationPayload(nextCursor: "page-2")
+            )
+            let response = try #require(
+                HTTPURLResponse(
+                    url: url,
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "application/json"]
+                )
+            )
+            return (response, data)
+        }
+        defer { MockURLProtocol.reset(session: session) }
+
+        let authService = AuthService(webKitManager: MockWebKitManager())
+        let resolver = YTMusicAPIKeyResolver(session: session, environment: { name in
+            name == YTMusicAPIKeyResolver.environmentVariable ? "mock-token" : nil
+        })
+        let client = YTMusicClient(
+            authService: authService,
+            session: session,
+            apiKeyResolver: resolver
+        )
+
+        async let staleContinuation = client.getSearchContinuation(token: "page-1")
+        try? await Task.sleep(for: .milliseconds(30))
+        client.resetSessionStateForAccountSwitch()
+
+        do {
+            _ = try await staleContinuation
+            Issue.record("Expected stale search continuation to be cancelled")
+        } catch is CancellationError {
+            // Expected: reset invalidates any continuation already in flight.
+        } catch {
+            Issue.record("Expected CancellationError, got \(error)")
+        }
+
+        #expect(requestCount.count == 1)
+
+        let retry = try await client.getSearchContinuation(token: "page-1")
+        #expect(retry.continuationToken == "page-2")
+        #expect(requestCount.count == 2)
+    }
+
     // swiftlint:disable:next modifier_order
     private nonisolated static func homePayload(cursor: String) -> [String: Any] {
         [
@@ -553,6 +851,22 @@ struct YTMusicClientContinuationResetTests {
                                     ]],
                                 ],
                             ],
+                        ],
+                    ]],
+                ],
+            ],
+        ]
+    }
+
+    // swiftlint:disable:next modifier_order
+    private nonisolated static func searchContinuationPayload(nextCursor: String) -> [String: Any] {
+        [
+            "continuationContents": [
+                "musicShelfContinuation": [
+                    "contents": [],
+                    "continuations": [[
+                        "nextContinuationData": [
+                            "continuation": nextCursor,
                         ],
                     ]],
                 ],

--- a/docs/adr/0028-ordered-semantic-music-search-results.md
+++ b/docs/adr/0028-ordered-semantic-music-search-results.md
@@ -1,0 +1,75 @@
+# ADR-0028: Ordered Semantic YouTube Music Search Results
+
+## Status
+
+Accepted
+
+## Context
+
+YouTube Music search responses are heterogeneous and change renderer wrappers
+without changing the underlying endpoint. Current mixed responses can contain a
+playable Top Result, nested card rows, individually wrapped
+`itemSectionRenderer` rows, direct shelves, podcast shows, podcast episodes,
+profiles, audiobooks, songs, and multiple video kinds.
+
+Kaset previously stored search results in separate type arrays and rebuilt the
+visible list in a fixed songs → albums → artists → playlists → podcasts order.
+That discarded YouTube Music's relevance ranking. The parser also assumed direct
+shelves, treated every playable row as a song, ignored podcast shows, and kept a
+single hidden client-owned search continuation value shared across filters.
+
+The hidden continuation value made ownership ambiguous: query changes, filter
+changes, fallback fan-out, and pagination all mutated one client cursor. Live
+search continuations are also carried by the result shelf and must be posted to
+the `search` endpoint, not the generic `browse` continuation path.
+
+## Decision
+
+`SearchResponse.items` is the canonical search representation.
+
+- `SearchResultItem` carries semantic cases for song, video, album, audiobook,
+  artist, profile, playlist, podcast show, and podcast episode.
+- Existing models remain the payloads: videos use `Song`, profiles use `Artist`,
+  audiobooks use `Album`, and episodes use `PodcastEpisode`.
+- Typed collections such as `songs`, `videos`, `profiles`, and
+  `podcastEpisodes` are computed projections. Compatibility initializers build a
+  grouped item list for existing category-specific callers, while mixed parsing
+  uses the ordered initializer.
+- Mixed parsing traverses only known result containers in response-array order:
+  Top Result, nested Top Result rows, direct shelves, and item-section wrappers.
+  It does not recursively enter menus, overlays, or unrelated commands.
+- First occurrence wins when multiple renderer paths expose the same content.
+  Deduplication uses destination identity rather than the semantic case prefix,
+  so a video and episode with the same playable ID cannot appear twice.
+- Playable rows retain `musicVideoType`; videos and podcast episodes are no
+  longer displayed as ordinary songs. `MUSIC_VIDEO_TYPE_OFFICIAL_SOURCE_MUSIC`
+  is recognized as a search video without changing the player bar's stricter
+  video-toggle policy.
+- Search pagination is caller-owned. Filtered responses expose their continuation
+  value, and callers pass that value explicitly to `getSearchContinuation`.
+  The client no longer owns a shared mutable search cursor. The view model also
+  scopes each continuation request to the current result generation and discards
+  responses after a query, filter, refresh, or clear invalidates that generation.
+- Search continuations are requested from `/search` and parsed through the same
+  ordered semantic item pipeline. Both legacy `musicShelfContinuation` envelopes
+  and action envelopes using append/reload continuation commands are supported.
+- Videos, Profiles, and Episodes are first-class filters alongside the existing
+  filters. Static no-spelling-correction params are retained as direct-filter
+  fallbacks because full server-issued chip params vary by query context.
+
+## Consequences
+
+- Search preserves the server's Top Result and relevance order.
+- Modern renderer wrappers no longer turn valid responses into empty results.
+- Videos, profiles, audiobooks, podcast shows, and episodes have correct labels,
+  navigation, and playback behavior.
+- Pagination no longer depends on hidden cross-query client state, cannot use
+  the wrong filter's cursor, and cannot append a stale page into newer results.
+- Existing rows remain visible during `.loadingMore`; only the inline continuation
+  footer changes to a progress indicator, preserving scroll context.
+- Parser and view-model tests must assert ordered semantic items rather than only
+  bucket counts.
+- Compatibility initializers still group category arrays, so non-mixed callers do
+  not need immediate migration.
+- Adding a future search type requires a new semantic case and explicit parser/UI
+  handling, making unsupported API changes visible at compile time.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -62,3 +62,4 @@ What becomes easier or more difficult because of this change?
 | [0025](0025-smart-shuffle.md) | Smart Shuffle (tri-state shuffle with interleaved recommendations) | Accepted |
 | [0026](0026-generation-scoped-web-playback-bridge.md) | Generation-Scoped Web Playback Bridge Events | Accepted |
 | [0027](0027-native-music-playback-intents-and-queue-entry-identity.md) | Native Music Playback Intents and Queue-Entry Identity | Accepted |
+| [0028](0028-ordered-semantic-music-search-results.md) | Ordered Semantic YouTube Music Search Results | Accepted |

--- a/docs/api-discovery.md
+++ b/docs/api-discovery.md
@@ -457,7 +457,7 @@ Action endpoints perform operations or fetch specific data.
 
 | Endpoint | Name | Auth | Description |
 |----------|------|------|-------------|
-| `search` | Search | 🌐 | Search songs, albums, artists, playlists |
+| `search` | Search | 🌐 | Search songs, videos, albums/audiobooks, artists/profiles, playlists, podcasts, and episodes |
 | `music/get_search_suggestions` | Suggestions | 🌐 | Autocomplete for search |
 | `next` | Now Playing | 🌐 | Track info, lyrics ID, radio queue |
 | `like/like` | Like | 🔐 | Like a song/album/playlist |
@@ -478,10 +478,12 @@ let body = ["query": "never gonna give you up"]
 ```
 
 **Response Structure**:
-- `musicCardShelfRenderer` — **Top Result** section (single prominent result: song, album, artist, or playlist)
-- `musicShelfRenderer` — Regular results (mixed songs, albums, artists, playlists)
+- `musicCardShelfRenderer` — **Top Result** section. Its title can navigate through either `browseEndpoint` or `watchEndpoint`, and its `contents` can include additional rows.
+- `itemSectionRenderer.contents[]` — Current mixed-search rows. Each wrapper commonly contains one `musicResponsiveListItemRenderer`.
+- `musicShelfRenderer` — Filtered result lists and occasional direct mixed-search sections.
+- `musicResponsiveListItemRenderer` — Songs, videos, albums, audiobooks, artists, profiles, playlists, podcast shows, and podcast episodes.
 
-> ⚠️ **Important**: The Top Result (most relevant match) is returned in `musicCardShelfRenderer`, not `musicShelfRenderer`. This is often the artist/album the user is looking for. Always parse both renderer types.
+> ⚠️ **Important**: Revalidated on 2026-07-19, mixed search no longer consistently returns direct `musicShelfRenderer` sections. Parse `musicCardShelfRenderer`, its nested `contents`, direct `musicShelfRenderer`, and `itemSectionRenderer.contents`. Top Results can be directly playable `watchEndpoint` videos, not only browse destinations.
 
 **Top Result Example** (searching "manifest"):
 ```json
@@ -509,7 +511,30 @@ let body = ["query": "never gonna give you up"]
 }
 ```
 
-**Parser**: `SearchResponseParser` (handles both `musicCardShelfRenderer` and `musicShelfRenderer`)
+**Observed mixed result types (guest session, 2026-07-19)**:
+
+- `Song` — usually `MUSIC_VIDEO_TYPE_ATV`
+- `Video` — `MUSIC_VIDEO_TYPE_OMV` or `MUSIC_VIDEO_TYPE_UGC`
+- `Album`
+- `Audiobook` — `MUSIC_PAGE_TYPE_AUDIOBOOK`; currently uses an album-like `MPRE...` browse destination
+- `Artist`
+- `Profile` — `MUSIC_PAGE_TYPE_USER_CHANNEL`
+- `Playlist`
+- `Podcast` — `MUSIC_PAGE_TYPE_PODCAST_SHOW_DETAIL_PAGE`
+- `Episode` — `MUSIC_VIDEO_TYPE_PODCAST_EPISODE` with an `MPED...` title destination
+
+Playable rows can expose the same video ID through several paths:
+
+```text
+playlistItemData.videoId
+navigationEndpoint.watchEndpoint.videoId
+flexColumns[0]...runs[0].navigationEndpoint.watchEndpoint.videoId
+overlay...musicPlayButtonRenderer.playNavigationEndpoint.watchEndpoint.videoId
+```
+
+Browse rows commonly use `musicResponsiveListItemRenderer.navigationEndpoint.browseEndpoint`.
+
+**Parser**: `SearchResponseParser`. The API shape audit command below reports which live rows the current parser can and cannot reach.
 
 **Filter Params** (base64-encoded filter values for `params` field):
 
@@ -523,7 +548,20 @@ let body = ["query": "never gonna give you up"]
 | Community Playlists | `EgeKAQQoAEABagwQDhAKEAMQBBAJEAU=` | User-created playlists |
 | Podcasts | `EgWKAQJQAWoQEBAQCRAEEAMQBRAKEBUQEQ%3D%3D` | Filter to podcast shows only |
 
-> **Filter Pattern**: `EgWKAQ` (base) + filter code + `AWoMEA4QChADEAQQCRAF` (no spelling correction suffix). The filter code encodes the content type (songs=II, albums=IY, artists=Ig, playlists=Io, podcasts=JQ).
+> **Static params vs. live chips**: The table above records Kaset's existing no-spelling-correction params. Live `chipCloudChipRenderer.navigationEndpoint.searchEndpoint.params` values are contextual: the same filter label had different complete suffixes for different queries on 2026-07-19. Do not assume one server-issued full params value is universal.
+
+Observed filter type codes in live chips:
+
+| Live Filter | Encoded Type Code | Current Kaset Filter |
+|-------------|-------------------|----------------------|
+| Songs | `II` | ✅ |
+| Videos | `IQ` | ✅ |
+| Albums | `IY` | ✅ |
+| Artists | `Ig` | ✅ |
+| Profiles | `JY` | ✅ |
+| Episodes | `JI` | ✅ |
+| Podcasts | `JQ` | ✅ |
+| Community / Featured playlists | Specialized playlist params | ✅ |
 
 **Usage Example** (podcasts):
 ```swift
@@ -532,6 +570,65 @@ let body: [String: Any] = [
     "params": "EgWKAQJQAWoQEBAQCRAEEAMQBRAKEBUQEQ%3D%3D"
 ]
 ```
+
+**Filtered Search Continuation** (revalidated 2026-07-19):
+
+The first-page token is carried by the shelf, not the enclosing section list:
+
+```text
+contents.tabbedSearchResultsRenderer.tabs[0].tabRenderer.content
+  .sectionListRenderer.contents[].musicShelfRenderer
+  .continuations[0].nextContinuationData.continuation
+```
+
+Send that token back to the `search` endpoint:
+
+```swift
+let body = ["continuation": token]
+// POST /youtubei/v1/search
+```
+
+The common response uses:
+
+```text
+continuationContents.musicShelfContinuation.contents[]
+continuationContents.musicShelfContinuation.continuations[]
+```
+
+Search continuations can also use action envelopes. Preserve action order and parse both append and reload commands:
+
+```text
+onResponseReceivedActions[] | onResponseReceivedCommands[] | onResponseReceivedEndpoints[]
+  .appendContinuationItemsAction.continuationItems[]
+  .reloadContinuationItemsCommand.continuationItems[]
+```
+
+The `continuationItems` array can mix result renderers with a trailing `continuationItemRenderer` carrying the next token. `SearchResponseParser.parseContinuation` supports both the shelf envelope and these action envelopes.
+
+Sending the captured search token to `browse` returned unrelated browse/home sections in the same guest session, not the next search page.
+
+**Deep audit command**:
+
+```bash
+swift run api-explorer --guest search-audit "ambient electronic mix"
+```
+
+This probes the unfiltered response, every live filter chip, and one `/search` continuation page per filter when offered. It reports renderer wrappers, destination paths, content/page types, token carrier locations, and current mixed-parser coverage without printing continuation values.
+
+To compare a response against Kaset's currently configured WEB_REMIX version instead of the live web version resolved by API Explorer:
+
+```bash
+swift run api-explorer --guest --client-version 1.20231204.01.00 \
+  search-audit "ambient electronic mix"
+```
+
+`search-audit` labels the client-version source as `live`, `override`, or `fallback`. When it reports `fallback`, use `--client-version` before drawing a version-comparison conclusion. API Explorer also resolves the live version independently when the API key comes from its environment override.
+
+For this query, the live version `1.20260715.04.00` and Kaset's configured `1.20231204.01.00` showed no structural difference in section wrappers, result-type counts, filter chips, or continuation carriers. This does not prove that every result identity was identical or fully rule out version-specific behavior; it does show that the observed parser gaps reproduce with Kaset's configured version.
+
+A July 19, 2026 guest audit matrix covering the reported query, `Taylor Swift`, `The Daily podcast`, and `lofi hip hop` found no unhandled result rows after the parser update. It also exposed `MUSIC_PAGE_TYPE_AUDIOBOOK` inside mixed and Albums-filter results; Kaset now keeps those results semantically distinct as audiobooks while reusing the existing album payload and playlist-style detail navigation.
+
+`search-audit` labels the version source as `live`, `override`, or `fallback`. The audit performs a bounded live-version lookup even when `KASET_YTMUSIC_API_KEY` supplies the API key; unrelated API Explorer commands keep the environment override's immediate behavior. If web configuration discovery fails, the report explicitly identifies the configured fallback instead of presenting it as live.
 
 ---
 
@@ -1298,7 +1395,8 @@ The `--brand` flag sets `context.user.onBehalfOfUser` in the request body. See [
 |---------|-------------|
 | `browse <id> [params]` | Explore a browse endpoint |
 | `action <endpoint> <json>` | Explore an action endpoint |
-| `continuation <token> [ep]` | Explore a continuation (`browse` or `next`) |
+| `search-audit <query>` | Audit live Music search shapes, filter chips, continuations, and parser coverage |
+| `continuation <token> [ep]` | Explore a continuation (`browse`, `search`, or `next`); use the same auth mode as the originating request (`--guest` for guest search) |
 | `list` | List all known endpoints |
 | `auth` | Check authentication status |
 | `accounts` | Discover accounts via authuser header |
@@ -1309,10 +1407,11 @@ The `--brand` flag sets `context.user.onBehalfOfUser` in the request body. See [
 
 | Option | Description |
 |--------|-------------|
-| `-v, --verbose` | Show full raw JSON response |
+| `-v, --verbose` | Show full raw JSON for browse/action/continuation commands; expand samples and filter params for `search-audit` |
 | `-o, --output <file>` | Save raw JSON to file |
 | `--authuser N` | Use Google account at index N |
 | `--brand <ID>` | Use brand account (21-digit ID) |
+| `--client-version <version>` | Override the resolved InnerTube client version for compatibility probes |
 | `--youtube`, `--yt` | Target regular YouTube (`www.youtube.com`, WEB client) instead of YouTube Music |
 
 ---
@@ -1332,6 +1431,7 @@ The `--brand` flag sets `context.user.onBehalfOfUser` in the request body. See [
 
 | Date | Changes |
 |------|---------|
+| 2026-07-19 | Revalidated Music search: `itemSectionRenderer` mixed rows, watch-endpoint Top Results, audiobooks, videos/profiles/episodes filters, shelf and action-envelope continuations, and `/search` routing; added `search-audit` |
 | 2026-06-24 | Documented regular YouTube `--youtube` API Explorer mode alongside YouTube Music |
 | 2026-01-16 | Added comprehensive Podcast ID Format section: MPSPP→PL conversion, L-prefix validation, double-L bug documentation |
 | 2026-01-14 | Added Brand Account Support: `account/accounts_list` endpoint, `--brand` flag, `brandaccounts` command |


### PR DESCRIPTION
## Summary

- Preserve YouTube Music's server-ranked search order with semantic result cases for songs, videos, albums, audiobooks, artists, profiles, playlists, podcast shows, and episodes.
- Parse current search containers, watch-based top results, localized metadata, playlist aliases, and legacy plus action-envelope continuations.
- Add Videos, Profiles, and Episodes filters with caller-owned, generation-safe pagination that stays valid across query, filter, and account changes.
- Keep existing rows visible while loading additional pages and provide localized labels and context-menu/navigation behavior for the new result families.
- Extend API Explorer with a bounded search audit, add sanitized fixtures, update discovery documentation and ADR-0028, and expand configurable UI-test mock coverage.

## Root cause

Search parsing assumed older shelf-only response shapes, rebuilt results from separate type buckets, and treated most playable rows as songs. This dropped modern item-section and watch-based results, discarded server ranking, and coupled pagination to a shared mutable client cursor.

## Validation

- `swift build`
- `swiftlint --strict` — 0 violations
- Focused search, parser, client, view-model, localization, and mock suites — 166 tests passed
- Parser/model continuation follow-ups — 97 tests passed
- Previously timing-sensitive suites rerun in isolation — 112 tests passed
- Localization catalog JSON and every `.strings` file validated
- Live guest API audit across representative queries reported zero unhandled result rows/cards
- Structured Codex autoreview — clean, no accepted/actionable findings

UI tests were not run.