### PR TITLE
feat(youtube): add float-on-top video window control

### DIFF
--- a/Sources/Kaset/AppDelegate.swift
+++ b/Sources/Kaset/AppDelegate.swift
@@ -6,6 +6,20 @@ extension Notification.Name {
     static let kasetOpenURLs = Notification.Name("kasetOpenURLs")
 }
 
+// MARK: - AppActivationWindowPolicy
+
+/// Decides whether a generic activation should reveal the main window. Explicit
+/// reopen actions such as the Dock icon and Window → Kaset bypass this policy.
+enum AppActivationWindowPolicy {
+    static func shouldRevealMainWindow(
+        keyWindowIdentifier: String?,
+        mainWindowIdentifier: String?
+    ) -> Bool {
+        !AccessibilityID.isAuxiliaryPlayerWindowIdentifier(keyWindowIdentifier)
+            && !AccessibilityID.isAuxiliaryPlayerWindowIdentifier(mainWindowIdentifier)
+    }
+}
+
 // MARK: - AppDelegate
 
 /// App delegate to control application lifecycle behavior.
@@ -126,14 +140,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // override. Stop the native timer and re-assert once immediately.
         SingletonPlayerWebView.shared.endBackgroundMediaControlReassertion()
         SingletonPlayerWebView.shared.reassertMediaControlOverride()
-        // When app becomes active (e.g., dock icon clicked), ensure main window is visible.
-        // This handles the case where video window is visible but main window is hidden.
+        // Generic activation normally reveals the main window, but activation
+        // through an auxiliary player must leave a deliberately hidden main
+        // window alone. Dock-icon reopening is handled explicitly below.
         if self.isSwitchedToMiniPlayer {
             if #available(macOS 26.0, *) {
                 MiniPlayerWindowController.shared.orderFrontIfVisible()
             }
             return
         }
+
+        let application = NSApplication.shared
+        guard AppActivationWindowPolicy.shouldRevealMainWindow(
+            keyWindowIdentifier: application.keyWindow?.identifier?.rawValue,
+            mainWindowIdentifier: application.mainWindow?.identifier?.rawValue
+        ) else { return }
+
         self.showMainWindowIfNeeded()
     }
 

--- a/Sources/Kaset/KasetApp.swift
+++ b/Sources/Kaset/KasetApp.swift
@@ -320,6 +320,9 @@ struct KasetApp: App {
                 .onChange(of: self.settings.keepMiniPlayerOnTop) { _, _ in
                     MiniPlayerWindowController.shared.syncWindowState()
                 }
+                .onChange(of: self.settings.keepYouTubeVideoOnTop) { _, _ in
+                    YouTubeVideoWindowController.shared.syncWindowState()
+                }
             }
         }
         .defaultSize(width: MainWindowLayout.defaultWidth, height: MainWindowLayout.defaultHeight)
@@ -507,6 +510,14 @@ struct KasetApp: App {
                     }
                     .keyboardShortcut("k", modifiers: .command)
                 }
+
+                Divider()
+
+                Toggle(String(localized: "Float on Top"), isOn: self.$settings.keepYouTubeVideoOnTop)
+                    .disabled(!YouTubeVideoWindowLevelPolicy.canToggleFloatOnTop(
+                        isFloating: self.youtubePlayerService.surfaceLocation == .floating,
+                        isFullscreenOrTransitioning: self.youtubePlayerService.isWindowFullscreen
+                    ))
             }
 
             // Window menu - show main window

--- a/Sources/Kaset/Resources/Localizable.xcstrings
+++ b/Sources/Kaset/Resources/Localizable.xcstrings
@@ -9287,6 +9287,95 @@
         }
       }
     },
+    "Float on Top": {
+      "comment": "Menu command, settings toggle, and video-window control. “On Top” refers to a higher window z-order above normal windows, not placement at the top edge of the screen.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "عائم في الأعلى"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oben schweben"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Colocar en primer plano"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Garder au premier plan"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apungkan di Atas"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sempre in primo piano"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "상단에 띄우기"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zwevend op voorgrond"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zawsze na wierzchu"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Em primeiro plano"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поверх всех окон"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Flytande överst"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "En Üstte Kalsın"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Поверх інших вікон"
+          }
+        }
+      }
+    },
     "Follow artists on YouTube Music to see them here.": {
       "localizations": {
         "ar": {
@@ -37515,6 +37604,95 @@
           "stringUnit": {
             "state": "translated",
             "value": "Тримати мініпрогравач поверх інших вікон"
+          }
+        }
+      }
+    },
+    "Keep the video above standard windows on this Space.": {
+      "comment": "Help text for Float on Top. “Above” refers to window z-order; “standard windows” means normal-level windows, and “this Space” means the current macOS desktop Space.",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أبقِ الفيديو فوق النوافذ العادية على سطح المكتب هذا."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Das Video auf diesem Schreibtisch über normalen Fenstern halten."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantén el video por encima de las ventanas estándar en este escritorio."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Garder la vidéo au-dessus des fenêtres standard sur ce bureau."
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pertahankan video di atas jendela standar di Desktop ini."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantieni il video sopra le finestre standard su questa scrivania."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 데스크탑에서 비디오를 일반 윈도우 위에 유지합니다."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Houd de video op dit bureaublad boven standaardvensters."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Utrzymuj wideo nad standardowymi oknami na tym biurku."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mantenha o vídeo acima das janelas padrão nesta secretária."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Держать видео поверх стандартных окон на этом Рабочем столе."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Håll videon ovanför standardfönster på det här skrivbordet."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Videoyu bu Masaüstünde standart pencerelerin üzerinde tut."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Тримати відео поверх стандартних вікон на цьому робочому столі."
           }
         }
       }

--- a/Sources/Kaset/Resources/ar.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/ar.lproj/Localizable.strings
@@ -167,6 +167,7 @@
 "Find songs, albums, artists, and playlists" = "ابحث عن أغاني وألبومات وفنانين وقوائم تشغيل";
 "Find videos, channels, and playlists." = "اعثر على الفيديوهات والقنوات وقوائم التشغيل.";
 "Flat" = "مسطح";
+"Float on Top" = "عائم في الأعلى";
 "Follow artists on YouTube Music to see them here." = "تابع الفنانين على YouTube Music لتراهم هنا.";
 "For you" = "من أجلك";
 "Force macOS 15 fallback views and materials while running on macOS 26+ for compatibility debugging" = "فرض استخدام الواجهات والمواد الاحتياطية الخاصة بـ macOS 15 أثناء التشغيل على macOS 26+ لتصحيح التوافق";
@@ -213,6 +214,7 @@
 "Keep Mini Player on Top" = "إبقاء المشغّل المصغّر في المقدمة";
 "Keep suggestions queued ahead" = "إبقاء الاقتراحات في قائمة الانتظار";
 "Keep the mini player visible above other windows" = "الإبقاء على المشغّل المصغّر ظاهرًا فوق النوافذ الأخرى";
+"Keep the video above standard windows on this Space." = "أبقِ الفيديو فوق النوافذ العادية على سطح المكتب هذا.";
 "Language" = "اللغة";
 "Language Not Supported" = "اللغة غير مدعومة";
 "Last checked: %@" = "آخر فحص: %@";

--- a/Sources/Kaset/Resources/de.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/de.lproj/Localizable.strings
@@ -167,6 +167,7 @@
 "Find songs, albums, artists, and playlists" = "Finde Titel, Alben, Interpreten und Playlists";
 "Find videos, channels, and playlists." = "Finde Videos, Kanäle und Playlists.";
 "Flat" = "Flach";
+"Float on Top" = "Oben schweben";
 "Follow artists on YouTube Music to see them here." = "Folge Interpreten auf YouTube Music, um sie hier zu sehen.";
 "For you" = "Für dich";
 "Force macOS 15 fallback views and materials while running on macOS 26+ for compatibility debugging" = "Erzwingt Fallback-Ansichten und -Materialien von macOS 15 unter macOS 26+ zur Kompatibilitätsprüfung";
@@ -213,6 +214,7 @@
 "Keep Mini Player on Top" = "Mini-Player im Vordergrund halten";
 "Keep suggestions queued ahead" = "Vorschläge in der Warteschlange voraus bereithalten";
 "Keep the mini player visible above other windows" = "Den Miniplayer über anderen Fenstern sichtbar halten";
+"Keep the video above standard windows on this Space." = "Das Video auf diesem Schreibtisch über normalen Fenstern halten.";
 "Language" = "Sprache";
 "Language Not Supported" = "Sprache wird nicht unterstützt";
 "Last checked: %@" = "Zuletzt geprüft: %@";

--- a/Sources/Kaset/Resources/es.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/es.lproj/Localizable.strings
@@ -167,6 +167,7 @@
 "Find songs, albums, artists, and playlists" = "Encuentra canciones, álbumes, artistas y playlists";
 "Find videos, channels, and playlists." = "Encuentra videos, canales y playlists.";
 "Flat" = "Plano";
+"Float on Top" = "Colocar en primer plano";
 "Follow artists on YouTube Music to see them here." = "Sigue artistas en YouTube Music para verlos aquí.";
 "For you" = "Para ti";
 "Force macOS 15 fallback views and materials while running on macOS 26+ for compatibility debugging" = "Fuerza vistas y materiales de respaldo de macOS 15 al ejecutarse en macOS 26+ para depurar compatibilidad";
@@ -213,6 +214,7 @@
 "Keep Mini Player on Top" = "Mantener el mini reproductor encima";
 "Keep suggestions queued ahead" = "Mantener sugerencias en cola por delante de";
 "Keep the mini player visible above other windows" = "Mantener el mini reproductor visible sobre otras ventanas";
+"Keep the video above standard windows on this Space." = "Mantén el video por encima de las ventanas estándar en este escritorio.";
 "Language" = "Idioma";
 "Language Not Supported" = "Idioma no compatible";
 "Last checked: %@" = "Última comprobación: %@";

--- a/Sources/Kaset/Resources/fr.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/fr.lproj/Localizable.strings
@@ -167,6 +167,7 @@
 "Find songs, albums, artists, and playlists" = "Trouvez des morceaux, albums, artistes et playlists";
 "Find videos, channels, and playlists." = "Trouvez des vidéos, des chaînes et des playlists.";
 "Flat" = "Plat";
+"Float on Top" = "Garder au premier plan";
 "Follow artists on YouTube Music to see them here." = "Suivez des artistes sur YouTube Music pour les voir ici.";
 "For you" = "Pour vous";
 "Force macOS 15 fallback views and materials while running on macOS 26+ for compatibility debugging" = "Force les vues et matériaux de repli de macOS 15 lors de l'exécution sur macOS 26+ pour le débogage de compatibilité";
@@ -213,6 +214,7 @@
 "Keep Mini Player on Top" = "Garder le mini lecteur au premier plan";
 "Keep suggestions queued ahead" = "Garder des suggestions en file d’attente";
 "Keep the mini player visible above other windows" = "Garder le mini-lecteur visible au-dessus des autres fenêtres";
+"Keep the video above standard windows on this Space." = "Garder la vidéo au-dessus des fenêtres standard sur ce bureau.";
 "Language" = "Langue";
 "Language Not Supported" = "Langue non prise en charge";
 "Last checked: %@" = "Dernière vérification : %@";

--- a/Sources/Kaset/Resources/id.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/id.lproj/Localizable.strings
@@ -167,6 +167,7 @@
 "Find songs, albums, artists, and playlists" = "Temukan lagu, album, artis, dan daftar putar";
 "Find videos, channels, and playlists." = "Temukan video, channel, dan playlist.";
 "Flat" = "Flat";
+"Float on Top" = "Apungkan di Atas";
 "Follow artists on YouTube Music to see them here." = "Ikuti artis di YouTube Music untuk melihatnya di sini.";
 "For you" = "Untuk Anda";
 "Force macOS 15 fallback views and materials while running on macOS 26+ for compatibility debugging" = "Paksa tampilan dan material fallback macOS 15 saat berjalan di macOS 26+ untuk debugging kompatibilitas";
@@ -213,6 +214,7 @@
 "Keep Mini Player on Top" = "Tampilkan Mini Player di Atas";
 "Keep suggestions queued ahead" = "Simpan saran dalam antrean di depan";
 "Keep the mini player visible above other windows" = "Pertahankan mini player tetap terlihat di atas jendela lain";
+"Keep the video above standard windows on this Space." = "Pertahankan video di atas jendela standar di Desktop ini.";
 "Language" = "Bahasa";
 "Language Not Supported" = "Bahasa Tidak Didukung";
 "Last checked: %@" = "Terakhir diperiksa: %@";

--- a/Sources/Kaset/Resources/it.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/it.lproj/Localizable.strings
@@ -167,6 +167,7 @@
 "Find songs, albums, artists, and playlists" = "Trova brani, album, artisti e playlist";
 "Find videos, channels, and playlists." = "Trova video, canali e playlist.";
 "Flat" = "Piatto";
+"Float on Top" = "Sempre in primo piano";
 "Follow artists on YouTube Music to see them here." = "Segui gli artisti su YouTube Music per vederli qui.";
 "For you" = "Per te";
 "Force macOS 15 fallback views and materials while running on macOS 26+ for compatibility debugging" = "Forza viste e materiali di fallback di macOS 15 durante l'esecuzione su macOS 26+ per il debug della compatibilità";
@@ -213,6 +214,7 @@
 "Keep Mini Player on Top" = "Mantieni mini player in primo piano";
 "Keep suggestions queued ahead" = "Mantieni i suggerimenti in coda davanti di";
 "Keep the mini player visible above other windows" = "Mantieni il mini player visibile sopra le altre finestre";
+"Keep the video above standard windows on this Space." = "Mantieni il video sopra le finestre standard su questa scrivania.";
 "Language" = "Lingua";
 "Language Not Supported" = "Lingua non supportata";
 "Last checked: %@" = "Ultimo controllo: %@";

--- a/Sources/Kaset/Resources/ko.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/ko.lproj/Localizable.strings
@@ -167,6 +167,7 @@
 "Find songs, albums, artists, and playlists" = "노래, 앨범, 아티스트, 재생목록 찾기";
 "Find videos, channels, and playlists." = "동영상, 채널 및 재생목록을 찾으세요.";
 "Flat" = "플랫";
+"Float on Top" = "상단에 띄우기";
 "Follow artists on YouTube Music to see them here." = "여기에서 보려면 YouTube Music에서 아티스트를 구독하세요.";
 "For you" = "추천";
 "Force macOS 15 fallback views and materials while running on macOS 26+ for compatibility debugging" = "호환성 디버깅을 위해 macOS 26+에서 실행 중일 때 macOS 15 대체 보기와 머티리얼을 강제로 사용합니다";
@@ -213,6 +214,7 @@
 "Keep Mini Player on Top" = "미니 플레이어를 항상 위에 표시";
 "Keep suggestions queued ahead" = "미리 대기열에 유지할 추천";
 "Keep the mini player visible above other windows" = "미니 플레이어를 다른 윈도우 위에 계속 표시";
+"Keep the video above standard windows on this Space." = "이 데스크탑에서 비디오를 일반 윈도우 위에 유지합니다.";
 "Language" = "언어";
 "Language Not Supported" = "지원되지 않는 언어";
 "Last checked: %@" = "마지막 확인: %@";

--- a/Sources/Kaset/Resources/nl.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/nl.lproj/Localizable.strings
@@ -167,6 +167,7 @@
 "Find songs, albums, artists, and playlists" = "Vind nummers, albums, artiesten en afspeellijsten";
 "Find videos, channels, and playlists." = "Zoek video's, kanalen en afspeellijsten.";
 "Flat" = "Vlak";
+"Float on Top" = "Zwevend op voorgrond";
 "Follow artists on YouTube Music to see them here." = "Volg artiesten op YouTube Music om ze hier te zien.";
 "For you" = "Voor jou";
 "Force macOS 15 fallback views and materials while running on macOS 26+ for compatibility debugging" = "Forceert macOS 15-terugvalweergaven en -materialen tijdens uitvoering op macOS 26+ voor compatibiliteitsdebugging";
@@ -213,6 +214,7 @@
 "Keep Mini Player on Top" = "Mini-speler bovenop houden";
 "Keep suggestions queued ahead" = "Houd suggesties vooruit in de wachtrij";
 "Keep the mini player visible above other windows" = "De minispeler zichtbaar houden boven andere vensters";
+"Keep the video above standard windows on this Space." = "Houd de video op dit bureaublad boven standaardvensters.";
 "Language" = "Taal";
 "Language Not Supported" = "Taal wordt niet ondersteund";
 "Last checked: %@" = "Laatst gecontroleerd: %@";

--- a/Sources/Kaset/Resources/pl.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/pl.lproj/Localizable.strings
@@ -167,6 +167,7 @@
 "Find songs, albums, artists, and playlists" = "Znajdź utwory, albumy, artystów i playlisty";
 "Find videos, channels, and playlists." = "Znajdź filmy, kanały i playlisty.";
 "Flat" = "Płaski";
+"Float on Top" = "Zawsze na wierzchu";
 "Follow artists on YouTube Music to see them here." = "Obserwuj artystów w YouTube Music, aby zobaczyć ich tutaj.";
 "For you" = "Dla Ciebie";
 "Force macOS 15 fallback views and materials while running on macOS 26+ for compatibility debugging" = "Wymusza widoki i materiały awaryjne z macOS 15 podczas działania na macOS 26+ w celu debugowania zgodności";
@@ -213,6 +214,7 @@
 "Keep Mini Player on Top" = "Trzymaj mini odtwarzacz na wierzchu";
 "Keep suggestions queued ahead" = "Utrzymuj sugestie w kolejce przed";
 "Keep the mini player visible above other windows" = "Utrzymuj miniodtwarzacz widoczny nad innymi oknami";
+"Keep the video above standard windows on this Space." = "Utrzymuj wideo nad standardowymi oknami na tym biurku.";
 "Language" = "Język";
 "Language Not Supported" = "Język nie jest obsługiwany";
 "Last checked: %@" = "Ostatnio sprawdzono: %@";

--- a/Sources/Kaset/Resources/pt.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/pt.lproj/Localizable.strings
@@ -167,6 +167,7 @@
 "Find songs, albums, artists, and playlists" = "Encontre músicas, álbuns, artistas e listas de reprodução";
 "Find videos, channels, and playlists." = "Encontre vídeos, canais e listas de reprodução.";
 "Flat" = "Plano";
+"Float on Top" = "Em primeiro plano";
 "Follow artists on YouTube Music to see them here." = "Siga artistas no YouTube Music para os ver aqui.";
 "For you" = "Para si";
 "Force macOS 15 fallback views and materials while running on macOS 26+ for compatibility debugging" = "Força as vistas e materiais de contingência do macOS 15 ao executar no macOS 26+ para depuração de compatibilidade";
@@ -213,6 +214,7 @@
 "Keep Mini Player on Top" = "Manter o mini player no topo";
 "Keep suggestions queued ahead" = "Manter sugestões preparadas na fila";
 "Keep the mini player visible above other windows" = "Manter o mini player visível acima das outras janelas";
+"Keep the video above standard windows on this Space." = "Mantenha o vídeo acima das janelas padrão nesta secretária.";
 "Language" = "Idioma";
 "Language Not Supported" = "Idioma não suportado";
 "Last checked: %@" = "Última verificação: %@";

--- a/Sources/Kaset/Resources/ru.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/ru.lproj/Localizable.strings
@@ -167,6 +167,7 @@
 "Find songs, albums, artists, and playlists" = "Находите треки, альбомы, исполнителей и плейлисты";
 "Find videos, channels, and playlists." = "Находите видео, каналы и плейлисты.";
 "Flat" = "Плоский";
+"Float on Top" = "Поверх всех окон";
 "Follow artists on YouTube Music to see them here." = "Подписывайтесь на исполнителей в YouTube Music, чтобы видеть их здесь.";
 "For you" = "Для вас";
 "Force macOS 15 fallback views and materials while running on macOS 26+ for compatibility debugging" = "Принудительно использует резервные представления и материалы macOS 15 при работе на macOS 26+ для отладки совместимости";
@@ -213,6 +214,7 @@
 "Keep Mini Player on Top" = "Держать мини-плеер поверх окон";
 "Keep suggestions queued ahead" = "Держать рекомендации впереди в очереди на";
 "Keep the mini player visible above other windows" = "Держать мини-проигрыватель поверх других окон";
+"Keep the video above standard windows on this Space." = "Держать видео поверх стандартных окон на этом Рабочем столе.";
 "Language" = "Язык";
 "Language Not Supported" = "Язык не поддерживается";
 "Last checked: %@" = "Последняя проверка: %@";

--- a/Sources/Kaset/Resources/sv.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/sv.lproj/Localizable.strings
@@ -167,6 +167,7 @@
 "Find songs, albums, artists, and playlists" = "Hitta låtar, album, artister och spellistor";
 "Find videos, channels, and playlists." = "Hitta videor, kanaler och spellistor.";
 "Flat" = "Platt";
+"Float on Top" = "Flytande överst";
 "Follow artists on YouTube Music to see them here." = "Följ artister i YouTube Music för att se dem här.";
 "For you" = "För dig";
 "Force macOS 15 fallback views and materials while running on macOS 26+ for compatibility debugging" = "Tvingar reservvyer och material från macOS 15 när appen körs på macOS 26+ för kompatibilitetsfelsökning";
@@ -213,6 +214,7 @@
 "Keep Mini Player on Top" = "Håll minispelaren överst";
 "Keep suggestions queued ahead" = "Håll förslag i kön framför";
 "Keep the mini player visible above other windows" = "Håll minispelaren synlig ovanför andra fönster";
+"Keep the video above standard windows on this Space." = "Håll videon ovanför standardfönster på det här skrivbordet.";
 "Language" = "Språk";
 "Language Not Supported" = "Språk stöds inte";
 "Last checked: %@" = "Senast kontrollerad: %@";

--- a/Sources/Kaset/Resources/tr.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/tr.lproj/Localizable.strings
@@ -167,6 +167,7 @@
 "Find songs, albums, artists, and playlists" = "Şarkıları, albümleri, sanatçıları ve çalma listelerini bulun";
 "Find videos, channels, and playlists." = "Videoları, kanalları ve oynatma listelerini bulun.";
 "Flat" = "Düz";
+"Float on Top" = "En Üstte Kalsın";
 "Follow artists on YouTube Music to see them here." = "Burada görmek için YouTube Music'te sanatçıları takip edin.";
 "For you" = "Senin için";
 "Force macOS 15 fallback views and materials while running on macOS 26+ for compatibility debugging" = "Uyumluluk hatalarını ayıklamak için macOS 26+ üzerinde çalışırken macOS 15 yedek görünümlerini ve materyallerini zorlar";
@@ -213,6 +214,7 @@
 "Keep Mini Player on Top" = "Mini Oynatıcıyı Üstte Tut";
 "Keep suggestions queued ahead" = "Önerileri ileride kuyrukta tut";
 "Keep the mini player visible above other windows" = "Mini oynatıcıyı diğer pencerelerin üzerinde görünür tut";
+"Keep the video above standard windows on this Space." = "Videoyu bu Masaüstünde standart pencerelerin üzerinde tut.";
 "Language" = "Dil";
 "Language Not Supported" = "Dil Desteklenmiyor";
 "Last checked: %@" = "Son kontrol: %@";

--- a/Sources/Kaset/Resources/uk.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/uk.lproj/Localizable.strings
@@ -167,6 +167,7 @@
 "Find songs, albums, artists, and playlists" = "Знаходьте пісні, альбоми, виконавців і плейлисти";
 "Find videos, channels, and playlists." = "Знаходьте відео, канали й плейлисти.";
 "Flat" = "Рівний";
+"Float on Top" = "Поверх інших вікон";
 "Follow artists on YouTube Music to see them here." = "Підписуйтеся на виконавців у YouTube Music, щоб побачити їх тут.";
 "For you" = "Для вас";
 "Force macOS 15 fallback views and materials while running on macOS 26+ for compatibility debugging" = "Примусово використовує резервні подання й матеріали macOS 15 під час роботи на macOS 26+ для налагодження сумісності";
@@ -213,6 +214,7 @@
 "Keep Mini Player on Top" = "Тримати міні-плеєр поверх інших вікон";
 "Keep suggestions queued ahead" = "Тримати пропозиції в черзі попереду";
 "Keep the mini player visible above other windows" = "Тримати мініпрогравач поверх інших вікон";
+"Keep the video above standard windows on this Space." = "Тримати відео поверх стандартних вікон на цьому робочому столі.";
 "Language" = "Мова";
 "Language Not Supported" = "Мову не підтримано";
 "Last checked: %@" = "Остання перевірка: %@";

--- a/Sources/Kaset/Services/Player/YouTubePlayerService.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService.swift
@@ -249,8 +249,14 @@ final class YouTubePlayerService {
     /// Whether the current video was added to Watch Later this session.
     private(set) var isInWatchLater = false
 
-    /// Whether the pop-out window is in fullscreen (set by its controller).
-    var isWindowFullscreen = false
+    /// Fullscreen lifecycle for the regular YouTube pop-out. The controller
+    /// advances this before each transition so commands and in-window controls
+    /// are gated for the animations as well as the fullscreen state itself.
+    var windowFullscreenPhase: YouTubeVideoWindowFullscreenPhase = .windowed
+
+    var isWindowFullscreen: Bool {
+        self.windowFullscreenPhase.blocksWindowedControls
+    }
 
     /// Caption tracks available on the current watch page.
     private(set) var captionTracks: [YouTubeCaptionTrack] = []

--- a/Sources/Kaset/Services/SettingsManager.swift
+++ b/Sources/Kaset/Services/SettingsManager.swift
@@ -26,6 +26,7 @@ final class SettingsManager {
         static let romanizationEnabled = "settings.romanizationEnabled"
         static let contentLanguage = "settings.contentLanguage"
         static let keepMiniPlayerOnTop = "settings.keepMiniPlayerOnTop"
+        static let keepYouTubeVideoOnTop = "settings.keepYouTubeVideoOnTop"
         static let smartShuffleEnabled = "settings.smartShuffleEnabled"
         static let smartShuffleSuggestEveryN = "settings.smartShuffleSuggestEveryN"
         static let smartShuffleBurst = "settings.smartShuffleBurst"
@@ -328,6 +329,13 @@ final class SettingsManager {
         }
     }
 
+    /// Whether the regular YouTube video window floats above standard windows.
+    var keepYouTubeVideoOnTop: Bool {
+        didSet {
+            UserDefaults.standard.set(self.keepYouTubeVideoOnTop, forKey: Keys.keepYouTubeVideoOnTop)
+        }
+    }
+
     // MARK: - Smart Shuffle defaults & ranges (single source of truth)
 
     /// Default cadence: insert a burst of suggestions every N originals.
@@ -454,6 +462,10 @@ final class SettingsManager {
 
     // MARK: - Initialization
 
+    static func loadKeepYouTubeVideoOnTop(from defaults: UserDefaults) -> Bool {
+        defaults.object(forKey: Keys.keepYouTubeVideoOnTop) as? Bool ?? false
+    }
+
     private init() {
         // Load persisted settings or use defaults
         self.showNowPlayingNotifications = UserDefaults.standard.object(forKey: Keys.showNowPlayingNotifications) as? Bool ?? true
@@ -474,6 +486,7 @@ final class SettingsManager {
         self.syncedLyricsEnabled = UserDefaults.standard.object(forKey: Keys.syncedLyricsEnabled) as? Bool ?? true
         self.romanizationEnabled = UserDefaults.standard.object(forKey: Keys.romanizationEnabled) as? Bool ?? true
         self.keepMiniPlayerOnTop = UserDefaults.standard.object(forKey: Keys.keepMiniPlayerOnTop) as? Bool ?? false
+        self.keepYouTubeVideoOnTop = Self.loadKeepYouTubeVideoOnTop(from: UserDefaults.standard)
         self.smartShuffleEnabled = UserDefaults.standard.object(forKey: Keys.smartShuffleEnabled) as? Bool ?? true
         // Property observers do not fire for assignments in init, so clamp persisted values here too.
         self.smartShuffleSuggestEveryN = Self.clamp(

--- a/Sources/Kaset/Utilities/AccessibilityIdentifiers.swift
+++ b/Sources/Kaset/Utilities/AccessibilityIdentifiers.swift
@@ -1,10 +1,14 @@
 import Foundation
 
+// MARK: - AccessibilityID
+
 /// Centralized accessibility identifiers for UI testing.
 /// Using an enum namespace prevents typos and enables autocomplete.
 enum AccessibilityID {
     static func isAuxiliaryPlayerWindowIdentifier(_ identifier: String?) -> Bool {
-        identifier == VideoWindow.container || identifier == MiniPlayer.container
+        identifier == VideoWindow.container
+            || identifier == MiniPlayer.container
+            || identifier == YouTubeContent.videoWindow
     }
 
     // MARK: - Sidebar
@@ -211,4 +215,9 @@ enum AccessibilityID {
         static let container = "videoWindow"
         static let videoContent = "videoWindow.content"
     }
+}
+
+extension AccessibilityID.YouTubeContent {
+    static let videoWindow = "youtubeContent.videoWindow"
+    static let videoWindowFloatOnTop = "youtubeContent.videoWindow.floatOnTop"
 }

--- a/Sources/Kaset/Views/YouTube/YouTubePlayerBar.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubePlayerBar.swift
@@ -51,6 +51,10 @@ struct YouTubePlayerBar: View {
     @State private var showsVolumeOverlay = false
     @State private var chapterPreviewMarker: PlayerBarProgressMarker?
 
+    init(isDetachedWindow: Bool) {
+        self.isDetachedWindow = isDetachedWindow
+    }
+
     var body: some View {
         CompatGlassContainer(spacing: 0) {
             GeometryReader { proxy in
@@ -781,25 +785,9 @@ struct YouTubePlayerBar: View {
             self.youtubePlayer.popOutToWindow()
         }
     }
-
-    private static func formatTime(_ seconds: Double) -> String {
-        guard seconds.isFinite, seconds >= 0 else { return "0:00" }
-        let total = Int(seconds)
-        let hours = total / 3600
-        let mins = (total % 3600) / 60
-        let secs = total % 60
-        if hours > 0 {
-            return String(format: "%d:%02d:%02d", hours, mins, secs)
-        }
-        return String(format: "%d:%02d", mins, secs)
-    }
 }
 
 extension YouTubePlayerBar {
-    init(isDetachedWindow: Bool) {
-        self.isDetachedWindow = isDetachedWindow
-    }
-
     static func shouldShowFloatOnTopControl(
         isDetachedWindow: Bool,
         surfaceLocation: YouTubePlayerService.SurfaceLocation,
@@ -818,6 +806,18 @@ extension YouTubePlayerBar {
 }
 
 private extension YouTubePlayerBar {
+    static func formatTime(_ seconds: Double) -> String {
+        guard seconds.isFinite, seconds >= 0 else { return "0:00" }
+        let total = Int(seconds)
+        let hours = total / 3600
+        let mins = (total % 3600) / 60
+        let secs = total % 60
+        if hours > 0 {
+            return String(format: "%d:%02d:%02d", hours, mins, secs)
+        }
+        return String(format: "%d:%02d", mins, secs)
+    }
+
     var hasPersonalAccount: Bool {
         self.authService.hasPersonalAccount
     }

--- a/Sources/Kaset/Views/YouTube/YouTubePlayerBar.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubePlayerBar.swift
@@ -18,13 +18,12 @@ struct YouTubePlayerBar: View {
     private static let brandAccent = PackageResourceLookup.brandAccent
     private static let fullVideoDetailsWidth: CGFloat = 294
     private static let compactVideoDetailsWidth: CGFloat = 141
+    private static let baseYouTubeOptionsWidth: CGFloat = 210
+    private static let floatOnTopOptionsWidthIncrement: CGFloat = 28 + 6
 
-    /// Below this the details block leaves the transport controls too little
-    /// room and they collide with the elapsed/remaining labels, so it is
-    /// dropped entirely. Only the pop-out window — which can be dragged down
-    /// to 512pt of content — ever gets this narrow; the main window's own
-    /// minimum keeps its bar well above this.
-    private static let hiddenVideoDetailsBreakpoint: CGFloat = 580
+    /// Below this the details block would collide with the transport controls.
+    /// Only the resizable detached window reaches this narrow layout.
+    private static let baseHiddenVideoDetailsBreakpoint: CGFloat = 580
 
     private struct ChapterProgressSpan {
         let chapter: YouTubeChapter
@@ -38,9 +37,12 @@ struct YouTubePlayerBar: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.colorScheme) private var colorScheme
 
+    private let isDetachedWindow: Bool
+
     /// Namespace for glass effect morphing.
     @Namespace private var playerNamespace
 
+    @State private var settings = SettingsManager.shared
     @State private var seekValue: Double = 0
     @State private var isSeeking = false
     @State private var seekHold = PlayerBarSeekHold()
@@ -53,7 +55,7 @@ struct YouTubePlayerBar: View {
         CompatGlassContainer(spacing: 0) {
             GeometryReader { proxy in
                 let usesCompactDetails = proxy.size.width <= PlayerBarLayout.compactDetailsBreakpoint
-                let hidesDetails = proxy.size.width <= Self.hiddenVideoDetailsBreakpoint
+                let hidesDetails = proxy.size.width <= self.hiddenVideoDetailsBreakpoint
 
                 HStack(spacing: 10) {
                     if !hidesDetails {
@@ -239,10 +241,6 @@ struct YouTubePlayerBar: View {
         }
         .padding(.leading, 14)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
-    }
-
-    private var hasPersonalAccount: Bool {
-        self.authService.hasPersonalAccount
     }
 
     private var currentVideoGlowSources: [URL] {
@@ -453,6 +451,10 @@ struct YouTubePlayerBar: View {
             self.compactCaptionsMenu
             self.compactQualityMenu
 
+            if self.showsFloatOnTopControl {
+                self.youtubeFloatOnTopButton
+            }
+
             PlayerBarIconButton(
                 action: self.toggleYouTubePictureInPicture,
                 isSelected: self.youtubePlayer.surfaceLocation == .floating,
@@ -585,10 +587,6 @@ struct YouTubePlayerBar: View {
 
     private var volumeOverlayShadow: Color {
         self.colorScheme == .dark ? .black.opacity(0.36) : .black.opacity(0.18)
-    }
-
-    private var youtubeOptionsWidth: CGFloat {
-        210
     }
 
     /// Fraction (0...1) to render: the live drag value while seeking, otherwise actual progress.
@@ -797,6 +795,78 @@ struct YouTubePlayerBar: View {
     }
 }
 
+extension YouTubePlayerBar {
+    init(isDetachedWindow: Bool) {
+        self.isDetachedWindow = isDetachedWindow
+    }
+
+    static func shouldShowFloatOnTopControl(
+        isDetachedWindow: Bool,
+        surfaceLocation: YouTubePlayerService.SurfaceLocation,
+        isFullscreenOrTransitioning: Bool
+    ) -> Bool {
+        isDetachedWindow && YouTubeVideoWindowLevelPolicy.canToggleFloatOnTop(
+            isFloating: surfaceLocation == .floating,
+            isFullscreenOrTransitioning: isFullscreenOrTransitioning
+        )
+    }
+
+    static func hiddenVideoDetailsBreakpoint(showsFloatOnTopControl: Bool) -> CGFloat {
+        self.baseHiddenVideoDetailsBreakpoint
+            + (showsFloatOnTopControl ? self.floatOnTopOptionsWidthIncrement : 0)
+    }
+}
+
+private extension YouTubePlayerBar {
+    var hasPersonalAccount: Bool {
+        self.authService.hasPersonalAccount
+    }
+
+    var youtubeFloatOnTopButton: some View {
+        let help = String(localized: "Keep the video above standard windows on this Space.")
+
+        return PlayerBarIconButton(
+            action: self.toggleYouTubeFloatOnTop,
+            isSelected: self.settings.keepYouTubeVideoOnTop,
+            accessibilityID: AccessibilityID.YouTubeContent.videoWindowFloatOnTop,
+            accessibilityLabel: String(localized: "Float on Top"),
+            accessibilityValue: self.settings.keepYouTubeVideoOnTop
+                ? String(localized: "On")
+                : String(localized: "Off")
+        ) {
+            Image(systemName: self.settings.keepYouTubeVideoOnTop ? "pin.fill" : "pin")
+                .font(.system(size: 15, weight: .regular))
+                .frame(width: 14, height: 16)
+                .foregroundStyle(self.settings.keepYouTubeVideoOnTop ? Self.brandAccent : .primary)
+                .contentTransition(.symbolEffect(.replace))
+        }
+        .accessibilityHint(Text(help))
+        .help(help)
+    }
+
+    var youtubeOptionsWidth: CGFloat {
+        Self.baseYouTubeOptionsWidth
+            + (self.showsFloatOnTopControl ? Self.floatOnTopOptionsWidthIncrement : 0)
+    }
+
+    var showsFloatOnTopControl: Bool {
+        Self.shouldShowFloatOnTopControl(
+            isDetachedWindow: self.isDetachedWindow,
+            surfaceLocation: self.youtubePlayer.surfaceLocation,
+            isFullscreenOrTransitioning: self.youtubePlayer.isWindowFullscreen
+        )
+    }
+
+    var hiddenVideoDetailsBreakpoint: CGFloat {
+        Self.hiddenVideoDetailsBreakpoint(showsFloatOnTopControl: self.showsFloatOnTopControl)
+    }
+
+    func toggleYouTubeFloatOnTop() {
+        HapticService.toggle()
+        self.settings.keepYouTubeVideoOnTop.toggle()
+    }
+}
+
 // MARK: - Per-View Inset
 
 extension View {
@@ -808,7 +878,7 @@ extension View {
     /// `PlayerBar` (see docs/architecture.md).
     func youtubePlayerBarInset() -> some View {
         safeAreaInset(edge: .bottom, spacing: 0) {
-            YouTubePlayerBar()
+            YouTubePlayerBar(isDetachedWindow: false)
         }
     }
 }

--- a/Sources/Kaset/Views/YouTube/YouTubeVideoWindowController.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeVideoWindowController.swift
@@ -1,6 +1,70 @@
 import AppKit
 import SwiftUI
 
+// MARK: - YouTubeVideoWindowLevelPolicy
+
+/// Deterministic presentation policy for the regular YouTube pop-out.
+/// Desired state lives in `SettingsManager`; the controller decides when it is
+/// safe to apply that state to the live AppKit window.
+@MainActor
+enum YouTubeVideoWindowLevelPolicy {
+    static let requiredCollectionBehavior: NSWindow.CollectionBehavior = [
+        .managed,
+        .participatesInCycle,
+        .fullScreenPrimary,
+    ]
+
+    static func windowedLevel(isPinned: Bool) -> NSWindow.Level {
+        isPinned ? .floating : .normal
+    }
+
+    static func canApplyLiveChange(isFullscreenOrTransitioning: Bool) -> Bool {
+        !isFullscreenOrTransitioning
+    }
+
+    static func canToggleFloatOnTop(
+        isFloating: Bool,
+        isFullscreenOrTransitioning: Bool
+    ) -> Bool {
+        isFloating && !isFullscreenOrTransitioning
+    }
+
+    static func collectionBehavior(
+        preserving current: NSWindow.CollectionBehavior
+    ) -> NSWindow.CollectionBehavior {
+        var behavior = current
+        // Non-normal levels default to transient Mission Control behavior and
+        // ignore window cycling. Remove any explicit conflicting bits before
+        // restoring the normal-window participation the pop-out had before.
+        behavior.remove(.transient)
+        behavior.remove(.stationary)
+        behavior.remove(.ignoresCycle)
+        behavior.formUnion(self.requiredCollectionBehavior)
+        return behavior
+    }
+
+    static func configureCollectionBehavior(of window: NSWindow) {
+        window.collectionBehavior = self.collectionBehavior(preserving: window.collectionBehavior)
+    }
+
+    static func applyWindowedLevel(isPinned: Bool, to window: NSWindow) {
+        window.level = self.windowedLevel(isPinned: isPinned)
+    }
+}
+
+// MARK: - YouTubeVideoWindowFullscreenPhase
+
+enum YouTubeVideoWindowFullscreenPhase: Equatable {
+    case windowed
+    case entering
+    case fullscreen
+    case exiting
+
+    var blocksWindowedControls: Bool {
+        self != .windowed
+    }
+}
+
 // MARK: - YouTubeVideoWindowController
 
 /// Manages the floating window that hosts the YouTube video surface when
@@ -42,6 +106,7 @@ final class YouTubeVideoWindowController {
         if let existingWindow = self.window {
             self.isClosing = false
             existingWindow.title = youtubePlayerService.currentVideo?.title ?? "YouTube"
+            self.syncWindowState()
             existingWindow.orderFront(nil)
             return
         }
@@ -67,10 +132,10 @@ final class YouTubeVideoWindowController {
         window.titlebarAppearsTransparent = true
         window.titleVisibility = .hidden
         window.isMovableByWindowBackground = true
-        window.level = .normal
-        // fullScreenPrimary so the green traffic light enters fullscreen
-        // (not just zoom).
-        window.collectionBehavior = [.fullScreenPrimary]
+        self.applyDesiredWindowedLevel(to: window)
+        // Preserve normal-window Mission Control and window-cycling behavior,
+        // plus fullScreenPrimary for the green traffic light, regardless of level.
+        YouTubeVideoWindowLevelPolicy.configureCollectionBehavior(of: window)
         // Aspect + floor are enforced by the resize-guard delegate below, NOT
         // by contentAspectRatio. With both contentAspectRatio and
         // contentMinSize set, AppKit honors the aspect lock on the dragged axis
@@ -136,9 +201,38 @@ final class YouTubeVideoWindowController {
         )
         NotificationCenter.default.addObserver(
             self,
+            selector: #selector(self.windowWillExitFullScreen),
+            name: NSWindow.willExitFullScreenNotification,
+            object: window
+        )
+        NotificationCenter.default.addObserver(
+            self,
             selector: #selector(self.windowDidExitFullScreen),
             name: NSWindow.didExitFullScreenNotification,
             object: window
+        )
+    }
+
+    /// Applies the latest desired Float on Top setting to a safely windowed
+    /// pop-out. Changes made during fullscreen or either transition remain
+    /// persisted and are restored by the confirmed exit/failure callbacks.
+    func syncWindowState() {
+        guard let window = self.window else { return }
+        let isFullscreenOrTransitioning = self.youtubePlayerService?.windowFullscreenPhase.blocksWindowedControls == true
+            || window.styleMask.contains(.fullScreen)
+        guard YouTubeVideoWindowLevelPolicy.canApplyLiveChange(
+            isFullscreenOrTransitioning: isFullscreenOrTransitioning
+        ) else { return }
+
+        self.applyDesiredWindowedLevel(to: window)
+    }
+
+    /// Applies desired state on lifecycle paths that have already confirmed the
+    /// window is back in a safe windowed phase.
+    private func applyDesiredWindowedLevel(to window: NSWindow) {
+        YouTubeVideoWindowLevelPolicy.applyWindowedLevel(
+            isPinned: SettingsManager.shared.keepYouTubeVideoOnTop,
+            to: window
         )
     }
 
@@ -149,18 +243,26 @@ final class YouTubeVideoWindowController {
     /// close-time save is too late.
     @objc private func windowWillEnterFullScreen(_ notification: Notification) {
         guard let window = notification.object as? NSWindow else { return }
+        // Gate controls and ordinary level changes for the entire entry
+        // animation, rather than waiting for didEnterFullScreen.
+        self.youtubePlayerService?.windowFullscreenPhase = .entering
         self.applyFrameAutosaveTransition(.willEnterFullScreen, to: window)
     }
 
     @objc private func windowDidEnterFullScreen(_: Notification) {
-        self.youtubePlayerService?.isWindowFullscreen = true
+        self.youtubePlayerService?.windowFullscreenPhase = .fullscreen
+    }
+
+    @objc private func windowWillExitFullScreen(_: Notification) {
+        self.youtubePlayerService?.windowFullscreenPhase = .exiting
     }
 
     @objc private func windowDidExitFullScreen(_ notification: Notification) {
         if let window = notification.object as? NSWindow {
             self.applyFrameAutosaveTransition(.didExitFullScreen, to: window)
+            self.applyDesiredWindowedLevel(to: window)
         }
-        self.youtubePlayerService?.isWindowFullscreen = false
+        self.youtubePlayerService?.windowFullscreenPhase = .windowed
         if self.fullscreenIntent.consumeReturnInlineOnExit() {
             self.youtubePlayerService?.requestPopIn()
         }
@@ -169,7 +271,8 @@ final class YouTubeVideoWindowController {
     private func handleFailedFullscreenEntry(_ window: NSWindow) {
         self.applyFrameAutosaveTransition(.didFailToEnterFullScreen, to: window)
         self.fullscreenIntent.cancelReturnInlineOnExit()
-        self.youtubePlayerService?.isWindowFullscreen = false
+        self.applyDesiredWindowedLevel(to: window)
+        self.youtubePlayerService?.windowFullscreenPhase = .windowed
     }
 
     private func applyFrameAutosaveTransition(
@@ -190,8 +293,13 @@ final class YouTubeVideoWindowController {
     ///   into the app instead of leaving the pop-out window around.
     func toggleFullscreen(returnInlineOnExit: Bool = false) {
         guard let window = self.window else { return }
-        if returnInlineOnExit, !window.styleMask.contains(.fullScreen) {
-            self.fullscreenIntent.requestReturnInlineOnExit()
+        if window.styleMask.contains(.fullScreen) {
+            self.youtubePlayerService?.windowFullscreenPhase = .exiting
+        } else {
+            self.youtubePlayerService?.windowFullscreenPhase = .entering
+            if returnInlineOnExit {
+                self.fullscreenIntent.requestReturnInlineOnExit()
+            }
         }
         window.toggleFullScreen(nil)
     }
@@ -242,7 +350,7 @@ final class YouTubeVideoWindowController {
     }
 
     private func performCleanup() {
-        self.youtubePlayerService?.isWindowFullscreen = false
+        self.youtubePlayerService?.windowFullscreenPhase = .windowed
         self.fullscreenIntent.cancelReturnInlineOnExit()
         // Remove the fullscreen observers registered in show() so they don't
         // stack on the shared singleton across show/close cycles. (The willClose
@@ -257,6 +365,11 @@ final class YouTubeVideoWindowController {
             NotificationCenter.default.removeObserver(
                 self,
                 name: NSWindow.didEnterFullScreenNotification,
+                object: window
+            )
+            NotificationCenter.default.removeObserver(
+                self,
+                name: NSWindow.willExitFullScreenNotification,
                 object: window
             )
             NotificationCenter.default.removeObserver(
@@ -434,13 +547,12 @@ final class YouTubeVideoWindowResizeGuard: NSObject, NSWindowDelegate {
 
 // MARK: - YouTubeVideoWindowContent
 
-/// Floating window content: corner-to-corner video with hover-revealed
-/// chrome — a compact Liquid Glass bar over the bottom of the video and a
-/// small glass backing under the traffic lights. Cursor leaves → all
-/// chrome fades out.
+/// Floating window content: corner-to-corner video with hover-revealed player
+/// chrome and a dedicated top drag region above the WebView.
 private struct YouTubeVideoWindowContent: View {
     @Environment(YouTubePlayerService.self) private var youtubePlayer
 
+    @State private var settings = SettingsManager.shared
     @State private var isHovering = false
 
     /// Height of the top strip that moves the window. Generous enough to be
@@ -455,25 +567,20 @@ private struct YouTubeVideoWindowContent: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
 
                 if self.isHovering {
-                    // The full player bar — same items as the main window.
-                    YouTubePlayerBar()
+                    // The full player bar — same items as the main window, plus
+                    // detached-only window controls owned by YouTubePlayerBar.
+                    YouTubePlayerBar(isDetachedWindow: true)
                         .transition(.opacity)
                 }
             }
 
-            // Top drag strip: the corner-to-corner WebView reports
-            // mouseDownCanMoveWindow == false and swallows mouseDown, so the
-            // window's isMovableByWindowBackground is dead everywhere the
-            // WebView covers — leaving only the hidden titlebar sliver to grab.
-            // This native strip sits above the WebView and moves the window
-            // explicitly via NSWindow.performDrag.
+            // The corner-to-corner WebView consumes mouseDown and cannot move the
+            // window. This native strip sits above it and drives performDrag.
             WindowDragHandle()
                 .frame(maxWidth: .infinity)
                 .frame(height: Self.dragStripHeight)
                 .overlay(alignment: .top) {
                     if self.isHovering {
-                        // Subtle grab affordance so the drag region is
-                        // discoverable without cluttering the chrome-free look.
                         Capsule()
                             .fill(.white.opacity(0.35))
                             .frame(width: 36, height: 5)
@@ -485,6 +592,7 @@ private struct YouTubeVideoWindowContent: View {
         }
         .background(.black)
         .ignoresSafeArea()
+        .environment(\.usesLegacyMacOS15UI, self.settings.useLegacyMacOS15UI)
         .onHover { hovering in
             withAnimation(.easeInOut(duration: 0.18)) {
                 self.isHovering = hovering
@@ -544,10 +652,4 @@ private final class WindowDragNSView: NSView {
             self.window?.performDrag(with: event)
         }
     }
-}
-
-// MARK: - AccessibilityID Additions
-
-extension AccessibilityID.YouTubeContent {
-    static let videoWindow = "youtubeContent.videoWindow"
 }

--- a/Sources/Kaset/Views/YouTubeSettingsView.swift
+++ b/Sources/Kaset/Views/YouTubeSettingsView.swift
@@ -29,6 +29,9 @@ struct YouTubeSettingsView: View {
             }
 
             Section {
+                Toggle(String(localized: "Float on Top"), isOn: self.$settings.keepYouTubeVideoOnTop)
+                    .help(String(localized: "Keep the video above standard windows on this Space."))
+
                 Toggle(String(localized: "Pop Out Video When Navigating Away"), isOn: self.$settings.popOutVideoOnNavigateAway)
                     .help(String(localized: "Keep a playing video in a floating window when you leave the page. When off, the video stops instead."))
             } header: {

--- a/Tests/KasetTests/AccessibilityIdentifiersTests.swift
+++ b/Tests/KasetTests/AccessibilityIdentifiersTests.swift
@@ -1,0 +1,25 @@
+import Testing
+@testable import Kaset
+
+@Suite("Accessibility identifiers")
+struct AccessibilityIdentifiersTests {
+    @Test("Player window identifiers are auxiliary")
+    func playerWindowIdentifiersAreAuxiliary() {
+        #expect(AccessibilityID.isAuxiliaryPlayerWindowIdentifier(AccessibilityID.VideoWindow.container))
+        #expect(AccessibilityID.isAuxiliaryPlayerWindowIdentifier(AccessibilityID.MiniPlayer.container))
+        #expect(AccessibilityID.isAuxiliaryPlayerWindowIdentifier(AccessibilityID.YouTubeContent.videoWindow))
+    }
+
+    @Test("YouTube video window identifiers are stable")
+    func youtubeVideoWindowIdentifiersAreStable() {
+        #expect(AccessibilityID.YouTubeContent.videoWindow == "youtubeContent.videoWindow")
+        #expect(AccessibilityID.YouTubeContent.videoWindowFloatOnTop == "youtubeContent.videoWindow.floatOnTop")
+    }
+
+    @Test("Missing and unrelated identifiers are not auxiliary")
+    func missingAndUnrelatedIdentifiersAreNotAuxiliary() {
+        #expect(!AccessibilityID.isAuxiliaryPlayerWindowIdentifier(nil))
+        #expect(!AccessibilityID.isAuxiliaryPlayerWindowIdentifier(""))
+        #expect(!AccessibilityID.isAuxiliaryPlayerWindowIdentifier("unrelated.window"))
+    }
+}

--- a/Tests/KasetTests/AppActivationWindowPolicyTests.swift
+++ b/Tests/KasetTests/AppActivationWindowPolicyTests.swift
@@ -1,0 +1,33 @@
+import Testing
+@testable import Kaset
+
+@Suite("App activation window policy", .tags(.service))
+struct AppActivationWindowPolicyTests {
+    @Test("Auxiliary key windows do not reveal the main window")
+    func auxiliaryKeyWindowDoesNotRevealMainWindow() {
+        #expect(!AppActivationWindowPolicy.shouldRevealMainWindow(
+            keyWindowIdentifier: AccessibilityID.YouTubeContent.videoWindow,
+            mainWindowIdentifier: nil
+        ))
+    }
+
+    @Test("Auxiliary main windows do not reveal the main window")
+    func auxiliaryMainWindowDoesNotRevealMainWindow() {
+        #expect(!AppActivationWindowPolicy.shouldRevealMainWindow(
+            keyWindowIdentifier: nil,
+            mainWindowIdentifier: AccessibilityID.MiniPlayer.container
+        ))
+    }
+
+    @Test("Ordinary or absent active windows allow normal activation behavior")
+    func ordinaryActivationRevealsMainWindow() {
+        #expect(AppActivationWindowPolicy.shouldRevealMainWindow(
+            keyWindowIdentifier: "settings",
+            mainWindowIdentifier: nil
+        ))
+        #expect(AppActivationWindowPolicy.shouldRevealMainWindow(
+            keyWindowIdentifier: nil,
+            mainWindowIdentifier: nil
+        ))
+    }
+}

--- a/Tests/KasetTests/SettingsManagerTests.swift
+++ b/Tests/KasetTests/SettingsManagerTests.swift
@@ -93,6 +93,63 @@ struct SettingsManagerTests {
         #expect(UserDefaults.standard.bool(forKey: SettingsManager.Keys.popOutVideoOnNavigateAway) == true)
     }
 
+    @Test("Missing keepYouTubeVideoOnTop value loads as false")
+    func missingKeepYouTubeVideoOnTopLoadsAsFalse() throws {
+        let suiteName = "SettingsManagerTests.keepYouTubeVideoOnTop.missing.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.removePersistentDomain(forName: suiteName)
+
+        #expect(SettingsManager.loadKeepYouTubeVideoOnTop(from: defaults) == false)
+    }
+
+    @Test("Stored true keepYouTubeVideoOnTop value loads as true")
+    func storedTrueKeepYouTubeVideoOnTopLoadsAsTrue() throws {
+        let suiteName = "SettingsManagerTests.keepYouTubeVideoOnTop.true.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(true, forKey: SettingsManager.Keys.keepYouTubeVideoOnTop)
+
+        #expect(SettingsManager.loadKeepYouTubeVideoOnTop(from: defaults) == true)
+    }
+
+    @Test("Stored false keepYouTubeVideoOnTop value loads as false")
+    func storedFalseKeepYouTubeVideoOnTopLoadsAsFalse() throws {
+        let suiteName = "SettingsManagerTests.keepYouTubeVideoOnTop.false.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(false, forKey: SettingsManager.Keys.keepYouTubeVideoOnTop)
+
+        #expect(SettingsManager.loadKeepYouTubeVideoOnTop(from: defaults) == false)
+    }
+
+    @Test("keepYouTubeVideoOnTop persists to shared UserDefaults")
+    func keepYouTubeVideoOnTopPersists() {
+        let manager = SettingsManager.shared
+        let defaults = UserDefaults.standard
+        let key = SettingsManager.Keys.keepYouTubeVideoOnTop
+        let originalValue = manager.keepYouTubeVideoOnTop
+        let originalStoredObject = defaults.object(forKey: key)
+
+        defer {
+            manager.keepYouTubeVideoOnTop = originalValue
+            if let originalStoredObject {
+                defaults.set(originalStoredObject, forKey: key)
+            } else {
+                defaults.removeObject(forKey: key)
+            }
+        }
+
+        manager.keepYouTubeVideoOnTop = true
+        #expect(defaults.object(forKey: key) as? Bool == true)
+
+        manager.keepYouTubeVideoOnTop = false
+        #expect(defaults.object(forKey: key) as? Bool == false)
+    }
+
     @Test("Disabling rememberPlaybackSettings clears persisted values")
     func disablingRememberPlaybackSettingsClearsValues() {
         let manager = SettingsManager.shared

--- a/Tests/KasetTests/YouTubePlayerBarTests.swift
+++ b/Tests/KasetTests/YouTubePlayerBarTests.swift
@@ -5,6 +5,52 @@ import Testing
 @Suite("YouTube player bar", .tags(.model))
 @MainActor
 struct YouTubePlayerBarTests {
+    @Test("Float on Top control appears for a windowed floating surface")
+    func floatOnTopControlAppearsForWindowedFloatingSurface() {
+        #expect(YouTubePlayerBar.shouldShowFloatOnTopControl(
+            isDetachedWindow: true,
+            surfaceLocation: .floating,
+            isFullscreenOrTransitioning: false
+        ))
+    }
+
+    @Test("Float on Top control stays hidden outside a windowed floating surface")
+    func floatOnTopControlStaysHiddenOutsideWindowedFloatingSurface() {
+        #expect(!YouTubePlayerBar.shouldShowFloatOnTopControl(
+            isDetachedWindow: true,
+            surfaceLocation: .none,
+            isFullscreenOrTransitioning: false
+        ))
+        #expect(!YouTubePlayerBar.shouldShowFloatOnTopControl(
+            isDetachedWindow: true,
+            surfaceLocation: .inline,
+            isFullscreenOrTransitioning: false
+        ))
+        #expect(!YouTubePlayerBar.shouldShowFloatOnTopControl(
+            isDetachedWindow: true,
+            surfaceLocation: .floating,
+            isFullscreenOrTransitioning: true
+        ))
+        #expect(!YouTubePlayerBar.shouldShowFloatOnTopControl(
+            isDetachedWindow: false,
+            surfaceLocation: .floating,
+            isFullscreenOrTransitioning: false
+        ))
+    }
+
+    @Test("Float on Top control width extends the details-hiding breakpoint")
+    func floatOnTopControlWidthExtendsDetailsHidingBreakpoint() {
+        let standardBreakpoint = YouTubePlayerBar.hiddenVideoDetailsBreakpoint(
+            showsFloatOnTopControl: false
+        )
+        let pinnedWindowBreakpoint = YouTubePlayerBar.hiddenVideoDetailsBreakpoint(
+            showsFloatOnTopControl: true
+        )
+
+        #expect(standardBreakpoint == 580)
+        #expect(pinnedWindowBreakpoint - standardBreakpoint == 34)
+    }
+
     @Test("Chapter segments resolve explicit, next-chapter, and duration end times")
     func chapterSegmentsResolveEndTimes() throws {
         let chapters = [

--- a/Tests/KasetTests/YouTubeVideoWindowLevelPolicyTests.swift
+++ b/Tests/KasetTests/YouTubeVideoWindowLevelPolicyTests.swift
@@ -1,0 +1,64 @@
+import AppKit
+import Testing
+@testable import Kaset
+
+@Suite("YouTube video window level policy", .serialized, .tags(.service))
+@MainActor
+struct YouTubeVideoWindowLevelPolicyTests {
+    @Test("Windowed unpinned state uses the normal level")
+    func unpinnedUsesNormalLevel() {
+        #expect(YouTubeVideoWindowLevelPolicy.windowedLevel(isPinned: false) == .normal)
+    }
+
+    @Test("Windowed pinned state uses the floating level")
+    func pinnedUsesFloatingLevel() {
+        #expect(YouTubeVideoWindowLevelPolicy.windowedLevel(isPinned: true) == .floating)
+    }
+
+    @Test("Live changes are allowed only outside fullscreen and transitions")
+    func liveChangeGating() {
+        #expect(YouTubeVideoWindowLevelPolicy.canApplyLiveChange(isFullscreenOrTransitioning: false))
+        #expect(!YouTubeVideoWindowLevelPolicy.canApplyLiveChange(isFullscreenOrTransitioning: true))
+    }
+
+    @Test("Fullscreen phases gate windowed controls across both transitions")
+    func fullscreenPhaseGating() {
+        #expect(!YouTubeVideoWindowFullscreenPhase.windowed.blocksWindowedControls)
+        #expect(YouTubeVideoWindowFullscreenPhase.entering.blocksWindowedControls)
+        #expect(YouTubeVideoWindowFullscreenPhase.fullscreen.blocksWindowedControls)
+        #expect(YouTubeVideoWindowFullscreenPhase.exiting.blocksWindowedControls)
+    }
+
+    @Test("Float on Top controls require a windowed floating surface")
+    func controlAvailability() {
+        #expect(YouTubeVideoWindowLevelPolicy.canToggleFloatOnTop(
+            isFloating: true,
+            isFullscreenOrTransitioning: false
+        ))
+        #expect(!YouTubeVideoWindowLevelPolicy.canToggleFloatOnTop(
+            isFloating: false,
+            isFullscreenOrTransitioning: false
+        ))
+        #expect(!YouTubeVideoWindowLevelPolicy.canToggleFloatOnTop(
+            isFloating: true,
+            isFullscreenOrTransitioning: true
+        ))
+    }
+
+    @Test("Collection behavior preserves normal-window Mission Control and cycling behavior")
+    func collectionBehaviorPreservesNormalWindowParticipation() {
+        let behavior = YouTubeVideoWindowLevelPolicy.collectionBehavior(preserving: [
+            .moveToActiveSpace,
+            .transient,
+            .ignoresCycle,
+        ])
+
+        #expect(behavior.contains(.moveToActiveSpace))
+        #expect(behavior.contains(.managed))
+        #expect(behavior.contains(.participatesInCycle))
+        #expect(behavior.contains(.fullScreenPrimary))
+        #expect(!behavior.contains(.transient))
+        #expect(!behavior.contains(.stationary))
+        #expect(!behavior.contains(.ignoresCycle))
+    }
+}

--- a/docs/youtube.md
+++ b/docs/youtube.md
@@ -172,6 +172,24 @@ KasetApp observes `surfaceLocation` and opens/closes the floating window;
 `NSView` reparenting (`ensureInHierarchy`) moves the WebView between
 containers without interrupting playback.
 
+### Float on Top
+
+When enabled, the regular YouTube pop-out stays above standard windows on its
+current Space. **Float on Top** is off by default and persists across pop-out
+closure and app relaunch. It can be changed from any of these synchronized
+controls:
+
+- Settings → YouTube → Video Window → Float on Top.
+- View → Float on Top while the pop-out is active.
+- The pin control in the detached player bar.
+
+Float on Top affects only the normal windowed pop-out. Fullscreen and pop-in
+behavior remain unchanged from the user's perspective. Visibility is not
+guaranteed across different Spaces or Stage Manager sets, above higher-level
+windows, or over another application's fullscreen Space. The setting applies
+only to the regular YouTube pop-out; YouTube Music's separate video window is
+unchanged.
+
 ### Shorts
 
 The Shorts surface is a vertical snap-paging player: opening it


### PR DESCRIPTION
## Summary

- add a persisted, default-off **Float on Top** preference for the regular YouTube pop-out
- expose the setting in YouTube Settings, the View menu, and a detached-only pin in the player bar
- defer window-level changes during fullscreen transitions and restore the latest preference afterward
- preserve Mission Control and window-cycling behavior while the pop-out uses a floating window level
- classify the regular YouTube pop-out as an auxiliary player window so interacting with it does not reopen a hidden main window
- add localization, documentation, accessibility identifiers, and focused regression coverage

YouTube Music’s separate video window is unchanged.

## Validation

- `swiftformat .`
- `swiftlint --strict`
- `swift build`
- `swift test --skip KasetUITests --no-parallel` — 2,742 tests passed
- `Scripts/build-app.sh debug`
- `Scripts/verify-release-app.sh .build/app/Kaset.app`
- integrated autoreview — clean, no actionable findings

Fixes #353

Related: #413 (duplicate request that motivated the detached player-bar pin control)