### PR TITLE
feat(library): add saved album support

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -18,7 +18,7 @@ The coordinator that keeps YouTube Music and regular YouTube from playing over e
 
 ## Library
 
-The signed-in user's saved YouTube Music collection. Kaset surfaces Music Library content as playlists, followed artists, subscribed podcast shows, and uploaded songs. Regular YouTube has separate library-like surfaces such as subscriptions, Watch Later, liked videos, history, and playlists.
+The signed-in user's saved YouTube Music collection. Kaset surfaces Music Library content as playlists, saved albums, followed artists, subscribed podcast shows, and uploaded songs. Regular YouTube has separate library-like surfaces such as subscriptions, Watch Later, liked videos, history, and playlists.
 
 ## Library Content Identity
 
@@ -43,6 +43,10 @@ The rules for preparing songs before they enter Kaset's native queue. This inclu
 ## Album Playback Actions
 
 The workflows that fetch album tracks from YouTube Music playlist details, prepare them as queue-ready songs, and either insert them into the queue or replace playback with the album.
+
+## Album Library Identity
+
+The two identifiers required for album Library behavior. An `MPRE...` browse ID identifies the album detail page and the visible saved album, while an `OLAK...` playlist ID is the target sent to YouTube Music's add/remove Library mutation endpoints.
 
 ## Playlist Playback Actions
 

--- a/Sources/APIExplorer/main.swift
+++ b/Sources/APIExplorer/main.swift
@@ -974,6 +974,31 @@ private func libraryFeedbackProbeSummary(_ data: [String: Any]) -> String {
     return output
 }
 
+private func collectAlbumPlaylistTargets(in value: Any, targets: inout Set<String>) {
+    if let dictionary = value as? [String: Any] {
+        if let playlistId = dictionary["playlistId"] as? String,
+           playlistId.hasPrefix("OLAK")
+        {
+            targets.insert(playlistId)
+        }
+        for child in dictionary.values {
+            collectAlbumPlaylistTargets(in: child, targets: &targets)
+        }
+    } else if let array = value as? [Any] {
+        for child in array {
+            collectAlbumPlaylistTargets(in: child, targets: &targets)
+        }
+    }
+}
+
+private func albumLibraryTargetSummary(_ data: [String: Any]) -> String {
+    var targets = Set<String>()
+    collectAlbumPlaylistTargets(in: data, targets: &targets)
+    guard !targets.isEmpty else { return "" }
+
+    return "\n💾 Album library target:\n  • Found \(targets.count) unique OLAK playlist target(s) for album mutations\n"
+}
+
 func analyzeResponse(
     _ data: [String: Any],
     verbose: Bool = false,
@@ -1064,6 +1089,8 @@ func analyzeResponse(
 
     output += playlistSetVideoIdSourceSummary(data)
 
+    output += albumLibraryTargetSummary(data)
+
     output += chapterProbeSummary(data)
 
     output += libraryFeedbackProbeSummary(data)
@@ -1085,10 +1112,10 @@ func analyzeResponse(
 /// Known endpoints that require authentication
 let authRequiredEndpoints = Set([
     "FEmusic_liked_playlists",
+    "FEmusic_liked_albums",
     "FEmusic_liked_videos",
     "FEmusic_history",
     "FEmusic_library_landing",
-    "FEmusic_library_albums",
     "FEmusic_library_artists",
     "FEmusic_library_corpus_artists",
     "FEmusic_library_corpus_track_artists",
@@ -1138,6 +1165,11 @@ func needsAuthentication(_ browseId: String) -> Bool {
     // Podcast shows (MPSPP...) require authentication for episode data
     if browseId.hasPrefix("MPSPP") {
         return true
+    }
+    // Album pages are public, but authenticated requests expose personalized
+    // Save/Remove library controls and their OLAK mutation targets.
+    if browseId.hasPrefix("MPRE") || browseId.hasPrefix("OLAK") {
+        return loadCookiesFromAppBackup() != nil
     }
     return false
 }
@@ -2288,10 +2320,10 @@ func listEndpoints() {
         🔐 AUTHENTICATED (Requires Sign-in)
         ───────────────────────────────────────────────────────────────────────────────
         FEmusic_liked_playlists       User's saved/created playlists
+        FEmusic_liked_albums          User's saved albums
         FEmusic_liked_videos          Liked songs (returns playlist format)
         FEmusic_history               Listening history (organized by time)
         FEmusic_library_landing       Library overview page
-        FEmusic_library_albums        Saved albums (requires params*)
         FEmusic_library_artists       Rejected with HTTP 400 in current sessions
         FEmusic_library_corpus_artists Followed artists (returns public UC... pages)
         FEmusic_library_corpus_track_artists  Artists chip from Library (returns MPLAUC... pages)
@@ -2390,16 +2422,15 @@ func listEndpoints() {
                                       Body: {}
 
         ═══════════════════════════════════════════════════════════════════════════════
-        📌 LIBRARY PARAMS (for library_albums, library_artists, library_songs)
+        📌 OPTIONAL LIBRARY SORT PARAMS
         ═══════════════════════════════════════════════════════════════════════════════
 
-        ggMGKgQIARAA    Recently Added
-        ggMGKgQIAhAA    Recently Played
-        ggMGKgQIAxAA    Alphabetical A-Z
-        ggMGKgQIBBAA    Alphabetical Z-A
-        ggMCCAE         Default Sort
+        ggMGKgQIARAA    Alphabetical A-Z
+        ggMGKgQIARAB    Alphabetical Z-A
+        ggMGKgQIABAB    Recently Added
 
-        Example: swift run api-explorer browse FEmusic_library_albums ggMGKgQIARAA
+        Saved albums use FEmusic_liked_albums and do not require params for the default order.
+        Example: swift run api-explorer browse FEmusic_liked_albums
 
         FEmusic_library_corpus_track_artists is the Library Artists chip endpoint.
         It requires sign-in for useful content but does not need sort params.

--- a/Sources/Kaset/KasetApp.swift
+++ b/Sources/Kaset/KasetApp.swift
@@ -26,6 +26,10 @@ extension EnvironmentValues {
 }
 
 extension EnvironmentValues {
+    @Entry var libraryViewModel: LibraryViewModel?
+}
+
+extension EnvironmentValues {
     @Entry var onPlaylistDeleted: (() -> Void)?
 }
 

--- a/Sources/Kaset/KasetApp.swift
+++ b/Sources/Kaset/KasetApp.swift
@@ -113,6 +113,25 @@ struct KasetApp: App {
 
         // Create account service
         let account = AccountService(ytMusicClient: client, authService: auth, webKitManager: webkit)
+        let beginAccountBoundary: @MainActor @Sendable () -> Void = {
+            LibraryMutationActions.beginAccountBoundary()
+        }
+        let endAccountBoundary: @MainActor @Sendable () -> Void = {
+            LibraryMutationActions.endAccountBoundary()
+        }
+        let drainAccountBoundary: @MainActor @Sendable () async -> Void = {
+            await LibraryMutationActions.awaitAccountBoundaryDrain()
+        }
+        auth.setAccountBoundaryHandlers(
+            willBegin: beginAccountBoundary,
+            didEnd: endAccountBoundary,
+            drain: drainAccountBoundary
+        )
+        account.setAccountBoundaryHandlers(
+            willBegin: beginAccountBoundary,
+            didEnd: endAccountBoundary,
+            drain: drainAccountBoundary
+        )
 
         // Wire up brand account provider so API requests use the correct account
         realClient.brandIdProvider = { [weak account] in

--- a/Sources/Kaset/KasetApp.swift
+++ b/Sources/Kaset/KasetApp.swift
@@ -118,6 +118,9 @@ struct KasetApp: App {
         realClient.brandIdProvider = { [weak account] in
             account?.currentBrandId
         }
+        realClient.accountScopeProvider = { [weak account] in
+            account?.currentAccountScopeID
+        }
 
         // YouTube (video) client — same login, www.youtube.com origin
         let realYouTubeClient = YouTubeClient(authService: auth, webKitManager: webkit)

--- a/Sources/Kaset/Models/Album.swift
+++ b/Sources/Kaset/Models/Album.swift
@@ -10,6 +10,25 @@ struct Album: Identifiable, Codable, Hashable {
     let thumbnailURL: URL?
     let year: String?
     let trackCount: Int?
+    let libraryTargetId: String?
+
+    init(
+        id: String,
+        title: String,
+        artists: [Artist]?,
+        thumbnailURL: URL?,
+        year: String?,
+        trackCount: Int?,
+        libraryTargetId: String? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.artists = artists
+        self.thumbnailURL = thumbnailURL
+        self.year = year
+        self.trackCount = trackCount
+        self.libraryTargetId = libraryTargetId
+    }
 
     /// Display string for artists (comma-separated).
     var artistsDisplay: String {
@@ -38,6 +57,7 @@ extension Album {
                 self.thumbnailURL = nil
                 self.year = nil
                 self.trackCount = nil
+                self.libraryTargetId = nil
                 return
             }
             return nil
@@ -71,5 +91,7 @@ extension Album {
         } else {
             self.trackCount = nil
         }
+
+        self.libraryTargetId = data["playlistId"] as? String
     }
 }

--- a/Sources/Kaset/Models/Playlist.swift
+++ b/Sources/Kaset/Models/Playlist.swift
@@ -193,6 +193,7 @@ struct PlaylistDetail: Identifiable {
     let canDelete: Bool
     let tracks: [Song]
     let duration: String?
+    let libraryTargetId: String?
 
     /// Whether this is an album (vs a playlist).
     /// Albums have IDs starting with "OLAK" or "MPRE".
@@ -210,7 +211,12 @@ struct PlaylistDetail: Identifiable {
         LikedMusicPlaylist.matches(id: self.id) || self.isUploadedSongs || self.canDelete
     }
 
-    init(playlist: Playlist, tracks: [Song], duration: String? = nil) {
+    init(
+        playlist: Playlist,
+        tracks: [Song],
+        duration: String? = nil,
+        libraryTargetId: String? = nil
+    ) {
         self.id = playlist.id
         self.title = playlist.title
         self.description = playlist.description
@@ -220,6 +226,7 @@ struct PlaylistDetail: Identifiable {
         self.canDelete = playlist.canDelete
         self.tracks = tracks
         self.duration = duration
+        self.libraryTargetId = libraryTargetId
     }
 
     /// Track count to show in the UI, preferring the API-reported total over the loaded row count.

--- a/Sources/Kaset/Models/Playlist.swift
+++ b/Sources/Kaset/Models/Playlist.swift
@@ -14,6 +14,7 @@ struct Playlist: Identifiable, Codable, Hashable {
     let author: Artist?
     let canDelete: Bool
     let moodCategoryEndpoint: MoodCategoryEndpoint?
+    let libraryTargetId: String?
 
     private enum CodingKeys: String, CodingKey {
         case id
@@ -24,6 +25,7 @@ struct Playlist: Identifiable, Codable, Hashable {
         case author
         case canDelete
         case moodCategoryEndpoint
+        case libraryTargetId
     }
 
     init(
@@ -34,7 +36,8 @@ struct Playlist: Identifiable, Codable, Hashable {
         trackCount: Int?,
         author: Artist? = nil,
         canDelete: Bool = false,
-        moodCategoryEndpoint: MoodCategoryEndpoint? = nil
+        moodCategoryEndpoint: MoodCategoryEndpoint? = nil,
+        libraryTargetId: String? = nil
     ) {
         self.id = id
         self.title = title
@@ -44,6 +47,7 @@ struct Playlist: Identifiable, Codable, Hashable {
         self.author = author
         self.canDelete = canDelete
         self.moodCategoryEndpoint = moodCategoryEndpoint
+        self.libraryTargetId = libraryTargetId
     }
 
     init(from decoder: any Decoder) throws {
@@ -67,6 +71,7 @@ struct Playlist: Identifiable, Codable, Hashable {
             MoodCategoryEndpoint.self,
             forKey: .moodCategoryEndpoint
         )
+        self.libraryTargetId = try container.decodeIfPresent(String.self, forKey: .libraryTargetId)
     }
 
     /// Whether this is an album (vs a playlist).
@@ -143,6 +148,7 @@ extension Playlist {
 
         self.canDelete = data["canDelete"] as? Bool ?? false
         self.moodCategoryEndpoint = nil
+        self.libraryTargetId = data["libraryTargetId"] as? String
     }
 }
 
@@ -226,7 +232,7 @@ struct PlaylistDetail: Identifiable {
         self.canDelete = playlist.canDelete
         self.tracks = tracks
         self.duration = duration
-        self.libraryTargetId = libraryTargetId
+        self.libraryTargetId = libraryTargetId ?? playlist.libraryTargetId
     }
 
     /// Track count to show in the UI, preferring the API-reported total over the loaded row count.

--- a/Sources/Kaset/Resources/Localizable.xcstrings
+++ b/Sources/Kaset/Resources/Localizable.xcstrings
@@ -14749,6 +14749,94 @@
         }
       }
     },
+    "No albums yet": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا توجد ألبومات بعد"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Noch keine Alben"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Todavía no hay álbumes"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun album pour le moment"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Belum ada album"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessun album ancora"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "아직 앨범이 없습니다"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nog geen albums"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nie ma jeszcze albumów"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ainda não há álbuns"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Альбомов пока нет"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inga album ännu"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Henüz albüm yok"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поки що немає альбомів"
+          }
+        }
+      }
+    },
     "No podcasts yet": {
       "localizations": {
         "ar": {
@@ -19680,6 +19768,94 @@
           "stringUnit": {
             "state": "translated",
             "value": "Зберігайте плейлисти, підписуйтеся на виконавців і подкасти в YouTube Music, щоб побачити їх тут."
+          }
+        }
+      }
+    },
+    "Save albums on YouTube Music to see them here.": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "احفظ الألبومات على YouTube Music لتراها هنا."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Speichere Alben auf YouTube Music, um sie hier zu sehen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guarda álbumes en YouTube Music para verlos aquí."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enregistrez des albums sur YouTube Music pour les voir ici."
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Simpan album di YouTube Music untuk melihatnya di sini."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Salva album su YouTube Music per vederli qui."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "여기에서 보려면 YouTube Music에서 앨범을 저장하세요."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bewaar albums op YouTube Music om ze hier te zien."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zapisuj albumy w YouTube Music, aby zobaczyć je tutaj."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Guarde álbuns no YouTube Music para os ver aqui."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сохраняйте альбомы в YouTube Music, чтобы видеть их здесь."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Spara album i YouTube Music för att se dem här."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Burada görmek için YouTube Music'te albümleri kaydedin."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Зберігайте альбоми в YouTube Music, щоб побачити їх тут."
           }
         }
       }

--- a/Sources/Kaset/Resources/ar.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/ar.lproj/Localizable.strings
@@ -287,6 +287,7 @@
 "No Playlists" = "لا توجد قوائم تشغيل";
 "No playlists" = "لا توجد قوائم تشغيل";
 "No playlists yet" = "لا توجد قوائم تشغيل بعد";
+"No albums yet" = "لا توجد ألبومات بعد";
 "No podcasts yet" = "لا توجد بودكاست بعد";
 "No Queue" = "لا توجد قائمة انتظار";
 "No recommendations yet" = "لا توجد توصيات بعد";
@@ -394,6 +395,7 @@
 "Romanize Lyrics" = "رومنة كلمات الأغاني";
 "Save playlists and subscribe to podcasts on YouTube Music to see them here." = "احفظ قوائم التشغيل واشترك في البودكاست على YouTube Music لتراها هنا.";
 "Save playlists, follow artists, and subscribe to podcasts on YouTube Music to see them here." = "احفظ قوائم التشغيل، وتابع الفنانين، واشترك في البودكاست على YouTube Music لتراها هنا.";
+"Save albums on YouTube Music to see them here." = "احفظ الألبومات على YouTube Music لتراها هنا.";
 "Save shuffle and repeat settings across app restarts" = "حفظ إعدادات الخلط والتكرار عند إعادة تشغيل التطبيق";
 "Save the current queue as a new private playlist." = "احفظ قائمة الانتظار الحالية كقائمة تشغيل خاصة جديدة.";
 "Save to Playlist" = "حفظ في قائمة تشغيل";

--- a/Sources/Kaset/Resources/de.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/de.lproj/Localizable.strings
@@ -287,6 +287,7 @@
 "No Playlists" = "Keine Playlists";
 "No playlists" = "Keine Playlists";
 "No playlists yet" = "Noch keine Playlists";
+"No albums yet" = "Noch keine Alben";
 "No podcasts yet" = "Noch keine Podcasts";
 "No Queue" = "Keine Warteschlange";
 "No recommendations yet" = "Noch keine Empfehlungen";
@@ -394,6 +395,7 @@
 "Romanize Lyrics" = "Songtexte romanisieren";
 "Save playlists and subscribe to podcasts on YouTube Music to see them here." = "Speichere Playlists und abonniere Podcasts auf YouTube Music, um sie hier zu sehen.";
 "Save playlists, follow artists, and subscribe to podcasts on YouTube Music to see them here." = "Speichere Playlists, folge Interpreten und abonniere Podcasts auf YouTube Music, um sie hier zu sehen.";
+"Save albums on YouTube Music to see them here." = "Speichere Alben auf YouTube Music, um sie hier zu sehen.";
 "Save shuffle and repeat settings across app restarts" = "Einstellungen für Zufallswiedergabe und Wiederholen über App-Neustarts hinweg speichern";
 "Save the current queue as a new private playlist." = "Speichere die aktuelle Warteschlange als neue private Playlist.";
 "Save to Playlist" = "In Playlist speichern";

--- a/Sources/Kaset/Resources/es.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/es.lproj/Localizable.strings
@@ -287,6 +287,7 @@
 "No Playlists" = "No hay playlists";
 "No playlists" = "No hay playlists";
 "No playlists yet" = "Todavía no hay playlists";
+"No albums yet" = "Todavía no hay álbumes";
 "No podcasts yet" = "Todavía no hay podcasts";
 "No Queue" = "Sin cola";
 "No recommendations yet" = "Aún no hay recomendaciones";
@@ -394,6 +395,7 @@
 "Romanize Lyrics" = "Romanizar letras";
 "Save playlists and subscribe to podcasts on YouTube Music to see them here." = "Guarda playlists y suscríbete a podcasts en YouTube Music para verlos aquí.";
 "Save playlists, follow artists, and subscribe to podcasts on YouTube Music to see them here." = "Guarda playlists, sigue artistas y suscríbete a podcasts en YouTube Music para verlos aquí.";
+"Save albums on YouTube Music to see them here." = "Guarda álbumes en YouTube Music para verlos aquí.";
 "Save shuffle and repeat settings across app restarts" = "Guardar la configuración de aleatorio y repetición entre reinicios de la app";
 "Save the current queue as a new private playlist." = "Guarda la cola actual como una nueva playlist privada.";
 "Save to Playlist" = "Guardar en playlist";

--- a/Sources/Kaset/Resources/fr.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/fr.lproj/Localizable.strings
@@ -287,6 +287,7 @@
 "No Playlists" = "Aucune playlist";
 "No playlists" = "Aucune playlist";
 "No playlists yet" = "Aucune playlist pour le moment";
+"No albums yet" = "Aucun album pour le moment";
 "No podcasts yet" = "Aucun podcast pour le moment";
 "No Queue" = "Aucune file d'attente";
 "No recommendations yet" = "Pas encore de recommandations";
@@ -394,6 +395,7 @@
 "Romanize Lyrics" = "Romaniser les paroles";
 "Save playlists and subscribe to podcasts on YouTube Music to see them here." = "Enregistrez des playlists et abonnez-vous à des podcasts sur YouTube Music pour les voir ici.";
 "Save playlists, follow artists, and subscribe to podcasts on YouTube Music to see them here." = "Enregistrez des playlists, suivez des artistes et abonnez-vous à des podcasts sur YouTube Music pour les voir ici.";
+"Save albums on YouTube Music to see them here." = "Enregistrez des albums sur YouTube Music pour les voir ici.";
 "Save shuffle and repeat settings across app restarts" = "Conserver les réglages de lecture aléatoire et de répétition entre les redémarrages";
 "Save the current queue as a new private playlist." = "Enregistrez la file d'attente actuelle comme nouvelle playlist privée.";
 "Save to Playlist" = "Enregistrer dans la playlist";

--- a/Sources/Kaset/Resources/id.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/id.lproj/Localizable.strings
@@ -287,6 +287,7 @@
 "No Playlists" = "Tidak Ada Playlist";
 "No playlists" = "Tidak ada playlist";
 "No playlists yet" = "Belum ada daftar putar";
+"No albums yet" = "Belum ada album";
 "No podcasts yet" = "Belum ada podcast";
 "No Queue" = "Tidak Ada Antrean";
 "No recommendations yet" = "Belum ada rekomendasi";
@@ -394,6 +395,7 @@
 "Romanize Lyrics" = "Romanisasi Lirik";
 "Save playlists and subscribe to podcasts on YouTube Music to see them here." = "Simpan daftar putar dan berlangganan podcast di YouTube Music untuk melihatnya di sini.";
 "Save playlists, follow artists, and subscribe to podcasts on YouTube Music to see them here." = "Simpan daftar putar, ikuti artis, dan berlangganan podcast di YouTube Music untuk melihatnya di sini.";
+"Save albums on YouTube Music to see them here." = "Simpan album di YouTube Music untuk melihatnya di sini.";
 "Save shuffle and repeat settings across app restarts" = "Simpan pengaturan acak dan ulangi setelah aplikasi dimulai ulang";
 "Save the current queue as a new private playlist." = "Simpan antrean saat ini sebagai playlist pribadi baru.";
 "Save to Playlist" = "Simpan ke Playlist";

--- a/Sources/Kaset/Resources/it.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/it.lproj/Localizable.strings
@@ -287,6 +287,7 @@
 "No Playlists" = "Nessuna playlist";
 "No playlists" = "Nessuna playlist";
 "No playlists yet" = "Nessuna playlist ancora";
+"No albums yet" = "Nessun album ancora";
 "No podcasts yet" = "Nessun podcast ancora";
 "No Queue" = "Nessuna coda";
 "No recommendations yet" = "Ancora nessun suggerimento";
@@ -394,6 +395,7 @@
 "Romanize Lyrics" = "Romanizza testo";
 "Save playlists and subscribe to podcasts on YouTube Music to see them here." = "Salva playlist e abbonati ai podcast su YouTube Music per vederli qui.";
 "Save playlists, follow artists, and subscribe to podcasts on YouTube Music to see them here." = "Salva playlist, segui artisti e abbonati ai podcast su YouTube Music per vederli qui.";
+"Save albums on YouTube Music to see them here." = "Salva album su YouTube Music per vederli qui.";
 "Save shuffle and repeat settings across app restarts" = "Salva le impostazioni di ordine casuale e ripetizione tra i riavvii dell'app";
 "Save the current queue as a new private playlist." = "Salva la coda attuale come nuova playlist privata.";
 "Save to Playlist" = "Salva nella playlist";

--- a/Sources/Kaset/Resources/ko.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/ko.lproj/Localizable.strings
@@ -287,6 +287,7 @@
 "No Playlists" = "재생목록 없음";
 "No playlists" = "재생목록 없음";
 "No playlists yet" = "아직 재생목록이 없습니다";
+"No albums yet" = "아직 앨범이 없습니다";
 "No podcasts yet" = "아직 팟캐스트가 없습니다";
 "No Queue" = "대기열 없음";
 "No recommendations yet" = "아직 추천이 없습니다";
@@ -394,6 +395,7 @@
 "Romanize Lyrics" = "가사 로마자 표시";
 "Save playlists and subscribe to podcasts on YouTube Music to see them here." = "여기에서 보려면 YouTube Music에서 재생목록을 저장하고 팟캐스트를 구독하세요.";
 "Save playlists, follow artists, and subscribe to podcasts on YouTube Music to see them here." = "여기에서 보려면 YouTube Music에서 재생목록을 저장하고, 아티스트를 구독하고, 팟캐스트를 구독하세요.";
+"Save albums on YouTube Music to see them here." = "여기에서 보려면 YouTube Music에서 앨범을 저장하세요.";
 "Save shuffle and repeat settings across app restarts" = "앱을 다시 시작해도 셔플 및 반복 설정 유지";
 "Save the current queue as a new private playlist." = "현재 대기열을 새 비공개 재생목록으로 저장합니다.";
 "Save to Playlist" = "재생목록에 저장";

--- a/Sources/Kaset/Resources/nl.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/nl.lproj/Localizable.strings
@@ -287,6 +287,7 @@
 "No Playlists" = "Geen afspeellijsten";
 "No playlists" = "Geen afspeellijsten";
 "No playlists yet" = "Nog geen afspeellijsten";
+"No albums yet" = "Nog geen albums";
 "No podcasts yet" = "Nog geen podcasts";
 "No Queue" = "Geen wachtrij";
 "No recommendations yet" = "Nog geen aanbevelingen";
@@ -394,6 +395,7 @@
 "Romanize Lyrics" = "Songteksten romaniseren";
 "Save playlists and subscribe to podcasts on YouTube Music to see them here." = "Bewaar afspeellijsten en abonneer je op podcasts op YouTube Music om ze hier te zien.";
 "Save playlists, follow artists, and subscribe to podcasts on YouTube Music to see them here." = "Bewaar afspeellijsten, volg artiesten en abonneer je op podcasts op YouTube Music om ze hier te zien.";
+"Save albums on YouTube Music to see them here." = "Bewaar albums op YouTube Music om ze hier te zien.";
 "Save shuffle and repeat settings across app restarts" = "Bewaar shuffle- en herhaalinstellingen tussen appstarts";
 "Save the current queue as a new private playlist." = "Sla de huidige wachtrij op als een nieuwe privé-afspeellijst.";
 "Save to Playlist" = "Opslaan in afspeellijst";

--- a/Sources/Kaset/Resources/pl.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/pl.lproj/Localizable.strings
@@ -287,6 +287,7 @@
 "No Playlists" = "Brak playlist";
 "No playlists" = "Brak playlist";
 "No playlists yet" = "Nie ma jeszcze playlist";
+"No albums yet" = "Nie ma jeszcze albumów";
 "No podcasts yet" = "Nie ma jeszcze podcastów";
 "No Queue" = "Brak kolejki";
 "No recommendations yet" = "Nie ma jeszcze rekomendacji";
@@ -394,6 +395,7 @@
 "Romanize Lyrics" = "Romanizuj tekst";
 "Save playlists and subscribe to podcasts on YouTube Music to see them here." = "Zapisuj playlisty i subskrybuj podcasty w YouTube Music, aby zobaczyć je tutaj.";
 "Save playlists, follow artists, and subscribe to podcasts on YouTube Music to see them here." = "Zapisuj playlisty, obserwuj artystów i subskrybuj podcasty w YouTube Music, aby zobaczyć je tutaj.";
+"Save albums on YouTube Music to see them here." = "Zapisuj albumy w YouTube Music, aby zobaczyć je tutaj.";
 "Save shuffle and repeat settings across app restarts" = "Zapisuj ustawienia losowania i powtarzania między ponownymi uruchomieniami aplikacji";
 "Save the current queue as a new private playlist." = "Zapisz bieżącą kolejkę jako nową prywatną playlistę.";
 "Save to Playlist" = "Zapisz do playlisty";

--- a/Sources/Kaset/Resources/pt.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/pt.lproj/Localizable.strings
@@ -287,6 +287,7 @@
 "No Playlists" = "Sem listas de reprodução";
 "No playlists" = "Sem listas de reprodução";
 "No playlists yet" = "Ainda não há listas de reprodução";
+"No albums yet" = "Ainda não há álbuns";
 "No podcasts yet" = "Ainda não há podcasts";
 "No Queue" = "Sem fila";
 "No recommendations yet" = "Ainda não há recomendações";
@@ -394,6 +395,7 @@
 "Romanize Lyrics" = "Romanizar letras";
 "Save playlists and subscribe to podcasts on YouTube Music to see them here." = "Guarde listas de reprodução e subscreva podcasts no YouTube Music para os ver aqui.";
 "Save playlists, follow artists, and subscribe to podcasts on YouTube Music to see them here." = "Guarde listas de reprodução, siga artistas e subscreva podcasts no YouTube Music para os ver aqui.";
+"Save albums on YouTube Music to see them here." = "Guarde álbuns no YouTube Music para os ver aqui.";
 "Save shuffle and repeat settings across app restarts" = "Guardar as definições de Aleatório e Repetir entre reinícios da app";
 "Save the current queue as a new private playlist." = "Guarde a fila atual como uma nova lista de reprodução privada.";
 "Save to Playlist" = "Guardar na lista de reprodução";

--- a/Sources/Kaset/Resources/ru.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/ru.lproj/Localizable.strings
@@ -287,6 +287,7 @@
 "No Playlists" = "Нет плейлистов";
 "No playlists" = "Нет плейлистов";
 "No playlists yet" = "Плейлистов пока нет";
+"No albums yet" = "Альбомов пока нет";
 "No podcasts yet" = "Подкастов пока нет";
 "No Queue" = "Очередь пуста";
 "No recommendations yet" = "Рекомендаций пока нет";
@@ -394,6 +395,7 @@
 "Romanize Lyrics" = "Романизировать текст";
 "Save playlists and subscribe to podcasts on YouTube Music to see them here." = "Сохраняйте плейлисты и подписывайтесь на подкасты в YouTube Music, чтобы видеть их здесь.";
 "Save playlists, follow artists, and subscribe to podcasts on YouTube Music to see them here." = "Сохраняйте плейлисты, подписывайтесь на исполнителей и подкасты в YouTube Music, чтобы видеть их здесь.";
+"Save albums on YouTube Music to see them here." = "Сохраняйте альбомы в YouTube Music, чтобы видеть их здесь.";
 "Save shuffle and repeat settings across app restarts" = "Сохранять настройки перемешивания и повтора между перезапусками приложения";
 "Save the current queue as a new private playlist." = "Сохраните текущую очередь как новый личный плейлист.";
 "Save to Playlist" = "Сохранить в плейлист";

--- a/Sources/Kaset/Resources/sv.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/sv.lproj/Localizable.strings
@@ -287,6 +287,7 @@
 "No Playlists" = "Inga spellistor";
 "No playlists" = "Inga spellistor";
 "No playlists yet" = "Inga spellistor ännu";
+"No albums yet" = "Inga album ännu";
 "No podcasts yet" = "Inga poddar ännu";
 "No Queue" = "Ingen kö";
 "No recommendations yet" = "Inga rekommendationer än";
@@ -394,6 +395,7 @@
 "Romanize Lyrics" = "Romanisera sångtext";
 "Save playlists and subscribe to podcasts on YouTube Music to see them here." = "Spara spellistor och prenumerera på poddar i YouTube Music för att se dem här.";
 "Save playlists, follow artists, and subscribe to podcasts on YouTube Music to see them here." = "Spara spellistor, följ artister och prenumerera på poddar i YouTube Music för att se dem här.";
+"Save albums on YouTube Music to see them here." = "Spara album i YouTube Music för att se dem här.";
 "Save shuffle and repeat settings across app restarts" = "Spara inställningar för blandning och upprepning mellan omstarter";
 "Save the current queue as a new private playlist." = "Spara den aktuella kön som en ny privat spellista.";
 "Save to Playlist" = "Spara i spellista";

--- a/Sources/Kaset/Resources/tr.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/tr.lproj/Localizable.strings
@@ -287,6 +287,7 @@
 "No Playlists" = "Çalma listesi yok";
 "No playlists" = "Çalma listesi yok";
 "No playlists yet" = "Henüz çalma listesi yok";
+"No albums yet" = "Henüz albüm yok";
 "No podcasts yet" = "Henüz podcast yok";
 "No Queue" = "Sıra Boş";
 "No recommendations yet" = "Henüz öneri yok";
@@ -394,6 +395,7 @@
 "Romanize Lyrics" = "Şarkı Sözlerini Romanize Et";
 "Save playlists and subscribe to podcasts on YouTube Music to see them here." = "Burada görmek için YouTube Music'te çalma listeleri kaydedin ve podcastlere abone olun.";
 "Save playlists, follow artists, and subscribe to podcasts on YouTube Music to see them here." = "Burada görmek için YouTube Music'te çalma listeleri kaydedin, sanatçıları takip edin ve podcastlere abone olun.";
+"Save albums on YouTube Music to see them here." = "Burada görmek için YouTube Music'te albümleri kaydedin.";
 "Save shuffle and repeat settings across app restarts" = "Uygulama yeniden başlatıldığında karıştırma ve tekrar ayarlarını koru";
 "Save the current queue as a new private playlist." = "Geçerli kuyruğu yeni bir özel oynatma listesi olarak kaydet.";
 "Save to Playlist" = "Çalma listesine kaydet";

--- a/Sources/Kaset/Resources/uk.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/uk.lproj/Localizable.strings
@@ -287,6 +287,7 @@
 "No Playlists" = "Немає плейлистів";
 "No playlists" = "Немає плейлистів";
 "No playlists yet" = "Поки що немає плейлистів";
+"No albums yet" = "Поки що немає альбомів";
 "No podcasts yet" = "Поки що немає подкастів";
 "No Queue" = "Черга порожня";
 "No recommendations yet" = "Рекомендацій ще немає";
@@ -394,6 +395,7 @@
 "Romanize Lyrics" = "Романізувати текст пісні";
 "Save playlists and subscribe to podcasts on YouTube Music to see them here." = "Зберігайте плейлисти та підписуйтеся на подкасти в YouTube Music, щоб побачити їх тут.";
 "Save playlists, follow artists, and subscribe to podcasts on YouTube Music to see them here." = "Зберігайте плейлисти, підписуйтеся на виконавців і подкасти в YouTube Music, щоб побачити їх тут.";
+"Save albums on YouTube Music to see them here." = "Зберігайте альбоми в YouTube Music, щоб побачити їх тут.";
 "Save shuffle and repeat settings across app restarts" = "Зберігати налаштування перемішування та повтору між перезапусками програми";
 "Save the current queue as a new private playlist." = "Збережіть поточну чергу як новий приватний плейлист.";
 "Save to Playlist" = "Зберегти до плейлиста";

--- a/Sources/Kaset/Services/API/MockUITestYTMusicClient.swift
+++ b/Sources/Kaset/Services/API/MockUITestYTMusicClient.swift
@@ -273,7 +273,12 @@ final class MockUITestYTMusicClient: YTMusicClientProtocol {
 
     func getLibraryContent() async throws -> PlaylistParser.LibraryContent {
         try? await Task.sleep(for: .milliseconds(100))
-        return PlaylistParser.LibraryContent(playlists: self.playlists, artists: [], podcastShows: [])
+        return PlaylistParser.LibraryContent(
+            playlists: self.playlists,
+            albums: Self.defaultAlbums(count: 4),
+            artists: [],
+            podcastShows: []
+        )
     }
 
     func getLikedSongs() async throws -> LikedSongsResponse {
@@ -298,7 +303,10 @@ final class MockUITestYTMusicClient: YTMusicClientProtocol {
         let detail = PlaylistDetail(
             playlist: playlist,
             tracks: Self.defaultSongs(count: 10),
-            duration: "30 minutes"
+            duration: "30 minutes",
+            libraryTargetId: playlist.isAlbum
+                ? (playlist.id.hasPrefix("OLAK") ? playlist.id : "OLAK-mock-album-target")
+                : nil
         )
         return PlaylistTracksResponse(detail: detail, continuationToken: nil)
     }

--- a/Sources/Kaset/Services/API/MockUITestYTMusicClient.swift
+++ b/Sources/Kaset/Services/API/MockUITestYTMusicClient.swift
@@ -275,7 +275,7 @@ final class MockUITestYTMusicClient: YTMusicClientProtocol {
         try? await Task.sleep(for: .milliseconds(100))
         return PlaylistParser.LibraryContent(
             playlists: self.playlists,
-            albums: Self.defaultAlbums(count: 4),
+            albums: Self.defaultLibraryAlbums(),
             artists: [],
             podcastShows: []
         )
@@ -292,23 +292,70 @@ final class MockUITestYTMusicClient: YTMusicClientProtocol {
 
     func getPlaylist(id: String) async throws -> PlaylistTracksResponse {
         try? await Task.sleep(for: .milliseconds(100))
-        let playlist = self.playlists.first { $0.id == id } ?? Playlist(
-            id: id,
-            title: "Test Playlist",
-            description: "A test playlist",
-            thumbnailURL: nil,
-            trackCount: 10,
-            author: Artist.inline(name: "Test User", namespace: "playlist-author")
-        )
+        let libraryAlbum = Self.defaultLibraryAlbums().first { $0.id == id }
+        let playlist = libraryAlbum.map(Self.playlist(from:))
+            ?? self.playlists.first { $0.id == id }
+            ?? Playlist(
+                id: id,
+                title: "Test Playlist",
+                description: "A test playlist",
+                thumbnailURL: nil,
+                trackCount: 10,
+                author: Artist.inline(name: "Test User", namespace: "playlist-author")
+            )
         let detail = PlaylistDetail(
             playlist: playlist,
             tracks: Self.defaultSongs(count: 10),
             duration: "30 minutes",
-            libraryTargetId: playlist.isAlbum
-                ? (playlist.id.hasPrefix("OLAK") ? playlist.id : "OLAK-mock-album-target")
-                : nil
+            libraryTargetId: Self.libraryTargetId(for: playlist, libraryAlbum: libraryAlbum)
         )
         return PlaylistTracksResponse(detail: detail, continuationToken: nil)
+    }
+
+    private static func defaultLibraryAlbums() -> [Album] {
+        (0 ..< 4).map { index in
+            let ordinal = index + 1
+            let browseId = "MPREbMockLibraryAlbum\(ordinal)"
+            return Album(
+                id: browseId,
+                title: "Test Album \(ordinal)",
+                artists: [Artist(id: "UCMockLibraryAlbumArtist\(ordinal)", name: "Album Artist \(ordinal)")],
+                thumbnailURL: nil,
+                year: "2024",
+                trackCount: 9 + ordinal,
+                libraryTargetId: Self.libraryTargetId(forAlbumId: browseId)
+            )
+        }
+    }
+
+    private static func playlist(from album: Album) -> Playlist {
+        Playlist(
+            id: album.id,
+            title: album.title,
+            description: "A mock saved album",
+            thumbnailURL: album.thumbnailURL,
+            trackCount: album.trackCount,
+            author: album.artistsDisplay.isEmpty
+                ? nil
+                : Artist.inline(name: album.artistsDisplay, namespace: "mock-library-album-artist")
+        )
+    }
+
+    private static func libraryTargetId(for playlist: Playlist, libraryAlbum: Album?) -> String? {
+        if let libraryTargetId = libraryAlbum?.libraryTargetId {
+            return libraryTargetId
+        }
+        if playlist.id.hasPrefix("OLAK") {
+            return playlist.id
+        }
+        if playlist.id.hasPrefix("MPRE") {
+            return Self.libraryTargetId(forAlbumId: playlist.id)
+        }
+        return nil
+    }
+
+    private static func libraryTargetId(forAlbumId albumId: String) -> String {
+        "OLAK5uy_l\(albumId.dropFirst(4))"
     }
 
     func getPlaylistContinuation(token _: String, requiresAuth _: Bool) async throws -> PlaylistContinuationResponse {

--- a/Sources/Kaset/Services/API/Parsers/LibraryContentParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/LibraryContentParser.swift
@@ -5,6 +5,12 @@ import os
 enum LibraryContentParser {
     private static let logger = DiagnosticsLogger.api
 
+    /// One page of saved albums and the token for the next page, when present.
+    struct LibraryAlbumsPage {
+        let albums: [Album]
+        let nextPage: String?
+    }
+
     /// Source used for followed-artist content in a combined Library response.
     enum LibraryArtistsSource {
         case dedicated
@@ -14,6 +20,7 @@ enum LibraryContentParser {
     /// Parsed Library content from YouTube Music browse responses.
     struct LibraryContent {
         let playlists: [Playlist]
+        let albums: [Album]
         let artists: [Artist]
         let podcastShows: [PodcastShow]
         let uploadedSongsPlaylist: Playlist?
@@ -21,12 +28,14 @@ enum LibraryContentParser {
 
         init(
             playlists: [Playlist],
+            albums: [Album] = [],
             artists: [Artist],
             podcastShows: [PodcastShow],
             uploadedSongsPlaylist: Playlist? = nil,
             artistsSource: LibraryArtistsSource = .dedicated
         ) {
             self.playlists = playlists
+            self.albums = albums
             self.artists = artists
             self.podcastShows = podcastShows
             self.uploadedSongsPlaylist = uploadedSongsPlaylist
@@ -40,6 +49,7 @@ enum LibraryContentParser {
         let browseEndpoint: [String: Any]
         let title: String
         let subtitle: String?
+        let subtitleRuns: [[String: Any]]
         let thumbnailURL: URL?
         let allowsRadioPlaylist: Bool
         let renderer: [String: Any]
@@ -49,9 +59,46 @@ enum LibraryContentParser {
         self.parseLibraryContent(data).playlists
     }
 
-    /// Parses library content from browse response, returning playlists, artists, and podcast shows.
+    /// Parses albums from the dedicated saved-albums browse response.
+    static func parseLibraryAlbums(_ data: [String: Any]) -> [Album] {
+        self.parseLibraryAlbumsPage(data).albums
+    }
+
+    /// Parses the first saved-albums page and its continuation token.
+    static func parseLibraryAlbumsPage(_ data: [String: Any]) -> LibraryAlbumsPage {
+        let albums = self.parseLibraryContent(data).albums
+        let gridRenderer = ResponseTreeSearch.firstDictionary(named: "gridRenderer", in: data)
+        return LibraryAlbumsPage(
+            albums: albums,
+            nextPage: gridRenderer.flatMap { Self.nextPage(from: $0, itemsKey: "items") }
+        )
+    }
+
+    /// Parses a saved-albums continuation response in legacy or append-action format.
+    static func parseLibraryAlbumsContinuation(_ data: [String: Any]) -> LibraryAlbumsPage {
+        if let gridContinuation = ResponseTreeSearch.firstDictionary(named: "gridContinuation", in: data) {
+            let items = gridContinuation["items"] as? [[String: Any]] ?? []
+            return LibraryAlbumsPage(
+                albums: Self.parseAlbumItems(items),
+                nextPage: Self.nextPage(from: gridContinuation, itemsKey: "items")
+            )
+        }
+
+        if let appendAction = ResponseTreeSearch.firstDictionary(named: "appendContinuationItemsAction", in: data) {
+            let items = appendAction["continuationItems"] as? [[String: Any]] ?? []
+            return LibraryAlbumsPage(
+                albums: Self.parseAlbumItems(items),
+                nextPage: Self.nextPage(from: appendAction, itemsKey: "continuationItems")
+            )
+        }
+
+        return LibraryAlbumsPage(albums: [], nextPage: nil)
+    }
+
+    /// Parses library content from browse response, returning playlists, albums, artists, and podcast shows.
     static func parseLibraryContent(_ data: [String: Any]) -> LibraryContent {
         var playlists: [Playlist] = []
+        var albums: [Album] = []
         var artists: [Artist] = []
         var podcastShows: [PodcastShow] = []
 
@@ -59,12 +106,18 @@ enum LibraryContentParser {
             Self.appendLibraryItems(
                 from: sectionData,
                 playlists: &playlists,
+                albums: &albums,
                 artists: &artists,
                 podcastShows: &podcastShows
             )
         }
 
-        return LibraryContent(playlists: playlists, artists: artists, podcastShows: podcastShows)
+        return LibraryContent(
+            playlists: playlists,
+            albums: albums,
+            artists: artists,
+            podcastShows: podcastShows
+        )
     }
 
     /// Merges library playlists using the dedicated endpoint as authoritative while retaining landing-only items.
@@ -81,16 +134,31 @@ enum LibraryContentParser {
         return mergedPlaylists
     }
 
+    /// Merges dedicated saved albums with any landing-page preview albums.
+    static func mergedLibraryAlbums(dedicated dedicatedAlbums: [Album], fallback fallbackAlbums: [Album]) -> [Album] {
+        var mergedAlbums = dedicatedAlbums
+        var seenAlbumIDs = Set(dedicatedAlbums.map(\.id))
+
+        for album in fallbackAlbums {
+            guard seenAlbumIDs.insert(album.id).inserted else { continue }
+            mergedAlbums.append(album)
+        }
+
+        return mergedAlbums
+    }
+
     /// Parses artists from the dedicated library artists browse response.
     static func parseLibraryArtists(_ data: [String: Any]) -> [Artist] {
         var artists: [Artist] = []
         var ignoredPlaylists: [Playlist] = []
+        var ignoredAlbums: [Album] = []
         var ignoredPodcastShows: [PodcastShow] = []
 
         for sectionData in Self.extractLibrarySections(from: data) {
             Self.appendLibraryItems(
                 from: sectionData,
                 playlists: &ignoredPlaylists,
+                albums: &ignoredAlbums,
                 artists: &artists,
                 podcastShows: &ignoredPodcastShows
             )
@@ -137,6 +205,7 @@ enum LibraryContentParser {
     private static func appendLibraryItems(
         from sectionData: [String: Any],
         playlists: inout [Playlist],
+        albums: inout [Album],
         artists: inout [Artist],
         podcastShows: inout [PodcastShow]
     ) {
@@ -149,6 +218,7 @@ enum LibraryContentParser {
                 Self.appendLibraryItem(
                     Self.twoRowCandidate(from: twoRowRenderer),
                     playlists: &playlists,
+                    albums: &albums,
                     artists: &artists,
                     podcastShows: &podcastShows
                 )
@@ -167,6 +237,7 @@ enum LibraryContentParser {
                 Self.appendResponsiveLibraryItems(
                     shelfContents,
                     playlists: &playlists,
+                    albums: &albums,
                     artists: &artists,
                     podcastShows: &podcastShows
                 )
@@ -180,6 +251,7 @@ enum LibraryContentParser {
             Self.appendResponsiveLibraryItems(
                 shelfContents,
                 playlists: &playlists,
+                albums: &albums,
                 artists: &artists,
                 podcastShows: &podcastShows
             )
@@ -189,6 +261,7 @@ enum LibraryContentParser {
     private static func appendResponsiveLibraryItems(
         _ shelfContents: [[String: Any]],
         playlists: inout [Playlist],
+        albums: inout [Album],
         artists: inout [Artist],
         podcastShows: inout [PodcastShow]
     ) {
@@ -197,9 +270,25 @@ enum LibraryContentParser {
             Self.appendLibraryItem(
                 Self.responsiveCandidate(from: responsiveRenderer),
                 playlists: &playlists,
+                albums: &albums,
                 artists: &artists,
                 podcastShows: &podcastShows
             )
+        }
+    }
+
+    private static func parseAlbumItems(_ items: [[String: Any]]) -> [Album] {
+        items.compactMap { item -> Album? in
+            let candidate: LibraryItemCandidate? = if let twoRowRenderer = item["musicTwoRowItemRenderer"] as? [String: Any] {
+                Self.twoRowCandidate(from: twoRowRenderer)
+            } else if let responsiveRenderer = item["musicResponsiveListItemRenderer"] as? [String: Any] {
+                Self.responsiveCandidate(from: responsiveRenderer)
+            } else {
+                nil
+            }
+
+            guard let candidate, Self.isAlbum(candidate) else { return nil }
+            return Self.album(from: candidate)
         }
     }
 
@@ -218,6 +307,7 @@ enum LibraryContentParser {
             browseEndpoint: browseEndpoint,
             title: ParsingHelpers.extractTitle(from: data) ?? "Unknown",
             subtitle: ParsingHelpers.extractSubtitle(from: data),
+            subtitleRuns: Self.twoRowSubtitleRuns(from: data),
             thumbnailURL: ParsingHelpers.extractThumbnailURL(from: data),
             allowsRadioPlaylist: true,
             renderer: data
@@ -239,6 +329,7 @@ enum LibraryContentParser {
             browseEndpoint: browseEndpoint,
             title: ParsingHelpers.extractTitleFromFlexColumns(data) ?? "Unknown",
             subtitle: ParsingHelpers.extractSubtitleFromFlexColumns(data),
+            subtitleRuns: Self.responsiveSubtitleRuns(from: data),
             thumbnailURL: ParsingHelpers.extractThumbnailURL(from: data),
             allowsRadioPlaylist: false,
             renderer: data
@@ -248,6 +339,7 @@ enum LibraryContentParser {
     private static func appendLibraryItem(
         _ candidate: LibraryItemCandidate?,
         playlists: inout [Playlist],
+        albums: inout [Album],
         artists: inout [Artist],
         podcastShows: inout [PodcastShow]
     ) {
@@ -258,6 +350,9 @@ enum LibraryContentParser {
         if candidate.browseId.hasPrefix("MPSPP") {
             podcastShows.append(Self.podcastShow(from: candidate))
             Self.logger.info("\(candidate.sourceName): Added podcast show: \(candidate.title)")
+        } else if Self.isAlbum(candidate) {
+            albums.append(Self.album(from: candidate))
+            Self.logger.info("\(candidate.sourceName): Added album: \(candidate.title)")
         } else if Self.isPlaylistBrowseID(candidate.browseId, allowsRadioPlaylist: candidate.allowsRadioPlaylist) {
             playlists.append(Self.playlist(from: candidate))
             Self.logger.info("\(candidate.sourceName): Added playlist: \(candidate.title)")
@@ -292,6 +387,49 @@ enum LibraryContentParser {
         )
     }
 
+    private static func album(from candidate: LibraryItemCandidate) -> Album {
+        var seenArtistIDs = Set<String>()
+        let linkedArtists = candidate.subtitleRuns.compactMap { run -> Artist? in
+            guard let name = Self.normalizedRunText(run),
+                  let navigationEndpoint = run["navigationEndpoint"] as? [String: Any],
+                  let browseEndpoint = navigationEndpoint["browseEndpoint"] as? [String: Any],
+                  let artistID = browseEndpoint["browseId"] as? String,
+                  Artist.isNavigableId(artistID),
+                  seenArtistIDs.insert(artistID).inserted
+            else {
+                return nil
+            }
+
+            return Artist(
+                id: artistID,
+                name: name,
+                profileKind: Artist.profileKind(forPageType: ParsingHelpers.extractPageType(from: browseEndpoint))
+            )
+        }
+
+        let year = candidate.subtitleRuns
+            .compactMap(Self.normalizedRunText)
+            .first(where: Self.isAlbumYear)
+
+        let artists: [Artist]? = if linkedArtists.isEmpty {
+            Self.fallbackAlbumArtist(from: candidate.subtitleRuns, year: year).map {
+                [Artist.inline(name: $0, namespace: "library-album-artist")]
+            }
+        } else {
+            linkedArtists
+        }
+
+        return Album(
+            id: candidate.browseId,
+            title: candidate.title,
+            artists: artists,
+            thumbnailURL: candidate.thumbnailURL,
+            year: year,
+            trackCount: nil,
+            libraryTargetId: ParsingHelpers.extractAlbumLibraryTargetId(from: candidate.renderer)
+        )
+    }
+
     private static func artist(from candidate: LibraryItemCandidate) -> Artist {
         let pageType = ParsingHelpers.extractPageType(from: candidate.browseEndpoint)
         return Artist(
@@ -301,6 +439,90 @@ enum LibraryContentParser {
             profileKind: Artist.profileKind(forPageType: pageType)
         )
     }
+
+    private static func isAlbum(_ candidate: LibraryItemCandidate) -> Bool {
+        let pageType = ParsingHelpers.extractPageType(from: candidate.browseEndpoint)
+        return pageType == "MUSIC_PAGE_TYPE_ALBUM"
+            || candidate.browseId.hasPrefix("MPRE")
+            || candidate.browseId.hasPrefix("OLAK")
+    }
+
+    private static func twoRowSubtitleRuns(from data: [String: Any]) -> [[String: Any]] {
+        guard let subtitle = data["subtitle"] as? [String: Any],
+              let runs = subtitle["runs"] as? [[String: Any]]
+        else {
+            return []
+        }
+
+        return runs
+    }
+
+    private static func responsiveSubtitleRuns(from data: [String: Any]) -> [[String: Any]] {
+        guard let flexColumns = data["flexColumns"] as? [[String: Any]],
+              flexColumns.count > 1,
+              let renderer = flexColumns[1]["musicResponsiveListItemFlexColumnRenderer"] as? [String: Any],
+              let text = renderer["text"] as? [String: Any],
+              let runs = text["runs"] as? [[String: Any]]
+        else {
+            return []
+        }
+
+        return runs
+    }
+
+    private static func normalizedRunText(_ run: [String: Any]) -> String? {
+        guard let text = (run["text"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !text.isEmpty,
+              text != "•",
+              text != "&",
+              text != ","
+        else {
+            return nil
+        }
+
+        return text
+    }
+
+    private static func fallbackAlbumArtist(from runs: [[String: Any]], year: String?) -> String? {
+        let metadata = runs.compactMap(Self.normalizedRunText).filter { text in
+            text != year && !Self.albumTypeLabels.contains(text.lowercased())
+        }
+        return metadata.last
+    }
+
+    private static func isAlbumYear(_ text: String) -> Bool {
+        guard text.count == 4,
+              text.allSatisfy(\.isNumber),
+              let year = Int(text)
+        else {
+            return false
+        }
+
+        return (1900 ... 2100).contains(year)
+    }
+
+    private static func nextPage(from renderer: [String: Any], itemsKey: String) -> String? {
+        if let continuations = renderer["continuations"] as? [[String: Any]],
+           let firstContinuation = continuations.first,
+           let nextContinuationData = firstContinuation["nextContinuationData"] as? [String: Any],
+           let cursor = nextContinuationData["continuation"] as? String
+        {
+            return cursor
+        }
+
+        guard let items = renderer[itemsKey] as? [[String: Any]],
+              let lastItem = items.last,
+              let continuationItemRenderer = lastItem["continuationItemRenderer"] as? [String: Any],
+              let continuationEndpoint = continuationItemRenderer["continuationEndpoint"] as? [String: Any],
+              let continuationCommand = continuationEndpoint["continuationCommand"] as? [String: Any]
+        else {
+            return nil
+        }
+
+        return continuationCommand["token"] as? String
+    }
+
+    private static let albumTypeLabels = Set(["album", "single", "ep"])
 
     private static func isPlaylistBrowseID(_ browseID: String, allowsRadioPlaylist: Bool) -> Bool {
         browseID.hasPrefix("VL") || browseID.hasPrefix("PL") || (allowsRadioPlaylist && browseID.hasPrefix("RDCLAK"))

--- a/Sources/Kaset/Services/API/Parsers/LibraryContentParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/LibraryContentParser.swift
@@ -8,7 +8,35 @@ enum LibraryContentParser {
     /// One page of saved albums and the token for the next page, when present.
     struct LibraryAlbumsPage {
         let albums: [Album]
-        let nextPage: String?
+        let nextPages: [String]
+        let isRecognized: Bool
+
+        var nextPage: String? {
+            self.nextPages.first
+        }
+
+        init(albums: [Album], nextPage: String?, isRecognized: Bool) {
+            self.albums = albums
+            self.nextPages = nextPage.map { [$0] } ?? []
+            self.isRecognized = isRecognized
+        }
+
+        init(albums: [Album], nextPages: [String], isRecognized: Bool) {
+            self.albums = albums
+            self.nextPages = nextPages
+            self.isRecognized = isRecognized
+        }
+    }
+
+    /// Source used for saved-album content in a combined Library response.
+    enum LibraryAlbumsSource {
+        case dedicated
+        case landingFallback
+        case partial
+
+        var isAuthoritative: Bool {
+            self == .dedicated
+        }
     }
 
     /// Source used for followed-artist content in a combined Library response.
@@ -24,7 +52,9 @@ enum LibraryContentParser {
         let artists: [Artist]
         let podcastShows: [PodcastShow]
         let uploadedSongsPlaylist: Playlist?
+        let albumsSource: LibraryAlbumsSource
         let artistsSource: LibraryArtistsSource
+        let accountScope: String?
 
         init(
             playlists: [Playlist],
@@ -32,15 +62,30 @@ enum LibraryContentParser {
             artists: [Artist],
             podcastShows: [PodcastShow],
             uploadedSongsPlaylist: Playlist? = nil,
-            artistsSource: LibraryArtistsSource = .dedicated
+            albumsSource: LibraryAlbumsSource = .dedicated,
+            artistsSource: LibraryArtistsSource = .dedicated,
+            accountScope: String? = nil
         ) {
             self.playlists = playlists
             self.albums = albums
             self.artists = artists
             self.podcastShows = podcastShows
             self.uploadedSongsPlaylist = uploadedSongsPlaylist
+            self.albumsSource = albumsSource
             self.artistsSource = artistsSource
+            self.accountScope = accountScope
         }
+    }
+
+    private struct AlbumRendererInput {
+        let renderer: [String: Any]
+        let itemsKey: String
+    }
+
+    private struct ParsedAlbumRenderers {
+        let albums: [Album]
+        let nextPages: [String]
+        let isRecognized: Bool
     }
 
     private struct LibraryItemCandidate {
@@ -61,38 +106,95 @@ enum LibraryContentParser {
 
     /// Parses albums from the dedicated saved-albums browse response.
     static func parseLibraryAlbums(_ data: [String: Any]) -> [Album] {
-        self.parseLibraryAlbumsPage(data).albums
+        let pageAlbums = self.parseLibraryAlbumsPage(data).albums
+        return self.mergedLibraryAlbums(
+            dedicated: pageAlbums,
+            fallback: self.parseLibraryContent(data).albums
+        )
     }
 
     /// Parses the first saved-albums page and its continuation token.
     static func parseLibraryAlbumsPage(_ data: [String: Any]) -> LibraryAlbumsPage {
-        let albums = self.parseLibraryContent(data).albums
-        let gridRenderer = ResponseTreeSearch.firstDictionary(named: "gridRenderer", in: data)
-        return LibraryAlbumsPage(
-            albums: albums,
-            nextPage: gridRenderer.flatMap { Self.nextPage(from: $0, itemsKey: "items") }
-        )
+        let genericAlbums = self.parseLibraryContent(data).albums
+        let rendererInputs = ResponseTreeSearch.dictionaries(named: "gridRenderer", in: data).map {
+            AlbumRendererInput(renderer: $0, itemsKey: "items")
+        } + ResponseTreeSearch.dictionaries(named: "musicShelfRenderer", in: data).map {
+            AlbumRendererInput(renderer: $0, itemsKey: "contents")
+        }
+
+        if !rendererInputs.isEmpty {
+            let parsedRenderers = Self.parseAlbumRenderers(
+                rendererInputs,
+                allowAuthoritativeEmpty: Self.isTrustedSavedAlbumsResponse(data)
+            )
+            return LibraryAlbumsPage(
+                albums: self.mergedLibraryAlbums(
+                    dedicated: genericAlbums,
+                    fallback: parsedRenderers.albums
+                ),
+                nextPages: parsedRenderers.nextPages,
+                isRecognized: parsedRenderers.isRecognized
+            )
+        }
+
+        if !genericAlbums.isEmpty {
+            return LibraryAlbumsPage(albums: genericAlbums, nextPage: nil, isRecognized: true)
+        }
+
+        return LibraryAlbumsPage(albums: [], nextPage: nil, isRecognized: false)
     }
 
     /// Parses a saved-albums continuation response in legacy or append-action format.
     static func parseLibraryAlbumsContinuation(_ data: [String: Any]) -> LibraryAlbumsPage {
         if let gridContinuation = ResponseTreeSearch.firstDictionary(named: "gridContinuation", in: data) {
-            let items = gridContinuation["items"] as? [[String: Any]] ?? []
+            guard let items = gridContinuation["items"] as? [[String: Any]] else {
+                return LibraryAlbumsPage(albums: [], nextPage: nil, isRecognized: false)
+            }
+            let parsedItems = Self.parseRecognizedAlbumItems(items)
+            let nextPage = Self.nextPage(from: gridContinuation, itemsKey: "items")
+            let hasContinuationSentinel = items.contains { $0["continuationItemRenderer"] != nil }
+            let advertisesContinuation = hasContinuationSentinel || gridContinuation["continuations"] != nil
             return LibraryAlbumsPage(
-                albums: Self.parseAlbumItems(items),
-                nextPage: Self.nextPage(from: gridContinuation, itemsKey: "items")
+                albums: parsedItems.albums,
+                nextPage: nextPage,
+                isRecognized: parsedItems.isRecognized
+                    && (!advertisesContinuation || nextPage != nil)
+            )
+        }
+
+        if let shelfContinuation = ResponseTreeSearch.firstDictionary(named: "musicShelfContinuation", in: data) {
+            guard let items = shelfContinuation["contents"] as? [[String: Any]] else {
+                return LibraryAlbumsPage(albums: [], nextPage: nil, isRecognized: false)
+            }
+            let parsedItems = Self.parseRecognizedAlbumItems(items)
+            let nextPage = Self.nextPage(from: shelfContinuation, itemsKey: "contents")
+            let hasContinuationSentinel = items.contains { $0["continuationItemRenderer"] != nil }
+            let advertisesContinuation = hasContinuationSentinel || shelfContinuation["continuations"] != nil
+            return LibraryAlbumsPage(
+                albums: parsedItems.albums,
+                nextPage: nextPage,
+                isRecognized: parsedItems.isRecognized
+                    && (!advertisesContinuation || nextPage != nil)
             )
         }
 
         if let appendAction = ResponseTreeSearch.firstDictionary(named: "appendContinuationItemsAction", in: data) {
-            let items = appendAction["continuationItems"] as? [[String: Any]] ?? []
+            guard let items = appendAction["continuationItems"] as? [[String: Any]] else {
+                return LibraryAlbumsPage(albums: [], nextPage: nil, isRecognized: false)
+            }
+            let parsedItems = Self.parseRecognizedAlbumItems(items)
+            let nextPage = Self.nextPage(from: appendAction, itemsKey: "continuationItems")
+            let hasContinuationSentinel = items.contains { $0["continuationItemRenderer"] != nil }
+            let advertisesContinuation = hasContinuationSentinel || appendAction["continuations"] != nil
             return LibraryAlbumsPage(
-                albums: Self.parseAlbumItems(items),
-                nextPage: Self.nextPage(from: appendAction, itemsKey: "continuationItems")
+                albums: parsedItems.albums,
+                nextPage: nextPage,
+                isRecognized: parsedItems.isRecognized
+                    && (!advertisesContinuation || nextPage != nil)
             )
         }
 
-        return LibraryAlbumsPage(albums: [], nextPage: nil)
+        return LibraryAlbumsPage(albums: [], nextPage: nil, isRecognized: false)
     }
 
     /// Parses library content from browse response, returning playlists, albums, artists, and podcast shows.
@@ -214,9 +316,15 @@ enum LibraryContentParser {
            let items = gridRenderer["items"] as? [[String: Any]]
         {
             for itemData in items {
-                guard let twoRowRenderer = itemData["musicTwoRowItemRenderer"] as? [String: Any] else { continue }
+                let candidate: LibraryItemCandidate? = if let twoRowRenderer = itemData["musicTwoRowItemRenderer"] as? [String: Any] {
+                    Self.twoRowCandidate(from: twoRowRenderer)
+                } else if let responsiveRenderer = itemData["musicResponsiveListItemRenderer"] as? [String: Any] {
+                    Self.responsiveCandidate(from: responsiveRenderer)
+                } else {
+                    nil
+                }
                 Self.appendLibraryItem(
-                    Self.twoRowCandidate(from: twoRowRenderer),
+                    candidate,
                     playlists: &playlists,
                     albums: &albums,
                     artists: &artists,
@@ -275,6 +383,88 @@ enum LibraryContentParser {
                 podcastShows: &podcastShows
             )
         }
+    }
+
+    private static func isTrustedSavedAlbumsResponse(_ data: [String: Any]) -> Bool {
+        self.trackingValue(for: "logged_in", in: data) == "1"
+            && self.trackingValue(for: "browse_id", in: data) == "FEmusic_liked_albums"
+    }
+
+    private static func trackingValue(for key: String, in data: [String: Any]) -> String? {
+        guard let responseContext = data["responseContext"] as? [String: Any],
+              let serviceTrackingParams = responseContext["serviceTrackingParams"] as? [[String: Any]]
+        else {
+            return nil
+        }
+
+        for serviceTrackingParam in serviceTrackingParams {
+            guard let params = serviceTrackingParam["params"] as? [[String: Any]] else { continue }
+            if let matchingParam = params.first(where: { $0["key"] as? String == key }) {
+                return matchingParam["value"] as? String
+            }
+        }
+
+        return nil
+    }
+
+    private static func parseAlbumRenderers(
+        _ rendererInputs: [AlbumRendererInput],
+        allowAuthoritativeEmpty: Bool
+    ) -> ParsedAlbumRenderers {
+        var albums: [Album] = []
+        var nextPages: [String] = []
+        var foundRelevantRenderer = false
+        var foundPartialRenderer = false
+
+        for input in rendererInputs {
+            guard let items = input.renderer[input.itemsKey] as? [[String: Any]] else { continue }
+            let parsedItems = Self.parseRecognizedAlbumItems(items)
+            let nextPage = Self.nextPage(from: input.renderer, itemsKey: input.itemsKey)
+            let hasContinuationSentinel = items.contains { $0["continuationItemRenderer"] != nil }
+            let hasRendererContinuations = input.renderer["continuations"] != nil
+            let advertisesContinuation = hasContinuationSentinel || hasRendererContinuations
+            let consumedContinuation = !advertisesContinuation || nextPage != nil
+            let rendererIsRecognized = parsedItems.isRecognized && consumedContinuation
+            let hasAlbums = !parsedItems.albums.isEmpty
+            let isContinuationOnlyRenderer = parsedItems.albums.isEmpty
+                && (advertisesContinuation || nextPage != nil)
+            let isTrustedEmptyRenderer = parsedItems.albums.isEmpty
+                && !hasContinuationSentinel
+                && rendererInputs.count == 1
+                && allowAuthoritativeEmpty
+            let isRelevantRenderer = hasAlbums || isContinuationOnlyRenderer || isTrustedEmptyRenderer
+
+            guard isRelevantRenderer else { continue }
+            foundRelevantRenderer = true
+            if !rendererIsRecognized {
+                foundPartialRenderer = true
+            }
+
+            albums = self.mergedLibraryAlbums(
+                dedicated: albums,
+                fallback: parsedItems.albums
+            )
+            if let nextPage, !nextPages.contains(nextPage) {
+                nextPages.append(nextPage)
+            }
+        }
+
+        return ParsedAlbumRenderers(
+            albums: albums,
+            nextPages: nextPages,
+            isRecognized: foundRelevantRenderer && !foundPartialRenderer
+        )
+    }
+
+    private static func parseRecognizedAlbumItems(
+        _ items: [[String: Any]]
+    ) -> (albums: [Album], isRecognized: Bool) {
+        let contentItems = items.filter { $0["continuationItemRenderer"] == nil }
+        let albums = Self.parseAlbumItems(contentItems)
+        return (
+            albums: albums,
+            isRecognized: contentItems.isEmpty || albums.count == contentItems.count
+        )
     }
 
     private static func parseAlbumItems(_ items: [[String: Any]]) -> [Album] {
@@ -513,13 +703,32 @@ enum LibraryContentParser {
         guard let items = renderer[itemsKey] as? [[String: Any]],
               let lastItem = items.last,
               let continuationItemRenderer = lastItem["continuationItemRenderer"] as? [String: Any],
-              let continuationEndpoint = continuationItemRenderer["continuationEndpoint"] as? [String: Any],
-              let continuationCommand = continuationEndpoint["continuationCommand"] as? [String: Any]
+              let continuationEndpoint = continuationItemRenderer["continuationEndpoint"] as? [String: Any]
         else {
             return nil
         }
 
-        return continuationCommand["token"] as? String
+        if let continuationCommand = continuationEndpoint["continuationCommand"] as? [String: Any],
+           let cursor = continuationCommand["token"] as? String
+        {
+            return cursor
+        }
+
+        guard let commandExecutor = continuationEndpoint["commandExecutorCommand"] as? [String: Any],
+              let commands = commandExecutor["commands"] as? [[String: Any]]
+        else {
+            return nil
+        }
+
+        for command in commands {
+            if let continuationCommand = command["continuationCommand"] as? [String: Any],
+               let cursor = continuationCommand["token"] as? String
+            {
+                return cursor
+            }
+        }
+
+        return nil
     }
 
     private static let albumTypeLabels = Set(["album", "single", "ep"])

--- a/Sources/Kaset/Services/API/Parsers/ParsingHelpers.swift
+++ b/Sources/Kaset/Services/API/Parsers/ParsingHelpers.swift
@@ -271,6 +271,31 @@ enum ParsingHelpers {
         return artists
     }
 
+    /// Finds the OLAK playlist target used by album Library mutations.
+    static func extractAlbumLibraryTargetId(from value: Any) -> String? {
+        if let dictionary = value as? [String: Any] {
+            if let playlistId = dictionary["playlistId"] as? String,
+               playlistId.hasPrefix("OLAK")
+            {
+                return playlistId
+            }
+
+            for child in dictionary.values {
+                if let playlistId = self.extractAlbumLibraryTargetId(from: child) {
+                    return playlistId
+                }
+            }
+        } else if let array = value as? [Any] {
+            for child in array {
+                if let playlistId = self.extractAlbumLibraryTargetId(from: child) {
+                    return playlistId
+                }
+            }
+        }
+
+        return nil
+    }
+
     /// Extracts subtitle text from data.
     /// Returns the full subtitle text including song counts (e.g., "Playlist • YouTube Music • 145 songs").
     static func extractSubtitle(from data: [String: Any]) -> String? {

--- a/Sources/Kaset/Services/API/Parsers/PlaylistParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/PlaylistParser.swift
@@ -25,7 +25,22 @@ enum PlaylistParser {
         LibraryContentParser.parseLibraryPlaylists(data)
     }
 
-    /// Parses library content from browse response, returning playlists, artists, and podcast shows.
+    /// Parses albums from the dedicated saved-albums browse response.
+    static func parseLibraryAlbums(_ data: [String: Any]) -> [Album] {
+        LibraryContentParser.parseLibraryAlbums(data)
+    }
+
+    /// Parses the first saved-albums page and its continuation token.
+    static func parseLibraryAlbumsPage(_ data: [String: Any]) -> LibraryContentParser.LibraryAlbumsPage {
+        LibraryContentParser.parseLibraryAlbumsPage(data)
+    }
+
+    /// Parses a saved-albums continuation response.
+    static func parseLibraryAlbumsContinuation(_ data: [String: Any]) -> LibraryContentParser.LibraryAlbumsPage {
+        LibraryContentParser.parseLibraryAlbumsContinuation(data)
+    }
+
+    /// Parses library content from browse response, returning playlists, albums, artists, and podcast shows.
     static func parseLibraryContent(_ data: [String: Any]) -> LibraryContent {
         LibraryContentParser.parseLibraryContent(data)
     }
@@ -33,6 +48,11 @@ enum PlaylistParser {
     /// Merges library playlists using the dedicated endpoint as authoritative while retaining landing-only items.
     static func mergedLibraryPlaylists(dedicated dedicatedPlaylists: [Playlist], fallback fallbackPlaylists: [Playlist]) -> [Playlist] {
         LibraryContentParser.mergedLibraryPlaylists(dedicated: dedicatedPlaylists, fallback: fallbackPlaylists)
+    }
+
+    /// Merges dedicated saved albums with any landing-page preview albums.
+    static func mergedLibraryAlbums(dedicated dedicatedAlbums: [Album], fallback fallbackAlbums: [Album]) -> [Album] {
+        LibraryContentParser.mergedLibraryAlbums(dedicated: dedicatedAlbums, fallback: fallbackAlbums)
     }
 
     /// Parses artists from the dedicated library artists browse response.
@@ -63,7 +83,12 @@ enum PlaylistParser {
             canDelete: PlaylistEditability.canDeletePlaylist(from: data)
         )
 
-        return PlaylistDetail(playlist: playlist, tracks: tracks, duration: header.duration)
+        return PlaylistDetail(
+            playlist: playlist,
+            tracks: tracks,
+            duration: header.duration,
+            libraryTargetId: Self.extractAlbumLibraryTargetId(from: data, albumId: playlistId)
+        )
     }
 
     /// Parses playlist detail from browse response with pagination support.
@@ -84,7 +109,12 @@ enum PlaylistParser {
             canDelete: PlaylistEditability.canDeletePlaylist(from: data)
         )
 
-        let detail = PlaylistDetail(playlist: playlist, tracks: tracks, duration: header.duration)
+        let detail = PlaylistDetail(
+            playlist: playlist,
+            tracks: tracks,
+            duration: header.duration,
+            libraryTargetId: Self.extractAlbumLibraryTargetId(from: data, albumId: playlistId)
+        )
         let continuationToken = Self.extractPlaylistContinuationToken(from: data)
 
         Self.logger.debug("parsePlaylistWithContinuation: tracks=\(tracks.count), hasToken=\(continuationToken != nil)")
@@ -1344,6 +1374,29 @@ enum PlaylistParser {
                 }
             }
         }
+        return nil
+    }
+
+    private static func extractAlbumLibraryTargetId(from data: [String: Any], albumId: String) -> String? {
+        if albumId.hasPrefix("OLAK") {
+            return albumId
+        }
+        guard albumId.hasPrefix("MPRE") else { return nil }
+
+        let headerRendererNames = [
+            "musicResponsiveHeaderRenderer",
+            "musicDetailHeaderRenderer",
+            "musicImmersiveHeaderRenderer",
+            "musicVisualHeaderRenderer",
+        ]
+        for rendererName in headerRendererNames {
+            if let headerRenderer = ResponseTreeSearch.firstDictionary(named: rendererName, in: data),
+               let targetId = ParsingHelpers.extractAlbumLibraryTargetId(from: headerRenderer)
+            {
+                return targetId
+            }
+        }
+
         return nil
     }
 

--- a/Sources/Kaset/Services/API/Parsers/PlaylistParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/PlaylistParser.swift
@@ -17,6 +17,7 @@ enum PlaylistParser {
         var duration: String?
     }
 
+    typealias LibraryAlbumsSource = LibraryContentParser.LibraryAlbumsSource
     typealias LibraryArtistsSource = LibraryContentParser.LibraryArtistsSource
     typealias LibraryContent = LibraryContentParser.LibraryContent
 

--- a/Sources/Kaset/Services/API/Parsers/ResponseTreeSearch.swift
+++ b/Sources/Kaset/Services/API/Parsers/ResponseTreeSearch.swift
@@ -24,6 +24,23 @@ enum ResponseTreeSearch {
         return nil
     }
 
+    static func dictionaries(named key: String, in value: Any) -> [[String: Any]] {
+        var matches: [[String: Any]] = []
+        if let dictionary = value as? [String: Any] {
+            if let match = dictionary[key] as? [String: Any] {
+                matches.append(match)
+            }
+            for child in dictionary.values {
+                matches.append(contentsOf: self.dictionaries(named: key, in: child))
+            }
+        } else if let array = value as? [Any] {
+            for child in array {
+                matches.append(contentsOf: self.dictionaries(named: key, in: child))
+            }
+        }
+        return matches
+    }
+
     static func containsKey(_ key: String, in value: Any) -> Bool {
         if let dictionary = value as? [String: Any] {
             if dictionary[key] != nil {

--- a/Sources/Kaset/Services/API/YTMusicClient.swift
+++ b/Sources/Kaset/Services/API/YTMusicClient.swift
@@ -692,10 +692,12 @@ final class YTMusicClient: YTMusicClientProtocol {
 
         let landingContent = PlaylistParser.parseLibraryContent(landingData)
         let playlists = try await self.fetchLibraryPlaylists(fallback: landingContent.playlists)
+        let albums = try await self.fetchLibraryAlbums(fallback: landingContent.albums)
         let (artists, artistsSource) = try await self.fetchLibraryArtists(fallback: landingContent.artists)
         let uploadedSongsPlaylist = try await self.fetchUploadedSongsPlaylist()
         let content = PlaylistParser.LibraryContent(
             playlists: playlists,
+            albums: albums,
             artists: artists,
             podcastShows: landingContent.podcastShows,
             uploadedSongsPlaylist: uploadedSongsPlaylist,
@@ -704,7 +706,7 @@ final class YTMusicClient: YTMusicClientProtocol {
 
         let hasUploadedSongs = content.uploadedSongsPlaylist != nil
         self.logger.info(
-            "Parsed \(content.playlists.count) library playlists, \(content.artists.count) artists, \(content.podcastShows.count) podcasts, uploads: \(hasUploadedSongs)"
+            "Parsed \(content.playlists.count) library playlists, \(content.albums.count) albums, \(content.artists.count) artists, \(content.podcastShows.count) podcasts, uploads: \(hasUploadedSongs)"
         )
         return content
     }
@@ -733,6 +735,57 @@ final class YTMusicClient: YTMusicClientProtocol {
         } catch {
             self.logger.warning("Library playlists endpoint failed, falling back to landing preview: \(error.localizedDescription)")
             return fallbackPlaylists
+        }
+    }
+
+    /// Fetches saved albums from the dedicated browse endpoint with graceful fallback to the Library landing preview.
+    private func fetchLibraryAlbums(fallback fallbackAlbums: [Album]) async throws -> [Album] {
+        do {
+            let albumsData = try await self.request(
+                "browse",
+                body: ["browseId": "FEmusic_liked_albums"],
+                ttl: APICache.TTL.library
+            )
+            let firstPage = PlaylistParser.parseLibraryAlbumsPage(albumsData)
+            var dedicatedAlbums = firstPage.albums
+            var nextPage = firstPage.nextPage
+            var requestedContinuationTokens = Set<String>()
+
+            while let cursor = nextPage,
+                  requestedContinuationTokens.insert(cursor).inserted
+            {
+                do {
+                    let continuationData = try await self.requestContinuation(
+                        cursor,
+                        ttl: APICache.TTL.library,
+                        authPolicy: .required
+                    )
+                    let page = PlaylistParser.parseLibraryAlbumsContinuation(continuationData)
+                    dedicatedAlbums = PlaylistParser.mergedLibraryAlbums(
+                        dedicated: dedicatedAlbums,
+                        fallback: page.albums
+                    )
+                    nextPage = page.nextPage
+                } catch {
+                    self.logger.warning("Saved albums continuation failed, keeping \(dedicatedAlbums.count) loaded albums: \(error.localizedDescription)")
+                    break
+                }
+            }
+
+            if dedicatedAlbums.isEmpty {
+                if !fallbackAlbums.isEmpty {
+                    self.logger.warning("Saved albums endpoint returned no albums, falling back to landing preview")
+                }
+                return fallbackAlbums
+            }
+
+            return PlaylistParser.mergedLibraryAlbums(
+                dedicated: dedicatedAlbums,
+                fallback: fallbackAlbums
+            )
+        } catch {
+            self.logger.warning("Saved albums endpoint failed, falling back to landing preview: \(error.localizedDescription)")
+            return fallbackAlbums
         }
     }
 
@@ -1720,10 +1773,10 @@ final class YTMusicClient: YTMusicClientProtocol {
 
     private static let authRequiredBrowseIds: Set<String> = [
         "FEmusic_liked_playlists",
+        "FEmusic_liked_albums",
         "FEmusic_liked_videos",
         "FEmusic_history",
         "FEmusic_library_landing",
-        "FEmusic_library_albums",
         "FEmusic_library_artists",
         "FEmusic_library_corpus_artists",
         "FEmusic_library_corpus_track_artists",

--- a/Sources/Kaset/Services/API/YTMusicClient.swift
+++ b/Sources/Kaset/Services/API/YTMusicClient.swift
@@ -789,6 +789,8 @@ final class YTMusicClient: YTMusicClientProtocol {
                         fallback: page.albums
                     )
                     pendingCursors.append(contentsOf: page.nextPages)
+                } catch is CancellationError {
+                    throw CancellationError()
                 } catch {
                     completedPagination = false
                     self.logger.warning("Saved albums continuation failed, keeping \(dedicatedAlbums.count) loaded albums: \(error.localizedDescription)")
@@ -815,6 +817,8 @@ final class YTMusicClient: YTMusicClientProtocol {
                 ),
                 .partial
             )
+        } catch is CancellationError {
+            throw CancellationError()
         } catch {
             self.logger.warning("Saved albums endpoint failed, falling back to landing preview: \(error.localizedDescription)")
             return (fallbackAlbums, .landingFallback)
@@ -2087,6 +2091,9 @@ final class YTMusicClient: YTMusicClientProtocol {
                 code: statusCode
             )
         case let .networkError(error):
+            if let urlError = error as? URLError, urlError.code == .cancelled {
+                throw CancellationError()
+            }
             throw YTMusicError.networkError(underlying: error)
         }
     }

--- a/Sources/Kaset/Services/API/YTMusicClient.swift
+++ b/Sources/Kaset/Services/API/YTMusicClient.swift
@@ -683,6 +683,7 @@ final class YTMusicClient: YTMusicClientProtocol {
     /// Fetches the user's library content including playlists, artists, and podcast shows.
     func getLibraryContent() async throws -> PlaylistParser.LibraryContent {
         self.logger.info("Fetching library content")
+        let accountScope = self.cacheScope(authenticated: true)
 
         let landingData = try await self.request(
             "browse",
@@ -692,7 +693,7 @@ final class YTMusicClient: YTMusicClientProtocol {
 
         let landingContent = PlaylistParser.parseLibraryContent(landingData)
         let playlists = try await self.fetchLibraryPlaylists(fallback: landingContent.playlists)
-        let albums = try await self.fetchLibraryAlbums(fallback: landingContent.albums)
+        let (albums, albumsSource) = try await self.fetchLibraryAlbums(fallback: landingContent.albums)
         let (artists, artistsSource) = try await self.fetchLibraryArtists(fallback: landingContent.artists)
         let uploadedSongsPlaylist = try await self.fetchUploadedSongsPlaylist()
         let content = PlaylistParser.LibraryContent(
@@ -701,7 +702,9 @@ final class YTMusicClient: YTMusicClientProtocol {
             artists: artists,
             podcastShows: landingContent.podcastShows,
             uploadedSongsPlaylist: uploadedSongsPlaylist,
-            artistsSource: artistsSource
+            albumsSource: albumsSource,
+            artistsSource: artistsSource,
+            accountScope: accountScope
         )
 
         let hasUploadedSongs = content.uploadedSongsPlaylist != nil
@@ -739,7 +742,9 @@ final class YTMusicClient: YTMusicClientProtocol {
     }
 
     /// Fetches saved albums from the dedicated browse endpoint with graceful fallback to the Library landing preview.
-    private func fetchLibraryAlbums(fallback fallbackAlbums: [Album]) async throws -> [Album] {
+    private func fetchLibraryAlbums(
+        fallback fallbackAlbums: [Album]
+    ) async throws -> ([Album], PlaylistParser.LibraryAlbumsSource) {
         do {
             let albumsData = try await self.request(
                 "browse",
@@ -747,13 +752,27 @@ final class YTMusicClient: YTMusicClientProtocol {
                 ttl: APICache.TTL.library
             )
             let firstPage = PlaylistParser.parseLibraryAlbumsPage(albumsData)
-            var dedicatedAlbums = firstPage.albums
-            var nextPage = firstPage.nextPage
-            var requestedContinuationTokens = Set<String>()
-
-            while let cursor = nextPage,
-                  requestedContinuationTokens.insert(cursor).inserted
+            if !firstPage.isRecognized,
+               firstPage.albums.isEmpty,
+               firstPage.nextPages.isEmpty
             {
+                self.logger.warning("Saved albums endpoint returned an unrecognized response, falling back to landing preview")
+                return (fallbackAlbums, .landingFallback)
+            }
+
+            var dedicatedAlbums = firstPage.albums
+            var pendingCursors = firstPage.nextPages
+            var requestedCursors = Set<String>()
+            var completedPagination = firstPage.isRecognized
+
+            while !pendingCursors.isEmpty {
+                let cursor = pendingCursors.removeFirst()
+                guard requestedCursors.insert(cursor).inserted else {
+                    completedPagination = false
+                    self.logger.warning("Saved albums pagination repeated a continuation token, keeping partial results")
+                    continue
+                }
+
                 do {
                     let continuationData = try await self.requestContinuation(
                         cursor,
@@ -761,31 +780,44 @@ final class YTMusicClient: YTMusicClientProtocol {
                         authPolicy: .required
                     )
                     let page = PlaylistParser.parseLibraryAlbumsContinuation(continuationData)
+                    if !page.isRecognized {
+                        completedPagination = false
+                        self.logger.warning("Saved albums continuation was only partially recognized, keeping partial results")
+                    }
                     dedicatedAlbums = PlaylistParser.mergedLibraryAlbums(
                         dedicated: dedicatedAlbums,
                         fallback: page.albums
                     )
-                    nextPage = page.nextPage
+                    pendingCursors.append(contentsOf: page.nextPages)
                 } catch {
+                    completedPagination = false
                     self.logger.warning("Saved albums continuation failed, keeping \(dedicatedAlbums.count) loaded albums: \(error.localizedDescription)")
-                    break
                 }
             }
 
             if dedicatedAlbums.isEmpty {
-                if !fallbackAlbums.isEmpty {
-                    self.logger.warning("Saved albums endpoint returned no albums, falling back to landing preview")
+                if completedPagination {
+                    self.logger.info("Saved albums endpoint returned an authoritative empty collection")
+                    return ([], .dedicated)
                 }
-                return fallbackAlbums
+
+                return (fallbackAlbums, .partial)
             }
 
-            return PlaylistParser.mergedLibraryAlbums(
-                dedicated: dedicatedAlbums,
-                fallback: fallbackAlbums
+            if completedPagination {
+                return (dedicatedAlbums, .dedicated)
+            }
+
+            return (
+                PlaylistParser.mergedLibraryAlbums(
+                    dedicated: dedicatedAlbums,
+                    fallback: fallbackAlbums
+                ),
+                .partial
             )
         } catch {
             self.logger.warning("Saved albums endpoint failed, falling back to landing preview: \(error.localizedDescription)")
-            return fallbackAlbums
+            return (fallbackAlbums, .landingFallback)
         }
     }
 

--- a/Sources/Kaset/Services/API/YTMusicClient.swift
+++ b/Sources/Kaset/Services/API/YTMusicClient.swift
@@ -47,6 +47,14 @@ final class YTMusicClient: YTMusicClientProtocol {
     /// Returns nil for primary account, brand ID string for brand accounts.
     var brandIdProvider: (() -> String?)?
 
+    /// Provider for the selected account's opaque owner-and-account scope.
+    ///
+    /// Primary Google accounts all use the literal ID `"primary"`, so brand
+    /// identity alone cannot distinguish a different signed-in Google account.
+    /// AccountService supplies a collision-resistant scope derived from the
+    /// authenticated Google owner and selected YouTube identity.
+    var accountScopeProvider: (() -> String?)?
+
     /// YouTube Music API base URL.
     private static let baseURL = "https://music.youtube.com/youtubei/v1"
 
@@ -1838,6 +1846,9 @@ final class YTMusicClient: YTMusicClientProtocol {
 
     private func cacheScope(authenticated: Bool) -> String {
         guard authenticated else { return "guest" }
+        if let accountScope = self.accountScopeProvider?(), !accountScope.isEmpty {
+            return accountScope
+        }
         let brandId = self.brandIdProvider?() ?? ""
         return brandId.isEmpty ? "primary" : brandId
     }
@@ -1978,11 +1989,11 @@ final class YTMusicClient: YTMusicClientProtocol {
 
         let cacheScope = self.cacheScope(authenticated: requestAuth.authenticated)
         let cacheKey = APICache.stableCacheKey(endpoint: endpoint, body: fullBody, brandId: cacheScope)
-        self.logger.debug("Request \(endpoint): cacheScope=\(cacheScope), cacheKey=\(cacheKey)")
+        self.logger.debug("Request \(endpoint): cacheKey=\(cacheKey)")
 
         // Check cache first.
         if ttl != nil, let cached = APICache.shared.get(key: cacheKey) {
-            self.logger.debug("Cache hit for \(endpoint) (cacheScope=\(cacheScope))")
+            self.logger.debug("Cache hit for \(endpoint)")
             return cached
         }
 

--- a/Sources/Kaset/Services/Auth/AccountService.swift
+++ b/Sources/Kaset/Services/Auth/AccountService.swift
@@ -64,6 +64,9 @@ final class AccountService { // swiftlint:disable:this type_body_length
     private let ytMusicClient: any YTMusicClientProtocol
     private let authService: AuthService
     private let favoritesOwnerDefaults: UserDefaults?
+    private var accountBoundaryWillBegin: (@MainActor @Sendable () -> Void)?
+    private var accountBoundaryDidEnd: (@MainActor @Sendable () -> Void)?
+    private var accountBoundaryDrain: (@MainActor @Sendable () async -> Void)?
 
     /// WebKit session manager used to re-point the playback session's active
     /// delegated identity on account switch. Optional so SwiftUI previews and
@@ -127,6 +130,16 @@ final class AccountService { // swiftlint:disable:this type_body_length
 
     var currentFavoritesScopeID: String? {
         self.favoritesScopeID(for: self.currentAccount)
+    }
+
+    func setAccountBoundaryHandlers(
+        willBegin: @escaping @MainActor @Sendable () -> Void,
+        didEnd: @escaping @MainActor @Sendable () -> Void,
+        drain: @escaping @MainActor @Sendable () async -> Void
+    ) {
+        self.accountBoundaryWillBegin = willBegin
+        self.accountBoundaryDidEnd = didEnd
+        self.accountBoundaryDrain = drain
     }
 
     // MARK: - Private
@@ -582,6 +595,17 @@ final class AccountService { // swiftlint:disable:this type_body_length
         to signinURL: URL,
         expectedBrandId: String?
     ) async throws {
+        let expectedSwitchGeneration = self.switchGeneration
+        let expectedAccountDataGeneration = self.accountDataGeneration
+        let expectedAuthIdentityGeneration = self.authService.accountIdentityGeneration
+        self.accountBoundaryWillBegin?()
+        defer { self.accountBoundaryDidEnd?() }
+        await self.accountBoundaryDrain?()
+        guard expectedSwitchGeneration == self.switchGeneration,
+              expectedAccountDataGeneration == self.accountDataGeneration,
+              expectedAuthIdentityGeneration == self.authService.accountIdentityGeneration,
+              !self.isAuthenticationBoundaryInProgress
+        else { throw CancellationError() }
         let navigation = Task { @MainActor in
             try await webKitManager.switchSessionIdentity(
                 to: signinURL,
@@ -683,28 +707,31 @@ final class AccountService { // swiftlint:disable:this type_body_length
                 return
             }
 
+            let nextAccount = self.restoredAccount(from: response)
+            let requiresBoundary = self.accountFetchRequiresBoundary(
+                response: response,
+                nextAccount: nextAccount
+            )
+            if requiresBoundary {
+                self.accountBoundaryWillBegin?()
+                defer { self.accountBoundaryDidEnd?() }
+                await self.accountBoundaryDrain?()
+                guard fetchGeneration == self.accountDataGeneration,
+                      fetchAuthIdentityGeneration == self.authService.accountIdentityGeneration,
+                      fetchSwitchGeneration == self.switchGeneration,
+                      self.manualSwitchInFlightCount == 0,
+                      self.authService.hasPersonalAccount,
+                      !self.isAuthenticationBoundaryInProgress
+                else {
+                    self.logger.info("AccountService: Account fetch became stale while draining Library mutations")
+                    return
+                }
+            }
+
             self.updateFavoritesScopes(from: response)
             self.accounts = response.accounts
             self.accountsAuthIdentityGeneration = fetchAuthIdentityGeneration
-
-            // Restore previously selected account if stored
-            if let savedBrandId = UserDefaults.standard.string(forKey: self.selectedBrandIdKey) {
-                self.logger.debug("AccountService: Found saved brand ID: \(savedBrandId)")
-
-                // Find the account with the saved brand ID
-                if let savedAccount = self.accounts.first(where: { $0.id == savedBrandId }) {
-                    self.currentAccount = savedAccount
-                    self.logger.info("AccountService: Restored previous account: \(savedAccount.name)")
-                } else {
-                    // Saved account no longer available, use API-selected
-                    self.currentAccount = response.selectedAccount ?? self.accounts.first
-                    self.logger.debug("AccountService: Saved account not found, using API-selected")
-                }
-            } else {
-                // Default to the currently selected account from API response
-                self.currentAccount = response.selectedAccount ?? self.accounts.first
-                self.logger.debug("AccountService: Using API-selected account")
-            }
+            self.currentAccount = nextAccount
 
             SongLikeStatusManager.shared.setActiveAccountID(self.currentAccount?.id)
             FavoritesManager.shared.setActiveAccountScopeID(
@@ -739,6 +766,46 @@ final class AccountService { // swiftlint:disable:this type_body_length
             self.lastErrorWasFetch = true
             self.errorSequence += 1
         }
+    }
+
+    private func restoredAccount(from response: AccountsListResponse) -> UserAccount? {
+        guard let savedAccountID = UserDefaults.standard.string(forKey: self.selectedBrandIdKey) else {
+            self.logger.debug("AccountService: Using API-selected account")
+            return response.selectedAccount ?? response.accounts.first
+        }
+
+        self.logger.debug("AccountService: Found saved brand ID: \(savedAccountID)")
+        guard let savedAccount = response.accounts.first(where: { $0.id == savedAccountID }) else {
+            self.logger.debug("AccountService: Saved account not found, using API-selected")
+            return response.selectedAccount ?? response.accounts.first
+        }
+
+        self.logger.info("AccountService: Restored previous account: \(savedAccount.name)")
+        return savedAccount
+    }
+
+    private func accountFetchRequiresBoundary(
+        response: AccountsListResponse,
+        nextAccount: UserAccount?
+    ) -> Bool {
+        guard let currentAccount = self.currentAccount,
+              let nextAccount,
+              currentAccount.id == nextAccount.id,
+              let currentScope = self.contentScopeByAccountID[currentAccount.id]
+        else { return true }
+
+        if currentScope.provisionalKind == .ownerConflict {
+            return true
+        }
+
+        guard let authFingerprintID = Self.favoritesAuthFingerprintID(from: self.authService.state),
+              let emailAliasID = Self.favoritesEmailAliasID(from: response.googleEmail),
+              let authBoundOwnerID = self.favoritesOwnerIDByAliasID[authFingerprintID]
+        else { return false }
+
+        let emailOwnerID = self.favoritesOwnerIDByAliasID[emailAliasID]
+        return self.favoritesOwnerHasEmailAlias(authBoundOwnerID)
+            && emailOwnerID != authBoundOwnerID
     }
 
     // swiftlint:disable cyclomatic_complexity function_body_length
@@ -847,6 +914,17 @@ final class AccountService { // swiftlint:disable:this type_body_length
                   self.authService.hasPersonalAccount,
                   !self.isAuthenticationBoundaryInProgress
             else { return }
+            self.accountBoundaryWillBegin?()
+            defer { self.accountBoundaryDidEnd?() }
+            await self.accountBoundaryDrain?()
+            guard !Task.isCancelled,
+                  self.sessionPinGeneration == pinGeneration,
+                  pinAuthIdentityGeneration == self.authService.accountIdentityGeneration,
+                  self.authService.hasPersonalAccount,
+                  !self.isAuthenticationBoundaryInProgress,
+                  self.currentAccount?.id == accountId,
+                  self.switchGeneration == switchGenerationAtPinStart
+            else { return }
             do {
                 try await webKitManager.switchSessionIdentity(to: signinURL, expectedBrandId: expectedBrandId)
                 guard !Task.isCancelled else { return }
@@ -904,6 +982,20 @@ final class AccountService { // swiftlint:disable:this type_body_length
         guard let fallback, fallback.id != account.id
         else { return }
 
+        let expectedSwitchGeneration = self.switchGeneration
+        let expectedAccountDataGeneration = self.accountDataGeneration
+        self.accountBoundaryWillBegin?()
+        defer { self.accountBoundaryDidEnd?() }
+        await self.accountBoundaryDrain?()
+        guard !Task.isCancelled,
+              pinGeneration == self.sessionPinGeneration,
+              expectedSwitchGeneration == self.switchGeneration,
+              expectedAccountDataGeneration == self.accountDataGeneration,
+              authIdentityGeneration == self.authService.accountIdentityGeneration,
+              self.authService.hasPersonalAccount,
+              !self.isAuthenticationBoundaryInProgress,
+              self.currentAccount?.id == account.id
+        else { return }
         var didVerifyFallback = false
         if let webKitManager = self.webKitManager, let fallbackSigninURL = fallback.signinURL {
             do {
@@ -917,9 +1009,14 @@ final class AccountService { // swiftlint:disable:this type_body_length
                 self.logger.error("AccountService: Could not restore fallback session identity: \(error.localizedDescription)")
             }
         }
-        guard self.sessionPinGeneration == pinGeneration,
+        guard !Task.isCancelled,
+              self.sessionPinGeneration == pinGeneration,
+              expectedSwitchGeneration == self.switchGeneration,
+              expectedAccountDataGeneration == self.accountDataGeneration,
               authIdentityGeneration == self.authService.accountIdentityGeneration,
-              self.authService.hasPersonalAccount
+              self.authService.hasPersonalAccount,
+              !self.isAuthenticationBoundaryInProgress,
+              self.currentAccount?.id == account.id
         else { return }
 
         self.ytMusicClient.resetSessionStateForAccountSwitch()
@@ -959,7 +1056,10 @@ final class AccountService { // swiftlint:disable:this type_body_length
     /// Drains old WebView session-identity mutations before reauthentication clears
     /// or samples cookies. The expired auth state already prevents new mutations.
     func prepareForReauthentication() async {
+        self.accountBoundaryWillBegin?()
+        defer { self.accountBoundaryDidEnd?() }
         self.isAuthenticationBoundaryInProgress = true
+        await self.accountBoundaryDrain?()
         self.resetFavoritesOwnerIfAuthenticationBoundaryChanged()
         await self.invalidateAndDrainSessionMutations()
     }
@@ -968,9 +1068,12 @@ final class AccountService { // swiftlint:disable:this type_body_length
     /// clears cookies/data. This prevents an in-flight hidden `/signin` navigation
     /// from writing cookies back into the shared data store after sign-out cleanup.
     func prepareForSignOut() async {
+        self.accountBoundaryWillBegin?()
+        defer { self.accountBoundaryDidEnd?() }
         // Set the fence before the first suspension. AuthService is still logged in
         // until this method returns, so its state alone cannot reject new work.
         self.isAuthenticationBoundaryInProgress = true
+        await self.accountBoundaryDrain?()
         await self.invalidateAndDrainSessionMutations()
     }
 
@@ -999,6 +1102,7 @@ final class AccountService { // swiftlint:disable:this type_body_length
     /// - Parameter account: The account to switch to.
     /// - Throws: An error if the switch fails.
     func switchAccount(to account: UserAccount) async throws {
+        self.authService.cancelPendingGuestModeTransition()
         let shouldExitGuestModeOnSuccess = self.authService.isGuestModeEnabled
         guard self.authService.state.isLoggedIn, !self.isAuthenticationBoundaryInProgress else {
             self.logger.info("AccountService: Rejecting account switch while authentication is unavailable")
@@ -1045,7 +1149,7 @@ final class AccountService { // swiftlint:disable:this type_body_length
                   self.currentAccount?.id == account.id
             else { throw CancellationError() }
             guard account.signinURL != nil else {
-                self.completeGuestModeAccountSelectionIfNeeded(
+                await self.completeGuestModeAccountSelectionIfNeeded(
                     shouldExitGuestModeOnSuccess,
                     accountID: account.id
                 )
@@ -1055,7 +1159,7 @@ final class AccountService { // swiftlint:disable:this type_body_length
         }
         guard !isSameAccount || (account.signinURL != nil && self.verifiedAccountId != account.id && self.webKitManager != nil) else {
             self.logger.debug("AccountService: Already using account \(account.name)")
-            self.completeGuestModeAccountSelectionIfNeeded(
+            await self.completeGuestModeAccountSelectionIfNeeded(
                 shouldExitGuestModeOnSuccess,
                 accountID: account.id
             )
@@ -1092,6 +1196,18 @@ final class AccountService { // swiftlint:disable:this type_body_length
         let myGeneration = self.switchGeneration
         let myAccountDataGeneration = self.accountDataGeneration
         var cancelledPriorSessionMutation = false
+
+        self.accountBoundaryWillBegin?()
+        defer { self.accountBoundaryDidEnd?() }
+        await self.accountBoundaryDrain?()
+        guard myGeneration == self.switchGeneration,
+              myAccountDataGeneration == self.accountDataGeneration,
+              switchAuthIdentityGeneration == self.authService.accountIdentityGeneration,
+              !self.isAuthenticationBoundaryInProgress
+        else {
+            self.logger.info("AccountService: Switch to \(account.name) superseded while draining Library mutations")
+            throw CancellationError()
+        }
 
         // Now cancel and await any in-flight session mutation (a cold-launch brand
         // restore pin AND/OR a prior manual switch's navigation) so neither can
@@ -1236,7 +1352,7 @@ final class AccountService { // swiftlint:disable:this type_body_length
             // The session identity is now verified for this account; signal
             // observers (e.g. MainWindow) to re-point in-flight playback.
             self.markIdentityVerified(account.id)
-            self.completeGuestModeAccountSelectionIfNeeded(
+            await self.completeGuestModeAccountSelectionIfNeeded(
                 shouldExitGuestModeOnSuccess,
                 accountID: account.id
             )
@@ -1370,9 +1486,9 @@ final class AccountService { // swiftlint:disable:this type_body_length
     private func completeGuestModeAccountSelectionIfNeeded(
         _ shouldExitGuestMode: Bool,
         accountID: String
-    ) {
+    ) async {
         guard shouldExitGuestMode else { return }
-        self.authService.exitGuestMode(activeAccountID: accountID)
+        await self.authService.exitGuestMode(activeAccountID: accountID)
     }
 
     private func refreshAccountForRollback(matching account: UserAccount) async -> UserAccount? {

--- a/Sources/Kaset/Services/Auth/AccountService.swift
+++ b/Sources/Kaset/Services/Auth/AccountService.swift
@@ -48,6 +48,17 @@ final class AccountService { // swiftlint:disable:this type_body_length
         var pendingFinalizations: [FavoritesOwnerFinalization]?
     }
 
+    private struct AccountContentScope {
+        enum ProvisionalKind {
+            case initialUnresolved
+            case ownerConflict
+        }
+
+        let id: String
+        var durableScopeID: String?
+        var provisionalKind: ProvisionalKind?
+    }
+
     // MARK: - Dependencies
 
     private let ytMusicClient: any YTMusicClientProtocol
@@ -105,6 +116,15 @@ final class AccountService { // swiftlint:disable:this type_body_length
         self.currentAccount?.brandId
     }
 
+    /// Opaque owner-and-account scope for personalized in-memory state.
+    ///
+    /// Unlike `UserAccount.id`, this distinguishes two different Google owners
+    /// whose selected YouTube identity is the primary account in both sessions.
+    var currentAccountScopeID: String? {
+        guard let currentAccount = self.currentAccount else { return nil }
+        return self.contentScopeByAccountID[currentAccount.id]?.id
+    }
+
     var currentFavoritesScopeID: String? {
         self.favoritesScopeID(for: self.currentAccount)
     }
@@ -115,6 +135,9 @@ final class AccountService { // swiftlint:disable:this type_body_length
     private let selectedBrandIdKey = "selectedBrandId"
     private static let favoritesOwnerStateKey = "favorites.ownerState"
     private var favoritesScopeByAccountID: [String: String] = [:]
+    private var contentScopeByAccountID: [String: AccountContentScope] = [:]
+    private var contentScopeGeneration: UInt64 = 0
+    private var didDetectFavoritesOwnerConflict = false
     private var favoritesOwnerID: String?
     private var favoritesOwnerIDByAliasID: [String: String] = [:]
     private var favoritesAccountIDsByOwnerID: [String: Set<String>] = [:]
@@ -174,27 +197,108 @@ final class AccountService { // swiftlint:disable:this type_body_length
     }
 
     private func updateFavoritesScopes(from response: AccountsListResponse) {
-        guard let ownerID = self.resolveFavoritesOwnerID(from: response) else {
-            self.favoritesScopeByAccountID = [:]
-            return
-        }
-
-        var scopes: [String: String] = [:]
-        for account in response.accounts {
-            scopes[account.id] = FavoritesManager.accountScopeID(
-                ownerID: ownerID,
-                accountID: account.id
-            )
-        }
-        self.favoritesScopeByAccountID = scopes
-        for account in response.accounts {
-            if let scopeID = scopes[account.id] {
-                FavoritesManager.shared.recoverLegacyAccountFavorites(
-                    accountID: account.id,
-                    toScopeID: scopeID
+        self.didDetectFavoritesOwnerConflict = false
+        if let ownerID = self.resolveFavoritesOwnerID(from: response) {
+            var scopes: [String: String] = [:]
+            for account in response.accounts {
+                scopes[account.id] = FavoritesManager.accountScopeID(
+                    ownerID: ownerID,
+                    accountID: account.id
                 )
             }
+            self.favoritesScopeByAccountID = scopes
+            for account in response.accounts {
+                if let scopeID = scopes[account.id] {
+                    FavoritesManager.shared.recoverLegacyAccountFavorites(
+                        accountID: account.id,
+                        toScopeID: scopeID
+                    )
+                }
+            }
+        } else {
+            self.favoritesScopeByAccountID = [:]
         }
+
+        self.updateContentScopes(
+            for: response.accounts,
+            ownerConflict: self.didDetectFavoritesOwnerConflict
+        )
+    }
+
+    private func updateContentScopes(
+        for accounts: [UserAccount],
+        ownerConflict: Bool
+    ) {
+        let accountIDs = Set(accounts.map(\.id))
+        self.contentScopeByAccountID = self.contentScopeByAccountID.filter { accountIDs.contains($0.key) }
+
+        for account in accounts {
+            let durableScopeID = self.favoritesScopeByAccountID[account.id]
+            guard var existingScope = self.contentScopeByAccountID[account.id] else {
+                let provisionalKind: AccountContentScope.ProvisionalKind? = if durableScopeID != nil {
+                    nil
+                } else if ownerConflict {
+                    .ownerConflict
+                } else {
+                    .initialUnresolved
+                }
+                self.contentScopeByAccountID[account.id] = AccountContentScope(
+                    id: durableScopeID ?? self.issueProvisionalContentScopeID(for: account.id),
+                    durableScopeID: durableScopeID,
+                    provisionalKind: provisionalKind
+                )
+                continue
+            }
+
+            if ownerConflict, durableScopeID == nil {
+                if existingScope.provisionalKind != .ownerConflict {
+                    self.contentScopeByAccountID[account.id] = AccountContentScope(
+                        id: self.issueProvisionalContentScopeID(for: account.id),
+                        durableScopeID: nil,
+                        provisionalKind: .ownerConflict
+                    )
+                }
+                continue
+            }
+
+            switch (existingScope.durableScopeID, durableScopeID) {
+            case let (existing?, resolved?) where existing != resolved:
+                self.contentScopeByAccountID[account.id] = AccountContentScope(
+                    id: resolved,
+                    durableScopeID: resolved,
+                    provisionalKind: nil
+                )
+            case (_?, nil):
+                self.contentScopeByAccountID[account.id] = AccountContentScope(
+                    id: self.issueProvisionalContentScopeID(for: account.id),
+                    durableScopeID: nil,
+                    provisionalKind: .ownerConflict
+                )
+            case (nil, let resolved?):
+                if existingScope.provisionalKind == .ownerConflict {
+                    self.contentScopeByAccountID[account.id] = AccountContentScope(
+                        id: resolved,
+                        durableScopeID: resolved,
+                        provisionalKind: nil
+                    )
+                } else {
+                    // Keep the initially-issued in-memory scope stable when
+                    // owner metadata is merely promoted to durable.
+                    existingScope.durableScopeID = resolved
+                    existingScope.provisionalKind = nil
+                    self.contentScopeByAccountID[account.id] = existingScope
+                }
+            case (nil, nil), _:
+                break
+            }
+        }
+    }
+
+    private func issueProvisionalContentScopeID(for accountID: String) -> String {
+        self.contentScopeGeneration &+= 1
+        return FavoritesManager.opaqueIdentityID(
+            for: "session-account\u{1F}\(self.authService.accountIdentityGeneration)\u{1F}\(self.contentScopeGeneration)\u{1F}\(accountID)"
+        )
     }
 
     private func resolveFavoritesOwnerID(from response: AccountsListResponse) -> String? {
@@ -303,6 +407,7 @@ final class AccountService { // swiftlint:disable:this type_body_length
             guard !authBoundOwnerHasEmail else {
                 self.logger.warning("AccountService: Conflicting durable favorites identities; leaving scope unresolved")
                 self.verifiedFavoritesOwnerID = nil
+                self.didDetectFavoritesOwnerConflict = true
                 return nil
             }
             return emailOwnerID
@@ -461,6 +566,7 @@ final class AccountService { // swiftlint:disable:this type_body_length
         SongLikeStatusManager.shared.clearCache()
         SongLikeStatusManager.shared.setActiveAccountID(nil)
         self.favoritesScopeByAccountID = [:]
+        self.contentScopeByAccountID = [:]
         self.verifiedFavoritesOwnerID = nil
         self.clearActiveFavoritesOwnerIdentity()
         FavoritesManager.shared.setActiveAccountScopeID(nil)
@@ -1310,6 +1416,7 @@ final class AccountService { // swiftlint:disable:this type_body_length
         SongLikeStatusManager.shared.setActiveAccountID(nil)
         FavoritesManager.shared.setActiveAccountScopeID(nil)
         self.favoritesScopeByAccountID = [:]
+        self.contentScopeByAccountID = [:]
         self.verifiedFavoritesOwnerID = nil
         self.clearActiveFavoritesOwnerIdentity()
         self.observedAuthIdentityGeneration = self.authService.accountIdentityGeneration

--- a/Sources/Kaset/Services/Auth/AuthService.swift
+++ b/Sources/Kaset/Services/Auth/AuthService.swift
@@ -83,6 +83,10 @@ final class AuthService: AuthServiceProtocol {
     private var loginCheckGeneration: UInt64 = 0
     private var signOutTask: Task<Void, Never>?
     private var signOutPreparation: (@MainActor @Sendable () async -> Void)?
+    private var accountBoundaryWillBegin: (@MainActor @Sendable () -> Void)?
+    private var accountBoundaryDidEnd: (@MainActor @Sendable () -> Void)?
+    private var accountBoundaryDrain: (@MainActor @Sendable () async -> Void)?
+    private var guestModeTransitionGeneration: UInt64 = 0
 
     init(webKitManager: WebKitManagerProtocol = WebKitManager.shared) {
         self.webKitManager = webKitManager
@@ -104,9 +108,22 @@ final class AuthService: AuthServiceProtocol {
     }
 
     /// Temporarily uses public guest mode while preserving the signed-in session.
-    func enterGuestMode() {
+    func enterGuestMode() async {
         guard self.state.isLoggedIn else { return }
         guard !self.isGuestModeEnabled else { return }
+        self.guestModeTransitionGeneration &+= 1
+        let transitionGeneration = self.guestModeTransitionGeneration
+        self.accountBoundaryWillBegin?()
+        defer { self.accountBoundaryDidEnd?() }
+        await self.accountBoundaryDrain?()
+        guard transitionGeneration == self.guestModeTransitionGeneration,
+              self.state.isLoggedIn,
+              !self.isGuestModeEnabled
+        else { return }
+        self.applyGuestMode()
+    }
+
+    private func applyGuestMode() {
         self.logger.info("Entering guest mode")
         self.clearAPIResponseCaches()
         SongLikeStatusManager.shared.setActiveAccountID(SongLikeStatusManager.guestAccountID)
@@ -115,8 +132,24 @@ final class AuthService: AuthServiceProtocol {
     }
 
     /// Leaves guest mode and resumes the signed-in personal account.
-    func exitGuestMode(activeAccountID: String? = nil) {
+    func exitGuestMode(activeAccountID: String? = nil) async {
         guard self.isGuestModeEnabled else { return }
+        self.guestModeTransitionGeneration &+= 1
+        let transitionGeneration = self.guestModeTransitionGeneration
+        self.accountBoundaryWillBegin?()
+        defer { self.accountBoundaryDidEnd?() }
+        await self.accountBoundaryDrain?()
+        guard transitionGeneration == self.guestModeTransitionGeneration,
+              self.isGuestModeEnabled
+        else { return }
+        self.applyPersonalMode(activeAccountID: activeAccountID)
+    }
+
+    func cancelPendingGuestModeTransition() {
+        self.guestModeTransitionGeneration &+= 1
+    }
+
+    private func applyPersonalMode(activeAccountID: String?) {
         self.logger.info("Leaving guest mode")
         self.clearAPIResponseCaches()
         SongLikeStatusManager.shared.setActiveAccountID(activeAccountID)
@@ -152,6 +185,18 @@ final class AuthService: AuthServiceProtocol {
         self.signOutPreparation = preparation
     }
 
+    /// Registers synchronous cancellation for account-scoped work before cookies,
+    /// guest mode, or authenticated identity can change.
+    func setAccountBoundaryHandlers(
+        willBegin: @escaping @MainActor @Sendable () -> Void,
+        didEnd: @escaping @MainActor @Sendable () -> Void,
+        drain: @escaping @MainActor @Sendable () async -> Void
+    ) {
+        self.accountBoundaryWillBegin = willBegin
+        self.accountBoundaryDidEnd = didEnd
+        self.accountBoundaryDrain = drain
+    }
+
     /// Checks if the user is logged in based on existing cookies.
     /// Waits for the initial Keychain restore before reading WebKit cookies.
     func checkLoginStatus() async {
@@ -176,7 +221,10 @@ final class AuthService: AuthServiceProtocol {
                   checkGeneration == self.loginCheckGeneration
             else { return }
 
-            self.transitionToResolvedState(resolvedState)
+            guard await self.transitionToResolvedState(
+                resolvedState,
+                expectedLoginCheckGeneration: checkGeneration
+            ) else { return }
             if resolvedState.isLoggedIn {
                 self.needsReauth = false
             }
@@ -189,6 +237,9 @@ final class AuthService: AuthServiceProtocol {
 
     /// Called when a session expires (e.g., 401/403 from API).
     func sessionExpired() {
+        self.cancelPendingGuestModeTransition()
+        self.accountBoundaryWillBegin?()
+        defer { self.accountBoundaryDidEnd?() }
         self.logger.warning("Session expired, requiring re-authentication")
         self.invalidateLoginCheck()
         self.advanceAccountIdentityGeneration()
@@ -216,10 +267,10 @@ final class AuthService: AuthServiceProtocol {
             return
         }
         self.logger.info("Signing out user")
+        self.cancelPendingGuestModeTransition()
+        self.accountBoundaryWillBegin?()
 
-        // Fence authenticated work synchronously before the account-owned drain
-        // can suspend. The drain prevents old WebKit mutations from outliving the
-        // later cookie deletion; this state change prevents new API mutations.
+        // Fence authenticated work synchronously before the first suspension.
         self.invalidateLoginCheck()
         self.advanceAccountIdentityGeneration()
         self.clearAPIResponseCaches()
@@ -231,6 +282,8 @@ final class AuthService: AuthServiceProtocol {
         let preparation = self.signOutPreparation
         let task = Task { @MainActor [weak self] in
             guard let self else { return }
+            defer { self.accountBoundaryDidEnd?() }
+            await self.accountBoundaryDrain?()
             await preparation?()
             await self.webKitManager.clearAllData()
             self.clearAPIResponseCaches()
@@ -249,15 +302,50 @@ final class AuthService: AuthServiceProtocol {
     }
 
     /// Called when login completes successfully (from LoginSheet observation).
-    func completeLogin(sapisid: String) {
+    func completeLoginAfterDraining(sapisid: String) async {
         self.logger.info("Login completed successfully")
         guard self.signOutTask == nil else {
             self.logger.info("Ignoring login completion while sign-out is in progress")
             return
         }
+        self.cancelPendingGuestModeTransition()
+        self.accountBoundaryWillBegin?()
+        defer { self.accountBoundaryDidEnd?() }
         self.invalidateLoginCheck()
+        let completionGeneration = self.loginCheckGeneration
+        await self.accountBoundaryDrain?()
+        guard self.signOutTask == nil,
+              completionGeneration == self.loginCheckGeneration
+        else {
+            self.logger.info("Ignoring login completion superseded while draining account work")
+            return
+        }
+        self.applyCompletedLogin(sapisid: sapisid)
+    }
+
+    #if DEBUG
+        /// Test-only fast path for isolated AuthService instances with no account-boundary wiring.
+        func completeLogin(sapisid: String) {
+            precondition(
+                self.accountBoundaryWillBegin == nil
+                    && self.accountBoundaryDidEnd == nil
+                    && self.accountBoundaryDrain == nil,
+                "Use completeLoginAfterDraining(sapisid:) when account-boundary handlers are installed"
+            )
+            self.logger.info("Login completed successfully")
+            guard self.signOutTask == nil else {
+                self.logger.info("Ignoring login completion while sign-out is in progress")
+                return
+            }
+            self.cancelPendingGuestModeTransition()
+            self.invalidateLoginCheck()
+            self.applyCompletedLogin(sapisid: sapisid)
+        }
+    #endif
+
+    private func applyCompletedLogin(sapisid: String) {
         if self.isGuestModeEnabled {
-            self.exitGuestMode()
+            self.applyPersonalMode(activeAccountID: nil)
         }
         // Login completion is an explicit identity boundary even when Google
         // reuses the same SAPISID across multi-login accounts. Fence every older
@@ -273,18 +361,38 @@ final class AuthService: AuthServiceProtocol {
         self.accountIdentityGeneration &+= 1
     }
 
-    private func transitionToResolvedState(_ newState: State) {
+    private func transitionToResolvedState(
+        _ newState: State,
+        expectedLoginCheckGeneration: UInt64
+    ) async -> Bool {
         let previousIdentity = self.activeAuthenticationIdentity
         let nextIdentity: String? = if case let .loggedIn(sapisid) = newState {
             sapisid
         } else {
             nil
         }
-        if let previousIdentity, previousIdentity != nextIdentity {
+        let identityChanged = previousIdentity != nil && previousIdentity != nextIdentity
+        if identityChanged {
+            self.cancelPendingGuestModeTransition()
+            self.accountBoundaryWillBegin?()
+        }
+        defer {
+            if identityChanged {
+                self.accountBoundaryDidEnd?()
+            }
+        }
+        if identityChanged {
+            await self.accountBoundaryDrain?()
+        }
+        guard expectedLoginCheckGeneration == self.loginCheckGeneration,
+              !Task.isCancelled
+        else { return false }
+        if identityChanged {
             self.advanceAccountIdentityGeneration()
             self.clearAPIResponseCaches()
         }
         self.state = newState
+        return true
     }
 
     private var activeAuthenticationIdentity: String? {

--- a/Sources/Kaset/Services/Library/LibraryContentIdentity.swift
+++ b/Sources/Kaset/Services/Library/LibraryContentIdentity.swift
@@ -27,6 +27,26 @@ enum LibraryContentIdentity {
         self.artistKey(for: artist.id)
     }
 
+    static func albumKey(albumId: String, targetPlaylistId: String? = nil) -> String {
+        targetPlaylistId ?? albumId
+    }
+
+    static func albumKey(for album: Album) -> String {
+        self.albumKey(albumId: album.id, targetPlaylistId: album.libraryTargetId)
+    }
+
+    static func albumKeys(for album: Album) -> Set<String> {
+        var keys = Set([album.id])
+        if let libraryTargetId = album.libraryTargetId {
+            keys.insert(libraryTargetId)
+        }
+        return keys
+    }
+
+    static func albumsMatch(_ lhs: Album, _ rhs: Album) -> Bool {
+        !self.albumKeys(for: lhs).isDisjoint(with: self.albumKeys(for: rhs))
+    }
+
     static func canonicalArtist(_ artist: Artist, libraryArtistID: String? = nil) -> Artist {
         let canonicalArtistID = self.artistKey(for: libraryArtistID ?? artist.id)
         if artist.id == canonicalArtistID {
@@ -65,6 +85,20 @@ enum LibraryContentIdentity {
         }
 
         return deduplicatedArtists
+    }
+
+    static func deduplicatedAlbums(_ albums: [Album]) -> [Album] {
+        var seenAlbumKeys: Set<String> = []
+        var deduplicatedAlbums: [Album] = []
+
+        for album in albums {
+            let albumKeys = self.albumKeys(for: album)
+            guard seenAlbumKeys.isDisjoint(with: albumKeys) else { continue }
+            seenAlbumKeys.formUnion(albumKeys)
+            deduplicatedAlbums.append(album)
+        }
+
+        return deduplicatedAlbums
     }
 
     static func containsPlaylist(_ playlistID: String, in libraryPlaylistIDs: Set<String>) -> Bool {

--- a/Sources/Kaset/Services/Library/LibraryContentReconciler.swift
+++ b/Sources/Kaset/Services/Library/LibraryContentReconciler.swift
@@ -5,6 +5,7 @@ import Foundation
 /// Visible Library content plus the ID indexes that power membership checks.
 struct LibraryContentSnapshot {
     var playlists: [Playlist]
+    var albums: [Album]
     var artists: [Artist]
     var podcastShows: [PodcastShow]
     var uploadedSongsPlaylist: Playlist?
@@ -14,6 +15,7 @@ struct LibraryContentSnapshot {
 
     static let empty = LibraryContentSnapshot(
         playlists: [],
+        albums: [],
         artists: [],
         podcastShows: [],
         uploadedSongsPlaylist: nil,
@@ -23,7 +25,7 @@ struct LibraryContentSnapshot {
     )
 
     var hasVisibleContent: Bool {
-        !self.playlists.isEmpty || !self.artists.isEmpty || !self.podcastShows.isEmpty
+        !self.playlists.isEmpty || !self.albums.isEmpty || !self.artists.isEmpty || !self.podcastShows.isEmpty
             || self.uploadedSongsPlaylist != nil
             || !self.playlistIds.isEmpty || !self.artistIds.isEmpty || !self.podcastIds.isEmpty
     }
@@ -43,12 +45,18 @@ struct LibraryContentReconciler {
     }
 
     private static let playlistMutationStableMatchCount = 2
+    private static let albumMutationStableMatchCount = 2
     private static let artistMutationStableMatchCount = 2
 
     private var pendingAddedPlaylists: [String: Playlist] = [:]
     private var pendingAddedPlaylistMatchCounts: [String: Int] = [:]
     private var pendingRemovedPlaylistKeys: Set<String> = []
     private var pendingRemovedPlaylistMissCounts: [String: Int] = [:]
+
+    private var pendingAddedAlbums: [String: Album] = [:]
+    private var pendingAddedAlbumMatchCounts: [String: Int] = [:]
+    private var pendingRemovedAlbumIdentities: [String: Set<String>] = [:]
+    private var pendingRemovedAlbumMissCounts: [String: Int] = [:]
 
     private struct ArtistReconciliationResult {
         let artists: [Artist]
@@ -66,12 +74,14 @@ struct LibraryContentReconciler {
         currentSnapshot: LibraryContentSnapshot
     ) -> Result {
         let playlists = self.reconciledPlaylists(from: content.playlists)
+        let albums = self.reconciledAlbums(from: content.albums)
         let artistResult = self.reconciledArtists(from: content, currentSnapshot: currentSnapshot)
         let podcastShows = content.podcastShows
 
         return Result(
             snapshot: LibraryContentSnapshot(
                 playlists: playlists,
+                albums: albums,
                 artists: artistResult.artists,
                 podcastShows: podcastShows,
                 uploadedSongsPlaylist: content.uploadedSongsPlaylist,
@@ -137,6 +147,60 @@ struct LibraryContentReconciler {
         self.removePlaylistId(playlistId, from: &snapshot)
         let playlistKey = LibraryContentIdentity.playlistKey(for: playlistId)
         snapshot.playlists.removeAll { LibraryContentIdentity.playlistKey(for: $0.id) == playlistKey }
+    }
+
+    mutating func addAlbum(_ album: Album, to snapshot: inout LibraryContentSnapshot) {
+        let albumIdentities = LibraryContentIdentity.albumKeys(for: album)
+        for removalKey in self.pendingRemovedAlbumIdentities.keys.filter({ key in
+            guard let identities = self.pendingRemovedAlbumIdentities[key] else { return false }
+            return !identities.isDisjoint(with: albumIdentities)
+        }) {
+            self.pendingRemovedAlbumIdentities.removeValue(forKey: removalKey)
+            self.pendingRemovedAlbumMissCounts.removeValue(forKey: removalKey)
+        }
+
+        for pendingKey in self.pendingAddedAlbums.keys.filter({ key in
+            guard let pendingAlbum = self.pendingAddedAlbums[key] else { return false }
+            return LibraryContentIdentity.albumsMatch(pendingAlbum, album)
+        }) {
+            self.pendingAddedAlbums.removeValue(forKey: pendingKey)
+            self.pendingAddedAlbumMatchCounts.removeValue(forKey: pendingKey)
+        }
+
+        self.pendingAddedAlbums[album.id] = album
+        self.pendingAddedAlbumMatchCounts[album.id] = 0
+
+        if let existingIndex = snapshot.albums.firstIndex(where: { LibraryContentIdentity.albumsMatch($0, album) }) {
+            snapshot.albums[existingIndex] = album
+        } else {
+            snapshot.albums.insert(album, at: 0)
+        }
+    }
+
+    mutating func removeAlbum(
+        albumId: String,
+        targetPlaylistId: String? = nil,
+        from snapshot: inout LibraryContentSnapshot
+    ) {
+        var albumIdentities = Set([albumId])
+        if let targetPlaylistId {
+            albumIdentities.insert(targetPlaylistId)
+        }
+
+        for pendingKey in self.pendingAddedAlbums.keys.filter({ key in
+            guard let pendingAlbum = self.pendingAddedAlbums[key] else { return false }
+            return !LibraryContentIdentity.albumKeys(for: pendingAlbum).isDisjoint(with: albumIdentities)
+        }) {
+            self.pendingAddedAlbums.removeValue(forKey: pendingKey)
+            self.pendingAddedAlbumMatchCounts.removeValue(forKey: pendingKey)
+        }
+
+        let removalKey = targetPlaylistId ?? albumId
+        self.pendingRemovedAlbumIdentities[removalKey] = albumIdentities
+        self.pendingRemovedAlbumMissCounts[removalKey] = 0
+        snapshot.albums.removeAll { album in
+            !LibraryContentIdentity.albumKeys(for: album).isDisjoint(with: albumIdentities)
+        }
     }
 
     mutating func addPodcast(_ podcast: PodcastShow, to snapshot: inout LibraryContentSnapshot) {
@@ -245,6 +309,59 @@ struct LibraryContentReconciler {
             if self.pendingRemovedPlaylistMissCounts[playlistKey, default: 0] >= Self.playlistMutationStableMatchCount {
                 self.pendingRemovedPlaylistKeys.remove(playlistKey)
                 self.pendingRemovedPlaylistMissCounts.removeValue(forKey: playlistKey)
+            }
+        }
+    }
+
+    private mutating func reconciledAlbums(from backendAlbums: [Album]) -> [Album] {
+        self.updatePendingAlbumAdditions(backendAlbums: backendAlbums)
+        self.updatePendingAlbumRemovals(backendAlbums: backendAlbums)
+
+        var albums = backendAlbums.filter { album in
+            let albumIdentities = LibraryContentIdentity.albumKeys(for: album)
+            return self.pendingRemovedAlbumIdentities.values.allSatisfy { identities in
+                albumIdentities.isDisjoint(with: identities)
+            }
+        }
+        albums = LibraryContentIdentity.deduplicatedAlbums(albums)
+
+        for album in self.pendingAddedAlbums.values where !albums.contains(where: { LibraryContentIdentity.albumsMatch($0, album) }) {
+            albums.insert(album, at: 0)
+        }
+
+        return albums
+    }
+
+    private mutating func updatePendingAlbumAdditions(backendAlbums: [Album]) {
+        for pendingKey in Array(self.pendingAddedAlbums.keys) {
+            guard let pendingAlbum = self.pendingAddedAlbums[pendingKey] else { continue }
+            if backendAlbums.contains(where: { LibraryContentIdentity.albumsMatch($0, pendingAlbum) }) {
+                self.pendingAddedAlbumMatchCounts[pendingKey, default: 0] += 1
+                if self.pendingAddedAlbumMatchCounts[pendingKey, default: 0] >= Self.albumMutationStableMatchCount {
+                    self.pendingAddedAlbums.removeValue(forKey: pendingKey)
+                    self.pendingAddedAlbumMatchCounts.removeValue(forKey: pendingKey)
+                }
+            } else {
+                self.pendingAddedAlbumMatchCounts[pendingKey] = 0
+            }
+        }
+    }
+
+    private mutating func updatePendingAlbumRemovals(backendAlbums: [Album]) {
+        for removalKey in Array(self.pendingRemovedAlbumIdentities.keys) {
+            guard let removedIdentities = self.pendingRemovedAlbumIdentities[removalKey] else { continue }
+            let backendStillContainsAlbum = backendAlbums.contains { album in
+                !LibraryContentIdentity.albumKeys(for: album).isDisjoint(with: removedIdentities)
+            }
+            if backendStillContainsAlbum {
+                self.pendingRemovedAlbumMissCounts[removalKey] = 0
+                continue
+            }
+
+            self.pendingRemovedAlbumMissCounts[removalKey, default: 0] += 1
+            if self.pendingRemovedAlbumMissCounts[removalKey, default: 0] >= Self.albumMutationStableMatchCount {
+                self.pendingRemovedAlbumIdentities.removeValue(forKey: removalKey)
+                self.pendingRemovedAlbumMissCounts.removeValue(forKey: removalKey)
             }
         }
     }

--- a/Sources/Kaset/Services/Library/LibraryContentReconciler.swift
+++ b/Sources/Kaset/Services/Library/LibraryContentReconciler.swift
@@ -12,6 +12,8 @@ struct LibraryContentSnapshot {
     var playlistIds: Set<String>
     var artistIds: Set<String>
     var podcastIds: Set<String>
+    var accountScope: String?
+    var albumsSource: LibraryContentParser.LibraryAlbumsSource?
 
     static let empty = LibraryContentSnapshot(
         playlists: [],
@@ -21,13 +23,19 @@ struct LibraryContentSnapshot {
         uploadedSongsPlaylist: nil,
         playlistIds: [],
         artistIds: [],
-        podcastIds: []
+        podcastIds: [],
+        accountScope: nil,
+        albumsSource: nil
     )
 
     var hasVisibleContent: Bool {
         !self.playlists.isEmpty || !self.albums.isEmpty || !self.artists.isEmpty || !self.podcastShows.isEmpty
             || self.uploadedSongsPlaylist != nil
             || !self.playlistIds.isEmpty || !self.artistIds.isEmpty || !self.podcastIds.isEmpty
+    }
+
+    var hasLoadedContent: Bool {
+        self.hasVisibleContent || self.albumsSource != nil
     }
 }
 
@@ -41,6 +49,7 @@ struct LibraryContentSnapshot {
 struct LibraryContentReconciler {
     struct Result {
         let snapshot: LibraryContentSnapshot
+        let preservedExistingAlbums: Bool
         let preservedExistingArtists: Bool
     }
 
@@ -58,6 +67,12 @@ struct LibraryContentReconciler {
     private var pendingRemovedAlbumIdentities: [String: Set<String>] = [:]
     private var pendingRemovedAlbumMissCounts: [String: Int] = [:]
 
+    private struct AlbumReconciliationResult {
+        let albums: [Album]
+        let preservedExistingAlbums: Bool
+        let albumsSource: LibraryContentParser.LibraryAlbumsSource
+    }
+
     private struct ArtistReconciliationResult {
         let artists: [Artist]
         let artistKeys: Set<String>
@@ -73,24 +88,57 @@ struct LibraryContentReconciler {
         _ content: LibraryContentParser.LibraryContent,
         currentSnapshot: LibraryContentSnapshot
     ) -> Result {
+        self.resetPendingMutationsIfAccountChanged(
+            from: currentSnapshot.accountScope,
+            to: content.accountScope
+        )
+
         let playlists = self.reconciledPlaylists(from: content.playlists)
-        let albums = self.reconciledAlbums(from: content.albums)
+        let albumResult = self.reconciledAlbums(from: content, currentSnapshot: currentSnapshot)
         let artistResult = self.reconciledArtists(from: content, currentSnapshot: currentSnapshot)
         let podcastShows = content.podcastShows
 
         return Result(
             snapshot: LibraryContentSnapshot(
                 playlists: playlists,
-                albums: albums,
+                albums: albumResult.albums,
                 artists: artistResult.artists,
                 podcastShows: podcastShows,
                 uploadedSongsPlaylist: content.uploadedSongsPlaylist,
                 playlistIds: Set(playlists.map(\.id)),
                 artistIds: artistResult.artistKeys,
-                podcastIds: Set(podcastShows.map(\.id))
+                podcastIds: Set(podcastShows.map(\.id)),
+                accountScope: content.accountScope,
+                albumsSource: albumResult.albumsSource
             ),
+            preservedExistingAlbums: albumResult.preservedExistingAlbums,
             preservedExistingArtists: artistResult.preservedExistingArtists
         )
+    }
+
+    private mutating func resetPendingMutationsIfAccountChanged(
+        from currentAccountScope: String?,
+        to newAccountScope: String?
+    ) {
+        guard let currentAccountScope,
+              let newAccountScope,
+              currentAccountScope != newAccountScope
+        else { return }
+
+        self.pendingAddedPlaylists.removeAll()
+        self.pendingAddedPlaylistMatchCounts.removeAll()
+        self.pendingRemovedPlaylistKeys.removeAll()
+        self.pendingRemovedPlaylistMissCounts.removeAll()
+
+        self.pendingAddedAlbums.removeAll()
+        self.pendingAddedAlbumMatchCounts.removeAll()
+        self.pendingRemovedAlbumIdentities.removeAll()
+        self.pendingRemovedAlbumMissCounts.removeAll()
+
+        self.pendingAddedArtists.removeAll()
+        self.pendingAddedArtistMatchCounts.removeAll()
+        self.pendingRemovedArtistKeys.removeAll()
+        self.pendingRemovedArtistMissCounts.removeAll()
     }
 
     func needsArtistReconciliation(artistIds: [String], expectedInLibrary: Bool) -> Bool {
@@ -313,11 +361,44 @@ struct LibraryContentReconciler {
         }
     }
 
-    private mutating func reconciledAlbums(from backendAlbums: [Album]) -> [Album] {
-        self.updatePendingAlbumAdditions(backendAlbums: backendAlbums)
-        self.updatePendingAlbumRemovals(backendAlbums: backendAlbums)
+    private mutating func reconciledAlbums(
+        from content: LibraryContentParser.LibraryContent,
+        currentSnapshot: LibraryContentSnapshot
+    ) -> AlbumReconciliationResult {
+        let sameAccount = content.accountScope == currentSnapshot.accountScope
+        let currentSource = currentSnapshot.albumsSource
+        let sourceAlbums: [Album]
+        let snapshotSource: LibraryContentParser.LibraryAlbumsSource
+        let preservedExistingAlbums: Bool
 
-        var albums = backendAlbums.filter { album in
+        switch content.albumsSource {
+        case .dedicated:
+            sourceAlbums = content.albums
+            snapshotSource = .dedicated
+            preservedExistingAlbums = false
+        case .partial where sameAccount && (currentSource == .dedicated || currentSource == .partial):
+            sourceAlbums = Self.mergedPartialAlbums(
+                existing: currentSnapshot.albums,
+                incoming: content.albums
+            )
+            snapshotSource = .partial
+            preservedExistingAlbums = true
+        case .landingFallback where sameAccount && (currentSource == .dedicated || currentSource == .partial):
+            sourceAlbums = currentSnapshot.albums
+            snapshotSource = currentSource ?? .landingFallback
+            preservedExistingAlbums = true
+        case .partial, .landingFallback:
+            sourceAlbums = content.albums
+            snapshotSource = content.albumsSource
+            preservedExistingAlbums = false
+        }
+
+        if content.albumsSource.isAuthoritative {
+            self.updatePendingAlbumAdditions(backendAlbums: content.albums)
+            self.updatePendingAlbumRemovals(backendAlbums: content.albums)
+        }
+
+        var albums = sourceAlbums.filter { album in
             let albumIdentities = LibraryContentIdentity.albumKeys(for: album)
             return self.pendingRemovedAlbumIdentities.values.allSatisfy { identities in
                 albumIdentities.isDisjoint(with: identities)
@@ -329,7 +410,52 @@ struct LibraryContentReconciler {
             albums.insert(album, at: 0)
         }
 
-        return albums
+        return AlbumReconciliationResult(
+            albums: albums,
+            preservedExistingAlbums: preservedExistingAlbums,
+            albumsSource: snapshotSource
+        )
+    }
+
+    private static func mergedPartialAlbums(
+        existing: [Album],
+        incoming: [Album]
+    ) -> [Album] {
+        var merged = existing
+        for album in incoming {
+            if let index = merged.firstIndex(where: { LibraryContentIdentity.albumsMatch($0, album) }) {
+                merged[index] = Self.mergedAlbum(existing: merged[index], incoming: album)
+            } else {
+                merged.append(album)
+            }
+        }
+        return merged
+    }
+
+    private static func mergedAlbum(existing: Album, incoming: Album) -> Album {
+        let incomingArtists = incoming.artists?.isEmpty == false ? incoming.artists : nil
+        let incomingTitle = incoming.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let title = incomingTitle.isEmpty || incomingTitle == "Unknown Album"
+            ? existing.title
+            : incoming.title
+        let albumId = if existing.id.hasPrefix("MPRE") {
+            existing.id
+        } else if incoming.id.hasPrefix("MPRE") {
+            incoming.id
+        } else {
+            incoming.id
+        }
+        let idBasedLibraryTarget = [incoming.id, existing.id].first { $0.hasPrefix("OLAK") }
+
+        return Album(
+            id: albumId,
+            title: title,
+            artists: incomingArtists ?? existing.artists,
+            thumbnailURL: incoming.thumbnailURL ?? existing.thumbnailURL,
+            year: incoming.year ?? existing.year,
+            trackCount: incoming.trackCount ?? existing.trackCount,
+            libraryTargetId: incoming.libraryTargetId ?? existing.libraryTargetId ?? idBasedLibraryTarget
+        )
     }
 
     private mutating func updatePendingAlbumAdditions(backendAlbums: [Album]) {
@@ -370,7 +496,9 @@ struct LibraryContentReconciler {
         from content: LibraryContentParser.LibraryContent,
         currentSnapshot: LibraryContentSnapshot
     ) -> ArtistReconciliationResult {
-        let preservedExistingArtists = content.artistsSource == .landingFallback && !currentSnapshot.artists.isEmpty
+        let preservedExistingArtists = content.artistsSource == .landingFallback
+            && content.accountScope == currentSnapshot.accountScope
+            && !currentSnapshot.artists.isEmpty
         let sourceArtists = preservedExistingArtists ? currentSnapshot.artists : content.artists
         let canonicalArtists = sourceArtists.map { LibraryContentIdentity.canonicalArtist($0) }
         let rawArtistKeys = Set(canonicalArtists.map(\.id))

--- a/Sources/Kaset/Services/Library/LibraryMutationActions.swift
+++ b/Sources/Kaset/Services/Library/LibraryMutationActions.swift
@@ -78,7 +78,7 @@ enum LibraryMutationActions {
         _ playlist: Playlist,
         client: any YTMusicClientProtocol,
         libraryViewModel: LibraryViewModel?
-    ) async {
+    ) async throws {
         do {
             try await client.subscribeToPlaylist(playlistId: playlist.id)
             self.invalidateResponseCaches()
@@ -98,6 +98,7 @@ enum LibraryMutationActions {
             DiagnosticsLogger.api.info("Added playlist to library: \(playlist.title)")
         } catch {
             DiagnosticsLogger.api.error("Failed to add playlist to library: \(error.localizedDescription)")
+            throw error
         }
     }
 
@@ -106,7 +107,7 @@ enum LibraryMutationActions {
         _ playlist: Playlist,
         client: any YTMusicClientProtocol,
         libraryViewModel: LibraryViewModel?
-    ) async {
+    ) async throws {
         do {
             try await client.unsubscribeFromPlaylist(playlistId: playlist.id)
             self.invalidateResponseCaches()
@@ -120,6 +121,68 @@ enum LibraryMutationActions {
             DiagnosticsLogger.api.info("Removed playlist from library: \(playlist.title)")
         } catch {
             DiagnosticsLogger.api.error("Failed to remove playlist from library: \(error.localizedDescription)")
+            throw error
+        }
+    }
+
+    /// Adds an album to the library using its OLAK playlist target.
+    static func addAlbumToLibrary(
+        _ album: Album,
+        targetPlaylistId: String,
+        client: any YTMusicClientProtocol,
+        libraryViewModel: LibraryViewModel?
+    ) async throws {
+        do {
+            try await client.subscribeToPlaylist(playlistId: targetPlaylistId)
+            let libraryAlbum = Album(
+                id: album.id,
+                title: album.title,
+                artists: album.artists,
+                thumbnailURL: album.thumbnailURL,
+                year: album.year,
+                trackCount: album.trackCount,
+                libraryTargetId: targetPlaylistId
+            )
+            self.invalidateResponseCaches()
+            libraryViewModel?.markNeedsReloadOnActivation()
+            LibraryMutationBroadcaster.shared.albumAdded(libraryAlbum)
+
+            try? await Task.sleep(for: .milliseconds(500))
+            await LibraryMutationBroadcaster.shared.reconcileAddedAlbum(libraryAlbum)
+            self.invalidateResponseCaches()
+            DiagnosticsLogger.api.info("Added album to library: \(album.title)")
+        } catch {
+            DiagnosticsLogger.api.error("Failed to add album to library: \(error.localizedDescription)")
+            throw error
+        }
+    }
+
+    /// Removes an album from the library using its OLAK playlist target.
+    static func removeAlbumFromLibrary(
+        _ album: Album,
+        targetPlaylistId: String,
+        client: any YTMusicClientProtocol,
+        libraryViewModel: LibraryViewModel?
+    ) async throws {
+        do {
+            try await client.unsubscribeFromPlaylist(playlistId: targetPlaylistId)
+            self.invalidateResponseCaches()
+            libraryViewModel?.markNeedsReloadOnActivation()
+            LibraryMutationBroadcaster.shared.albumRemoved(
+                albumId: album.id,
+                targetPlaylistId: targetPlaylistId
+            )
+
+            try? await Task.sleep(for: .milliseconds(500))
+            await LibraryMutationBroadcaster.shared.reconcileRemovedAlbum(
+                albumId: album.id,
+                targetPlaylistId: targetPlaylistId
+            )
+            self.invalidateResponseCaches()
+            DiagnosticsLogger.api.info("Removed album from library: \(album.title)")
+        } catch {
+            DiagnosticsLogger.api.error("Failed to remove album from library: \(error.localizedDescription)")
+            throw error
         }
     }
 

--- a/Sources/Kaset/Services/Library/LibraryMutationActions.swift
+++ b/Sources/Kaset/Services/Library/LibraryMutationActions.swift
@@ -1,8 +1,11 @@
+// swiftlint:disable file_length
+
 import Foundation
 
 /// Orchestrates Library mutations that need optimistic UI updates, cache invalidation,
 /// and eventual-consistency reconciliation after YouTube Music accepts a change.
 @MainActor
+// swiftlint:disable:next type_body_length
 enum LibraryMutationActions {
     private struct PlaylistDeletionKey: Hashable {
         let playlistId: String
@@ -15,8 +18,36 @@ enum LibraryMutationActions {
     }
 
     private struct PendingAlbumMutation {
-        let id: UUID
+        let owner: AlbumMutationOwner
         let task: Task<Void, Error>
+    }
+
+    private struct PendingPlaylistMutation {
+        let owner: PlaylistMutationOwner
+        let task: Task<Void, Error>
+    }
+
+    private struct PendingArtistReconciliation {
+        let task: Task<Void, Never>
+    }
+
+    private enum TrackedMutationResult<Value> {
+        case pending
+        case value(Value)
+    }
+
+    private enum PlaylistMutationOwner: Hashable {
+        case viewModel(ObjectIdentifier)
+        case unscoped
+    }
+
+    private struct PlaylistMutationContext {
+        let owner: PlaylistMutationOwner
+        let generation: UInt64
+    }
+
+    private struct PlaylistMutationKey: Hashable {
+        let identity: String
     }
 
     private enum AlbumMutationOwner: Hashable {
@@ -26,7 +57,6 @@ enum LibraryMutationActions {
 
     private struct AlbumMutationKey: Hashable {
         let identity: String
-        let owner: AlbumMutationOwner
     }
 
     private struct AlbumMutationContext {
@@ -45,16 +75,191 @@ enum LibraryMutationActions {
 
     static var artistReconciliationRetryDelays: [Duration] = [.seconds(2), .seconds(3)]
 
-    private static var artistReconciliationTasks: [String: Task<Void, Never>] = [:]
+    private static var artistReconciliationTasks: [String: PendingArtistReconciliation] = [:]
+    private static var latestArtistReconciliationIDs: [String: String] = [:]
     private static var pendingPlaylistDeletions: [PlaylistDeletionKey: PendingPlaylistDeletion] = [:]
-    private static var pendingAlbumMutations: [AlbumMutationKey: PendingAlbumMutation] = [:]
+    private static var pendingPlaylistMutations: [UUID: PendingPlaylistMutation] = [:]
+    private static var latestPlaylistMutationIDs: [PlaylistMutationKey: UUID] = [:]
+    private static var playlistMutationGenerations: [PlaylistMutationOwner: UInt64] = [:]
+    private static var pendingAlbumMutations: [UUID: PendingAlbumMutation] = [:]
+    private static var latestAlbumMutationIDs: [AlbumMutationKey: UUID] = [:]
     private static var albumMutationGenerations: [AlbumMutationOwner: UInt64] = [:]
+    private static var accountBoundaryGeneration: UInt64 = 0
+    private static var accountBoundaryDepth: Int = 0
+    private static var pendingAccountBoundaryMutations: [UUID: Task<Void, Error>] = [:]
+    private static var accountBoundaryDrainTask: Task<Void, Never>?
+
+    static func beginAccountBoundary() {
+        self.accountBoundaryDepth += 1
+        let throwingTasks = self.pendingPlaylistMutations.values.map(\.task)
+            + self.pendingAlbumMutations.values.map(\.task)
+            + self.pendingPlaylistDeletions.values.map(\.task)
+            + Array(self.pendingAccountBoundaryMutations.values)
+        let nonthrowingTasks = self.artistReconciliationTasks.values.map(\.task)
+        self.cancelAllPendingLibraryMutations()
+        guard self.accountBoundaryDrainTask == nil else { return }
+        guard !throwingTasks.isEmpty || !nonthrowingTasks.isEmpty else { return }
+        let drainTask = Task { @MainActor in
+            for task in throwingTasks {
+                _ = try? await task.value
+            }
+            for task in nonthrowingTasks {
+                await task.value
+            }
+        }
+        self.accountBoundaryDrainTask = drainTask
+        Task { @MainActor in
+            await drainTask.value
+            if self.accountBoundaryDrainTask == drainTask {
+                self.accountBoundaryDrainTask = nil
+            }
+        }
+    }
+
+    static func endAccountBoundary() {
+        precondition(self.accountBoundaryDepth > 0, "Unbalanced Library account boundary")
+        self.accountBoundaryDepth -= 1
+    }
+
+    static func awaitAccountBoundaryDrain() async {
+        while let drainTask = self.accountBoundaryDrainTask {
+            await drainTask.value
+            if self.accountBoundaryDrainTask == drainTask {
+                self.accountBoundaryDrainTask = nil
+            }
+        }
+    }
+
+    static func cancelPendingLibraryMutations(for libraryViewModel: LibraryViewModel?) {
+        self.cancelPendingPlaylistMutations(for: libraryViewModel)
+        self.cancelPendingAlbumMutations(for: libraryViewModel)
+    }
+
+    static func cancelAllPendingLibraryMutations() {
+        self.accountBoundaryGeneration &+= 1
+        self.cancelAllPendingPlaylistMutations()
+        self.cancelAllPendingAlbumMutations()
+        self.cancelAllPendingPlaylistDeletions()
+        self.cancelAllArtistReconciliationTasks()
+        self.cancelAllPendingAccountBoundaryMutations()
+    }
+
+    static func cancelPendingPlaylistMutations(for libraryViewModel: LibraryViewModel?) {
+        let owner = self.playlistMutationOwner(for: libraryViewModel)
+        self.playlistMutationGenerations[owner, default: 0] &+= 1
+        let matchingIDs = self.pendingPlaylistMutations.compactMap { id, mutation in
+            mutation.owner == owner ? id : nil
+        }
+        let tasks = matchingIDs.compactMap { self.pendingPlaylistMutations[$0]?.task }
+        for task in tasks {
+            task.cancel()
+        }
+    }
+
+    static func cancelAllPendingPlaylistMutations() {
+        let owners = Set(self.playlistMutationGenerations.keys)
+            .union(self.pendingPlaylistMutations.values.map(\.owner))
+            .union([.unscoped])
+        for owner in owners {
+            self.playlistMutationGenerations[owner, default: 0] &+= 1
+        }
+
+        let tasks = self.pendingPlaylistMutations.values.map(\.task)
+        self.pendingPlaylistMutations.removeAll()
+        self.latestPlaylistMutationIDs.removeAll()
+        for task in tasks {
+            task.cancel()
+        }
+    }
+
+    private static func cancelAllPendingPlaylistDeletions() {
+        let tasks = self.pendingPlaylistDeletions.values.map(\.task)
+        self.pendingPlaylistDeletions.removeAll()
+        for task in tasks {
+            task.cancel()
+        }
+    }
+
+    private static func cancelAllArtistReconciliationTasks() {
+        let tasks = self.artistReconciliationTasks.values.map(\.task)
+        self.artistReconciliationTasks.removeAll()
+        self.latestArtistReconciliationIDs.removeAll()
+        for task in tasks {
+            task.cancel()
+        }
+    }
+
+    private static func cancelAllPendingAccountBoundaryMutations() {
+        let tasks = self.pendingAccountBoundaryMutations.values
+        self.pendingAccountBoundaryMutations.removeAll()
+        for task in tasks {
+            task.cancel()
+        }
+    }
+
+    private static func checkAccountBoundary(_ generation: UInt64) throws {
+        try Task.checkCancellation()
+        guard self.accountBoundaryDepth == 0,
+              self.accountBoundaryDrainTask == nil,
+              generation == self.accountBoundaryGeneration
+        else { throw CancellationError() }
+    }
+
+    private static func isAccountBoundaryCurrent(_ generation: UInt64) -> Bool {
+        !Task.isCancelled
+            && self.accountBoundaryDepth == 0
+            && self.accountBoundaryDrainTask == nil
+            && generation == self.accountBoundaryGeneration
+    }
+
+    private static func runTrackedAccountBoundaryMutation(
+        _ operation: @MainActor @escaping () async throws -> Void
+    ) async throws {
+        let boundaryGeneration = self.accountBoundaryGeneration
+        try self.checkAccountBoundary(boundaryGeneration)
+        let operationID = UUID()
+        let task = Task { @MainActor in
+            try self.checkAccountBoundary(boundaryGeneration)
+            try await operation()
+        }
+        self.pendingAccountBoundaryMutations[operationID] = task
+        defer { self.pendingAccountBoundaryMutations.removeValue(forKey: operationID) }
+
+        try await withTaskCancellationHandler {
+            try await task.value
+        } onCancel: {
+            task.cancel()
+        }
+    }
+
+    static func withAccountBoundaryTracking<Value>(
+        _ operation: @MainActor @escaping () async throws -> Value
+    ) async throws -> Value {
+        let boundaryGeneration = self.accountBoundaryGeneration
+        var result: TrackedMutationResult<Value> = .pending
+        try await self.runTrackedAccountBoundaryMutation {
+            do {
+                let value = try await operation()
+                try self.checkAccountBoundary(boundaryGeneration)
+                result = .value(value)
+            } catch {
+                guard self.isAccountBoundaryCurrent(boundaryGeneration) else {
+                    throw CancellationError()
+                }
+                throw error
+            }
+        }
+        guard case let .value(value) = result else { throw CancellationError() }
+        return value
+    }
 
     static func cancelPendingAlbumMutations(for libraryViewModel: LibraryViewModel?) {
         let owner = self.albumMutationOwner(for: libraryViewModel)
         self.albumMutationGenerations[owner, default: 0] &+= 1
-        let matchingKeys = self.pendingAlbumMutations.keys.filter { $0.owner == owner }
-        let tasks = matchingKeys.compactMap { self.pendingAlbumMutations.removeValue(forKey: $0)?.task }
+        let matchingIDs = self.pendingAlbumMutations.compactMap { id, mutation in
+            mutation.owner == owner ? id : nil
+        }
+        let tasks = matchingIDs.compactMap { self.pendingAlbumMutations[$0]?.task }
         for task in tasks {
             task.cancel()
         }
@@ -62,7 +267,7 @@ enum LibraryMutationActions {
 
     static func cancelAllPendingAlbumMutations() {
         let owners = Set(self.albumMutationGenerations.keys)
-            .union(self.pendingAlbumMutations.keys.map(\.owner))
+            .union(self.pendingAlbumMutations.values.map(\.owner))
             .union([.unscoped])
         for owner in owners {
             self.albumMutationGenerations[owner, default: 0] &+= 1
@@ -70,6 +275,7 @@ enum LibraryMutationActions {
 
         let tasks = self.pendingAlbumMutations.values.map(\.task)
         self.pendingAlbumMutations.removeAll()
+        self.latestAlbumMutationIDs.removeAll()
         for task in tasks {
             task.cancel()
         }
@@ -81,15 +287,23 @@ enum LibraryMutationActions {
         playlist: AddToPlaylistOption,
         client: any YTMusicClientProtocol
     ) async {
+        let boundaryGeneration = self.accountBoundaryGeneration
         do {
-            try await client.addSongToPlaylist(
-                videoId: song.videoId,
-                playlistId: playlist.playlistId,
-                allowDuplicate: false
-            )
-            self.invalidateResponseCaches()
-            DiagnosticsLogger.api.info("Added song '\(song.title)' to playlist '\(playlist.title)'")
+            try await self.runTrackedAccountBoundaryMutation {
+                try self.checkAccountBoundary(boundaryGeneration)
+                try await client.addSongToPlaylist(
+                    videoId: song.videoId,
+                    playlistId: playlist.playlistId,
+                    allowDuplicate: false
+                )
+                try self.checkAccountBoundary(boundaryGeneration)
+                self.invalidateResponseCaches()
+                DiagnosticsLogger.api.info("Added song '\(song.title)' to playlist '\(playlist.title)'")
+            }
+        } catch is CancellationError {
+            return
         } catch {
+            guard self.isAccountBoundaryCurrent(boundaryGeneration) else { return }
             DiagnosticsLogger.api.error("Failed to add song to playlist: \(error.localizedDescription)")
         }
     }
@@ -106,25 +320,46 @@ enum LibraryMutationActions {
             HapticService.error()
             return
         }
-        guard let removal = viewModel.beginOptimisticTrackRemoval(setVideoId: setVideoId) else { return }
 
+        let boundaryGeneration = self.accountBoundaryGeneration
         do {
-            try Task.checkCancellation()
-            try await client.removeSongFromPlaylist(
-                videoId: song.videoId,
-                setVideoId: setVideoId,
-                playlistId: viewModel.playlistID
-            )
-            Self.invalidateResponseCaches()
-            viewModel.confirmTrackRemoval(removal)
-            HapticService.success()
-            DiagnosticsLogger.api.info("Removed song '\(song.title)' from playlist")
+            try await self.runTrackedAccountBoundaryMutation {
+                try self.checkAccountBoundary(boundaryGeneration)
+                guard let removal = viewModel.beginOptimisticTrackRemoval(setVideoId: setVideoId) else { return }
+
+                var didMutateRemotely = false
+                do {
+                    try await client.removeSongFromPlaylist(
+                        videoId: song.videoId,
+                        setVideoId: setVideoId,
+                        playlistId: viewModel.playlistID
+                    )
+                    didMutateRemotely = true
+                    viewModel.confirmTrackRemoval(removal)
+                    try self.checkAccountBoundary(boundaryGeneration)
+                    Self.invalidateResponseCaches()
+                    HapticService.success()
+                    DiagnosticsLogger.api.info("Removed song '\(song.title)' from playlist")
+                } catch is CancellationError {
+                    if !didMutateRemotely {
+                        await viewModel.rollbackTrackRemoval(removal)
+                    }
+                    throw CancellationError()
+                } catch {
+                    guard self.isAccountBoundaryCurrent(boundaryGeneration) else {
+                        if !didMutateRemotely {
+                            await viewModel.rollbackTrackRemoval(removal)
+                        }
+                        throw CancellationError()
+                    }
+                    await viewModel.rollbackTrackRemoval(removal)
+                    HapticService.error()
+                    DiagnosticsLogger.api.error("Failed to remove song from playlist: \(error.localizedDescription)")
+                }
+            }
         } catch is CancellationError {
-            await viewModel.rollbackTrackRemoval(removal)
             return
         } catch {
-            await viewModel.rollbackTrackRemoval(removal)
-            HapticService.error()
             DiagnosticsLogger.api.error("Failed to remove song from playlist: \(error.localizedDescription)")
         }
     }
@@ -134,31 +369,38 @@ enum LibraryMutationActions {
         _ playlist: Playlist,
         client: any YTMusicClientProtocol,
         libraryViewModel: LibraryViewModel?,
-        onMutationApplied: @MainActor () -> Void = {}
+        reconciliationDelay: Duration = .milliseconds(500),
+        onMutationApplied: @MainActor @escaping () -> Void = {}
     ) async throws {
-        do {
-            try await client.subscribeToPlaylist(playlistId: playlist.id)
-            self.invalidateResponseCaches()
-            libraryViewModel?.markNeedsReloadOnActivation()
-            if let libraryViewModel {
-                libraryViewModel.addToLibrary(playlist: playlist)
-            }
-            onMutationApplied()
-            if let libraryViewModel {
-                // Library browse responses can lag briefly behind a successful add.
-                try? await Task.sleep(for: .milliseconds(500))
-                await libraryViewModel.refresh()
+        try await self.enqueuePlaylistMutation(
+            playlistId: playlist.id,
+            libraryViewModel: libraryViewModel
+        ) { context in
+            do {
+                try self.checkPlaylistMutationIsCurrent(context.generation, owner: context.owner)
+                try await client.subscribeToPlaylist(playlistId: playlist.id)
+                try self.checkPlaylistMutationIsCurrent(context.generation, owner: context.owner)
                 self.invalidateResponseCaches()
+                LibraryMutationBroadcaster.shared.playlistAdded(playlist)
+                onMutationApplied()
 
-                if !libraryViewModel.isInLibrary(playlistId: playlist.id) {
-                    libraryViewModel.addToLibrary(playlist: playlist)
-                    self.invalidateResponseCaches()
-                }
+                // Library browse responses can lag briefly behind a successful add.
+                try await Task.sleep(for: reconciliationDelay)
+                try self.checkPlaylistMutationIsCurrent(context.generation, owner: context.owner)
+                let reconciled = await LibraryMutationBroadcaster.shared.reconcileAddedPlaylist(
+                    playlist,
+                    whileValid: { Self.isPlaylistMutationCurrent(context) }
+                )
+                guard reconciled else { throw CancellationError() }
+                self.invalidateResponseCaches()
+                DiagnosticsLogger.api.info("Added playlist to library: \(playlist.title)")
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                guard Self.isPlaylistMutationCurrent(context) else { throw CancellationError() }
+                DiagnosticsLogger.api.error("Failed to add playlist to library: \(error.localizedDescription)")
+                throw error
             }
-            DiagnosticsLogger.api.info("Added playlist to library: \(playlist.title)")
-        } catch {
-            DiagnosticsLogger.api.error("Failed to add playlist to library: \(error.localizedDescription)")
-            throw error
         }
     }
 
@@ -167,24 +409,103 @@ enum LibraryMutationActions {
         _ playlist: Playlist,
         client: any YTMusicClientProtocol,
         libraryViewModel: LibraryViewModel?,
-        onMutationApplied: @MainActor () -> Void = {}
+        reconciliationDelay: Duration = .milliseconds(500),
+        onMutationApplied: @MainActor @escaping () -> Void = {}
     ) async throws {
-        do {
-            try await client.unsubscribeFromPlaylist(playlistId: playlist.id)
-            self.invalidateResponseCaches()
-            libraryViewModel?.markNeedsReloadOnActivation()
-            LibraryMutationBroadcaster.shared.playlistRemoved(playlistId: playlist.id)
-            onMutationApplied()
+        try await self.enqueuePlaylistMutation(
+            playlistId: playlist.id,
+            libraryViewModel: libraryViewModel
+        ) { context in
+            do {
+                try self.checkPlaylistMutationIsCurrent(context.generation, owner: context.owner)
+                try await client.unsubscribeFromPlaylist(playlistId: playlist.id)
+                try self.checkPlaylistMutationIsCurrent(context.generation, owner: context.owner)
+                self.invalidateResponseCaches()
+                libraryViewModel?.markNeedsReloadOnActivation()
+                LibraryMutationBroadcaster.shared.playlistRemoved(playlistId: playlist.id)
+                onMutationApplied()
 
-            // Library browse responses can lag briefly behind a successful removal.
-            try? await Task.sleep(for: .milliseconds(500))
-            await LibraryMutationBroadcaster.shared.reconcileRemovedPlaylist(playlistId: playlist.id)
-            self.invalidateResponseCaches()
-            DiagnosticsLogger.api.info("Removed playlist from library: \(playlist.title)")
-        } catch {
-            DiagnosticsLogger.api.error("Failed to remove playlist from library: \(error.localizedDescription)")
-            throw error
+                // Library browse responses can lag briefly behind a successful removal.
+                try await Task.sleep(for: reconciliationDelay)
+                try self.checkPlaylistMutationIsCurrent(context.generation, owner: context.owner)
+                let reconciled = await LibraryMutationBroadcaster.shared.reconcileRemovedPlaylist(
+                    playlistId: playlist.id,
+                    whileValid: { Self.isPlaylistMutationCurrent(context) }
+                )
+                guard reconciled else { throw CancellationError() }
+                self.invalidateResponseCaches()
+                DiagnosticsLogger.api.info("Removed playlist from library: \(playlist.title)")
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                guard Self.isPlaylistMutationCurrent(context) else { throw CancellationError() }
+                DiagnosticsLogger.api.error("Failed to remove playlist from library: \(error.localizedDescription)")
+                throw error
+            }
         }
+    }
+
+    private static func enqueuePlaylistMutation(
+        playlistId: String,
+        libraryViewModel: LibraryViewModel?,
+        operation: @MainActor @escaping (PlaylistMutationContext) async throws -> Void
+    ) async throws {
+        let owner = self.playlistMutationOwner(for: libraryViewModel)
+        let boundaryGeneration = self.accountBoundaryGeneration
+        try self.checkAccountBoundary(boundaryGeneration)
+        let key = PlaylistMutationKey(
+            identity: LibraryContentIdentity.playlistKey(for: playlistId)
+        )
+        let previousTask = self.latestPlaylistMutationIDs[key]
+            .flatMap { self.pendingPlaylistMutations[$0]?.task }
+        let operationID = UUID()
+        let generation = self.playlistMutationGenerations[owner, default: 0]
+        let task = Task { @MainActor in
+            if let previousTask {
+                _ = try? await previousTask.value
+            }
+            try self.checkAccountBoundary(boundaryGeneration)
+            try self.checkPlaylistMutationIsCurrent(generation, owner: owner)
+            try await operation(PlaylistMutationContext(owner: owner, generation: generation))
+        }
+
+        self.pendingPlaylistMutations[operationID] = PendingPlaylistMutation(
+            owner: owner,
+            task: task
+        )
+        self.latestPlaylistMutationIDs[key] = operationID
+        defer {
+            self.pendingPlaylistMutations.removeValue(forKey: operationID)
+            if self.latestPlaylistMutationIDs[key] == operationID {
+                self.latestPlaylistMutationIDs.removeValue(forKey: key)
+            }
+        }
+
+        try await withTaskCancellationHandler {
+            try await task.value
+        } onCancel: {
+            task.cancel()
+        }
+    }
+
+    private static func checkPlaylistMutationIsCurrent(
+        _ generation: UInt64,
+        owner: PlaylistMutationOwner
+    ) throws {
+        try Task.checkCancellation()
+        guard generation == self.playlistMutationGenerations[owner, default: 0] else {
+            throw CancellationError()
+        }
+    }
+
+    private static func isPlaylistMutationCurrent(_ context: PlaylistMutationContext) -> Bool {
+        !Task.isCancelled
+            && context.generation == self.playlistMutationGenerations[context.owner, default: 0]
+    }
+
+    private static func playlistMutationOwner(for libraryViewModel: LibraryViewModel?) -> PlaylistMutationOwner {
+        guard let libraryViewModel else { return .unscoped }
+        return .viewModel(ObjectIdentifier(libraryViewModel))
     }
 
     /// Adds an album to the library using its OLAK playlist target.
@@ -247,6 +568,7 @@ enum LibraryMutationActions {
         } catch is CancellationError {
             throw CancellationError()
         } catch {
+            guard self.isAlbumMutationCurrent(context) else { throw CancellationError() }
             DiagnosticsLogger.api.error("Failed to add album to library: \(error.localizedDescription)")
             throw error
         }
@@ -307,6 +629,7 @@ enum LibraryMutationActions {
         } catch is CancellationError {
             throw CancellationError()
         } catch {
+            guard self.isAlbumMutationCurrent(context) else { throw CancellationError() }
             DiagnosticsLogger.api.error("Failed to remove album from library: \(error.localizedDescription)")
             throw error
         }
@@ -323,29 +646,39 @@ enum LibraryMutationActions {
             targetPlaylistId: targetPlaylistId
         )
         let owner = self.albumMutationOwner(for: libraryViewModel)
-        let key = AlbumMutationKey(identity: identity, owner: owner)
-        let previousTask = self.pendingAlbumMutations[key]?.task
+        let boundaryGeneration = self.accountBoundaryGeneration
+        try self.checkAccountBoundary(boundaryGeneration)
+        let key = AlbumMutationKey(identity: identity)
+        let previousTask = self.latestAlbumMutationIDs[key]
+            .flatMap { self.pendingAlbumMutations[$0]?.task }
         let mutationId = UUID()
         let mutationGeneration = self.albumMutationGenerations[owner, default: 0]
         let task = Task { @MainActor in
             if let previousTask {
                 _ = try? await previousTask.value
             }
+            try self.checkAccountBoundary(boundaryGeneration)
             try self.checkAlbumMutationIsCurrent(mutationGeneration, owner: owner)
             try await operation(AlbumMutationContext(owner: owner, generation: mutationGeneration))
         }
 
-        self.pendingAlbumMutations[key] = PendingAlbumMutation(
-            id: mutationId,
+        self.pendingAlbumMutations[mutationId] = PendingAlbumMutation(
+            owner: owner,
             task: task
         )
+        self.latestAlbumMutationIDs[key] = mutationId
         defer {
-            if self.pendingAlbumMutations[key]?.id == mutationId {
-                self.pendingAlbumMutations.removeValue(forKey: key)
+            self.pendingAlbumMutations.removeValue(forKey: mutationId)
+            if self.latestAlbumMutationIDs[key] == mutationId {
+                self.latestAlbumMutationIDs.removeValue(forKey: key)
             }
         }
 
-        try await task.value
+        try await withTaskCancellationHandler {
+            try await task.value
+        } onCancel: {
+            task.cancel()
+        }
     }
 
     private static func checkAlbumMutationIsCurrent(
@@ -377,6 +710,8 @@ enum LibraryMutationActions {
         whileValid isCurrent: @escaping () -> Bool = { true }
     ) async throws {
         guard isCurrent() else { throw CancellationError() }
+        let boundaryGeneration = self.accountBoundaryGeneration
+        try self.checkAccountBoundary(boundaryGeneration)
         let key = PlaylistDeletionKey(
             playlistId: LibraryContentIdentity.playlistKey(for: playlist.id),
             owner: owner
@@ -395,21 +730,47 @@ enum LibraryMutationActions {
         let task = Task { @MainActor in
             var didDeleteRemotely = false
             do {
+                try self.checkAccountBoundary(boundaryGeneration)
                 guard isCurrent() else { throw CancellationError() }
                 try await client.deletePlaylist(playlistId: playlist.id)
                 didDeleteRemotely = true
                 pinnedItemsManager.commitPlaylistPinRemoval(removedPins)
+                try self.checkAccountBoundary(boundaryGeneration)
                 guard isCurrent() else { throw CancellationError() }
                 self.invalidateResponseCaches()
                 libraryViewModel?.markNeedsReloadOnActivation()
                 DiagnosticsLogger.api.info("Deleted playlist: \(playlist.title)")
 
                 // Library browse responses can lag briefly behind a successful deletion.
-                try? await Task.sleep(for: .milliseconds(500))
+                try await Task.sleep(for: .milliseconds(500))
+                try self.checkAccountBoundary(boundaryGeneration)
                 guard isCurrent() else { throw CancellationError() }
-                await LibraryMutationBroadcaster.shared.reconcileRemovedPlaylist(playlistId: playlist.id)
+                let reconciled = await LibraryMutationBroadcaster.shared.reconcileRemovedPlaylist(
+                    playlistId: playlist.id,
+                    whileValid: { Self.isAccountBoundaryCurrent(boundaryGeneration) && isCurrent() }
+                )
+                guard reconciled else { throw CancellationError() }
                 self.invalidateResponseCaches()
+            } catch is CancellationError {
+                if !didDeleteRemotely {
+                    pinnedItemsManager.restore(removedPins)
+                    LibraryMutationBroadcaster.shared.rollbackPlaylistRemoval(
+                        playlist,
+                        receipt: removalReceipt
+                    )
+                }
+                throw CancellationError()
             } catch {
+                guard self.isAccountBoundaryCurrent(boundaryGeneration), isCurrent() else {
+                    if !didDeleteRemotely {
+                        pinnedItemsManager.restore(removedPins)
+                        LibraryMutationBroadcaster.shared.rollbackPlaylistRemoval(
+                            playlist,
+                            receipt: removalReceipt
+                        )
+                    }
+                    throw CancellationError()
+                }
                 guard isCurrent() else {
                     if !didDeleteRemotely {
                         pinnedItemsManager.restore(removedPins)
@@ -443,23 +804,37 @@ enum LibraryMutationActions {
         client: any YTMusicClientProtocol,
         libraryViewModel: LibraryViewModel?
     ) async throws {
-        try await client.subscribeToPodcast(showId: show.id)
-        self.invalidateResponseCaches()
-        libraryViewModel?.markNeedsReloadOnActivation()
-        if let libraryViewModel {
-            libraryViewModel.addToLibrary(podcast: show)
-
-            // Library browse responses can lag briefly behind a successful subscribe.
-            try? await Task.sleep(for: .milliseconds(500))
-            await libraryViewModel.refresh()
-            self.invalidateResponseCaches()
-
-            if !libraryViewModel.isInLibrary(podcastId: show.id) {
-                libraryViewModel.addToLibrary(podcast: show)
+        let boundaryGeneration = self.accountBoundaryGeneration
+        try await self.runTrackedAccountBoundaryMutation {
+            do {
+                try self.checkAccountBoundary(boundaryGeneration)
+                try await client.subscribeToPodcast(showId: show.id)
+                try self.checkAccountBoundary(boundaryGeneration)
                 self.invalidateResponseCaches()
+                libraryViewModel?.markNeedsReloadOnActivation()
+                if let libraryViewModel {
+                    libraryViewModel.addToLibrary(podcast: show)
+
+                    // Library browse responses can lag briefly behind a successful subscribe.
+                    try await Task.sleep(for: .milliseconds(500))
+                    try self.checkAccountBoundary(boundaryGeneration)
+                    await libraryViewModel.refresh()
+                    try self.checkAccountBoundary(boundaryGeneration)
+                    self.invalidateResponseCaches()
+
+                    if !libraryViewModel.isInLibrary(podcastId: show.id) {
+                        libraryViewModel.addToLibrary(podcast: show)
+                        self.invalidateResponseCaches()
+                    }
+                }
+                DiagnosticsLogger.api.info("Subscribed to podcast: \(show.title)")
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                guard self.isAccountBoundaryCurrent(boundaryGeneration) else { throw CancellationError() }
+                throw error
             }
         }
-        DiagnosticsLogger.api.info("Subscribed to podcast: \(show.title)")
     }
 
     /// Unsubscribes from a podcast show (removes from library).
@@ -469,23 +844,37 @@ enum LibraryMutationActions {
         libraryViewModel: LibraryViewModel?
     ) async throws {
         DiagnosticsLogger.api.debug("Attempting to unsubscribe from podcast: \(show.id), libraryViewModel is \(libraryViewModel == nil ? "nil" : "present")")
-        try await client.unsubscribeFromPodcast(showId: show.id)
-        self.invalidateResponseCaches()
-        libraryViewModel?.markNeedsReloadOnActivation()
-        if let libraryViewModel {
-            libraryViewModel.removeFromLibrary(podcastId: show.id)
-
-            // Library browse responses can lag briefly behind a successful removal.
-            try? await Task.sleep(for: .milliseconds(500))
-            await libraryViewModel.refresh()
-            self.invalidateResponseCaches()
-
-            if libraryViewModel.isInLibrary(podcastId: show.id) {
-                libraryViewModel.removeFromLibrary(podcastId: show.id)
+        let boundaryGeneration = self.accountBoundaryGeneration
+        try await self.runTrackedAccountBoundaryMutation {
+            do {
+                try self.checkAccountBoundary(boundaryGeneration)
+                try await client.unsubscribeFromPodcast(showId: show.id)
+                try self.checkAccountBoundary(boundaryGeneration)
                 self.invalidateResponseCaches()
+                libraryViewModel?.markNeedsReloadOnActivation()
+                if let libraryViewModel {
+                    libraryViewModel.removeFromLibrary(podcastId: show.id)
+
+                    // Library browse responses can lag briefly behind a successful removal.
+                    try await Task.sleep(for: .milliseconds(500))
+                    try self.checkAccountBoundary(boundaryGeneration)
+                    await libraryViewModel.refresh()
+                    try self.checkAccountBoundary(boundaryGeneration)
+                    self.invalidateResponseCaches()
+
+                    if libraryViewModel.isInLibrary(podcastId: show.id) {
+                        libraryViewModel.removeFromLibrary(podcastId: show.id)
+                        self.invalidateResponseCaches()
+                    }
+                }
+                DiagnosticsLogger.api.info("Unsubscribed from podcast: \(show.title)")
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                guard self.isAccountBoundaryCurrent(boundaryGeneration) else { throw CancellationError() }
+                throw error
             }
         }
-        DiagnosticsLogger.api.info("Unsubscribed from podcast: \(show.title)")
     }
 
     /// Subscribes to an artist (adds to library).
@@ -495,30 +884,58 @@ enum LibraryMutationActions {
         client: any YTMusicClientProtocol,
         libraryViewModel: LibraryViewModel?
     ) async throws {
-        if let libraryViewModel {
-            self.addArtistToLibrary(artist, channelId: channelId, libraryViewModel: libraryViewModel)
-            libraryViewModel.markNeedsReloadOnActivation()
-        }
-
-        do {
-            try await client.subscribeToArtist(channelId: channelId)
-            Self.invalidateResponseCaches()
+        let boundaryGeneration = self.accountBoundaryGeneration
+        let accountScopeGeneration = libraryViewModel?.currentAccountScopeGeneration
+        try await self.runTrackedAccountBoundaryMutation {
+            try self.checkAccountBoundary(boundaryGeneration)
             if let libraryViewModel {
-                Self.scheduleArtistReconciliation(
-                    artist,
-                    channelId: channelId,
-                    expectedInLibrary: true,
-                    libraryViewModel: libraryViewModel
-                )
-            }
-            DiagnosticsLogger.api.info("Subscribed to artist: \(artist.name)")
-        } catch {
-            if let libraryViewModel {
-                Self.removeArtistFromLibrary(artist, channelId: channelId, libraryViewModel: libraryViewModel)
+                self.addArtistToLibrary(artist, channelId: channelId, libraryViewModel: libraryViewModel)
                 libraryViewModel.markNeedsReloadOnActivation()
             }
-            DiagnosticsLogger.api.error("Failed to subscribe to artist: \(error.localizedDescription)")
-            throw error
+
+            var didMutateRemotely = false
+            do {
+                try await client.subscribeToArtist(channelId: channelId)
+                didMutateRemotely = true
+                try self.checkAccountBoundary(boundaryGeneration)
+                Self.invalidateResponseCaches()
+                if let libraryViewModel {
+                    Self.scheduleArtistReconciliation(
+                        artist,
+                        channelId: channelId,
+                        expectedInLibrary: true,
+                        libraryViewModel: libraryViewModel,
+                        boundaryGeneration: boundaryGeneration
+                    )
+                }
+                DiagnosticsLogger.api.info("Subscribed to artist: \(artist.name)")
+            } catch is CancellationError {
+                if !didMutateRemotely,
+                   let libraryViewModel,
+                   libraryViewModel.currentAccountScopeGeneration == accountScopeGeneration
+                {
+                    Self.removeArtistFromLibrary(artist, channelId: channelId, libraryViewModel: libraryViewModel)
+                    libraryViewModel.markNeedsReloadOnActivation()
+                }
+                throw CancellationError()
+            } catch {
+                guard self.isAccountBoundaryCurrent(boundaryGeneration) else {
+                    if !didMutateRemotely,
+                       let libraryViewModel,
+                       libraryViewModel.currentAccountScopeGeneration == accountScopeGeneration
+                    {
+                        Self.removeArtistFromLibrary(artist, channelId: channelId, libraryViewModel: libraryViewModel)
+                        libraryViewModel.markNeedsReloadOnActivation()
+                    }
+                    throw CancellationError()
+                }
+                if let libraryViewModel {
+                    Self.removeArtistFromLibrary(artist, channelId: channelId, libraryViewModel: libraryViewModel)
+                    libraryViewModel.markNeedsReloadOnActivation()
+                }
+                DiagnosticsLogger.api.error("Failed to subscribe to artist: \(error.localizedDescription)")
+                throw error
+            }
         }
     }
 
@@ -529,30 +946,58 @@ enum LibraryMutationActions {
         client: any YTMusicClientProtocol,
         libraryViewModel: LibraryViewModel?
     ) async throws {
-        if let libraryViewModel {
-            self.removeArtistFromLibrary(artist, channelId: channelId, libraryViewModel: libraryViewModel)
-            libraryViewModel.markNeedsReloadOnActivation()
-        }
-
-        do {
-            try await client.unsubscribeFromArtist(channelId: channelId)
-            Self.invalidateResponseCaches()
+        let boundaryGeneration = self.accountBoundaryGeneration
+        let accountScopeGeneration = libraryViewModel?.currentAccountScopeGeneration
+        try await self.runTrackedAccountBoundaryMutation {
+            try self.checkAccountBoundary(boundaryGeneration)
             if let libraryViewModel {
-                Self.scheduleArtistReconciliation(
-                    artist,
-                    channelId: channelId,
-                    expectedInLibrary: false,
-                    libraryViewModel: libraryViewModel
-                )
-            }
-            DiagnosticsLogger.api.info("Unsubscribed from artist: \(artist.name)")
-        } catch {
-            if let libraryViewModel {
-                Self.addArtistToLibrary(artist, channelId: channelId, libraryViewModel: libraryViewModel)
+                self.removeArtistFromLibrary(artist, channelId: channelId, libraryViewModel: libraryViewModel)
                 libraryViewModel.markNeedsReloadOnActivation()
             }
-            DiagnosticsLogger.api.error("Failed to unsubscribe from artist: \(error.localizedDescription)")
-            throw error
+
+            var didMutateRemotely = false
+            do {
+                try await client.unsubscribeFromArtist(channelId: channelId)
+                didMutateRemotely = true
+                try self.checkAccountBoundary(boundaryGeneration)
+                Self.invalidateResponseCaches()
+                if let libraryViewModel {
+                    Self.scheduleArtistReconciliation(
+                        artist,
+                        channelId: channelId,
+                        expectedInLibrary: false,
+                        libraryViewModel: libraryViewModel,
+                        boundaryGeneration: boundaryGeneration
+                    )
+                }
+                DiagnosticsLogger.api.info("Unsubscribed from artist: \(artist.name)")
+            } catch is CancellationError {
+                if !didMutateRemotely,
+                   let libraryViewModel,
+                   libraryViewModel.currentAccountScopeGeneration == accountScopeGeneration
+                {
+                    Self.addArtistToLibrary(artist, channelId: channelId, libraryViewModel: libraryViewModel)
+                    libraryViewModel.markNeedsReloadOnActivation()
+                }
+                throw CancellationError()
+            } catch {
+                guard self.isAccountBoundaryCurrent(boundaryGeneration) else {
+                    if !didMutateRemotely,
+                       let libraryViewModel,
+                       libraryViewModel.currentAccountScopeGeneration == accountScopeGeneration
+                    {
+                        Self.addArtistToLibrary(artist, channelId: channelId, libraryViewModel: libraryViewModel)
+                        libraryViewModel.markNeedsReloadOnActivation()
+                    }
+                    throw CancellationError()
+                }
+                if let libraryViewModel {
+                    Self.addArtistToLibrary(artist, channelId: channelId, libraryViewModel: libraryViewModel)
+                    libraryViewModel.markNeedsReloadOnActivation()
+                }
+                DiagnosticsLogger.api.error("Failed to unsubscribe from artist: \(error.localizedDescription)")
+                throw error
+            }
         }
     }
 
@@ -567,25 +1012,35 @@ enum LibraryMutationActions {
         _ artist: Artist,
         channelId: String,
         expectedInLibrary: Bool,
-        libraryViewModel: LibraryViewModel
+        libraryViewModel: LibraryViewModel,
+        boundaryGeneration: UInt64
     ) {
         let normalizedArtistId = Artist.publicChannelId(for: channelId) ?? channelId
-        Self.artistReconciliationTasks[normalizedArtistId]?.cancel()
-
-        Self.artistReconciliationTasks[normalizedArtistId] = Task { @MainActor in
-            defer { Self.artistReconciliationTasks.removeValue(forKey: normalizedArtistId) }
+        if let previousID = Self.latestArtistReconciliationIDs[normalizedArtistId] {
+            Self.artistReconciliationTasks[previousID]?.task.cancel()
+        }
+        let operationID = UUID().uuidString
+        let task = Task { @MainActor in
+            defer {
+                Self.artistReconciliationTasks.removeValue(forKey: operationID)
+                if Self.latestArtistReconciliationIDs[normalizedArtistId] == operationID {
+                    Self.latestArtistReconciliationIDs.removeValue(forKey: normalizedArtistId)
+                }
+            }
 
             for delay in Self.artistReconciliationRetryDelays {
+                guard Self.isAccountBoundaryCurrent(boundaryGeneration) else { return }
                 do {
                     try await Task.sleep(for: delay)
                 } catch {
                     return
                 }
 
-                guard !Task.isCancelled else { return }
+                guard Self.isAccountBoundaryCurrent(boundaryGeneration) else { return }
 
                 Self.invalidateResponseCaches()
                 await libraryViewModel.refresh()
+                guard Self.isAccountBoundaryCurrent(boundaryGeneration) else { return }
                 Self.invalidateResponseCaches()
 
                 let needsReconciliation = libraryViewModel.needsArtistLibraryReconciliation(
@@ -621,6 +1076,8 @@ enum LibraryMutationActions {
                 libraryViewModel.markNeedsReloadOnActivation()
             }
         }
+        Self.artistReconciliationTasks[operationID] = PendingArtistReconciliation(task: task)
+        Self.latestArtistReconciliationIDs[normalizedArtistId] = operationID
     }
 
     private static func addArtistToLibrary(

--- a/Sources/Kaset/Services/Library/LibraryMutationActions.swift
+++ b/Sources/Kaset/Services/Library/LibraryMutationActions.swift
@@ -14,10 +14,16 @@ enum LibraryMutationActions {
         let task: Task<Void, Error>
     }
 
+    private struct PendingAlbumMutation {
+        let id: UUID
+        let task: Task<Void, Error>
+    }
+
     static var artistReconciliationRetryDelays: [Duration] = [.seconds(2), .seconds(3)]
 
     private static var artistReconciliationTasks: [String: Task<Void, Never>] = [:]
     private static var pendingPlaylistDeletions: [PlaylistDeletionKey: PendingPlaylistDeletion] = [:]
+    private static var pendingAlbumMutations: [String: PendingAlbumMutation] = [:]
 
     /// Adds a song to a playlist.
     static func addSongToPlaylist(
@@ -130,7 +136,29 @@ enum LibraryMutationActions {
         _ album: Album,
         targetPlaylistId: String,
         client: any YTMusicClientProtocol,
-        libraryViewModel: LibraryViewModel?
+        libraryViewModel: LibraryViewModel?,
+        reconciliationDelay: Duration = .milliseconds(500)
+    ) async throws {
+        try await self.enqueueAlbumMutation(
+            albumId: album.id,
+            targetPlaylistId: targetPlaylistId
+        ) {
+            try await Self.performAddAlbumToLibrary(
+                album,
+                targetPlaylistId: targetPlaylistId,
+                client: client,
+                libraryViewModel: libraryViewModel,
+                reconciliationDelay: reconciliationDelay
+            )
+        }
+    }
+
+    private static func performAddAlbumToLibrary(
+        _ album: Album,
+        targetPlaylistId: String,
+        client: any YTMusicClientProtocol,
+        libraryViewModel: LibraryViewModel?,
+        reconciliationDelay: Duration
     ) async throws {
         do {
             try await client.subscribeToPlaylist(playlistId: targetPlaylistId)
@@ -147,7 +175,7 @@ enum LibraryMutationActions {
             libraryViewModel?.markNeedsReloadOnActivation()
             LibraryMutationBroadcaster.shared.albumAdded(libraryAlbum)
 
-            try? await Task.sleep(for: .milliseconds(500))
+            try? await Task.sleep(for: reconciliationDelay)
             await LibraryMutationBroadcaster.shared.reconcileAddedAlbum(libraryAlbum)
             self.invalidateResponseCaches()
             DiagnosticsLogger.api.info("Added album to library: \(album.title)")
@@ -162,7 +190,29 @@ enum LibraryMutationActions {
         _ album: Album,
         targetPlaylistId: String,
         client: any YTMusicClientProtocol,
-        libraryViewModel: LibraryViewModel?
+        libraryViewModel: LibraryViewModel?,
+        reconciliationDelay: Duration = .milliseconds(500)
+    ) async throws {
+        try await self.enqueueAlbumMutation(
+            albumId: album.id,
+            targetPlaylistId: targetPlaylistId
+        ) {
+            try await Self.performRemoveAlbumFromLibrary(
+                album,
+                targetPlaylistId: targetPlaylistId,
+                client: client,
+                libraryViewModel: libraryViewModel,
+                reconciliationDelay: reconciliationDelay
+            )
+        }
+    }
+
+    private static func performRemoveAlbumFromLibrary(
+        _ album: Album,
+        targetPlaylistId: String,
+        client: any YTMusicClientProtocol,
+        libraryViewModel: LibraryViewModel?,
+        reconciliationDelay: Duration
     ) async throws {
         do {
             try await client.unsubscribeFromPlaylist(playlistId: targetPlaylistId)
@@ -173,7 +223,7 @@ enum LibraryMutationActions {
                 targetPlaylistId: targetPlaylistId
             )
 
-            try? await Task.sleep(for: .milliseconds(500))
+            try? await Task.sleep(for: reconciliationDelay)
             await LibraryMutationBroadcaster.shared.reconcileRemovedAlbum(
                 albumId: album.id,
                 targetPlaylistId: targetPlaylistId
@@ -184,6 +234,37 @@ enum LibraryMutationActions {
             DiagnosticsLogger.api.error("Failed to remove album from library: \(error.localizedDescription)")
             throw error
         }
+    }
+
+    private static func enqueueAlbumMutation(
+        albumId: String,
+        targetPlaylistId: String,
+        operation: @MainActor @escaping () async throws -> Void
+    ) async throws {
+        let identity = LibraryContentIdentity.albumKey(
+            albumId: albumId,
+            targetPlaylistId: targetPlaylistId
+        )
+        let previousTask = self.pendingAlbumMutations[identity]?.task
+        let mutationId = UUID()
+        let task = Task { @MainActor in
+            if let previousTask {
+                _ = try? await previousTask.value
+            }
+            try await operation()
+        }
+
+        self.pendingAlbumMutations[identity] = PendingAlbumMutation(
+            id: mutationId,
+            task: task
+        )
+        defer {
+            if self.pendingAlbumMutations[identity]?.id == mutationId {
+                self.pendingAlbumMutations.removeValue(forKey: identity)
+            }
+        }
+
+        try await task.value
     }
 
     /// Permanently deletes a playlist owned by the user.

--- a/Sources/Kaset/Services/Library/LibraryMutationActions.swift
+++ b/Sources/Kaset/Services/Library/LibraryMutationActions.swift
@@ -19,11 +19,61 @@ enum LibraryMutationActions {
         let task: Task<Void, Error>
     }
 
+    private enum AlbumMutationOwner: Hashable {
+        case viewModel(ObjectIdentifier)
+        case unscoped
+    }
+
+    private struct AlbumMutationKey: Hashable {
+        let identity: String
+        let owner: AlbumMutationOwner
+    }
+
+    private struct AlbumMutationContext {
+        let owner: AlbumMutationOwner
+        let generation: UInt64
+    }
+
+    private struct AlbumMutationRequest {
+        let album: Album
+        let targetPlaylistId: String
+        let client: any YTMusicClientProtocol
+        let libraryViewModel: LibraryViewModel?
+        let reconciliationDelay: Duration
+        let onMutationApplied: @MainActor () -> Void
+    }
+
     static var artistReconciliationRetryDelays: [Duration] = [.seconds(2), .seconds(3)]
 
     private static var artistReconciliationTasks: [String: Task<Void, Never>] = [:]
     private static var pendingPlaylistDeletions: [PlaylistDeletionKey: PendingPlaylistDeletion] = [:]
-    private static var pendingAlbumMutations: [String: PendingAlbumMutation] = [:]
+    private static var pendingAlbumMutations: [AlbumMutationKey: PendingAlbumMutation] = [:]
+    private static var albumMutationGenerations: [AlbumMutationOwner: UInt64] = [:]
+
+    static func cancelPendingAlbumMutations(for libraryViewModel: LibraryViewModel?) {
+        let owner = self.albumMutationOwner(for: libraryViewModel)
+        self.albumMutationGenerations[owner, default: 0] &+= 1
+        let matchingKeys = self.pendingAlbumMutations.keys.filter { $0.owner == owner }
+        let tasks = matchingKeys.compactMap { self.pendingAlbumMutations.removeValue(forKey: $0)?.task }
+        for task in tasks {
+            task.cancel()
+        }
+    }
+
+    static func cancelAllPendingAlbumMutations() {
+        let owners = Set(self.albumMutationGenerations.keys)
+            .union(self.pendingAlbumMutations.keys.map(\.owner))
+            .union([.unscoped])
+        for owner in owners {
+            self.albumMutationGenerations[owner, default: 0] &+= 1
+        }
+
+        let tasks = self.pendingAlbumMutations.values.map(\.task)
+        self.pendingAlbumMutations.removeAll()
+        for task in tasks {
+            task.cancel()
+        }
+    }
 
     /// Adds a song to a playlist.
     static func addSongToPlaylist(
@@ -83,7 +133,8 @@ enum LibraryMutationActions {
     static func addPlaylistToLibrary(
         _ playlist: Playlist,
         client: any YTMusicClientProtocol,
-        libraryViewModel: LibraryViewModel?
+        libraryViewModel: LibraryViewModel?,
+        onMutationApplied: @MainActor () -> Void = {}
     ) async throws {
         do {
             try await client.subscribeToPlaylist(playlistId: playlist.id)
@@ -91,6 +142,9 @@ enum LibraryMutationActions {
             libraryViewModel?.markNeedsReloadOnActivation()
             if let libraryViewModel {
                 libraryViewModel.addToLibrary(playlist: playlist)
+            }
+            onMutationApplied()
+            if let libraryViewModel {
                 // Library browse responses can lag briefly behind a successful add.
                 try? await Task.sleep(for: .milliseconds(500))
                 await libraryViewModel.refresh()
@@ -112,13 +166,15 @@ enum LibraryMutationActions {
     static func removePlaylistFromLibrary(
         _ playlist: Playlist,
         client: any YTMusicClientProtocol,
-        libraryViewModel: LibraryViewModel?
+        libraryViewModel: LibraryViewModel?,
+        onMutationApplied: @MainActor () -> Void = {}
     ) async throws {
         do {
             try await client.unsubscribeFromPlaylist(playlistId: playlist.id)
             self.invalidateResponseCaches()
             libraryViewModel?.markNeedsReloadOnActivation()
             LibraryMutationBroadcaster.shared.playlistRemoved(playlistId: playlist.id)
+            onMutationApplied()
 
             // Library browse responses can lag briefly behind a successful removal.
             try? await Task.sleep(for: .milliseconds(500))
@@ -137,48 +193,59 @@ enum LibraryMutationActions {
         targetPlaylistId: String,
         client: any YTMusicClientProtocol,
         libraryViewModel: LibraryViewModel?,
-        reconciliationDelay: Duration = .milliseconds(500)
+        reconciliationDelay: Duration = .milliseconds(500),
+        onMutationApplied: @MainActor @escaping () -> Void = {}
     ) async throws {
+        let request = AlbumMutationRequest(
+            album: album,
+            targetPlaylistId: targetPlaylistId,
+            client: client,
+            libraryViewModel: libraryViewModel,
+            reconciliationDelay: reconciliationDelay,
+            onMutationApplied: onMutationApplied
+        )
         try await self.enqueueAlbumMutation(
             albumId: album.id,
-            targetPlaylistId: targetPlaylistId
-        ) {
-            try await Self.performAddAlbumToLibrary(
-                album,
-                targetPlaylistId: targetPlaylistId,
-                client: client,
-                libraryViewModel: libraryViewModel,
-                reconciliationDelay: reconciliationDelay
-            )
+            targetPlaylistId: targetPlaylistId,
+            libraryViewModel: libraryViewModel
+        ) { context in
+            try await Self.performAddAlbumToLibrary(request, context: context)
         }
     }
 
     private static func performAddAlbumToLibrary(
-        _ album: Album,
-        targetPlaylistId: String,
-        client: any YTMusicClientProtocol,
-        libraryViewModel: LibraryViewModel?,
-        reconciliationDelay: Duration
+        _ request: AlbumMutationRequest,
+        context: AlbumMutationContext
     ) async throws {
         do {
-            try await client.subscribeToPlaylist(playlistId: targetPlaylistId)
+            try self.checkAlbumMutationIsCurrent(context.generation, owner: context.owner)
+            try await request.client.subscribeToPlaylist(playlistId: request.targetPlaylistId)
+            try self.checkAlbumMutationIsCurrent(context.generation, owner: context.owner)
             let libraryAlbum = Album(
-                id: album.id,
-                title: album.title,
-                artists: album.artists,
-                thumbnailURL: album.thumbnailURL,
-                year: album.year,
-                trackCount: album.trackCount,
-                libraryTargetId: targetPlaylistId
+                id: request.album.id,
+                title: request.album.title,
+                artists: request.album.artists,
+                thumbnailURL: request.album.thumbnailURL,
+                year: request.album.year,
+                trackCount: request.album.trackCount,
+                libraryTargetId: request.targetPlaylistId
             )
             self.invalidateResponseCaches()
-            libraryViewModel?.markNeedsReloadOnActivation()
+            request.libraryViewModel?.markNeedsReloadOnActivation()
             LibraryMutationBroadcaster.shared.albumAdded(libraryAlbum)
+            request.onMutationApplied()
 
-            try? await Task.sleep(for: reconciliationDelay)
-            await LibraryMutationBroadcaster.shared.reconcileAddedAlbum(libraryAlbum)
+            try await Task.sleep(for: request.reconciliationDelay)
+            try self.checkAlbumMutationIsCurrent(context.generation, owner: context.owner)
+            let reconciled = await LibraryMutationBroadcaster.shared.reconcileAddedAlbum(
+                libraryAlbum,
+                whileValid: { Self.isAlbumMutationCurrent(context) }
+            )
+            guard reconciled else { throw CancellationError() }
             self.invalidateResponseCaches()
-            DiagnosticsLogger.api.info("Added album to library: \(album.title)")
+            DiagnosticsLogger.api.info("Added album to library: \(request.album.title)")
+        } catch is CancellationError {
+            throw CancellationError()
         } catch {
             DiagnosticsLogger.api.error("Failed to add album to library: \(error.localizedDescription)")
             throw error
@@ -191,45 +258,54 @@ enum LibraryMutationActions {
         targetPlaylistId: String,
         client: any YTMusicClientProtocol,
         libraryViewModel: LibraryViewModel?,
-        reconciliationDelay: Duration = .milliseconds(500)
+        reconciliationDelay: Duration = .milliseconds(500),
+        onMutationApplied: @MainActor @escaping () -> Void = {}
     ) async throws {
+        let request = AlbumMutationRequest(
+            album: album,
+            targetPlaylistId: targetPlaylistId,
+            client: client,
+            libraryViewModel: libraryViewModel,
+            reconciliationDelay: reconciliationDelay,
+            onMutationApplied: onMutationApplied
+        )
         try await self.enqueueAlbumMutation(
             albumId: album.id,
-            targetPlaylistId: targetPlaylistId
-        ) {
-            try await Self.performRemoveAlbumFromLibrary(
-                album,
-                targetPlaylistId: targetPlaylistId,
-                client: client,
-                libraryViewModel: libraryViewModel,
-                reconciliationDelay: reconciliationDelay
-            )
+            targetPlaylistId: targetPlaylistId,
+            libraryViewModel: libraryViewModel
+        ) { context in
+            try await Self.performRemoveAlbumFromLibrary(request, context: context)
         }
     }
 
     private static func performRemoveAlbumFromLibrary(
-        _ album: Album,
-        targetPlaylistId: String,
-        client: any YTMusicClientProtocol,
-        libraryViewModel: LibraryViewModel?,
-        reconciliationDelay: Duration
+        _ request: AlbumMutationRequest,
+        context: AlbumMutationContext
     ) async throws {
         do {
-            try await client.unsubscribeFromPlaylist(playlistId: targetPlaylistId)
+            try self.checkAlbumMutationIsCurrent(context.generation, owner: context.owner)
+            try await request.client.unsubscribeFromPlaylist(playlistId: request.targetPlaylistId)
+            try self.checkAlbumMutationIsCurrent(context.generation, owner: context.owner)
             self.invalidateResponseCaches()
-            libraryViewModel?.markNeedsReloadOnActivation()
+            request.libraryViewModel?.markNeedsReloadOnActivation()
             LibraryMutationBroadcaster.shared.albumRemoved(
-                albumId: album.id,
-                targetPlaylistId: targetPlaylistId
+                albumId: request.album.id,
+                targetPlaylistId: request.targetPlaylistId
             )
+            request.onMutationApplied()
 
-            try? await Task.sleep(for: reconciliationDelay)
-            await LibraryMutationBroadcaster.shared.reconcileRemovedAlbum(
-                albumId: album.id,
-                targetPlaylistId: targetPlaylistId
+            try await Task.sleep(for: request.reconciliationDelay)
+            try self.checkAlbumMutationIsCurrent(context.generation, owner: context.owner)
+            let reconciled = await LibraryMutationBroadcaster.shared.reconcileRemovedAlbum(
+                albumId: request.album.id,
+                targetPlaylistId: request.targetPlaylistId,
+                whileValid: { Self.isAlbumMutationCurrent(context) }
             )
+            guard reconciled else { throw CancellationError() }
             self.invalidateResponseCaches()
-            DiagnosticsLogger.api.info("Removed album from library: \(album.title)")
+            DiagnosticsLogger.api.info("Removed album from library: \(request.album.title)")
+        } catch is CancellationError {
+            throw CancellationError()
         } catch {
             DiagnosticsLogger.api.error("Failed to remove album from library: \(error.localizedDescription)")
             throw error
@@ -239,32 +315,57 @@ enum LibraryMutationActions {
     private static func enqueueAlbumMutation(
         albumId: String,
         targetPlaylistId: String,
-        operation: @MainActor @escaping () async throws -> Void
+        libraryViewModel: LibraryViewModel?,
+        operation: @MainActor @escaping (AlbumMutationContext) async throws -> Void
     ) async throws {
         let identity = LibraryContentIdentity.albumKey(
             albumId: albumId,
             targetPlaylistId: targetPlaylistId
         )
-        let previousTask = self.pendingAlbumMutations[identity]?.task
+        let owner = self.albumMutationOwner(for: libraryViewModel)
+        let key = AlbumMutationKey(identity: identity, owner: owner)
+        let previousTask = self.pendingAlbumMutations[key]?.task
         let mutationId = UUID()
+        let mutationGeneration = self.albumMutationGenerations[owner, default: 0]
         let task = Task { @MainActor in
             if let previousTask {
                 _ = try? await previousTask.value
             }
-            try await operation()
+            try self.checkAlbumMutationIsCurrent(mutationGeneration, owner: owner)
+            try await operation(AlbumMutationContext(owner: owner, generation: mutationGeneration))
         }
 
-        self.pendingAlbumMutations[identity] = PendingAlbumMutation(
+        self.pendingAlbumMutations[key] = PendingAlbumMutation(
             id: mutationId,
             task: task
         )
         defer {
-            if self.pendingAlbumMutations[identity]?.id == mutationId {
-                self.pendingAlbumMutations.removeValue(forKey: identity)
+            if self.pendingAlbumMutations[key]?.id == mutationId {
+                self.pendingAlbumMutations.removeValue(forKey: key)
             }
         }
 
         try await task.value
+    }
+
+    private static func checkAlbumMutationIsCurrent(
+        _ generation: UInt64,
+        owner: AlbumMutationOwner
+    ) throws {
+        try Task.checkCancellation()
+        guard generation == self.albumMutationGenerations[owner, default: 0] else {
+            throw CancellationError()
+        }
+    }
+
+    private static func isAlbumMutationCurrent(_ context: AlbumMutationContext) -> Bool {
+        !Task.isCancelled
+            && context.generation == self.albumMutationGenerations[context.owner, default: 0]
+    }
+
+    private static func albumMutationOwner(for libraryViewModel: LibraryViewModel?) -> AlbumMutationOwner {
+        guard let libraryViewModel else { return .unscoped }
+        return .viewModel(ObjectIdentifier(libraryViewModel))
     }
 
     /// Permanently deletes a playlist owned by the user.

--- a/Sources/Kaset/Services/Player/PlayerService+QueuePlaylist.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+QueuePlaylist.swift
@@ -43,44 +43,46 @@ extension PlayerService {
         }
 
         let videoIds = songs.map(\.videoId)
-        let playlistId = try await client.createPlaylist(
-            title: trimmedTitle,
-            description: nil,
-            privacyStatus: .private,
-            videoIds: videoIds
-        )
-        guard self.acceptsAccountMutationOwner(owner) else {
-            throw CancellationError()
+        return try await LibraryMutationActions.withAccountBoundaryTracking {
+            let playlistId = try await client.createPlaylist(
+                title: trimmedTitle,
+                description: nil,
+                privacyStatus: .private,
+                videoIds: videoIds
+            )
+            guard !Task.isCancelled, self.acceptsAccountMutationOwner(owner) else {
+                throw CancellationError()
+            }
+
+            let playlist = Playlist(
+                id: playlistId,
+                title: trimmedTitle,
+                description: nil,
+                thumbnailURL: songs.first?.thumbnailURL,
+                trackCount: songs.count
+            )
+
+            SongActionsHelper.invalidateLibraryResponseCaches()
+            LibraryMutationBroadcaster.shared.playlistCreated(playlist)
+
+            try? await Task.sleep(for: .milliseconds(500))
+            guard !Task.isCancelled, self.acceptsAccountMutationOwner(owner) else {
+                LibraryMutationBroadcaster.shared.discardCreatedPlaylist(playlist)
+                throw CancellationError()
+            }
+            SongActionsHelper.invalidateLibraryResponseCaches()
+            let didReconcile = await LibraryMutationBroadcaster.shared.reconcileCreatedPlaylist(
+                playlist,
+                whileValid: { !Task.isCancelled && self.acceptsAccountMutationOwner(owner) }
+            )
+            guard didReconcile, !Task.isCancelled, self.acceptsAccountMutationOwner(owner) else {
+                LibraryMutationBroadcaster.shared.discardCreatedPlaylist(playlist)
+                throw CancellationError()
+            }
+            SongActionsHelper.invalidateLibraryResponseCaches()
+
+            self.logger.info("Saved queue as playlist '\(trimmedTitle)' with \(songs.count) songs")
+            return playlist
         }
-
-        let playlist = Playlist(
-            id: playlistId,
-            title: trimmedTitle,
-            description: nil,
-            thumbnailURL: songs.first?.thumbnailURL,
-            trackCount: songs.count
-        )
-
-        SongActionsHelper.invalidateLibraryResponseCaches()
-        LibraryMutationBroadcaster.shared.playlistCreated(playlist)
-
-        try? await Task.sleep(for: .milliseconds(500))
-        guard self.acceptsAccountMutationOwner(owner) else {
-            LibraryMutationBroadcaster.shared.discardCreatedPlaylist(playlist)
-            throw CancellationError()
-        }
-        SongActionsHelper.invalidateLibraryResponseCaches()
-        let didReconcile = await LibraryMutationBroadcaster.shared.reconcileCreatedPlaylist(
-            playlist,
-            whileValid: { self.acceptsAccountMutationOwner(owner) }
-        )
-        guard didReconcile, self.acceptsAccountMutationOwner(owner) else {
-            LibraryMutationBroadcaster.shared.discardCreatedPlaylist(playlist)
-            throw CancellationError()
-        }
-        SongActionsHelper.invalidateLibraryResponseCaches()
-
-        self.logger.info("Saved queue as playlist '\(trimmedTitle)' with \(songs.count) songs")
-        return playlist
     }
 }

--- a/Sources/Kaset/Services/Protocols.swift
+++ b/Sources/Kaset/Services/Protocols.swift
@@ -331,8 +331,8 @@ protocol AuthServiceProtocol: AnyObject, Sendable {
     /// Signs out the user by clearing all cookies and data.
     func signOut() async
 
-    /// Called when login completes successfully.
-    func completeLogin(sapisid: String)
+    /// Called when login completes successfully and account-scoped work has drained.
+    func completeLoginAfterDraining(sapisid: String) async
 }
 
 // MARK: - PlayerServiceProtocol

--- a/Sources/Kaset/ViewModels/LibraryViewModel.swift
+++ b/Sources/Kaset/ViewModels/LibraryViewModel.swift
@@ -126,6 +126,43 @@ final class LibraryMutationBroadcaster {
             libraryViewModel.markNeedsReloadOnActivation()
         }
     }
+
+    func albumAdded(_ album: Album) {
+        for libraryViewModel in self.activeLibraryViewModels {
+            libraryViewModel.markNeedsReloadOnActivation()
+            libraryViewModel.addToLibrary(album: album)
+        }
+    }
+
+    func reconcileAddedAlbum(_ album: Album) async {
+        for libraryViewModel in self.activeLibraryViewModels {
+            await libraryViewModel.refresh()
+            if !libraryViewModel.isInLibrary(
+                albumId: album.id,
+                targetPlaylistId: album.libraryTargetId
+            ) {
+                libraryViewModel.addToLibrary(album: album)
+            }
+            libraryViewModel.markNeedsReloadOnActivation()
+        }
+    }
+
+    func albumRemoved(albumId: String, targetPlaylistId: String?) {
+        for libraryViewModel in self.activeLibraryViewModels {
+            libraryViewModel.markNeedsReloadOnActivation()
+            libraryViewModel.removeFromLibrary(albumId: albumId, targetPlaylistId: targetPlaylistId)
+        }
+    }
+
+    func reconcileRemovedAlbum(albumId: String, targetPlaylistId: String?) async {
+        for libraryViewModel in self.activeLibraryViewModels {
+            await libraryViewModel.refresh()
+            if libraryViewModel.isInLibrary(albumId: albumId, targetPlaylistId: targetPlaylistId) {
+                libraryViewModel.removeFromLibrary(albumId: albumId, targetPlaylistId: targetPlaylistId)
+            }
+            libraryViewModel.markNeedsReloadOnActivation()
+        }
+    }
 }
 
 // MARK: - LibraryViewModel
@@ -139,6 +176,9 @@ final class LibraryViewModel {
 
     /// User's playlists.
     private(set) var playlists: [Playlist] = []
+
+    /// User's saved albums.
+    private(set) var albums: [Album] = []
 
     /// User's followed artists.
     private(set) var artists: [Artist] = []
@@ -200,6 +240,7 @@ final class LibraryViewModel {
         get {
             LibraryContentSnapshot(
                 playlists: self.playlists,
+                albums: self.albums,
                 artists: self.artists,
                 podcastShows: self.podcastShows,
                 uploadedSongsPlaylist: self.uploadedSongsPlaylist,
@@ -210,6 +251,7 @@ final class LibraryViewModel {
         }
         set {
             self.playlists = newValue.playlists
+            self.albums = newValue.albums
             self.artists = newValue.artists
             self.podcastShows = newValue.podcastShows
             self.uploadedSongsPlaylist = newValue.uploadedSongsPlaylist
@@ -280,6 +322,17 @@ final class LibraryViewModel {
         LibraryContentIdentity.containsPlaylist(playlistId, in: self.libraryPlaylistIds)
     }
 
+    /// Checks if an album is in the user's library.
+    func isInLibrary(albumId: String, targetPlaylistId: String? = nil) -> Bool {
+        self.albums.contains { album in
+            if album.id == albumId {
+                return true
+            }
+            guard let targetPlaylistId else { return false }
+            return album.libraryTargetId == targetPlaylistId
+        }
+    }
+
     /// Checks if a podcast show is in the user's library.
     func isInLibrary(podcastId: String) -> Bool {
         self.libraryPodcastIds.contains(podcastId)
@@ -316,6 +369,14 @@ final class LibraryViewModel {
         self.markPlaylistStateChanged(playlistId)
         var snapshot = self.librarySnapshot
         self.contentReconciler.discardAddedPlaylist(playlistId, from: &snapshot)
+        self.librarySnapshot = snapshot
+    }
+
+    /// Adds a saved album to the visible library immediately.
+    func addToLibrary(album: Album) {
+        self.markLibraryStateChanged()
+        var snapshot = self.librarySnapshot
+        self.contentReconciler.addAlbum(album, to: &snapshot)
         self.librarySnapshot = snapshot
     }
 
@@ -370,6 +431,18 @@ final class LibraryViewModel {
         self.librarySnapshot = snapshot
     }
 
+    /// Removes a saved album from the visible library immediately.
+    func removeFromLibrary(albumId: String, targetPlaylistId: String? = nil) {
+        self.markLibraryStateChanged()
+        var snapshot = self.librarySnapshot
+        self.contentReconciler.removeAlbum(
+            albumId: albumId,
+            targetPlaylistId: targetPlaylistId,
+            from: &snapshot
+        )
+        self.librarySnapshot = snapshot
+    }
+
     /// Removes a podcast from the library (called after successful unsubscribe).
     /// Updates both the ID set and the shows array for immediate UI update.
     func removeFromLibrary(podcastId: String) {
@@ -404,7 +477,7 @@ final class LibraryViewModel {
         self.librarySnapshot = snapshot
     }
 
-    /// Loads library content (playlists, artists, and podcasts).
+    /// Loads library content (playlists, albums, artists, and podcasts).
     func load() async {
         guard self.loadingState != .loading else { return }
 
@@ -426,7 +499,7 @@ final class LibraryViewModel {
             self.applyLibraryContent(content)
             self.loadingState = .loaded
             self.logger.info(
-                "Loaded \(content.playlists.count) playlists, \(content.artists.count) artists, and \(content.podcastShows.count) podcasts"
+                "Loaded \(content.playlists.count) playlists, \(content.albums.count) albums, \(content.artists.count) artists, and \(content.podcastShows.count) podcasts"
             )
 
             if self.needsReloadAfterCurrentLoad {

--- a/Sources/Kaset/ViewModels/LibraryViewModel.swift
+++ b/Sources/Kaset/ViewModels/LibraryViewModel.swift
@@ -134,17 +134,25 @@ final class LibraryMutationBroadcaster {
         }
     }
 
-    func reconcileAddedAlbum(_ album: Album) async {
+    @discardableResult
+    func reconcileAddedAlbum(
+        _ album: Album,
+        whileValid isCurrent: () -> Bool = { true }
+    ) async -> Bool {
         for libraryViewModel in self.activeLibraryViewModels {
+            guard isCurrent() else { return false }
             await libraryViewModel.refresh()
+            guard isCurrent() else { return false }
             if !libraryViewModel.isInLibrary(
                 albumId: album.id,
                 targetPlaylistId: album.libraryTargetId
             ) {
+                guard isCurrent() else { return false }
                 libraryViewModel.addToLibrary(album: album)
             }
             libraryViewModel.markNeedsReloadOnActivation()
         }
+        return isCurrent()
     }
 
     func albumRemoved(albumId: String, targetPlaylistId: String?) {
@@ -154,14 +162,23 @@ final class LibraryMutationBroadcaster {
         }
     }
 
-    func reconcileRemovedAlbum(albumId: String, targetPlaylistId: String?) async {
+    @discardableResult
+    func reconcileRemovedAlbum(
+        albumId: String,
+        targetPlaylistId: String?,
+        whileValid isCurrent: () -> Bool = { true }
+    ) async -> Bool {
         for libraryViewModel in self.activeLibraryViewModels {
+            guard isCurrent() else { return false }
             await libraryViewModel.refresh()
+            guard isCurrent() else { return false }
             if libraryViewModel.isInLibrary(albumId: albumId, targetPlaylistId: targetPlaylistId) {
+                guard isCurrent() else { return false }
                 libraryViewModel.removeFromLibrary(albumId: albumId, targetPlaylistId: targetPlaylistId)
             }
             libraryViewModel.markNeedsReloadOnActivation()
         }
+        return isCurrent()
     }
 }
 
@@ -197,6 +214,12 @@ final class LibraryViewModel {
 
     /// Set of followed artist IDs normalized to channel IDs (for quick lookup).
     private(set) var libraryArtistIds: Set<String> = []
+
+    /// Account scope that produced the current Library snapshot.
+    private var libraryAccountScope: String?
+
+    /// Strength of the response that produced the current album snapshot.
+    private var libraryAlbumsSource: LibraryContentParser.LibraryAlbumsSource?
 
     /// Selected playlist detail.
     private(set) var selectedPlaylistDetail: PlaylistDetail?
@@ -246,7 +269,9 @@ final class LibraryViewModel {
                 uploadedSongsPlaylist: self.uploadedSongsPlaylist,
                 playlistIds: self.libraryPlaylistIds,
                 artistIds: self.libraryArtistIds,
-                podcastIds: self.libraryPodcastIds
+                podcastIds: self.libraryPodcastIds,
+                accountScope: self.libraryAccountScope,
+                albumsSource: self.libraryAlbumsSource
             )
         }
         set {
@@ -258,11 +283,26 @@ final class LibraryViewModel {
             self.libraryPlaylistIds = newValue.playlistIds
             self.libraryArtistIds = newValue.artistIds
             self.libraryPodcastIds = newValue.podcastIds
+            self.libraryAccountScope = newValue.accountScope
+            self.libraryAlbumsSource = newValue.albumsSource
         }
     }
 
     private var hasLibrarySnapshot: Bool {
-        self.librarySnapshot.hasVisibleContent
+        self.librarySnapshot.hasLoadedContent
+    }
+
+    func activateAccountScope(_ accountScope: String?) {
+        guard self.libraryAccountScope != accountScope else { return }
+
+        self.markLibraryStateChanged()
+        let shouldClearState = self.libraryAccountScope != nil
+            || (accountScope != nil && accountScope != "primary")
+        if shouldClearState {
+            self.librarySnapshot = .empty
+            self.contentReconciler = LibraryContentReconciler()
+        }
+        self.libraryAccountScope = accountScope
     }
 
     private func markLibraryStateChanged() {
@@ -289,6 +329,9 @@ final class LibraryViewModel {
 
     private func applyLibraryContent(_ content: PlaylistParser.LibraryContent) {
         let result = self.contentReconciler.apply(content, currentSnapshot: self.librarySnapshot)
+        if result.preservedExistingAlbums {
+            self.logger.debug("Preserving existing album snapshot because refresh fell back to landing preview")
+        }
         if result.preservedExistingArtists {
             self.logger.debug("Preserving existing artist snapshot because refresh fell back to landing preview")
         }

--- a/Sources/Kaset/ViewModels/LibraryViewModel.swift
+++ b/Sources/Kaset/ViewModels/LibraryViewModel.swift
@@ -292,12 +292,12 @@ final class LibraryViewModel {
         self.librarySnapshot.hasLoadedContent
     }
 
-    func activateAccountScope(_ accountScope: String?) {
+    func activateAccountScope(_ accountScope: String?, isPrimary: Bool = false) {
         guard self.libraryAccountScope != accountScope else { return }
 
         self.markLibraryStateChanged()
         let shouldClearState = self.libraryAccountScope != nil
-            || (accountScope != nil && accountScope != "primary")
+            || (accountScope != nil && !isPrimary && accountScope != "primary")
         if shouldClearState {
             self.librarySnapshot = .empty
             self.contentReconciler = LibraryContentReconciler()

--- a/Sources/Kaset/ViewModels/LibraryViewModel.swift
+++ b/Sources/Kaset/ViewModels/LibraryViewModel.swift
@@ -17,6 +17,7 @@ final class LibraryMutationBroadcaster {
         fileprivate struct Target {
             let viewModel: LibraryViewModel
             let playlistRevision: UInt64
+            let accountScopeGeneration: UInt64
         }
 
         fileprivate let targets: [Target]
@@ -55,6 +56,13 @@ final class LibraryMutationBroadcaster {
         }
     }
 
+    func playlistAdded(_ playlist: Playlist) {
+        for libraryViewModel in self.activeLibraryViewModels {
+            libraryViewModel.markNeedsReloadOnActivation()
+            libraryViewModel.addToLibrary(playlist: playlist)
+        }
+    }
+
     @discardableResult
     func reconcileCreatedPlaylist(
         _ playlist: Playlist,
@@ -82,6 +90,23 @@ final class LibraryMutationBroadcaster {
         return true
     }
 
+    @discardableResult
+    func reconcileAddedPlaylist(
+        _ playlist: Playlist,
+        whileValid isCurrent: () -> Bool = { true }
+    ) async -> Bool {
+        for libraryViewModel in self.activeLibraryViewModels {
+            guard isCurrent() else { return false }
+            await libraryViewModel.refresh()
+            guard isCurrent() else { return false }
+            if !libraryViewModel.isInLibrary(playlistId: playlist.id) {
+                libraryViewModel.addToLibrary(playlist: playlist)
+            }
+            libraryViewModel.markNeedsReloadOnActivation()
+        }
+        return isCurrent()
+    }
+
     func discardCreatedPlaylist(_ playlist: Playlist) {
         for libraryViewModel in self.activeLibraryViewModels {
             libraryViewModel.discardOptimisticPlaylist(playlistId: playlist.id)
@@ -100,7 +125,8 @@ final class LibraryMutationBroadcaster {
             if wasInLibrary {
                 targets.append(PlaylistRemovalReceipt.Target(
                     viewModel: libraryViewModel,
-                    playlistRevision: libraryViewModel.playlistMutationRevision(for: playlistId)
+                    playlistRevision: libraryViewModel.playlistMutationRevision(for: playlistId),
+                    accountScopeGeneration: libraryViewModel.currentAccountScopeGeneration
                 ))
             }
         }
@@ -109,6 +135,7 @@ final class LibraryMutationBroadcaster {
 
     func rollbackPlaylistRemoval(_ playlist: Playlist, receipt: PlaylistRemovalReceipt) {
         for target in receipt.targets {
+            guard target.viewModel.currentAccountScopeGeneration == target.accountScopeGeneration else { continue }
             guard target.viewModel.rollbackPlaylistRemoval(
                 playlist,
                 expectedPlaylistRevision: target.playlistRevision
@@ -117,14 +144,21 @@ final class LibraryMutationBroadcaster {
         }
     }
 
-    func reconcileRemovedPlaylist(playlistId: String) async {
+    @discardableResult
+    func reconcileRemovedPlaylist(
+        playlistId: String,
+        whileValid isCurrent: () -> Bool = { true }
+    ) async -> Bool {
         for libraryViewModel in self.activeLibraryViewModels {
+            guard isCurrent() else { return false }
             await libraryViewModel.refresh()
+            guard isCurrent() else { return false }
             if libraryViewModel.isInLibrary(playlistId: playlistId) {
                 libraryViewModel.removeFromLibrary(playlistId: playlistId)
             }
             libraryViewModel.markNeedsReloadOnActivation()
         }
+        return isCurrent()
     }
 
     func albumAdded(_ album: Album) {
@@ -217,6 +251,15 @@ final class LibraryViewModel {
 
     /// Account scope that produced the current Library snapshot.
     private var libraryAccountScope: String?
+    private var accountScopeGeneration: UInt64 = 0
+
+    var currentAccountScope: String? {
+        self.libraryAccountScope
+    }
+
+    var currentAccountScopeGeneration: UInt64 {
+        self.accountScopeGeneration
+    }
 
     /// Strength of the response that produced the current album snapshot.
     private var libraryAlbumsSource: LibraryContentParser.LibraryAlbumsSource?
@@ -299,6 +342,7 @@ final class LibraryViewModel {
         let shouldClearState = self.libraryAccountScope != nil
             || (accountScope != nil && !isPrimary && accountScope != "primary")
         if shouldClearState {
+            self.accountScopeGeneration &+= 1
             self.librarySnapshot = .empty
             self.contentReconciler = LibraryContentReconciler()
         }

--- a/Sources/Kaset/ViewModels/PlaylistDetailViewModel.swift
+++ b/Sources/Kaset/ViewModels/PlaylistDetailViewModel.swift
@@ -338,7 +338,12 @@ extension PlaylistDetailViewModel {
             author: detail.author,
             canDelete: detail.canDelete || self.playlist.canDelete
         )
-        return PlaylistDetail(playlist: playlist, tracks: allTracks, duration: detail.duration)
+        return PlaylistDetail(
+            playlist: playlist,
+            tracks: allTracks,
+            duration: detail.duration,
+            libraryTargetId: detail.libraryTargetId
+        )
     }
 
     private func detailByMergingOriginalPlaylistMetadata(into detail: PlaylistDetail) -> PlaylistDetail {
@@ -362,7 +367,12 @@ extension PlaylistDetailViewModel {
             author: detail.author ?? self.stripSongCountAuthor(from: self.playlist.author),
             canDelete: detail.canDelete || self.playlist.canDelete
         )
-        return PlaylistDetail(playlist: playlist, tracks: detail.tracks, duration: detail.duration)
+        return PlaylistDetail(
+            playlist: playlist,
+            tracks: detail.tracks,
+            duration: detail.duration,
+            libraryTargetId: detail.libraryTargetId
+        )
     }
 
     private func reconciledLikedMusicDetail(
@@ -918,7 +928,8 @@ extension PlaylistDetailViewModel {
         return PlaylistDetail(
             playlist: updatedPlaylist,
             tracks: tracks,
-            duration: detail.duration
+            duration: detail.duration,
+            libraryTargetId: detail.libraryTargetId
         )
     }
 

--- a/Sources/Kaset/ViewModels/PlaylistDetailViewModel.swift
+++ b/Sources/Kaset/ViewModels/PlaylistDetailViewModel.swift
@@ -342,7 +342,7 @@ extension PlaylistDetailViewModel {
             playlist: playlist,
             tracks: allTracks,
             duration: detail.duration,
-            libraryTargetId: detail.libraryTargetId
+            libraryTargetId: detail.libraryTargetId ?? self.playlist.libraryTargetId
         )
     }
 
@@ -371,7 +371,7 @@ extension PlaylistDetailViewModel {
             playlist: playlist,
             tracks: detail.tracks,
             duration: detail.duration,
-            libraryTargetId: detail.libraryTargetId
+            libraryTargetId: detail.libraryTargetId ?? self.playlist.libraryTargetId
         )
     }
 
@@ -929,7 +929,7 @@ extension PlaylistDetailViewModel {
             playlist: updatedPlaylist,
             tracks: tracks,
             duration: detail.duration,
-            libraryTargetId: detail.libraryTargetId
+            libraryTargetId: detail.libraryTargetId ?? self.playlist.libraryTargetId
         )
     }
 

--- a/Sources/Kaset/Views/AccountSwitcherPopover.swift
+++ b/Sources/Kaset/Views/AccountSwitcherPopover.swift
@@ -64,8 +64,10 @@ struct AccountSwitcherPopover: View {
 
     private var guestModeRow: some View {
         Button {
-            self.authService.enterGuestMode()
-            self.dismiss()
+            Task { @MainActor in
+                await self.authService.enterGuestMode()
+                self.dismiss()
+            }
         } label: {
             HStack(spacing: 12) {
                 Circle()

--- a/Sources/Kaset/Views/LibraryView.swift
+++ b/Sources/Kaset/Views/LibraryView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 enum LibraryFilter: String, CaseIterable, Identifiable {
     case all = "All"
     case playlists = "Playlists"
+    case albums = "Albums"
     case uploads = "Uploads"
     case artists = "Artists"
     case podcasts = "Podcasts"
@@ -18,6 +19,7 @@ enum LibraryFilter: String, CaseIterable, Identifiable {
         switch self {
         case .all: "square.grid.2x2"
         case .playlists: "music.note.list"
+        case .albums: "square.stack"
         case .uploads: "tray.and.arrow.up.fill"
         case .artists: "person.fill"
         case .podcasts: "mic.fill"
@@ -30,6 +32,8 @@ enum LibraryFilter: String, CaseIterable, Identifiable {
             String(localized: "All")
         case .playlists:
             String(localized: "Playlists")
+        case .albums:
+            String(localized: "Albums")
         case .uploads:
             String(localized: "Uploads")
         case .artists:
@@ -42,7 +46,7 @@ enum LibraryFilter: String, CaseIterable, Identifiable {
 
 // MARK: - LibraryView
 
-/// Library view displaying user's playlists and podcast shows.
+/// Library view displaying the user's saved music and followed content.
 struct LibraryView: View {
     @State var viewModel: LibraryViewModel
     @Environment(PlayerService.self) private var playerService
@@ -212,10 +216,13 @@ struct LibraryView: View {
         case .all:
             items = self.uploadItems
                 + self.viewModel.playlists.map { .playlist($0) }
+                + self.viewModel.albums.map { .album($0) }
                 + self.viewModel.artists.map { .artist($0) }
                 + self.viewModel.podcastShows.map { .podcast($0) }
         case .playlists:
             items = self.viewModel.playlists.map { .playlist($0) }
+        case .albums:
+            items = self.viewModel.albums.map { .album($0) }
         case .uploads:
             items = self.uploadItems
         case .artists:
@@ -246,6 +253,8 @@ struct LibraryView: View {
                     switch item {
                     case let .playlist(playlist):
                         self.playlistCard(playlist)
+                    case let .album(album):
+                        self.albumCard(album)
                     case let .uploadedSongs(playlist):
                         self.uploadedSongsCard(playlist)
                     case let .artist(artist):
@@ -284,6 +293,8 @@ struct LibraryView: View {
             String(localized: "Your library is empty")
         case .playlists:
             String(localized: "No playlists yet")
+        case .albums:
+            String(localized: "No albums yet")
         case .uploads:
             String(localized: "No uploaded songs yet")
         case .artists:
@@ -296,9 +307,11 @@ struct LibraryView: View {
     private var emptyStateMessage: String {
         switch self.selectedFilter {
         case .all:
-            String(localized: "Save playlists, follow artists, and subscribe to podcasts on YouTube Music to see them here.")
+            String(localized: "Save albums and playlists, follow artists, and subscribe to podcasts on YouTube Music to see them here.")
         case .playlists:
             String(localized: "Create or save playlists on YouTube Music to see them here.")
+        case .albums:
+            String(localized: "Save albums on YouTube Music to see them here.")
         case .uploads:
             String(localized: "Upload songs to YouTube Music to browse them here.")
         case .artists:
@@ -362,6 +375,105 @@ struct LibraryView: View {
                 }
             }
         }
+    }
+
+    private func albumCard(_ album: Album) -> some View {
+        let metadata = [album.artistsDisplay.isEmpty ? nil : album.artistsDisplay, album.year]
+            .compactMap(\.self)
+            .joined(separator: " • ")
+
+        return Button {
+            self.navigationPath.append(self.playlist(from: album))
+        } label: {
+            VStack(alignment: .leading, spacing: 8) {
+                CachedAsyncImage(url: album.thumbnailURL?.highQualityThumbnailURL) { image in
+                    image
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                } placeholder: {
+                    Rectangle()
+                        .fill(.quaternary)
+                        .overlay {
+                            Image(systemName: "square.stack")
+                                .font(.largeTitle)
+                                .foregroundStyle(.secondary)
+                        }
+                }
+                .frame(width: self.libraryItemSize, height: self.libraryItemSize)
+                .clipShape(.rect(cornerRadius: 8))
+
+                Text(album.title)
+                    .font(.system(size: 13, weight: .medium))
+                    .lineLimit(2)
+                    .multilineTextAlignment(.leading)
+                    .frame(width: self.libraryItemSize, alignment: .topLeading)
+
+                Text(metadata.isEmpty ? String(localized: "Album") : metadata)
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .frame(width: self.libraryItemSize, alignment: .leading)
+            }
+            .frame(width: self.libraryItemSize, height: self.libraryItemCardHeight, alignment: .topLeading)
+        }
+        .buttonStyle(.plain)
+        .contextMenu {
+            Button {
+                self.navigationPath.append(self.playlist(from: album))
+            } label: {
+                Label("View Album", systemImage: "square.stack")
+            }
+
+            Divider()
+
+            Button {
+                SongActionsHelper.playAlbum(
+                    album,
+                    client: self.viewModel.client,
+                    playerService: self.playerService
+                )
+            } label: {
+                Label("Play", systemImage: "play.fill")
+            }
+
+            Button {
+                SongActionsHelper.addAlbumToQueueNext(
+                    album,
+                    client: self.viewModel.client,
+                    playerService: self.playerService
+                )
+            } label: {
+                Label("Play Next", systemImage: "text.insert")
+            }
+
+            Button {
+                SongActionsHelper.addAlbumToQueueLast(
+                    album,
+                    client: self.viewModel.client,
+                    playerService: self.playerService
+                )
+            } label: {
+                Label("Add to Queue", systemImage: "text.append")
+            }
+
+            Divider()
+
+            FavoritesContextMenu.menuItem(for: album, manager: self.favoritesManager)
+            ShareContextMenu.menuItem(for: album)
+        }
+    }
+
+    private func playlist(from album: Album) -> Playlist {
+        Playlist(
+            id: album.id,
+            title: album.title,
+            description: nil,
+            thumbnailURL: album.thumbnailURL,
+            trackCount: album.trackCount,
+            author: album.artistsDisplay.isEmpty
+                ? nil
+                : Artist.inline(name: album.artistsDisplay, namespace: "album-artist")
+        )
     }
 
     private func uploadedSongsCard(_ playlist: Playlist) -> some View {
@@ -498,9 +610,10 @@ struct LibraryView: View {
 
 // MARK: - LibraryItem
 
-/// Represents a library item that can be a playlist, artist, or podcast show.
+/// Represents a tile displayed in the combined Library grid.
 enum LibraryItem: Identifiable {
     case playlist(Playlist)
+    case album(Album)
     case uploadedSongs(Playlist)
     case artist(Artist)
     case podcast(PodcastShow)
@@ -509,6 +622,8 @@ enum LibraryItem: Identifiable {
         switch self {
         case let .playlist(playlist):
             "playlist-\(playlist.id)"
+        case let .album(album):
+            "album-\(album.id)"
         case let .uploadedSongs(playlist):
             "uploads-\(playlist.id)"
         case let .artist(artist):

--- a/Sources/Kaset/Views/LibraryView.swift
+++ b/Sources/Kaset/Views/LibraryView.swift
@@ -307,7 +307,7 @@ struct LibraryView: View {
     private var emptyStateMessage: String {
         switch self.selectedFilter {
         case .all:
-            String(localized: "Save albums and playlists, follow artists, and subscribe to podcasts on YouTube Music to see them here.")
+            String(localized: "Save playlists, follow artists, and subscribe to podcasts on YouTube Music to see them here.")
         case .playlists:
             String(localized: "Create or save playlists on YouTube Music to see them here.")
         case .albums:

--- a/Sources/Kaset/Views/LibraryView.swift
+++ b/Sources/Kaset/Views/LibraryView.swift
@@ -96,6 +96,7 @@ struct LibraryView: View {
                         ),
                         playerBarNavigationAction: self.playerBarNavigationAction
                     )
+                    .environment(\.libraryViewModel, self.viewModel)
                 } else {
                     SimplePlaylistDetailView(
                         playlist: playlist,
@@ -105,6 +106,7 @@ struct LibraryView: View {
                         ),
                         playerBarNavigationAction: self.playerBarNavigationAction
                     )
+                    .environment(\.libraryViewModel, self.viewModel)
                 }
             }
             .navigationDestination(for: Artist.self) { artist in
@@ -132,7 +134,7 @@ struct LibraryView: View {
             .playerBarMusicNavigation(path: self.$navigationPath)
         }
         .playerBarMusicNavigation(path: self.$navigationPath)
-        .environment(self.viewModel)
+        .environment(\.libraryViewModel, self.viewModel)
         .safeAreaInset(edge: .bottom, spacing: 0) {
             PlayerBar()
                 .playerBarMusicNavigation(path: self.$navigationPath)
@@ -472,7 +474,8 @@ struct LibraryView: View {
             trackCount: album.trackCount,
             author: album.artistsDisplay.isEmpty
                 ? nil
-                : Artist.inline(name: album.artistsDisplay, namespace: "album-artist")
+                : Artist.inline(name: album.artistsDisplay, namespace: "album-artist"),
+            libraryTargetId: album.libraryTargetId
         )
     }
 

--- a/Sources/Kaset/Views/LoginSheet.swift
+++ b/Sources/Kaset/Views/LoginSheet.swift
@@ -137,7 +137,7 @@ struct LoginSheet: View {
             }
 
             self.didCompleteLogin = true
-            self.authService.completeLogin(sapisid: sapisid)
+            await self.authService.completeLoginAfterDraining(sapisid: sapisid)
             self.pollTask?.cancel()
             self.dismiss()
         }

--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -260,10 +260,17 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
                 VideoWindowController.shared.close()
             }
         }
-        .onChange(of: self.accountService.currentAccount?.id) { _, newAccountId in
+        .onChange(of: self.accountService.currentAccountScopeID) { _, newAccountScope in
+            let currentAccount = self.accountService.currentAccount
+            let newAccountId = self.accountService.currentAccount?.id
+            self.client.resetSessionStateForAccountSwitch()
+            self.youtubeClient.resetSessionStateForAccountSwitch()
+            self.likeStatusManager.clearCache()
             LibraryMutationActions.cancelPendingAlbumMutations(for: self.libraryViewModel)
-            let accountScope = self.accountService.currentAccount.map { $0.brandId ?? "primary" }
-            self.libraryViewModel?.activateAccountScope(accountScope)
+            self.libraryViewModel?.activateAccountScope(
+                newAccountScope,
+                isPrimary: currentAccount?.isPrimary == true
+            )
             self.playerService.resetTrackStatus()
             self.searchViewModel?.clear()
             self.podcastsViewModel?.configure(
@@ -824,8 +831,11 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
             client: self.client
         )
         let libraryViewModel = LibraryViewModel(client: self.client)
-        let accountScope = self.accountService.currentAccount.map { $0.brandId ?? "primary" }
-        libraryViewModel.activateAccountScope(accountScope)
+        let currentAccount = self.accountService.currentAccount
+        libraryViewModel.activateAccountScope(
+            self.accountService.currentAccountScopeID,
+            isPrimary: currentAccount?.isPrimary == true
+        )
         self.libraryViewModel = libraryViewModel
         self.historyViewModel = HistoryViewModel(client: self.client)
         self.likedMusicNavigationPath = NavigationPath()

--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -266,6 +266,9 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
             }
         }
         .onChange(of: self.accountService.currentAccount?.id) { _, newAccountId in
+            LibraryMutationActions.cancelPendingAlbumMutations(for: self.libraryViewModel)
+            let accountScope = self.accountService.currentAccount.map { $0.brandId ?? "primary" }
+            self.libraryViewModel?.activateAccountScope(accountScope)
             self.playerService.resetTrackStatus()
             self.searchViewModel?.clear()
             self.podcastsViewModel?.configure(
@@ -602,12 +605,14 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
                                     viewModel: vm,
                                     playerBarNavigationAction: self.likedMusicPlayerBarNavigationAction
                                 )
+                                .environment(\.libraryViewModel, self.libraryViewModel)
                             } else {
                                 SimplePlaylistDetailView(
                                     playlist: LikedMusicPlaylist.playlist,
                                     viewModel: vm,
                                     playerBarNavigationAction: self.likedMusicPlayerBarNavigationAction
                                 )
+                                .environment(\.libraryViewModel, self.libraryViewModel)
                             }
                         }
                         .navigationDestinations(
@@ -635,7 +640,7 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
                 }
             }
         }
-        .environment(self.libraryViewModel)
+        .environment(\.libraryViewModel, self.libraryViewModel)
     }
 
     private var hasPersonalAccount: Bool {
@@ -677,6 +682,7 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
                             client: client
                         )
                     )
+                    .environment(\.libraryViewModel, self.libraryViewModel)
                 } else {
                     SimplePlaylistDetailView(
                         playlist: item.playlistRoute,
@@ -685,12 +691,13 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
                             client: client
                         )
                     )
+                    .environment(\.libraryViewModel, self.libraryViewModel)
                 }
             }
             .id(item.contentId)
             .navigationDestinations(client: client)
         }
-        .environment(self.libraryViewModel)
+        .environment(\.libraryViewModel, self.libraryViewModel)
         .environment(\.onPlaylistDeleted) {
             self.selectedSidebarPinnedItem = nil
             self.navigationSelection = .home
@@ -806,6 +813,7 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
     }
 
     private func rebuildMusicViewModels(accountId: String? = nil) {
+        LibraryMutationActions.cancelAllPendingAlbumMutations()
         self.homeViewModel = HomeViewModel(client: self.client)
         self.exploreViewModel = ExploreViewModel(client: self.client)
         self.searchViewModel = SearchViewModel(client: self.client)
@@ -819,7 +827,10 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
             playlist: LikedMusicPlaylist.playlist,
             client: self.client
         )
-        self.libraryViewModel = LibraryViewModel(client: self.client)
+        let libraryViewModel = LibraryViewModel(client: self.client)
+        let accountScope = self.accountService.currentAccount.map { $0.brandId ?? "primary" }
+        libraryViewModel.activateAccountScope(accountScope)
+        self.libraryViewModel = libraryViewModel
         self.historyViewModel = HistoryViewModel(client: self.client)
         self.likedMusicNavigationPath = NavigationPath()
         self.pinnedNavigationPaths = [:]

--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -266,7 +266,7 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
             self.client.resetSessionStateForAccountSwitch()
             self.youtubeClient.resetSessionStateForAccountSwitch()
             self.likeStatusManager.clearCache()
-            LibraryMutationActions.cancelPendingAlbumMutations(for: self.libraryViewModel)
+            LibraryMutationActions.cancelAllPendingLibraryMutations()
             self.libraryViewModel?.activateAccountScope(
                 newAccountScope,
                 isPrimary: currentAccount?.isPrimary == true
@@ -816,7 +816,7 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
     }
 
     private func rebuildMusicViewModels(accountId: String? = nil) {
-        LibraryMutationActions.cancelAllPendingAlbumMutations()
+        LibraryMutationActions.cancelAllPendingLibraryMutations()
         self.homeViewModel = HomeViewModel(client: self.client)
         self.exploreViewModel = ExploreViewModel(client: self.client)
         self.searchViewModel = SearchViewModel(client: self.client)

--- a/Sources/Kaset/Views/PlaylistDetailView+HeaderActions.swift
+++ b/Sources/Kaset/Views/PlaylistDetailView+HeaderActions.swift
@@ -134,12 +134,12 @@ extension PlaylistDetailView {
     @ViewBuilder
     private func libraryButton(_ detail: PlaylistDetail, showsTitles: Bool) -> some View {
         if !detail.isUploadedSongs, self.hasPersonalAccount {
-            let currentlyInLibrary = self.isInLibrary || self.isAddedToLibrary
+            let currentlyInLibrary = self.isInLibrary
             let libraryTitle = currentlyInLibrary
                 ? String(localized: "Added to Library")
                 : String(localized: "Add to Library")
             Button {
-                self.toggleLibrary()
+                self.toggleLibrary(detail)
             } label: {
                 self.headerActionLabel(
                     libraryTitle,
@@ -149,6 +149,7 @@ extension PlaylistDetailView {
             }
             .buttonStyle(.bordered)
             .controlSize(.large)
+            .disabled(detail.isAlbum && detail.libraryTargetId == nil)
         }
     }
 

--- a/Sources/Kaset/Views/PlaylistDetailView+HeaderActions.swift
+++ b/Sources/Kaset/Views/PlaylistDetailView+HeaderActions.swift
@@ -149,7 +149,7 @@ extension PlaylistDetailView {
             }
             .buttonStyle(.bordered)
             .controlSize(.large)
-            .disabled(detail.isAlbum && detail.libraryTargetId == nil)
+            .disabled(self.isUpdatingLibrary || (detail.isAlbum && detail.libraryTargetId == nil))
         }
     }
 

--- a/Sources/Kaset/Views/PlaylistDetailView+LibraryActions.swift
+++ b/Sources/Kaset/Views/PlaylistDetailView+LibraryActions.swift
@@ -1,0 +1,64 @@
+import os
+import SwiftUI
+
+@available(macOS 26.0, *)
+extension PlaylistDetailView {
+    func toggleLibrary(_ detail: PlaylistDetail) {
+        let currentlyInLibrary = self.isInLibrary
+        Task {
+            do {
+                if detail.isAlbum {
+                    guard let targetPlaylistId = detail.libraryTargetId else {
+                        DiagnosticsLogger.api.error(
+                            "Album library target is unavailable for \(detail.id, privacy: .public)"
+                        )
+                        HapticService.error()
+                        return
+                    }
+                    let album = Album(
+                        id: detail.id,
+                        title: detail.title,
+                        artists: detail.author.map { [$0] },
+                        thumbnailURL: detail.thumbnailURL,
+                        year: nil,
+                        trackCount: detail.trackCount,
+                        libraryTargetId: targetPlaylistId
+                    )
+
+                    if currentlyInLibrary {
+                        try await SongActionsHelper.removeAlbumFromLibrary(
+                            album,
+                            targetPlaylistId: targetPlaylistId,
+                            client: self.viewModel.client,
+                            libraryViewModel: self.libraryViewModel
+                        )
+                    } else {
+                        try await SongActionsHelper.addAlbumToLibrary(
+                            album,
+                            targetPlaylistId: targetPlaylistId,
+                            client: self.viewModel.client,
+                            libraryViewModel: self.libraryViewModel
+                        )
+                    }
+                } else if currentlyInLibrary {
+                    try await SongActionsHelper.removePlaylistFromLibrary(
+                        self.playlist,
+                        client: self.viewModel.client,
+                        libraryViewModel: self.libraryViewModel
+                    )
+                } else {
+                    try await SongActionsHelper.addPlaylistToLibrary(
+                        self.playlist,
+                        client: self.viewModel.client,
+                        libraryViewModel: self.libraryViewModel
+                    )
+                }
+
+                HapticService.success()
+            } catch {
+                DiagnosticsLogger.api.error("Failed to update library status: \(error.localizedDescription)")
+                HapticService.error()
+            }
+        }
+    }
+}

--- a/Sources/Kaset/Views/PlaylistDetailView+LibraryActions.swift
+++ b/Sources/Kaset/Views/PlaylistDetailView+LibraryActions.swift
@@ -1,17 +1,41 @@
+import Foundation
 import os
 import SwiftUI
+
+// MARK: - PlaylistDetailLibraryMutationActivity
+
+struct PlaylistDetailLibraryMutationActivity {
+    private(set) var operationID: UUID?
+
+    var isActive: Bool {
+        self.operationID != nil
+    }
+
+    mutating func begin() -> UUID? {
+        guard self.operationID == nil else { return nil }
+        let operationID = UUID()
+        self.operationID = operationID
+        return operationID
+    }
+
+    mutating func finish(_ operationID: UUID) {
+        guard self.operationID == operationID else { return }
+        self.operationID = nil
+    }
+}
 
 @available(macOS 26.0, *)
 extension PlaylistDetailView {
     func toggleLibrary(_ detail: PlaylistDetail) {
-        guard !self.isUpdatingLibrary else { return }
+        var activity = self.libraryMutationActivity
+        guard let operationID = activity.begin() else { return }
+        self.libraryMutationActivity = activity
 
         let currentlyInLibrary = self.isInLibrary
-        self.isUpdatingLibrary = true
         Task { @MainActor in
-            defer { self.isUpdatingLibrary = false }
+            defer { self.finishLibraryMutation(operationID) }
             let mutationApplied: @MainActor @Sendable () -> Void = {
-                self.isUpdatingLibrary = false
+                self.finishLibraryMutation(operationID)
             }
             do {
                 if detail.isAlbum {
@@ -73,5 +97,11 @@ extension PlaylistDetailView {
                 HapticService.error()
             }
         }
+    }
+
+    private func finishLibraryMutation(_ operationID: UUID) {
+        var activity = self.libraryMutationActivity
+        activity.finish(operationID)
+        self.libraryMutationActivity = activity
     }
 }

--- a/Sources/Kaset/Views/PlaylistDetailView+LibraryActions.swift
+++ b/Sources/Kaset/Views/PlaylistDetailView+LibraryActions.swift
@@ -4,8 +4,15 @@ import SwiftUI
 @available(macOS 26.0, *)
 extension PlaylistDetailView {
     func toggleLibrary(_ detail: PlaylistDetail) {
+        guard !self.isUpdatingLibrary else { return }
+
         let currentlyInLibrary = self.isInLibrary
-        Task {
+        self.isUpdatingLibrary = true
+        Task { @MainActor in
+            defer { self.isUpdatingLibrary = false }
+            let mutationApplied: @MainActor @Sendable () -> Void = {
+                self.isUpdatingLibrary = false
+            }
             do {
                 if detail.isAlbum {
                     guard let targetPlaylistId = detail.libraryTargetId else {
@@ -30,31 +37,37 @@ extension PlaylistDetailView {
                             album,
                             targetPlaylistId: targetPlaylistId,
                             client: self.viewModel.client,
-                            libraryViewModel: self.libraryViewModel
+                            libraryViewModel: self.libraryViewModel,
+                            onMutationApplied: mutationApplied
                         )
                     } else {
                         try await SongActionsHelper.addAlbumToLibrary(
                             album,
                             targetPlaylistId: targetPlaylistId,
                             client: self.viewModel.client,
-                            libraryViewModel: self.libraryViewModel
+                            libraryViewModel: self.libraryViewModel,
+                            onMutationApplied: mutationApplied
                         )
                     }
                 } else if currentlyInLibrary {
                     try await SongActionsHelper.removePlaylistFromLibrary(
                         self.playlist,
                         client: self.viewModel.client,
-                        libraryViewModel: self.libraryViewModel
+                        libraryViewModel: self.libraryViewModel,
+                        onMutationApplied: mutationApplied
                     )
                 } else {
                     try await SongActionsHelper.addPlaylistToLibrary(
                         self.playlist,
                         client: self.viewModel.client,
-                        libraryViewModel: self.libraryViewModel
+                        libraryViewModel: self.libraryViewModel,
+                        onMutationApplied: mutationApplied
                     )
                 }
 
                 HapticService.success()
+            } catch is CancellationError {
+                return
             } catch {
                 DiagnosticsLogger.api.error("Failed to update library status: \(error.localizedDescription)")
                 HapticService.error()

--- a/Sources/Kaset/Views/PlaylistDetailView.swift
+++ b/Sources/Kaset/Views/PlaylistDetailView.swift
@@ -17,8 +17,6 @@ struct PlaylistDetailView: View {
     @Environment(LibraryViewModel.self) var libraryViewModel: LibraryViewModel?
     @Environment(\.dismiss) var dismiss
     @Environment(\.onPlaylistDeleted) var onPlaylistDeleted
-    /// Tracks whether this playlist has been added to library in this session.
-    @State var isAddedToLibrary: Bool = false
     /// Whether the refine playlist sheet is visible.
     @State var showRefineSheet: Bool = false
     /// AI-generated playlist changes.
@@ -31,7 +29,13 @@ struct PlaylistDetailView: View {
     @State private var refineError: String?
     /// Computed property to check if playlist is in library.
     var isInLibrary: Bool {
-        self.libraryViewModel?.isInLibrary(playlistId: self.playlist.id) ?? false
+        if self.playlist.isAlbum {
+            return self.libraryViewModel?.isInLibrary(
+                albumId: self.playlist.id,
+                targetPlaylistId: self.viewModel.playlistDetail?.libraryTargetId
+            ) ?? false
+        }
+        return self.libraryViewModel?.isInLibrary(playlistId: self.playlist.id) ?? false
     }
 
     var hasPersonalAccount: Bool {
@@ -616,28 +620,6 @@ struct PlaylistDetailView: View {
                 isPlayable: song.isPlayable,
                 playlistSetVideoId: song.playlistSetVideoId
             )
-        }
-    }
-
-    func toggleLibrary() {
-        let currentlyInLibrary = self.isInLibrary || self.isAddedToLibrary
-        HapticService.success()
-        Task {
-            if currentlyInLibrary {
-                await SongActionsHelper.removePlaylistFromLibrary(
-                    self.playlist,
-                    client: self.viewModel.client,
-                    libraryViewModel: self.libraryViewModel
-                )
-                self.isAddedToLibrary = false
-            } else {
-                await SongActionsHelper.addPlaylistToLibrary(
-                    self.playlist,
-                    client: self.viewModel.client,
-                    libraryViewModel: self.libraryViewModel
-                )
-                self.isAddedToLibrary = true
-            }
         }
     }
 

--- a/Sources/Kaset/Views/PlaylistDetailView.swift
+++ b/Sources/Kaset/Views/PlaylistDetailView.swift
@@ -14,11 +14,13 @@ struct PlaylistDetailView: View {
     @Environment(FavoritesManager.self) private var favoritesManager
     @Environment(SidebarPinnedItemsManager.self) var sidebarPinnedItemsManager: SidebarPinnedItemsManager?
     @Environment(SongLikeStatusManager.self) private var likeStatusManager
-    @Environment(LibraryViewModel.self) var libraryViewModel: LibraryViewModel?
+    @Environment(\.libraryViewModel) var libraryViewModel: LibraryViewModel?
     @Environment(\.dismiss) var dismiss
     @Environment(\.onPlaylistDeleted) var onPlaylistDeleted
     /// Whether the refine playlist sheet is visible.
     @State var showRefineSheet: Bool = false
+    /// Whether an add/remove Library request is currently in flight.
+    @State var isUpdatingLibrary: Bool = false
     /// AI-generated playlist changes.
     @State private var playlistChanges: PlaylistChanges?
     /// Partial playlist changes during streaming.

--- a/Sources/Kaset/Views/PlaylistDetailView.swift
+++ b/Sources/Kaset/Views/PlaylistDetailView.swift
@@ -20,7 +20,7 @@ struct PlaylistDetailView: View {
     /// Whether the refine playlist sheet is visible.
     @State var showRefineSheet: Bool = false
     /// Whether an add/remove Library request is currently in flight.
-    @State var isUpdatingLibrary: Bool = false
+    @State var libraryMutationActivity = PlaylistDetailLibraryMutationActivity()
     /// AI-generated playlist changes.
     @State private var playlistChanges: PlaylistChanges?
     /// Partial playlist changes during streaming.
@@ -38,6 +38,10 @@ struct PlaylistDetailView: View {
             ) ?? false
         }
         return self.libraryViewModel?.isInLibrary(playlistId: self.playlist.id) ?? false
+    }
+
+    var isUpdatingLibrary: Bool {
+        self.libraryMutationActivity.isActive
     }
 
     var hasPersonalAccount: Bool {

--- a/Sources/Kaset/Views/PodcastsView.swift
+++ b/Sources/Kaset/Views/PodcastsView.swift
@@ -261,7 +261,7 @@ struct PodcastShowView: View {
     @Environment(AuthService.self) private var authService
     @Environment(PlayerService.self) private var playerService
     @Environment(FavoritesManager.self) private var favoritesManager
-    @Environment(LibraryViewModel.self) private var libraryViewModel: LibraryViewModel?
+    @Environment(\.libraryViewModel) private var libraryViewModel: LibraryViewModel?
 
     @State private var episodes: [PodcastEpisode] = []
     @State private var continuationToken: String?

--- a/Sources/Kaset/Views/SearchView.swift
+++ b/Sources/Kaset/Views/SearchView.swift
@@ -597,7 +597,7 @@ struct SearchView: View {
         if self.authService.hasPersonalAccount {
             Button {
                 Task {
-                    await SongActionsHelper.addPlaylistToLibrary(
+                    try? await SongActionsHelper.addPlaylistToLibrary(
                         playlist,
                         client: self.viewModel.client,
                         libraryViewModel: self.libraryViewModel

--- a/Sources/Kaset/Views/SearchView.swift
+++ b/Sources/Kaset/Views/SearchView.swift
@@ -9,7 +9,7 @@ struct SearchView: View {
     @Environment(FavoritesManager.self) private var favoritesManager
     @Environment(SongLikeStatusManager.self) private var likeStatusManager
     @Environment(AuthService.self) private var authService
-    @Environment(LibraryViewModel.self) private var libraryViewModel: LibraryViewModel?
+    @Environment(\.libraryViewModel) private var libraryViewModel: LibraryViewModel?
     @State private var navigationPath = NavigationPath()
     @State private var networkMonitor = NetworkMonitor.shared
 

--- a/Sources/Kaset/Views/SharedViews/NavigationDestinationsModifier.swift
+++ b/Sources/Kaset/Views/SharedViews/NavigationDestinationsModifier.swift
@@ -7,7 +7,7 @@ import SwiftUI
 struct NavigationDestinationsModifier: ViewModifier {
     let client: any YTMusicClientProtocol
     let playerBarNavigationAction: PlayerBarNavigationAction
-    @Environment(LibraryViewModel.self) private var libraryViewModel: LibraryViewModel?
+    @Environment(\.libraryViewModel) private var libraryViewModel: LibraryViewModel?
     @Environment(\.usesLegacyMacOS15UI) private var usesLegacyMacOS15UI
 
     // swiftlint:disable:next function_body_length
@@ -39,6 +39,7 @@ struct NavigationDestinationsModifier: ViewModifier {
                                 ),
                                 playerBarNavigationAction: self.playerBarNavigationAction
                             )
+                            .environment(\.libraryViewModel, self.libraryViewModel)
                         } else {
                             SimplePlaylistDetailView(
                                 playlist: playlist,
@@ -48,6 +49,7 @@ struct NavigationDestinationsModifier: ViewModifier {
                                 ),
                                 playerBarNavigationAction: self.playerBarNavigationAction
                             )
+                            .environment(\.libraryViewModel, self.libraryViewModel)
                         }
                     }
                 } else {
@@ -60,6 +62,7 @@ struct NavigationDestinationsModifier: ViewModifier {
                             ),
                             playerBarNavigationAction: self.playerBarNavigationAction
                         )
+                        .environment(\.libraryViewModel, self.libraryViewModel)
                     } else {
                         SimplePlaylistDetailView(
                             playlist: playlist,
@@ -69,6 +72,7 @@ struct NavigationDestinationsModifier: ViewModifier {
                             ),
                             playerBarNavigationAction: self.playerBarNavigationAction
                         )
+                        .environment(\.libraryViewModel, self.libraryViewModel)
                     }
                 }
             }
@@ -99,7 +103,7 @@ struct NavigationDestinationsModifier: ViewModifier {
             }
             .navigationDestination(for: PodcastShow.self) { [libraryViewModel] show in
                 PodcastShowView(show: show, client: self.client)
-                    .environment(libraryViewModel)
+                    .environment(\.libraryViewModel, libraryViewModel)
             }
             .navigationDestination(for: ArtistSeeAllDestination.self) { destination in
                 switch destination.endpoint.pageType {

--- a/Sources/Kaset/Views/SharedViews/SongActionsHelper.swift
+++ b/Sources/Kaset/Views/SharedViews/SongActionsHelper.swift
@@ -95,8 +95,8 @@ enum SongActionsHelper {
         _ playlist: Playlist,
         client: any YTMusicClientProtocol,
         libraryViewModel: LibraryViewModel?
-    ) async {
-        await LibraryMutationActions.addPlaylistToLibrary(
+    ) async throws {
+        try await LibraryMutationActions.addPlaylistToLibrary(
             playlist,
             client: client,
             libraryViewModel: libraryViewModel
@@ -108,9 +108,39 @@ enum SongActionsHelper {
         _ playlist: Playlist,
         client: any YTMusicClientProtocol,
         libraryViewModel: LibraryViewModel?
-    ) async {
-        await LibraryMutationActions.removePlaylistFromLibrary(
+    ) async throws {
+        try await LibraryMutationActions.removePlaylistFromLibrary(
             playlist,
+            client: client,
+            libraryViewModel: libraryViewModel
+        )
+    }
+
+    /// Adds an album to the library using its album playlist target.
+    static func addAlbumToLibrary(
+        _ album: Album,
+        targetPlaylistId: String,
+        client: any YTMusicClientProtocol,
+        libraryViewModel: LibraryViewModel?
+    ) async throws {
+        try await LibraryMutationActions.addAlbumToLibrary(
+            album,
+            targetPlaylistId: targetPlaylistId,
+            client: client,
+            libraryViewModel: libraryViewModel
+        )
+    }
+
+    /// Removes an album from the library using its album playlist target.
+    static func removeAlbumFromLibrary(
+        _ album: Album,
+        targetPlaylistId: String,
+        client: any YTMusicClientProtocol,
+        libraryViewModel: LibraryViewModel?
+    ) async throws {
+        try await LibraryMutationActions.removeAlbumFromLibrary(
+            album,
+            targetPlaylistId: targetPlaylistId,
             client: client,
             libraryViewModel: libraryViewModel
         )

--- a/Sources/Kaset/Views/SharedViews/SongActionsHelper.swift
+++ b/Sources/Kaset/Views/SharedViews/SongActionsHelper.swift
@@ -94,12 +94,14 @@ enum SongActionsHelper {
     static func addPlaylistToLibrary(
         _ playlist: Playlist,
         client: any YTMusicClientProtocol,
-        libraryViewModel: LibraryViewModel?
+        libraryViewModel: LibraryViewModel?,
+        onMutationApplied: @MainActor () -> Void = {}
     ) async throws {
         try await LibraryMutationActions.addPlaylistToLibrary(
             playlist,
             client: client,
-            libraryViewModel: libraryViewModel
+            libraryViewModel: libraryViewModel,
+            onMutationApplied: onMutationApplied
         )
     }
 
@@ -107,12 +109,14 @@ enum SongActionsHelper {
     static func removePlaylistFromLibrary(
         _ playlist: Playlist,
         client: any YTMusicClientProtocol,
-        libraryViewModel: LibraryViewModel?
+        libraryViewModel: LibraryViewModel?,
+        onMutationApplied: @MainActor () -> Void = {}
     ) async throws {
         try await LibraryMutationActions.removePlaylistFromLibrary(
             playlist,
             client: client,
-            libraryViewModel: libraryViewModel
+            libraryViewModel: libraryViewModel,
+            onMutationApplied: onMutationApplied
         )
     }
 
@@ -121,13 +125,15 @@ enum SongActionsHelper {
         _ album: Album,
         targetPlaylistId: String,
         client: any YTMusicClientProtocol,
-        libraryViewModel: LibraryViewModel?
+        libraryViewModel: LibraryViewModel?,
+        onMutationApplied: @MainActor @escaping () -> Void = {}
     ) async throws {
         try await LibraryMutationActions.addAlbumToLibrary(
             album,
             targetPlaylistId: targetPlaylistId,
             client: client,
-            libraryViewModel: libraryViewModel
+            libraryViewModel: libraryViewModel,
+            onMutationApplied: onMutationApplied
         )
     }
 
@@ -136,13 +142,15 @@ enum SongActionsHelper {
         _ album: Album,
         targetPlaylistId: String,
         client: any YTMusicClientProtocol,
-        libraryViewModel: LibraryViewModel?
+        libraryViewModel: LibraryViewModel?,
+        onMutationApplied: @MainActor @escaping () -> Void = {}
     ) async throws {
         try await LibraryMutationActions.removeAlbumFromLibrary(
             album,
             targetPlaylistId: targetPlaylistId,
             client: client,
-            libraryViewModel: libraryViewModel
+            libraryViewModel: libraryViewModel,
+            onMutationApplied: onMutationApplied
         )
     }
 

--- a/Sources/Kaset/Views/SharedViews/SongActionsHelper.swift
+++ b/Sources/Kaset/Views/SharedViews/SongActionsHelper.swift
@@ -95,7 +95,7 @@ enum SongActionsHelper {
         _ playlist: Playlist,
         client: any YTMusicClientProtocol,
         libraryViewModel: LibraryViewModel?,
-        onMutationApplied: @MainActor () -> Void = {}
+        onMutationApplied: @MainActor @escaping () -> Void = {}
     ) async throws {
         try await LibraryMutationActions.addPlaylistToLibrary(
             playlist,
@@ -110,7 +110,7 @@ enum SongActionsHelper {
         _ playlist: Playlist,
         client: any YTMusicClientProtocol,
         libraryViewModel: LibraryViewModel?,
-        onMutationApplied: @MainActor () -> Void = {}
+        onMutationApplied: @MainActor @escaping () -> Void = {}
     ) async throws {
         try await LibraryMutationActions.removePlaylistFromLibrary(
             playlist,
@@ -324,45 +324,48 @@ enum SongActionsHelper {
         }
 
         do {
-            let playlistId = try await request.client.createPlaylist(
-                title: title,
-                description: nil,
-                privacyStatus: .private,
-                videoIds: request.videoIds
-            )
-            guard !Task.isCancelled, request.isValid() else {
-                throw CancellationError()
-            }
-            let playlist = Playlist(
-                id: playlistId,
-                title: title,
-                description: nil,
-                thumbnailURL: request.thumbnailURL,
-                trackCount: request.videoIds.count,
-                canDelete: true
-            )
+            let playlist = try await LibraryMutationActions.withAccountBoundaryTracking {
+                let playlistId = try await request.client.createPlaylist(
+                    title: title,
+                    description: nil,
+                    privacyStatus: .private,
+                    videoIds: request.videoIds
+                )
+                guard !Task.isCancelled, request.isValid() else {
+                    throw CancellationError()
+                }
+                let playlist = Playlist(
+                    id: playlistId,
+                    title: title,
+                    description: nil,
+                    thumbnailURL: request.thumbnailURL,
+                    trackCount: request.videoIds.count,
+                    canDelete: true
+                )
 
-            Self.invalidateLibraryResponseCaches()
-            LibraryMutationBroadcaster.shared.playlistCreated(playlist)
+                Self.invalidateLibraryResponseCaches()
+                LibraryMutationBroadcaster.shared.playlistCreated(playlist)
 
-            // Library browse responses can lag briefly behind a successful playlist creation.
-            // Refresh in the background, but keep the optimistic playlist visible if the
-            // cache/backend still returns a stale snapshot.
-            try? await Task.sleep(for: .milliseconds(500))
-            guard !Task.isCancelled, request.isValid() else {
-                LibraryMutationBroadcaster.shared.discardCreatedPlaylist(playlist)
-                throw CancellationError()
+                // Library browse responses can lag briefly behind a successful playlist creation.
+                // Refresh in the background, but keep the optimistic playlist visible if the
+                // cache/backend still returns a stale snapshot.
+                try? await Task.sleep(for: .milliseconds(500))
+                guard !Task.isCancelled, request.isValid() else {
+                    LibraryMutationBroadcaster.shared.discardCreatedPlaylist(playlist)
+                    throw CancellationError()
+                }
+                Self.invalidateLibraryResponseCaches()
+                let didReconcile = await LibraryMutationBroadcaster.shared.reconcileCreatedPlaylist(
+                    playlist,
+                    whileValid: { !Task.isCancelled && request.isValid() }
+                )
+                guard didReconcile, !Task.isCancelled, request.isValid() else {
+                    LibraryMutationBroadcaster.shared.discardCreatedPlaylist(playlist)
+                    throw CancellationError()
+                }
+                Self.invalidateLibraryResponseCaches()
+                return playlist
             }
-            Self.invalidateLibraryResponseCaches()
-            let didReconcile = await LibraryMutationBroadcaster.shared.reconcileCreatedPlaylist(
-                playlist,
-                whileValid: request.isValid
-            )
-            guard didReconcile, !Task.isCancelled, request.isValid() else {
-                LibraryMutationBroadcaster.shared.discardCreatedPlaylist(playlist)
-                throw CancellationError()
-            }
-            Self.invalidateLibraryResponseCaches()
 
             completion(.success(playlist))
         } catch is CancellationError {

--- a/Sources/Kaset/Views/SignInRequiredView.swift
+++ b/Sources/Kaset/Views/SignInRequiredView.swift
@@ -31,7 +31,9 @@ struct SignInRequiredView: View {
 
             Button {
                 if shouldExitGuestMode {
-                    self.authService.exitGuestMode(activeAccountID: self.accountService.currentAccount?.id)
+                    Task { @MainActor in
+                        await self.authService.exitGuestMode(activeAccountID: self.accountService.currentAccount?.id)
+                    }
                 } else {
                     self.authService.startLogin()
                 }

--- a/Tests/KasetTests/AccountServiceTests.swift
+++ b/Tests/KasetTests/AccountServiceTests.swift
@@ -157,6 +157,13 @@ struct AccountServiceTests {
         )
         await services.account.fetchAccounts()
         let initialScope = try #require(services.account.currentFavoritesScopeID)
+        let begins = LockedCounter()
+        let ends = LockedCounter()
+        services.account.setAccountBoundaryHandlers(
+            willBegin: { begins.increment() },
+            didEnd: { ends.increment() },
+            drain: {}
+        )
 
         services.client.accountsListResponse = AccountsListResponse(
             googleEmail: "different@example.test",
@@ -164,6 +171,8 @@ struct AccountServiceTests {
         )
         await services.account.fetchAccounts()
         #expect(services.account.currentFavoritesScopeID == nil)
+        #expect(begins.count == 1)
+        #expect(ends.count == 1)
 
         services.auth.sessionExpired()
         services.account.authenticationIdentityDidChange()
@@ -515,6 +524,67 @@ struct AccountServiceTests {
         #expect(services.account.currentFavoritesScopeID == nil)
     }
 
+    @Test @MainActor func staleAccountFetchCannotPublishWhileBoundaryDrainIsPending() async {
+        let services = Self.createService()
+        services.auth.completeLogin(sapisid: "first-session")
+        let drainStarted = AsyncGate()
+        let releaseDrain = AsyncGate()
+        let primary = UserAccount.from(
+            name: "First User",
+            handle: "@first",
+            brandId: nil,
+            thumbnailURL: nil,
+            isSelected: true
+        )
+        services.client.accountsListResponse = AccountsListResponse(
+            googleEmail: "first@example.test",
+            accounts: [primary]
+        )
+        services.account.setAccountBoundaryHandlers(
+            willBegin: {},
+            didEnd: {},
+            drain: {
+                await drainStarted.open()
+                await releaseDrain.wait()
+            }
+        )
+
+        let staleFetch = Task { @MainActor in
+            await services.account.fetchAccounts()
+        }
+        await drainStarted.wait()
+        #expect(services.account.accounts.isEmpty)
+        #expect(services.account.currentAccount == nil)
+
+        services.auth.sessionExpired()
+        services.auth.completeLogin(sapisid: "second-session")
+        await releaseDrain.open()
+        await staleFetch.value
+
+        #expect(services.account.accounts.isEmpty)
+        #expect(services.account.currentAccount == nil)
+        #expect(services.account.currentFavoritesScopeID == nil)
+    }
+
+    @Test @MainActor func sameAccountRefreshDoesNotOpenMutationBoundary() async {
+        let services = Self.createService()
+        let begins = LockedCounter()
+        let ends = LockedCounter()
+        let primary = MockUserAccountData.primaryAccount
+        await Self.populateAccounts(services, accounts: [primary])
+        services.account.setAccountBoundaryHandlers(
+            willBegin: { begins.increment() },
+            didEnd: { ends.increment() },
+            drain: {}
+        )
+
+        await services.account.fetchAccounts()
+
+        #expect(services.account.currentAccount?.id == primary.id)
+        #expect(begins.isEmpty)
+        #expect(ends.isEmpty)
+    }
+
     // MARK: - Switch Account Tests
 
     @Test @MainActor func switchAccountUpdatesCurrentAccount() async throws {
@@ -612,6 +682,42 @@ struct AccountServiceTests {
         #expect(mockWebKit.switchSessionIdentityCalled == true)
         #expect(mockWebKit.switchSessionIdentityExpectedBrandIds == [brandAccount.brandId])
         #expect(services.account.currentAccount == brandAccount)
+    }
+
+    @Test @MainActor func accountTransitionPreparationRunsBeforeSessionNavigation() async throws {
+        let mockWebKit = MockWebKitManager()
+        let services = Self.createService(webKitManager: mockWebKit)
+        let begins = LockedCounter()
+        let ends = LockedCounter()
+        let drainStarted = AsyncGate()
+        let releaseDrain = AsyncGate()
+        let primary = MockUserAccountData.primaryAccount
+        let brand = MockUserAccountData.brandAccountWithSigninURL
+        await Self.populateAccounts(services, accounts: [primary, brand])
+
+        services.account.setAccountBoundaryHandlers(
+            willBegin: { begins.increment() },
+            didEnd: { ends.increment() },
+            drain: {
+                await drainStarted.open()
+                await releaseDrain.wait()
+            }
+        )
+        mockWebKit.switchSessionIdentityGate = {
+            #expect(begins.count > ends.count)
+        }
+
+        let switchTask = Task {
+            try await services.account.switchAccount(to: brand)
+        }
+        await drainStarted.wait()
+        #expect(!mockWebKit.switchSessionIdentityCalled)
+        await releaseDrain.open()
+        try await switchTask.value
+
+        #expect(begins.count >= 1)
+        #expect(ends.count == begins.count)
+        #expect(mockWebKit.switchSessionIdentityCompletedBrandIds == [brand.brandId])
     }
 
     @Test @MainActor func failedSessionSwitchRevertsToPreviousAccount() async throws {
@@ -1313,7 +1419,7 @@ struct AccountServiceTests {
         await services.account.awaitRestoredSessionPinForTesting()
         mockWebKit.reset()
 
-        services.auth.enterGuestMode()
+        await services.auth.enterGuestMode()
         #expect(services.auth.isGuestModeEnabled)
 
         try await services.account.switchAccount(to: brand)
@@ -1341,7 +1447,7 @@ struct AccountServiceTests {
             nil,
         ]
 
-        services.auth.enterGuestMode()
+        await services.auth.enterGuestMode()
         await #expect(throws: SessionSwitchError.self) {
             try await services.account.switchAccount(to: brand)
         }
@@ -1421,6 +1527,53 @@ struct AccountServiceTests {
         #expect(services.account.verifiedAccountId == primaryAccount.id)
         #expect(services.account.lastError != nil)
         #expect(SongLikeStatusManager.shared.activeAccountID == primaryAccount.id)
+    }
+
+    @Test @MainActor func staleRestoredBrandFallbackCannotRecreateSignedOutSession() async {
+        let mockWebKit = MockWebKitManager()
+        let services = Self.createService(webKitManager: mockWebKit)
+        let fallbackDrainStarted = AsyncGate()
+        let releaseFallbackDrain = AsyncGate()
+        let drainCount = LockedCounter()
+        let primaryAccount = UserAccount.from(
+            name: "Primary", handle: "@primary", brandId: nil, thumbnailURL: nil, isSelected: true,
+            signinURL: URL(string: "https://example.com/mock-signin")
+        )
+        let brandAccount = MockUserAccountData.brandAccountWithSigninURL
+        UserDefaults.standard.set(brandAccount.id, forKey: "selectedBrandId")
+        defer { UserDefaults.standard.removeObject(forKey: "selectedBrandId") }
+
+        services.account.setAccountBoundaryHandlers(
+            willBegin: {},
+            didEnd: {},
+            drain: {
+                drainCount.increment()
+                if drainCount.count == 3 {
+                    await fallbackDrainStarted.open()
+                    await releaseFallbackDrain.wait()
+                }
+            }
+        )
+        mockWebKit.switchSessionIdentityErrorQueue = [
+            SessionSwitchError.identityNotApplied(expectedBrandId: brandAccount.brandId),
+            nil,
+        ]
+        services.client.accountsListResponse = AccountsListResponse(
+            googleEmail: "test@gmail.com",
+            accounts: [primaryAccount, brandAccount]
+        )
+        services.auth.completeLogin(sapisid: "test-sapisid")
+        await services.account.fetchAccounts()
+        await fallbackDrainStarted.wait()
+
+        services.auth.sessionExpired()
+        await releaseFallbackDrain.open()
+        await services.account.awaitRestoredSessionPinForTesting()
+
+        #expect(services.auth.state == .loggedOut)
+        #expect(mockWebKit.switchSessionIdentityExpectedBrandIds == [brandAccount.brandId])
+        #expect(services.account.currentAccount?.id == brandAccount.id)
+        #expect(services.account.verifiedAccountId == nil)
     }
 
     @Test @MainActor func restoredBrandWithoutSigninURLFallsBackToPrimary() async {

--- a/Tests/KasetTests/AccountServiceTests.swift
+++ b/Tests/KasetTests/AccountServiceTests.swift
@@ -76,6 +76,7 @@ struct AccountServiceTests {
         )
         await services.account.fetchAccounts()
         #expect(services.account.currentFavoritesScopeID == nil)
+        let provisionalContentScope = try #require(services.account.currentAccountScopeID)
         #expect(!FavoritesManager.shared.canMutate)
 
         services.client.accountsListResponse = AccountsListResponse(
@@ -84,6 +85,7 @@ struct AccountServiceTests {
         )
         await services.account.fetchAccounts()
         let resolvedScope = try #require(services.account.currentFavoritesScopeID)
+        #expect(services.account.currentAccountScopeID == provisionalContentScope)
 
         let renamedPrimary = UserAccount.from(
             name: "Renamed Profile",
@@ -98,6 +100,7 @@ struct AccountServiceTests {
         )
         await services.account.fetchAccounts()
         #expect(services.account.currentFavoritesScopeID == resolvedScope)
+        #expect(services.account.currentAccountScopeID == provisionalContentScope)
 
         services.client.accountsListResponse = AccountsListResponse(
             googleEmail: "different@example.test",
@@ -105,6 +108,8 @@ struct AccountServiceTests {
         )
         await services.account.fetchAccounts()
         #expect(services.account.currentFavoritesScopeID == nil)
+        let conflictedContentScope = try #require(services.account.currentAccountScopeID)
+        #expect(conflictedContentScope != provisionalContentScope)
 
         services.client.accountsListResponse = AccountsListResponse(
             googleEmail: "owner@example.test",
@@ -112,6 +117,8 @@ struct AccountServiceTests {
         )
         await services.account.fetchAccounts()
         #expect(services.account.currentFavoritesScopeID == resolvedScope)
+        let recoveredContentScope = try #require(services.account.currentAccountScopeID)
+        #expect(recoveredContentScope != conflictedContentScope)
 
         services.auth.sessionExpired()
         services.account.authenticationIdentityDidChange()
@@ -122,6 +129,8 @@ struct AccountServiceTests {
         )
         await services.account.fetchAccounts()
         #expect(services.account.currentFavoritesScopeID == nil)
+        let newAuthenticationContentScope = try #require(services.account.currentAccountScopeID)
+        #expect(newAuthenticationContentScope != recoveredContentScope)
 
         services.client.accountsListResponse = AccountsListResponse(
             googleEmail: "owner@example.test",
@@ -129,6 +138,7 @@ struct AccountServiceTests {
         )
         await services.account.fetchAccounts()
         #expect(services.account.currentFavoritesScopeID == resolvedScope)
+        #expect(services.account.currentAccountScopeID == newAuthenticationContentScope)
     }
 
     @Test @MainActor func unverifiedEmailChangeDoesNotBecomeOwnerAlias() async throws {
@@ -199,14 +209,33 @@ struct AccountServiceTests {
         services.account.authenticationIdentityDidChange()
         services.auth.completeLogin(sapisid: "first-session")
         services.client.accountsListResponse = AccountsListResponse(
+            googleEmail: nil,
+            accounts: [primary]
+        )
+        await services.account.fetchAccounts()
+        let unresolvedContentScope = try #require(services.account.currentAccountScopeID)
+        #expect(services.account.currentFavoritesScopeID == nil)
+
+        services.client.accountsListResponse = AccountsListResponse(
             googleEmail: "second@example.test",
             accounts: [primary]
         )
         await services.account.fetchAccounts()
 
         #expect(services.account.currentFavoritesScopeID == nil)
+        let conflictedContentScope = try #require(services.account.currentAccountScopeID)
+        #expect(conflictedContentScope != unresolvedContentScope)
         #expect(!FavoritesManager.shared.canMutate)
         #expect(!FavoritesManager.shared.isPinned(contentId: "first-owner-favorite"))
+
+        services.client.accountsListResponse = AccountsListResponse(
+            googleEmail: "first@example.test",
+            accounts: [primary]
+        )
+        await services.account.fetchAccounts()
+
+        #expect(services.account.currentFavoritesScopeID == firstScope)
+        #expect(services.account.currentAccountScopeID != conflictedContentScope)
     }
 
     @Test @MainActor func reauthenticationDoesNotReuseOwnerForEmailLessResponse() async throws {

--- a/Tests/KasetTests/ArtistDetailViewModelTests.swift
+++ b/Tests/KasetTests/ArtistDetailViewModelTests.swift
@@ -3,425 +3,427 @@ import Testing
 @testable import Kaset
 
 /// Tests for ArtistDetailViewModel using mock client.
-@Suite(.serialized, .tags(.viewModel), .timeLimit(.minutes(1)))
-@MainActor
-struct ArtistDetailViewModelTests {
-    var mockClient: MockYTMusicClient
-    var libraryViewModel: LibraryViewModel
-    var viewModel: ArtistDetailViewModel
+extension LibraryMutationSerialTests {
+    @Suite(.tags(.viewModel), .timeLimit(.minutes(1)))
+    @MainActor
+    struct ArtistDetailViewModelTests {
+        var mockClient: MockYTMusicClient
+        var libraryViewModel: LibraryViewModel
+        var viewModel: ArtistDetailViewModel
 
-    init() {
-        self.mockClient = MockYTMusicClient()
-        self.libraryViewModel = LibraryViewModel(client: self.mockClient)
-        let artist = TestFixtures.makeArtist(id: "UC-test-artist", name: "Test Artist")
-        self.viewModel = ArtistDetailViewModel(
-            artist: artist,
-            client: self.mockClient,
-            libraryViewModel: self.libraryViewModel
-        )
-        SongActionsHelper.artistLibraryReconciliationRetryDelays = [.milliseconds(1), .milliseconds(1)]
-    }
-
-    private func awaitArtistReconciliation(refreshes expectedRefreshCount: Int = 1) async {
-        let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: .seconds(1))
-
-        while self.mockClient.getLibraryContentCallCount < expectedRefreshCount {
-            guard clock.now < deadline else { return }
-            try? await Task.sleep(for: .milliseconds(10))
+        init() {
+            self.mockClient = MockYTMusicClient()
+            self.libraryViewModel = LibraryViewModel(client: self.mockClient)
+            let artist = TestFixtures.makeArtist(id: "UC-test-artist", name: "Test Artist")
+            self.viewModel = ArtistDetailViewModel(
+                artist: artist,
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel
+            )
+            SongActionsHelper.artistLibraryReconciliationRetryDelays = [.milliseconds(1), .milliseconds(1)]
         }
-    }
 
-    // MARK: - Initial State Tests
+        private func awaitArtistReconciliation(refreshes expectedRefreshCount: Int = 1) async {
+            let clock = ContinuousClock()
+            let deadline = clock.now.advanced(by: .seconds(1))
 
-    @Test("Initial state is idle with no artist detail")
-    func initialState() {
-        #expect(self.viewModel.loadingState == .idle)
-        #expect(self.viewModel.artistDetail == nil)
-        #expect(self.viewModel.showAllSongs == false)
-    }
-
-    // MARK: - Load Tests
-
-    @Test("Load success sets artist detail")
-    func loadSuccess() async {
-        let artistDetail = TestFixtures.makeArtistDetail(
-            artist: TestFixtures.makeArtist(id: "UC-test-artist"),
-            songCount: 10,
-            albumCount: 3,
-            playlistCount: 2,
-            featuredOnPlaylistCount: 1,
-            similarArtistCount: 2
-        )
-        self.mockClient.artistDetails["UC-test-artist"] = artistDetail
-
-        await self.viewModel.load()
-
-        #expect(self.mockClient.getArtistCalled == true)
-        #expect(self.mockClient.getArtistIds.first == "UC-test-artist")
-        #expect(self.viewModel.loadingState == .loaded)
-        #expect(self.viewModel.artistDetail != nil)
-        #expect(self.viewModel.artistDetail?.songs.count == 10)
-        #expect(self.viewModel.artistDetail?.orderedSections.map(\.title) == ["Albums", "Featured on", "Playlists", "Similar artists"])
-    }
-
-    @Test("Load error sets error state")
-    func loadError() async {
-        self.mockClient.shouldThrowError = YTMusicError.networkError(underlying: URLError(.notConnectedToInternet))
-
-        await self.viewModel.load()
-
-        #expect(self.mockClient.getArtistCalled == true)
-        if case let .error(error) = viewModel.loadingState {
-            #expect(!error.message.isEmpty)
-            #expect(error.isRetryable)
-        } else {
-            Issue.record("Expected error state")
+            while self.mockClient.getLibraryContentCallCount < expectedRefreshCount {
+                guard clock.now < deadline else { return }
+                try? await Task.sleep(for: .milliseconds(10))
+            }
         }
-        #expect(self.viewModel.artistDetail == nil)
-    }
 
-    @Test("Load does not duplicate when already loading")
-    func loadDoesNotDuplicateWhenAlreadyLoading() async {
-        let artistDetail = TestFixtures.makeArtistDetail(
-            artist: TestFixtures.makeArtist(id: "UC-test-artist"),
-            songCount: 5
-        )
-        self.mockClient.artistDetails["UC-test-artist"] = artistDetail
+        // MARK: - Initial State Tests
 
-        await self.viewModel.load()
-        await self.viewModel.load()
+        @Test("Initial state is idle with no artist detail")
+        func initialState() {
+            #expect(self.viewModel.loadingState == .idle)
+            #expect(self.viewModel.artistDetail == nil)
+            #expect(self.viewModel.showAllSongs == false)
+        }
 
-        #expect(self.viewModel.loadingState == .loaded)
-    }
+        // MARK: - Load Tests
 
-    @Test("Load uses original artist info for unknown name")
-    func loadUsesOriginalArtistInfoForUnknownName() async {
-        let originalArtist = TestFixtures.makeArtist(
-            id: "UC-test-artist",
-            name: "Test Artist",
-            profileKind: .profile
-        )
-        let viewModel = ArtistDetailViewModel(
-            artist: originalArtist,
-            client: self.mockClient,
-            libraryViewModel: self.libraryViewModel
-        )
+        @Test("Load success sets artist detail")
+        func loadSuccess() async {
+            let artistDetail = TestFixtures.makeArtistDetail(
+                artist: TestFixtures.makeArtist(id: "UC-test-artist"),
+                songCount: 10,
+                albumCount: 3,
+                playlistCount: 2,
+                featuredOnPlaylistCount: 1,
+                similarArtistCount: 2
+            )
+            self.mockClient.artistDetails["UC-test-artist"] = artistDetail
 
-        // Create an artist detail with "Unknown Artist" name
-        let unknownArtist = Artist(
-            id: "UC-test-artist",
-            name: "Unknown Artist",
-            thumbnailURL: nil,
-            profileKind: .unknown
-        )
-        let artistDetail = ArtistDetail(
-            artist: unknownArtist,
-            description: nil,
-            songs: TestFixtures.makeSongs(count: 3),
-            orderedSections: [
-                ArtistDetailSection(
-                    title: "Singles & EPs",
-                    content: .albums([TestFixtures.makeAlbum(id: "MPRE-single", title: "Single")])
-                ),
-                ArtistDetailSection(
-                    title: "Featured on",
-                    content: .playlists([TestFixtures.makePlaylist(id: "VL-featured", title: "Featured Playlist")])
-                ),
-                ArtistDetailSection(
-                    title: "Playlists on repeat",
-                    content: .playlists([TestFixtures.makePlaylist(id: "VL-preserved", title: "Preserved Playlist")])
-                ),
-                ArtistDetailSection(
-                    title: "Artists on repeat",
-                    content: .artists([TestFixtures.makeArtist(id: "UC-similar", name: "Similar Artist")])
-                ),
-            ],
-            thumbnailURL: nil,
-            monthlyAudience: "2.59M"
-        )
-        self.mockClient.artistDetails["UC-test-artist"] = artistDetail
+            await self.viewModel.load()
 
-        await viewModel.load()
+            #expect(self.mockClient.getArtistCalled == true)
+            #expect(self.mockClient.getArtistIds.first == "UC-test-artist")
+            #expect(self.viewModel.loadingState == .loaded)
+            #expect(self.viewModel.artistDetail != nil)
+            #expect(self.viewModel.artistDetail?.songs.count == 10)
+            #expect(self.viewModel.artistDetail?.orderedSections.map(\.title) == ["Albums", "Featured on", "Playlists", "Similar artists"])
+        }
 
-        // Should use original artist name "Test Artist" instead of "Unknown Artist"
-        #expect(viewModel.artistDetail?.name == "Test Artist")
-        #expect(viewModel.artistDetail?.profileKind == .profile)
-        #expect(viewModel.artistDetail?.monthlyAudience == "2.59M")
-        #expect(viewModel.artistDetail?.orderedSections.map(\.title) == ["Singles & EPs", "Featured on", "Playlists on repeat", "Artists on repeat"])
-    }
+        @Test("Load error sets error state")
+        func loadError() async {
+            self.mockClient.shouldThrowError = YTMusicError.networkError(underlying: URLError(.notConnectedToInternet))
 
-    // MARK: - Refresh Tests
+            await self.viewModel.load()
 
-    @Test("Refresh clears detail and reloads")
-    func refreshClearsDetailAndReloads() async {
-        let artistDetail = TestFixtures.makeArtistDetail(
-            artist: TestFixtures.makeArtist(id: "UC-test-artist"),
-            songCount: 5
-        )
-        self.mockClient.artistDetails["UC-test-artist"] = artistDetail
+            #expect(self.mockClient.getArtistCalled == true)
+            if case let .error(error) = viewModel.loadingState {
+                #expect(!error.message.isEmpty)
+                #expect(error.isRetryable)
+            } else {
+                Issue.record("Expected error state")
+            }
+            #expect(self.viewModel.artistDetail == nil)
+        }
 
-        await self.viewModel.load()
-        #expect(self.viewModel.artistDetail?.songs.count == 5)
+        @Test("Load does not duplicate when already loading")
+        func loadDoesNotDuplicateWhenAlreadyLoading() async {
+            let artistDetail = TestFixtures.makeArtistDetail(
+                artist: TestFixtures.makeArtist(id: "UC-test-artist"),
+                songCount: 5
+            )
+            self.mockClient.artistDetails["UC-test-artist"] = artistDetail
 
-        // Update mock to return different song count
-        let newArtistDetail = TestFixtures.makeArtistDetail(
-            artist: TestFixtures.makeArtist(id: "UC-test-artist"),
-            songCount: 8
-        )
-        self.mockClient.artistDetails["UC-test-artist"] = newArtistDetail
+            await self.viewModel.load()
+            await self.viewModel.load()
 
-        await self.viewModel.refresh()
+            #expect(self.viewModel.loadingState == .loaded)
+        }
 
-        #expect(self.viewModel.artistDetail?.songs.count == 8)
-        #expect(self.viewModel.showAllSongs == false)
-    }
+        @Test("Load uses original artist info for unknown name")
+        func loadUsesOriginalArtistInfoForUnknownName() async {
+            let originalArtist = TestFixtures.makeArtist(
+                id: "UC-test-artist",
+                name: "Test Artist",
+                profileKind: .profile
+            )
+            let viewModel = ArtistDetailViewModel(
+                artist: originalArtist,
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel
+            )
 
-    // MARK: - Displayed Songs Tests
+            // Create an artist detail with "Unknown Artist" name
+            let unknownArtist = Artist(
+                id: "UC-test-artist",
+                name: "Unknown Artist",
+                thumbnailURL: nil,
+                profileKind: .unknown
+            )
+            let artistDetail = ArtistDetail(
+                artist: unknownArtist,
+                description: nil,
+                songs: TestFixtures.makeSongs(count: 3),
+                orderedSections: [
+                    ArtistDetailSection(
+                        title: "Singles & EPs",
+                        content: .albums([TestFixtures.makeAlbum(id: "MPRE-single", title: "Single")])
+                    ),
+                    ArtistDetailSection(
+                        title: "Featured on",
+                        content: .playlists([TestFixtures.makePlaylist(id: "VL-featured", title: "Featured Playlist")])
+                    ),
+                    ArtistDetailSection(
+                        title: "Playlists on repeat",
+                        content: .playlists([TestFixtures.makePlaylist(id: "VL-preserved", title: "Preserved Playlist")])
+                    ),
+                    ArtistDetailSection(
+                        title: "Artists on repeat",
+                        content: .artists([TestFixtures.makeArtist(id: "UC-similar", name: "Similar Artist")])
+                    ),
+                ],
+                thumbnailURL: nil,
+                monthlyAudience: "2.59M"
+            )
+            self.mockClient.artistDetails["UC-test-artist"] = artistDetail
 
-    @Test("displayedSongs returns preview count by default")
-    func displayedSongsReturnsPreviewCount() async {
-        let artistDetail = TestFixtures.makeArtistDetail(
-            artist: TestFixtures.makeArtist(id: "UC-test-artist"),
-            songCount: 10
-        )
-        self.mockClient.artistDetails["UC-test-artist"] = artistDetail
+            await viewModel.load()
 
-        await self.viewModel.load()
+            // Should use original artist name "Test Artist" instead of "Unknown Artist"
+            #expect(viewModel.artistDetail?.name == "Test Artist")
+            #expect(viewModel.artistDetail?.profileKind == .profile)
+            #expect(viewModel.artistDetail?.monthlyAudience == "2.59M")
+            #expect(viewModel.artistDetail?.orderedSections.map(\.title) == ["Singles & EPs", "Featured on", "Playlists on repeat", "Artists on repeat"])
+        }
 
-        #expect(self.viewModel.displayedSongs.count == ArtistDetailViewModel.previewSongCount)
-    }
+        // MARK: - Refresh Tests
 
-    @Test("displayedSongs returns all songs when showAllSongs is true")
-    func displayedSongsReturnsAllWhenShowAllSongs() async {
-        let artistDetail = TestFixtures.makeArtistDetail(
-            artist: TestFixtures.makeArtist(id: "UC-test-artist"),
-            songCount: 10
-        )
-        self.mockClient.artistDetails["UC-test-artist"] = artistDetail
+        @Test("Refresh clears detail and reloads")
+        func refreshClearsDetailAndReloads() async {
+            let artistDetail = TestFixtures.makeArtistDetail(
+                artist: TestFixtures.makeArtist(id: "UC-test-artist"),
+                songCount: 5
+            )
+            self.mockClient.artistDetails["UC-test-artist"] = artistDetail
 
-        await self.viewModel.load()
-        self.viewModel.showAllSongs = true
+            await self.viewModel.load()
+            #expect(self.viewModel.artistDetail?.songs.count == 5)
 
-        #expect(self.viewModel.displayedSongs.count == 10)
-    }
+            // Update mock to return different song count
+            let newArtistDetail = TestFixtures.makeArtistDetail(
+                artist: TestFixtures.makeArtist(id: "UC-test-artist"),
+                songCount: 8
+            )
+            self.mockClient.artistDetails["UC-test-artist"] = newArtistDetail
 
-    @Test("displayedSongs returns empty when no detail")
-    func displayedSongsReturnsEmptyWhenNoDetail() {
-        #expect(self.viewModel.displayedSongs.isEmpty)
-    }
+            await self.viewModel.refresh()
 
-    // MARK: - Has More Songs Tests
+            #expect(self.viewModel.artistDetail?.songs.count == 8)
+            #expect(self.viewModel.showAllSongs == false)
+        }
 
-    @Test("hasMoreSongs returns false when no detail")
-    func hasMoreSongsReturnsFalseWhenNoDetail() {
-        #expect(self.viewModel.hasMoreSongs == false)
-    }
+        // MARK: - Displayed Songs Tests
 
-    @Test("hasMoreSongs returns true when songs exceed preview count")
-    func hasMoreSongsReturnsTrueWhenExceedsPreview() async {
-        let artistDetail = TestFixtures.makeArtistDetail(
-            artist: TestFixtures.makeArtist(id: "UC-test-artist"),
-            songCount: 10 // More than previewSongCount
-        )
-        self.mockClient.artistDetails["UC-test-artist"] = artistDetail
+        @Test("displayedSongs returns preview count by default")
+        func displayedSongsReturnsPreviewCount() async {
+            let artistDetail = TestFixtures.makeArtistDetail(
+                artist: TestFixtures.makeArtist(id: "UC-test-artist"),
+                songCount: 10
+            )
+            self.mockClient.artistDetails["UC-test-artist"] = artistDetail
 
-        await self.viewModel.load()
+            await self.viewModel.load()
 
-        #expect(self.viewModel.hasMoreSongs == true)
-    }
+            #expect(self.viewModel.displayedSongs.count == ArtistDetailViewModel.previewSongCount)
+        }
 
-    @Test("hasMoreSongs returns false when songs within preview count")
-    func hasMoreSongsReturnsFalseWhenWithinPreview() async {
-        let artistDetail = TestFixtures.makeArtistDetail(
-            artist: TestFixtures.makeArtist(id: "UC-test-artist"),
-            songCount: 3 // Less than previewSongCount
-        )
-        self.mockClient.artistDetails["UC-test-artist"] = artistDetail
+        @Test("displayedSongs returns all songs when showAllSongs is true")
+        func displayedSongsReturnsAllWhenShowAllSongs() async {
+            let artistDetail = TestFixtures.makeArtistDetail(
+                artist: TestFixtures.makeArtist(id: "UC-test-artist"),
+                songCount: 10
+            )
+            self.mockClient.artistDetails["UC-test-artist"] = artistDetail
 
-        await self.viewModel.load()
+            await self.viewModel.load()
+            self.viewModel.showAllSongs = true
 
-        #expect(self.viewModel.hasMoreSongs == false)
-    }
+            #expect(self.viewModel.displayedSongs.count == 10)
+        }
 
-    // MARK: - Subscription Tests
+        @Test("displayedSongs returns empty when no detail")
+        func displayedSongsReturnsEmptyWhenNoDetail() {
+            #expect(self.viewModel.displayedSongs.isEmpty)
+        }
 
-    @Test("toggleSubscription does nothing without channel ID")
-    func toggleSubscriptionNoChannelId() async {
-        let artistDetail = ArtistDetail(
-            artist: TestFixtures.makeArtist(id: "UC-test-artist"),
-            description: nil,
-            songs: [],
-            thumbnailURL: nil,
-            channelId: nil // No channel ID
-        )
-        self.mockClient.artistDetails["UC-test-artist"] = artistDetail
+        // MARK: - Has More Songs Tests
 
-        await self.viewModel.load()
-        await self.viewModel.toggleSubscription()
+        @Test("hasMoreSongs returns false when no detail")
+        func hasMoreSongsReturnsFalseWhenNoDetail() {
+            #expect(self.viewModel.hasMoreSongs == false)
+        }
 
-        #expect(self.mockClient.subscribeToArtistCalled == false)
-        #expect(self.mockClient.unsubscribeFromArtistCalled == false)
-    }
+        @Test("hasMoreSongs returns true when songs exceed preview count")
+        func hasMoreSongsReturnsTrueWhenExceedsPreview() async {
+            let artistDetail = TestFixtures.makeArtistDetail(
+                artist: TestFixtures.makeArtist(id: "UC-test-artist"),
+                songCount: 10 // More than previewSongCount
+            )
+            self.mockClient.artistDetails["UC-test-artist"] = artistDetail
 
-    @Test("toggleSubscription subscribes and refreshes the library")
-    func toggleSubscriptionSubscribes() async {
-        let artistDetail = ArtistDetail(
-            artist: TestFixtures.makeArtist(id: "MPLAUC-channel-123", name: "Test Artist"),
-            description: nil,
-            songs: [],
-            thumbnailURL: nil,
-            channelId: "UC-channel-123",
-            isSubscribed: false
-        )
-        self.mockClient.artistDetails["UC-test-artist"] = artistDetail
+            await self.viewModel.load()
 
-        await self.viewModel.load()
-        self.mockClient.reset()
-        await self.viewModel.toggleSubscription()
-        await self.awaitArtistReconciliation()
+            #expect(self.viewModel.hasMoreSongs == true)
+        }
 
-        #expect(self.mockClient.subscribeToArtistCalled == true)
-        #expect(self.mockClient.subscribeToArtistIds.first == "UC-channel-123")
-        #expect(self.mockClient.getLibraryContentCalled == true)
-        #expect(self.viewModel.artistDetail?.isSubscribed == true)
-        #expect(self.libraryViewModel.libraryArtistIds == Set(["UC-channel-123"]))
-        #expect(self.libraryViewModel.isInLibrary(artistId: "UC-channel-123") == true)
-        #expect(self.libraryViewModel.artists.first?.id == "UC-channel-123")
-    }
+        @Test("hasMoreSongs returns false when songs within preview count")
+        func hasMoreSongsReturnsFalseWhenWithinPreview() async {
+            let artistDetail = TestFixtures.makeArtistDetail(
+                artist: TestFixtures.makeArtist(id: "UC-test-artist"),
+                songCount: 3 // Less than previewSongCount
+            )
+            self.mockClient.artistDetails["UC-test-artist"] = artistDetail
 
-    @Test("toggleSubscription keeps optimistic artist when refresh response is stale")
-    func toggleSubscriptionSubscribePreservesOptimisticArtist() async {
-        let artistDetail = ArtistDetail(
-            artist: TestFixtures.makeArtist(id: "MPLAUC-channel-123", name: "Test Artist"),
-            description: nil,
-            songs: [],
-            thumbnailURL: nil,
-            channelId: "UC-channel-123",
-            isSubscribed: false
-        )
-        self.mockClient.artistDetails["UC-test-artist"] = artistDetail
-        self.mockClient.shouldAutoUpdateArtistLibraryOnMutation = false
+            await self.viewModel.load()
 
-        await self.viewModel.load()
-        self.mockClient.reset()
-        await self.viewModel.toggleSubscription()
-        await self.awaitArtistReconciliation(refreshes: 2)
+            #expect(self.viewModel.hasMoreSongs == false)
+        }
 
-        #expect(self.mockClient.subscribeToArtistCalled == true)
-        #expect(self.mockClient.getLibraryContentCalled == true)
-        #expect(self.viewModel.artistDetail?.isSubscribed == true)
-        #expect(self.libraryViewModel.isInLibrary(artistId: "UC-channel-123") == true)
-        #expect(self.libraryViewModel.artists.first?.id == "UC-channel-123")
-    }
+        // MARK: - Subscription Tests
 
-    @Test("toggleSubscription unsubscribes and refreshes the library")
-    func toggleSubscriptionUnsubscribes() async {
-        let artistDetail = ArtistDetail(
-            artist: TestFixtures.makeArtist(id: "MPLAUC-channel-123", name: "Test Artist"),
-            description: nil,
-            songs: [],
-            thumbnailURL: nil,
-            channelId: "UC-channel-123",
-            isSubscribed: true
-        )
-        self.mockClient.artistDetails["UC-test-artist"] = artistDetail
-        self.mockClient.libraryArtists = [
-            TestFixtures.makeArtist(id: "MPLAUC-channel-123", name: "Test Artist"),
-        ]
+        @Test("toggleSubscription does nothing without channel ID")
+        func toggleSubscriptionNoChannelId() async {
+            let artistDetail = ArtistDetail(
+                artist: TestFixtures.makeArtist(id: "UC-test-artist"),
+                description: nil,
+                songs: [],
+                thumbnailURL: nil,
+                channelId: nil // No channel ID
+            )
+            self.mockClient.artistDetails["UC-test-artist"] = artistDetail
 
-        await self.libraryViewModel.load()
-        await self.viewModel.load()
-        self.mockClient.reset()
-        await self.viewModel.toggleSubscription()
-        await self.awaitArtistReconciliation()
+            await self.viewModel.load()
+            await self.viewModel.toggleSubscription()
 
-        #expect(self.mockClient.unsubscribeFromArtistCalled == true)
-        #expect(self.mockClient.unsubscribeFromArtistIds.first == "UC-channel-123")
-        #expect(self.mockClient.getLibraryContentCalled == true)
-        #expect(self.viewModel.artistDetail?.isSubscribed == false)
-        #expect(self.libraryViewModel.libraryArtistIds.isEmpty)
-        #expect(self.libraryViewModel.isInLibrary(artistId: "UC-channel-123") == false)
-        #expect(self.libraryViewModel.artists.isEmpty)
-    }
+            #expect(self.mockClient.subscribeToArtistCalled == false)
+            #expect(self.mockClient.unsubscribeFromArtistCalled == false)
+        }
 
-    @Test("toggleSubscription sets error on failure")
-    func toggleSubscriptionSetsErrorOnFailure() async {
-        let artistDetail = ArtistDetail(
-            artist: TestFixtures.makeArtist(id: "UC-test-artist"),
-            description: nil,
-            songs: [],
-            thumbnailURL: nil,
-            channelId: "UC-channel-123",
-            isSubscribed: false
-        )
-        self.mockClient.artistDetails["UC-test-artist"] = artistDetail
+        @Test("toggleSubscription subscribes and refreshes the library")
+        func toggleSubscriptionSubscribes() async {
+            let artistDetail = ArtistDetail(
+                artist: TestFixtures.makeArtist(id: "MPLAUC-channel-123", name: "Test Artist"),
+                description: nil,
+                songs: [],
+                thumbnailURL: nil,
+                channelId: "UC-channel-123",
+                isSubscribed: false
+            )
+            self.mockClient.artistDetails["UC-test-artist"] = artistDetail
 
-        await self.viewModel.load()
-        self.mockClient.shouldThrowError = YTMusicError.networkError(underlying: URLError(.notConnectedToInternet))
+            await self.viewModel.load()
+            self.mockClient.reset()
+            await self.viewModel.toggleSubscription()
+            await self.awaitArtistReconciliation()
 
-        await self.viewModel.toggleSubscription()
+            #expect(self.mockClient.subscribeToArtistCalled == true)
+            #expect(self.mockClient.subscribeToArtistIds.first == "UC-channel-123")
+            #expect(self.mockClient.getLibraryContentCalled == true)
+            #expect(self.viewModel.artistDetail?.isSubscribed == true)
+            #expect(self.libraryViewModel.libraryArtistIds == Set(["UC-channel-123"]))
+            #expect(self.libraryViewModel.isInLibrary(artistId: "UC-channel-123") == true)
+            #expect(self.libraryViewModel.artists.first?.id == "UC-channel-123")
+        }
 
-        #expect(self.viewModel.subscriptionError != nil)
-        #expect(self.viewModel.artistDetail?.isSubscribed == false) // Unchanged
-    }
+        @Test("toggleSubscription keeps optimistic artist when refresh response is stale")
+        func toggleSubscriptionSubscribePreservesOptimisticArtist() async {
+            let artistDetail = ArtistDetail(
+                artist: TestFixtures.makeArtist(id: "MPLAUC-channel-123", name: "Test Artist"),
+                description: nil,
+                songs: [],
+                thumbnailURL: nil,
+                channelId: "UC-channel-123",
+                isSubscribed: false
+            )
+            self.mockClient.artistDetails["UC-test-artist"] = artistDetail
+            self.mockClient.shouldAutoUpdateArtistLibraryOnMutation = false
 
-    // MARK: - Get All Songs Tests
+            await self.viewModel.load()
+            self.mockClient.reset()
+            await self.viewModel.toggleSubscription()
+            await self.awaitArtistReconciliation(refreshes: 2)
 
-    @Test("getAllSongs returns artist detail songs when no browse ID")
-    func getAllSongsReturnsDetailSongs() async {
-        let artistDetail = TestFixtures.makeArtistDetail(
-            artist: TestFixtures.makeArtist(id: "UC-test-artist"),
-            songCount: 5
-        )
-        self.mockClient.artistDetails["UC-test-artist"] = artistDetail
+            #expect(self.mockClient.subscribeToArtistCalled == true)
+            #expect(self.mockClient.getLibraryContentCalled == true)
+            #expect(self.viewModel.artistDetail?.isSubscribed == true)
+            #expect(self.libraryViewModel.isInLibrary(artistId: "UC-channel-123") == true)
+            #expect(self.libraryViewModel.artists.first?.id == "UC-channel-123")
+        }
 
-        await self.viewModel.load()
-        let songs = await self.viewModel.getAllSongs()
+        @Test("toggleSubscription unsubscribes and refreshes the library")
+        func toggleSubscriptionUnsubscribes() async {
+            let artistDetail = ArtistDetail(
+                artist: TestFixtures.makeArtist(id: "MPLAUC-channel-123", name: "Test Artist"),
+                description: nil,
+                songs: [],
+                thumbnailURL: nil,
+                channelId: "UC-channel-123",
+                isSubscribed: true
+            )
+            self.mockClient.artistDetails["UC-test-artist"] = artistDetail
+            self.mockClient.libraryArtists = [
+                TestFixtures.makeArtist(id: "MPLAUC-channel-123", name: "Test Artist"),
+            ]
 
-        #expect(songs.count == 5)
-        #expect(self.mockClient.getArtistSongsCalled == false)
-    }
+            await self.libraryViewModel.load()
+            await self.viewModel.load()
+            self.mockClient.reset()
+            await self.viewModel.toggleSubscription()
+            await self.awaitArtistReconciliation()
 
-    @Test("getAllSongs fetches from API when browse ID available")
-    func getAllSongsFetchesFromAPI() async {
-        let artistDetail = ArtistDetail(
-            artist: TestFixtures.makeArtist(id: "UC-test-artist"),
-            description: nil,
-            songs: TestFixtures.makeSongs(count: 5),
-            thumbnailURL: nil,
-            hasMoreSongs: true,
-            songsBrowseId: "artist-songs-browse-id"
-        )
-        self.mockClient.artistDetails["UC-test-artist"] = artistDetail
-        self.mockClient.artistSongs["artist-songs-browse-id"] = TestFixtures.makeSongs(count: 20)
+            #expect(self.mockClient.unsubscribeFromArtistCalled == true)
+            #expect(self.mockClient.unsubscribeFromArtistIds.first == "UC-channel-123")
+            #expect(self.mockClient.getLibraryContentCalled == true)
+            #expect(self.viewModel.artistDetail?.isSubscribed == false)
+            #expect(self.libraryViewModel.libraryArtistIds.isEmpty)
+            #expect(self.libraryViewModel.isInLibrary(artistId: "UC-channel-123") == false)
+            #expect(self.libraryViewModel.artists.isEmpty)
+        }
 
-        await self.viewModel.load()
-        let songs = await self.viewModel.getAllSongs()
+        @Test("toggleSubscription sets error on failure")
+        func toggleSubscriptionSetsErrorOnFailure() async {
+            let artistDetail = ArtistDetail(
+                artist: TestFixtures.makeArtist(id: "UC-test-artist"),
+                description: nil,
+                songs: [],
+                thumbnailURL: nil,
+                channelId: "UC-channel-123",
+                isSubscribed: false
+            )
+            self.mockClient.artistDetails["UC-test-artist"] = artistDetail
 
-        #expect(songs.count == 20)
-        #expect(self.mockClient.getArtistSongsCalled == true)
-        #expect(self.mockClient.getArtistSongsBrowseIds.first == "artist-songs-browse-id")
-    }
+            await self.viewModel.load()
+            self.mockClient.shouldThrowError = YTMusicError.networkError(underlying: URLError(.notConnectedToInternet))
 
-    @Test("getAllSongs returns cached songs on subsequent calls")
-    func getAllSongsReturnsCached() async {
-        let artistDetail = ArtistDetail(
-            artist: TestFixtures.makeArtist(id: "UC-test-artist"),
-            description: nil,
-            songs: TestFixtures.makeSongs(count: 5),
-            thumbnailURL: nil,
-            hasMoreSongs: true,
-            songsBrowseId: "artist-songs-browse-id"
-        )
-        self.mockClient.artistDetails["UC-test-artist"] = artistDetail
-        self.mockClient.artistSongs["artist-songs-browse-id"] = TestFixtures.makeSongs(count: 20)
+            await self.viewModel.toggleSubscription()
 
-        await self.viewModel.load()
-        _ = await self.viewModel.getAllSongs()
-        _ = await self.viewModel.getAllSongs()
+            #expect(self.viewModel.subscriptionError != nil)
+            #expect(self.viewModel.artistDetail?.isSubscribed == false) // Unchanged
+        }
 
-        // Should only call API once
-        #expect(self.mockClient.getArtistSongsBrowseIds.count == 1)
+        // MARK: - Get All Songs Tests
+
+        @Test("getAllSongs returns artist detail songs when no browse ID")
+        func getAllSongsReturnsDetailSongs() async {
+            let artistDetail = TestFixtures.makeArtistDetail(
+                artist: TestFixtures.makeArtist(id: "UC-test-artist"),
+                songCount: 5
+            )
+            self.mockClient.artistDetails["UC-test-artist"] = artistDetail
+
+            await self.viewModel.load()
+            let songs = await self.viewModel.getAllSongs()
+
+            #expect(songs.count == 5)
+            #expect(self.mockClient.getArtistSongsCalled == false)
+        }
+
+        @Test("getAllSongs fetches from API when browse ID available")
+        func getAllSongsFetchesFromAPI() async {
+            let artistDetail = ArtistDetail(
+                artist: TestFixtures.makeArtist(id: "UC-test-artist"),
+                description: nil,
+                songs: TestFixtures.makeSongs(count: 5),
+                thumbnailURL: nil,
+                hasMoreSongs: true,
+                songsBrowseId: "artist-songs-browse-id"
+            )
+            self.mockClient.artistDetails["UC-test-artist"] = artistDetail
+            self.mockClient.artistSongs["artist-songs-browse-id"] = TestFixtures.makeSongs(count: 20)
+
+            await self.viewModel.load()
+            let songs = await self.viewModel.getAllSongs()
+
+            #expect(songs.count == 20)
+            #expect(self.mockClient.getArtistSongsCalled == true)
+            #expect(self.mockClient.getArtistSongsBrowseIds.first == "artist-songs-browse-id")
+        }
+
+        @Test("getAllSongs returns cached songs on subsequent calls")
+        func getAllSongsReturnsCached() async {
+            let artistDetail = ArtistDetail(
+                artist: TestFixtures.makeArtist(id: "UC-test-artist"),
+                description: nil,
+                songs: TestFixtures.makeSongs(count: 5),
+                thumbnailURL: nil,
+                hasMoreSongs: true,
+                songsBrowseId: "artist-songs-browse-id"
+            )
+            self.mockClient.artistDetails["UC-test-artist"] = artistDetail
+            self.mockClient.artistSongs["artist-songs-browse-id"] = TestFixtures.makeSongs(count: 20)
+
+            await self.viewModel.load()
+            _ = await self.viewModel.getAllSongs()
+            _ = await self.viewModel.getAllSongs()
+
+            // Should only call API once
+            #expect(self.mockClient.getArtistSongsBrowseIds.count == 1)
+        }
     }
 }

--- a/Tests/KasetTests/AuthServiceTests.swift
+++ b/Tests/KasetTests/AuthServiceTests.swift
@@ -105,6 +105,30 @@ struct AuthServiceTests {
         #expect(self.authService.needsReauth == false)
     }
 
+    @Test("Complete login waits for account-boundary drain")
+    func completeLoginWaitsForAccountBoundaryDrain() async {
+        let drainStarted = AsyncGate()
+        let releaseDrain = AsyncGate()
+        self.authService.setAccountBoundaryHandlers(
+            willBegin: {},
+            didEnd: {},
+            drain: {
+                await drainStarted.open()
+                await releaseDrain.wait()
+            }
+        )
+
+        let completionTask = Task {
+            await self.authService.completeLoginAfterDraining(sapisid: "test-sapisid")
+        }
+        await drainStarted.wait()
+        #expect(self.authService.state == .initializing)
+
+        await releaseDrain.open()
+        await completionTask.value
+        #expect(self.authService.state == .loggedIn(sapisid: "test-sapisid"))
+    }
+
     @Test("Session expired transitions to loggedOut and sets needsReauth")
     func sessionExpired() {
         self.authService.completeLogin(sapisid: "test-sapisid")
@@ -180,11 +204,11 @@ struct AuthServiceTests {
         self.authService.completeLogin(sapisid: "placeholder")
 
         let enterRequest = try self.storeCachedResponse(identifier: "enter-guest-mode")
-        self.authService.enterGuestMode()
+        await self.authService.enterGuestMode()
         #expect(await self.cachedResponseWasCleared(for: enterRequest))
 
         let exitRequest = try self.storeCachedResponse(identifier: "exit-guest-mode")
-        self.authService.exitGuestMode()
+        await self.authService.exitGuestMode()
         #expect(await self.cachedResponseWasCleared(for: exitRequest))
     }
 
@@ -203,11 +227,11 @@ struct AuthServiceTests {
     }
 
     @Test("Logged-in users can enter and exit guest mode")
-    func loggedInGuestModeToggle() {
+    func loggedInGuestModeToggle() async {
         self.authService.completeLogin(sapisid: "test-sapisid")
         let cacheGeneration = APICache.shared.generation
 
-        self.authService.enterGuestMode()
+        await self.authService.enterGuestMode()
         #expect(SongLikeStatusManager.shared.activeAccountID == SongLikeStatusManager.guestAccountID)
         #expect(self.authService.state.isLoggedIn == true)
         #expect(self.authService.isGuestModeEnabled == true)
@@ -216,10 +240,10 @@ struct AuthServiceTests {
         #expect(self.authService.shouldUseCookieFreePlaybackDataStore == true)
         #expect(APICache.shared.generation == cacheGeneration &+ 1)
 
-        self.authService.enterGuestMode()
+        await self.authService.enterGuestMode()
         #expect(APICache.shared.generation == cacheGeneration &+ 1)
 
-        self.authService.exitGuestMode()
+        await self.authService.exitGuestMode()
         #expect(SongLikeStatusManager.shared.activeAccountID != SongLikeStatusManager.guestAccountID)
         #expect(self.authService.state.isLoggedIn == true)
         #expect(self.authService.isGuestModeEnabled == false)
@@ -227,16 +251,92 @@ struct AuthServiceTests {
         #expect(self.authService.shouldUseCookieFreePlaybackDataStore == false)
         #expect(APICache.shared.generation == cacheGeneration &+ 2)
 
-        self.authService.exitGuestMode()
+        await self.authService.exitGuestMode()
         #expect(APICache.shared.generation == cacheGeneration &+ 2)
     }
 
-    @Test("Exit guest mode restores provided account like scope")
-    func exitGuestModeRestoresProvidedAccountLikeScope() {
-        self.authService.completeLogin(sapisid: "placeholder")
-        self.authService.enterGuestMode()
+    @Test("Guest mode boundaries prepare account-scoped work before state changes")
+    func guestModeBoundariesPrepareAccountWork() async {
+        self.authService.completeLogin(sapisid: "test-sapisid")
+        let begins = LockedCounter()
+        let ends = LockedCounter()
+        let enterDrainStarted = AsyncGate()
+        let releaseEnterDrain = AsyncGate()
+        self.authService.setAccountBoundaryHandlers(
+            willBegin: { begins.increment() },
+            didEnd: { ends.increment() },
+            drain: {
+                await enterDrainStarted.open()
+                await releaseEnterDrain.wait()
+            }
+        )
 
-        self.authService.exitGuestMode(activeAccountID: "brand-account")
+        let enterTask = Task { await self.authService.enterGuestMode() }
+        await enterDrainStarted.wait()
+        #expect(begins.count == 1)
+        #expect(ends.isEmpty)
+        #expect(!self.authService.isGuestModeEnabled)
+        await releaseEnterDrain.open()
+        await enterTask.value
+        #expect(ends.count == 1)
+        #expect(self.authService.isGuestModeEnabled)
+
+        let exitDrainStarted = AsyncGate()
+        let releaseExitDrain = AsyncGate()
+        self.authService.setAccountBoundaryHandlers(
+            willBegin: { begins.increment() },
+            didEnd: { ends.increment() },
+            drain: {
+                await exitDrainStarted.open()
+                await releaseExitDrain.wait()
+            }
+        )
+
+        let exitTask = Task { await self.authService.exitGuestMode() }
+        await exitDrainStarted.wait()
+        #expect(begins.count == 2)
+        #expect(ends.count == 1)
+        #expect(self.authService.isGuestModeEnabled)
+        await releaseExitDrain.open()
+        await exitTask.value
+        #expect(ends.count == 2)
+        #expect(!self.authService.isGuestModeEnabled)
+    }
+
+    @Test("Completing login cancels pending guest-mode entry")
+    func completingLoginCancelsPendingGuestModeEntry() async {
+        self.authService.completeLogin(sapisid: "test-sapisid")
+        let drainStarted = AsyncGate()
+        let releaseDrain = AsyncGate()
+        self.authService.setAccountBoundaryHandlers(
+            willBegin: {},
+            didEnd: {},
+            drain: {
+                await drainStarted.open()
+                await releaseDrain.wait()
+            }
+        )
+
+        let guestTask = Task { await self.authService.enterGuestMode() }
+        await drainStarted.wait()
+        let loginTask = Task {
+            await self.authService.completeLoginAfterDraining(sapisid: "replacement-session")
+        }
+        await releaseDrain.open()
+        await guestTask.value
+        await loginTask.value
+
+        #expect(!self.authService.isGuestModeEnabled)
+        #expect(self.authService.hasPersonalAccount)
+        #expect(self.authService.state == .loggedIn(sapisid: "replacement-session"))
+    }
+
+    @Test("Exit guest mode restores provided account like scope")
+    func exitGuestModeRestoresProvidedAccountLikeScope() async {
+        self.authService.completeLogin(sapisid: "placeholder")
+        await self.authService.enterGuestMode()
+
+        await self.authService.exitGuestMode(activeAccountID: "brand-account")
 
         #expect(self.authService.isGuestModeEnabled == false)
         #expect(SongLikeStatusManager.shared.activeAccountID == "brand-account")
@@ -245,14 +345,14 @@ struct AuthServiceTests {
     @Test("Completing login and sign out clear guest mode")
     func loginAndSignOutClearGuestMode() async {
         self.authService.completeLogin(sapisid: "test-sapisid")
-        self.authService.enterGuestMode()
+        await self.authService.enterGuestMode()
 
         self.authService.completeLogin(sapisid: "new-sapisid")
         #expect(self.authService.isGuestModeEnabled == false)
         #expect(self.authService.hasPersonalAccount == true)
         #expect(FavoritesManager.shared.activeScopeID != "guest")
 
-        self.authService.enterGuestMode()
+        await self.authService.enterGuestMode()
         await self.authService.signOut()
         #expect(self.authService.isGuestModeEnabled == false)
         #expect(self.authService.hasPersonalAccount == false)
@@ -291,6 +391,25 @@ struct AuthServiceTests {
         #expect(self.mockWebKitManager.waitForInitialCookieRestoreCallCount == 1)
         #expect(self.mockWebKitManager.getSAPISIDCallCount == 1)
         #expect(self.mockWebKitManager.callSequence == ["waitForInitialCookieRestore", "getSAPISID"])
+    }
+
+    @Test("Checking login status fences replacement of a logged-in identity")
+    func checkLoginStatusFencesIdentityReplacement() async {
+        self.authService.completeLogin(sapisid: "session-a")
+        let begins = LockedCounter()
+        let ends = LockedCounter()
+        self.authService.setAccountBoundaryHandlers(
+            willBegin: { begins.increment() },
+            didEnd: { ends.increment() },
+            drain: {}
+        )
+        self.mockWebKitManager.sapisidValue = "session-b"
+
+        await self.authService.checkLoginStatus()
+
+        #expect(self.authService.state == .loggedIn(sapisid: "session-b"))
+        #expect(begins.count == 1)
+        #expect(ends.count == 1)
     }
 
     @Test("Check login status waits for restore and logs out when SAPISID is missing")

--- a/Tests/KasetTests/GuestModeAPIClientTests.swift
+++ b/Tests/KasetTests/GuestModeAPIClientTests.swift
@@ -151,7 +151,7 @@ struct GuestModeAPIClientTests {
         let webKitManager = MockWebKitManager()
         let authService = AuthService(webKitManager: webKitManager)
         authService.completeLogin(sapisid: "test-sapisid")
-        authService.enterGuestMode()
+        await authService.enterGuestMode()
 
         let session = MockURLProtocol.makeMockSession()
         nonisolated(unsafe) var apiRequestCount = 0
@@ -188,7 +188,7 @@ struct GuestModeAPIClientTests {
         let webKitManager = MockWebKitManager()
         let authService = AuthService(webKitManager: webKitManager)
         authService.completeLogin(sapisid: "test-sapisid")
-        authService.enterGuestMode()
+        await authService.enterGuestMode()
 
         let session = MockURLProtocol.makeMockSession()
         nonisolated(unsafe) var requestCount = 0
@@ -220,7 +220,7 @@ struct GuestModeAPIClientTests {
         await webKitManager.dataStore.httpCookieStore.setCookie(authCookie)
         let authService = AuthService(webKitManager: webKitManager)
         authService.completeLogin(sapisid: "mock-token")
-        authService.enterGuestMode()
+        await authService.enterGuestMode()
 
         let session = MockURLProtocol.makeMockSession()
         nonisolated(unsafe) var accountRequestCount = 0
@@ -271,7 +271,7 @@ struct GuestModeAPIClientTests {
         let webKitManager = WebKitManager.makeTestInstance()
         let authService = AuthService(webKitManager: webKitManager)
         authService.completeLogin(sapisid: "test-sapisid")
-        authService.enterGuestMode()
+        await authService.enterGuestMode()
 
         let session = MockURLProtocol.makeMockSession()
         nonisolated(unsafe) var apiRequestCount = 0
@@ -321,7 +321,7 @@ struct GuestModeAPIClientTests {
         let webKitManager = WebKitManager.makeTestInstance()
         let authService = AuthService(webKitManager: webKitManager)
         authService.completeLogin(sapisid: "test-sapisid")
-        authService.enterGuestMode()
+        await authService.enterGuestMode()
 
         let session = MockURLProtocol.makeMockSession()
         nonisolated(unsafe) var apiRequestCount = 0

--- a/Tests/KasetTests/Helpers/MockYTMusicClient.swift
+++ b/Tests/KasetTests/Helpers/MockYTMusicClient.swift
@@ -67,6 +67,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     var searchContinuationResponses: [String: SearchResponse] = [:]
     var searchSuggestions: [SearchSuggestion] = []
     var libraryPlaylists: [Playlist] = []
+    var libraryAlbums: [Album] = []
     var libraryArtists: [Artist] = []
     var libraryPodcastShows: [PodcastShow] = []
     var uploadedSongsPlaylist: Playlist?
@@ -764,6 +765,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         }
         return PlaylistParser.LibraryContent(
             playlists: self.libraryPlaylists,
+            albums: self.libraryAlbums,
             artists: self.libraryArtists,
             podcastShows: self.libraryPodcastShows,
             uploadedSongsPlaylist: self.uploadedSongsPlaylist

--- a/Tests/KasetTests/Helpers/MockYTMusicClient.swift
+++ b/Tests/KasetTests/Helpers/MockYTMusicClient.swift
@@ -80,6 +80,8 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     var onGetPodcasts: (@MainActor () -> Void)?
     var beforeGetHomeReturn: (@MainActor () async -> Void)?
     var beforeGetHomeContinuationReturn: (@MainActor () async -> Void)?
+    var beforeSubscribeToPlaylistReturn: (@MainActor (String) async -> Void)?
+    var beforeUnsubscribeFromPlaylistReturn: (@MainActor (String) async -> Void)?
     var subscribeToArtistDelay: Duration?
     var unsubscribeFromArtistDelay: Duration?
     var rateSongDelay: Duration?
@@ -963,6 +965,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     func subscribeToPlaylist(playlistId: String) async throws {
         self.subscribeToPlaylistCalled = true
         self.subscribeToPlaylistIds.append(playlistId)
+        if let beforeSubscribeToPlaylistReturn {
+            await beforeSubscribeToPlaylistReturn(playlistId)
+        }
         if let error = shouldThrowError {
             throw error
         }
@@ -1090,6 +1095,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     func unsubscribeFromPlaylist(playlistId: String) async throws {
         self.unsubscribeFromPlaylistCalled = true
         self.unsubscribeFromPlaylistIds.append(playlistId)
+        if let beforeUnsubscribeFromPlaylistReturn {
+            await beforeUnsubscribeFromPlaylistReturn(playlistId)
+        }
         if let error = shouldThrowError {
             throw error
         }
@@ -1373,6 +1381,8 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.defaultAddToPlaylistMenu = AddToPlaylistMenu(title: nil, options: [], canCreatePlaylist: false)
         self.unsubscribeFromPlaylistCalled = false
         self.unsubscribeFromPlaylistIds = []
+        self.beforeSubscribeToPlaylistReturn = nil
+        self.beforeUnsubscribeFromPlaylistReturn = nil
         self.subscribeToArtistCalled = false
         self.subscribeToArtistIds = []
         self.unsubscribeFromArtistCalled = false

--- a/Tests/KasetTests/Helpers/MockYTMusicClient.swift
+++ b/Tests/KasetTests/Helpers/MockYTMusicClient.swift
@@ -80,8 +80,14 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     var onGetPodcasts: (@MainActor () -> Void)?
     var beforeGetHomeReturn: (@MainActor () async -> Void)?
     var beforeGetHomeContinuationReturn: (@MainActor () async -> Void)?
+    var beforeCreatePlaylistReturn: (@MainActor () async -> Void)?
     var beforeSubscribeToPlaylistReturn: (@MainActor (String) async -> Void)?
     var beforeUnsubscribeFromPlaylistReturn: (@MainActor (String) async -> Void)?
+    var beforeDeletePlaylistReturn: (@MainActor (String) async -> Void)?
+    var beforeSubscribeToPodcastReturn: (@MainActor (String) async -> Void)?
+    var beforeUnsubscribeFromPodcastReturn: (@MainActor (String) async -> Void)?
+    var subscribeToPodcastDelay: Duration?
+    var unsubscribeFromPodcastDelay: Duration?
     var subscribeToArtistDelay: Duration?
     var unsubscribeFromArtistDelay: Duration?
     var rateSongDelay: Duration?
@@ -986,6 +992,10 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     func deletePlaylist(playlistId: String) async throws {
         self.deletePlaylistCalled = true
         self.deletePlaylistIds.append(playlistId)
+        if let beforeDeletePlaylistReturn {
+            await beforeDeletePlaylistReturn(playlistId)
+            try Task.checkCancellation()
+        }
         if let error = shouldThrowError {
             throw error
         }
@@ -1020,6 +1030,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
             privacyStatus: privacyStatus,
             videoIds: videoIds
         ))
+        await self.beforeCreatePlaylistReturn?()
         if let error = shouldThrowError {
             throw error
         }
@@ -1112,6 +1123,13 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     }
 
     func subscribeToPodcast(showId: String) async throws {
+        if let beforeSubscribeToPodcastReturn {
+            await beforeSubscribeToPodcastReturn(showId)
+        }
+        if let subscribeToPodcastDelay {
+            try? await Task.sleep(for: subscribeToPodcastDelay)
+        }
+        try Task.checkCancellation()
         if let error = shouldThrowError {
             throw error
         }
@@ -1134,6 +1152,13 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     }
 
     func unsubscribeFromPodcast(showId: String) async throws {
+        if let beforeUnsubscribeFromPodcastReturn {
+            await beforeUnsubscribeFromPodcastReturn(showId)
+        }
+        if let unsubscribeFromPodcastDelay {
+            try? await Task.sleep(for: unsubscribeFromPodcastDelay)
+        }
+        try Task.checkCancellation()
         if let error = shouldThrowError {
             throw error
         }
@@ -1159,6 +1184,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         if let delay = self.subscribeToArtistDelay {
             try? await Task.sleep(for: delay)
         }
+        try Task.checkCancellation()
         if let error = shouldThrowError {
             throw error
         }
@@ -1180,6 +1206,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         if let delay = self.unsubscribeFromArtistDelay {
             try? await Task.sleep(for: delay)
         }
+        try Task.checkCancellation()
         if let error = shouldThrowError {
             throw error
         }
@@ -1385,6 +1412,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.deletePlaylistIds = []
         self.getAddToPlaylistOptionsVideoIds = []
         self.createPlaylistCalls = []
+        self.beforeCreatePlaylistReturn = nil
         self.addSongToPlaylistCalls = []
         self.addToPlaylistMenus = [:]
         self.defaultAddToPlaylistMenu = AddToPlaylistMenu(title: nil, options: [], canCreatePlaylist: false)
@@ -1392,6 +1420,12 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.unsubscribeFromPlaylistIds = []
         self.beforeSubscribeToPlaylistReturn = nil
         self.beforeUnsubscribeFromPlaylistReturn = nil
+        self.beforeDeletePlaylistReturn = nil
+        self.beforeSubscribeToPodcastReturn = nil
+        self.beforeUnsubscribeFromPodcastReturn = nil
+        self.subscribeToPodcastDelay = nil
+        self.unsubscribeFromPodcastDelay = nil
+        self.subscribeToArtistDelay = nil
         self.subscribeToArtistCalled = false
         self.subscribeToArtistIds = []
         self.unsubscribeFromArtistCalled = false

--- a/Tests/KasetTests/Helpers/TestFixtures.swift
+++ b/Tests/KasetTests/Helpers/TestFixtures.swift
@@ -40,7 +40,8 @@ enum TestFixtures {
         id: String = "MPRE-test-album",
         title: String = "Test Album",
         artistName: String = "Test Artist",
-        year: String? = "2024"
+        year: String? = "2024",
+        libraryTargetId: String? = nil
     ) -> Album {
         Album(
             id: id,
@@ -48,7 +49,8 @@ enum TestFixtures {
             artists: artistName.isEmpty ? nil : [Artist(id: "UC123", name: artistName)],
             thumbnailURL: URL(string: "https://example.com/album.jpg"),
             year: year,
-            trackCount: 12
+            trackCount: 12,
+            libraryTargetId: libraryTargetId
         )
     }
 
@@ -88,13 +90,15 @@ enum TestFixtures {
 
     static func makePlaylistDetail(
         playlist: Playlist? = nil,
-        trackCount: Int = 10
+        trackCount: Int = 10,
+        libraryTargetId: String? = nil
     ) -> PlaylistDetail {
         let pl = playlist ?? self.makePlaylist()
         return PlaylistDetail(
             playlist: pl,
             tracks: self.makeSongs(count: trackCount),
-            duration: "\(trackCount * 3) minutes"
+            duration: "\(trackCount * 3) minutes",
+            libraryTargetId: libraryTargetId
         )
     }
 

--- a/Tests/KasetTests/LibraryContentReconcilerTests.swift
+++ b/Tests/KasetTests/LibraryContentReconcilerTests.swift
@@ -61,6 +61,118 @@ struct LibraryContentReconcilerTests {
         #expect(snapshot.artistIds == Set(["UC-channel-1"]))
     }
 
+    @Test("Saved album snapshots update from backend content")
+    func savedAlbumSnapshotsUpdateFromBackendContent() {
+        var reconciler = LibraryContentReconciler()
+        let firstAlbum = TestFixtures.makeAlbum(id: "MPRE-first", title: "First Album")
+        let secondAlbum = TestFixtures.makeAlbum(id: "MPRE-second", title: "Second Album")
+
+        var snapshot = reconciler.apply(Self.content(albums: [firstAlbum]), currentSnapshot: .empty).snapshot
+        #expect(snapshot.albums == [firstAlbum])
+        #expect(snapshot.hasVisibleContent)
+
+        snapshot = reconciler.apply(Self.content(albums: [secondAlbum]), currentSnapshot: snapshot).snapshot
+        #expect(snapshot.albums == [secondAlbum])
+    }
+
+    @Test("Album addition remains visible until backend stabilizes")
+    func albumAdditionRemainsVisibleUntilBackendStabilizes() {
+        var reconciler = LibraryContentReconciler()
+        var snapshot = LibraryContentSnapshot.empty
+        let optimisticAlbum = TestFixtures.makeAlbum(
+            id: "MPRE-optimistic",
+            title: "Optimistic Album",
+            libraryTargetId: "OLAK-shared"
+        )
+        let backendAlbum = TestFixtures.makeAlbum(
+            id: "MPRE-backend",
+            title: "Backend Album",
+            libraryTargetId: "OLAK-shared"
+        )
+
+        reconciler.addAlbum(optimisticAlbum, to: &snapshot)
+        snapshot = reconciler.apply(Self.content(albums: []), currentSnapshot: snapshot).snapshot
+        #expect(snapshot.albums == [optimisticAlbum])
+
+        snapshot = reconciler.apply(Self.content(albums: [backendAlbum]), currentSnapshot: snapshot).snapshot
+        snapshot = reconciler.apply(Self.content(albums: [backendAlbum]), currentSnapshot: snapshot).snapshot
+        #expect(snapshot.albums == [backendAlbum])
+
+        snapshot = reconciler.apply(Self.content(albums: []), currentSnapshot: snapshot).snapshot
+        #expect(snapshot.albums.isEmpty)
+    }
+
+    @Test("Album removal stays suppressed until backend stabilizes")
+    func albumRemovalStaysSuppressedUntilBackendStabilizes() {
+        var reconciler = LibraryContentReconciler()
+        let album = TestFixtures.makeAlbum(
+            id: "MPRE-saved",
+            title: "Saved Album",
+            libraryTargetId: "OLAK-saved"
+        )
+        var snapshot = reconciler.apply(Self.content(albums: [album]), currentSnapshot: .empty).snapshot
+
+        reconciler.removeAlbum(
+            albumId: album.id,
+            targetPlaylistId: album.libraryTargetId,
+            from: &snapshot
+        )
+        snapshot = reconciler.apply(Self.content(albums: [album]), currentSnapshot: snapshot).snapshot
+        #expect(snapshot.albums.isEmpty)
+
+        snapshot = reconciler.apply(Self.content(albums: []), currentSnapshot: snapshot).snapshot
+        snapshot = reconciler.apply(Self.content(albums: []), currentSnapshot: snapshot).snapshot
+        #expect(snapshot.albums.isEmpty)
+
+        snapshot = reconciler.apply(Self.content(albums: [album]), currentSnapshot: snapshot).snapshot
+        #expect(snapshot.albums == [album])
+    }
+
+    @Test("Album removal matches MPRE-only snapshot when mutation also has OLAK target")
+    func albumRemovalMatchesMPREOnlySnapshot() {
+        var reconciler = LibraryContentReconciler()
+        let backendAlbum = TestFixtures.makeAlbum(
+            id: "MPRE-saved",
+            title: "Saved Album",
+            libraryTargetId: nil
+        )
+        var snapshot = reconciler.apply(Self.content(albums: [backendAlbum]), currentSnapshot: .empty).snapshot
+
+        reconciler.removeAlbum(
+            albumId: backendAlbum.id,
+            targetPlaylistId: "OLAK-saved",
+            from: &snapshot
+        )
+        snapshot = reconciler.apply(Self.content(albums: [backendAlbum]), currentSnapshot: snapshot).snapshot
+
+        #expect(snapshot.albums.isEmpty)
+    }
+
+    @Test("Album addition matches backend row that only returns MPRE identity")
+    func albumAdditionMatchesMPREOnlyBackendRow() {
+        var reconciler = LibraryContentReconciler()
+        var snapshot = LibraryContentSnapshot.empty
+        let optimisticAlbum = TestFixtures.makeAlbum(
+            id: "MPRE-shared",
+            title: "Optimistic Album",
+            libraryTargetId: "OLAK-shared"
+        )
+        let backendAlbum = TestFixtures.makeAlbum(
+            id: "MPRE-shared",
+            title: "Backend Album",
+            libraryTargetId: nil
+        )
+
+        reconciler.addAlbum(optimisticAlbum, to: &snapshot)
+        snapshot = reconciler.apply(Self.content(albums: [backendAlbum]), currentSnapshot: snapshot).snapshot
+        snapshot = reconciler.apply(Self.content(albums: [backendAlbum]), currentSnapshot: snapshot).snapshot
+
+        #expect(snapshot.albums == [backendAlbum])
+
+        snapshot = reconciler.apply(Self.content(albums: []), currentSnapshot: snapshot).snapshot
+        #expect(snapshot.albums.isEmpty)
+    }
+
     @Test("Artist removal stays suppressed through stale backend response")
     func artistRemovalStaysSuppressedThroughStaleBackendResponse() {
         var reconciler = LibraryContentReconciler()
@@ -77,12 +189,14 @@ struct LibraryContentReconcilerTests {
 
     private static func content(
         playlists: [Playlist] = [],
+        albums: [Album] = [],
         artists: [Artist] = [],
         podcastShows: [PodcastShow] = [],
         artistsSource: LibraryContentParser.LibraryArtistsSource = .dedicated
     ) -> LibraryContentParser.LibraryContent {
         LibraryContentParser.LibraryContent(
             playlists: playlists,
+            albums: albums,
             artists: artists,
             podcastShows: podcastShows,
             artistsSource: artistsSource

--- a/Tests/KasetTests/LibraryContentReconcilerTests.swift
+++ b/Tests/KasetTests/LibraryContentReconcilerTests.swift
@@ -43,6 +43,228 @@ struct LibraryContentReconcilerTests {
         #expect(snapshot.playlists.map(\.id) == ["VLold-playlist"])
     }
 
+    @Test("Landing fallback preserves existing album snapshot")
+    func landingFallbackPreservesExistingAlbums() {
+        var reconciler = LibraryContentReconciler()
+        let authoritativeAlbum = TestFixtures.makeAlbum(id: "MPRE-authoritative", title: "Authoritative Album")
+        let fallbackAlbum = TestFixtures.makeAlbum(id: "MPRE-preview", title: "Preview Album")
+        var snapshot = reconciler.apply(
+            Self.content(albums: [authoritativeAlbum], accountScope: "account-a"),
+            currentSnapshot: .empty
+        ).snapshot
+
+        let result = reconciler.apply(
+            Self.content(
+                albums: [fallbackAlbum],
+                albumsSource: .landingFallback,
+                accountScope: "account-a"
+            ),
+            currentSnapshot: snapshot
+        )
+        snapshot = result.snapshot
+
+        #expect(result.preservedExistingAlbums)
+        #expect(snapshot.albums == [authoritativeAlbum])
+    }
+
+    @Test("Partial album pagination preserves existing same-account snapshot")
+    func partialAlbumPaginationPreservesExistingAlbums() {
+        var reconciler = LibraryContentReconciler()
+        let firstAlbum = TestFixtures.makeAlbum(id: "MPRE-first", title: "First Album")
+        let laterAlbum = TestFixtures.makeAlbum(id: "MPRE-later", title: "Later Album")
+        let freshFirstAlbum = TestFixtures.makeAlbum(
+            id: "MPRE-first",
+            title: "Updated First Album",
+            year: "2026",
+            libraryTargetId: "OLAK-first"
+        )
+        let newlyLoadedAlbum = TestFixtures.makeAlbum(id: "MPRE-new", title: "Newly Loaded Album")
+        var snapshot = reconciler.apply(
+            Self.content(albums: [firstAlbum, laterAlbum], accountScope: "account-a"),
+            currentSnapshot: .empty
+        ).snapshot
+
+        let result = reconciler.apply(
+            Self.content(
+                albums: [freshFirstAlbum, newlyLoadedAlbum],
+                albumsSource: .partial,
+                accountScope: "account-a"
+            ),
+            currentSnapshot: snapshot
+        )
+        snapshot = result.snapshot
+
+        #expect(result.preservedExistingAlbums)
+        #expect(snapshot.albums.map(\.id) == ["MPRE-first", "MPRE-later", "MPRE-new"])
+        #expect(snapshot.albums.first?.title == "Updated First Album")
+        #expect(snapshot.albums.first?.year == "2026")
+        #expect(snapshot.albums.first?.libraryTargetId == "OLAK-first")
+        #expect(snapshot.albumsSource == .partial)
+    }
+
+    @Test("Partial album merge preserves the canonical MPRE browse ID")
+    func partialAlbumMergePreservesCanonicalBrowseID() {
+        var reconciler = LibraryContentReconciler()
+        let existing = TestFixtures.makeAlbum(
+            id: "MPRE-canonical",
+            title: "Canonical Album",
+            libraryTargetId: "OLAK-canonical"
+        )
+        var snapshot = reconciler.apply(
+            Self.content(albums: [existing], accountScope: "account-a"),
+            currentSnapshot: .empty
+        ).snapshot
+        let incoming = TestFixtures.makeAlbum(
+            id: "OLAK-canonical",
+            title: "Updated Album"
+        )
+
+        snapshot = reconciler.apply(
+            Self.content(
+                albums: [incoming],
+                albumsSource: .partial,
+                accountScope: "account-a"
+            ),
+            currentSnapshot: snapshot
+        ).snapshot
+
+        #expect(snapshot.albums.first?.id == "MPRE-canonical")
+        #expect(snapshot.albums.first?.libraryTargetId == "OLAK-canonical")
+        #expect(snapshot.albums.first?.title == "Updated Album")
+    }
+
+    @Test("Partial album snapshots do not downgrade on weaker refreshes")
+    func partialAlbumSnapshotsDoNotDowngrade() {
+        var reconciler = LibraryContentReconciler()
+        let firstAlbum = TestFixtures.makeAlbum(id: "MPRE-first", title: "First Album")
+        let secondAlbum = TestFixtures.makeAlbum(id: "MPRE-second", title: "Second Album")
+        let thirdAlbum = TestFixtures.makeAlbum(id: "MPRE-third", title: "Third Album")
+        let previewAlbum = TestFixtures.makeAlbum(id: "MPRE-preview", title: "Preview Album")
+        var snapshot = reconciler.apply(
+            Self.content(
+                albums: [firstAlbum, secondAlbum],
+                albumsSource: .partial,
+                accountScope: "account-a"
+            ),
+            currentSnapshot: .empty
+        ).snapshot
+
+        let shorterPartial = reconciler.apply(
+            Self.content(
+                albums: [firstAlbum, thirdAlbum],
+                albumsSource: .partial,
+                accountScope: "account-a"
+            ),
+            currentSnapshot: snapshot
+        )
+        snapshot = shorterPartial.snapshot
+
+        #expect(shorterPartial.preservedExistingAlbums)
+        #expect(snapshot.albums == [firstAlbum, secondAlbum, thirdAlbum])
+        #expect(snapshot.albumsSource == .partial)
+
+        let fallback = reconciler.apply(
+            Self.content(
+                albums: [previewAlbum],
+                albumsSource: .landingFallback,
+                accountScope: "account-a"
+            ),
+            currentSnapshot: snapshot
+        )
+
+        #expect(fallback.preservedExistingAlbums)
+        #expect(fallback.snapshot.albums == [firstAlbum, secondAlbum, thirdAlbum])
+        #expect(fallback.snapshot.albumsSource == .partial)
+    }
+
+    @Test("Album fallback does not preserve another account's snapshot")
+    func albumFallbackDoesNotCrossAccountScope() {
+        var reconciler = LibraryContentReconciler()
+        let firstAccountAlbum = TestFixtures.makeAlbum(id: "MPRE-account-a", title: "Account A Album")
+        let secondAccountPreview = TestFixtures.makeAlbum(id: "MPRE-account-b", title: "Account B Preview")
+        var snapshot = reconciler.apply(
+            Self.content(albums: [firstAccountAlbum], accountScope: "account-a"),
+            currentSnapshot: .empty
+        ).snapshot
+
+        let result = reconciler.apply(
+            Self.content(
+                albums: [secondAccountPreview],
+                albumsSource: .landingFallback,
+                accountScope: "account-b"
+            ),
+            currentSnapshot: snapshot
+        )
+        snapshot = result.snapshot
+
+        #expect(!result.preservedExistingAlbums)
+        #expect(snapshot.albums == [secondAccountPreview])
+        #expect(snapshot.accountScope == "account-b")
+    }
+
+    @Test("Account scope changes clear pending optimistic library state")
+    func accountScopeChangesClearPendingMutations() {
+        var reconciler = LibraryContentReconciler()
+        var snapshot = reconciler.apply(
+            Self.content(accountScope: "account-a"),
+            currentSnapshot: .empty
+        ).snapshot
+        let playlist = TestFixtures.makePlaylist(id: "VL-account-a", title: "Account A Playlist")
+        let album = TestFixtures.makeAlbum(id: "MPRE-account-a", title: "Account A Album")
+        let artist = TestFixtures.makeArtist(id: "UC-account-a", name: "Account A Artist")
+
+        reconciler.addPlaylist(playlist, to: &snapshot)
+        reconciler.addAlbum(album, to: &snapshot)
+        reconciler.addArtist(artist, to: &snapshot)
+
+        let result = reconciler.apply(
+            Self.content(accountScope: "account-b"),
+            currentSnapshot: snapshot
+        )
+
+        #expect(result.snapshot.playlists.isEmpty)
+        #expect(result.snapshot.albums.isEmpty)
+        #expect(result.snapshot.artists.isEmpty)
+        #expect(result.snapshot.playlistIds.isEmpty)
+        #expect(result.snapshot.artistIds.isEmpty)
+        #expect(result.snapshot.accountScope == "account-b")
+    }
+
+    @Test("Authoritative empty albums clear an existing snapshot")
+    func authoritativeEmptyAlbumsClearExistingSnapshot() {
+        var reconciler = LibraryContentReconciler()
+        let album = TestFixtures.makeAlbum(id: "MPRE-existing", title: "Existing Album")
+        var snapshot = reconciler.apply(
+            Self.content(albums: [album], accountScope: "account-a"),
+            currentSnapshot: .empty
+        ).snapshot
+
+        let result = reconciler.apply(
+            Self.content(albums: [], albumsSource: .dedicated, accountScope: "account-a"),
+            currentSnapshot: snapshot
+        )
+        snapshot = result.snapshot
+
+        #expect(!result.preservedExistingAlbums)
+        #expect(snapshot.albums.isEmpty)
+        #expect(snapshot.albumsSource == .dedicated)
+        #expect(snapshot.hasLoadedContent)
+
+        let fallbackAlbum = TestFixtures.makeAlbum(id: "MPRE-stale-preview", title: "Stale Preview")
+        let fallbackResult = reconciler.apply(
+            Self.content(
+                albums: [fallbackAlbum],
+                albumsSource: .landingFallback,
+                accountScope: "account-a"
+            ),
+            currentSnapshot: snapshot
+        )
+
+        #expect(fallbackResult.preservedExistingAlbums)
+        #expect(fallbackResult.snapshot.albums.isEmpty)
+        #expect(fallbackResult.snapshot.albumsSource == .dedicated)
+    }
+
     @Test("Landing fallback preserves existing artist snapshot")
     func landingFallbackPreservesExistingArtists() {
         var reconciler = LibraryContentReconciler()
@@ -192,14 +414,18 @@ struct LibraryContentReconcilerTests {
         albums: [Album] = [],
         artists: [Artist] = [],
         podcastShows: [PodcastShow] = [],
-        artistsSource: LibraryContentParser.LibraryArtistsSource = .dedicated
+        albumsSource: LibraryContentParser.LibraryAlbumsSource = .dedicated,
+        artistsSource: LibraryContentParser.LibraryArtistsSource = .dedicated,
+        accountScope: String? = nil
     ) -> LibraryContentParser.LibraryContent {
         LibraryContentParser.LibraryContent(
             playlists: playlists,
             albums: albums,
             artists: artists,
             podcastShows: podcastShows,
-            artistsSource: artistsSource
+            albumsSource: albumsSource,
+            artistsSource: artistsSource,
+            accountScope: accountScope
         )
     }
 }

--- a/Tests/KasetTests/LibraryMutationActionsTests.swift
+++ b/Tests/KasetTests/LibraryMutationActionsTests.swift
@@ -321,6 +321,74 @@ struct LibraryMutationActionsTests {
         #expect(otherLibraryViewModel.isInLibrary(playlistId: playlist.id))
     }
 
+    @Test("Add album uses OLAK target and updates visible library")
+    func addAlbumUsesLibraryTarget() async throws {
+        let album = TestFixtures.makeAlbum(id: "MPRE-album", title: "Album")
+        self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
+
+        try await LibraryMutationActions.addAlbumToLibrary(
+            album,
+            targetPlaylistId: "OLAK-album-target",
+            client: self.mockClient,
+            libraryViewModel: self.libraryViewModel
+        )
+
+        #expect(self.mockClient.subscribeToPlaylistIds == ["OLAK-album-target"])
+        #expect(self.libraryViewModel.isInLibrary(albumId: "MPRE-album"))
+    }
+
+    @Test("Remove album uses OLAK target and updates visible library")
+    func removeAlbumUsesLibraryTarget() async throws {
+        let album = TestFixtures.makeAlbum(id: "MPRE-album", title: "Album")
+        self.libraryViewModel.addToLibrary(album: album)
+        self.mockClient.libraryAlbums = [album]
+        self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
+
+        try await LibraryMutationActions.removeAlbumFromLibrary(
+            album,
+            targetPlaylistId: "OLAK-album-target",
+            client: self.mockClient,
+            libraryViewModel: self.libraryViewModel
+        )
+
+        #expect(self.mockClient.unsubscribeFromPlaylistIds == ["OLAK-album-target"])
+        #expect(!self.libraryViewModel.isInLibrary(albumId: "MPRE-album"))
+    }
+
+    @Test("Failed album add leaves visible library unchanged")
+    func failedAlbumAddLeavesLibraryUnchanged() async {
+        let album = TestFixtures.makeAlbum(id: "MPRE-album", title: "Album")
+        self.mockClient.shouldThrowError = YTMusicError.apiError(message: "Rejected", code: 400)
+
+        await #expect(throws: YTMusicError.self) {
+            try await LibraryMutationActions.addAlbumToLibrary(
+                album,
+                targetPlaylistId: "OLAK-album-target",
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel
+            )
+        }
+
+        #expect(!self.libraryViewModel.isInLibrary(albumId: "MPRE-album"))
+    }
+
+    @Test("Failed playlist removal propagates and preserves membership")
+    func failedPlaylistRemovalPreservesMembership() async {
+        let playlist = TestFixtures.makePlaylist(id: "VL-saved", title: "Saved Playlist")
+        self.libraryViewModel.addToLibrary(playlist: playlist)
+        self.mockClient.shouldThrowError = YTMusicError.apiError(message: "Rejected", code: 400)
+
+        await #expect(throws: YTMusicError.self) {
+            try await LibraryMutationActions.removePlaylistFromLibrary(
+                playlist,
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel
+            )
+        }
+
+        #expect(self.libraryViewModel.isInLibrary(playlistId: playlist.id))
+    }
+
     private func waitUntil(_ condition: @autoclosure () -> Bool, timeout: Duration = .seconds(1)) async -> Bool {
         let clock = ContinuousClock()
         let deadline = clock.now.advanced(by: timeout)

--- a/Tests/KasetTests/LibraryMutationActionsTests.swift
+++ b/Tests/KasetTests/LibraryMutationActionsTests.swift
@@ -337,6 +337,33 @@ struct LibraryMutationActionsTests {
         #expect(self.libraryViewModel.isInLibrary(albumId: "MPRE-album"))
     }
 
+    @Test("Album mutation callback fires before delayed reconciliation completes")
+    func albumMutationCallbackPrecedesReconciliation() async {
+        let album = TestFixtures.makeAlbum(id: "MPRE-callback", title: "Callback Album")
+        let applied = LockedCounter()
+        let completed = LockedCounter()
+        self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
+
+        let task = Task {
+            defer { completed.increment() }
+            try await LibraryMutationActions.addAlbumToLibrary(
+                album,
+                targetPlaylistId: "OLAK-callback",
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel,
+                reconciliationDelay: .seconds(10),
+                onMutationApplied: { applied.increment() }
+            )
+        }
+
+        #expect(await self.waitUntil(applied.count == 1))
+        #expect(completed.isEmpty)
+        #expect(self.libraryViewModel.isInLibrary(albumId: album.id))
+
+        LibraryMutationActions.cancelPendingAlbumMutations(for: self.libraryViewModel)
+        await #expect(throws: CancellationError.self) { try await task.value }
+    }
+
     @Test("Remove album uses OLAK target and updates visible library")
     func removeAlbumUsesLibraryTarget() async throws {
         let album = TestFixtures.makeAlbum(id: "MPRE-album", title: "Album")
@@ -353,6 +380,77 @@ struct LibraryMutationActionsTests {
 
         #expect(self.mockClient.unsubscribeFromPlaylistIds == ["OLAK-album-target"])
         #expect(!self.libraryViewModel.isInLibrary(albumId: "MPRE-album"))
+    }
+
+    @Test("Cancelling pending album add prevents an account-crossing update")
+    func cancellingPendingAlbumAddPreventsAccountCrossingUpdate() async {
+        let album = TestFixtures.makeAlbum(
+            id: "MPRE-cancelled-add",
+            title: "Cancelled Add",
+            libraryTargetId: "OLAK-cancelled-add"
+        )
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        self.mockClient.beforeSubscribeToPlaylistReturn = { _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+        self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
+
+        let task = Task {
+            try await LibraryMutationActions.addAlbumToLibrary(
+                album,
+                targetPlaylistId: "OLAK-cancelled-add",
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel,
+                reconciliationDelay: .zero
+            )
+        }
+
+        await requestStarted.wait()
+        LibraryMutationActions.cancelPendingAlbumMutations(for: self.libraryViewModel)
+        await releaseRequest.open()
+
+        await #expect(throws: CancellationError.self) {
+            try await task.value
+        }
+        #expect(!self.libraryViewModel.isInLibrary(albumId: album.id))
+    }
+
+    @Test("Cancelling pending album removal preserves the next account snapshot")
+    func cancellingPendingAlbumRemovalPreservesSnapshot() async {
+        let album = TestFixtures.makeAlbum(
+            id: "MPRE-cancelled-remove",
+            title: "Cancelled Remove",
+            libraryTargetId: "OLAK-cancelled-remove"
+        )
+        self.libraryViewModel.addToLibrary(album: album)
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        self.mockClient.beforeUnsubscribeFromPlaylistReturn = { _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+        self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
+
+        let task = Task {
+            try await LibraryMutationActions.removeAlbumFromLibrary(
+                album,
+                targetPlaylistId: "OLAK-cancelled-remove",
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel,
+                reconciliationDelay: .zero
+            )
+        }
+
+        await requestStarted.wait()
+        LibraryMutationActions.cancelPendingAlbumMutations(for: self.libraryViewModel)
+        await releaseRequest.open()
+
+        await #expect(throws: CancellationError.self) {
+            try await task.value
+        }
+        #expect(self.libraryViewModel.isInLibrary(albumId: album.id))
     }
 
     @Test("Newer album removal wins over delayed add reconciliation")
@@ -441,6 +539,7 @@ struct LibraryMutationActionsTests {
     @Test("Failed album add leaves visible library unchanged")
     func failedAlbumAddLeavesLibraryUnchanged() async {
         let album = TestFixtures.makeAlbum(id: "MPRE-album", title: "Album")
+        let applied = LockedCounter()
         self.mockClient.shouldThrowError = YTMusicError.apiError(message: "Rejected", code: 400)
 
         await #expect(throws: YTMusicError.self) {
@@ -448,11 +547,13 @@ struct LibraryMutationActionsTests {
                 album,
                 targetPlaylistId: "OLAK-album-target",
                 client: self.mockClient,
-                libraryViewModel: self.libraryViewModel
+                libraryViewModel: self.libraryViewModel,
+                onMutationApplied: { applied.increment() }
             )
         }
 
         #expect(!self.libraryViewModel.isInLibrary(albumId: "MPRE-album"))
+        #expect(applied.isEmpty)
     }
 
     @Test("Failed playlist removal propagates and preserves membership")

--- a/Tests/KasetTests/LibraryMutationActionsTests.swift
+++ b/Tests/KasetTests/LibraryMutationActionsTests.swift
@@ -2,586 +2,597 @@ import Foundation
 import Testing
 @testable import Kaset
 
-@Suite(.serialized, .tags(.viewModel), .timeLimit(.minutes(1)))
-@MainActor
-struct LibraryMutationActionsTests {
-    var mockClient: MockYTMusicClient
-    var libraryViewModel: LibraryViewModel
+// MARK: - LibraryMutationSerialTests
 
-    init() {
-        self.mockClient = MockYTMusicClient()
-        self.libraryViewModel = LibraryViewModel(client: self.mockClient)
-        APICache.shared.invalidateAll()
-        URLCache.shared.removeAllCachedResponses()
-        LibraryMutationActions.artistReconciliationRetryDelays = [.milliseconds(1), .milliseconds(1)]
-    }
+/// Serializes every suite that exercises LibraryMutationActions' process-wide
+/// mutation coordinator. Separate `.serialized` suites may still run concurrently.
+@Suite(.serialized)
+struct LibraryMutationSerialTests {}
 
-    @Test("Add song to playlist delegates to client")
-    func addSongToPlaylistDelegatesToClient() async {
-        let song = TestFixtures.makeSong(id: "song-1", title: "Song 1")
-        let playlist = AddToPlaylistOption(
-            playlistId: "VL-target",
-            title: "Target Playlist",
-            subtitle: nil,
-            thumbnailURL: nil,
-            isSelected: false,
-            privacyStatus: nil
-        )
+// MARK: LibraryMutationSerialTests.LibraryMutationActionsTests
 
-        await LibraryMutationActions.addSongToPlaylist(song, playlist: playlist, client: self.mockClient)
+extension LibraryMutationSerialTests {
+    @Suite(.tags(.viewModel), .timeLimit(.minutes(1)))
+    @MainActor
+    struct LibraryMutationActionsTests {
+        var mockClient: MockYTMusicClient
+        var libraryViewModel: LibraryViewModel
 
-        #expect(self.mockClient.addSongToPlaylistCalls == [
-            MockYTMusicClient.AddSongToPlaylistCall(
-                videoId: "song-1",
+        init() {
+            self.mockClient = MockYTMusicClient()
+            self.libraryViewModel = LibraryViewModel(client: self.mockClient)
+            APICache.shared.invalidateAll()
+            URLCache.shared.removeAllCachedResponses()
+            LibraryMutationActions.artistReconciliationRetryDelays = [.milliseconds(1), .milliseconds(1)]
+        }
+
+        @Test("Add song to playlist delegates to client")
+        func addSongToPlaylistDelegatesToClient() async {
+            let song = TestFixtures.makeSong(id: "song-1", title: "Song 1")
+            let playlist = AddToPlaylistOption(
                 playlistId: "VL-target",
-                allowDuplicate: false
-            ),
-        ])
-    }
+                title: "Target Playlist",
+                subtitle: nil,
+                thumbnailURL: nil,
+                isSelected: false,
+                privacyStatus: nil
+            )
 
-    @Test("Remove song from playlist delegates to client and removes it from the loaded list")
-    func removeSongFromPlaylistDelegatesToClient() async {
-        let song = Song(id: "song-1", title: "Song 1", artists: [], videoId: "song-1", playlistSetVideoId: "set-1")
-        let playlist = Playlist(
-            id: "VL-test-playlist", title: "Test Playlist", description: nil,
-            thumbnailURL: nil, trackCount: 1, canDelete: true
-        )
-        self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(playlist: playlist, tracks: [song], duration: nil)
-        let viewModel = PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
-        await viewModel.load()
+            await LibraryMutationActions.addSongToPlaylist(song, playlist: playlist, client: self.mockClient)
 
-        await LibraryMutationActions.removeSongFromPlaylist(song, from: viewModel, client: self.mockClient)
+            #expect(self.mockClient.addSongToPlaylistCalls == [
+                MockYTMusicClient.AddSongToPlaylistCall(
+                    videoId: "song-1",
+                    playlistId: "VL-target",
+                    allowDuplicate: false
+                ),
+            ])
+        }
 
-        #expect(self.mockClient.removeSongFromPlaylistCalls == [
-            MockYTMusicClient.RemoveSongFromPlaylistCall(videoId: "song-1", setVideoId: "set-1", playlistId: "VL-test-playlist"),
-        ])
-        #expect(viewModel.playlistDetail?.tracks.isEmpty == true)
-    }
+        @Test("Remove song from playlist delegates to client and removes it from the loaded list")
+        func removeSongFromPlaylistDelegatesToClient() async {
+            let song = Song(id: "song-1", title: "Song 1", artists: [], videoId: "song-1", playlistSetVideoId: "set-1")
+            let playlist = Playlist(
+                id: "VL-test-playlist", title: "Test Playlist", description: nil,
+                thumbnailURL: nil, trackCount: 1, canDelete: true
+            )
+            self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(playlist: playlist, tracks: [song], duration: nil)
+            let viewModel = PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
+            await viewModel.load()
 
-    @Test("Remove song from playlist rolls back the optimistic change when the API call fails")
-    func removeSongFromPlaylistRollsBackOnFailure() async {
-        let song = Song(id: "song-1", title: "Song 1", artists: [], videoId: "song-1", playlistSetVideoId: "set-1")
-        let playlist = Playlist(
-            id: "VL-test-playlist", title: "Test Playlist", description: nil,
-            thumbnailURL: nil, trackCount: 1, canDelete: true
-        )
-        self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(playlist: playlist, tracks: [song], duration: nil)
-        let viewModel = PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
-        await viewModel.load()
-        self.mockClient.shouldWaitForRemoveSongFromPlaylistResponse = true
-        self.mockClient.removeSongFromPlaylistError = YTMusicError.networkError(underlying: URLError(.notConnectedToInternet))
-
-        let removalTask = Task {
             await LibraryMutationActions.removeSongFromPlaylist(song, from: viewModel, client: self.mockClient)
-        }
-        let requestStarted = await self.waitUntil(self.mockClient.removeSongFromPlaylistCalls.count == 1)
-        #expect(requestStarted)
-        guard requestStarted else {
-            self.mockClient.shouldWaitForRemoveSongFromPlaylistResponse = false
-            removalTask.cancel()
-            return
+
+            #expect(self.mockClient.removeSongFromPlaylistCalls == [
+                MockYTMusicClient.RemoveSongFromPlaylistCall(videoId: "song-1", setVideoId: "set-1", playlistId: "VL-test-playlist"),
+            ])
+            #expect(viewModel.playlistDetail?.tracks.isEmpty == true)
         }
 
-        #expect(viewModel.playlistDetail?.tracks.isEmpty == true)
-        #expect(viewModel.playlistDetail?.trackCount == 0)
+        @Test("Remove song from playlist rolls back the optimistic change when the API call fails")
+        func removeSongFromPlaylistRollsBackOnFailure() async {
+            let song = Song(id: "song-1", title: "Song 1", artists: [], videoId: "song-1", playlistSetVideoId: "set-1")
+            let playlist = Playlist(
+                id: "VL-test-playlist", title: "Test Playlist", description: nil,
+                thumbnailURL: nil, trackCount: 1, canDelete: true
+            )
+            self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(playlist: playlist, tracks: [song], duration: nil)
+            let viewModel = PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
+            await viewModel.load()
+            self.mockClient.shouldWaitForRemoveSongFromPlaylistResponse = true
+            self.mockClient.removeSongFromPlaylistError = YTMusicError.networkError(underlying: URLError(.notConnectedToInternet))
 
-        self.mockClient.resumeNextRemoveSongFromPlaylistResponse()
-        await removalTask.value
+            let removalTask = Task {
+                await LibraryMutationActions.removeSongFromPlaylist(song, from: viewModel, client: self.mockClient)
+            }
+            let requestStarted = await self.waitUntil(self.mockClient.removeSongFromPlaylistCalls.count == 1)
+            #expect(requestStarted)
+            guard requestStarted else {
+                self.mockClient.shouldWaitForRemoveSongFromPlaylistResponse = false
+                removalTask.cancel()
+                return
+            }
 
-        #expect(viewModel.playlistDetail?.tracks.map(\.videoId) == ["song-1"])
-        #expect(viewModel.playlistDetail?.trackCount == 1)
-    }
+            #expect(viewModel.playlistDetail?.tracks.isEmpty == true)
+            #expect(viewModel.playlistDetail?.trackCount == 0)
 
-    @Test("Optimistic removal stays applied while refresh is requested")
-    func optimisticRemovalBlocksRefreshUntilCompletion() async {
-        let songs = [
-            Song(id: "song-a", title: "A", artists: [], videoId: "song-a", playlistSetVideoId: "set-a"),
-            Song(id: "song-b", title: "B", artists: [], videoId: "song-b", playlistSetVideoId: "set-b"),
-        ]
-        let playlist = Playlist(
-            id: "VL-test-playlist", title: "Test Playlist", description: nil,
-            thumbnailURL: nil, trackCount: songs.count, canDelete: true
-        )
-        self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(playlist: playlist, tracks: songs, duration: nil)
-        let viewModel = PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
-        await viewModel.load()
-        self.mockClient.shouldWaitForRemoveSongFromPlaylistResponse = true
+            self.mockClient.resumeNextRemoveSongFromPlaylistResponse()
+            await removalTask.value
 
-        let removalTask = Task {
+            #expect(viewModel.playlistDetail?.tracks.map(\.videoId) == ["song-1"])
+            #expect(viewModel.playlistDetail?.trackCount == 1)
+        }
+
+        @Test("Optimistic removal stays applied while refresh is requested")
+        func optimisticRemovalBlocksRefreshUntilCompletion() async {
+            let songs = [
+                Song(id: "song-a", title: "A", artists: [], videoId: "song-a", playlistSetVideoId: "set-a"),
+                Song(id: "song-b", title: "B", artists: [], videoId: "song-b", playlistSetVideoId: "set-b"),
+            ]
+            let playlist = Playlist(
+                id: "VL-test-playlist", title: "Test Playlist", description: nil,
+                thumbnailURL: nil, trackCount: songs.count, canDelete: true
+            )
+            self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(playlist: playlist, tracks: songs, duration: nil)
+            let viewModel = PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
+            await viewModel.load()
+            self.mockClient.shouldWaitForRemoveSongFromPlaylistResponse = true
+
+            let removalTask = Task {
+                await LibraryMutationActions.removeSongFromPlaylist(songs[0], from: viewModel, client: self.mockClient)
+            }
+            let requestStarted = await self.waitUntil(self.mockClient.removeSongFromPlaylistCalls.count == 1)
+            #expect(requestStarted)
+            guard requestStarted else {
+                self.mockClient.shouldWaitForRemoveSongFromPlaylistResponse = false
+                removalTask.cancel()
+                return
+            }
+
+            #expect(viewModel.playlistDetail?.tracks.map(\.videoId) == ["song-b"])
+            #expect(viewModel.playlistDetail?.trackCount == 1)
+            #expect(viewModel.isRemovingTrack)
+
+            let refreshed = await viewModel.refresh()
+            #expect(!refreshed)
+            #expect(viewModel.playlistDetail?.tracks.map(\.videoId) == ["song-b"])
+
+            self.mockClient.resumeNextRemoveSongFromPlaylistResponse()
+            await removalTask.value
+
+            #expect(viewModel.playlistDetail?.tracks.map(\.videoId) == ["song-b"])
+            #expect(viewModel.playlistDetail?.trackCount == 1)
+            #expect(!viewModel.isRemovingTrack)
+        }
+
+        @Test("Duplicate removal requests for one occurrence call the API once")
+        func duplicateRemovalRequestsAreDeduplicated() async {
+            let song = Song(id: "song-a", title: "A", artists: [], videoId: "song-a", playlistSetVideoId: "set-a")
+            let playlist = Playlist(
+                id: "VL-test-playlist", title: "Test Playlist", description: nil,
+                thumbnailURL: nil, trackCount: 1, canDelete: true
+            )
+            self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(playlist: playlist, tracks: [song], duration: nil)
+            let viewModel = PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
+            await viewModel.load()
+            self.mockClient.shouldWaitForRemoveSongFromPlaylistResponse = true
+
+            let firstRemoval = Task {
+                await LibraryMutationActions.removeSongFromPlaylist(song, from: viewModel, client: self.mockClient)
+            }
+            let requestStarted = await self.waitUntil(self.mockClient.removeSongFromPlaylistCalls.count == 1)
+            #expect(requestStarted)
+            guard requestStarted else {
+                self.mockClient.shouldWaitForRemoveSongFromPlaylistResponse = false
+                firstRemoval.cancel()
+                return
+            }
+
+            let duplicateRemoval = Task {
+                await LibraryMutationActions.removeSongFromPlaylist(song, from: viewModel, client: self.mockClient)
+            }
+            await Task.yield()
+
+            self.mockClient.resumeNextRemoveSongFromPlaylistResponse()
+            await firstRemoval.value
+            await duplicateRemoval.value
+
+            #expect(self.mockClient.removeSongFromPlaylistCalls.count == 1)
+            #expect(viewModel.playlistDetail?.tracks.isEmpty == true)
+        }
+
+        @Test("A stale action cannot remove an occurrence already confirmed deleted")
+        func confirmedRemovalRejectsStaleRetry() async {
+            let song = Song(id: "song-a", title: "A", artists: [], videoId: "song-a", playlistSetVideoId: "set-a")
+            let playlist = Playlist(
+                id: "VL-test-playlist", title: "Test Playlist", description: nil,
+                thumbnailURL: nil, trackCount: 1, canDelete: true
+            )
+            self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(playlist: playlist, tracks: [song], duration: nil)
+            let viewModel = PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
+            await viewModel.load()
+
+            await LibraryMutationActions.removeSongFromPlaylist(song, from: viewModel, client: self.mockClient)
+            await LibraryMutationActions.removeSongFromPlaylist(song, from: viewModel, client: self.mockClient)
+
+            #expect(self.mockClient.removeSongFromPlaylistCalls.count == 1)
+            #expect(viewModel.playlistDetail?.tracks.isEmpty == true)
+        }
+
+        @Test("Track removal does not interrupt an awaited full-playlist drain")
+        func removalDoesNotInterruptFullPlaylistDrain() async {
+            let songs = [
+                Song(id: "song-a", title: "A", artists: [], videoId: "song-a", playlistSetVideoId: "set-a"),
+                Song(id: "song-b", title: "B", artists: [], videoId: "song-b", playlistSetVideoId: "set-b"),
+                Song(id: "song-c", title: "C", artists: [], videoId: "song-c", playlistSetVideoId: "set-c"),
+                Song(id: "song-d", title: "D", artists: [], videoId: "song-d", playlistSetVideoId: "set-d"),
+            ]
+            let playlist = Playlist(
+                id: "VL-test-playlist", title: "Test Playlist", description: nil,
+                thumbnailURL: nil, trackCount: songs.count, canDelete: true
+            )
+            self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(
+                playlist: playlist,
+                tracks: Array(songs.prefix(2)),
+                duration: nil
+            )
+            self.mockClient.playlistContinuationTracks[playlist.id] = [Array(songs.suffix(2))]
+            self.mockClient.playlistContinuationDelay = .milliseconds(250)
+            let viewModel = PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
+            await viewModel.load()
+
+            let drainTask = Task { await viewModel.loadAllRemaining() }
+            let continuationStarted = await self.waitUntil(self.mockClient.getPlaylistContinuationCallCount == 1)
+            #expect(continuationStarted)
+            guard continuationStarted else {
+                drainTask.cancel()
+                return
+            }
+
             await LibraryMutationActions.removeSongFromPlaylist(songs[0], from: viewModel, client: self.mockClient)
-        }
-        let requestStarted = await self.waitUntil(self.mockClient.removeSongFromPlaylistCalls.count == 1)
-        #expect(requestStarted)
-        guard requestStarted else {
-            self.mockClient.shouldWaitForRemoveSongFromPlaylistResponse = false
-            removalTask.cancel()
-            return
+            await drainTask.value
+
+            #expect(viewModel.playlistDetail?.tracks.map(\.videoId) == ["song-b", "song-c", "song-d"])
+            #expect(viewModel.playlistDetail?.trackCount == 3)
+            #expect(!viewModel.hasMore)
         }
 
-        #expect(viewModel.playlistDetail?.tracks.map(\.videoId) == ["song-b"])
-        #expect(viewModel.playlistDetail?.trackCount == 1)
-        #expect(viewModel.isRemovingTrack)
+        @Test("Subscribe to artist applies optimistic library state while request is in flight")
+        func subscribeToArtistAppliesOptimisticState() async throws {
+            let artist = TestFixtures.makeArtist(id: "MPLAUC-channel-123", name: "Test Artist")
+            self.mockClient.subscribeToArtistDelay = .milliseconds(700)
 
-        let refreshed = await viewModel.refresh()
-        #expect(!refreshed)
-        #expect(viewModel.playlistDetail?.tracks.map(\.videoId) == ["song-b"])
+            let subscribeTask = Task {
+                try await LibraryMutationActions.subscribeToArtist(
+                    artist,
+                    channelId: "UC-channel-123",
+                    client: self.mockClient,
+                    libraryViewModel: self.libraryViewModel
+                )
+            }
 
-        self.mockClient.resumeNextRemoveSongFromPlaylistResponse()
-        await removalTask.value
+            #expect(await self.waitUntil(self.mockClient.subscribeToArtistCalled, timeout: .seconds(3)))
 
-        #expect(viewModel.playlistDetail?.tracks.map(\.videoId) == ["song-b"])
-        #expect(viewModel.playlistDetail?.trackCount == 1)
-        #expect(!viewModel.isRemovingTrack)
-    }
+            #expect(self.libraryViewModel.isInLibrary(artistId: "UC-channel-123"))
+            #expect(self.libraryViewModel.artists.first?.id == "UC-channel-123")
 
-    @Test("Duplicate removal requests for one occurrence call the API once")
-    func duplicateRemovalRequestsAreDeduplicated() async {
-        let song = Song(id: "song-a", title: "A", artists: [], videoId: "song-a", playlistSetVideoId: "set-a")
-        let playlist = Playlist(
-            id: "VL-test-playlist", title: "Test Playlist", description: nil,
-            thumbnailURL: nil, trackCount: 1, canDelete: true
-        )
-        self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(playlist: playlist, tracks: [song], duration: nil)
-        let viewModel = PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
-        await viewModel.load()
-        self.mockClient.shouldWaitForRemoveSongFromPlaylistResponse = true
-
-        let firstRemoval = Task {
-            await LibraryMutationActions.removeSongFromPlaylist(song, from: viewModel, client: self.mockClient)
-        }
-        let requestStarted = await self.waitUntil(self.mockClient.removeSongFromPlaylistCalls.count == 1)
-        #expect(requestStarted)
-        guard requestStarted else {
-            self.mockClient.shouldWaitForRemoveSongFromPlaylistResponse = false
-            firstRemoval.cancel()
-            return
+            try await subscribeTask.value
         }
 
-        let duplicateRemoval = Task {
-            await LibraryMutationActions.removeSongFromPlaylist(song, from: viewModel, client: self.mockClient)
-        }
-        await Task.yield()
+        @Test("Delete playlist removes it optimistically and calls client")
+        func deletePlaylistRemovesOptimisticallyAndCallsClient() async throws {
+            let playlist = TestFixtures.makePlaylist(id: "VL-owned", title: "Owned Playlist")
+            self.libraryViewModel.addToLibrary(playlist: playlist)
+            self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
 
-        self.mockClient.resumeNextRemoveSongFromPlaylistResponse()
-        await firstRemoval.value
-        await duplicateRemoval.value
-
-        #expect(self.mockClient.removeSongFromPlaylistCalls.count == 1)
-        #expect(viewModel.playlistDetail?.tracks.isEmpty == true)
-    }
-
-    @Test("A stale action cannot remove an occurrence already confirmed deleted")
-    func confirmedRemovalRejectsStaleRetry() async {
-        let song = Song(id: "song-a", title: "A", artists: [], videoId: "song-a", playlistSetVideoId: "set-a")
-        let playlist = Playlist(
-            id: "VL-test-playlist", title: "Test Playlist", description: nil,
-            thumbnailURL: nil, trackCount: 1, canDelete: true
-        )
-        self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(playlist: playlist, tracks: [song], duration: nil)
-        let viewModel = PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
-        await viewModel.load()
-
-        await LibraryMutationActions.removeSongFromPlaylist(song, from: viewModel, client: self.mockClient)
-        await LibraryMutationActions.removeSongFromPlaylist(song, from: viewModel, client: self.mockClient)
-
-        #expect(self.mockClient.removeSongFromPlaylistCalls.count == 1)
-        #expect(viewModel.playlistDetail?.tracks.isEmpty == true)
-    }
-
-    @Test("Track removal does not interrupt an awaited full-playlist drain")
-    func removalDoesNotInterruptFullPlaylistDrain() async {
-        let songs = [
-            Song(id: "song-a", title: "A", artists: [], videoId: "song-a", playlistSetVideoId: "set-a"),
-            Song(id: "song-b", title: "B", artists: [], videoId: "song-b", playlistSetVideoId: "set-b"),
-            Song(id: "song-c", title: "C", artists: [], videoId: "song-c", playlistSetVideoId: "set-c"),
-            Song(id: "song-d", title: "D", artists: [], videoId: "song-d", playlistSetVideoId: "set-d"),
-        ]
-        let playlist = Playlist(
-            id: "VL-test-playlist", title: "Test Playlist", description: nil,
-            thumbnailURL: nil, trackCount: songs.count, canDelete: true
-        )
-        self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(
-            playlist: playlist,
-            tracks: Array(songs.prefix(2)),
-            duration: nil
-        )
-        self.mockClient.playlistContinuationTracks[playlist.id] = [Array(songs.suffix(2))]
-        self.mockClient.playlistContinuationDelay = .milliseconds(250)
-        let viewModel = PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
-        await viewModel.load()
-
-        let drainTask = Task { await viewModel.loadAllRemaining() }
-        let continuationStarted = await self.waitUntil(self.mockClient.getPlaylistContinuationCallCount == 1)
-        #expect(continuationStarted)
-        guard continuationStarted else {
-            drainTask.cancel()
-            return
-        }
-
-        await LibraryMutationActions.removeSongFromPlaylist(songs[0], from: viewModel, client: self.mockClient)
-        await drainTask.value
-
-        #expect(viewModel.playlistDetail?.tracks.map(\.videoId) == ["song-b", "song-c", "song-d"])
-        #expect(viewModel.playlistDetail?.trackCount == 3)
-        #expect(!viewModel.hasMore)
-    }
-
-    @Test("Subscribe to artist applies optimistic library state while request is in flight")
-    func subscribeToArtistAppliesOptimisticState() async throws {
-        let artist = TestFixtures.makeArtist(id: "MPLAUC-channel-123", name: "Test Artist")
-        self.mockClient.subscribeToArtistDelay = .milliseconds(700)
-
-        let subscribeTask = Task {
-            try await LibraryMutationActions.subscribeToArtist(
-                artist,
-                channelId: "UC-channel-123",
-                client: self.mockClient,
-                libraryViewModel: self.libraryViewModel
-            )
-        }
-
-        try await Task.sleep(for: .milliseconds(100))
-
-        #expect(self.libraryViewModel.isInLibrary(artistId: "UC-channel-123"))
-        #expect(self.libraryViewModel.artists.first?.id == "UC-channel-123")
-
-        try await subscribeTask.value
-    }
-
-    @Test("Delete playlist removes it optimistically and calls client")
-    func deletePlaylistRemovesOptimisticallyAndCallsClient() async throws {
-        let playlist = TestFixtures.makePlaylist(id: "VL-owned", title: "Owned Playlist")
-        self.libraryViewModel.addToLibrary(playlist: playlist)
-        self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
-
-        try await LibraryMutationActions.deletePlaylist(
-            playlist,
-            client: self.mockClient,
-            libraryViewModel: self.libraryViewModel
-        )
-
-        #expect(self.mockClient.deletePlaylistCalled)
-        #expect(self.mockClient.deletePlaylistIds == ["VL-owned"])
-        #expect(!self.libraryViewModel.isInLibrary(playlistId: "VL-owned"))
-    }
-
-    @Test("Delete playlist unpins it from the sidebar")
-    func deletePlaylistUnpinsFromSidebar() async throws {
-        let pinnedPlaylist = TestFixtures.makePlaylist(id: "PL-pinned-delete", title: "Pinned Playlist")
-        let playlist = TestFixtures.makePlaylist(id: "VLPL-pinned-delete", title: "Pinned Playlist")
-        SidebarPinnedItemsManager.shared.add(.from(pinnedPlaylist))
-
-        try await LibraryMutationActions.deletePlaylist(
-            playlist,
-            client: self.mockClient,
-            libraryViewModel: self.libraryViewModel
-        )
-
-        #expect(!SidebarPinnedItemsManager.shared.isPinned(contentId: "PL-pinned-delete"))
-    }
-
-    @Test("Failed playlist deletion restores the sidebar pin and library entry")
-    func deletePlaylistRestoresStateOnFailure() async throws {
-        let pinnedPlaylist = TestFixtures.makePlaylist(id: "PL-delete-fails", title: "Sticky Playlist")
-        let playlist = TestFixtures.makePlaylist(id: "VLPL-delete-fails", title: "Sticky Playlist")
-        self.libraryViewModel.addToLibrary(playlist: playlist)
-        SidebarPinnedItemsManager.shared.add(.from(pinnedPlaylist))
-        self.mockClient.shouldThrowError = URLError(.notConnectedToInternet)
-
-        await #expect(throws: (any Error).self) {
             try await LibraryMutationActions.deletePlaylist(
                 playlist,
                 client: self.mockClient,
                 libraryViewModel: self.libraryViewModel
             )
+
+            #expect(self.mockClient.deletePlaylistCalled)
+            #expect(self.mockClient.deletePlaylistIds == ["VL-owned"])
+            #expect(!self.libraryViewModel.isInLibrary(playlistId: "VL-owned"))
         }
 
-        #expect(SidebarPinnedItemsManager.shared.isPinned(contentId: "PL-delete-fails"))
-        #expect(self.libraryViewModel.isInLibrary(playlistId: "VLPL-delete-fails"))
-        SidebarPinnedItemsManager.shared.remove(contentId: "PL-delete-fails")
-    }
+        @Test("Delete playlist unpins it from the sidebar")
+        func deletePlaylistUnpinsFromSidebar() async throws {
+            let pinnedPlaylist = TestFixtures.makePlaylist(id: "PL-pinned-delete", title: "Pinned Playlist")
+            let playlist = TestFixtures.makePlaylist(id: "VLPL-pinned-delete", title: "Pinned Playlist")
+            SidebarPinnedItemsManager.shared.add(.from(pinnedPlaylist))
 
-    @Test("Failed playlist deletion restores every library model that observed the optimistic removal")
-    func deletePlaylistRestoresAllAffectedLibraryModels() async {
-        let playlist = TestFixtures.makePlaylist(id: "VL-delete-multi-window", title: "Shared Playlist")
-        let otherLibraryViewModel = LibraryViewModel(client: self.mockClient)
-        self.libraryViewModel.addToLibrary(playlist: playlist)
-        otherLibraryViewModel.addToLibrary(playlist: playlist)
-        self.mockClient.shouldThrowError = URLError(.notConnectedToInternet)
-
-        await #expect(throws: (any Error).self) {
             try await LibraryMutationActions.deletePlaylist(
                 playlist,
                 client: self.mockClient,
-                libraryViewModel: nil
+                libraryViewModel: self.libraryViewModel
             )
+
+            #expect(!SidebarPinnedItemsManager.shared.isPinned(contentId: "PL-pinned-delete"))
         }
 
-        #expect(self.libraryViewModel.isInLibrary(playlistId: playlist.id))
-        #expect(otherLibraryViewModel.isInLibrary(playlistId: playlist.id))
-    }
+        @Test("Failed playlist deletion restores the sidebar pin and library entry")
+        func deletePlaylistRestoresStateOnFailure() async throws {
+            let pinnedPlaylist = TestFixtures.makePlaylist(id: "PL-delete-fails", title: "Sticky Playlist")
+            let playlist = TestFixtures.makePlaylist(id: "VLPL-delete-fails", title: "Sticky Playlist")
+            self.libraryViewModel.addToLibrary(playlist: playlist)
+            SidebarPinnedItemsManager.shared.add(.from(pinnedPlaylist))
+            self.mockClient.shouldThrowError = URLError(.notConnectedToInternet)
 
-    @Test("Add album uses OLAK target and updates visible library")
-    func addAlbumUsesLibraryTarget() async throws {
-        let album = TestFixtures.makeAlbum(id: "MPRE-album", title: "Album")
-        self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
+            await #expect(throws: (any Error).self) {
+                try await LibraryMutationActions.deletePlaylist(
+                    playlist,
+                    client: self.mockClient,
+                    libraryViewModel: self.libraryViewModel
+                )
+            }
 
-        try await LibraryMutationActions.addAlbumToLibrary(
-            album,
-            targetPlaylistId: "OLAK-album-target",
-            client: self.mockClient,
-            libraryViewModel: self.libraryViewModel
-        )
-
-        #expect(self.mockClient.subscribeToPlaylistIds == ["OLAK-album-target"])
-        #expect(self.libraryViewModel.isInLibrary(albumId: "MPRE-album"))
-    }
-
-    @Test("Album mutation callback fires before delayed reconciliation completes")
-    func albumMutationCallbackPrecedesReconciliation() async {
-        let album = TestFixtures.makeAlbum(id: "MPRE-callback", title: "Callback Album")
-        let applied = LockedCounter()
-        let completed = LockedCounter()
-        self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
-
-        let task = Task {
-            defer { completed.increment() }
-            try await LibraryMutationActions.addAlbumToLibrary(
-                album,
-                targetPlaylistId: "OLAK-callback",
-                client: self.mockClient,
-                libraryViewModel: self.libraryViewModel,
-                reconciliationDelay: .seconds(10),
-                onMutationApplied: { applied.increment() }
-            )
+            #expect(SidebarPinnedItemsManager.shared.isPinned(contentId: "PL-delete-fails"))
+            #expect(self.libraryViewModel.isInLibrary(playlistId: "VLPL-delete-fails"))
+            SidebarPinnedItemsManager.shared.remove(contentId: "PL-delete-fails")
         }
 
-        #expect(await self.waitUntil(applied.count == 1))
-        #expect(completed.isEmpty)
-        #expect(self.libraryViewModel.isInLibrary(albumId: album.id))
+        @Test("Failed playlist deletion restores every library model that observed the optimistic removal")
+        func deletePlaylistRestoresAllAffectedLibraryModels() async {
+            let playlist = TestFixtures.makePlaylist(id: "VL-delete-multi-window", title: "Shared Playlist")
+            let otherLibraryViewModel = LibraryViewModel(client: self.mockClient)
+            self.libraryViewModel.addToLibrary(playlist: playlist)
+            otherLibraryViewModel.addToLibrary(playlist: playlist)
+            self.mockClient.shouldThrowError = URLError(.notConnectedToInternet)
 
-        LibraryMutationActions.cancelPendingAlbumMutations(for: self.libraryViewModel)
-        await #expect(throws: CancellationError.self) { try await task.value }
-    }
+            await #expect(throws: (any Error).self) {
+                try await LibraryMutationActions.deletePlaylist(
+                    playlist,
+                    client: self.mockClient,
+                    libraryViewModel: nil
+                )
+            }
 
-    @Test("Remove album uses OLAK target and updates visible library")
-    func removeAlbumUsesLibraryTarget() async throws {
-        let album = TestFixtures.makeAlbum(id: "MPRE-album", title: "Album")
-        self.libraryViewModel.addToLibrary(album: album)
-        self.mockClient.libraryAlbums = [album]
-        self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
-
-        try await LibraryMutationActions.removeAlbumFromLibrary(
-            album,
-            targetPlaylistId: "OLAK-album-target",
-            client: self.mockClient,
-            libraryViewModel: self.libraryViewModel
-        )
-
-        #expect(self.mockClient.unsubscribeFromPlaylistIds == ["OLAK-album-target"])
-        #expect(!self.libraryViewModel.isInLibrary(albumId: "MPRE-album"))
-    }
-
-    @Test("Cancelling pending album add prevents an account-crossing update")
-    func cancellingPendingAlbumAddPreventsAccountCrossingUpdate() async {
-        let album = TestFixtures.makeAlbum(
-            id: "MPRE-cancelled-add",
-            title: "Cancelled Add",
-            libraryTargetId: "OLAK-cancelled-add"
-        )
-        let requestStarted = AsyncGate()
-        let releaseRequest = AsyncGate()
-        self.mockClient.beforeSubscribeToPlaylistReturn = { _ in
-            await requestStarted.open()
-            await releaseRequest.wait()
-        }
-        self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
-
-        let task = Task {
-            try await LibraryMutationActions.addAlbumToLibrary(
-                album,
-                targetPlaylistId: "OLAK-cancelled-add",
-                client: self.mockClient,
-                libraryViewModel: self.libraryViewModel,
-                reconciliationDelay: .zero
-            )
+            #expect(self.libraryViewModel.isInLibrary(playlistId: playlist.id))
+            #expect(otherLibraryViewModel.isInLibrary(playlistId: playlist.id))
         }
 
-        await requestStarted.wait()
-        LibraryMutationActions.cancelPendingAlbumMutations(for: self.libraryViewModel)
-        await releaseRequest.open()
+        @Test("Add album uses OLAK target and updates visible library")
+        func addAlbumUsesLibraryTarget() async throws {
+            let album = TestFixtures.makeAlbum(id: "MPRE-album", title: "Album")
+            self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
 
-        await #expect(throws: CancellationError.self) {
-            try await task.value
-        }
-        #expect(!self.libraryViewModel.isInLibrary(albumId: album.id))
-    }
-
-    @Test("Cancelling pending album removal preserves the next account snapshot")
-    func cancellingPendingAlbumRemovalPreservesSnapshot() async {
-        let album = TestFixtures.makeAlbum(
-            id: "MPRE-cancelled-remove",
-            title: "Cancelled Remove",
-            libraryTargetId: "OLAK-cancelled-remove"
-        )
-        self.libraryViewModel.addToLibrary(album: album)
-        let requestStarted = AsyncGate()
-        let releaseRequest = AsyncGate()
-        self.mockClient.beforeUnsubscribeFromPlaylistReturn = { _ in
-            await requestStarted.open()
-            await releaseRequest.wait()
-        }
-        self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
-
-        let task = Task {
-            try await LibraryMutationActions.removeAlbumFromLibrary(
-                album,
-                targetPlaylistId: "OLAK-cancelled-remove",
-                client: self.mockClient,
-                libraryViewModel: self.libraryViewModel,
-                reconciliationDelay: .zero
-            )
-        }
-
-        await requestStarted.wait()
-        LibraryMutationActions.cancelPendingAlbumMutations(for: self.libraryViewModel)
-        await releaseRequest.open()
-
-        await #expect(throws: CancellationError.self) {
-            try await task.value
-        }
-        #expect(self.libraryViewModel.isInLibrary(albumId: album.id))
-    }
-
-    @Test("Newer album removal wins over delayed add reconciliation")
-    func newerAlbumRemovalWinsOverDelayedAddReconciliation() async throws {
-        let album = TestFixtures.makeAlbum(
-            id: "MPRE-overlap",
-            title: "Overlap Album",
-            libraryTargetId: "OLAK-overlap"
-        )
-        self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
-        self.mockClient.libraryContentResponses = [
-            PlaylistParser.LibraryContent(playlists: [], albums: [], artists: [], podcastShows: []),
-            PlaylistParser.LibraryContent(playlists: [], albums: [], artists: [], podcastShows: []),
-        ]
-        self.mockClient.libraryContentResponseDelays = [.milliseconds(100), .zero]
-
-        async let add: Void = LibraryMutationActions.addAlbumToLibrary(
-            album,
-            targetPlaylistId: "OLAK-overlap",
-            client: self.mockClient,
-            libraryViewModel: self.libraryViewModel,
-            reconciliationDelay: .milliseconds(50)
-        )
-
-        #expect(await self.waitUntil(self.libraryViewModel.isInLibrary(albumId: album.id)))
-
-        async let remove: Void = LibraryMutationActions.removeAlbumFromLibrary(
-            album,
-            targetPlaylistId: "OLAK-overlap",
-            client: self.mockClient,
-            libraryViewModel: self.libraryViewModel,
-            reconciliationDelay: .milliseconds(50)
-        )
-
-        try await remove
-        try await add
-
-        #expect(!self.libraryViewModel.isInLibrary(albumId: album.id))
-        #expect(self.mockClient.subscribeToPlaylistIds == ["OLAK-overlap"])
-        #expect(self.mockClient.unsubscribeFromPlaylistIds == ["OLAK-overlap"])
-        #expect(self.mockClient.getLibraryContentCallCount == 2)
-    }
-
-    @Test("Newer album add wins over delayed removal reconciliation")
-    func newerAlbumAddWinsOverDelayedRemovalReconciliation() async throws {
-        let album = TestFixtures.makeAlbum(
-            id: "MPRE-overlap",
-            title: "Overlap Album",
-            libraryTargetId: "OLAK-overlap"
-        )
-        self.libraryViewModel.addToLibrary(album: album)
-        self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
-        self.mockClient.libraryContentResponses = [
-            PlaylistParser.LibraryContent(playlists: [], albums: [album], artists: [], podcastShows: []),
-            PlaylistParser.LibraryContent(playlists: [], albums: [album], artists: [], podcastShows: []),
-        ]
-        self.mockClient.libraryContentResponseDelays = [.milliseconds(100), .zero]
-
-        async let remove: Void = LibraryMutationActions.removeAlbumFromLibrary(
-            album,
-            targetPlaylistId: "OLAK-overlap",
-            client: self.mockClient,
-            libraryViewModel: self.libraryViewModel,
-            reconciliationDelay: .milliseconds(50)
-        )
-
-        #expect(await self.waitUntil(!self.libraryViewModel.isInLibrary(albumId: album.id)))
-
-        async let add: Void = LibraryMutationActions.addAlbumToLibrary(
-            album,
-            targetPlaylistId: "OLAK-overlap",
-            client: self.mockClient,
-            libraryViewModel: self.libraryViewModel,
-            reconciliationDelay: .milliseconds(50)
-        )
-
-        try await add
-        try await remove
-
-        #expect(self.libraryViewModel.isInLibrary(albumId: album.id))
-        #expect(self.mockClient.unsubscribeFromPlaylistIds == ["OLAK-overlap"])
-        #expect(self.mockClient.subscribeToPlaylistIds == ["OLAK-overlap"])
-        #expect(self.mockClient.getLibraryContentCallCount == 2)
-    }
-
-    @Test("Failed album add leaves visible library unchanged")
-    func failedAlbumAddLeavesLibraryUnchanged() async {
-        let album = TestFixtures.makeAlbum(id: "MPRE-album", title: "Album")
-        let applied = LockedCounter()
-        self.mockClient.shouldThrowError = YTMusicError.apiError(message: "Rejected", code: 400)
-
-        await #expect(throws: YTMusicError.self) {
             try await LibraryMutationActions.addAlbumToLibrary(
                 album,
                 targetPlaylistId: "OLAK-album-target",
                 client: self.mockClient,
-                libraryViewModel: self.libraryViewModel,
-                onMutationApplied: { applied.increment() }
+                libraryViewModel: self.libraryViewModel
             )
+
+            #expect(self.mockClient.subscribeToPlaylistIds == ["OLAK-album-target"])
+            #expect(self.libraryViewModel.isInLibrary(albumId: "MPRE-album"))
         }
 
-        #expect(!self.libraryViewModel.isInLibrary(albumId: "MPRE-album"))
-        #expect(applied.isEmpty)
-    }
+        @Test("Album mutation callback fires before delayed reconciliation completes")
+        func albumMutationCallbackPrecedesReconciliation() async {
+            let album = TestFixtures.makeAlbum(id: "MPRE-callback", title: "Callback Album")
+            let applied = LockedCounter()
+            let completed = LockedCounter()
+            self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
 
-    @Test("Failed playlist removal propagates and preserves membership")
-    func failedPlaylistRemovalPreservesMembership() async {
-        let playlist = TestFixtures.makePlaylist(id: "VL-saved", title: "Saved Playlist")
-        self.libraryViewModel.addToLibrary(playlist: playlist)
-        self.mockClient.shouldThrowError = YTMusicError.apiError(message: "Rejected", code: 400)
+            let task = Task {
+                defer { completed.increment() }
+                try await LibraryMutationActions.addAlbumToLibrary(
+                    album,
+                    targetPlaylistId: "OLAK-callback",
+                    client: self.mockClient,
+                    libraryViewModel: self.libraryViewModel,
+                    reconciliationDelay: .seconds(10),
+                    onMutationApplied: { applied.increment() }
+                )
+            }
 
-        await #expect(throws: YTMusicError.self) {
-            try await LibraryMutationActions.removePlaylistFromLibrary(
-                playlist,
+            #expect(await self.waitUntil(applied.count == 1))
+            #expect(completed.isEmpty)
+            #expect(self.libraryViewModel.isInLibrary(albumId: album.id))
+
+            LibraryMutationActions.cancelPendingAlbumMutations(for: self.libraryViewModel)
+            await #expect(throws: CancellationError.self) { try await task.value }
+        }
+
+        @Test("Remove album uses OLAK target and updates visible library")
+        func removeAlbumUsesLibraryTarget() async throws {
+            let album = TestFixtures.makeAlbum(id: "MPRE-album", title: "Album")
+            self.libraryViewModel.addToLibrary(album: album)
+            self.mockClient.libraryAlbums = [album]
+            self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
+
+            try await LibraryMutationActions.removeAlbumFromLibrary(
+                album,
+                targetPlaylistId: "OLAK-album-target",
                 client: self.mockClient,
                 libraryViewModel: self.libraryViewModel
             )
+
+            #expect(self.mockClient.unsubscribeFromPlaylistIds == ["OLAK-album-target"])
+            #expect(!self.libraryViewModel.isInLibrary(albumId: "MPRE-album"))
         }
 
-        #expect(self.libraryViewModel.isInLibrary(playlistId: playlist.id))
-    }
+        @Test("Cancelling pending album add prevents an account-crossing update")
+        func cancellingPendingAlbumAddPreventsAccountCrossingUpdate() async {
+            let album = TestFixtures.makeAlbum(
+                id: "MPRE-cancelled-add",
+                title: "Cancelled Add",
+                libraryTargetId: "OLAK-cancelled-add"
+            )
+            let requestStarted = AsyncGate()
+            let releaseRequest = AsyncGate()
+            self.mockClient.beforeSubscribeToPlaylistReturn = { _ in
+                await requestStarted.open()
+                await releaseRequest.wait()
+            }
+            self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
 
-    private func waitUntil(_ condition: @autoclosure () -> Bool, timeout: Duration = .seconds(1)) async -> Bool {
-        let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: timeout)
+            let task = Task {
+                try await LibraryMutationActions.addAlbumToLibrary(
+                    album,
+                    targetPlaylistId: "OLAK-cancelled-add",
+                    client: self.mockClient,
+                    libraryViewModel: self.libraryViewModel,
+                    reconciliationDelay: .zero
+                )
+            }
 
-        while !condition() {
-            guard clock.now < deadline else { return condition() }
-            try? await Task.sleep(for: .milliseconds(10))
+            await requestStarted.wait()
+            LibraryMutationActions.cancelPendingAlbumMutations(for: self.libraryViewModel)
+            await releaseRequest.open()
+
+            await #expect(throws: CancellationError.self) {
+                try await task.value
+            }
+            #expect(!self.libraryViewModel.isInLibrary(albumId: album.id))
         }
 
-        return true
+        @Test("Cancelling pending album removal preserves the next account snapshot")
+        func cancellingPendingAlbumRemovalPreservesSnapshot() async {
+            let album = TestFixtures.makeAlbum(
+                id: "MPRE-cancelled-remove",
+                title: "Cancelled Remove",
+                libraryTargetId: "OLAK-cancelled-remove"
+            )
+            self.libraryViewModel.addToLibrary(album: album)
+            let requestStarted = AsyncGate()
+            let releaseRequest = AsyncGate()
+            self.mockClient.beforeUnsubscribeFromPlaylistReturn = { _ in
+                await requestStarted.open()
+                await releaseRequest.wait()
+            }
+            self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
+
+            let task = Task {
+                try await LibraryMutationActions.removeAlbumFromLibrary(
+                    album,
+                    targetPlaylistId: "OLAK-cancelled-remove",
+                    client: self.mockClient,
+                    libraryViewModel: self.libraryViewModel,
+                    reconciliationDelay: .zero
+                )
+            }
+
+            await requestStarted.wait()
+            LibraryMutationActions.cancelPendingAlbumMutations(for: self.libraryViewModel)
+            await releaseRequest.open()
+
+            await #expect(throws: CancellationError.self) {
+                try await task.value
+            }
+            #expect(self.libraryViewModel.isInLibrary(albumId: album.id))
+        }
+
+        @Test("Newer album removal wins over delayed add reconciliation")
+        func newerAlbumRemovalWinsOverDelayedAddReconciliation() async throws {
+            let album = TestFixtures.makeAlbum(
+                id: "MPRE-overlap",
+                title: "Overlap Album",
+                libraryTargetId: "OLAK-overlap"
+            )
+            self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
+            self.mockClient.libraryContentResponses = [
+                PlaylistParser.LibraryContent(playlists: [], albums: [], artists: [], podcastShows: []),
+                PlaylistParser.LibraryContent(playlists: [], albums: [], artists: [], podcastShows: []),
+            ]
+            self.mockClient.libraryContentResponseDelays = [.milliseconds(100), .zero]
+
+            async let add: Void = LibraryMutationActions.addAlbumToLibrary(
+                album,
+                targetPlaylistId: "OLAK-overlap",
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel,
+                reconciliationDelay: .milliseconds(50)
+            )
+
+            #expect(await self.waitUntil(self.libraryViewModel.isInLibrary(albumId: album.id)))
+
+            async let remove: Void = LibraryMutationActions.removeAlbumFromLibrary(
+                album,
+                targetPlaylistId: "OLAK-overlap",
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel,
+                reconciliationDelay: .milliseconds(50)
+            )
+
+            try await remove
+            try await add
+
+            #expect(!self.libraryViewModel.isInLibrary(albumId: album.id))
+            #expect(self.mockClient.subscribeToPlaylistIds == ["OLAK-overlap"])
+            #expect(self.mockClient.unsubscribeFromPlaylistIds == ["OLAK-overlap"])
+            #expect(self.mockClient.getLibraryContentCallCount == 2)
+        }
+
+        @Test("Newer album add wins over delayed removal reconciliation")
+        func newerAlbumAddWinsOverDelayedRemovalReconciliation() async throws {
+            let album = TestFixtures.makeAlbum(
+                id: "MPRE-overlap",
+                title: "Overlap Album",
+                libraryTargetId: "OLAK-overlap"
+            )
+            self.libraryViewModel.addToLibrary(album: album)
+            self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
+            self.mockClient.libraryContentResponses = [
+                PlaylistParser.LibraryContent(playlists: [], albums: [album], artists: [], podcastShows: []),
+                PlaylistParser.LibraryContent(playlists: [], albums: [album], artists: [], podcastShows: []),
+            ]
+            self.mockClient.libraryContentResponseDelays = [.milliseconds(100), .zero]
+
+            async let remove: Void = LibraryMutationActions.removeAlbumFromLibrary(
+                album,
+                targetPlaylistId: "OLAK-overlap",
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel,
+                reconciliationDelay: .milliseconds(50)
+            )
+
+            #expect(await self.waitUntil(!self.libraryViewModel.isInLibrary(albumId: album.id)))
+
+            async let add: Void = LibraryMutationActions.addAlbumToLibrary(
+                album,
+                targetPlaylistId: "OLAK-overlap",
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel,
+                reconciliationDelay: .milliseconds(50)
+            )
+
+            try await add
+            try await remove
+
+            #expect(self.libraryViewModel.isInLibrary(albumId: album.id))
+            #expect(self.mockClient.unsubscribeFromPlaylistIds == ["OLAK-overlap"])
+            #expect(self.mockClient.subscribeToPlaylistIds == ["OLAK-overlap"])
+            #expect(self.mockClient.getLibraryContentCallCount == 2)
+        }
+
+        @Test("Failed album add leaves visible library unchanged")
+        func failedAlbumAddLeavesLibraryUnchanged() async {
+            let album = TestFixtures.makeAlbum(id: "MPRE-album", title: "Album")
+            let applied = LockedCounter()
+            self.mockClient.shouldThrowError = YTMusicError.apiError(message: "Rejected", code: 400)
+
+            await #expect(throws: YTMusicError.self) {
+                try await LibraryMutationActions.addAlbumToLibrary(
+                    album,
+                    targetPlaylistId: "OLAK-album-target",
+                    client: self.mockClient,
+                    libraryViewModel: self.libraryViewModel,
+                    onMutationApplied: { applied.increment() }
+                )
+            }
+
+            #expect(!self.libraryViewModel.isInLibrary(albumId: "MPRE-album"))
+            #expect(applied.isEmpty)
+        }
+
+        @Test("Failed playlist removal propagates and preserves membership")
+        func failedPlaylistRemovalPreservesMembership() async {
+            let playlist = TestFixtures.makePlaylist(id: "VL-saved", title: "Saved Playlist")
+            self.libraryViewModel.addToLibrary(playlist: playlist)
+            self.mockClient.shouldThrowError = YTMusicError.apiError(message: "Rejected", code: 400)
+
+            await #expect(throws: YTMusicError.self) {
+                try await LibraryMutationActions.removePlaylistFromLibrary(
+                    playlist,
+                    client: self.mockClient,
+                    libraryViewModel: self.libraryViewModel
+                )
+            }
+
+            #expect(self.libraryViewModel.isInLibrary(playlistId: playlist.id))
+        }
+
+        private func waitUntil(_ condition: @autoclosure () -> Bool, timeout: Duration = .seconds(3)) async -> Bool {
+            let clock = ContinuousClock()
+            let deadline = clock.now.advanced(by: timeout)
+
+            while !condition() {
+                guard clock.now < deadline else { return condition() }
+                try? await Task.sleep(for: .milliseconds(10))
+            }
+
+            return true
+        }
     }
 }

--- a/Tests/KasetTests/LibraryMutationActionsTests.swift
+++ b/Tests/KasetTests/LibraryMutationActionsTests.swift
@@ -355,6 +355,89 @@ struct LibraryMutationActionsTests {
         #expect(!self.libraryViewModel.isInLibrary(albumId: "MPRE-album"))
     }
 
+    @Test("Newer album removal wins over delayed add reconciliation")
+    func newerAlbumRemovalWinsOverDelayedAddReconciliation() async throws {
+        let album = TestFixtures.makeAlbum(
+            id: "MPRE-overlap",
+            title: "Overlap Album",
+            libraryTargetId: "OLAK-overlap"
+        )
+        self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
+        self.mockClient.libraryContentResponses = [
+            PlaylistParser.LibraryContent(playlists: [], albums: [], artists: [], podcastShows: []),
+            PlaylistParser.LibraryContent(playlists: [], albums: [], artists: [], podcastShows: []),
+        ]
+        self.mockClient.libraryContentResponseDelays = [.milliseconds(100), .zero]
+
+        async let add: Void = LibraryMutationActions.addAlbumToLibrary(
+            album,
+            targetPlaylistId: "OLAK-overlap",
+            client: self.mockClient,
+            libraryViewModel: self.libraryViewModel,
+            reconciliationDelay: .milliseconds(50)
+        )
+
+        #expect(await self.waitUntil(self.libraryViewModel.isInLibrary(albumId: album.id)))
+
+        async let remove: Void = LibraryMutationActions.removeAlbumFromLibrary(
+            album,
+            targetPlaylistId: "OLAK-overlap",
+            client: self.mockClient,
+            libraryViewModel: self.libraryViewModel,
+            reconciliationDelay: .milliseconds(50)
+        )
+
+        try await remove
+        try await add
+
+        #expect(!self.libraryViewModel.isInLibrary(albumId: album.id))
+        #expect(self.mockClient.subscribeToPlaylistIds == ["OLAK-overlap"])
+        #expect(self.mockClient.unsubscribeFromPlaylistIds == ["OLAK-overlap"])
+        #expect(self.mockClient.getLibraryContentCallCount == 2)
+    }
+
+    @Test("Newer album add wins over delayed removal reconciliation")
+    func newerAlbumAddWinsOverDelayedRemovalReconciliation() async throws {
+        let album = TestFixtures.makeAlbum(
+            id: "MPRE-overlap",
+            title: "Overlap Album",
+            libraryTargetId: "OLAK-overlap"
+        )
+        self.libraryViewModel.addToLibrary(album: album)
+        self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
+        self.mockClient.libraryContentResponses = [
+            PlaylistParser.LibraryContent(playlists: [], albums: [album], artists: [], podcastShows: []),
+            PlaylistParser.LibraryContent(playlists: [], albums: [album], artists: [], podcastShows: []),
+        ]
+        self.mockClient.libraryContentResponseDelays = [.milliseconds(100), .zero]
+
+        async let remove: Void = LibraryMutationActions.removeAlbumFromLibrary(
+            album,
+            targetPlaylistId: "OLAK-overlap",
+            client: self.mockClient,
+            libraryViewModel: self.libraryViewModel,
+            reconciliationDelay: .milliseconds(50)
+        )
+
+        #expect(await self.waitUntil(!self.libraryViewModel.isInLibrary(albumId: album.id)))
+
+        async let add: Void = LibraryMutationActions.addAlbumToLibrary(
+            album,
+            targetPlaylistId: "OLAK-overlap",
+            client: self.mockClient,
+            libraryViewModel: self.libraryViewModel,
+            reconciliationDelay: .milliseconds(50)
+        )
+
+        try await add
+        try await remove
+
+        #expect(self.libraryViewModel.isInLibrary(albumId: album.id))
+        #expect(self.mockClient.unsubscribeFromPlaylistIds == ["OLAK-overlap"])
+        #expect(self.mockClient.subscribeToPlaylistIds == ["OLAK-overlap"])
+        #expect(self.mockClient.getLibraryContentCallCount == 2)
+    }
+
     @Test("Failed album add leaves visible library unchanged")
     func failedAlbumAddLeavesLibraryUnchanged() async {
         let album = TestFixtures.makeAlbum(id: "MPRE-album", title: "Album")

--- a/Tests/KasetTests/LibraryViewModelTests.swift
+++ b/Tests/KasetTests/LibraryViewModelTests.swift
@@ -21,6 +21,7 @@ struct LibraryViewModelTests {
     func initialState() {
         #expect(self.viewModel.loadingState == .idle)
         #expect(self.viewModel.playlists.isEmpty)
+        #expect(self.viewModel.albums.isEmpty)
         #expect(self.viewModel.artists.isEmpty)
         #expect(self.viewModel.podcastShows.isEmpty)
         #expect(self.viewModel.uploadedSongsPlaylist == nil)
@@ -35,6 +36,18 @@ struct LibraryViewModelTests {
         self.mockClient.libraryPlaylists = [
             TestFixtures.makePlaylist(id: "VL1", title: "Playlist 1"),
             TestFixtures.makePlaylist(id: "VL2", title: "Playlist 2"),
+        ]
+        self.mockClient.libraryAlbums = [
+            Album(
+                id: "MPRE1",
+                title: "Album 1",
+                artists: nil,
+                thumbnailURL: nil,
+                year: "2024",
+                trackCount: 10,
+                libraryTargetId: "OLAK1"
+            ),
+            TestFixtures.makeAlbum(id: "MPRE2", title: "Album 2"),
         ]
         self.mockClient.libraryArtists = [
             TestFixtures.makeArtist(id: "MPLAUC-channel-1", name: "Artist 1"),
@@ -57,6 +70,9 @@ struct LibraryViewModelTests {
         #expect(self.viewModel.loadingState == .loaded)
         #expect(self.viewModel.playlists.count == 2)
         #expect(self.viewModel.playlists[0].title == "Playlist 1")
+        #expect(self.viewModel.albums.map(\.title) == ["Album 1", "Album 2"])
+        #expect(self.viewModel.isInLibrary(albumId: "MPRE1"))
+        #expect(self.viewModel.isInLibrary(albumId: "different-browse-id", targetPlaylistId: "OLAK1"))
         #expect(self.viewModel.artists.count == 1)
         #expect(self.viewModel.artists[0].name == "Artist 1")
         #expect(self.viewModel.podcastShows.count == 1)
@@ -82,11 +98,28 @@ struct LibraryViewModelTests {
             Issue.record("Expected error state")
         }
         #expect(self.viewModel.playlists.isEmpty)
+        #expect(self.viewModel.albums.isEmpty)
         #expect(self.viewModel.artists.isEmpty)
         #expect(self.viewModel.podcastShows.isEmpty)
         #expect(self.viewModel.libraryPlaylistIds.isEmpty)
         #expect(self.viewModel.libraryArtistIds.isEmpty)
         #expect(self.viewModel.libraryPodcastIds.isEmpty)
+    }
+
+    @Test("Adding album deduplicates equivalent OLAK target")
+    func addAlbumDeduplicatesLibraryTarget() {
+        self.viewModel.addToLibrary(album: TestFixtures.makeAlbum(
+            id: "MPRE-old",
+            title: "Old Album",
+            libraryTargetId: "OLAK-shared"
+        ))
+        self.viewModel.addToLibrary(album: TestFixtures.makeAlbum(
+            id: "MPRE-new",
+            title: "New Album",
+            libraryTargetId: "OLAK-shared"
+        ))
+
+        #expect(self.viewModel.albums.map(\.id) == ["MPRE-new"])
     }
 
     @Test("Load playlist success")

--- a/Tests/KasetTests/LibraryViewModelTests.swift
+++ b/Tests/KasetTests/LibraryViewModelTests.swift
@@ -1,6 +1,9 @@
 import Foundation
+import SwiftUI
 import Testing
 @testable import Kaset
+
+// MARK: - LibraryViewModelTests
 
 /// Tests for LibraryViewModel using mock client.
 @Suite(.serialized, .tags(.viewModel), .timeLimit(.minutes(1)))
@@ -29,6 +32,62 @@ struct LibraryViewModelTests {
         #expect(self.viewModel.libraryArtistIds.isEmpty)
         #expect(self.viewModel.libraryPodcastIds.isEmpty)
         #expect(self.viewModel.selectedPlaylistDetail == nil)
+    }
+
+    @Test("Activating the first account scope preserves pending optimistic state")
+    func firstAccountScopePreservesPendingMutations() async {
+        let album = TestFixtures.makeAlbum(
+            id: "MPRE-pending",
+            title: "Pending Album",
+            libraryTargetId: "OLAK-pending"
+        )
+        self.viewModel.addToLibrary(album: album)
+        self.viewModel.activateAccountScope("primary")
+        self.mockClient.libraryContentResponses = [
+            PlaylistParser.LibraryContent(
+                playlists: [],
+                albums: [],
+                artists: [],
+                podcastShows: [],
+                albumsSource: .dedicated,
+                accountScope: "primary"
+            ),
+        ]
+
+        await self.viewModel.load()
+
+        #expect(self.viewModel.albums == [album])
+    }
+
+    @Test("Activating a brand scope clears unscoped optimistic state")
+    func firstBrandScopeClearsPendingMutations() {
+        let album = TestFixtures.makeAlbum(
+            id: "MPRE-unscoped",
+            title: "Unscoped Album",
+            libraryTargetId: "OLAK-unscoped"
+        )
+        self.viewModel.addToLibrary(album: album)
+
+        self.viewModel.activateAccountScope("brand-account")
+
+        #expect(self.viewModel.albums.isEmpty)
+        #expect(!self.viewModel.isInLibrary(albumId: album.id))
+    }
+
+    @Test("Changing known account scopes clears prior library state")
+    func accountScopeChangeClearsLibraryState() {
+        let album = TestFixtures.makeAlbum(
+            id: "MPRE-account-a",
+            title: "Account A Album",
+            libraryTargetId: "OLAK-account-a"
+        )
+        self.viewModel.activateAccountScope("account-a")
+        self.viewModel.addToLibrary(album: album)
+
+        self.viewModel.activateAccountScope("account-b")
+
+        #expect(self.viewModel.albums.isEmpty)
+        #expect(!self.viewModel.isInLibrary(albumId: album.id))
     }
 
     @Test("Load success sets library content and ID sets")
@@ -86,6 +145,7 @@ struct LibraryViewModelTests {
 
     @Test("Load error sets error state")
     func loadError() async {
+        self.viewModel.activateAccountScope("primary")
         self.mockClient.shouldThrowError = YTMusicError.authExpired
 
         await self.viewModel.load()
@@ -367,6 +427,81 @@ struct LibraryViewModelTests {
         #expect(self.viewModel.artists.first?.id == "UC-channel-1")
     }
 
+    @Test("refresh preserves existing albums when refresh falls back to landing preview")
+    func refreshPreservesAlbumsDuringLandingFallback() async {
+        let authoritativeAlbum = TestFixtures.makeAlbum(
+            id: "MPRE-authoritative",
+            title: "Authoritative Album",
+            libraryTargetId: "OLAK-authoritative"
+        )
+        let fallbackPreviewAlbum = TestFixtures.makeAlbum(
+            id: "MPRE-preview",
+            title: "Preview Album",
+            libraryTargetId: "OLAK-preview"
+        )
+
+        self.mockClient.libraryContentResponses = [
+            PlaylistParser.LibraryContent(
+                playlists: [],
+                albums: [authoritativeAlbum],
+                artists: [],
+                podcastShows: []
+            ),
+        ]
+        await self.viewModel.load()
+
+        self.mockClient.libraryContentResponses = [
+            PlaylistParser.LibraryContent(
+                playlists: [],
+                albums: [fallbackPreviewAlbum],
+                artists: [],
+                podcastShows: [],
+                albumsSource: .landingFallback
+            ),
+        ]
+
+        await self.viewModel.refresh()
+
+        #expect(self.viewModel.albums == [authoritativeAlbum])
+    }
+
+    @Test("refresh preserves an authoritative empty album snapshot during fallback")
+    func refreshPreservesAuthoritativeEmptyAlbumsDuringFallback() async {
+        let stalePreviewAlbum = TestFixtures.makeAlbum(
+            id: "MPRE-stale-preview",
+            title: "Stale Preview",
+            libraryTargetId: "OLAK-stale-preview"
+        )
+
+        self.mockClient.libraryContentResponses = [
+            PlaylistParser.LibraryContent(
+                playlists: [],
+                albums: [],
+                artists: [],
+                podcastShows: [],
+                albumsSource: .dedicated,
+                accountScope: "primary"
+            ),
+        ]
+        await self.viewModel.load()
+
+        self.mockClient.libraryContentResponses = [
+            PlaylistParser.LibraryContent(
+                playlists: [],
+                albums: [stalePreviewAlbum],
+                artists: [],
+                podcastShows: [],
+                albumsSource: .landingFallback,
+                accountScope: "primary"
+            ),
+        ]
+
+        await self.viewModel.refresh()
+
+        #expect(self.viewModel.loadingState == .loaded)
+        #expect(self.viewModel.albums.isEmpty)
+    }
+
     @Test("refresh preserves existing artists when refresh falls back to landing preview")
     func refreshPreservesArtistsDuringLandingFallback() async {
         let authoritativeArtist = TestFixtures.makeArtist(id: "UC-channel-1", name: "Artist 1")
@@ -595,5 +730,25 @@ struct LibraryViewModelTests {
     @Test("isInLibrary returns false for non-added podcast")
     func isInLibraryForNonAddedPodcast() {
         #expect(self.viewModel.isInLibrary(podcastId: "MPSPPLXz2p9test123") == false)
+    }
+}
+
+// MARK: - LibraryViewModelEnvironmentTests
+
+@Suite(.tags(.viewModel))
+@MainActor
+struct LibraryViewModelEnvironmentTests {
+    @Test("Library view model environment stores the active model")
+    func environmentStoresActiveModel() {
+        var environment = EnvironmentValues()
+        #expect(environment.libraryViewModel == nil)
+
+        let viewModel = LibraryViewModel(
+            client: MockYTMusicClient(),
+            registerForLibraryMutations: false
+        )
+        environment.libraryViewModel = viewModel
+
+        #expect(environment.libraryViewModel === viewModel)
     }
 }

--- a/Tests/KasetTests/LibraryViewModelTests.swift
+++ b/Tests/KasetTests/LibraryViewModelTests.swift
@@ -36,13 +36,17 @@ struct LibraryViewModelTests {
 
     @Test("Activating the first account scope preserves pending optimistic state")
     func firstAccountScopePreservesPendingMutations() async {
+        let primaryAccountScope = FavoritesManager.accountScopeID(
+            ownerID: "primary-owner",
+            accountID: "primary"
+        )
         let album = TestFixtures.makeAlbum(
             id: "MPRE-pending",
             title: "Pending Album",
             libraryTargetId: "OLAK-pending"
         )
         self.viewModel.addToLibrary(album: album)
-        self.viewModel.activateAccountScope("primary")
+        self.viewModel.activateAccountScope(primaryAccountScope, isPrimary: true)
         self.mockClient.libraryContentResponses = [
             PlaylistParser.LibraryContent(
                 playlists: [],
@@ -50,7 +54,7 @@ struct LibraryViewModelTests {
                 artists: [],
                 podcastShows: [],
                 albumsSource: .dedicated,
-                accountScope: "primary"
+                accountScope: primaryAccountScope
             ),
         ]
 
@@ -86,6 +90,46 @@ struct LibraryViewModelTests {
 
         self.viewModel.activateAccountScope("account-b")
 
+        #expect(self.viewModel.albums.isEmpty)
+        #expect(!self.viewModel.isInLibrary(albumId: album.id))
+    }
+
+    @Test("Switching between primary account identities clears prior library state")
+    func primaryAccountIdentityChangeClearsLibraryState() {
+        let firstAccount = UserAccount.from(
+            name: "First User",
+            handle: "@first",
+            brandId: nil,
+            thumbnailURL: nil,
+            isSelected: true
+        )
+        let secondAccount = UserAccount.from(
+            name: "Second User",
+            handle: "@second",
+            brandId: nil,
+            thumbnailURL: nil,
+            isSelected: true
+        )
+        let firstAccountScope = FavoritesManager.accountScopeID(
+            ownerID: "first-owner",
+            accountID: firstAccount.id
+        )
+        let secondAccountScope = FavoritesManager.accountScopeID(
+            ownerID: "second-owner",
+            accountID: secondAccount.id
+        )
+        let album = TestFixtures.makeAlbum(
+            id: "MPRE-first-primary",
+            title: "First Primary Album",
+            libraryTargetId: "OLAK-first-primary"
+        )
+        self.viewModel.activateAccountScope(firstAccountScope, isPrimary: true)
+        self.viewModel.addToLibrary(album: album)
+
+        self.viewModel.activateAccountScope(secondAccountScope, isPrimary: true)
+
+        #expect(firstAccount.id == secondAccount.id)
+        #expect(firstAccountScope != secondAccountScope)
         #expect(self.viewModel.albums.isEmpty)
         #expect(!self.viewModel.isInLibrary(albumId: album.id))
     }

--- a/Tests/KasetTests/MockUITestYTMusicClientLibraryTests.swift
+++ b/Tests/KasetTests/MockUITestYTMusicClientLibraryTests.swift
@@ -1,0 +1,43 @@
+import Testing
+@testable import Kaset
+
+@Suite("Mock UI-test YouTube Music Library")
+struct MockUITestYTMusicClientLibraryTests {
+    @Test("Library albums use distinct browse and mutation identities")
+    @MainActor
+    func libraryAlbumsUseDistinctBrowseAndMutationIdentities() async throws {
+        let content = try await MockUITestYTMusicClient().getLibraryContent()
+        let browseIds = content.albums.map(\.id)
+        let libraryTargetIds = try content.albums.map { album in
+            try #require(album.libraryTargetId)
+        }
+
+        #expect(content.albums.count == 4)
+        #expect(browseIds.allSatisfy { $0.hasPrefix("MPRE") })
+        #expect(libraryTargetIds.allSatisfy { $0.hasPrefix("OLAK") })
+        #expect(Set(browseIds).count == browseIds.count)
+        #expect(Set(libraryTargetIds).count == libraryTargetIds.count)
+        #expect(zip(browseIds, libraryTargetIds).allSatisfy { identityPair in identityPair.0 != identityPair.1 })
+        for album in content.albums {
+            #expect(album.hasNavigableId)
+        }
+    }
+
+    @Test("Library album details preserve the matching mutation target")
+    @MainActor
+    func libraryAlbumDetailsPreserveMatchingMutationTarget() async throws {
+        let client = MockUITestYTMusicClient()
+        let content = try await client.getLibraryContent()
+        let albums = content.albums
+
+        for album in albums {
+            let response = try await client.getPlaylist(id: album.id)
+
+            #expect(response.detail.id == album.id)
+            #expect(response.detail.title == album.title)
+            #expect(response.detail.isAlbum)
+            #expect(response.detail.libraryTargetId == album.libraryTargetId)
+            #expect(!response.detail.tracks.isEmpty)
+        }
+    }
+}

--- a/Tests/KasetTests/PlayerServiceLibraryTests.swift
+++ b/Tests/KasetTests/PlayerServiceLibraryTests.swift
@@ -874,57 +874,6 @@ struct PlayerServiceLibraryTests { // swiftlint:disable:this type_body_length
         #expect(self.playerService.currentTrackFeedbackTokens == FeedbackTokens(add: "add-token", remove: "remove-token"))
     }
 
-    @Test("A stale account owner cannot create a captured queue playlist")
-    func staleAccountOwnerCannotCreateCapturedQueuePlaylist() async {
-        let songs = [TestFixtures.makeSong(id: "stale-playlist-owner")]
-        let owner = self.playerService.currentAccountMutationOwner
-        self.playerService.songLikeStatusManager.setActiveAccountID("brand-account")
-
-        await #expect(throws: CancellationError.self) {
-            _ = try await self.playerService.saveQueueAsPlaylist(
-                title: "Stale Snapshot",
-                songs: songs,
-                owner: owner
-            )
-        }
-
-        #expect(self.mockClient.createPlaylistCalls.isEmpty)
-    }
-
-    @Test("An account switch during playlist reconciliation removes the stale optimistic playlist")
-    func accountSwitchDuringPlaylistReconciliationRemovesOptimisticPlaylist() async {
-        let libraryViewModel = LibraryViewModel(client: self.mockClient)
-        let songs = [TestFixtures.makeSong(id: "reconcile-account-switch")]
-        let owner = self.playerService.currentAccountMutationOwner
-        self.mockClient.shouldWaitForLibraryContentResponse = true
-
-        var saveTask: Task<Playlist, any Error>!
-        await withCheckedContinuation { continuation in
-            self.mockClient.onGetLibraryContent = {
-                self.mockClient.onGetLibraryContent = nil
-                continuation.resume()
-            }
-            saveTask = Task { @MainActor in
-                try await self.playerService.saveQueueAsPlaylist(
-                    title: "Old Account Playlist",
-                    songs: songs,
-                    owner: owner
-                )
-            }
-        }
-
-        #expect(libraryViewModel.isInLibrary(playlistId: "PLCREATED"))
-        self.playerService.songLikeStatusManager.setActiveAccountID("brand-account")
-        self.mockClient.shouldWaitForLibraryContentResponse = false
-        self.mockClient.resumeNextLibraryContentResponse()
-
-        await #expect(throws: CancellationError.self) {
-            _ = try await saveTask.value
-        }
-        #expect(!libraryViewModel.isInLibrary(playlistId: "PLCREATED"))
-        #expect(!libraryViewModel.playlists.contains { $0.id == "PLCREATED" })
-    }
-
     // MARK: - Update Like Status Tests
 
     @Test("updateLikeStatus updates status")

--- a/Tests/KasetTests/PlayerServicePlaylistCreationBoundaryTests.swift
+++ b/Tests/KasetTests/PlayerServicePlaylistCreationBoundaryTests.swift
@@ -1,0 +1,113 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+// MARK: - PlayerServicePlaylistCreationBoundaryTests
+
+extension LibraryMutationSerialTests {
+    @Suite(.tags(.service), .timeLimit(.minutes(1)))
+    @MainActor
+    struct PlayerServicePlaylistCreationBoundaryTests {
+        var playerService: PlayerService
+        var mockClient: MockYTMusicClient
+
+        init() {
+            self.mockClient = MockYTMusicClient()
+            self.playerService = PlayerService()
+            let likeStatusManager = SongLikeStatusManager()
+            likeStatusManager.setActiveAccountID(nil)
+            self.playerService.setSongLikeStatusManager(likeStatusManager)
+            self.playerService.setYTMusicClient(self.mockClient)
+        }
+
+        @Test("A stale account owner cannot create a captured queue playlist")
+        func staleAccountOwnerCannotCreateCapturedQueuePlaylist() async {
+            let songs = [TestFixtures.makeSong(id: "stale-playlist-owner")]
+            let owner = self.playerService.currentAccountMutationOwner
+            self.playerService.songLikeStatusManager.setActiveAccountID("brand-account")
+
+            await #expect(throws: CancellationError.self) {
+                _ = try await self.playerService.saveQueueAsPlaylist(
+                    title: "Stale Snapshot",
+                    songs: songs,
+                    owner: owner
+                )
+            }
+
+            #expect(self.mockClient.createPlaylistCalls.isEmpty)
+        }
+
+        @Test("An account switch during playlist reconciliation removes the stale optimistic playlist")
+        func accountSwitchDuringPlaylistReconciliationRemovesOptimisticPlaylist() async {
+            let libraryViewModel = LibraryViewModel(client: self.mockClient)
+            let songs = [TestFixtures.makeSong(id: "reconcile-account-switch")]
+            let owner = self.playerService.currentAccountMutationOwner
+            self.mockClient.shouldWaitForLibraryContentResponse = true
+
+            var saveTask: Task<Playlist, any Error>!
+            await withCheckedContinuation { continuation in
+                self.mockClient.onGetLibraryContent = {
+                    self.mockClient.onGetLibraryContent = nil
+                    continuation.resume()
+                }
+                saveTask = Task { @MainActor in
+                    try await self.playerService.saveQueueAsPlaylist(
+                        title: "Old Account Playlist",
+                        songs: songs,
+                        owner: owner
+                    )
+                }
+            }
+
+            #expect(libraryViewModel.isInLibrary(playlistId: "PLCREATED"))
+            self.playerService.songLikeStatusManager.setActiveAccountID("brand-account")
+            self.mockClient.shouldWaitForLibraryContentResponse = false
+            self.mockClient.resumeNextLibraryContentResponse()
+
+            await #expect(throws: CancellationError.self) {
+                _ = try await saveTask.value
+            }
+            #expect(!libraryViewModel.isInLibrary(playlistId: "PLCREATED"))
+            #expect(!libraryViewModel.playlists.contains { $0.id == "PLCREATED" })
+        }
+
+        @Test("Account boundary drains queue-playlist reconciliation before reopening")
+        func accountBoundaryDrainsQueuePlaylistReconciliation() async {
+            let libraryViewModel = LibraryViewModel(client: self.mockClient)
+            let songs = [TestFixtures.makeSong(id: "boundary-reconciliation")]
+            self.mockClient.shouldWaitForLibraryContentResponse = true
+
+            var saveTask: Task<Playlist, any Error>!
+            await withCheckedContinuation { continuation in
+                self.mockClient.onGetLibraryContent = {
+                    self.mockClient.onGetLibraryContent = nil
+                    continuation.resume()
+                }
+                saveTask = Task { @MainActor in
+                    try await self.playerService.saveQueueAsPlaylist(
+                        title: "Boundary Playlist",
+                        songs: songs,
+                        owner: self.playerService.currentAccountMutationOwner
+                    )
+                }
+            }
+            #expect(libraryViewModel.isInLibrary(playlistId: "PLCREATED"))
+
+            LibraryMutationActions.beginAccountBoundary()
+            let drainTask = Task { await LibraryMutationActions.awaitAccountBoundaryDrain() }
+            for _ in 0 ..< 10 {
+                await Task.yield()
+            }
+            #expect(libraryViewModel.isInLibrary(playlistId: "PLCREATED"))
+            self.mockClient.shouldWaitForLibraryContentResponse = false
+            self.mockClient.resumeNextLibraryContentResponse()
+            await drainTask.value
+            LibraryMutationActions.endAccountBoundary()
+
+            await #expect(throws: CancellationError.self) {
+                _ = try await saveTask.value
+            }
+            #expect(!libraryViewModel.isInLibrary(playlistId: "PLCREATED"))
+        }
+    }
+}

--- a/Tests/KasetTests/PlayerServiceQueueTests.swift
+++ b/Tests/KasetTests/PlayerServiceQueueTests.swift
@@ -479,7 +479,7 @@ struct PlayerServiceQueueTests {
     func authenticatedStartupClearsGuestOwnedRestoredPlayback() async {
         let authService = AuthService(webKitManager: MockWebKitManager())
         authService.completeLogin(sapisid: "placeholder")
-        authService.enterGuestMode()
+        await authService.enterGuestMode()
         self.playerService.setAuthService(authService)
         let songs = TestFixtures.makeSongs(count: 2)
         await self.playerService.playQueue(songs, startingAt: 1)
@@ -501,7 +501,7 @@ struct PlayerServiceQueueTests {
     func authDataStoreReloadDoesNotRetagDeferredGuestRestoreBeforeStartupCleanup() async {
         let authService = AuthService(webKitManager: MockWebKitManager())
         authService.completeLogin(sapisid: "placeholder")
-        authService.enterGuestMode()
+        await authService.enterGuestMode()
         self.playerService.setAuthService(authService)
         let songs = TestFixtures.makeSongs(count: 2)
         await self.playerService.playQueue(songs, startingAt: 1)
@@ -525,7 +525,7 @@ struct PlayerServiceQueueTests {
     func authDataStoreReloadMarksRestoredGuestPlaybackAuthenticated() async {
         let authService = AuthService(webKitManager: MockWebKitManager())
         authService.completeLogin(sapisid: "placeholder")
-        authService.enterGuestMode()
+        await authService.enterGuestMode()
         self.playerService.setAuthService(authService)
         let songs = TestFixtures.makeSongs(count: 2)
         await self.playerService.playQueue(songs, startingAt: 1)

--- a/Tests/KasetTests/PlaylistDetailLibraryMutationActivityTests.swift
+++ b/Tests/KasetTests/PlaylistDetailLibraryMutationActivityTests.swift
@@ -1,0 +1,29 @@
+import Testing
+@testable import Kaset
+
+// MARK: - PlaylistDetailLibraryMutationActivityTests
+
+@Suite(.tags(.viewModel))
+struct PlaylistDetailLibraryMutationActivityTests {
+    @Test("An older operation cannot clear a newer operation's loading state")
+    func olderOperationCannotFinishNewerActivity() {
+        var activity = PlaylistDetailLibraryMutationActivity()
+        guard let firstOperation = activity.begin() else {
+            Issue.record("Expected the first operation to start")
+            return
+        }
+
+        activity.finish(firstOperation)
+        guard let secondOperation = activity.begin() else {
+            Issue.record("Expected the second operation to start")
+            return
+        }
+        activity.finish(firstOperation)
+
+        #expect(activity.isActive)
+        #expect(activity.operationID == secondOperation)
+
+        activity.finish(secondOperation)
+        #expect(!activity.isActive)
+    }
+}

--- a/Tests/KasetTests/PlaylistDetailViewModelTests.swift
+++ b/Tests/KasetTests/PlaylistDetailViewModelTests.swift
@@ -871,7 +871,8 @@ struct PlaylistDetailViewModelTests {
         let detail = PlaylistDetail(
             playlist: album,
             tracks: TestFixtures.makeSongs(count: 100),
-            duration: nil
+            duration: nil,
+            libraryTargetId: "OLAK-test-album"
         )
         self.mockClient.playlistDetails[album.id] = detail
         self.mockClient.playlistContinuationTracks[album.id] = [
@@ -884,7 +885,13 @@ struct PlaylistDetailViewModelTests {
 
         #expect(self.mockClient.getPlaylistContinuationCalled == false)
         #expect(albumViewModel.playlistDetail?.tracks.count == 100)
+        #expect(albumViewModel.playlistDetail?.libraryTargetId == "OLAK-test-album")
         #expect(albumViewModel.hasMore == true)
+
+        await albumViewModel.loadMore()
+
+        #expect(albumViewModel.playlistDetail?.tracks.count == 125)
+        #expect(albumViewModel.playlistDetail?.libraryTargetId == "OLAK-test-album")
     }
 
     // MARK: - Load More Tests

--- a/Tests/KasetTests/PlaylistDetailViewModelTests.swift
+++ b/Tests/KasetTests/PlaylistDetailViewModelTests.swift
@@ -894,6 +894,36 @@ struct PlaylistDetailViewModelTests {
         #expect(albumViewModel.playlistDetail?.libraryTargetId == "OLAK-test-album")
     }
 
+    @Test("Album load preserves a known route mutation target")
+    func albumLoadPreservesRouteMutationTarget() async {
+        let routeAlbum = Playlist(
+            id: "MPRE-route-album",
+            title: "Route Album",
+            description: nil,
+            thumbnailURL: nil,
+            trackCount: 1,
+            author: Artist.inline(name: "Route Artist", namespace: "playlist-author"),
+            libraryTargetId: "OLAK-route-album"
+        )
+        let loadedAlbum = Playlist(
+            id: routeAlbum.id,
+            title: routeAlbum.title,
+            description: nil,
+            thumbnailURL: nil,
+            trackCount: 1,
+            author: routeAlbum.author
+        )
+        self.mockClient.playlistDetails[routeAlbum.id] = PlaylistDetail(
+            playlist: loadedAlbum,
+            tracks: [TestFixtures.makeSong(id: "route-track")]
+        )
+
+        let viewModel = PlaylistDetailViewModel(playlist: routeAlbum, client: self.mockClient)
+        await viewModel.load()
+
+        #expect(viewModel.playlistDetail?.libraryTargetId == "OLAK-route-album")
+    }
+
     // MARK: - Load More Tests
 
     @Test("Load more appends tracks")

--- a/Tests/KasetTests/PlaylistLibraryMutationBoundaryTests.swift
+++ b/Tests/KasetTests/PlaylistLibraryMutationBoundaryTests.swift
@@ -1,0 +1,895 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+// MARK: - Playlist mutation boundary tests
+
+extension LibraryMutationSerialTests.LibraryMutationActionsTests {
+    @Test("Library mutations resume immediately after an empty account boundary")
+    func mutationsResumeImmediatelyAfterEmptyAccountBoundary() async throws {
+        let playlist = TestFixtures.makePlaylist(id: "VL-boundary-reopened", title: "Boundary Reopened")
+
+        LibraryMutationActions.beginAccountBoundary()
+        LibraryMutationActions.endAccountBoundary()
+
+        try await LibraryMutationActions.addPlaylistToLibrary(
+            playlist,
+            client: self.mockClient,
+            libraryViewModel: self.libraryViewModel,
+            reconciliationDelay: .zero
+        )
+
+        #expect(self.mockClient.subscribeToPlaylistIds == [playlist.id])
+        #expect(self.libraryViewModel.isInLibrary(playlistId: playlist.id))
+    }
+
+    @Test("Library mutations cannot start while an account boundary is active")
+    func libraryMutationCannotStartDuringAccountBoundary() async {
+        let playlist = TestFixtures.makePlaylist(id: "VL-boundary-closed", title: "Boundary Closed")
+        let podcast = TestFixtures.makePodcastShow(id: "MPSPPLboundary-closed")
+        let artist = TestFixtures.makeArtist(id: "UC-boundary-closed", name: "Boundary Closed")
+        let song = TestFixtures.makeSong(id: "boundary-song", title: "Boundary Song")
+        let addToPlaylistOption = AddToPlaylistOption(
+            playlistId: "VL-boundary-target",
+            title: "Boundary Target",
+            subtitle: nil,
+            thumbnailURL: nil,
+            isSelected: false,
+            privacyStatus: nil
+        )
+        LibraryMutationActions.beginAccountBoundary()
+        defer { LibraryMutationActions.endAccountBoundary() }
+
+        await #expect(throws: CancellationError.self) {
+            try await LibraryMutationActions.addPlaylistToLibrary(
+                playlist,
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel,
+                reconciliationDelay: .zero
+            )
+        }
+        await #expect(throws: CancellationError.self) {
+            try await LibraryMutationActions.subscribeToPodcast(
+                podcast,
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel
+            )
+        }
+        await #expect(throws: CancellationError.self) {
+            try await LibraryMutationActions.subscribeToArtist(
+                artist,
+                channelId: artist.id,
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel
+            )
+        }
+        await LibraryMutationActions.addSongToPlaylist(
+            song,
+            playlist: addToPlaylistOption,
+            client: self.mockClient
+        )
+        #expect(self.mockClient.subscribeToPlaylistIds.isEmpty)
+        #expect(self.mockClient.addSongToPlaylistCalls.isEmpty)
+        #expect(!self.mockClient.subscribeToArtistCalled)
+        #expect(!self.libraryViewModel.isInLibrary(podcastId: podcast.id))
+        #expect(!self.libraryViewModel.isInLibrary(artistId: artist.id))
+    }
+
+    @Test("Account boundary drain waits for cancelled mutations to finish")
+    func accountBoundaryDrainWaitsForCancelledMutation() async {
+        let playlist = TestFixtures.makePlaylist(id: "VL-boundary-drain", title: "Boundary Drain")
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        let drainCompleted = LockedCounter()
+        self.mockClient.beforeSubscribeToPlaylistReturn = { _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+
+        let mutationTask = Task {
+            try await LibraryMutationActions.addPlaylistToLibrary(
+                playlist,
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel,
+                reconciliationDelay: .zero
+            )
+        }
+        await requestStarted.wait()
+
+        LibraryMutationActions.beginAccountBoundary()
+        let drainTask = Task {
+            await LibraryMutationActions.awaitAccountBoundaryDrain()
+            drainCompleted.increment()
+        }
+        for _ in 0 ..< 10 {
+            await Task.yield()
+        }
+        #expect(drainCompleted.isEmpty)
+
+        await releaseRequest.open()
+        await drainTask.value
+        LibraryMutationActions.endAccountBoundary()
+
+        await #expect(throws: CancellationError.self) { try await mutationTask.value }
+        #expect(drainCompleted.count == 1)
+    }
+
+    @Test("Account boundary drains in-flight playlist creation")
+    func accountBoundaryDrainsInFlightPlaylistCreation() async {
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        let drainCompleted = LockedCounter()
+        self.mockClient.beforeCreatePlaylistReturn = {
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+
+        let creationTask = Task {
+            try await LibraryMutationActions.withAccountBoundaryTracking {
+                try await self.mockClient.createPlaylist(
+                    title: "Boundary Playlist",
+                    description: nil,
+                    privacyStatus: .private,
+                    videoIds: ["boundary-video"]
+                )
+            }
+        }
+        await requestStarted.wait()
+
+        LibraryMutationActions.beginAccountBoundary()
+        let drainTask = Task {
+            await LibraryMutationActions.awaitAccountBoundaryDrain()
+            drainCompleted.increment()
+        }
+        for _ in 0 ..< 10 {
+            await Task.yield()
+        }
+        #expect(drainCompleted.isEmpty)
+
+        await releaseRequest.open()
+        await drainTask.value
+        LibraryMutationActions.endAccountBoundary()
+
+        await #expect(throws: CancellationError.self) {
+            _ = try await creationTask.value
+        }
+        #expect(drainCompleted.count == 1)
+        #expect(self.mockClient.createPlaylistCalls.count == 1)
+    }
+
+    @Test("Account boundary keeps a completed track removal applied")
+    func accountBoundaryKeepsCompletedTrackRemovalApplied() async {
+        let song = Song(
+            id: "boundary-track",
+            title: "Boundary Track",
+            artists: [],
+            videoId: "boundary-track",
+            playlistSetVideoId: "boundary-set"
+        )
+        let playlist = Playlist(
+            id: "VL-boundary-track",
+            title: "Boundary Tracks",
+            description: nil,
+            thumbnailURL: nil,
+            trackCount: 1,
+            canDelete: true
+        )
+        self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(
+            playlist: playlist,
+            tracks: [song],
+            duration: nil
+        )
+        let viewModel = PlaylistDetailViewModel(playlist: playlist, client: self.mockClient)
+        await viewModel.load()
+        self.mockClient.shouldWaitForRemoveSongFromPlaylistResponse = true
+
+        let removalTask = Task {
+            await LibraryMutationActions.removeSongFromPlaylist(
+                song,
+                from: viewModel,
+                client: self.mockClient
+            )
+        }
+        #expect(await self.waitForCondition(self.mockClient.removeSongFromPlaylistCalls.count == 1))
+
+        LibraryMutationActions.beginAccountBoundary()
+        self.mockClient.resumeNextRemoveSongFromPlaylistResponse()
+        await LibraryMutationActions.awaitAccountBoundaryDrain()
+        LibraryMutationActions.endAccountBoundary()
+        await removalTask.value
+
+        #expect(viewModel.playlistDetail?.tracks.isEmpty == true)
+        #expect(viewModel.playlistDetail?.trackCount == 0)
+    }
+
+    @Test("Replacing artist reconciliation keeps the successor boundary-tracked")
+    func replacingArtistReconciliationKeepsSuccessorTracked() async throws {
+        let artist = TestFixtures.makeArtist(id: "UC-reconciliation-successor", name: "Tracked Artist")
+        let drainCompleted = LockedCounter()
+        LibraryMutationActions.artistReconciliationRetryDelays = [.zero]
+        self.mockClient.shouldAutoUpdateArtistLibraryOnMutation = false
+        self.mockClient.shouldWaitForLibraryContentResponse = true
+
+        try await LibraryMutationActions.subscribeToArtist(
+            artist,
+            channelId: artist.id,
+            client: self.mockClient,
+            libraryViewModel: self.libraryViewModel
+        )
+        #expect(await self.waitForCondition(self.mockClient.getLibraryContentCallCount == 1))
+
+        LibraryMutationActions.artistReconciliationRetryDelays = [.seconds(10)]
+        try await LibraryMutationActions.subscribeToArtist(
+            artist,
+            channelId: artist.id,
+            client: self.mockClient,
+            libraryViewModel: self.libraryViewModel
+        )
+        for _ in 0 ..< 10 {
+            await Task.yield()
+        }
+
+        LibraryMutationActions.beginAccountBoundary()
+        let drainTask = Task {
+            await LibraryMutationActions.awaitAccountBoundaryDrain()
+            drainCompleted.increment()
+        }
+        for _ in 0 ..< 10 {
+            await Task.yield()
+        }
+        #expect(drainCompleted.isEmpty)
+
+        self.mockClient.shouldWaitForLibraryContentResponse = false
+        self.mockClient.resumeNextLibraryContentResponse()
+        await drainTask.value
+        LibraryMutationActions.endAccountBoundary()
+
+        #expect(drainCompleted.count == 1)
+        #expect(self.mockClient.getLibraryContentCallCount == 1)
+    }
+
+    @Test("Stale playlist-creation errors normalize to cancellation")
+    func stalePlaylistCreationErrorsNormalizeToCancellation() async {
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        self.mockClient.beforeCreatePlaylistReturn = {
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+
+        let creationTask = Task {
+            try await LibraryMutationActions.withAccountBoundaryTracking {
+                try await self.mockClient.createPlaylist(
+                    title: "Cancelled Boundary Playlist",
+                    description: nil,
+                    privacyStatus: .private,
+                    videoIds: []
+                )
+            }
+        }
+        await requestStarted.wait()
+
+        LibraryMutationActions.beginAccountBoundary()
+        self.mockClient.shouldThrowError = YTMusicError.networkError(underlying: URLError(.cancelled))
+        await releaseRequest.open()
+        await LibraryMutationActions.awaitAccountBoundaryDrain()
+        LibraryMutationActions.endAccountBoundary()
+
+        await #expect(throws: CancellationError.self) {
+            _ = try await creationTask.value
+        }
+    }
+
+    @Test("Cancelling an in-flight playlist add prevents an account-crossing update")
+    func cancellingInFlightPlaylistAddPreventsAccountCrossingUpdate() async {
+        let playlist = TestFixtures.makePlaylist(id: "VL-cancelled-add", title: "Cancelled Add")
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        self.libraryViewModel.activateAccountScope("account-a")
+        self.mockClient.beforeSubscribeToPlaylistReturn = { _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+        self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
+
+        let task = Task {
+            try await LibraryMutationActions.addPlaylistToLibrary(
+                playlist,
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel,
+                reconciliationDelay: .zero
+            )
+        }
+
+        await requestStarted.wait()
+        LibraryMutationActions.cancelPendingPlaylistMutations(for: self.libraryViewModel)
+        self.libraryViewModel.activateAccountScope("account-b")
+        await releaseRequest.open()
+
+        await #expect(throws: CancellationError.self) {
+            try await task.value
+        }
+        #expect(!self.libraryViewModel.isInLibrary(playlistId: playlist.id))
+    }
+
+    @Test("Cancelling delayed playlist add does not reinsert into the next account")
+    func cancellingDelayedPlaylistAddPreservesNextAccountSnapshot() async {
+        let playlist = TestFixtures.makePlaylist(id: "VL-delayed-add", title: "Delayed Add")
+        let applied = LockedCounter()
+        self.libraryViewModel.activateAccountScope("account-a")
+        self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
+
+        let task = Task {
+            try await LibraryMutationActions.addPlaylistToLibrary(
+                playlist,
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel,
+                reconciliationDelay: .seconds(10),
+                onMutationApplied: { applied.increment() }
+            )
+        }
+
+        #expect(await self.waitForCondition(applied.count == 1))
+        #expect(self.libraryViewModel.isInLibrary(playlistId: playlist.id))
+        LibraryMutationActions.cancelPendingPlaylistMutations(for: self.libraryViewModel)
+        self.libraryViewModel.activateAccountScope("account-b")
+
+        await #expect(throws: CancellationError.self) {
+            try await task.value
+        }
+        #expect(!self.libraryViewModel.isInLibrary(playlistId: playlist.id))
+    }
+
+    @Test("Cancelling delayed playlist removal preserves the next account membership")
+    func cancellingDelayedPlaylistRemovalPreservesNextAccountSnapshot() async {
+        let playlist = TestFixtures.makePlaylist(id: "VL-delayed-remove", title: "Delayed Remove")
+        let applied = LockedCounter()
+        self.libraryViewModel.activateAccountScope("account-a")
+        self.libraryViewModel.addToLibrary(playlist: playlist)
+        self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
+
+        let task = Task {
+            try await LibraryMutationActions.removePlaylistFromLibrary(
+                playlist,
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel,
+                reconciliationDelay: .seconds(10),
+                onMutationApplied: { applied.increment() }
+            )
+        }
+
+        #expect(await self.waitForCondition(applied.count == 1))
+        #expect(!self.libraryViewModel.isInLibrary(playlistId: playlist.id))
+        LibraryMutationActions.cancelPendingPlaylistMutations(for: self.libraryViewModel)
+        self.libraryViewModel.activateAccountScope("account-b")
+        self.libraryViewModel.addToLibrary(playlist: playlist)
+
+        await #expect(throws: CancellationError.self) {
+            try await task.value
+        }
+        #expect(self.libraryViewModel.isInLibrary(playlistId: playlist.id))
+    }
+
+    @Test("Account boundary during playlist add refresh cannot reinsert old content")
+    func accountBoundaryDuringPlaylistAddRefreshCannotReinsertOldPlaylist() async {
+        let oldPlaylist = TestFixtures.makePlaylist(id: "VL-old-account-add", title: "Old Account")
+        let nextPlaylist = TestFixtures.makePlaylist(id: "VL-next-account", title: "Next Account")
+        self.libraryViewModel.activateAccountScope("account-a")
+        self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
+        self.mockClient.shouldWaitForLibraryContentResponse = true
+
+        let task = Task {
+            try await LibraryMutationActions.addPlaylistToLibrary(
+                oldPlaylist,
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel,
+                reconciliationDelay: .zero
+            )
+        }
+
+        #expect(await self.waitForCondition(self.mockClient.getLibraryContentCallCount == 1))
+        LibraryMutationActions.cancelPendingPlaylistMutations(for: self.libraryViewModel)
+        self.libraryViewModel.activateAccountScope("account-b")
+        self.libraryViewModel.addToLibrary(playlist: nextPlaylist)
+        self.mockClient.resumeNextLibraryContentResponse()
+
+        await #expect(throws: CancellationError.self) {
+            try await task.value
+        }
+        #expect(!self.libraryViewModel.isInLibrary(playlistId: oldPlaylist.id))
+        #expect(self.libraryViewModel.isInLibrary(playlistId: nextPlaylist.id))
+    }
+
+    @Test("Account boundary during playlist removal refresh preserves matching next-account content")
+    func accountBoundaryDuringPlaylistRemovalRefreshPreservesNextAccountPlaylist() async {
+        let oldPlaylist = TestFixtures.makePlaylist(id: "VL-shared-account", title: "Old Account")
+        let nextPlaylist = TestFixtures.makePlaylist(id: "VL-shared-account", title: "Next Account")
+        self.libraryViewModel.activateAccountScope("account-a")
+        self.libraryViewModel.addToLibrary(playlist: oldPlaylist)
+        self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
+        self.mockClient.shouldWaitForLibraryContentResponse = true
+
+        let task = Task {
+            try await LibraryMutationActions.removePlaylistFromLibrary(
+                oldPlaylist,
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel,
+                reconciliationDelay: .zero
+            )
+        }
+
+        #expect(await self.waitForCondition(self.mockClient.getLibraryContentCallCount == 1))
+        LibraryMutationActions.cancelPendingPlaylistMutations(for: self.libraryViewModel)
+        self.libraryViewModel.activateAccountScope("account-b")
+        self.libraryViewModel.addToLibrary(playlist: nextPlaylist)
+        self.mockClient.resumeNextLibraryContentResponse()
+
+        await #expect(throws: CancellationError.self) {
+            try await task.value
+        }
+        #expect(self.libraryViewModel.playlists.contains(nextPlaylist))
+    }
+
+    @Test("Newer playlist removal wins over delayed add reconciliation")
+    func newerPlaylistRemovalWinsOverDelayedAddReconciliation() async throws {
+        let playlist = TestFixtures.makePlaylist(id: "VL-overlap-add-remove", title: "Overlap Playlist")
+        self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
+        self.mockClient.libraryContentResponses = [
+            PlaylistParser.LibraryContent(playlists: [], artists: [], podcastShows: []),
+            PlaylistParser.LibraryContent(playlists: [], artists: [], podcastShows: []),
+        ]
+        self.mockClient.libraryContentResponseDelays = [.milliseconds(100), .zero]
+
+        async let add: Void = LibraryMutationActions.addPlaylistToLibrary(
+            playlist,
+            client: self.mockClient,
+            libraryViewModel: self.libraryViewModel,
+            reconciliationDelay: .zero
+        )
+
+        #expect(await self.waitForCondition(self.libraryViewModel.isInLibrary(playlistId: playlist.id)))
+
+        async let remove: Void = LibraryMutationActions.removePlaylistFromLibrary(
+            playlist,
+            client: self.mockClient,
+            libraryViewModel: self.libraryViewModel,
+            reconciliationDelay: .zero
+        )
+
+        try await add
+        try await remove
+
+        #expect(!self.libraryViewModel.isInLibrary(playlistId: playlist.id))
+        #expect(self.mockClient.subscribeToPlaylistIds == [playlist.id])
+        #expect(self.mockClient.unsubscribeFromPlaylistIds == [playlist.id])
+        #expect(self.mockClient.getLibraryContentCallCount == 2)
+    }
+
+    @Test("Playlist mutations serialize across different library models")
+    func playlistMutationsSerializeAcrossLibraryModels() async throws {
+        let playlist = TestFixtures.makePlaylist(id: "VL-multi-model-overlap", title: "Shared Playlist")
+        let otherLibraryViewModel = LibraryViewModel(client: self.mockClient)
+        self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
+        self.mockClient.libraryContentResponses = [
+            PlaylistParser.LibraryContent(playlists: [], artists: [], podcastShows: []),
+            PlaylistParser.LibraryContent(playlists: [], artists: [], podcastShows: []),
+            PlaylistParser.LibraryContent(playlists: [], artists: [], podcastShows: []),
+        ]
+        self.mockClient.libraryContentResponseDelays = [.milliseconds(100), .zero, .zero]
+
+        async let add: Void = LibraryMutationActions.addPlaylistToLibrary(
+            playlist,
+            client: self.mockClient,
+            libraryViewModel: self.libraryViewModel,
+            reconciliationDelay: .zero
+        )
+
+        #expect(await self.waitForCondition(self.libraryViewModel.isInLibrary(playlistId: playlist.id)))
+
+        async let remove: Void = LibraryMutationActions.removePlaylistFromLibrary(
+            playlist,
+            client: self.mockClient,
+            libraryViewModel: otherLibraryViewModel,
+            reconciliationDelay: .zero
+        )
+
+        try await add
+        try await remove
+
+        #expect(!self.libraryViewModel.isInLibrary(playlistId: playlist.id))
+        #expect(!otherLibraryViewModel.isInLibrary(playlistId: playlist.id))
+        #expect(self.mockClient.subscribeToPlaylistIds == [playlist.id])
+        #expect(self.mockClient.unsubscribeFromPlaylistIds == [playlist.id])
+    }
+
+    @Test("Playlist additions update every active library model")
+    func playlistAdditionsUpdateEveryActiveLibraryModel() async throws {
+        let playlist = TestFixtures.makePlaylist(id: "VL-multi-model-add", title: "Shared Addition")
+        let otherLibraryViewModel = LibraryViewModel(client: self.mockClient)
+        self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
+
+        try await LibraryMutationActions.addPlaylistToLibrary(
+            playlist,
+            client: self.mockClient,
+            libraryViewModel: otherLibraryViewModel,
+            reconciliationDelay: .zero
+        )
+
+        #expect(self.libraryViewModel.isInLibrary(playlistId: playlist.id))
+        #expect(otherLibraryViewModel.isInLibrary(playlistId: playlist.id))
+    }
+
+    @Test("Newer playlist add wins over delayed removal reconciliation")
+    func newerPlaylistAddWinsOverDelayedRemovalReconciliation() async throws {
+        let playlist = TestFixtures.makePlaylist(id: "VL-overlap-remove-add", title: "Overlap Playlist")
+        self.libraryViewModel.addToLibrary(playlist: playlist)
+        self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
+        self.mockClient.libraryContentResponses = [
+            PlaylistParser.LibraryContent(playlists: [], artists: [], podcastShows: []),
+            PlaylistParser.LibraryContent(playlists: [], artists: [], podcastShows: []),
+        ]
+        self.mockClient.libraryContentResponseDelays = [.milliseconds(100), .zero]
+
+        async let remove: Void = LibraryMutationActions.removePlaylistFromLibrary(
+            playlist,
+            client: self.mockClient,
+            libraryViewModel: self.libraryViewModel,
+            reconciliationDelay: .zero
+        )
+
+        #expect(await self.waitForCondition(!self.libraryViewModel.isInLibrary(playlistId: playlist.id)))
+
+        async let add: Void = LibraryMutationActions.addPlaylistToLibrary(
+            playlist,
+            client: self.mockClient,
+            libraryViewModel: self.libraryViewModel,
+            reconciliationDelay: .zero
+        )
+
+        try await remove
+        try await add
+
+        #expect(self.libraryViewModel.isInLibrary(playlistId: playlist.id))
+        #expect(self.mockClient.unsubscribeFromPlaylistIds == [playlist.id])
+        #expect(self.mockClient.subscribeToPlaylistIds == [playlist.id])
+        #expect(self.mockClient.getLibraryContentCallCount == 2)
+    }
+
+    @Test("Cancelling a playlist mutation caller cancels its tracked operation")
+    func callerCancellationPropagatesToPlaylistMutation() async {
+        let playlist = TestFixtures.makePlaylist(id: "VL-caller-cancelled", title: "Caller Cancelled")
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        let applied = LockedCounter()
+        self.mockClient.beforeSubscribeToPlaylistReturn = { _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+        self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
+
+        let task = Task {
+            try await LibraryMutationActions.addPlaylistToLibrary(
+                playlist,
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel,
+                reconciliationDelay: .zero,
+                onMutationApplied: { applied.increment() }
+            )
+        }
+
+        await requestStarted.wait()
+        task.cancel()
+        await releaseRequest.open()
+
+        await #expect(throws: CancellationError.self) {
+            try await task.value
+        }
+        #expect(applied.isEmpty)
+        #expect(!self.libraryViewModel.isInLibrary(playlistId: playlist.id))
+        #expect(self.mockClient.getLibraryContentCallCount == 0)
+    }
+
+    @Test("Account cancellation cancels every queued mutation for one playlist")
+    func accountCancellationCancelsEveryQueuedPlaylistMutation() async {
+        let playlist = TestFixtures.makePlaylist(id: "VL-cancel-chain", title: "Cancel Chain")
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        let predecessorWasCancelled = LockedCounter()
+        self.mockClient.beforeSubscribeToPlaylistReturn = { _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+            if Task.isCancelled {
+                predecessorWasCancelled.increment()
+            }
+        }
+        self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
+
+        let firstTask = Task {
+            try await LibraryMutationActions.addPlaylistToLibrary(
+                playlist,
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel,
+                reconciliationDelay: .zero
+            )
+        }
+        await requestStarted.wait()
+
+        let secondTask = Task {
+            try await LibraryMutationActions.removePlaylistFromLibrary(
+                playlist,
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel,
+                reconciliationDelay: .zero
+            )
+        }
+        for _ in 0 ..< 10 {
+            await Task.yield()
+        }
+
+        LibraryMutationActions.cancelAllPendingLibraryMutations()
+        await releaseRequest.open()
+
+        await #expect(throws: CancellationError.self) { try await firstTask.value }
+        await #expect(throws: CancellationError.self) { try await secondTask.value }
+        #expect(predecessorWasCancelled.count == 1)
+        #expect(self.mockClient.unsubscribeFromPlaylistIds.isEmpty)
+    }
+
+    @Test("Account cancellation cancels every queued mutation for one album")
+    func accountCancellationCancelsEveryQueuedAlbumMutation() async {
+        let album = TestFixtures.makeAlbum(
+            id: "MPRE-cancel-chain",
+            title: "Cancel Chain",
+            libraryTargetId: "OLAK-cancel-chain"
+        )
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        let predecessorWasCancelled = LockedCounter()
+        self.mockClient.beforeSubscribeToPlaylistReturn = { _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+            if Task.isCancelled {
+                predecessorWasCancelled.increment()
+            }
+        }
+        self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
+
+        let firstTask = Task {
+            try await LibraryMutationActions.addAlbumToLibrary(
+                album,
+                targetPlaylistId: "OLAK-cancel-chain",
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel,
+                reconciliationDelay: .zero
+            )
+        }
+        await requestStarted.wait()
+
+        let secondTask = Task {
+            try await LibraryMutationActions.removeAlbumFromLibrary(
+                album,
+                targetPlaylistId: "OLAK-cancel-chain",
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel,
+                reconciliationDelay: .zero
+            )
+        }
+        for _ in 0 ..< 10 {
+            await Task.yield()
+        }
+
+        LibraryMutationActions.cancelAllPendingLibraryMutations()
+        await releaseRequest.open()
+
+        await #expect(throws: CancellationError.self) { try await firstTask.value }
+        await #expect(throws: CancellationError.self) { try await secondTask.value }
+        #expect(predecessorWasCancelled.count == 1)
+        #expect(self.mockClient.unsubscribeFromPlaylistIds.isEmpty)
+    }
+
+    @Test("Cancelling one owner preserves the shared playlist serialization tail")
+    func ownerCancellationPreservesSharedPlaylistSerializationTail() async throws {
+        let playlist = TestFixtures.makePlaylist(id: "VL-owner-tail", title: "Owner Tail")
+        let firstLibraryViewModel = self.libraryViewModel
+        let cancelledLibraryViewModel = LibraryViewModel(client: self.mockClient)
+        let latestLibraryViewModel = LibraryViewModel(client: self.mockClient)
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        self.mockClient.beforeSubscribeToPlaylistReturn = { _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+        self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
+
+        let firstTask = Task {
+            try await LibraryMutationActions.addPlaylistToLibrary(
+                playlist,
+                client: self.mockClient,
+                libraryViewModel: firstLibraryViewModel,
+                reconciliationDelay: .zero
+            )
+        }
+        await requestStarted.wait()
+
+        let cancelledTask = Task {
+            try await LibraryMutationActions.removePlaylistFromLibrary(
+                playlist,
+                client: self.mockClient,
+                libraryViewModel: cancelledLibraryViewModel,
+                reconciliationDelay: .zero
+            )
+        }
+        for _ in 0 ..< 10 {
+            await Task.yield()
+        }
+        LibraryMutationActions.cancelPendingPlaylistMutations(for: cancelledLibraryViewModel)
+
+        let latestTask = Task {
+            try await LibraryMutationActions.removePlaylistFromLibrary(
+                playlist,
+                client: self.mockClient,
+                libraryViewModel: latestLibraryViewModel,
+                reconciliationDelay: .zero
+            )
+        }
+        for _ in 0 ..< 10 {
+            await Task.yield()
+        }
+        #expect(self.mockClient.unsubscribeFromPlaylistIds.isEmpty)
+
+        await releaseRequest.open()
+        try await firstTask.value
+        await #expect(throws: CancellationError.self) { try await cancelledTask.value }
+        try await latestTask.value
+
+        #expect(!firstLibraryViewModel.isInLibrary(playlistId: playlist.id))
+        #expect(self.mockClient.unsubscribeFromPlaylistIds == [playlist.id])
+    }
+
+    @Test("Stale playlist client errors normalize to cancellation")
+    func stalePlaylistClientErrorNormalizesToCancellation() async {
+        let playlist = TestFixtures.makePlaylist(id: "VL-stale-error", title: "Stale Error")
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        self.mockClient.beforeSubscribeToPlaylistReturn = { _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+
+        let task = Task {
+            try await LibraryMutationActions.addPlaylistToLibrary(
+                playlist,
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel,
+                reconciliationDelay: .zero
+            )
+        }
+
+        await requestStarted.wait()
+        LibraryMutationActions.cancelPendingPlaylistMutations(for: self.libraryViewModel)
+        self.mockClient.shouldThrowError = URLError(.notConnectedToInternet)
+        await releaseRequest.open()
+
+        await #expect(throws: CancellationError.self) {
+            try await task.value
+        }
+    }
+
+    @Test("Account boundary prevents an in-flight podcast add from updating the next account")
+    func accountBoundaryCancelsInFlightPodcastAdd() async {
+        let podcast = TestFixtures.makePodcastShow(id: "MPSPPLboundary-podcast")
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        self.libraryViewModel.activateAccountScope("account-a")
+        self.mockClient.beforeSubscribeToPodcastReturn = { _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+        self.mockClient.shouldAutoUpdatePodcastLibraryOnMutation = false
+
+        let task = Task {
+            try await LibraryMutationActions.subscribeToPodcast(
+                podcast,
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel
+            )
+        }
+
+        await requestStarted.wait()
+        LibraryMutationActions.cancelAllPendingLibraryMutations()
+        self.libraryViewModel.activateAccountScope("account-b")
+        await releaseRequest.open()
+
+        await #expect(throws: CancellationError.self) { try await task.value }
+        #expect(!self.libraryViewModel.isInLibrary(podcastId: podcast.id))
+    }
+
+    @Test("Account boundary prevents an in-flight artist add from updating the next account")
+    func accountBoundaryCancelsInFlightArtistAdd() async {
+        let artist = TestFixtures.makeArtist(id: "UC-boundary-artist", name: "Boundary Artist")
+        self.libraryViewModel.activateAccountScope("account-a")
+        self.mockClient.subscribeToArtistDelay = .milliseconds(100)
+        self.mockClient.shouldAutoUpdateArtistLibraryOnMutation = false
+
+        let task = Task {
+            try await LibraryMutationActions.subscribeToArtist(
+                artist,
+                channelId: artist.id,
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel
+            )
+        }
+
+        #expect(await self.waitForCondition(self.mockClient.subscribeToArtistCalled))
+        LibraryMutationActions.cancelAllPendingLibraryMutations()
+        self.libraryViewModel.activateAccountScope("account-b")
+
+        await #expect(throws: CancellationError.self) { try await task.value }
+        #expect(!self.libraryViewModel.isInLibrary(artistId: artist.id))
+    }
+
+    @Test("Caller cancellation rolls back an uncommitted optimistic artist add")
+    func callerCancellationRollsBackOptimisticArtistAdd() async {
+        let artist = TestFixtures.makeArtist(id: "UC-cancelled-artist", name: "Cancelled Artist")
+        self.libraryViewModel.activateAccountScope("account-a")
+        self.mockClient.subscribeToArtistDelay = .milliseconds(100)
+        self.mockClient.shouldAutoUpdateArtistLibraryOnMutation = false
+
+        let task = Task {
+            try await LibraryMutationActions.subscribeToArtist(
+                artist,
+                channelId: artist.id,
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel
+            )
+        }
+
+        #expect(await self.waitForCondition(self.mockClient.subscribeToArtistCalled))
+        #expect(self.libraryViewModel.isInLibrary(artistId: artist.id))
+        task.cancel()
+
+        await #expect(throws: CancellationError.self) { try await task.value }
+        #expect(!self.libraryViewModel.isInLibrary(artistId: artist.id))
+    }
+
+    @Test("Cancelling playlist deletion before server success restores optimistic membership")
+    func cancelledPlaylistDeletionRestoresMembership() async {
+        let playlist = TestFixtures.makePlaylist(id: "VL-cancelled-delete", title: "Cancelled Delete")
+        let requestStarted = AsyncGate()
+        let releaseRequest = AsyncGate()
+        self.libraryViewModel.addToLibrary(playlist: playlist)
+        self.mockClient.beforeDeletePlaylistReturn = { _ in
+            await requestStarted.open()
+            await releaseRequest.wait()
+        }
+
+        let task = Task {
+            try await LibraryMutationActions.deletePlaylist(
+                playlist,
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel
+            )
+        }
+
+        await requestStarted.wait()
+        #expect(!self.libraryViewModel.isInLibrary(playlistId: playlist.id))
+        LibraryMutationActions.cancelAllPendingLibraryMutations()
+        self.libraryViewModel.activateAccountScope("resolved-primary", isPrimary: true)
+        await releaseRequest.open()
+
+        await #expect(throws: CancellationError.self) { try await task.value }
+        #expect(self.libraryViewModel.isInLibrary(playlistId: playlist.id))
+    }
+
+    private func waitForCondition(_ condition: @autoclosure () -> Bool, timeout: Duration = .seconds(1)) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+
+        while !condition() {
+            guard clock.now < deadline else { return condition() }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+
+        return true
+    }
+}

--- a/Tests/KasetTests/PlaylistParserTests.swift
+++ b/Tests/KasetTests/PlaylistParserTests.swift
@@ -81,6 +81,21 @@ struct PlaylistParserTests { // swiftlint:disable:this type_body_length
         #expect(playlists[0].title == "Dedicated Title")
     }
 
+    @Test("Merge dedicated saved albums preserves order and removes fallback duplicates")
+    func mergedLibraryAlbumsPreservesDedicatedOrder() {
+        let dedicatedAlbum = TestFixtures.makeAlbum(id: "MPRE-dedicated", title: "Dedicated Album")
+        let fallbackDuplicate = TestFixtures.makeAlbum(id: "MPRE-dedicated", title: "Fallback Title")
+        let fallbackOnlyAlbum = TestFixtures.makeAlbum(id: "MPRE-fallback", title: "Fallback Album")
+
+        let albums = PlaylistParser.mergedLibraryAlbums(
+            dedicated: [dedicatedAlbum],
+            fallback: [fallbackDuplicate, fallbackOnlyAlbum]
+        )
+
+        #expect(albums.map(\.id) == ["MPRE-dedicated", "MPRE-fallback"])
+        #expect(albums.map(\.title) == ["Dedicated Album", "Fallback Album"])
+    }
+
     @Test("Parse library playlist delete eligibility")
     func parseLibraryPlaylistDeleteEligibility() {
         let data: [String: Any] = [
@@ -149,12 +164,57 @@ struct PlaylistParserTests { // swiftlint:disable:this type_body_length
         #expect(content.playlists.map(\.title) == ["Grid Playlist", "Shelf Playlist"])
         #expect(content.playlists.map(\.author?.name) == ["Grid Curator", "Shelf Curator"])
 
+        #expect(content.albums.map(\.id) == ["MPREGRIDALBUM123", "MPRESHELFALBUM456"])
+        #expect(content.albums.map(\.title) == ["Grid Album", "Shelf Album"])
+        #expect(content.albums.map(\.artistsDisplay) == ["Grid Album Artist", "Shelf Album Artist"])
+        #expect(content.albums.map(\.year) == ["2024", "2023"])
+        #expect(content.albums.map(\.libraryTargetId) == ["OLAKGRIDALBUM123", "OLAKSHELFALBUM456"])
+
         #expect(content.artists.map(\.id) == ["MPLAUCGRIDARTIST123", "MPLAUCSHELFARTIST456"])
         #expect(content.artists.map(\.name) == ["Grid Artist", "Shelf Artist"])
 
         #expect(content.podcastShows.map(\.id) == ["MPSPPGRID123", "MPSPPSHELF456"])
         #expect(content.podcastShows.map(\.title) == ["Grid Podcast", "Shelf Podcast"])
         #expect(content.podcastShows.map(\.author) == ["Grid Host", "Shelf Host"])
+
+        let dedicatedAlbums = PlaylistParser.parseLibraryAlbums(data)
+        #expect(dedicatedAlbums == content.albums)
+    }
+
+    @Test("Parse initial saved albums page with continuation token")
+    func parseLibraryAlbumsPage() {
+        let page = PlaylistParser.parseLibraryAlbumsPage(
+            self.makeLibraryAlbumsPageData(
+                albumID: "MPREINITIAL123",
+                title: "Initial Album",
+                continuationToken: "albums-page-2"
+            )
+        )
+
+        #expect(page.albums.map(\.id) == ["MPREINITIAL123"])
+        #expect(page.albums.map(\.artistsDisplay) == ["Initial Album Artist"])
+        #expect(page.albums.map(\.year) == ["2022"])
+        #expect(page.nextPage == "albums-page-2")
+    }
+
+    @Test("Parse legacy saved albums continuation")
+    func parseLibraryAlbumsLegacyContinuation() {
+        let page = PlaylistParser.parseLibraryAlbumsContinuation(
+            self.makeLibraryAlbumsLegacyContinuationData(continuationToken: "albums-page-3")
+        )
+
+        #expect(page.albums.map(\.id) == ["MPRELEGACY456"])
+        #expect(page.nextPage == "albums-page-3")
+    }
+
+    @Test("Parse append-action saved albums continuation")
+    func parseLibraryAlbumsAppendActionContinuation() {
+        let page = PlaylistParser.parseLibraryAlbumsContinuation(
+            self.makeLibraryAlbumsAppendContinuationData(continuationToken: "albums-page-4")
+        )
+
+        #expect(page.albums.map(\.id) == ["MPREAPPEND789"])
+        #expect(page.nextPage == "albums-page-4")
     }
 
     @Test("Parse dedicated library artists response")
@@ -236,6 +296,47 @@ struct PlaylistParserTests { // swiftlint:disable:this type_body_length
         #expect(detail.author?.name == "Album Artist")
         #expect(detail.author?.id == "UCALBUMARTIST")
         #expect(detail.trackCount == 1)
+    }
+
+    @Test("Parse album library target playlist ID")
+    func parseAlbumLibraryTargetPlaylistID() {
+        var data = self.makePlaylistDetailData(
+            title: "Album Title",
+            description: nil,
+            author: "Album Artist",
+            trackCount: 1
+        )
+        data["albumHeader"] = [
+            "musicResponsiveHeaderRenderer": [
+                "buttons": [[
+                    "musicPlayButtonRenderer": [
+                        "playNavigationEndpoint": [
+                            "watchPlaylistEndpoint": ["playlistId": "OLAK-library-target"],
+                        ],
+                    ],
+                ]],
+            ],
+        ]
+        data["relatedAlbum"] = ["playlistId": "OLAK-unrelated-target"]
+
+        let detail = PlaylistParser.parsePlaylistDetail(data, playlistId: "MPRE-album")
+
+        #expect(detail.libraryTargetId == "OLAK-library-target")
+    }
+
+    @Test("Ignore album library targets outside the album header")
+    func ignoreAlbumLibraryTargetOutsideHeader() {
+        var data = self.makePlaylistDetailData(
+            title: "Album Title",
+            description: nil,
+            author: "Album Artist",
+            trackCount: 1
+        )
+        data["relatedAlbum"] = ["playlistId": "OLAK-unrelated-target"]
+
+        let detail = PlaylistParser.parsePlaylistDetail(data, playlistId: "MPRE-album")
+
+        #expect(detail.libraryTargetId == nil)
     }
 
     @Test("Parse responsive album detail uses strapline artist and ignores duration metadata")
@@ -1172,6 +1273,55 @@ struct PlaylistParserTests { // swiftlint:disable:this type_body_length
             ],
             [
                 "musicTwoRowItemRenderer": [
+                    "title": ["runs": [["text": "Grid Album"]]],
+                    "subtitle": [
+                        "runs": [
+                            ["text": "Album"],
+                            ["text": " • "],
+                            [
+                                "text": "Grid Album Artist",
+                                "navigationEndpoint": [
+                                    "browseEndpoint": [
+                                        "browseId": "UCGRIDALBUMARTIST123",
+                                        "browseEndpointContextSupportedConfigs": [
+                                            "browseEndpointContextMusicConfig": [
+                                                "pageType": "MUSIC_PAGE_TYPE_ARTIST",
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                            ["text": " • "],
+                            ["text": "2024"],
+                        ],
+                    ],
+                    "navigationEndpoint": [
+                        "browseEndpoint": [
+                            "browseId": "MPREGRIDALBUM123",
+                            "browseEndpointContextSupportedConfigs": [
+                                "browseEndpointContextMusicConfig": [
+                                    "pageType": "MUSIC_PAGE_TYPE_ALBUM",
+                                ],
+                            ],
+                        ],
+                    ],
+                    "menu": [
+                        "menuRenderer": [
+                            "items": [[
+                                "toggleMenuServiceItemRenderer": [
+                                    "toggledServiceEndpoint": [
+                                        "likeEndpoint": [
+                                            "target": ["playlistId": "OLAKGRIDALBUM123"],
+                                        ],
+                                    ],
+                                ],
+                            ]],
+                        ],
+                    ],
+                ],
+            ],
+            [
+                "musicTwoRowItemRenderer": [
                     "title": ["runs": [["text": "Grid Artist"]]],
                     "navigationEndpoint": [
                         "browseEndpoint": ["browseId": "MPLAUCGRIDARTIST123"],
@@ -1211,6 +1361,7 @@ struct PlaylistParserTests { // swiftlint:disable:this type_body_length
                     ],
                 ],
             ],
+            self.makeMixedLibraryShelfAlbumItem(),
             [
                 "musicResponsiveListItemRenderer": [
                     "navigationEndpoint": [
@@ -1239,6 +1390,181 @@ struct PlaylistParserTests { // swiftlint:disable:this type_body_length
                         [
                             "musicResponsiveListItemFlexColumnRenderer": [
                                 "text": ["runs": [["text": "Shelf Host"]]],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]
+    }
+
+    private func makeMixedLibraryShelfAlbumItem() -> [String: Any] {
+        [
+            "musicResponsiveListItemRenderer": [
+                "navigationEndpoint": [
+                    "browseEndpoint": [
+                        "browseId": "MPRESHELFALBUM456",
+                        "browseEndpointContextSupportedConfigs": [
+                            "browseEndpointContextMusicConfig": [
+                                "pageType": "MUSIC_PAGE_TYPE_ALBUM",
+                            ],
+                        ],
+                    ],
+                ],
+                "flexColumns": [
+                    [
+                        "musicResponsiveListItemFlexColumnRenderer": [
+                            "text": ["runs": [["text": "Shelf Album"]]],
+                        ],
+                    ],
+                    [
+                        "musicResponsiveListItemFlexColumnRenderer": [
+                            "text": [
+                                "runs": [
+                                    [
+                                        "text": "Shelf Album Artist",
+                                        "navigationEndpoint": [
+                                            "browseEndpoint": [
+                                                "browseId": "UCSHELFALBUMARTIST456",
+                                                "browseEndpointContextSupportedConfigs": [
+                                                    "browseEndpointContextMusicConfig": [
+                                                        "pageType": "MUSIC_PAGE_TYPE_ARTIST",
+                                                    ],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                    ["text": " • "],
+                                    ["text": "2023"],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                "menu": [
+                    "menuRenderer": [
+                        "items": [[
+                            "toggleMenuServiceItemRenderer": [
+                                "toggledServiceEndpoint": [
+                                    "likeEndpoint": [
+                                        "target": ["playlistId": "OLAKSHELFALBUM456"],
+                                    ],
+                                ],
+                            ],
+                        ]],
+                    ],
+                ],
+            ],
+        ]
+    }
+
+    private func makeLibraryAlbumsPageData(
+        albumID: String,
+        title: String,
+        continuationToken: String?
+    ) -> [String: Any] {
+        var gridRenderer: [String: Any] = [
+            "items": [self.makeLibraryAlbumItem(id: albumID, title: title, artist: "Initial Album Artist", year: "2022")],
+        ]
+        if let continuationToken {
+            gridRenderer["continuations"] = [[
+                "nextContinuationData": ["continuation": continuationToken],
+            ]]
+        }
+
+        return [
+            "contents": [
+                "singleColumnBrowseResultsRenderer": [
+                    "tabs": [[
+                        "tabRenderer": [
+                            "content": [
+                                "sectionListRenderer": [
+                                    "contents": [["gridRenderer": gridRenderer]],
+                                ],
+                            ],
+                        ],
+                    ]],
+                ],
+            ],
+        ]
+    }
+
+    private func makeLibraryAlbumsLegacyContinuationData(continuationToken: String?) -> [String: Any] {
+        var gridContinuation: [String: Any] = [
+            "items": [
+                self.makeLibraryAlbumItem(
+                    id: "MPRELEGACY456",
+                    title: "Legacy Continuation Album",
+                    artist: "Legacy Artist",
+                    year: "2021"
+                ),
+            ],
+        ]
+        if let continuationToken {
+            gridContinuation["continuations"] = [[
+                "nextContinuationData": ["continuation": continuationToken],
+            ]]
+        }
+
+        return [
+            "continuationContents": [
+                "gridContinuation": gridContinuation,
+            ],
+        ]
+    }
+
+    private func makeLibraryAlbumsAppendContinuationData(continuationToken: String?) -> [String: Any] {
+        var continuationItems = [
+            self.makeLibraryAlbumItem(
+                id: "MPREAPPEND789",
+                title: "Append Continuation Album",
+                artist: "Append Artist",
+                year: "2020"
+            ),
+        ]
+        if let continuationToken {
+            continuationItems.append([
+                "continuationItemRenderer": [
+                    "continuationEndpoint": [
+                        "continuationCommand": ["token": continuationToken],
+                    ],
+                ],
+            ])
+        }
+
+        return [
+            "onResponseReceivedActions": [[
+                "appendContinuationItemsAction": [
+                    "continuationItems": continuationItems,
+                ],
+            ]],
+        ]
+    }
+
+    private func makeLibraryAlbumItem(
+        id: String,
+        title: String,
+        artist: String,
+        year: String
+    ) -> [String: Any] {
+        [
+            "musicTwoRowItemRenderer": [
+                "title": ["runs": [["text": title]]],
+                "subtitle": [
+                    "runs": [
+                        ["text": "Album"],
+                        ["text": " • "],
+                        ["text": artist],
+                        ["text": " • "],
+                        ["text": year],
+                    ],
+                ],
+                "navigationEndpoint": [
+                    "browseEndpoint": [
+                        "browseId": id,
+                        "browseEndpointContextSupportedConfigs": [
+                            "browseEndpointContextMusicConfig": [
+                                "pageType": "MUSIC_PAGE_TYPE_ALBUM",
                             ],
                         ],
                     ],

--- a/Tests/KasetTests/PlaylistParserTests.swift
+++ b/Tests/KasetTests/PlaylistParserTests.swift
@@ -177,8 +177,21 @@ struct PlaylistParserTests { // swiftlint:disable:this type_body_length
         #expect(content.podcastShows.map(\.title) == ["Grid Podcast", "Shelf Podcast"])
         #expect(content.podcastShows.map(\.author) == ["Grid Host", "Shelf Host"])
 
+        let page = PlaylistParser.parseLibraryAlbumsPage(data)
+        #expect(page.albums == content.albums)
+
         let dedicatedAlbums = PlaylistParser.parseLibraryAlbums(data)
         #expect(dedicatedAlbums == content.albums)
+    }
+
+    @Test("Parse saved albums from both grid and shelf sections")
+    func parseLibraryAlbumsPageFromGridAndShelf() {
+        let page = PlaylistParser.parseLibraryAlbumsPage(
+            self.makeLibraryAlbumsGridAndShelfData()
+        )
+
+        #expect(page.albums.map(\.id) == ["MPREGRIDALBUM789", "MPRESHELFALBUM456"])
+        #expect(page.isRecognized)
     }
 
     @Test("Parse initial saved albums page with continuation token")
@@ -195,6 +208,7 @@ struct PlaylistParserTests { // swiftlint:disable:this type_body_length
         #expect(page.albums.map(\.artistsDisplay) == ["Initial Album Artist"])
         #expect(page.albums.map(\.year) == ["2022"])
         #expect(page.nextPage == "albums-page-2")
+        #expect(page.isRecognized)
     }
 
     @Test("Parse legacy saved albums continuation")
@@ -205,6 +219,136 @@ struct PlaylistParserTests { // swiftlint:disable:this type_body_length
 
         #expect(page.albums.map(\.id) == ["MPRELEGACY456"])
         #expect(page.nextPage == "albums-page-3")
+        #expect(page.isRecognized)
+    }
+
+    @Test("Parse saved albums shelf continuation")
+    func parseLibraryAlbumsShelfContinuation() {
+        let page = PlaylistParser.parseLibraryAlbumsContinuation(
+            self.makeLibraryAlbumsShelfContinuationData(continuationToken: "albums-page-4")
+        )
+
+        #expect(page.albums.map(\.id) == ["MPRESHELFALBUM456"])
+        #expect(page.nextPage == "albums-page-4")
+        #expect(page.isRecognized)
+    }
+
+    @Test("Parse command-executor saved albums continuation")
+    func parseLibraryAlbumsCommandExecutorContinuation() {
+        let page = PlaylistParser.parseLibraryAlbumsContinuation([
+            "continuationContents": [
+                "musicShelfContinuation": [
+                    "contents": [
+                        self.makeLibraryAlbumItem(
+                            id: "MPRECOMMANDEXECUTOR",
+                            title: "Command Executor Album",
+                            artist: "Command Executor Artist",
+                            year: "2026"
+                        ),
+                        [
+                            "continuationItemRenderer": [
+                                "continuationEndpoint": [
+                                    "commandExecutorCommand": [
+                                        "commands": [[
+                                            "continuationCommand": [
+                                                "token": "albums-command-executor-page",
+                                            ],
+                                        ]],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ])
+
+        #expect(page.albums.map(\.id) == ["MPRECOMMANDEXECUTOR"])
+        #expect(page.nextPage == "albums-command-executor-page")
+        #expect(page.isRecognized)
+    }
+
+    @Test("Mark malformed saved-album shelf continuation as partial")
+    func markMalformedShelfContinuationAsPartial() {
+        let page = PlaylistParser.parseLibraryAlbumsContinuation([
+            "continuationContents": [
+                "musicShelfContinuation": [
+                    "contents": [
+                        self.makeLibraryAlbumItem(
+                            id: "MPRECONTINUED",
+                            title: "Continued Album",
+                            artist: "Continued Artist",
+                            year: "2026"
+                        ),
+                        [
+                            "continuationItemRenderer": [
+                                "continuationEndpoint": [
+                                    "commandExecutorCommand": [:],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ])
+
+        #expect(page.albums.map(\.id) == ["MPRECONTINUED"])
+        #expect(page.nextPages.isEmpty)
+        #expect(!page.isRecognized)
+    }
+
+    @Test("Mark malformed renderer-level continuation page as partial")
+    func markMalformedRendererContinuationPageAsPartial() {
+        let page = PlaylistParser.parseLibraryAlbumsContinuation([
+            "continuationContents": [
+                "gridContinuation": [
+                    "items": [self.makeLibraryAlbumItem(
+                        id: "MPREMALFORMEDPAGE",
+                        title: "Malformed Page Album",
+                        artist: "Test Artist",
+                        year: "2026"
+                    )],
+                    "continuations": [["nextContinuationData": [:]]],
+                ],
+            ],
+        ])
+
+        #expect(page.albums.map(\.id) == ["MPREMALFORMEDPAGE"])
+        #expect(page.nextPages.isEmpty)
+        #expect(!page.isRecognized)
+    }
+
+    @Test("Mark malformed renderer-level continuation as partial")
+    func markMalformedRendererContinuationAsPartial() {
+        let page = PlaylistParser.parseLibraryAlbumsPage([
+            "contents": [
+                "singleColumnBrowseResultsRenderer": [
+                    "tabs": [[
+                        "tabRenderer": [
+                            "content": [
+                                "sectionListRenderer": [
+                                    "contents": [[
+                                        "gridRenderer": [
+                                            "items": [self.makeLibraryAlbumItem(
+                                                id: "MPREMALFORMEDCONTINUATION",
+                                                title: "Malformed Continuation Album",
+                                                artist: "Test Artist",
+                                                year: "2026"
+                                            )],
+                                            "continuations": [["nextContinuationData": [:]]],
+                                        ],
+                                    ]],
+                                ],
+                            ],
+                        ],
+                    ]],
+                ],
+            ],
+        ])
+
+        #expect(page.albums.map(\.id) == ["MPREMALFORMEDCONTINUATION"])
+        #expect(page.nextPages.isEmpty)
+        #expect(!page.isRecognized)
     }
 
     @Test("Parse append-action saved albums continuation")
@@ -215,6 +359,249 @@ struct PlaylistParserTests { // swiftlint:disable:this type_body_length
 
         #expect(page.albums.map(\.id) == ["MPREAPPEND789"])
         #expect(page.nextPage == "albums-page-4")
+        #expect(page.isRecognized)
+    }
+
+    @Test("Reject an ambiguous saved-albums tab shell without a renderer")
+    func rejectAmbiguousLibraryAlbumsTabShell() {
+        let page = PlaylistParser.parseLibraryAlbumsPage([
+            "contents": [
+                "singleColumnBrowseResultsRenderer": [
+                    "tabs": [[
+                        "tabRenderer": [:],
+                    ]],
+                ],
+            ],
+            "responseContext": Self.loggedInResponseContext(value: "1"),
+        ])
+
+        #expect(page.albums.isEmpty)
+        #expect(page.nextPage == nil)
+        #expect(!page.isRecognized)
+    }
+
+    @Test("Reject a signed-out message response as an album collection")
+    func rejectSignedOutLibraryAlbumsResponse() {
+        let page = PlaylistParser.parseLibraryAlbumsPage([
+            "contents": [
+                "singleColumnBrowseResultsRenderer": [
+                    "tabs": [[
+                        "tabRenderer": [
+                            "content": [
+                                "sectionListRenderer": [
+                                    "contents": [[
+                                        "itemSectionRenderer": [
+                                            "contents": [[
+                                                "messageRenderer": [
+                                                    "button": [
+                                                        "buttonRenderer": [
+                                                            "navigationEndpoint": [
+                                                                "signInEndpoint": [:],
+                                                            ],
+                                                        ],
+                                                    ],
+                                                ],
+                                            ]],
+                                        ],
+                                    ]],
+                                ],
+                            ],
+                        ],
+                    ]],
+                ],
+            ],
+            "responseContext": Self.loggedInResponseContext(value: "0"),
+        ])
+
+        #expect(page.albums.isEmpty)
+        #expect(!page.isRecognized)
+    }
+
+    @Test("Aggregate albums across multiple saved-album shelves")
+    func parseLibraryAlbumsAcrossMultipleShelves() {
+        let page = PlaylistParser.parseLibraryAlbumsPage([
+            "contents": [
+                "singleColumnBrowseResultsRenderer": [
+                    "tabs": [[
+                        "tabRenderer": [
+                            "content": [
+                                "sectionListRenderer": [
+                                    "contents": [
+                                        [
+                                            "musicShelfRenderer": [
+                                                "contents": [[
+                                                    "musicResponsiveListItemRenderer": [
+                                                        "navigationEndpoint": [
+                                                            "browseEndpoint": ["browseId": "VLPLAYLIST"],
+                                                        ],
+                                                        "flexColumns": [[
+                                                            "musicResponsiveListItemFlexColumnRenderer": [
+                                                                "text": ["runs": [["text": "Playlist"]]],
+                                                            ],
+                                                        ]],
+                                                    ],
+                                                ]],
+                                            ],
+                                        ],
+                                        [
+                                            "musicShelfRenderer": [
+                                                "contents": [
+                                                    self.makeLibraryResponsiveAlbumItem(
+                                                        id: "MPRESHELFONE",
+                                                        title: "Shelf One"
+                                                    ),
+                                                ],
+                                                "continuations": [[
+                                                    "nextContinuationData": ["continuation": "shelf-one-next"],
+                                                ]],
+                                            ],
+                                        ],
+                                        [
+                                            "musicShelfRenderer": [
+                                                "contents": [
+                                                    self.makeLibraryResponsiveAlbumItem(
+                                                        id: "MPRESHELFTWO",
+                                                        title: "Shelf Two"
+                                                    ),
+                                                ],
+                                                "continuations": [[
+                                                    "nextContinuationData": ["continuation": "shelf-two-next"],
+                                                ]],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ]],
+                ],
+            ],
+        ])
+
+        #expect(page.albums.map(\.id) == ["MPRESHELFONE", "MPRESHELFTWO"])
+        #expect(page.nextPages == ["shelf-one-next", "shelf-two-next"])
+        #expect(page.isRecognized)
+    }
+
+    @Test("Recognize an empty saved-albums shelf")
+    func recognizeEmptyLibraryAlbumsShelf() {
+        let page = PlaylistParser.parseLibraryAlbumsPage([
+            "contents": [
+                "singleColumnBrowseResultsRenderer": [
+                    "tabs": [[
+                        "tabRenderer": [
+                            "content": [
+                                "sectionListRenderer": [
+                                    "contents": [[
+                                        "musicShelfRenderer": [
+                                            "contents": [],
+                                        ],
+                                    ]],
+                                ],
+                            ],
+                        ],
+                    ]],
+                ],
+            ],
+            "responseContext": Self.loggedInResponseContext(value: "1"),
+        ])
+
+        #expect(page.albums.isEmpty)
+        #expect(page.isRecognized)
+    }
+
+    @Test("Parse saved album rows from a non-grid shelf")
+    func parseLibraryAlbumsShelfPage() {
+        let page = PlaylistParser.parseLibraryAlbumsPage([
+            "contents": [
+                "singleColumnBrowseResultsRenderer": [
+                    "tabs": [[
+                        "tabRenderer": [
+                            "content": [
+                                "sectionListRenderer": [
+                                    "contents": [[
+                                        "musicShelfRenderer": [
+                                            "contents": [self.makeMixedLibraryShelfAlbumItem()],
+                                        ],
+                                    ]],
+                                ],
+                            ],
+                        ],
+                    ]],
+                ],
+            ],
+            "responseContext": Self.loggedInResponseContext(value: "1"),
+        ])
+
+        #expect(page.albums.map(\.id) == ["MPRESHELFALBUM456"])
+        #expect(page.isRecognized)
+    }
+
+    @Test("Parse responsive saved album rows directly from the grid")
+    func parseResponsiveLibraryAlbumsPage() {
+        let data = self.makeLibraryAlbumsGridData(items: [self.makeMixedLibraryShelfAlbumItem()])
+        let page = PlaylistParser.parseLibraryAlbumsPage(data)
+
+        #expect(page.albums.map(\.id) == ["MPRESHELFALBUM456"])
+        #expect(page.isRecognized)
+        #expect(PlaylistParser.parseLibraryAlbums(data).map(\.id) == ["MPRESHELFALBUM456"])
+    }
+
+    @Test("Mark a mixed supported and unknown album grid as partial")
+    func markPartiallyParsedLibraryAlbumsGrid() {
+        let page = PlaylistParser.parseLibraryAlbumsPage(
+            self.makeLibraryAlbumsGridData(
+                items: [
+                    self.makeLibraryAlbumItem(
+                        id: "MPREPARSED",
+                        title: "Parsed Album",
+                        artist: "Parsed Artist",
+                        year: "2026"
+                    ),
+                    ["unknownRenderer": [:]],
+                ],
+                nextPage: "albums-page-2"
+            )
+        )
+
+        #expect(page.albums.map(\.id) == ["MPREPARSED"])
+        #expect(page.nextPages == ["albums-page-2"])
+        #expect(!page.isRecognized)
+    }
+
+    @Test("Mark an unconsumed continuation sentinel as partial")
+    func markMalformedAlbumContinuationAsPartial() {
+        let page = PlaylistParser.parseLibraryAlbumsPage(
+            self.makeLibraryAlbumsGridData(items: [
+                self.makeLibraryAlbumItem(
+                    id: "MPREPARSED",
+                    title: "Parsed Album",
+                    artist: "Parsed Artist",
+                    year: "2026"
+                ),
+                [
+                    "continuationItemRenderer": [
+                        "continuationEndpoint": [
+                            "commandExecutorCommand": [:],
+                        ],
+                    ],
+                ],
+            ])
+        )
+
+        #expect(page.albums.map(\.id) == ["MPREPARSED"])
+        #expect(page.nextPages.isEmpty)
+        #expect(!page.isRecognized)
+    }
+
+    @Test("Reject an album grid whose nonempty items cannot be parsed")
+    func rejectUnrecognizedLibraryAlbumsGrid() {
+        let page = PlaylistParser.parseLibraryAlbumsPage(
+            self.makeLibraryAlbumsGridData(items: [["unknownRenderer": [:]]])
+        )
+
+        #expect(page.albums.isEmpty)
+        #expect(!page.isRecognized)
     }
 
     @Test("Parse dedicated library artists response")
@@ -1458,6 +1845,124 @@ struct PlaylistParserTests { // swiftlint:disable:this type_body_length
         ]
     }
 
+    private func makeLibraryResponsiveAlbumItem(id: String, title: String) -> [String: Any] {
+        [
+            "musicResponsiveListItemRenderer": [
+                "navigationEndpoint": [
+                    "browseEndpoint": [
+                        "browseId": id,
+                        "browseEndpointContextSupportedConfigs": [
+                            "browseEndpointContextMusicConfig": [
+                                "pageType": "MUSIC_PAGE_TYPE_ALBUM",
+                            ],
+                        ],
+                    ],
+                ],
+                "flexColumns": [
+                    [
+                        "musicResponsiveListItemFlexColumnRenderer": [
+                            "text": ["runs": [["text": title]]],
+                        ],
+                    ],
+                    [
+                        "musicResponsiveListItemFlexColumnRenderer": [
+                            "text": [
+                                "runs": [
+                                    ["text": "Album"],
+                                    ["text": " • "],
+                                    ["text": "Test Artist"],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]
+    }
+
+    private func makeLibraryAlbumsGridAndShelfData() -> [String: Any] {
+        [
+            "contents": [
+                "singleColumnBrowseResultsRenderer": [
+                    "tabs": [[
+                        "tabRenderer": [
+                            "content": [
+                                "sectionListRenderer": [
+                                    "contents": [
+                                        [
+                                            "gridRenderer": [
+                                                "items": [
+                                                    self.makeLibraryAlbumItem(
+                                                        id: "MPREGRIDALBUM789",
+                                                        title: "Grid Album",
+                                                        artist: "Grid Artist",
+                                                        year: "2025"
+                                                    ),
+                                                ],
+                                            ],
+                                        ],
+                                        [
+                                            "musicShelfRenderer": [
+                                                "contents": [self.makeMixedLibraryShelfAlbumItem()],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ]],
+                ],
+            ],
+        ]
+    }
+
+    private static func loggedInResponseContext(value: String) -> [String: Any] {
+        [
+            "serviceTrackingParams": [[
+                "params": [
+                    [
+                        "key": "logged_in",
+                        "value": value,
+                    ],
+                    [
+                        "key": "browse_id",
+                        "value": "FEmusic_liked_albums",
+                    ],
+                ],
+            ]],
+        ]
+    }
+
+    private func makeLibraryAlbumsGridData(
+        items: [[String: Any]],
+        nextPage: String? = nil
+    ) -> [String: Any] {
+        var gridRenderer: [String: Any] = [
+            "items": items,
+        ]
+        if let nextPage {
+            gridRenderer["continuations"] = [[
+                "nextContinuationData": ["continuation": nextPage],
+            ]]
+        }
+
+        return [
+            "contents": [
+                "singleColumnBrowseResultsRenderer": [
+                    "tabs": [[
+                        "tabRenderer": [
+                            "content": [
+                                "sectionListRenderer": [
+                                    "contents": [["gridRenderer": gridRenderer]],
+                                ],
+                            ],
+                        ],
+                    ]],
+                ],
+            ],
+        ]
+    }
+
     private func makeLibraryAlbumsPageData(
         albumID: String,
         title: String,
@@ -1484,6 +1989,27 @@ struct PlaylistParserTests { // swiftlint:disable:this type_body_length
                             ],
                         ],
                     ]],
+                ],
+            ],
+        ]
+    }
+
+    private func makeLibraryAlbumsShelfContinuationData(continuationToken: String?) -> [String: Any] {
+        var contents = [self.makeMixedLibraryShelfAlbumItem()]
+        if let continuationToken {
+            contents.append([
+                "continuationItemRenderer": [
+                    "continuationEndpoint": [
+                        "continuationCommand": ["token": continuationToken],
+                    ],
+                ],
+            ])
+        }
+
+        return [
+            "continuationContents": [
+                "musicShelfContinuation": [
+                    "contents": contents,
                 ],
             ],
         ]

--- a/Tests/KasetTests/SongActionsHelperTests.swift
+++ b/Tests/KasetTests/SongActionsHelperTests.swift
@@ -329,11 +329,11 @@ struct SongActionsHelperTests {
     }
 
     @Test("addPlaylistToLibrary keeps optimistic playlist when refresh response is stale")
-    func addPlaylistToLibraryPreservesOptimisticPlaylist() async {
+    func addPlaylistToLibraryPreservesOptimisticPlaylist() async throws {
         let playlist = TestFixtures.makePlaylist(id: "VL-test-playlist", title: "Test Playlist")
         self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
 
-        await SongActionsHelper.addPlaylistToLibrary(
+        try await SongActionsHelper.addPlaylistToLibrary(
             playlist,
             client: self.mockClient,
             libraryViewModel: self.libraryViewModel
@@ -346,7 +346,7 @@ struct SongActionsHelperTests {
     }
 
     @Test("removePlaylistFromLibrary keeps optimistic removal when refresh response is stale")
-    func removePlaylistFromLibraryPreservesOptimisticRemoval() async {
+    func removePlaylistFromLibraryPreservesOptimisticRemoval() async throws {
         let playlist = TestFixtures.makePlaylist(id: "VL-test-playlist", title: "Test Playlist")
         self.mockClient.libraryPlaylists = [playlist]
         self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
@@ -354,7 +354,7 @@ struct SongActionsHelperTests {
         await self.libraryViewModel.load()
         self.mockClient.reset()
 
-        await SongActionsHelper.removePlaylistFromLibrary(
+        try await SongActionsHelper.removePlaylistFromLibrary(
             playlist,
             client: self.mockClient,
             libraryViewModel: self.libraryViewModel

--- a/Tests/KasetTests/SongActionsHelperTests.swift
+++ b/Tests/KasetTests/SongActionsHelperTests.swift
@@ -10,683 +10,685 @@ private let realWorldArtistIdMismatchCases = [
     ),
 ]
 
-// MARK: - SongActionsHelperTests
+// MARK: - LibraryMutationSerialTests.SongActionsHelperTests
 
 /// Tests for SongActionsHelper library mutation flows.
-@Suite(.serialized, .tags(.viewModel), .timeLimit(.minutes(1)))
-@MainActor
-struct SongActionsHelperTests {
-    var mockClient: MockYTMusicClient
-    var libraryViewModel: LibraryViewModel
+extension LibraryMutationSerialTests {
+    @Suite(.tags(.viewModel), .timeLimit(.minutes(1)))
+    @MainActor
+    struct SongActionsHelperTests {
+        var mockClient: MockYTMusicClient
+        var libraryViewModel: LibraryViewModel
 
-    init() {
-        self.mockClient = MockYTMusicClient()
-        self.libraryViewModel = LibraryViewModel(client: self.mockClient)
-        APICache.shared.invalidateAll()
-        URLCache.shared.removeAllCachedResponses()
-        SongActionsHelper.artistLibraryReconciliationRetryDelays = [.milliseconds(1), .milliseconds(1)]
-    }
-
-    private func awaitArtistReconciliation(refreshes expectedRefreshCount: Int = 1) async {
-        let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: .seconds(1))
-
-        while self.mockClient.getLibraryContentCallCount < expectedRefreshCount {
-            guard clock.now < deadline else { return }
-            try? await Task.sleep(for: .milliseconds(10))
+        init() {
+            self.mockClient = MockYTMusicClient()
+            self.libraryViewModel = LibraryViewModel(client: self.mockClient)
+            APICache.shared.invalidateAll()
+            URLCache.shared.removeAllCachedResponses()
+            SongActionsHelper.artistLibraryReconciliationRetryDelays = [.milliseconds(1), .milliseconds(1)]
         }
-    }
 
-    private func waitUntil(
-        timeout: Duration = .seconds(3),
-        condition: () -> Bool
-    ) async -> Bool {
-        let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: timeout)
-        while clock.now < deadline {
-            if condition() {
-                return true
+        private func awaitArtistReconciliation(refreshes expectedRefreshCount: Int = 1) async {
+            let clock = ContinuousClock()
+            let deadline = clock.now.advanced(by: .seconds(1))
+
+            while self.mockClient.getLibraryContentCallCount < expectedRefreshCount {
+                guard clock.now < deadline else { return }
+                try? await Task.sleep(for: .milliseconds(10))
             }
-            try? await Task.sleep(for: .milliseconds(10))
-        }
-        return false
-    }
-
-    private func awaitQueueCount(_ expectedCount: Int, in playerService: PlayerService) async {
-        let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: .seconds(1))
-
-        while playerService.queue.count != expectedCount {
-            guard clock.now < deadline else { return }
-            try? await Task.sleep(for: .milliseconds(10))
-        }
-    }
-
-    private func awaitPlaylistContinuationReturns(_ expectedCount: Int = 1) async {
-        let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: .seconds(1))
-
-        while self.mockClient.getPlaylistContinuationReturnCount < expectedCount {
-            guard clock.now < deadline else { return }
-            try? await Task.sleep(for: .milliseconds(10))
-        }
-    }
-
-    @Test("Add to Library cannot toggle a newer track")
-    func addToLibraryCannotMutateNewerTrack() async {
-        let playerService = PlayerService()
-        let authService = AuthService(webKitManager: MockWebKitManager())
-        authService.completeLogin(sapisid: "REDACTED")
-        playerService.setAuthService(authService)
-        playerService.setYTMusicClient(self.mockClient)
-        let songA = TestFixtures.makeSong(id: "library-a")
-        let songB = TestFixtures.makeSong(id: "library-b")
-        self.mockClient.songResponses[songA.videoId] = Song(
-            id: songA.id,
-            title: songA.title,
-            artists: songA.artists,
-            videoId: songA.videoId,
-            feedbackTokens: FeedbackTokens(add: "a-add", remove: "a-remove")
-        )
-        let metadataStarted = AsyncGate()
-        let releaseMetadata = AsyncGate()
-        self.mockClient.beforeGetSongReturn = { videoID in
-            guard videoID == songA.videoId else { return }
-            await metadataStarted.open()
-            await releaseMetadata.wait()
         }
 
-        let addTask = SongActionsHelper.addToLibrary(songA, playerService: playerService)
-        await metadataStarted.wait()
-        await playerService.play(song: songB)
-        await releaseMetadata.open()
-        await addTask.value
-
-        #expect(playerService.currentTrack?.videoId == songB.videoId)
-        #expect(!playerService.currentTrackInLibrary)
-        #expect(!self.mockClient.editSongLibraryStatusCalled)
-    }
-
-    @Test("Add to Library waits for tokens on an already-loading song")
-    func addToLibraryWaitsForLoadingMetadata() async {
-        let playerService = PlayerService()
-        let authService = AuthService(webKitManager: MockWebKitManager())
-        authService.completeLogin(sapisid: "REDACTED")
-        playerService.setAuthService(authService)
-        playerService.setYTMusicClient(self.mockClient)
-        let song = TestFixtures.makeSong(id: "loading-library")
-        self.mockClient.songResponses[song.videoId] = Song(
-            id: song.id,
-            title: song.title,
-            artists: song.artists,
-            videoId: song.videoId,
-            feedbackTokens: FeedbackTokens(add: "mock-token", remove: "test-cookie")
-        )
-        let metadataStarted = AsyncGate()
-        let releaseMetadata = AsyncGate()
-        self.mockClient.beforeGetSongReturn = { videoID in
-            guard videoID == song.videoId else { return }
-            await metadataStarted.open()
-            await releaseMetadata.wait()
+        private func waitUntil(
+            timeout: Duration = .seconds(3),
+            condition: () -> Bool
+        ) async -> Bool {
+            let clock = ContinuousClock()
+            let deadline = clock.now.advanced(by: timeout)
+            while clock.now < deadline {
+                if condition() {
+                    return true
+                }
+                try? await Task.sleep(for: .milliseconds(10))
+            }
+            return false
         }
 
-        let initialPlay = Task { @MainActor in
-            await playerService.play(song: song)
-        }
-        await metadataStarted.wait()
-        let addTask = SongActionsHelper.addToLibrary(song, playerService: playerService)
-        await releaseMetadata.open()
-        await initialPlay.value
-        await addTask.value
-        let clock = ContinuousClock()
-        let deadline = clock.now + .seconds(1)
-        while !self.mockClient.editSongLibraryStatusCalled, clock.now < deadline {
-            try? await Task.sleep(for: .milliseconds(10))
+        private func awaitQueueCount(_ expectedCount: Int, in playerService: PlayerService) async {
+            let clock = ContinuousClock()
+            let deadline = clock.now.advanced(by: .seconds(1))
+
+            while playerService.queue.count != expectedCount {
+                guard clock.now < deadline else { return }
+                try? await Task.sleep(for: .milliseconds(10))
+            }
         }
 
-        #expect(self.mockClient.editSongLibraryStatusCalled)
-    }
+        private func awaitPlaylistContinuationReturns(_ expectedCount: Int = 1) async {
+            let clock = ContinuousClock()
+            let deadline = clock.now.advanced(by: .seconds(1))
 
-    @Test("Add to Library does not remove an already-saved song")
-    func addToLibraryDoesNotToggleSavedSong() async {
-        let playerService = PlayerService()
-        let authService = AuthService(webKitManager: MockWebKitManager())
-        authService.completeLogin(sapisid: "REDACTED")
-        playerService.setAuthService(authService)
-        playerService.setYTMusicClient(self.mockClient)
-        let song = Song(
-            id: "already-saved",
-            title: "Already Saved",
-            artists: [],
-            videoId: "already-saved",
-            isInLibrary: true,
-            feedbackTokens: FeedbackTokens(add: nil, remove: "mock-token")
-        )
+            while self.mockClient.getPlaylistContinuationReturnCount < expectedCount {
+                guard clock.now < deadline else { return }
+                try? await Task.sleep(for: .milliseconds(10))
+            }
+        }
 
-        let task = SongActionsHelper.addToLibrary(song, playerService: playerService)
-        await task.value
-        try? await Task.sleep(for: .milliseconds(25))
+        @Test("Add to Library cannot toggle a newer track")
+        func addToLibraryCannotMutateNewerTrack() async {
+            let playerService = PlayerService()
+            let authService = AuthService(webKitManager: MockWebKitManager())
+            authService.completeLogin(sapisid: "REDACTED")
+            playerService.setAuthService(authService)
+            playerService.setYTMusicClient(self.mockClient)
+            let songA = TestFixtures.makeSong(id: "library-a")
+            let songB = TestFixtures.makeSong(id: "library-b")
+            self.mockClient.songResponses[songA.videoId] = Song(
+                id: songA.id,
+                title: songA.title,
+                artists: songA.artists,
+                videoId: songA.videoId,
+                feedbackTokens: FeedbackTokens(add: "a-add", remove: "a-remove")
+            )
+            let metadataStarted = AsyncGate()
+            let releaseMetadata = AsyncGate()
+            self.mockClient.beforeGetSongReturn = { videoID in
+                guard videoID == songA.videoId else { return }
+                await metadataStarted.open()
+                await releaseMetadata.wait()
+            }
 
-        #expect(playerService.currentTrackInLibrary)
-        #expect(!self.mockClient.editSongLibraryStatusCalled)
-    }
+            let addTask = SongActionsHelper.addToLibrary(songA, playerService: playerService)
+            await metadataStarted.wait()
+            await playerService.play(song: songB)
+            await releaseMetadata.open()
+            await addTask.value
 
-    @Test("canQuickPlayPlaylist rejects mood category browse IDs")
-    func canQuickPlayPlaylistRejectsMoodCategories() {
-        let playlist = TestFixtures.makePlaylist(id: "VL-test-playlist")
-        let moodCategory = TestFixtures.makePlaylist(id: "FEmusic_moods_and_genres_category_test")
+            #expect(playerService.currentTrack?.videoId == songB.videoId)
+            #expect(!playerService.currentTrackInLibrary)
+            #expect(!self.mockClient.editSongLibraryStatusCalled)
+        }
 
-        #expect(SongActionsHelper.canQuickPlayPlaylist(playlist))
-        #expect(!SongActionsHelper.canQuickPlayPlaylist(moodCategory))
-    }
+        @Test("Add to Library waits for tokens on an already-loading song")
+        func addToLibraryWaitsForLoadingMetadata() async {
+            let playerService = PlayerService()
+            let authService = AuthService(webKitManager: MockWebKitManager())
+            authService.completeLogin(sapisid: "REDACTED")
+            playerService.setAuthService(authService)
+            playerService.setYTMusicClient(self.mockClient)
+            let song = TestFixtures.makeSong(id: "loading-library")
+            self.mockClient.songResponses[song.videoId] = Song(
+                id: song.id,
+                title: song.title,
+                artists: song.artists,
+                videoId: song.videoId,
+                feedbackTokens: FeedbackTokens(add: "mock-token", remove: "test-cookie")
+            )
+            let metadataStarted = AsyncGate()
+            let releaseMetadata = AsyncGate()
+            self.mockClient.beforeGetSongReturn = { videoID in
+                guard videoID == song.videoId else { return }
+                await metadataStarted.open()
+                await releaseMetadata.wait()
+            }
 
-    @Test("playPlaylist filters unavailable initial and continuation tracks before queueing")
-    func playPlaylistFiltersUnavailableTracks() async {
-        let playlist = TestFixtures.makePlaylist(id: "VL-test-playlist", title: "Test Playlist")
-        let unavailableFirst = Song(
-            id: "unavailable-first",
-            title: "Unavailable First",
-            artists: [],
-            videoId: "unavailable-first",
-            isPlayable: false
-        )
-        let playable = Song(
-            id: "playable",
-            title: "Playable",
-            artists: [],
-            videoId: "playable"
-        )
-        let unavailableContinuation = Song(
-            id: "unavailable-continuation",
-            title: "Unavailable Continuation",
-            artists: [],
-            videoId: "unavailable-continuation",
-            isPlayable: false
-        )
-        let playableContinuation = Song(
-            id: "playable-continuation",
-            title: "Playable Continuation",
-            artists: [],
-            videoId: "playable-continuation"
-        )
-        self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(
-            playlist: playlist,
-            tracks: [unavailableFirst, playable],
-            duration: nil
-        )
-        self.mockClient.playlistContinuationTracks[playlist.id] = [
-            [unavailableContinuation, playableContinuation],
-        ]
-        self.mockClient.playlistAllTracks[playlist.id] = [
-            Song(
+            let initialPlay = Task { @MainActor in
+                await playerService.play(song: song)
+            }
+            await metadataStarted.wait()
+            let addTask = SongActionsHelper.addToLibrary(song, playerService: playerService)
+            await releaseMetadata.open()
+            await initialPlay.value
+            await addTask.value
+            let clock = ContinuousClock()
+            let deadline = clock.now + .seconds(1)
+            while !self.mockClient.editSongLibraryStatusCalled, clock.now < deadline {
+                try? await Task.sleep(for: .milliseconds(10))
+            }
+
+            #expect(self.mockClient.editSongLibraryStatusCalled)
+        }
+
+        @Test("Add to Library does not remove an already-saved song")
+        func addToLibraryDoesNotToggleSavedSong() async {
+            let playerService = PlayerService()
+            let authService = AuthService(webKitManager: MockWebKitManager())
+            authService.completeLogin(sapisid: "REDACTED")
+            playerService.setAuthService(authService)
+            playerService.setYTMusicClient(self.mockClient)
+            let song = Song(
+                id: "already-saved",
+                title: "Already Saved",
+                artists: [],
+                videoId: "already-saved",
+                isInLibrary: true,
+                feedbackTokens: FeedbackTokens(add: nil, remove: "mock-token")
+            )
+
+            let task = SongActionsHelper.addToLibrary(song, playerService: playerService)
+            await task.value
+            try? await Task.sleep(for: .milliseconds(25))
+
+            #expect(playerService.currentTrackInLibrary)
+            #expect(!self.mockClient.editSongLibraryStatusCalled)
+        }
+
+        @Test("canQuickPlayPlaylist rejects mood category browse IDs")
+        func canQuickPlayPlaylistRejectsMoodCategories() {
+            let playlist = TestFixtures.makePlaylist(id: "VL-test-playlist")
+            let moodCategory = TestFixtures.makePlaylist(id: "FEmusic_moods_and_genres_category_test")
+
+            #expect(SongActionsHelper.canQuickPlayPlaylist(playlist))
+            #expect(!SongActionsHelper.canQuickPlayPlaylist(moodCategory))
+        }
+
+        @Test("playPlaylist filters unavailable initial and continuation tracks before queueing")
+        func playPlaylistFiltersUnavailableTracks() async {
+            let playlist = TestFixtures.makePlaylist(id: "VL-test-playlist", title: "Test Playlist")
+            let unavailableFirst = Song(
                 id: "unavailable-first",
                 title: "Unavailable First",
                 artists: [],
-                videoId: "unavailable-first"
-            ),
-            playable,
-            Song(
+                videoId: "unavailable-first",
+                isPlayable: false
+            )
+            let playable = Song(
+                id: "playable",
+                title: "Playable",
+                artists: [],
+                videoId: "playable"
+            )
+            let unavailableContinuation = Song(
                 id: "unavailable-continuation",
                 title: "Unavailable Continuation",
                 artists: [],
-                videoId: "unavailable-continuation"
-            ),
-            playableContinuation,
-        ]
-        let playerService = PlayerService()
-
-        SongActionsHelper.playPlaylist(
-            playlist,
-            client: self.mockClient,
-            playerService: playerService
-        )
-        await self.awaitQueueCount(2, in: playerService)
-
-        #expect(playerService.queue.map(\.videoId) == ["playable", "playable-continuation"])
-        #expect(playerService.currentTrack?.videoId == "playable")
-        #expect(playerService.queue.first?.thumbnailURL == playlist.thumbnailURL)
-    }
-
-    @Test("playPlaylist starts playback before loading continuations")
-    func playPlaylistStartsBeforeContinuations() async {
-        let playlist = TestFixtures.makePlaylist(id: "VL-test-playlist", title: "Test Playlist")
-        let initial = Song(
-            id: "initial",
-            title: "Initial",
-            artists: [],
-            videoId: "initial"
-        )
-        let continuation = Song(
-            id: "continuation",
-            title: "Continuation",
-            artists: [],
-            videoId: "continuation"
-        )
-        self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(
-            playlist: playlist,
-            tracks: [initial],
-            duration: nil
-        )
-        self.mockClient.playlistContinuationTracks[playlist.id] = [[continuation]]
-        self.mockClient.playlistContinuationDelay = .milliseconds(250)
-        let playerService = PlayerService()
-
-        SongActionsHelper.playPlaylist(
-            playlist,
-            client: self.mockClient,
-            playerService: playerService
-        )
-        await self.awaitQueueCount(1, in: playerService)
-
-        #expect(playerService.currentTrack?.videoId == "initial")
-        #expect(playerService.queue.map(\.videoId) == ["initial"])
-
-        await self.awaitQueueCount(2, in: playerService)
-        #expect(playerService.queue.map(\.videoId) == ["initial", "continuation"])
-    }
-
-    @Test("playPlaylist discards continuations after queue replacement")
-    func playPlaylistDiscardsContinuationsAfterQueueReplacement() async {
-        let playlist = TestFixtures.makePlaylist(id: "VL-test-playlist", title: "Test Playlist")
-        let initial = Song(
-            id: "initial",
-            title: "Initial",
-            artists: [],
-            videoId: "initial"
-        )
-        let continuation = Song(
-            id: "continuation",
-            title: "Continuation",
-            artists: [],
-            videoId: "continuation"
-        )
-        let replacement = Song(
-            id: "replacement",
-            title: "Replacement",
-            artists: [],
-            videoId: "replacement"
-        )
-        self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(
-            playlist: playlist,
-            tracks: [initial],
-            duration: nil
-        )
-        self.mockClient.playlistContinuationTracks[playlist.id] = [[continuation]]
-        self.mockClient.playlistContinuationDelay = .milliseconds(250)
-        let playerService = PlayerService()
-
-        SongActionsHelper.playPlaylist(
-            playlist,
-            client: self.mockClient,
-            playerService: playerService
-        )
-        await self.awaitQueueCount(1, in: playerService)
-
-        await playerService.playQueue([replacement], startingAt: 0)
-        await self.awaitPlaylistContinuationReturns()
-
-        #expect(playerService.queue.map(\.videoId) == ["replacement"])
-    }
-
-    @Test("addPlaylistToLibrary keeps optimistic playlist when refresh response is stale")
-    func addPlaylistToLibraryPreservesOptimisticPlaylist() async throws {
-        let playlist = TestFixtures.makePlaylist(id: "VL-test-playlist", title: "Test Playlist")
-        self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
-
-        try await SongActionsHelper.addPlaylistToLibrary(
-            playlist,
-            client: self.mockClient,
-            libraryViewModel: self.libraryViewModel
-        )
-
-        #expect(self.mockClient.subscribeToPlaylistCalled == true)
-        #expect(self.mockClient.getLibraryContentCalled == true)
-        #expect(self.libraryViewModel.isInLibrary(playlistId: playlist.id) == true)
-        #expect(self.libraryViewModel.playlists.first?.id == playlist.id)
-    }
-
-    @Test("removePlaylistFromLibrary keeps optimistic removal when refresh response is stale")
-    func removePlaylistFromLibraryPreservesOptimisticRemoval() async throws {
-        let playlist = TestFixtures.makePlaylist(id: "VL-test-playlist", title: "Test Playlist")
-        self.mockClient.libraryPlaylists = [playlist]
-        self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
-
-        await self.libraryViewModel.load()
-        self.mockClient.reset()
-
-        try await SongActionsHelper.removePlaylistFromLibrary(
-            playlist,
-            client: self.mockClient,
-            libraryViewModel: self.libraryViewModel
-        )
-
-        #expect(self.mockClient.unsubscribeFromPlaylistCalled == true)
-        #expect(self.mockClient.getLibraryContentCalled == true)
-        #expect(self.libraryViewModel.isInLibrary(playlistId: playlist.id) == false)
-        #expect(self.libraryViewModel.playlists.isEmpty)
-    }
-
-    @Test("subscribeToPodcast keeps optimistic show when refresh response is stale")
-    func subscribeToPodcastPreservesOptimisticShow() async throws {
-        let show = TestFixtures.makePodcastShow(id: "MPSPPL-test-podcast", title: "Test Podcast")
-        self.mockClient.shouldAutoUpdatePodcastLibraryOnMutation = false
-
-        try await SongActionsHelper.subscribeToPodcast(
-            show,
-            client: self.mockClient,
-            libraryViewModel: self.libraryViewModel
-        )
-
-        #expect(self.mockClient.getLibraryContentCalled == true)
-        #expect(self.libraryViewModel.isInLibrary(podcastId: show.id) == true)
-        #expect(self.libraryViewModel.podcastShows.first?.id == show.id)
-    }
-
-    @Test("unsubscribeFromPodcast keeps optimistic removal when refresh response is stale")
-    func unsubscribeFromPodcastPreservesOptimisticRemoval() async throws {
-        let show = TestFixtures.makePodcastShow(id: "MPSPPL-test-podcast", title: "Test Podcast")
-        self.mockClient.libraryPodcastShows = [show]
-        self.mockClient.shouldAutoUpdatePodcastLibraryOnMutation = false
-
-        await self.libraryViewModel.load()
-        self.mockClient.reset()
-
-        try await SongActionsHelper.unsubscribeFromPodcast(
-            show,
-            client: self.mockClient,
-            libraryViewModel: self.libraryViewModel
-        )
-
-        #expect(self.mockClient.getLibraryContentCalled == true)
-        #expect(self.libraryViewModel.isInLibrary(podcastId: show.id) == false)
-        #expect(self.libraryViewModel.podcastShows.isEmpty)
-    }
-
-    @Test("unsubscribeFromArtist keeps optimistic removal when refresh response is stale")
-    func unsubscribeFromArtistPreservesOptimisticRemoval() async throws {
-        let artist = TestFixtures.makeArtist(id: "MPLAUC-channel-123", name: "Test Artist")
-        self.mockClient.libraryArtists = [artist]
-        self.mockClient.shouldAutoUpdateArtistLibraryOnMutation = false
-        self.mockClient.libraryContentResponses = [
-            PlaylistParser.LibraryContent(playlists: [], artists: [artist], podcastShows: []),
-            PlaylistParser.LibraryContent(playlists: [], artists: [], podcastShows: []),
-        ]
-
-        await self.libraryViewModel.load()
-        self.mockClient.reset()
-        self.mockClient.libraryContentResponses = [
-            PlaylistParser.LibraryContent(playlists: [], artists: [artist], podcastShows: []),
-            PlaylistParser.LibraryContent(playlists: [], artists: [], podcastShows: []),
-        ]
-
-        try await SongActionsHelper.unsubscribeFromArtist(
-            artist,
-            channelId: "UC-channel-123",
-            client: self.mockClient,
-            libraryViewModel: self.libraryViewModel
-        )
-        await self.awaitArtistReconciliation(refreshes: 2)
-
-        #expect(self.mockClient.unsubscribeFromArtistCalled == true)
-        #expect(self.mockClient.getLibraryContentCallCount == 2)
-        #expect(self.libraryViewModel.isInLibrary(artistId: "UC-channel-123") == false)
-        #expect(self.libraryViewModel.artists.isEmpty)
-    }
-
-    @Test("unsubscribeFromArtist clears stale browse cache after stale refresh")
-    func unsubscribeFromArtistClearsStaleBrowseCache() async throws {
-        let artist = TestFixtures.makeArtist(id: "MPLAUC-channel-123", name: "Test Artist")
-        self.mockClient.libraryArtists = [artist]
-        self.mockClient.shouldAutoUpdateArtistLibraryOnMutation = false
-        self.mockClient.onGetLibraryContent = {
-            APICache.shared.set(key: "browse:stale-library", data: ["stale": true], ttl: 300)
-        }
-
-        await self.libraryViewModel.load()
-        self.mockClient.reset()
-        self.mockClient.shouldAutoUpdateArtistLibraryOnMutation = false
-        self.mockClient.onGetLibraryContent = {
-            APICache.shared.set(key: "browse:stale-library", data: ["stale": true], ttl: 300)
-        }
-
-        try await SongActionsHelper.unsubscribeFromArtist(
-            artist,
-            channelId: "UC-channel-123",
-            client: self.mockClient,
-            libraryViewModel: self.libraryViewModel
-        )
-        await self.awaitArtistReconciliation()
-
-        #expect(APICache.shared.get(key: "browse:stale-library") == nil)
-    }
-
-    @Test("unsubscribeFromArtist clears URL cache before refreshing library")
-    func unsubscribeFromArtistClearsURLCache() async throws {
-        let artist = TestFixtures.makeArtist(id: "MPLAUC-channel-123", name: "Test Artist")
-        self.mockClient.libraryArtists = [artist]
-
-        let url = try #require(URL(string: "https://music.youtube.com/library-artists-test"))
-        let request = URLRequest(url: url)
-        let response = try #require(
-            HTTPURLResponse(
-                url: url,
-                statusCode: 200,
-                httpVersion: nil,
-                headerFields: ["Cache-Control": "max-age=300"]
+                videoId: "unavailable-continuation",
+                isPlayable: false
             )
-        )
-        URLCache.shared.storeCachedResponse(
-            CachedURLResponse(response: response, data: Data("cached-library".utf8)),
-            for: request
-        )
-        #expect(URLCache.shared.cachedResponse(for: request) != nil)
+            let playableContinuation = Song(
+                id: "playable-continuation",
+                title: "Playable Continuation",
+                artists: [],
+                videoId: "playable-continuation"
+            )
+            self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(
+                playlist: playlist,
+                tracks: [unavailableFirst, playable],
+                duration: nil
+            )
+            self.mockClient.playlistContinuationTracks[playlist.id] = [
+                [unavailableContinuation, playableContinuation],
+            ]
+            self.mockClient.playlistAllTracks[playlist.id] = [
+                Song(
+                    id: "unavailable-first",
+                    title: "Unavailable First",
+                    artists: [],
+                    videoId: "unavailable-first"
+                ),
+                playable,
+                Song(
+                    id: "unavailable-continuation",
+                    title: "Unavailable Continuation",
+                    artists: [],
+                    videoId: "unavailable-continuation"
+                ),
+                playableContinuation,
+            ]
+            let playerService = PlayerService()
 
-        await self.libraryViewModel.load()
-        self.mockClient.reset()
+            SongActionsHelper.playPlaylist(
+                playlist,
+                client: self.mockClient,
+                playerService: playerService
+            )
+            await self.awaitQueueCount(2, in: playerService)
 
-        try await SongActionsHelper.unsubscribeFromArtist(
-            artist,
-            channelId: "UC-channel-123",
-            client: self.mockClient,
-            libraryViewModel: self.libraryViewModel
-        )
-        await self.awaitArtistReconciliation()
-
-        #expect(URLCache.shared.cachedResponse(for: request) == nil)
-    }
-
-    @Test("unsubscribeFromArtist discards an older in-flight library load")
-    func unsubscribeFromArtistDiscardsInflightLibraryLoad() async throws {
-        let staleArtist = TestFixtures.makeArtist(id: "MPLAUC-channel-123", name: "Test Artist")
-        self.mockClient.libraryContentResponses = [
-            PlaylistParser.LibraryContent(playlists: [], artists: [staleArtist], podcastShows: []),
-            PlaylistParser.LibraryContent(playlists: [], artists: [], podcastShows: []),
-        ]
-        self.mockClient.libraryContentResponseDelays = [.milliseconds(700)]
-
-        var initialLoadTask: Task<Void, Never>!
-        await withCheckedContinuation { continuation in
-            self.mockClient.onGetLibraryContent = {
-                self.mockClient.onGetLibraryContent = nil
-                continuation.resume()
-            }
-            initialLoadTask = Task {
-                await self.libraryViewModel.load()
-            }
+            #expect(playerService.queue.map(\.videoId) == ["playable", "playable-continuation"])
+            #expect(playerService.currentTrack?.videoId == "playable")
+            #expect(playerService.queue.first?.thumbnailURL == playlist.thumbnailURL)
         }
 
-        try await SongActionsHelper.unsubscribeFromArtist(
-            staleArtist,
-            channelId: "UC-channel-123",
-            client: self.mockClient,
-            libraryViewModel: self.libraryViewModel
-        )
+        @Test("playPlaylist starts playback before loading continuations")
+        func playPlaylistStartsBeforeContinuations() async {
+            let playlist = TestFixtures.makePlaylist(id: "VL-test-playlist", title: "Test Playlist")
+            let initial = Song(
+                id: "initial",
+                title: "Initial",
+                artists: [],
+                videoId: "initial"
+            )
+            let continuation = Song(
+                id: "continuation",
+                title: "Continuation",
+                artists: [],
+                videoId: "continuation"
+            )
+            self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(
+                playlist: playlist,
+                tracks: [initial],
+                duration: nil
+            )
+            self.mockClient.playlistContinuationTracks[playlist.id] = [[continuation]]
+            self.mockClient.playlistContinuationDelay = .milliseconds(250)
+            let playerService = PlayerService()
 
-        await initialLoadTask.value
-        let didDiscardStaleLoad = await self.waitUntil {
-            self.mockClient.getLibraryContentCallCount >= 2
-                && !self.libraryViewModel.isInLibrary(artistId: "UC-channel-123")
-                && self.libraryViewModel.artists.isEmpty
+            SongActionsHelper.playPlaylist(
+                playlist,
+                client: self.mockClient,
+                playerService: playerService
+            )
+            await self.awaitQueueCount(1, in: playerService)
+
+            #expect(playerService.currentTrack?.videoId == "initial")
+            #expect(playerService.queue.map(\.videoId) == ["initial"])
+
+            await self.awaitQueueCount(2, in: playerService)
+            #expect(playerService.queue.map(\.videoId) == ["initial", "continuation"])
         }
 
-        #expect(didDiscardStaleLoad)
-        #expect(self.mockClient.getLibraryContentCallCount >= 2)
-        #expect(self.libraryViewModel.isInLibrary(artistId: "UC-channel-123") == false)
-        #expect(self.libraryViewModel.artists.isEmpty)
-    }
+        @Test("playPlaylist discards continuations after queue replacement")
+        func playPlaylistDiscardsContinuationsAfterQueueReplacement() async {
+            let playlist = TestFixtures.makePlaylist(id: "VL-test-playlist", title: "Test Playlist")
+            let initial = Song(
+                id: "initial",
+                title: "Initial",
+                artists: [],
+                videoId: "initial"
+            )
+            let continuation = Song(
+                id: "continuation",
+                title: "Continuation",
+                artists: [],
+                videoId: "continuation"
+            )
+            let replacement = Song(
+                id: "replacement",
+                title: "Replacement",
+                artists: [],
+                videoId: "replacement"
+            )
+            self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(
+                playlist: playlist,
+                tracks: [initial],
+                duration: nil
+            )
+            self.mockClient.playlistContinuationTracks[playlist.id] = [[continuation]]
+            self.mockClient.playlistContinuationDelay = .milliseconds(250)
+            let playerService = PlayerService()
 
-    @Test("unsubscribeFromArtist removes artist from library immediately while request is in flight")
-    func unsubscribeFromArtistRemovesArtistOptimistically() async throws {
-        let artist = TestFixtures.makeArtist(id: "MPLAUC-channel-123", name: "Test Artist")
-        self.mockClient.libraryArtists = [artist]
-        self.mockClient.unsubscribeFromArtistDelay = .milliseconds(700)
+            SongActionsHelper.playPlaylist(
+                playlist,
+                client: self.mockClient,
+                playerService: playerService
+            )
+            await self.awaitQueueCount(1, in: playerService)
 
-        await self.libraryViewModel.load()
-        self.mockClient.reset()
-        self.mockClient.unsubscribeFromArtistDelay = .milliseconds(700)
+            await playerService.playQueue([replacement], startingAt: 0)
+            await self.awaitPlaylistContinuationReturns()
 
-        let unsubscribeTask = Task {
+            #expect(playerService.queue.map(\.videoId) == ["replacement"])
+        }
+
+        @Test("addPlaylistToLibrary keeps optimistic playlist when refresh response is stale")
+        func addPlaylistToLibraryPreservesOptimisticPlaylist() async throws {
+            let playlist = TestFixtures.makePlaylist(id: "VL-test-playlist", title: "Test Playlist")
+            self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
+
+            try await SongActionsHelper.addPlaylistToLibrary(
+                playlist,
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel
+            )
+
+            #expect(self.mockClient.subscribeToPlaylistCalled == true)
+            #expect(self.mockClient.getLibraryContentCalled == true)
+            #expect(self.libraryViewModel.isInLibrary(playlistId: playlist.id) == true)
+            #expect(self.libraryViewModel.playlists.first?.id == playlist.id)
+        }
+
+        @Test("removePlaylistFromLibrary keeps optimistic removal when refresh response is stale")
+        func removePlaylistFromLibraryPreservesOptimisticRemoval() async throws {
+            let playlist = TestFixtures.makePlaylist(id: "VL-test-playlist", title: "Test Playlist")
+            self.mockClient.libraryPlaylists = [playlist]
+            self.mockClient.shouldAutoUpdatePlaylistLibraryOnMutation = false
+
+            await self.libraryViewModel.load()
+            self.mockClient.reset()
+
+            try await SongActionsHelper.removePlaylistFromLibrary(
+                playlist,
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel
+            )
+
+            #expect(self.mockClient.unsubscribeFromPlaylistCalled == true)
+            #expect(self.mockClient.getLibraryContentCalled == true)
+            #expect(self.libraryViewModel.isInLibrary(playlistId: playlist.id) == false)
+            #expect(self.libraryViewModel.playlists.isEmpty)
+        }
+
+        @Test("subscribeToPodcast keeps optimistic show when refresh response is stale")
+        func subscribeToPodcastPreservesOptimisticShow() async throws {
+            let show = TestFixtures.makePodcastShow(id: "MPSPPL-test-podcast", title: "Test Podcast")
+            self.mockClient.shouldAutoUpdatePodcastLibraryOnMutation = false
+
+            try await SongActionsHelper.subscribeToPodcast(
+                show,
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel
+            )
+
+            #expect(self.mockClient.getLibraryContentCalled == true)
+            #expect(self.libraryViewModel.isInLibrary(podcastId: show.id) == true)
+            #expect(self.libraryViewModel.podcastShows.first?.id == show.id)
+        }
+
+        @Test("unsubscribeFromPodcast keeps optimistic removal when refresh response is stale")
+        func unsubscribeFromPodcastPreservesOptimisticRemoval() async throws {
+            let show = TestFixtures.makePodcastShow(id: "MPSPPL-test-podcast", title: "Test Podcast")
+            self.mockClient.libraryPodcastShows = [show]
+            self.mockClient.shouldAutoUpdatePodcastLibraryOnMutation = false
+
+            await self.libraryViewModel.load()
+            self.mockClient.reset()
+
+            try await SongActionsHelper.unsubscribeFromPodcast(
+                show,
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel
+            )
+
+            #expect(self.mockClient.getLibraryContentCalled == true)
+            #expect(self.libraryViewModel.isInLibrary(podcastId: show.id) == false)
+            #expect(self.libraryViewModel.podcastShows.isEmpty)
+        }
+
+        @Test("unsubscribeFromArtist keeps optimistic removal when refresh response is stale")
+        func unsubscribeFromArtistPreservesOptimisticRemoval() async throws {
+            let artist = TestFixtures.makeArtist(id: "MPLAUC-channel-123", name: "Test Artist")
+            self.mockClient.libraryArtists = [artist]
+            self.mockClient.shouldAutoUpdateArtistLibraryOnMutation = false
+            self.mockClient.libraryContentResponses = [
+                PlaylistParser.LibraryContent(playlists: [], artists: [artist], podcastShows: []),
+                PlaylistParser.LibraryContent(playlists: [], artists: [], podcastShows: []),
+            ]
+
+            await self.libraryViewModel.load()
+            self.mockClient.reset()
+            self.mockClient.libraryContentResponses = [
+                PlaylistParser.LibraryContent(playlists: [], artists: [artist], podcastShows: []),
+                PlaylistParser.LibraryContent(playlists: [], artists: [], podcastShows: []),
+            ]
+
             try await SongActionsHelper.unsubscribeFromArtist(
                 artist,
                 channelId: "UC-channel-123",
                 client: self.mockClient,
                 libraryViewModel: self.libraryViewModel
             )
+            await self.awaitArtistReconciliation(refreshes: 2)
+
+            #expect(self.mockClient.unsubscribeFromArtistCalled == true)
+            #expect(self.mockClient.getLibraryContentCallCount == 2)
+            #expect(self.libraryViewModel.isInLibrary(artistId: "UC-channel-123") == false)
+            #expect(self.libraryViewModel.artists.isEmpty)
         }
 
-        try await Task.sleep(for: .milliseconds(100))
+        @Test("unsubscribeFromArtist clears stale browse cache after stale refresh")
+        func unsubscribeFromArtistClearsStaleBrowseCache() async throws {
+            let artist = TestFixtures.makeArtist(id: "MPLAUC-channel-123", name: "Test Artist")
+            self.mockClient.libraryArtists = [artist]
+            self.mockClient.shouldAutoUpdateArtistLibraryOnMutation = false
+            self.mockClient.onGetLibraryContent = {
+                APICache.shared.set(key: "browse:stale-library", data: ["stale": true], ttl: 300)
+            }
 
-        #expect(self.libraryViewModel.isInLibrary(artistId: "UC-channel-123") == false)
-        #expect(self.libraryViewModel.artists.isEmpty)
+            await self.libraryViewModel.load()
+            self.mockClient.reset()
+            self.mockClient.shouldAutoUpdateArtistLibraryOnMutation = false
+            self.mockClient.onGetLibraryContent = {
+                APICache.shared.set(key: "browse:stale-library", data: ["stale": true], ttl: 300)
+            }
 
-        try await unsubscribeTask.value
-        await self.awaitArtistReconciliation()
-    }
-
-    @Test("unsubscribeFromArtist suppresses stale artist when library browse ID differs from channel ID")
-    func unsubscribeFromArtistSuppressesArtistWithDifferentBrowseId() async throws {
-        let artist = TestFixtures.makeArtist(id: "MPLAUC-library-browse-123", name: "Test Artist")
-        self.mockClient.libraryArtists = [artist]
-        self.mockClient.shouldAutoUpdateArtistLibraryOnMutation = false
-
-        await self.libraryViewModel.load()
-        self.mockClient.reset()
-        self.mockClient.shouldAutoUpdateArtistLibraryOnMutation = false
-
-        try await SongActionsHelper.unsubscribeFromArtist(
-            artist,
-            channelId: "UC-channel-123",
-            client: self.mockClient,
-            libraryViewModel: self.libraryViewModel
-        )
-
-        #expect(self.libraryViewModel.artists.isEmpty)
-    }
-
-    @Test(
-        "Real-world mismatched artist IDs remove the library artist on unsubscribe",
-        arguments: realWorldArtistIdMismatchCases
-    )
-    func unsubscribeFromArtistHandlesRealWorldMismatchedIds(
-        artistName: String,
-        libraryBrowseId: String,
-        subscriptionChannelId: String
-    ) async throws {
-        let artist = TestFixtures.makeArtist(id: libraryBrowseId, name: artistName)
-        self.mockClient.libraryArtists = [artist]
-        self.mockClient.shouldAutoUpdateArtistLibraryOnMutation = false
-
-        await self.libraryViewModel.load()
-        self.mockClient.reset()
-        self.mockClient.shouldAutoUpdateArtistLibraryOnMutation = false
-
-        try await SongActionsHelper.unsubscribeFromArtist(
-            artist,
-            channelId: subscriptionChannelId,
-            client: self.mockClient,
-            libraryViewModel: self.libraryViewModel
-        )
-
-        #expect(self.libraryViewModel.artists.isEmpty)
-        #expect(self.libraryViewModel.isInLibrary(artistId: libraryBrowseId) == false)
-        #expect(self.libraryViewModel.isInLibrary(artistId: subscriptionChannelId) == false)
-    }
-
-    @Test("subscribeToArtist adds artist to library immediately while request is in flight")
-    func subscribeToArtistAddsArtistOptimistically() async throws {
-        let artist = TestFixtures.makeArtist(id: "MPLAUC-channel-123", name: "Test Artist")
-        self.mockClient.subscribeToArtistDelay = .milliseconds(700)
-
-        let subscribeTask = Task {
-            try await SongActionsHelper.subscribeToArtist(
+            try await SongActionsHelper.unsubscribeFromArtist(
                 artist,
                 channelId: "UC-channel-123",
                 client: self.mockClient,
                 libraryViewModel: self.libraryViewModel
             )
+            await self.awaitArtistReconciliation()
+
+            #expect(APICache.shared.get(key: "browse:stale-library") == nil)
         }
 
-        try await Task.sleep(for: .milliseconds(100))
+        @Test("unsubscribeFromArtist clears URL cache before refreshing library")
+        func unsubscribeFromArtistClearsURLCache() async throws {
+            let artist = TestFixtures.makeArtist(id: "MPLAUC-channel-123", name: "Test Artist")
+            self.mockClient.libraryArtists = [artist]
 
-        #expect(self.libraryViewModel.isInLibrary(artistId: "UC-channel-123") == true)
-        #expect(self.libraryViewModel.artists.first?.id == "UC-channel-123")
+            let url = try #require(URL(string: "https://music.youtube.com/library-artists-test"))
+            let request = URLRequest(url: url)
+            let response = try #require(
+                HTTPURLResponse(
+                    url: url,
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: ["Cache-Control": "max-age=300"]
+                )
+            )
+            URLCache.shared.storeCachedResponse(
+                CachedURLResponse(response: response, data: Data("cached-library".utf8)),
+                for: request
+            )
+            #expect(URLCache.shared.cachedResponse(for: request) != nil)
 
-        try await subscribeTask.value
-        await self.awaitArtistReconciliation()
-    }
+            await self.libraryViewModel.load()
+            self.mockClient.reset()
 
-    @Test("subscribeToArtist does not duplicate artist when library browse ID differs from subscription channel ID")
-    func subscribeToArtistDoesNotDuplicateArtistWithDifferentBrowseId() async throws {
-        let artist = TestFixtures.makeArtist(id: "UC-library-browse-123", name: "Test Artist")
-        let libraryContent = PlaylistParser.LibraryContent(
-            playlists: [],
-            artists: [artist],
-            podcastShows: []
+            try await SongActionsHelper.unsubscribeFromArtist(
+                artist,
+                channelId: "UC-channel-123",
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel
+            )
+            await self.awaitArtistReconciliation()
+
+            #expect(URLCache.shared.cachedResponse(for: request) == nil)
+        }
+
+        @Test("unsubscribeFromArtist discards an older in-flight library load")
+        func unsubscribeFromArtistDiscardsInflightLibraryLoad() async throws {
+            let staleArtist = TestFixtures.makeArtist(id: "MPLAUC-channel-123", name: "Test Artist")
+            self.mockClient.libraryContentResponses = [
+                PlaylistParser.LibraryContent(playlists: [], artists: [staleArtist], podcastShows: []),
+                PlaylistParser.LibraryContent(playlists: [], artists: [], podcastShows: []),
+            ]
+            self.mockClient.libraryContentResponseDelays = [.milliseconds(700)]
+
+            var initialLoadTask: Task<Void, Never>!
+            await withCheckedContinuation { continuation in
+                self.mockClient.onGetLibraryContent = {
+                    self.mockClient.onGetLibraryContent = nil
+                    continuation.resume()
+                }
+                initialLoadTask = Task {
+                    await self.libraryViewModel.load()
+                }
+            }
+
+            try await SongActionsHelper.unsubscribeFromArtist(
+                staleArtist,
+                channelId: "UC-channel-123",
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel
+            )
+
+            await initialLoadTask.value
+            let didDiscardStaleLoad = await self.waitUntil {
+                self.mockClient.getLibraryContentCallCount >= 2
+                    && !self.libraryViewModel.isInLibrary(artistId: "UC-channel-123")
+                    && self.libraryViewModel.artists.isEmpty
+            }
+
+            #expect(didDiscardStaleLoad)
+            #expect(self.mockClient.getLibraryContentCallCount >= 2)
+            #expect(self.libraryViewModel.isInLibrary(artistId: "UC-channel-123") == false)
+            #expect(self.libraryViewModel.artists.isEmpty)
+        }
+
+        @Test("unsubscribeFromArtist removes artist from library immediately while request is in flight")
+        func unsubscribeFromArtistRemovesArtistOptimistically() async throws {
+            let artist = TestFixtures.makeArtist(id: "MPLAUC-channel-123", name: "Test Artist")
+            self.mockClient.libraryArtists = [artist]
+            self.mockClient.unsubscribeFromArtistDelay = .milliseconds(700)
+
+            await self.libraryViewModel.load()
+            self.mockClient.reset()
+            self.mockClient.unsubscribeFromArtistDelay = .milliseconds(700)
+
+            let unsubscribeTask = Task {
+                try await SongActionsHelper.unsubscribeFromArtist(
+                    artist,
+                    channelId: "UC-channel-123",
+                    client: self.mockClient,
+                    libraryViewModel: self.libraryViewModel
+                )
+            }
+
+            try await Task.sleep(for: .milliseconds(100))
+
+            #expect(self.libraryViewModel.isInLibrary(artistId: "UC-channel-123") == false)
+            #expect(self.libraryViewModel.artists.isEmpty)
+
+            try await unsubscribeTask.value
+            await self.awaitArtistReconciliation()
+        }
+
+        @Test("unsubscribeFromArtist suppresses stale artist when library browse ID differs from channel ID")
+        func unsubscribeFromArtistSuppressesArtistWithDifferentBrowseId() async throws {
+            let artist = TestFixtures.makeArtist(id: "MPLAUC-library-browse-123", name: "Test Artist")
+            self.mockClient.libraryArtists = [artist]
+            self.mockClient.shouldAutoUpdateArtistLibraryOnMutation = false
+
+            await self.libraryViewModel.load()
+            self.mockClient.reset()
+            self.mockClient.shouldAutoUpdateArtistLibraryOnMutation = false
+
+            try await SongActionsHelper.unsubscribeFromArtist(
+                artist,
+                channelId: "UC-channel-123",
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel
+            )
+
+            #expect(self.libraryViewModel.artists.isEmpty)
+        }
+
+        @Test(
+            "Real-world mismatched artist IDs remove the library artist on unsubscribe",
+            arguments: realWorldArtistIdMismatchCases
         )
-        self.mockClient.shouldAutoUpdateArtistLibraryOnMutation = false
-        self.mockClient.libraryContentResponses = [libraryContent, libraryContent]
+        func unsubscribeFromArtistHandlesRealWorldMismatchedIds(
+            artistName: String,
+            libraryBrowseId: String,
+            subscriptionChannelId: String
+        ) async throws {
+            let artist = TestFixtures.makeArtist(id: libraryBrowseId, name: artistName)
+            self.mockClient.libraryArtists = [artist]
+            self.mockClient.shouldAutoUpdateArtistLibraryOnMutation = false
 
-        try await SongActionsHelper.subscribeToArtist(
-            artist,
-            channelId: "UC-subscribe-channel-456",
-            client: self.mockClient,
-            libraryViewModel: self.libraryViewModel
+            await self.libraryViewModel.load()
+            self.mockClient.reset()
+            self.mockClient.shouldAutoUpdateArtistLibraryOnMutation = false
+
+            try await SongActionsHelper.unsubscribeFromArtist(
+                artist,
+                channelId: subscriptionChannelId,
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel
+            )
+
+            #expect(self.libraryViewModel.artists.isEmpty)
+            #expect(self.libraryViewModel.isInLibrary(artistId: libraryBrowseId) == false)
+            #expect(self.libraryViewModel.isInLibrary(artistId: subscriptionChannelId) == false)
+        }
+
+        @Test("subscribeToArtist adds artist to library immediately while request is in flight")
+        func subscribeToArtistAddsArtistOptimistically() async throws {
+            let artist = TestFixtures.makeArtist(id: "MPLAUC-channel-123", name: "Test Artist")
+            self.mockClient.subscribeToArtistDelay = .milliseconds(700)
+
+            let subscribeTask = Task {
+                try await SongActionsHelper.subscribeToArtist(
+                    artist,
+                    channelId: "UC-channel-123",
+                    client: self.mockClient,
+                    libraryViewModel: self.libraryViewModel
+                )
+            }
+
+            try await Task.sleep(for: .milliseconds(100))
+
+            #expect(self.libraryViewModel.isInLibrary(artistId: "UC-channel-123") == true)
+            #expect(self.libraryViewModel.artists.first?.id == "UC-channel-123")
+
+            try await subscribeTask.value
+            await self.awaitArtistReconciliation()
+        }
+
+        @Test("subscribeToArtist does not duplicate artist when library browse ID differs from subscription channel ID")
+        func subscribeToArtistDoesNotDuplicateArtistWithDifferentBrowseId() async throws {
+            let artist = TestFixtures.makeArtist(id: "UC-library-browse-123", name: "Test Artist")
+            let libraryContent = PlaylistParser.LibraryContent(
+                playlists: [],
+                artists: [artist],
+                podcastShows: []
+            )
+            self.mockClient.shouldAutoUpdateArtistLibraryOnMutation = false
+            self.mockClient.libraryContentResponses = [libraryContent, libraryContent]
+
+            try await SongActionsHelper.subscribeToArtist(
+                artist,
+                channelId: "UC-subscribe-channel-456",
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel
+            )
+            await self.awaitArtistReconciliation(refreshes: 2)
+
+            #expect(self.libraryViewModel.artists.count == 1)
+            #expect(self.libraryViewModel.artists.first?.id == "UC-library-browse-123")
+        }
+
+        @Test(
+            "Real-world mismatched artist IDs do not duplicate on subscribe",
+            arguments: realWorldArtistIdMismatchCases
         )
-        await self.awaitArtistReconciliation(refreshes: 2)
+        func subscribeToArtistDoesNotDuplicateRealWorldMismatchedIds(
+            artistName: String,
+            libraryBrowseId: String,
+            subscriptionChannelId: String
+        ) async throws {
+            let artist = TestFixtures.makeArtist(id: libraryBrowseId, name: artistName)
+            let libraryContent = PlaylistParser.LibraryContent(
+                playlists: [],
+                artists: [artist],
+                podcastShows: []
+            )
+            self.mockClient.shouldAutoUpdateArtistLibraryOnMutation = false
+            self.mockClient.libraryContentResponses = [libraryContent, libraryContent]
 
-        #expect(self.libraryViewModel.artists.count == 1)
-        #expect(self.libraryViewModel.artists.first?.id == "UC-library-browse-123")
-    }
+            try await SongActionsHelper.subscribeToArtist(
+                artist,
+                channelId: subscriptionChannelId,
+                client: self.mockClient,
+                libraryViewModel: self.libraryViewModel
+            )
+            await self.awaitArtistReconciliation(refreshes: 2)
 
-    @Test(
-        "Real-world mismatched artist IDs do not duplicate on subscribe",
-        arguments: realWorldArtistIdMismatchCases
-    )
-    func subscribeToArtistDoesNotDuplicateRealWorldMismatchedIds(
-        artistName: String,
-        libraryBrowseId: String,
-        subscriptionChannelId: String
-    ) async throws {
-        let artist = TestFixtures.makeArtist(id: libraryBrowseId, name: artistName)
-        let libraryContent = PlaylistParser.LibraryContent(
-            playlists: [],
-            artists: [artist],
-            podcastShows: []
-        )
-        self.mockClient.shouldAutoUpdateArtistLibraryOnMutation = false
-        self.mockClient.libraryContentResponses = [libraryContent, libraryContent]
-
-        try await SongActionsHelper.subscribeToArtist(
-            artist,
-            channelId: subscriptionChannelId,
-            client: self.mockClient,
-            libraryViewModel: self.libraryViewModel
-        )
-        await self.awaitArtistReconciliation(refreshes: 2)
-
-        #expect(self.libraryViewModel.artists.count == 1)
-        #expect(self.libraryViewModel.artists.first?.id == libraryBrowseId)
-        #expect(self.libraryViewModel.isInLibrary(artistId: libraryBrowseId) == true)
-        #expect(self.libraryViewModel.isInLibrary(artistId: subscriptionChannelId) == true)
+            #expect(self.libraryViewModel.artists.count == 1)
+            #expect(self.libraryViewModel.artists.first?.id == libraryBrowseId)
+            #expect(self.libraryViewModel.isInLibrary(artistId: libraryBrowseId) == true)
+            #expect(self.libraryViewModel.isInLibrary(artistId: subscriptionChannelId) == true)
+        }
     }
 }

--- a/Tests/KasetTests/YTMusicClientLibraryContentTests.swift
+++ b/Tests/KasetTests/YTMusicClientLibraryContentTests.swift
@@ -1,0 +1,276 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+// MARK: - YTMusicClientLibraryRequestTests
+
+@Suite(.serialized, .tags(.api), .timeLimit(.minutes(1)))
+@MainActor
+struct YTMusicClientLibraryRequestTests {
+    @Test("Library content fetches all saved album pages and stops on a repeated token")
+    func libraryContentFetchesAllSavedAlbumPages() async throws {
+        APICache.shared.invalidateAll()
+        let session = MockURLProtocol.makeMockSession()
+        let recorder = LibraryRequestRecorder()
+
+        MockURLProtocol.setRequestHandler(for: session) { request in
+            let url = try #require(request.url)
+            if request.httpMethod == "GET" {
+                let response = try #require(
+                    HTTPURLResponse(
+                        url: url,
+                        statusCode: 200,
+                        httpVersion: nil,
+                        headerFields: ["Content-Type": "text/html"]
+                    )
+                )
+                return (response, Data(#"ytcfg.set({"INNERTUBE_API_KEY":"REDACTED"});"#.utf8))
+            }
+
+            let bodyData = try LibraryRequestTestSupport.bodyData(from: request)
+            let body = try #require(
+                JSONSerialization.jsonObject(with: bodyData) as? [String: Any]
+            )
+
+            let payload: [String: Any]
+            let statusCode: Int
+            if let continuation = body["continuation"] as? String {
+                recorder.appendCursor(continuation)
+                switch continuation {
+                case "albums-page-2":
+                    payload = Self.libraryAlbumsContinuationPayload(
+                        albumID: "MPREALBUMB",
+                        title: "Album B",
+                        nextPage: "albums-page-3"
+                    )
+                    statusCode = 200
+                case "albums-page-3":
+                    payload = Self.libraryAlbumsContinuationPayload(
+                        albumID: "MPREALBUMC",
+                        title: "Album C",
+                        nextPage: "albums-page-2"
+                    )
+                    statusCode = 200
+                default:
+                    payload = [:]
+                    statusCode = 400
+                }
+            } else if let browseID = body["browseId"] as? String {
+                recorder.appendBrowseID(browseID)
+                switch browseID {
+                case "FEmusic_liked_albums":
+                    payload = Self.libraryAlbumsPagePayload(
+                        albumID: "MPREALBUMA",
+                        title: "Album A",
+                        nextPage: "albums-page-2"
+                    )
+                    statusCode = 200
+                case "FEmusic_library_landing",
+                     "FEmusic_liked_playlists",
+                     "FEmusic_library_corpus_artists",
+                     Playlist.uploadedSongsBrowseID:
+                    payload = [:]
+                    statusCode = 200
+                default:
+                    payload = [:]
+                    statusCode = 400
+                }
+            } else {
+                payload = [:]
+                statusCode = 400
+            }
+
+            let data = try JSONSerialization.data(withJSONObject: payload)
+            let response = try #require(
+                HTTPURLResponse(
+                    url: url,
+                    statusCode: statusCode,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "application/json"]
+                )
+            )
+            return (response, data)
+        }
+        defer { MockURLProtocol.reset(session: session) }
+
+        let client = try await Self.makeAuthenticatedClient(session: session)
+        let content = try await client.getLibraryContent()
+
+        #expect(content.albums.map(\.id) == [
+            "MPREALBUMA",
+            "MPREALBUMB",
+            "MPREALBUMC",
+        ])
+        #expect(recorder.cursors == [
+            "albums-page-2",
+            "albums-page-3",
+        ])
+        #expect(recorder.browseIDs == [
+            "FEmusic_library_landing",
+            "FEmusic_liked_playlists",
+            "FEmusic_liked_albums",
+            "FEmusic_library_corpus_artists",
+            Playlist.uploadedSongsBrowseID,
+        ])
+    }
+
+    private static func makeAuthenticatedClient(session: URLSession) async throws -> YTMusicClient {
+        let webKitManager = WebKitManager.makeTestInstance()
+        let cookie = try #require(HTTPCookie(properties: [
+            .name: WebKitManager.fallbackAuthCookieName,
+            .value: "test-cookie",
+            .domain: ".youtube.com",
+            .path: "/",
+        ]))
+        await webKitManager.dataStore.httpCookieStore.setCookie(cookie)
+
+        let authService = AuthService(webKitManager: webKitManager)
+        authService.completeLogin(sapisid: "test-cookie")
+        return YTMusicClient(
+            authService: authService,
+            webKitManager: webKitManager,
+            session: session
+        )
+    }
+
+    // swiftlint:disable:next modifier_order
+    private nonisolated static func libraryAlbumsPagePayload(
+        albumID: String,
+        title: String,
+        nextPage: String?
+    ) -> [String: Any] {
+        var gridRenderer: [String: Any] = [
+            "items": [Self.libraryAlbumItem(id: albumID, title: title)],
+        ]
+        if let nextPage {
+            gridRenderer["continuations"] = [[
+                "nextContinuationData": ["continuation": nextPage],
+            ]]
+        }
+
+        return [
+            "contents": [
+                "singleColumnBrowseResultsRenderer": [
+                    "tabs": [[
+                        "tabRenderer": [
+                            "content": [
+                                "sectionListRenderer": [
+                                    "contents": [["gridRenderer": gridRenderer]],
+                                ],
+                            ],
+                        ],
+                    ]],
+                ],
+            ],
+        ]
+    }
+
+    // swiftlint:disable:next modifier_order
+    private nonisolated static func libraryAlbumsContinuationPayload(
+        albumID: String,
+        title: String,
+        nextPage: String?
+    ) -> [String: Any] {
+        var gridContinuation: [String: Any] = [
+            "items": [Self.libraryAlbumItem(id: albumID, title: title)],
+        ]
+        if let nextPage {
+            gridContinuation["continuations"] = [[
+                "nextContinuationData": ["continuation": nextPage],
+            ]]
+        }
+
+        return [
+            "continuationContents": [
+                "gridContinuation": gridContinuation,
+            ],
+        ]
+    }
+
+    // swiftlint:disable:next modifier_order
+    private nonisolated static func libraryAlbumItem(id: String, title: String) -> [String: Any] {
+        [
+            "musicTwoRowItemRenderer": [
+                "title": ["runs": [["text": title]]],
+                "subtitle": [
+                    "runs": [
+                        ["text": "Album"],
+                        ["text": " • "],
+                        ["text": "Test Artist"],
+                        ["text": " • "],
+                        ["text": "2026"],
+                    ],
+                ],
+                "navigationEndpoint": [
+                    "browseEndpoint": [
+                        "browseId": id,
+                        "browseEndpointContextSupportedConfigs": [
+                            "browseEndpointContextMusicConfig": [
+                                "pageType": "MUSIC_PAGE_TYPE_ALBUM",
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]
+    }
+}
+
+// MARK: - LibraryRequestTestSupport
+
+private enum LibraryRequestTestSupport {
+    /// URLSession may bridge `httpBody` to a stream before URLProtocol observes the request.
+    static func bodyData(from request: URLRequest) throws -> Data {
+        if let body = request.httpBody {
+            return body
+        }
+
+        guard let stream = request.httpBodyStream else {
+            throw YTMusicError.parseError(message: "Request body was missing")
+        }
+
+        stream.open()
+        defer { stream.close() }
+
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while true {
+            let count = stream.read(&buffer, maxLength: buffer.count)
+            if count < 0 {
+                throw stream.streamError ?? YTMusicError.parseError(message: "Request body could not be read")
+            }
+            if count == 0 {
+                return data
+            }
+            data.append(buffer, count: count)
+        }
+    }
+}
+
+// MARK: - LibraryRequestRecorder
+
+private final class LibraryRequestRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedBrowseIDs: [String] = []
+    private var storedCursors: [String] = []
+
+    var browseIDs: [String] {
+        self.lock.withLock { self.storedBrowseIDs }
+    }
+
+    var cursors: [String] {
+        self.lock.withLock { self.storedCursors }
+    }
+
+    func appendBrowseID(_ browseID: String) {
+        self.lock.withLock {
+            self.storedBrowseIDs.append(browseID)
+        }
+    }
+
+    func appendCursor(_ cursor: String) {
+        self.lock.withLock {
+            self.storedCursors.append(cursor)
+        }
+    }
+}

--- a/Tests/KasetTests/YTMusicClientLibraryContentTests.swift
+++ b/Tests/KasetTests/YTMusicClientLibraryContentTests.swift
@@ -1,3 +1,5 @@
+// swiftlint:disable file_length
+
 import Foundation
 import Testing
 @testable import Kaset
@@ -112,9 +114,519 @@ struct YTMusicClientLibraryRequestTests {
             "FEmusic_library_corpus_artists",
             Playlist.uploadedSongsBrowseID,
         ])
+        #expect(content.albumsSource == .partial)
     }
 
-    private static func makeAuthenticatedClient(session: URLSession) async throws -> YTMusicClient {
+    @Test("Complete dedicated album results exclude landing-only previews")
+    func completeDedicatedAlbumsExcludeLandingPreview() async throws {
+        APICache.shared.invalidateAll()
+        let session = MockURLProtocol.makeMockSession()
+
+        MockURLProtocol.setRequestHandler(for: session) { request in
+            let url = try #require(request.url)
+            if request.httpMethod == "GET" {
+                let response = try #require(
+                    HTTPURLResponse(
+                        url: url,
+                        statusCode: 200,
+                        httpVersion: nil,
+                        headerFields: ["Content-Type": "text/html"]
+                    )
+                )
+                return (response, Data(#"ytcfg.set({"INNERTUBE_API_KEY":"REDACTED"});"#.utf8))
+            }
+
+            let bodyData = try LibraryRequestTestSupport.bodyData(from: request)
+            let body = try #require(JSONSerialization.jsonObject(with: bodyData) as? [String: Any])
+            let payload: [String: Any] = switch body["browseId"] as? String {
+            case "FEmusic_library_landing":
+                Self.libraryAlbumsPagePayload(
+                    albumID: "MPREPREVIEW",
+                    title: "Preview Album",
+                    nextPage: nil
+                )
+            case "FEmusic_liked_albums":
+                Self.libraryAlbumsPagePayload(
+                    albumID: "MPREDEDICATED",
+                    title: "Dedicated Album",
+                    nextPage: nil
+                )
+            default:
+                [:]
+            }
+
+            let data = try JSONSerialization.data(withJSONObject: payload)
+            let response = try #require(
+                HTTPURLResponse(
+                    url: url,
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "application/json"]
+                )
+            )
+            return (response, data)
+        }
+        defer { MockURLProtocol.reset(session: session) }
+
+        let client = try await Self.makeAuthenticatedClient(session: session)
+        let content = try await client.getLibraryContent()
+
+        #expect(content.albums.map(\.id) == ["MPREDEDICATED"])
+        #expect(content.albumsSource == .dedicated)
+    }
+
+    @Test("Library content paginates shelf-based saved album responses")
+    func libraryContentPaginatesShelfBasedAlbums() async throws {
+        APICache.shared.invalidateAll()
+        let session = MockURLProtocol.makeMockSession()
+
+        MockURLProtocol.setRequestHandler(for: session) { request in
+            let url = try #require(request.url)
+            if request.httpMethod == "GET" {
+                let response = try #require(
+                    HTTPURLResponse(
+                        url: url,
+                        statusCode: 200,
+                        httpVersion: nil,
+                        headerFields: ["Content-Type": "text/html"]
+                    )
+                )
+                return (response, Data(#"ytcfg.set({"INNERTUBE_API_KEY":"REDACTED"});"#.utf8))
+            }
+
+            let bodyData = try LibraryRequestTestSupport.bodyData(from: request)
+            let body = try #require(JSONSerialization.jsonObject(with: bodyData) as? [String: Any])
+            let payload: [String: Any] = if body["continuation"] as? String == "albums-page-2" {
+                Self.libraryAlbumsShelfContinuationPayload(
+                    albumID: "MPRESHELFB",
+                    title: "Shelf Album B"
+                )
+            } else if body["browseId"] as? String == "FEmusic_liked_albums" {
+                Self.libraryAlbumsShelfPagePayload(
+                    albumID: "MPRESHELFA",
+                    title: "Shelf Album A",
+                    nextPage: "albums-page-2"
+                )
+            } else {
+                [:]
+            }
+
+            let data = try JSONSerialization.data(withJSONObject: payload)
+            let response = try #require(
+                HTTPURLResponse(
+                    url: url,
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "application/json"]
+                )
+            )
+            return (response, data)
+        }
+        defer { MockURLProtocol.reset(session: session) }
+
+        let client = try await Self.makeAuthenticatedClient(session: session)
+        let content = try await client.getLibraryContent()
+
+        #expect(content.albums.map(\.id) == ["MPRESHELFA", "MPRESHELFB"])
+        #expect(content.albumsSource == .dedicated)
+    }
+
+    @Test("Library content consumes independent album continuation chains")
+    func libraryContentConsumesIndependentAlbumContinuations() async throws {
+        APICache.shared.invalidateAll()
+        let session = MockURLProtocol.makeMockSession()
+
+        MockURLProtocol.setRequestHandler(for: session) { request in
+            let url = try #require(request.url)
+            if request.httpMethod == "GET" {
+                let response = try #require(
+                    HTTPURLResponse(
+                        url: url,
+                        statusCode: 200,
+                        httpVersion: nil,
+                        headerFields: ["Content-Type": "text/html"]
+                    )
+                )
+                return (response, Data(#"ytcfg.set({"INNERTUBE_API_KEY":"REDACTED"});"#.utf8))
+            }
+
+            let bodyData = try LibraryRequestTestSupport.bodyData(from: request)
+            let body = try #require(JSONSerialization.jsonObject(with: bodyData) as? [String: Any])
+            let payload: [String: Any] = switch body["continuation"] as? String {
+            case "shelf-one-next":
+                Self.libraryAlbumsShelfContinuationPayload(
+                    albumID: "MPRESHELFONECONTINUED",
+                    title: "Shelf One Continued"
+                )
+            case "shelf-two-next":
+                Self.libraryAlbumsShelfContinuationPayload(
+                    albumID: "MPRESHELFTWOCONTINUED",
+                    title: "Shelf Two Continued"
+                )
+            default:
+                if body["browseId"] as? String == "FEmusic_liked_albums" {
+                    Self.libraryAlbumsMultipleShelfPagePayload()
+                } else {
+                    [:]
+                }
+            }
+
+            let data = try JSONSerialization.data(withJSONObject: payload)
+            let response = try #require(
+                HTTPURLResponse(
+                    url: url,
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "application/json"]
+                )
+            )
+            return (response, data)
+        }
+        defer { MockURLProtocol.reset(session: session) }
+
+        let client = try await Self.makeAuthenticatedClient(session: session)
+        let content = try await client.getLibraryContent()
+
+        #expect(Set(content.albums.map(\.id)) == Set([
+            "MPRESHELFONE",
+            "MPRESHELFTWO",
+            "MPRESHELFONECONTINUED",
+            "MPRESHELFTWOCONTINUED",
+        ]))
+        #expect(content.albumsSource == .dedicated)
+    }
+
+    @Test("Library content marks landing albums as fallback when the dedicated request fails")
+    func libraryContentMarksAlbumFallbackAfterDedicatedFailure() async throws {
+        APICache.shared.invalidateAll()
+        let session = MockURLProtocol.makeMockSession()
+
+        MockURLProtocol.setRequestHandler(for: session) { request in
+            let url = try #require(request.url)
+            if request.httpMethod == "GET" {
+                let response = try #require(
+                    HTTPURLResponse(
+                        url: url,
+                        statusCode: 200,
+                        httpVersion: nil,
+                        headerFields: ["Content-Type": "text/html"]
+                    )
+                )
+                return (response, Data(#"ytcfg.set({"INNERTUBE_API_KEY":"REDACTED"});"#.utf8))
+            }
+
+            let bodyData = try LibraryRequestTestSupport.bodyData(from: request)
+            let body = try #require(
+                JSONSerialization.jsonObject(with: bodyData) as? [String: Any]
+            )
+            let browseID = body["browseId"] as? String
+            let statusCode = browseID == "FEmusic_liked_albums" ? 400 : 200
+            let payload: [String: Any] = if browseID == "FEmusic_library_landing" {
+                Self.libraryAlbumsPagePayload(
+                    albumID: "MPREFALLBACK",
+                    title: "Fallback Album",
+                    nextPage: nil
+                )
+            } else {
+                [:]
+            }
+
+            let data = try JSONSerialization.data(withJSONObject: payload)
+            let response = try #require(
+                HTTPURLResponse(
+                    url: url,
+                    statusCode: statusCode,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "application/json"]
+                )
+            )
+            return (response, data)
+        }
+        defer { MockURLProtocol.reset(session: session) }
+
+        let client = try await Self.makeAuthenticatedClient(session: session)
+        let content = try await client.getLibraryContent()
+
+        #expect(content.albums.map(\.id) == ["MPREFALLBACK"])
+        #expect(content.albumsSource == .landingFallback)
+        #expect(content.accountScope == "primary")
+    }
+
+    @Test("Library content treats a recognized empty saved-albums page as authoritative")
+    func libraryContentTreatsRecognizedEmptyAlbumsAsAuthoritative() async throws {
+        APICache.shared.invalidateAll()
+        let session = MockURLProtocol.makeMockSession()
+
+        MockURLProtocol.setRequestHandler(for: session) { request in
+            let url = try #require(request.url)
+            if request.httpMethod == "GET" {
+                let response = try #require(
+                    HTTPURLResponse(
+                        url: url,
+                        statusCode: 200,
+                        httpVersion: nil,
+                        headerFields: ["Content-Type": "text/html"]
+                    )
+                )
+                return (response, Data(#"ytcfg.set({"INNERTUBE_API_KEY":"REDACTED"});"#.utf8))
+            }
+
+            let bodyData = try LibraryRequestTestSupport.bodyData(from: request)
+            let body = try #require(JSONSerialization.jsonObject(with: bodyData) as? [String: Any])
+            let browseID = body["browseId"] as? String
+            let payload: [String: Any] = if browseID == "FEmusic_library_landing" {
+                Self.libraryAlbumsPagePayload(
+                    albumID: "MPREFALLBACK",
+                    title: "Fallback Album",
+                    nextPage: nil
+                )
+            } else if browseID == "FEmusic_liked_albums" {
+                Self.emptyLibraryAlbumsPagePayload(nextPage: nil)
+            } else {
+                [:]
+            }
+
+            let data = try JSONSerialization.data(withJSONObject: payload)
+            let response = try #require(
+                HTTPURLResponse(
+                    url: url,
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "application/json"]
+                )
+            )
+            return (response, data)
+        }
+        defer { MockURLProtocol.reset(session: session) }
+
+        let client = try await Self.makeAuthenticatedClient(session: session)
+        let content = try await client.getLibraryContent()
+
+        #expect(content.albums.isEmpty)
+        #expect(content.albumsSource == .dedicated)
+    }
+
+    @Test("Library content keeps empty incomplete pagination non-authoritative")
+    func libraryContentKeepsEmptyIncompletePaginationNonAuthoritative() async throws {
+        APICache.shared.invalidateAll()
+        let session = MockURLProtocol.makeMockSession()
+
+        MockURLProtocol.setRequestHandler(for: session) { request in
+            let url = try #require(request.url)
+            if request.httpMethod == "GET" {
+                let response = try #require(
+                    HTTPURLResponse(
+                        url: url,
+                        statusCode: 200,
+                        httpVersion: nil,
+                        headerFields: ["Content-Type": "text/html"]
+                    )
+                )
+                return (response, Data(#"ytcfg.set({"INNERTUBE_API_KEY":"REDACTED"});"#.utf8))
+            }
+
+            let bodyData = try LibraryRequestTestSupport.bodyData(from: request)
+            let body = try #require(JSONSerialization.jsonObject(with: bodyData) as? [String: Any])
+            let payload: [String: Any]
+            let statusCode: Int
+            if body["continuation"] != nil {
+                payload = [:]
+                statusCode = 400
+            } else if let browseID = body["browseId"] as? String {
+                switch browseID {
+                case "FEmusic_library_landing":
+                    payload = Self.libraryAlbumsPagePayload(
+                        albumID: "MPREFALLBACK",
+                        title: "Fallback Album",
+                        nextPage: nil
+                    )
+                case "FEmusic_liked_albums":
+                    payload = Self.emptyLibraryAlbumsPagePayload(nextPage: "albums-page-2")
+                default:
+                    payload = [:]
+                }
+                statusCode = 200
+            } else {
+                payload = [:]
+                statusCode = 400
+            }
+
+            let data = try JSONSerialization.data(withJSONObject: payload)
+            let response = try #require(
+                HTTPURLResponse(
+                    url: url,
+                    statusCode: statusCode,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "application/json"]
+                )
+            )
+            return (response, data)
+        }
+        defer { MockURLProtocol.reset(session: session) }
+
+        let client = try await Self.makeAuthenticatedClient(session: session)
+        let content = try await client.getLibraryContent()
+
+        #expect(content.albums.map(\.id) == ["MPREFALLBACK"])
+        #expect(content.albumsSource == .partial)
+    }
+
+    @Test("Library content follows continuations from an unrecognized empty first page")
+    func libraryContentFollowsContinuationFromUnrecognizedFirstPage() async throws {
+        APICache.shared.invalidateAll()
+        let session = MockURLProtocol.makeMockSession()
+        let recorder = LibraryRequestRecorder()
+
+        MockURLProtocol.setRequestHandler(for: session) { request in
+            let url = try #require(request.url)
+            if request.httpMethod == "GET" {
+                let response = try #require(
+                    HTTPURLResponse(
+                        url: url,
+                        statusCode: 200,
+                        httpVersion: nil,
+                        headerFields: ["Content-Type": "text/html"]
+                    )
+                )
+                return (response, Data(#"ytcfg.set({"INNERTUBE_API_KEY":"REDACTED"});"#.utf8))
+            }
+
+            let bodyData = try LibraryRequestTestSupport.bodyData(from: request)
+            let body = try #require(JSONSerialization.jsonObject(with: bodyData) as? [String: Any])
+            let payload: [String: Any]
+            if let continuation = body["continuation"] as? String {
+                recorder.appendCursor(continuation)
+                payload = Self.libraryAlbumsContinuationPayload(
+                    albumID: "MPREFROMCONTINUATION",
+                    title: "Continuation Album",
+                    nextPage: nil
+                )
+            } else if let browseID = body["browseId"] as? String {
+                switch browseID {
+                case "FEmusic_library_landing":
+                    payload = Self.libraryAlbumsPagePayload(
+                        albumID: "MPREFALLBACK",
+                        title: "Fallback Album",
+                        nextPage: nil
+                    )
+                case "FEmusic_liked_albums":
+                    payload = Self.unrecognizedLibraryAlbumsPagePayload(nextPage: "albums-page-2")
+                default:
+                    payload = [:]
+                }
+            } else {
+                payload = [:]
+            }
+
+            let data = try JSONSerialization.data(withJSONObject: payload)
+            let response = try #require(
+                HTTPURLResponse(
+                    url: url,
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "application/json"]
+                )
+            )
+            return (response, data)
+        }
+        defer { MockURLProtocol.reset(session: session) }
+
+        let client = try await Self.makeAuthenticatedClient(session: session)
+        let content = try await client.getLibraryContent()
+
+        #expect(content.albums.map(\.id) == ["MPREFROMCONTINUATION", "MPREFALLBACK"])
+        #expect(content.albumsSource == .partial)
+        #expect(recorder.cursors == ["albums-page-2"])
+    }
+
+    @Test("Library content marks failed album pagination as partial")
+    func libraryContentMarksFailedAlbumPaginationAsPartial() async throws {
+        APICache.shared.invalidateAll()
+        let session = MockURLProtocol.makeMockSession()
+
+        MockURLProtocol.setRequestHandler(for: session) { request in
+            let url = try #require(request.url)
+            if request.httpMethod == "GET" {
+                let response = try #require(
+                    HTTPURLResponse(
+                        url: url,
+                        statusCode: 200,
+                        httpVersion: nil,
+                        headerFields: ["Content-Type": "text/html"]
+                    )
+                )
+                return (response, Data(#"ytcfg.set({"INNERTUBE_API_KEY":"REDACTED"});"#.utf8))
+            }
+
+            let bodyData = try LibraryRequestTestSupport.bodyData(from: request)
+            let body = try #require(JSONSerialization.jsonObject(with: bodyData) as? [String: Any])
+            let payload: [String: Any]
+            let statusCode: Int
+            if let continuation = body["continuation"] as? String {
+                switch continuation {
+                case "albums-page-2":
+                    payload = Self.libraryAlbumsContinuationPayload(
+                        albumID: "MPREPARTIALB",
+                        title: "Partial Album B",
+                        nextPage: "albums-page-3"
+                    )
+                    statusCode = 200
+                default:
+                    payload = [:]
+                    statusCode = 400
+                }
+            } else if let browseID = body["browseId"] as? String {
+                switch browseID {
+                case "FEmusic_library_landing":
+                    payload = Self.libraryAlbumsPagePayload(
+                        albumID: "MPREFALLBACK",
+                        title: "Fallback Album",
+                        nextPage: nil
+                    )
+                    statusCode = 200
+                case "FEmusic_liked_albums":
+                    payload = Self.libraryAlbumsPagePayload(
+                        albumID: "MPREPARTIALA",
+                        title: "Partial Album A",
+                        nextPage: "albums-page-2"
+                    )
+                    statusCode = 200
+                default:
+                    payload = [:]
+                    statusCode = 200
+                }
+            } else {
+                payload = [:]
+                statusCode = 400
+            }
+
+            let data = try JSONSerialization.data(withJSONObject: payload)
+            let response = try #require(
+                HTTPURLResponse(
+                    url: url,
+                    statusCode: statusCode,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "application/json"]
+                )
+            )
+            return (response, data)
+        }
+        defer { MockURLProtocol.reset(session: session) }
+
+        let client = try await Self.makeAuthenticatedClient(session: session)
+        let content = try await client.getLibraryContent()
+
+        #expect(content.albums.map(\.id) == [
+            "MPREPARTIALA",
+            "MPREPARTIALB",
+            "MPREFALLBACK",
+        ])
+        #expect(content.albumsSource == .partial)
+    }
+}
+
+private extension YTMusicClientLibraryRequestTests {
+    static func makeAuthenticatedClient(session: URLSession) async throws -> YTMusicClient {
         let webKitManager = WebKitManager.makeTestInstance()
         let cookie = try #require(HTTPCookie(properties: [
             .name: WebKitManager.fallbackAuthCookieName,
@@ -166,6 +678,174 @@ struct YTMusicClientLibraryRequestTests {
     }
 
     // swiftlint:disable:next modifier_order
+    private nonisolated static func libraryAlbumsMultipleShelfPagePayload() -> [String: Any] {
+        [
+            "contents": [
+                "singleColumnBrowseResultsRenderer": [
+                    "tabs": [[
+                        "tabRenderer": [
+                            "content": [
+                                "sectionListRenderer": [
+                                    "contents": [
+                                        [
+                                            "musicShelfRenderer": [
+                                                "contents": [
+                                                    self.libraryResponsiveAlbumItem(
+                                                        id: "MPRESHELFONE",
+                                                        title: "Shelf One"
+                                                    ),
+                                                ],
+                                                "continuations": [[
+                                                    "nextContinuationData": [
+                                                        "continuation": "shelf-one-next",
+                                                    ],
+                                                ]],
+                                            ],
+                                        ],
+                                        [
+                                            "musicShelfRenderer": [
+                                                "contents": [
+                                                    self.libraryResponsiveAlbumItem(
+                                                        id: "MPRESHELFTWO",
+                                                        title: "Shelf Two"
+                                                    ),
+                                                ],
+                                                "continuations": [[
+                                                    "nextContinuationData": [
+                                                        "continuation": "shelf-two-next",
+                                                    ],
+                                                ]],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ]],
+                ],
+            ],
+        ]
+    }
+
+    // swiftlint:disable:next modifier_order
+    private nonisolated static func libraryAlbumsShelfPagePayload(
+        albumID: String,
+        title: String,
+        nextPage: String?
+    ) -> [String: Any] {
+        var shelfRenderer: [String: Any] = [
+            "contents": [Self.libraryResponsiveAlbumItem(id: albumID, title: title)],
+        ]
+        if let nextPage {
+            shelfRenderer["continuations"] = [[
+                "nextContinuationData": ["continuation": nextPage],
+            ]]
+        }
+
+        return [
+            "contents": [
+                "singleColumnBrowseResultsRenderer": [
+                    "tabs": [[
+                        "tabRenderer": [
+                            "content": [
+                                "sectionListRenderer": [
+                                    "contents": [["musicShelfRenderer": shelfRenderer]],
+                                ],
+                            ],
+                        ],
+                    ]],
+                ],
+            ],
+        ]
+    }
+
+    // swiftlint:disable:next modifier_order
+    private nonisolated static func libraryAlbumsShelfContinuationPayload(
+        albumID: String,
+        title: String
+    ) -> [String: Any] {
+        [
+            "continuationContents": [
+                "musicShelfContinuation": [
+                    "contents": [self.libraryResponsiveAlbumItem(id: albumID, title: title)],
+                ],
+            ],
+        ]
+    }
+
+    // swiftlint:disable:next modifier_order
+    private nonisolated static func emptyLibraryAlbumsPagePayload(nextPage: String?) -> [String: Any] {
+        var gridRenderer: [String: Any] = [
+            "items": [],
+        ]
+        if let nextPage {
+            gridRenderer["continuations"] = [[
+                "nextContinuationData": ["continuation": nextPage],
+            ]]
+        }
+
+        return [
+            "contents": [
+                "singleColumnBrowseResultsRenderer": [
+                    "tabs": [[
+                        "tabRenderer": [
+                            "content": [
+                                "sectionListRenderer": [
+                                    "contents": [["gridRenderer": gridRenderer]],
+                                ],
+                            ],
+                        ],
+                    ]],
+                ],
+            ],
+            "responseContext": [
+                "serviceTrackingParams": [[
+                    "params": [
+                        [
+                            "key": "logged_in",
+                            "value": "1",
+                        ],
+                        [
+                            "key": "browse_id",
+                            "value": "FEmusic_liked_albums",
+                        ],
+                    ],
+                ]],
+            ],
+        ]
+    }
+
+    // swiftlint:disable:next modifier_order
+    private nonisolated static func unrecognizedLibraryAlbumsPagePayload(nextPage: String) -> [String: Any] {
+        [
+            "contents": [
+                "singleColumnBrowseResultsRenderer": [
+                    "tabs": [[
+                        "tabRenderer": [
+                            "content": [
+                                "sectionListRenderer": [
+                                    "contents": [[
+                                        "gridRenderer": [
+                                            "items": [[
+                                                "musicTwoRowItemRenderer": [
+                                                    "title": ["runs": [["text": "Unsupported Promo"]]],
+                                                ],
+                                            ]],
+                                            "continuations": [[
+                                                "nextContinuationData": ["continuation": nextPage],
+                                            ]],
+                                        ],
+                                    ]],
+                                ],
+                            ],
+                        ],
+                    ]],
+                ],
+            ],
+        ]
+    }
+
+    // swiftlint:disable:next modifier_order
     private nonisolated static func libraryAlbumsContinuationPayload(
         albumID: String,
         title: String,
@@ -183,6 +863,44 @@ struct YTMusicClientLibraryRequestTests {
         return [
             "continuationContents": [
                 "gridContinuation": gridContinuation,
+            ],
+        ]
+    }
+
+    // swiftlint:disable:next modifier_order
+    private nonisolated static func libraryResponsiveAlbumItem(id: String, title: String) -> [String: Any] {
+        [
+            "musicResponsiveListItemRenderer": [
+                "navigationEndpoint": [
+                    "browseEndpoint": [
+                        "browseId": id,
+                        "browseEndpointContextSupportedConfigs": [
+                            "browseEndpointContextMusicConfig": [
+                                "pageType": "MUSIC_PAGE_TYPE_ALBUM",
+                            ],
+                        ],
+                    ],
+                ],
+                "flexColumns": [
+                    [
+                        "musicResponsiveListItemFlexColumnRenderer": [
+                            "text": ["runs": [["text": title]]],
+                        ],
+                    ],
+                    [
+                        "musicResponsiveListItemFlexColumnRenderer": [
+                            "text": [
+                                "runs": [
+                                    ["text": "Album"],
+                                    ["text": " • "],
+                                    ["text": "Test Artist"],
+                                    ["text": " • "],
+                                    ["text": "2026"],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
             ],
         ]
     }

--- a/Tests/KasetTests/YTMusicClientLibraryContentTests.swift
+++ b/Tests/KasetTests/YTMusicClientLibraryContentTests.swift
@@ -623,6 +623,93 @@ struct YTMusicClientLibraryRequestTests {
         ])
         #expect(content.albumsSource == .partial)
     }
+
+    @Test("Library content propagates initial saved-albums cancellation")
+    func libraryContentPropagatesInitialAlbumCancellation() async throws {
+        APICache.shared.invalidateAll()
+        let session = MockURLProtocol.makeMockSession()
+
+        MockURLProtocol.setRequestHandler(for: session) { request in
+            let url = try #require(request.url)
+            if request.httpMethod == "GET" {
+                let response = try #require(HTTPURLResponse(
+                    url: url,
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "text/html"]
+                ))
+                return (response, Data(#"ytcfg.set({"INNERTUBE_API_KEY":"REDACTED"});"#.utf8))
+            }
+
+            let bodyData = try LibraryRequestTestSupport.bodyData(from: request)
+            let body = try #require(JSONSerialization.jsonObject(with: bodyData) as? [String: Any])
+            if body["browseId"] as? String == "FEmusic_liked_albums" {
+                throw URLError(.cancelled)
+            }
+
+            let response = try #require(HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            ))
+            return (response, Data("{}".utf8))
+        }
+        defer { MockURLProtocol.reset(session: session) }
+
+        let client = try await Self.makeAuthenticatedClient(session: session)
+        await #expect(throws: CancellationError.self) {
+            try await client.getLibraryContent()
+        }
+    }
+
+    @Test("Library content propagates saved-albums continuation cancellation")
+    func libraryContentPropagatesAlbumContinuationCancellation() async throws {
+        APICache.shared.invalidateAll()
+        let session = MockURLProtocol.makeMockSession()
+
+        MockURLProtocol.setRequestHandler(for: session) { request in
+            let url = try #require(request.url)
+            if request.httpMethod == "GET" {
+                let response = try #require(HTTPURLResponse(
+                    url: url,
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "text/html"]
+                ))
+                return (response, Data(#"ytcfg.set({"INNERTUBE_API_KEY":"REDACTED"});"#.utf8))
+            }
+
+            let bodyData = try LibraryRequestTestSupport.bodyData(from: request)
+            let body = try #require(JSONSerialization.jsonObject(with: bodyData) as? [String: Any])
+            if body["continuation"] != nil {
+                throw URLError(.cancelled)
+            }
+
+            let payload: [String: Any] = if body["browseId"] as? String == "FEmusic_liked_albums" {
+                Self.libraryAlbumsPagePayload(
+                    albumID: "MPRECANCEL",
+                    title: "Cancellation Album",
+                    nextPage: "cancelled-page"
+                )
+            } else {
+                [:]
+            }
+            let response = try #require(HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            ))
+            return try (response, JSONSerialization.data(withJSONObject: payload))
+        }
+        defer { MockURLProtocol.reset(session: session) }
+
+        let client = try await Self.makeAuthenticatedClient(session: session)
+        await #expect(throws: CancellationError.self) {
+            try await client.getLibraryContent()
+        }
+    }
 }
 
 private extension YTMusicClientLibraryRequestTests {

--- a/Tests/KasetTests/YTMusicClientLibraryContentTests.swift
+++ b/Tests/KasetTests/YTMusicClientLibraryContentTests.swift
@@ -344,12 +344,17 @@ struct YTMusicClientLibraryRequestTests {
         }
         defer { MockURLProtocol.reset(session: session) }
 
+        let primaryAccountScope = FavoritesManager.accountScopeID(
+            ownerID: "primary-owner",
+            accountID: "primary"
+        )
         let client = try await Self.makeAuthenticatedClient(session: session)
+        client.accountScopeProvider = { primaryAccountScope }
         let content = try await client.getLibraryContent()
 
         #expect(content.albums.map(\.id) == ["MPREFALLBACK"])
         #expect(content.albumsSource == .landingFallback)
-        #expect(content.accountScope == "primary")
+        #expect(content.accountScope == primaryAccountScope)
     }
 
     @Test("Library content treats a recognized empty saved-albums page as authoritative")

--- a/docs/adr/0031-saved-album-library-reconciliation.md
+++ b/docs/adr/0031-saved-album-library-reconciliation.md
@@ -42,8 +42,14 @@ Saved albums use an explicit identity and reconciliation model:
 4. Same-account `.partial` and `.landingFallback` snapshots cannot replace a
    stronger existing album snapshot. Partial data may enrich or append albums,
    while pending optimistic additions and removals remain applied.
-5. Album mutations are serialized per canonical album identity and initiating
-   Library model. Library snapshots use `AccountService.currentAccountScopeID`,
+5. Album mutations are serialized by canonical album identity across active
+   Library models, while model-owned generations provide scoped cancellation.
+   Playlist mutations use the same generation fence plus a shared per-playlist
+   ordering tail because additions and removals reconcile across all active
+   Library models. Account/auth services synchronously cancel every tracked
+   Library mutation and reconciliation registry before session cookies or guest
+   mode can change, so in-flight requests and delayed reconciliation cannot cross
+   account/model boundaries. Library snapshots use `AccountService.currentAccountScopeID`,
    an opaque scope derived from the authenticated Google owner and selected
    YouTube identity (with an authentication-generation fallback until the owner
    is resolved). Promoting that provisional scope to a durable owner keeps the
@@ -54,8 +60,10 @@ Saved albums use an explicit identity and reconciliation model:
    pending work at account or model replacement boundaries. Reconciliation checks
    that generation before and after every awaited refresh.
 6. The UI disables duplicate mutation clicks only until the server accepts the
-   mutation and the optimistic state is applied. Delayed backend reconciliation
-   continues without keeping the control disabled.
+   mutation and the optimistic state is applied. Each click owns an operation
+   token, so an older delayed reconciliation cannot clear a newer click's loading
+   state. Delayed backend reconciliation continues without keeping the control
+   disabled.
 7. Cancellation is propagated through initial and continuation requests rather
    than converted into fallback or partial success.
 

--- a/docs/adr/0031-saved-album-library-reconciliation.md
+++ b/docs/adr/0031-saved-album-library-reconciliation.md
@@ -43,9 +43,16 @@ Saved albums use an explicit identity and reconciliation model:
    stronger existing album snapshot. Partial data may enrich or append albums,
    while pending optimistic additions and removals remain applied.
 5. Album mutations are serialized per canonical album identity and initiating
-   Library model. A generation invalidates pending work at account or model
-   replacement boundaries. Reconciliation checks that generation before and
-   after every awaited refresh.
+   Library model. Library snapshots use `AccountService.currentAccountScopeID`,
+   an opaque scope derived from the authenticated Google owner and selected
+   YouTube identity (with an authentication-generation fallback until the owner
+   is resolved). Promoting that provisional scope to a durable owner keeps the
+   initially-issued in-memory identifier stable. A known owner conflict rotates
+   the provisional scope and rotates again when an owner is resolved, preventing
+   ambiguous-session data from joining either owner. Switching between primary
+   Google accounts is therefore an account boundary too. A generation invalidates
+   pending work at account or model replacement boundaries. Reconciliation checks
+   that generation before and after every awaited refresh.
 6. The UI disables duplicate mutation clicks only until the server accepts the
    mutation and the optimistic state is applied. Delayed backend reconciliation
    continues without keeping the control disabled.

--- a/docs/adr/0031-saved-album-library-reconciliation.md
+++ b/docs/adr/0031-saved-album-library-reconciliation.md
@@ -1,0 +1,70 @@
+# ADR-0031: Saved-Album Library Identity and Reconciliation
+
+## Status
+
+Accepted
+
+## Context
+
+YouTube Music represents one saved album with two distinct identifiers:
+
+- an `MPRE...` browse ID for album detail navigation; and
+- an `OLAK...` playlist ID for add/remove Library mutations.
+
+Library responses are also eventually consistent. A successful mutation may not
+appear in `FEmusic_liked_albums` immediately, while the Library landing page
+contains only a non-authoritative preview. Saved-album responses can span grid
+or shelf renderers, multiple continuation chains, and partially understood
+response shapes.
+
+Treating every refresh as authoritative causes visible albums to disappear or
+reappear while the backend converges. Treating `MPRE...` and `OLAK...` as the
+same interchangeable identifier can also break either navigation or mutation.
+Account switches add another boundary: delayed mutation or reconciliation work
+from one account must never update the next account's Library.
+
+## Decision
+
+Saved albums use an explicit identity and reconciliation model:
+
+1. `Album.id` preserves the canonical `MPRE...` browse identity whenever one is
+   available. `Album.libraryTargetId` stores the distinct `OLAK...` mutation
+   target.
+2. Album equality for Library reconciliation accepts either identity, but model
+   merges preserve the canonical browse ID and only merge `OLAK...` values into
+   the mutation-target field.
+3. Dedicated saved-album fetches are classified by provenance:
+   - `.dedicated` for complete, recognized results, including a recognized empty
+     collection;
+   - `.partial` when pagination fails, repeats, or contains unreadable response
+     shapes; and
+   - `.landingFallback` when the dedicated endpoint fails.
+4. Same-account `.partial` and `.landingFallback` snapshots cannot replace a
+   stronger existing album snapshot. Partial data may enrich or append albums,
+   while pending optimistic additions and removals remain applied.
+5. Album mutations are serialized per canonical album identity and initiating
+   Library model. A generation invalidates pending work at account or model
+   replacement boundaries. Reconciliation checks that generation before and
+   after every awaited refresh.
+6. The UI disables duplicate mutation clicks only until the server accepts the
+   mutation and the optimistic state is applied. Delayed backend reconciliation
+   continues without keeping the control disabled.
+7. Cancellation is propagated through initial and continuation requests rather
+   than converted into fallback or partial success.
+
+WebViews remain limited to authentication and DRM playback. Album Library data
+and mutations continue to use `YTMusicClient` API calls.
+
+## Consequences
+
+- Album tiles navigate with stable `MPRE...` IDs while mutations use the correct
+  `OLAK...` targets.
+- Temporary endpoint failures or incomplete pagination no longer erase a
+  previously complete same-account album collection.
+- A genuinely empty dedicated response still clears stale albums.
+- Rapid opposite mutations converge according to the latest serialized intent.
+- Account switches and view-model replacement cancel stale mutation work before
+  it can update the next account.
+- Parser and reconciliation code carry explicit provenance and generation state,
+  increasing implementation complexity but making eventual-consistency rules
+  testable and centralized.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -65,3 +65,4 @@ What becomes easier or more difficult because of this change?
 | [0028](0028-ordered-semantic-music-search-results.md) | Ordered Semantic YouTube Music Search Results | Accepted |
 | [0029](0029-now-playing-tracklist-provider.md) | Shared Now-Playing Mix Tracklist Provider | Accepted |
 | [0030](0030-account-scoped-favorites.md) | Account-Scoped Favorites Persistence | Accepted |
+| [0031](0031-saved-album-library-reconciliation.md) | Saved-Album Library Identity and Reconciliation | Accepted |

--- a/docs/api-discovery.md
+++ b/docs/api-discovery.md
@@ -206,8 +206,9 @@ Browse endpoints use `POST /browse` with a `browseId` parameter.
 | `FEmusic_charts` | Charts | 🌐 | Top songs, albums by country/genre | `HomeResponseParser` |
 | `FEmusic_moods_and_genres` | Moods & Genres | 🌐 | Browse by mood/genre grids | `HomeResponseParser` |
 | `FEmusic_new_releases` | New Releases | 🌐 | Recent albums, singles, videos | `HomeResponseParser` |
-| `FEmusic_library_landing` | Library Landing | 🔐 | All library content (playlists, podcasts, artists) | `PlaylistParser.parseLibraryContent` |
+| `FEmusic_library_landing` | Library Landing | 🔐 | Library content previews (playlists, albums, podcasts, artists) | `PlaylistParser.parseLibraryContent` |
 | `FEmusic_liked_playlists` | Library Playlists | 🔐 | User's saved/created playlists | `PlaylistParser` |
+| `FEmusic_liked_albums` | Library Albums | 🔐 | User's saved albums | `PlaylistParser.parseLibraryAlbums` |
 | `FEmusic_library_privately_owned_tracks` | Uploaded Songs | 🔐 | User-uploaded songs with playlist-style rows and continuation | `PlaylistParser` |
 | `VLLM` | Liked Songs | 🔐 | All songs user has liked (with pagination) | `PlaylistParser` |
 | `VL{playlistId}` | Playlist Detail | 🌐 | Playlist tracks and metadata | `PlaylistParser` |
@@ -270,6 +271,21 @@ let body = ["browseId": "FEmusic_liked_playlists"]
 
 ---
 
+#### Library Albums (`FEmusic_liked_albums`)
+
+```swift
+let body = ["browseId": "FEmusic_liked_albums"]
+// Requires authentication; params are optional for the default order
+```
+
+**Returns**: A paginated grid of saved albums with album browse IDs, artwork, artist metadata, and release year. Kaset follows grid continuation tokens until the saved-album collection is exhausted.
+
+**Parser**: Uses `PlaylistParser.parseLibraryAlbums()` and merges any landing-page preview albums as a fallback.
+
+**Library mutations**: Album detail navigation uses an `MPRE...` browse ID, but `like/like` and `like/removelike` must target the album's `OLAK...` playlist ID. Album browse responses expose that playlist ID through play/queue endpoints even when the personalized Save button is unavailable.
+
+---
+
 #### Liked Songs (`VLLM`)
 
 > ⚠️ **Use `VLLM`, not `FEmusic_liked_videos`** — The `FEmusic_liked_videos` browse ID returns only ~13 songs with NO continuation token. To fetch all liked songs, use `VLLM` (VL prefix + LM playlist ID) which returns the full list with proper pagination.
@@ -297,7 +313,6 @@ These endpoints are functional but not yet implemented in Kaset.
 |-----------|------|------|----------|-------|
 | `FEmusic_history` | History | 🔐 | **High** | Recently played tracks |
 | `FEmusic_library_non_music_audio_list` | Subscribed Podcasts | 🔐 | Medium | User's subscribed podcast shows |
-| `FEmusic_library_albums` | Library Albums | 🔐 | Medium | Requires auth + params* |
 | `FEmusic_library_corpus_track_artists` | Library Artists (Artists chip) | 🔐 | Medium | Sign-in backed; returns `MPLAUC...` library artist pages |
 | `FEmusic_library_artists` | Library Artists (param-based) | 🔐 | Medium | Requires auth + params*; distinct from the Artists chip |
 | `FEmusic_library_songs` | Library Songs | 🔐 | Low | Requires auth + params* |
@@ -307,7 +322,9 @@ These endpoints are functional but not yet implemented in Kaset.
 
 > `FEmusic_library_corpus_track_artists` is the browseId behind the Library landing Artists chip. With authentication it returns `musicResponsiveListItemRenderer` rows whose `browseId` values look like `MPLAUC...` and use `pageType = MUSIC_PAGE_TYPE_LIBRARY_ARTIST`. Without authentication it still returns HTTP 200, but only with a sign-in prompt.
 >
-> \* `FEmusic_library_albums`, `FEmusic_library_artists`, and `FEmusic_library_songs` are separate param-based library endpoints. They return HTTP 400 without authentication and the correct `params` value.
+> `FEmusic_library_albums` is a legacy browse ID that currently returns HTTP 400. Saved albums use `FEmusic_liked_albums`; optional sorting params are not required for the default order.
+>
+> \* `FEmusic_library_artists` and `FEmusic_library_songs` are separate param-based library endpoints. They return HTTP 400 without authentication and the correct `params` value.
 
 #### Uploaded Songs (`FEmusic_library_privately_owned_tracks`)
 
@@ -1141,7 +1158,7 @@ All parsers are located in `Sources/Kaset/Services/API/Parsers/`. Each parser is
 | `HomeResponseParser` | `HomeResponseParser.swift` | Home/Explore browse response | `HomeResponse` with `[HomeSection]` | `FEmusic_home`, `FEmusic_explore` |
 | `SearchResponseParser` | `SearchResponseParser.swift` | Search response | `SearchResponse` with songs, albums, artists, playlists | `search` endpoint |
 | `SearchSuggestionsParser` | `SearchSuggestionsParser.swift` | Suggestions response | `[SearchSuggestion]` | `music/get_search_suggestions` |
-| `PlaylistParser` | `PlaylistParser.swift` | Playlist/library response | `[Playlist]`, `LibraryContent` | `VL{id}`, `VLLM`, `FEmusic_liked_playlists`, `FEmusic_library_landing` |
+| `PlaylistParser` | `PlaylistParser.swift` | Playlist/library response | `[Playlist]`, `[Album]`, `LibraryContent` | `VL{id}`, `VLLM`, `FEmusic_liked_playlists`, `FEmusic_liked_albums`, `FEmusic_library_landing` |
 | `ArtistParser` | `ArtistParser.swift` | Artist browse response | `ArtistDetail` with songs, albums | `UC{channelId}` |
 | `LyricsParser` | `LyricsParser.swift` | Next/lyrics response | `Lyrics` or lyrics browse ID | `next`, `MPLYt{id}` |
 | `PodcastParser` | `PodcastParser.swift` | Podcast browse response | `[PodcastSection]`, `PodcastShowDetail` | `FEmusic_podcasts`, `MPSPP{id}` |
@@ -1261,7 +1278,7 @@ let result = try await RetryPolicy.execute(
 
 | Feature | Endpoint | Effort | Impact |
 |---------|----------|--------|--------|
-| Library Albums | `FEmusic_library_albums` | Medium | Medium |
+| Library Albums | `FEmusic_liked_albums` | Implemented | Medium |
 | Library Artists | `FEmusic_library_corpus_track_artists` | Medium | Medium |
 | Add to Playlist | `playlist/get_add_to_playlist` + `browse/edit_playlist` | Implemented | Medium |
 
@@ -1377,7 +1394,7 @@ swift run api-explorer auth
 # If authenticated, explore library endpoints
 swift run api-explorer browse FEmusic_liked_playlists
 swift run api-explorer browse FEmusic_history
-swift run api-explorer browse FEmusic_library_albums ggMGKgQIARAA
+swift run api-explorer browse FEmusic_liked_albums
 ```
 
 Debug builds export auth cookies for the API explorer to `~/Library/Application Support/Kaset/cookies.dat`.
@@ -1581,6 +1598,7 @@ The following endpoints were tested without authentication on 2024-12-21. `FEmus
 | Endpoint | Status | Notes |
 |----------|--------|-------|
 | `FEmusic_liked_playlists` | HTTP 200 | Works with session cookies |
+| `FEmusic_liked_albums` | HTTP 200* | Returns saved album rows with current auth; stale or missing auth returns a sign-in prompt |
 | `FEmusic_liked_videos` | HTTP 200 | Works with session cookies |
 | `FEmusic_history` | HTTP 200 | Returns login prompt without full auth |
 
@@ -1590,7 +1608,7 @@ The following endpoints were tested without authentication on 2024-12-21. `FEmus
 |----------|--------|-------|
 | `FEmusic_history` | HTTP 200* | Returns content with full auth, login prompt without |
 | `FEmusic_library_corpus_track_artists` | HTTP 200* | Returns library artist rows with full auth, sign-in prompt without |
-| `FEmusic_library_albums` | HTTP 400 | Needs auth + specific `params` value |
+| `FEmusic_library_albums` | HTTP 400 | Legacy saved-albums browse ID; use `FEmusic_liked_albums` |
 | `FEmusic_library_artists` | HTTP 400 | Rejected as invalid argument in current authenticated sessions |
 | `FEmusic_library_corpus_artists` | HTTP 200* | Returns followed artists with full auth and public `UC...` browseIds |
 | `FEmusic_library_songs` | HTTP 400 | Needs auth + specific `params` value |

--- a/docs/api-discovery.md
+++ b/docs/api-discovery.md
@@ -208,7 +208,7 @@ Browse endpoints use `POST /browse` with a `browseId` parameter.
 | `FEmusic_new_releases` | New Releases | 🌐 | Recent albums, singles, videos | `HomeResponseParser` |
 | `FEmusic_library_landing` | Library Landing | 🔐 | Library content previews (playlists, albums, podcasts, artists) | `PlaylistParser.parseLibraryContent` |
 | `FEmusic_liked_playlists` | Library Playlists | 🔐 | User's saved/created playlists | `PlaylistParser` |
-| `FEmusic_liked_albums` | Library Albums | 🔐 | User's saved albums | `PlaylistParser.parseLibraryAlbums` |
+| `FEmusic_liked_albums` | Library Albums | 🔐 | User's saved albums | `PlaylistParser.parseLibraryAlbumsPage` / `parseLibraryAlbumsContinuation` |
 | `FEmusic_library_privately_owned_tracks` | Uploaded Songs | 🔐 | User-uploaded songs with playlist-style rows and continuation | `PlaylistParser` |
 | `VLLM` | Liked Songs | 🔐 | All songs user has liked (with pagination) | `PlaylistParser` |
 | `VL{playlistId}` | Playlist Detail | 🌐 | Playlist tracks and metadata | `PlaylistParser` |
@@ -280,7 +280,7 @@ let body = ["browseId": "FEmusic_liked_albums"]
 
 **Returns**: A paginated grid of saved albums with album browse IDs, artwork, artist metadata, and release year. Kaset follows grid continuation tokens until the saved-album collection is exhausted.
 
-**Parser**: Uses `PlaylistParser.parseLibraryAlbums()` and merges any landing-page preview albums as a fallback.
+**Parser**: Uses `PlaylistParser.parseLibraryAlbumsPage()` for the initial response and `PlaylistParser.parseLibraryAlbumsContinuation()` for subsequent grid pages, then merges any landing-page preview albums as a fallback.
 
 **Library mutations**: Album detail navigation uses an `MPRE...` browse ID, but `like/like` and `like/removelike` must target the album's `OLAK...` playlist ID. Album browse responses expose that playlist ID through play/queue endpoints even when the personalized Save button is unavailable.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -126,6 +126,7 @@ Makes authenticated requests to YouTube Music's internal API:
 - `getExplore()` → Explore page (new releases, charts, moods)
 - `search(query:)` → Search results
 - `getLibraryPlaylists()` → User's playlists
+- `getLibraryContent()` → User's playlists, saved albums, followed artists, podcasts, and uploads
 - `getLikedSongs()` → User's liked songs (with pagination via `getLikedSongsContinuation()`)
 - `getPlaylist(id:)` → Playlist details (with pagination via `getPlaylistContinuation()`)
 - `getPlaylistAllTracks(playlistId:)` → All tracks via queue API (for radio playlists)
@@ -175,7 +176,7 @@ Response parsing is extracted into specialized modules:
 | `ResponseTreeSearch.swift` | Recursive search helpers for nested YouTube Music response trees |
 | `HomeResponseParser.swift` | Home/Explore page sections |
 | `SearchResponseParser.swift` | Search results |
-| `LibraryContentParser.swift` | Library browse content, including playlists, followed artists, podcast shows, and uploaded-song virtual tile parsing |
+| `LibraryContentParser.swift` | Library browse content, including playlists, saved albums, followed artists, podcast shows, and uploaded-song virtual tile parsing |
 | `PlaylistEditability.swift` | Playlist ownership/delete affordance detection |
 | `PlaylistParser.swift` | Playlist details, queue tracks, pagination, add-to-playlist menu options, and create-playlist IDs |
 | `ArtistParser.swift` | Artist details (songs, albums, subscription status) |


### PR DESCRIPTION
## Description

Add first-class saved album support to the YouTube Music Library. Albums are fetched from the dedicated authenticated Library endpoint, displayed alongside playlists, artists, podcasts, and uploads, and can be filtered independently.

This also fixes album Library mutations end to end. YouTube Music uses an `MPRE…` browse ID for album navigation and an `OLAK…` playlist ID for add/remove mutations, so the implementation preserves and reconciles both identities instead of treating albums as ordinary playlists.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📚 Documentation update
- [x] 🎨 UI/UX improvement
- [x] 🧪 Test update

## Related Issues

Fixes #226

## Changes Made

- Fetch saved albums from `FEmusic_liked_albums`, including all continuation pages and landing-page fallback content.
- Parse album artwork, artist/year metadata, and the `OLAK…` Library mutation target.
- Add Albums to Library state, filtering, empty states, cards, navigation, playback, queue, favorites, and sharing actions.
- Add album-aware Library add/remove actions using the correct `OLAK…` target.
- Reconcile optimistic album mutations across stale responses and differing `MPRE…`/`OLAK…` identity shapes.
- Keep detail-view Library state model-driven so an added album displays **Added to Library** after reopening it.
- Propagate playlist mutation failures instead of showing false success.
- Extend API Explorer diagnostics and update domain, API discovery, and architecture documentation.

## Testing

- [x] `swift build`
- [x] Focused affected suites: 135 tests passed
  - `LibraryContentReconcilerTests`
  - `LibraryMutationActionsTests`
  - `LibraryViewModelTests`
  - `PlaylistParserTests`
  - `SongActionsHelperTests`
- [x] `swiftlint --strict` — 0 violations
- [x] `swiftformat .`
- [ ] UI tests — not run because they require explicit approval

The full unfiltered suite was also attempted after rebasing onto the latest `main`, but the Swift Testing runner terminated in unrelated concurrent suites with signal 5 / `Index out of range`. The affected Library and parser suites pass consistently.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `swiftlint --strict && swiftformat .`
- [x] I have added tests that prove my fix/feature works
- [x] I have updated documentation if needed
- [x] I have checked for performance implications

## Screenshots

Not included. The change uses the existing Library grid and album-detail visual patterns.

## Additional Notes

Structured autoreview findings around pagination, mutation-target scoping, failure propagation, and optimistic reconciliation were addressed. A final reported caller-audit finding was verified as a false positive by auditing every caller and compiling/running the affected suites.
