### PR TITLE
feat(youtube): segment video chapter seek bar

### DIFF
--- a/Sources/Kaset/Resources/Localizable.xcstrings
+++ b/Sources/Kaset/Resources/Localizable.xcstrings
@@ -33465,6 +33465,100 @@
         }
       }
     },
+    "Chapter": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "الفصل"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kapitel"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chapter"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capítulo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chapitre"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bab"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capitolo"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "챕터"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hoofdstuk"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rozdział"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capítulo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Глава"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kapitel"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bölüm"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Розділ"
+          }
+        }
+      }
+    },
     "Chapters": {
       "localizations": {
         "ar": {

--- a/Sources/Kaset/Resources/ar.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/ar.lproj/Localizable.strings
@@ -66,6 +66,7 @@
 "Category" = "الفئة";
 "Change your system language to English or another supported language." = "غيّر لغة النظام إلى الإنجليزية أو لغة مدعومة أخرى.";
 "Channels" = "القنوات";
+"Chapter" = "الفصل";
 "Chapters" = "الفصول";
 "Charts" = "الأكثر رواجًا";
 "Check for Updates" = "التحقق من التحديثات";

--- a/Sources/Kaset/Resources/de.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/de.lproj/Localizable.strings
@@ -66,6 +66,7 @@
 "Category" = "Kategorie";
 "Change your system language to English or another supported language." = "Ändere die Systemsprache auf Englisch oder eine andere unterstützte Sprache.";
 "Channels" = "Kanäle";
+"Chapter" = "Kapitel";
 "Chapters" = "Kapitel";
 "Charts" = "Charts";
 "Check for Updates" = "Nach Updates suchen";

--- a/Sources/Kaset/Resources/en.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/en.lproj/Localizable.strings
@@ -7,3 +7,4 @@
 "Song" = "Song";
 "Podcast" = "Podcast";
 "Episode" = "Episode";
+"Chapter" = "Chapter";

--- a/Sources/Kaset/Resources/es.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/es.lproj/Localizable.strings
@@ -66,6 +66,7 @@
 "Category" = "Categoría";
 "Change your system language to English or another supported language." = "Cambia el idioma del sistema a inglés u otro idioma compatible.";
 "Channels" = "Canales";
+"Chapter" = "Capítulo";
 "Chapters" = "Capítulos";
 "Charts" = "Éxitos";
 "Check for Updates" = "Buscar actualizaciones";

--- a/Sources/Kaset/Resources/fr.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/fr.lproj/Localizable.strings
@@ -66,6 +66,7 @@
 "Category" = "Catégorie";
 "Change your system language to English or another supported language." = "Changez la langue de votre système en anglais ou dans une autre langue prise en charge.";
 "Channels" = "Chaînes";
+"Chapter" = "Chapitre";
 "Chapters" = "Chapitres";
 "Charts" = "Classements";
 "Check for Updates" = "Rechercher des mises à jour";

--- a/Sources/Kaset/Resources/id.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/id.lproj/Localizable.strings
@@ -66,6 +66,7 @@
 "Category" = "Kategori";
 "Change your system language to English or another supported language." = "Ubah bahasa sistem Anda ke bahasa Inggris atau bahasa yang didukung lainnya.";
 "Channels" = "Channel";
+"Chapter" = "Bab";
 "Chapters" = "Bab";
 "Charts" = "Tangga Lagu";
 "Check for Updates" = "Periksa Pembaruan";

--- a/Sources/Kaset/Resources/it.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/it.lproj/Localizable.strings
@@ -66,6 +66,7 @@
 "Category" = "Categoria";
 "Change your system language to English or another supported language." = "Cambia la lingua di sistema in inglese o in un'altra lingua supportata.";
 "Channels" = "Canali";
+"Chapter" = "Capitolo";
 "Chapters" = "Capitoli";
 "Charts" = "Classifiche";
 "Check for Updates" = "Controlla aggiornamenti";

--- a/Sources/Kaset/Resources/ko.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/ko.lproj/Localizable.strings
@@ -66,6 +66,7 @@
 "Category" = "카테고리";
 "Change your system language to English or another supported language." = "시스템 언어를 영어 또는 다른 지원 언어로 변경하세요.";
 "Channels" = "채널";
+"Chapter" = "챕터";
 "Chapters" = "챕터";
 "Charts" = "차트";
 "Check for Updates" = "업데이트 확인";

--- a/Sources/Kaset/Resources/nl.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/nl.lproj/Localizable.strings
@@ -66,6 +66,7 @@
 "Category" = "Categorie";
 "Change your system language to English or another supported language." = "Wijzig de systeemtaal naar Engels of een andere ondersteunde taal.";
 "Channels" = "Kanalen";
+"Chapter" = "Hoofdstuk";
 "Chapters" = "Hoofdstukken";
 "Charts" = "Hitlijsten";
 "Check for Updates" = "Zoek naar updates";

--- a/Sources/Kaset/Resources/pl.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/pl.lproj/Localizable.strings
@@ -66,6 +66,7 @@
 "Category" = "Kategoria";
 "Change your system language to English or another supported language." = "Zmień język systemu na angielski lub inny obsługiwany język.";
 "Channels" = "Kanały";
+"Chapter" = "Rozdział";
 "Chapters" = "Rozdziały";
 "Charts" = "Listy przebojów";
 "Check for Updates" = "Sprawdź uaktualnienia";

--- a/Sources/Kaset/Resources/pt.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/pt.lproj/Localizable.strings
@@ -66,6 +66,7 @@
 "Category" = "Categoria";
 "Change your system language to English or another supported language." = "Altere o idioma do sistema para inglês ou outro idioma suportado.";
 "Channels" = "Canais";
+"Chapter" = "Capítulo";
 "Chapters" = "Capítulos";
 "Charts" = "Tops";
 "Check for Updates" = "Procurar atualizações";

--- a/Sources/Kaset/Resources/ru.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/ru.lproj/Localizable.strings
@@ -66,6 +66,7 @@
 "Category" = "Категория";
 "Change your system language to English or another supported language." = "Измените язык системы на английский или другой поддерживаемый язык.";
 "Channels" = "Каналы";
+"Chapter" = "Глава";
 "Chapters" = "Главы";
 "Charts" = "Чарты";
 "Check for Updates" = "Проверить обновления";

--- a/Sources/Kaset/Resources/sv.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/sv.lproj/Localizable.strings
@@ -66,6 +66,7 @@
 "Category" = "Kategori";
 "Change your system language to English or another supported language." = "Byt systemspråk till engelska eller ett annat språk som stöds.";
 "Channels" = "Kanaler";
+"Chapter" = "Kapitel";
 "Chapters" = "Kapitel";
 "Charts" = "Topplistor";
 "Check for Updates" = "Sök efter uppdateringar";

--- a/Sources/Kaset/Resources/tr.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/tr.lproj/Localizable.strings
@@ -66,6 +66,7 @@
 "Category" = "Kategori";
 "Change your system language to English or another supported language." = "Sistem dilinizi İngilizceye veya desteklenen başka bir dile değiştirin.";
 "Channels" = "Kanallar";
+"Chapter" = "Bölüm";
 "Chapters" = "Bölümler";
 "Charts" = "Listeler";
 "Check for Updates" = "Güncellemeleri Denetle";

--- a/Sources/Kaset/Resources/uk.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/uk.lproj/Localizable.strings
@@ -66,6 +66,7 @@
 "Category" = "Категорія";
 "Change your system language to English or another supported language." = "Змініть мову системи на англійську або іншу підтримувану мову.";
 "Channels" = "Канали";
+"Chapter" = "Розділ";
 "Chapters" = "Розділи";
 "Charts" = "Чарти";
 "Check for Updates" = "Перевірити оновлення";

--- a/Sources/Kaset/Views/PlayerBarProgressLane.swift
+++ b/Sources/Kaset/Views/PlayerBarProgressLane.swift
@@ -381,7 +381,7 @@ struct PlayerBarProgressLane: View {
                     .lineLimit(1)
             }
 
-            Text("\(String(localized: "Track")) \(segment.index + 1)/\(segment.count)  ·  \(segment.rangeText)")
+            Text(segment.detailText)
                 .font(.system(size: 10))
                 .foregroundStyle(.tertiary)
                 .monospacedDigit()
@@ -542,9 +542,9 @@ struct PlayerBarProgressSegmentGeometry: Equatable {
 
 // MARK: - PlayerBarProgressSegment
 
-/// A contiguous span of the seek bar corresponding to one sub-track of a mix. When a lane is given
-/// segments it renders a YouTube-style gapped track (one piece per segment) instead of the single
-/// continuous bar, and reveals the segment's label on hover.
+/// A contiguous span of the seek bar corresponding to one item, such as a mix track or video
+/// chapter. When a lane is given segments it renders a gapped track (one piece per segment) instead
+/// of the single continuous bar, and reveals the segment's label on hover.
 struct PlayerBarProgressSegment: Identifiable, Hashable {
     let id: String
     let start: Double
@@ -554,6 +554,7 @@ struct PlayerBarProgressSegment: Identifiable, Hashable {
     let title: String
     let subtitle: String?
     let rangeText: String
+    let itemLabel: String
 
     init(
         id: String,
@@ -563,6 +564,7 @@ struct PlayerBarProgressSegment: Identifiable, Hashable {
         count: Int,
         title: String,
         subtitle: String? = nil,
+        itemLabel: String = String(localized: "Track"),
         rangeText: String = ""
     ) {
         self.id = id
@@ -573,6 +575,7 @@ struct PlayerBarProgressSegment: Identifiable, Hashable {
         self.title = title
         self.subtitle = subtitle
         self.rangeText = rangeText
+        self.itemLabel = itemLabel
     }
 
     /// Whether the given progress fraction falls within this segment.
@@ -580,8 +583,14 @@ struct PlayerBarProgressSegment: Identifiable, Hashable {
         fraction >= self.start && fraction < self.end
     }
 
+    var detailText: String {
+        let ordinal = "\(self.itemLabel) \(self.index + 1)/\(self.count)"
+        guard !self.rangeText.isEmpty else { return ordinal }
+        return "\(ordinal)  ·  \(self.rangeText)"
+    }
+
     var accessibilityDescription: String {
-        var components = ["\(String(localized: "Track")) \(self.index + 1)/\(self.count)", self.title]
+        var components = ["\(self.itemLabel) \(self.index + 1)/\(self.count)", self.title]
         if let subtitle = self.subtitle, !subtitle.isEmpty {
             components.append(subtitle)
         }

--- a/Sources/Kaset/Views/YouTube/YouTubePlayerBar.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubePlayerBar.swift
@@ -19,6 +19,12 @@ struct YouTubePlayerBar: View {
     private static let fullVideoDetailsWidth: CGFloat = 294
     private static let compactVideoDetailsWidth: CGFloat = 141
 
+    private struct ChapterProgressSpan {
+        let chapter: YouTubeChapter
+        let start: TimeInterval
+        let end: TimeInterval
+    }
+
     @Environment(AuthService.self) private var authService
     @Environment(YouTubePlayerService.self) private var youtubePlayer
     @Environment(YouTubeViewModelStore.self) private var youtubeStore: YouTubeViewModelStore?
@@ -81,6 +87,11 @@ struct YouTubePlayerBar: View {
         .onChange(of: self.currentSeekIdentity) { _, _ in
             self.clearSeekHold()
             self.chapterPreviewMarker = nil
+        }
+        .onChange(of: self.youtubePlayer.isShowingAd) { _, isShowingAd in
+            if isShowingAd {
+                self.chapterPreviewMarker = nil
+            }
         }
         .onChange(of: self.youtubePlayer.volume) { _, newValue in
             if !self.isAdjustingVolume {
@@ -277,6 +288,7 @@ struct YouTubePlayerBar: View {
                 elapsedText: Self.formatTime(self.progressTextValue),
                 remainingText: "-\(Self.formatTime(max(0, self.youtubePlayer.duration - self.progressTextValue)))",
                 markers: self.chapterProgressMarkers,
+                segments: self.chapterProgressSegments,
                 isLive: false,
                 canSeek: self.canSeek,
                 isLoading: self.isProgressLoading,
@@ -292,6 +304,9 @@ struct YouTubePlayerBar: View {
                 }
             )
             .padding(.top, 18)
+            // Match the music player's segmented lane layering so chapter tooltips stay above
+            // transport controls without intercepting their clicks.
+            .zIndex(1)
 
             self.youtubeTransportControls
                 .padding(.top, 2)
@@ -586,7 +601,7 @@ struct YouTubePlayerBar: View {
     }
 
     private var chapterProgressMarkers: [PlayerBarProgressMarker] {
-        guard self.youtubePlayer.duration > 0 else { return [] }
+        guard self.youtubePlayer.duration > 0, !self.youtubePlayer.isShowingAd else { return [] }
         return self.youtubePlayer.chapters.compactMap { chapter in
             guard chapter.startTime > 0, chapter.startTime < self.youtubePlayer.duration else { return nil }
             return PlayerBarProgressMarker(
@@ -594,6 +609,70 @@ struct YouTubePlayerBar: View {
                 fraction: chapter.startTime / self.youtubePlayer.duration,
                 title: chapter.title,
                 subtitle: chapter.timeText ?? Self.formatTime(chapter.startTime)
+            )
+        }
+    }
+
+    private var chapterProgressSegments: [PlayerBarProgressSegment] {
+        guard !self.youtubePlayer.isShowingAd else { return [] }
+        return Self.chapterProgressSegments(
+            chapters: self.youtubePlayer.chapters,
+            duration: self.youtubePlayer.duration
+        )
+    }
+
+    /// Converts YouTube's chapter starts and optional bounds into the same normalized spans used by
+    /// the music player's segmented mix seek bar. Marker data remains separate so chapter snapping
+    /// and the existing metadata preview continue to work while segment visuals are active.
+    static func chapterProgressSegments(
+        chapters: [YouTubeChapter],
+        duration: TimeInterval
+    ) -> [PlayerBarProgressSegment] {
+        guard duration.isFinite, duration > 0 else { return [] }
+
+        let sortedChapters = chapters
+            .filter { chapter in
+                chapter.startTime.isFinite
+                    && chapter.startTime >= 0
+                    && chapter.startTime < duration
+            }
+            .sorted { lhs, rhs in
+                if lhs.startTime != rhs.startTime {
+                    return lhs.startTime < rhs.startTime
+                }
+                return lhs.title < rhs.title
+            }
+
+        var uniqueChapters: [YouTubeChapter] = []
+        for chapter in sortedChapters where uniqueChapters.last?.startTime != chapter.startTime {
+            uniqueChapters.append(chapter)
+        }
+
+        let resolvedChapters: [ChapterProgressSpan] = uniqueChapters.enumerated().compactMap { index, chapter in
+            let start = chapter.startTime
+            let nextStart = uniqueChapters.indices.contains(index + 1)
+                ? uniqueChapters[index + 1].startTime
+                : duration
+            let upperBound = min(nextStart, duration)
+            let explicitEnd = chapter.endTime.flatMap { endTime in
+                endTime.isFinite && endTime > start ? endTime : nil
+            }
+            let end = min(explicitEnd ?? upperBound, upperBound)
+            guard end > start else { return nil }
+            return ChapterProgressSpan(chapter: chapter, start: start, end: end)
+        }
+
+        let count = resolvedChapters.count
+        return resolvedChapters.enumerated().map { index, resolved in
+            PlayerBarProgressSegment(
+                id: resolved.chapter.id,
+                start: resolved.start / duration,
+                end: resolved.end / duration,
+                index: index,
+                count: count,
+                title: resolved.chapter.title,
+                itemLabel: String(localized: "Chapter"),
+                rangeText: "\(Self.formatTime(resolved.start)) – \(Self.formatTime(resolved.end))"
             )
         }
     }

--- a/Tests/KasetTests/PlayerBarProgressLaneTests.swift
+++ b/Tests/KasetTests/PlayerBarProgressLaneTests.swift
@@ -118,11 +118,37 @@ struct PlayerBarProgressLaneTests {
         ))
     }
 
-    @Test("Accessibility value announces only the current mix segment")
+    @Test("Segment item label defaults to Track")
+    func segmentItemLabelDefaultsToTrack() {
+        let segment = self.gappedSegments[1]
+        #expect(segment.itemLabel == String(localized: "Track"))
+        #expect(segment.detailText == "\(String(localized: "Track")) 2/3  ·  1:00 – 2:00")
+        #expect(segment.accessibilityDescription.contains("\(String(localized: "Track")) 2/3"))
+    }
+
+    @Test("Custom segment item label appears in detail and accessibility text")
+    func customSegmentItemLabelAppearsInText() {
+        let segment = PlayerBarProgressSegment(
+            id: "chapter-2",
+            start: 0.25,
+            end: 0.5,
+            index: 1,
+            count: 3,
+            title: "Second chapter",
+            itemLabel: String(localized: "Chapter"),
+            rangeText: "1:00 – 2:00"
+        )
+
+        #expect(segment.detailText == "\(String(localized: "Chapter")) 2/3  ·  1:00 – 2:00")
+        #expect(segment.accessibilityDescription.contains("\(String(localized: "Chapter")) 2/3"))
+        #expect(!segment.accessibilityDescription.contains("\(String(localized: "Track")) 2/3"))
+    }
+
+    @Test("Accessibility value announces only the current segment")
     func accessibilityValueAnnouncesCurrentSegment() {
         let segment = self.gappedSegments[1]
         let description = segment.accessibilityDescription
-        #expect(description.contains("Track 2/3"))
+        #expect(description.contains("\(String(localized: "Track")) 2/3"))
         #expect(description.contains("Second"))
         #expect(description.contains("Artist B"))
         #expect(description.contains("1:00 – 2:00"))

--- a/Tests/KasetTests/YouTubePlayerBarTests.swift
+++ b/Tests/KasetTests/YouTubePlayerBarTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+@Suite("YouTube player bar", .tags(.model))
+@MainActor
+struct YouTubePlayerBarTests {
+    @Test("Chapter segments resolve explicit, next-chapter, and duration end times")
+    func chapterSegmentsResolveEndTimes() throws {
+        let chapters = [
+            self.chapter(title: "Opening", start: 0, end: 45),
+            self.chapter(title: "Main topic", start: 60),
+            self.chapter(title: "Closing", start: 180),
+        ]
+
+        let segments = YouTubePlayerBar.chapterProgressSegments(chapters: chapters, duration: 300)
+        #expect(segments.count == 3)
+
+        let opening = try #require(segments.first)
+        #expect(opening.start == 0)
+        #expect(abs(opening.end - 0.15) < 0.000_001)
+        #expect(opening.title == "Opening")
+        #expect(opening.itemLabel == String(localized: "Chapter"))
+        #expect(opening.rangeText == "0:00 – 0:45")
+
+        let mainTopic = segments[1]
+        #expect(abs(mainTopic.start - 0.2) < 0.000_001)
+        #expect(abs(mainTopic.end - 0.6) < 0.000_001)
+        #expect(mainTopic.title == "Main topic")
+        #expect(mainTopic.itemLabel == String(localized: "Chapter"))
+        #expect(mainTopic.rangeText == "1:00 – 3:00")
+
+        let closing = try #require(segments.last)
+        #expect(abs(closing.start - 0.6) < 0.000_001)
+        #expect(closing.end == 1)
+        #expect(closing.title == "Closing")
+        #expect(closing.itemLabel == String(localized: "Chapter"))
+        #expect(closing.rangeText == "3:00 – 5:00")
+
+        #expect(segments.map(\.index) == [0, 1, 2])
+        #expect(segments.allSatisfy { $0.count == 3 })
+    }
+
+    @Test("Explicit chapter ends are capped by the next chapter and video duration")
+    func explicitEndsAreCapped() throws {
+        let chapters = [
+            self.chapter(title: "Overlaps next", start: 0, end: 180),
+            self.chapter(title: "Past duration", start: 100, end: 500),
+        ]
+
+        let segments = YouTubePlayerBar.chapterProgressSegments(chapters: chapters, duration: 240)
+        #expect(segments.count == 2)
+
+        let first = try #require(segments.first)
+        #expect(first.start == 0)
+        #expect(abs(first.end - (100.0 / 240.0)) < 0.000_001)
+        #expect(first.rangeText == "0:00 – 1:40")
+
+        let second = try #require(segments.last)
+        #expect(abs(second.start - (100.0 / 240.0)) < 0.000_001)
+        #expect(second.end == 1)
+        #expect(second.rangeText == "1:40 – 4:00")
+    }
+
+    @Test("Invalid starts and duplicate boundaries are omitted and valid spans are reindexed")
+    func invalidChaptersAreOmittedAndSegmentsAreReindexed() {
+        let chapters = [
+            self.chapter(title: "Intro", start: 0, end: 80),
+            self.chapter(title: "Recovered end", start: 80, end: 80),
+            self.chapter(title: "Final", start: 180),
+            self.chapter(title: "Final", start: 180),
+            self.chapter(title: "Negative", start: -1, end: 20),
+            self.chapter(title: "Not a number", start: .nan, end: 20),
+            self.chapter(title: "Infinite", start: .infinity, end: nil),
+            self.chapter(title: "At duration", start: 300, end: nil),
+            self.chapter(title: "Past duration", start: 450, end: nil),
+        ]
+
+        let segments = YouTubePlayerBar.chapterProgressSegments(chapters: chapters, duration: 300)
+
+        #expect(segments.count == 3)
+        #expect(segments.map(\.index) == [0, 1, 2])
+        #expect(segments.allSatisfy { $0.count == 3 })
+        #expect(segments.map(\.title) == ["Intro", "Recovered end", "Final"])
+
+        #expect(segments[0].start == 0)
+        #expect(abs(segments[0].end - (80.0 / 300.0)) < 0.000_001)
+        #expect(abs(segments[1].start - (80.0 / 300.0)) < 0.000_001)
+        #expect(abs(segments[1].end - (180.0 / 300.0)) < 0.000_001)
+        #expect(segments[1].rangeText == "1:20 – 3:00")
+        #expect(abs(segments[2].start - (180.0 / 300.0)) < 0.000_001)
+        #expect(segments[2].end == 1)
+    }
+
+    private func chapter(
+        title: String,
+        start: TimeInterval,
+        end: TimeInterval? = nil
+    ) -> YouTubeChapter {
+        YouTubeChapter(
+            videoId: "video-id",
+            title: title,
+            startTime: start,
+            endTime: end,
+            timeText: nil,
+            thumbnailURL: nil
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- render YouTube video chapters with the same gapped, independently filled seek-bar segments introduced for mixes in #368
- resolve chapter spans from explicit end times, the next chapter boundary, or the video duration while filtering invalid and duplicate boundaries
- preserve chapter snapping and metadata previews, and suppress chapter UI while ads own the playback clock
- generalize progress-segment tooltip and accessibility labels so mixes use “Track” and videos use localized “Chapter”
- add the singular “Chapter” translation across all supported locales

## Why

The YouTube player bar still rendered chapters as narrow markers on a continuous track, while mix tracklists used the newer segmented presentation. This made equivalent timeline metadata look and behave inconsistently across the music and video players.

## User impact

Chaptered videos now use the same visual language as segmented mixes: visible gaps, independently filled spans, active and hover prominence, and chapter tooltips with ordinal and time-range details. Existing seek snapping remains available, and content chapter metadata is hidden during ads.

## Validation

- `swiftformat .`
- `swiftlint --strict`
- `swift build`
- `swift test --skip KasetUITests --filter 'PlayerBarProgressLaneTests|YouTubePlayerBarTests|AppLocalizationTests'` — 37 tests passed
- structured autoreview — clean, no actionable findings

The full non-UI suite was also attempted; unrelated timing-sensitive suites failed and the test runner eventually crashed with an index-out-of-range error. No UI tests were run.