### PR TITLE
fix: pin What's New notes to app version

### DIFF
--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -222,12 +222,9 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
         }
         .onChange(of: self.showWhatsNew.wrappedValue) { _, newValue in
             if newValue {
-                // Manual trigger from Help menu — fetch release notes, bypass version store
+                // Manual trigger from Help menu — fetch exact-version release notes, bypass version store
                 Task { @MainActor in
-                    await self.presentCurrentWhatsNew(
-                        respectingPresentedVersions: false,
-                        allowsGenericFallback: true
-                    )
+                    await self.presentCurrentWhatsNew(respectingPresentedVersions: false)
                 }
                 self.showWhatsNew.wrappedValue = false
             }
@@ -880,15 +877,12 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
     }
 
     @MainActor
-    private func presentCurrentWhatsNew(
-        respectingPresentedVersions: Bool = true,
-        allowsGenericFallback: Bool = false
-    ) async {
+    private func presentCurrentWhatsNew(respectingPresentedVersions: Bool = true) async {
         let currentVersion = WhatsNew.Version.current()
         let whatsNew = await WhatsNewProvider.fetchWhatsNew(
             for: currentVersion,
             respectingPresentedVersions: respectingPresentedVersions
-        ) ?? (allowsGenericFallback ? WhatsNewProvider.fallbackCollection.first : nil)
+        )
 
         guard let whatsNew else { return }
 

--- a/Sources/Kaset/WhatsNewProvider.swift
+++ b/Sources/Kaset/WhatsNewProvider.swift
@@ -41,8 +41,8 @@ enum WhatsNewProvider {
 
     // MARK: - Fetch from GitHub
 
-    /// Fetches the release notes for the current app version from GitHub.
-    /// Falls back to the static collection if the network request fails.
+    /// Fetches release notes pinned to the current app version from GitHub.
+    /// Falls back only to a static entry for that exact version.
     static func fetchWhatsNew(
         for currentVersion: WhatsNew.Version = .current(),
         store: WhatsNewVersionStore = WhatsNewVersionStore(),
@@ -76,16 +76,7 @@ enum WhatsNewProvider {
             return nil
         }
 
-        if let exact = fallbackCollection.first(where: { $0.version == currentVersion }) {
-            return exact
-        }
-
-        let minorVersion = currentVersion.minorRelease
-        if respectingPresentedVersions, store.hasPresented(minorVersion) {
-            return nil
-        }
-
-        return Self.fallbackCollection.first { $0.version == minorVersion }
+        return self.fallbackCollection.first { $0.version == currentVersion }
     }
 
     // MARK: - GitHub API
@@ -94,24 +85,40 @@ enum WhatsNewProvider {
         for version: WhatsNew.Version,
         session: URLSession = .shared
     ) async -> WhatsNew? {
-        // Try exact tag (v1.2.3), then minor (v1.2.0)
-        var tags: [String] = []
-
-        for candidate in [version, version.minorRelease] {
-            let tag = "v\(candidate.description)"
-            if !tags.contains(tag) {
-                tags.append(tag)
+        for tag in self.releaseTags(for: version) {
+            guard let whatsNew = await fetchRelease(tag: tag, session: session) else {
+                continue
             }
+
+            guard whatsNew.version == version else {
+                DiagnosticsLogger.app.debug(
+                    "Ignoring release notes for \(whatsNew.version.description); expected \(version.description)"
+                )
+                continue
+            }
+
+            return whatsNew
         }
 
-        for tag in tags {
-            if let whatsNew = await Self.fetchRelease(tag: tag, session: session) {
-                return whatsNew
-            }
+        return nil
+    }
+
+    /// Returns semantically equivalent tag spellings without considering another app version.
+    private static func releaseTags(for version: WhatsNew.Version) -> [String] {
+        let canonicalCore = "\(version.major).\(version.minor).\(version.patch)"
+        let suffix = version.description.dropFirst(canonicalCore.count)
+        var tags = ["v\(version.description)"]
+
+        guard version.patch == 0 else {
+            return tags
         }
 
-        // Try latest release as last resort
-        return await Self.fetchLatestRelease(session: session)
+        tags.append("v\(version.major).\(version.minor)\(suffix)")
+        if version.minor == 0 {
+            tags.append("v\(version.major)\(suffix)")
+        }
+
+        return tags
     }
 
     /// Fetches a release by tag — useful for testing a specific version.
@@ -123,12 +130,6 @@ enum WhatsNewProvider {
 
     private static func fetchRelease(tag: String, session: URLSession = .shared) async -> WhatsNew? {
         await self.fetchForTag(tag, session: session)
-    }
-
-    private static func fetchLatestRelease(session: URLSession = .shared) async -> WhatsNew? {
-        let urlString = "https://api.github.com/repos/\(Self.owner)/\(Self.repo)/releases/latest"
-        guard let url = URL(string: urlString) else { return nil }
-        return await Self.performRequest(url: url, session: session)
     }
 
     private static func performRequest(url: URL, session: URLSession = .shared) async -> WhatsNew? {

--- a/Tests/KasetTests/WhatsNewTests.swift
+++ b/Tests/KasetTests/WhatsNewTests.swift
@@ -193,18 +193,9 @@ struct WhatsNewProviderTests {
         #expect(result == nil)
     }
 
-    @Test("Falls back to minor release version")
-    func minorReleaseFallback() {
+    @Test("Does not fall back to a different static app version")
+    func noStaticVersionFallback() {
         let store = WhatsNewVersionStore(defaults: self.defaults)
-        let result = WhatsNewProvider.staticWhatsNew(for: "1.0.2", store: store)
-        #expect(result != nil)
-        #expect(result?.version == "1.0.0")
-    }
-
-    @Test("Returns nil when minor release already presented")
-    func minorReleaseAlreadyPresented() {
-        let store = WhatsNewVersionStore(defaults: self.defaults)
-        store.markPresented("1.0.0")
         let result = WhatsNewProvider.staticWhatsNew(for: "1.0.2", store: store)
         #expect(result == nil)
     }
@@ -300,6 +291,211 @@ struct WhatsNewProviderTests {
 
         #expect(result?.version == "1.0.0")
         #expect(result?.releaseNotes == "Release notes")
+    }
+
+    @Test("Does not substitute the latest release when exact notes are unavailable")
+    func doesNotSubstituteLatestRelease() async {
+        let session = MockURLProtocol.makeMockSession()
+
+        MockURLProtocol.setRequestHandler(for: session) { request in
+            guard let url = request.url else {
+                throw URLError(.badURL)
+            }
+
+            let body: [String: Any]
+            let statusCode: Int
+
+            switch url.path {
+            case "/repos/sozercan/kaset/releases/latest":
+                body = [
+                    "tag_name": "v0.13.0",
+                    "name": "What's New in Kaset 0.13.0",
+                    "body": "Latest release notes",
+                    "html_url": "https://github.com/sozercan/kaset/releases/tag/v0.13.0",
+                ]
+                statusCode = 200
+            default:
+                body = [:]
+                statusCode = 404
+            }
+
+            let data = try JSONSerialization.data(withJSONObject: body)
+            guard let response = HTTPURLResponse(
+                url: url,
+                statusCode: statusCode,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            ) else {
+                throw URLError(.badServerResponse)
+            }
+
+            return (response, data)
+        }
+        defer {
+            MockURLProtocol.reset(session: session)
+        }
+
+        let result = await WhatsNewProvider.fetchWhatsNew(
+            for: "0.12.0",
+            store: WhatsNewVersionStore(defaults: self.defaults),
+            respectingPresentedVersions: false,
+            session: session
+        )
+
+        #expect(result == nil)
+    }
+
+    @Test("Does not substitute minor-release notes for a different patch version")
+    func doesNotSubstituteMinorRelease() async {
+        let session = MockURLProtocol.makeMockSession()
+
+        MockURLProtocol.setRequestHandler(for: session) { request in
+            guard let url = request.url else {
+                throw URLError(.badURL)
+            }
+
+            let body: [String: Any]
+            let statusCode: Int
+
+            if url.path == "/repos/sozercan/kaset/releases/tags/v0.12.0" {
+                body = [
+                    "tag_name": "v0.12.0",
+                    "name": "What's New in Kaset 0.12.0",
+                    "body": "Minor release notes",
+                    "html_url": "https://github.com/sozercan/kaset/releases/tag/v0.12.0",
+                ]
+                statusCode = 200
+            } else {
+                body = [:]
+                statusCode = 404
+            }
+
+            let data = try JSONSerialization.data(withJSONObject: body)
+            guard let response = HTTPURLResponse(
+                url: url,
+                statusCode: statusCode,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            ) else {
+                throw URLError(.badServerResponse)
+            }
+
+            return (response, data)
+        }
+        defer {
+            MockURLProtocol.reset(session: session)
+        }
+
+        let result = await WhatsNewProvider.fetchWhatsNew(
+            for: "0.12.3",
+            store: WhatsNewVersionStore(defaults: self.defaults),
+            respectingPresentedVersions: false,
+            session: session
+        )
+
+        #expect(result == nil)
+    }
+
+    @Test("Rejects a release whose tag does not match the requested app version")
+    func rejectsMismatchedReleaseTag() async {
+        let session = MockURLProtocol.makeMockSession()
+
+        MockURLProtocol.setRequestHandler(for: session) { request in
+            guard let url = request.url else {
+                throw URLError(.badURL)
+            }
+
+            let body: [String: Any]
+            let statusCode: Int
+
+            if url.path == "/repos/sozercan/kaset/releases/tags/v0.12.0" {
+                body = [
+                    "tag_name": "v0.13.0",
+                    "name": "What's New in Kaset 0.13.0",
+                    "body": "Mismatched release notes",
+                    "html_url": "https://github.com/sozercan/kaset/releases/tag/v0.13.0",
+                ]
+                statusCode = 200
+            } else {
+                body = [:]
+                statusCode = 404
+            }
+
+            let data = try JSONSerialization.data(withJSONObject: body)
+            guard let response = HTTPURLResponse(
+                url: url,
+                statusCode: statusCode,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            ) else {
+                throw URLError(.badServerResponse)
+            }
+
+            return (response, data)
+        }
+        defer {
+            MockURLProtocol.reset(session: session)
+        }
+
+        let result = await WhatsNewProvider.fetchWhatsNew(
+            for: "0.12.0",
+            store: WhatsNewVersionStore(defaults: self.defaults),
+            respectingPresentedVersions: false,
+            session: session
+        )
+
+        #expect(result == nil)
+    }
+
+    @Test("Fetches an exact short-form release tag")
+    func fetchesExactShortFormTag() async {
+        let session = MockURLProtocol.makeMockSession()
+
+        MockURLProtocol.setRequestHandler(for: session) { request in
+            guard let url = request.url else {
+                throw URLError(.badURL)
+            }
+
+            let body: [String: Any]
+            let statusCode: Int
+
+            if url.path == "/repos/sozercan/kaset/releases/tags/v2.5" {
+                body = [
+                    "tag_name": "v2.5",
+                    "name": "What's New in Kaset 2.5",
+                    "body": "Short-form release notes",
+                    "html_url": "https://github.com/sozercan/kaset/releases/tag/v2.5",
+                ]
+                statusCode = 200
+            } else {
+                body = [:]
+                statusCode = 404
+            }
+
+            let data = try JSONSerialization.data(withJSONObject: body)
+            guard let response = HTTPURLResponse(
+                url: url,
+                statusCode: statusCode,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            ) else {
+                throw URLError(.badServerResponse)
+            }
+
+            return (response, data)
+        }
+        defer {
+            MockURLProtocol.reset(session: session)
+        }
+
+        let result = await WhatsNewProvider.fetchWhatsNew(
+            for: "2.5",
+            store: WhatsNewVersionStore(defaults: self.defaults),
+            session: session
+        )
+
+        #expect(result?.version == "2.5")
+        #expect(result?.releaseNotes == "Short-form release notes")
     }
 
     @Test("Fetches the exact prerelease tag")


### PR DESCRIPTION
## Summary

- fetch What's New notes only for the running app version
- validate that GitHub's returned release tag matches the requested version
- remove minor-version, latest-release, and unrelated generic fallbacks
- preserve semantically equivalent short-form tags such as `v2.5` and `v2.5.0`
- add regression coverage for cross-version substitution and tag matching

## Root cause

When an exact release lookup failed, `WhatsNewProvider` tried the minor release and then GitHub's `/releases/latest` endpoint. That allowed an older app build to display a newer release's version and notes. The manual Help-menu path also had an unrelated static fallback.

## User impact

What's New now either displays notes for the installed app version or stays closed when matching notes are unavailable. It no longer presents notes from a newer or otherwise different release.

## Validation

- `swift build`
- `swift test --skip KasetUITests --disable-xctest --filter WhatsNewProviderTests` — 16 tests passed
- `swift test --skip KasetUITests --disable-xctest --no-parallel` — 2,679 tests passed
- `swiftlint --strict` — 0 violations
- `swiftformat .` — clean
- autoreview — no accepted/actionable findings

UI tests were not run.