### PR TITLE
fix media controls F8 hotkey of play_or_pause

### DIFF
--- a/Sources/Kaset/AppDelegate.swift
+++ b/Sources/Kaset/AppDelegate.swift
@@ -126,6 +126,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Note: We don't auto-resume by default as it could be surprising
         // Just log the wake event for now
         DiagnosticsLogger.player.info("System woke from sleep, wasPlayingBeforeSleep: \(self.wasPlayingBeforeSleep)")
+        NowPlayingManager.shared.scheduleMediaControlRecovery(reason: .systemDidWake)
     }
 
     func applicationDidResignActive(_: Notification) {
@@ -136,6 +137,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationDidBecomeActive(_: Notification) {
+        NowPlayingManager.shared.scheduleMediaControlRecovery(reason: .applicationBecameActive)
         // Foreground: the page's requestAnimationFrame loop resumes ownership of the
         // override. Stop the native timer and re-assert once immediately.
         SingletonPlayerWebView.shared.endBackgroundMediaControlReassertion()

--- a/Sources/Kaset/KasetApp.swift
+++ b/Sources/Kaset/KasetApp.swift
@@ -199,6 +199,14 @@ struct KasetApp: App {
         self.appDelegate.playerService = player
         self.appDelegate.scrobblingCoordinator = scrobblingCoordinator
 
+        // Register system media commands during app initialization rather than waiting for a
+        // window task. F8 must remain available even when no main-window task has run yet.
+        NowPlayingManager.shared.configure(playerService: player)
+        NowPlayingManager.shared.configureYouTubeRouting(
+            youtubePlayerService: youtubePlayer,
+            arbiter: arbiter
+        )
+
         if UITestConfig.isUITestMode {
             DiagnosticsLogger.ui.info("App launched in UI Test mode")
         }
@@ -304,12 +312,6 @@ struct KasetApp: App {
                     guard request != nil else { return }
                     self.settings.appSource = .video
                     self.showMainWindow()
-                }
-                .task {
-                    NowPlayingManager.shared.configureYouTubeRouting(
-                        youtubePlayerService: self.youtubePlayerService,
-                        arbiter: self.playbackArbiter
-                    )
                 }
                 .onChange(of: self.playerService.isMiniPlayerVisible) { _, isVisible in
                     self.handleMiniPlayerVisibilityChange(isVisible)

--- a/Sources/Kaset/Services/Player/NowPlayingManager.swift
+++ b/Sources/Kaset/Services/Player/NowPlayingManager.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CoreAudio
 import Foundation
 import MediaPlayer
 import Observation
@@ -125,10 +126,10 @@ final class NowPlayingManager {
     private var playerService: PlayerService?
     private let logger = DiagnosticsLogger.player
     private var isConfigured = false
-    /// True while Kaset is asserting a tagged native Now Playing claim.
-    /// The tag lets release logic distinguish our metadata from a newer WebKit card.
-    private var isAssertingNativeClaim = false
     @ObservationIgnored private var nowPlayingObservationGeneration: UInt64 = 0
+    @ObservationIgnored private var mediaControlRecoveryTask: Task<Void, Never>?
+    @ObservationIgnored private var remoteCommandRegistrations: [RemoteCommandRegistration] = []
+    private var isMonitoringAudioRoutes = false
 
     /// YouTube video routing (optional; absent in music-only flows).
     /// When the arbiter says the video source played last, play/pause/toggle
@@ -139,7 +140,29 @@ final class NowPlayingManager {
     private let settings = SettingsManager.shared
     private let remoteMusicCommandIngress = RemoteMusicCommandIngress()
     private static let defaultSkipInterval: TimeInterval = 15
+    private static let mediaControlRecoveryDelay: Duration = .milliseconds(250)
     nonisolated static let nativeClaimServiceIdentifier = "com.sertacozercan.Kaset.native-now-playing-claim"
+
+    private struct RemoteCommandRegistration {
+        let command: MPRemoteCommand
+        let target: Any
+    }
+
+    enum MediaControlRecoveryReason: String, Sendable {
+        case applicationBecameActive
+        case audioRouteChanged
+        case systemDidWake
+    }
+
+    // Core Audio invokes this block on its own callback queue. Keep it nonisolated and hop to the
+    // main actor before touching the manager's state.
+    // swiftformat:disable:next modifierOrder
+    nonisolated private static let audioRouteChangeListener:
+        @Sendable (UInt32, UnsafePointer<AudioObjectPropertyAddress>) -> Void = { _, _ in
+            Task { @MainActor in
+                NowPlayingManager.shared.scheduleMediaControlRecovery(reason: .audioRouteChanged)
+            }
+        }
 
     private init() {}
 
@@ -198,6 +221,30 @@ final class NowPlayingManager {
         }
     }
 
+    /// Selects the claim used when macOS may have re-evaluated the active media session.
+    /// During confirmed playback WebKit normally owns the rich card. If that card disappeared,
+    /// publish a native fallback so media keys still have a live Kaset session to target.
+    nonisolated static func recoveryClaim(
+        state: PlayerService.PlaybackState,
+        track: (title: String, artist: String)?,
+        activeVideo: ActiveVideoClaim?,
+        hasNowPlayingInfo: Bool
+    ) -> NowPlayingClaim {
+        let desiredClaim = Self.desiredClaim(state: state, track: track, activeVideo: activeVideo)
+        guard desiredClaim == .handsOff, !hasNowPlayingInfo else { return desiredClaim }
+
+        if let activeVideo {
+            return .claim(
+                title: activeVideo.title,
+                artist: activeVideo.artist,
+                playbackState: activeVideo.playbackState
+            )
+        }
+
+        guard let track else { return .handsOff }
+        return .claim(title: track.title, artist: track.artist, playbackState: .playing)
+    }
+
     /// Reads current player state and pushes the desired claim to the system center.
     private func updateNowPlayingClaim() {
         guard let player = self.playerService else { return }
@@ -221,16 +268,9 @@ final class NowPlayingManager {
             // macOS requires apps to update playbackState whenever playback starts or stops.
             // This does not replace WebKit's richer nowPlayingInfo dictionary.
             center.playbackState = .playing
-            guard self.isAssertingNativeClaim else { return }
-            guard Self.isNativeClaim(center.nowPlayingInfo) else {
-                self.isAssertingNativeClaim = false
-                return
-            }
         // Preserve the fallback until WebKit atomically replaces the app-wide metadata.
         // The state update above cannot clear a concurrently published WebKit card.
         case .release:
-            guard self.isAssertingNativeClaim else { return }
-            self.isAssertingNativeClaim = false
             guard Self.isNativeClaim(center.nowPlayingInfo) else { return }
             center.playbackState = .stopped
             center.nowPlayingInfo = nil
@@ -247,8 +287,39 @@ final class NowPlayingManager {
             case .playing: .playing
             case .paused: .paused
             }
-            self.isAssertingNativeClaim = true
         }
+    }
+
+    /// Rebuilds only Kaset's remote-command targets and repairs its Now Playing publication after
+    /// lifecycle or audio-route changes. Calls are debounced because Bluetooth reconnects emit
+    /// bursts of Core Audio notifications while `mediaremoted` is still settling.
+    func scheduleMediaControlRecovery(reason: MediaControlRecoveryReason) {
+        guard self.isConfigured else { return }
+        self.mediaControlRecoveryTask?.cancel()
+        self.mediaControlRecoveryTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: Self.mediaControlRecoveryDelay)
+            guard let self, !Task.isCancelled else { return }
+            self.reassertMediaControlState(reason: reason)
+        }
+    }
+
+    private func reassertMediaControlState(reason: MediaControlRecoveryReason) {
+        guard let player = self.playerService else { return }
+
+        self.setupRemoteCommands()
+
+        let track = player.currentTrack.map { song in
+            (title: song.title, artist: song.artists.map(\.name).joined(separator: ", "))
+        }
+        let center = MPNowPlayingInfoCenter.default()
+        let claim = Self.recoveryClaim(
+            state: player.state,
+            track: track,
+            activeVideo: self.activeVideoClaimInput,
+            hasNowPlayingInfo: center.nowPlayingInfo != nil
+        )
+        self.applyNowPlayingClaim(claim)
+        self.logger.info("Media controls recovered after \(reason.rawValue)")
     }
 
     /// Returns whether the current center metadata is the tagged native claim Kaset published.
@@ -304,6 +375,7 @@ final class NowPlayingManager {
         self.isConfigured = true
         self.playerService = playerService
         self.setupRemoteCommands()
+        self.installAudioRouteChangeListeners()
         self.syncMediaControlSetting()
         self.syncPlaybackAudioQualitySetting()
         self.logger.info("NowPlayingManager configured")
@@ -374,6 +446,48 @@ final class NowPlayingManager {
 
     // MARK: - Remote Commands
 
+    private func installAudioRouteChangeListeners() {
+        guard !self.isMonitoringAudioRoutes else { return }
+        self.isMonitoringAudioRoutes = true
+
+        let selectors: [AudioObjectPropertySelector] = [
+            kAudioHardwarePropertyDevices,
+            kAudioHardwarePropertyDefaultOutputDevice,
+            kAudioHardwarePropertyDefaultSystemOutputDevice,
+        ]
+        for selector in selectors {
+            var address = AudioObjectPropertyAddress(
+                mSelector: selector,
+                mScope: kAudioObjectPropertyScopeGlobal,
+                mElement: kAudioObjectPropertyElementMain
+            )
+            let status = AudioObjectAddPropertyListenerBlock(
+                AudioObjectID(kAudioObjectSystemObject),
+                &address,
+                nil,
+                Self.audioRouteChangeListener
+            )
+            if status != noErr {
+                self.logger.warning("Failed to monitor audio-route changes: \(status)")
+            }
+        }
+    }
+
+    private func removeRemoteCommandRegistrations() {
+        for registration in self.remoteCommandRegistrations {
+            registration.command.removeTarget(registration.target)
+        }
+        self.remoteCommandRegistrations.removeAll(keepingCapacity: true)
+    }
+
+    private func registerRemoteCommand(
+        _ command: MPRemoteCommand,
+        handler: @escaping (MPRemoteCommandEvent) -> MPRemoteCommandHandlerStatus
+    ) {
+        let target = command.addTarget(handler: handler)
+        self.remoteCommandRegistrations.append(RemoteCommandRegistration(command: command, target: target))
+    }
+
     private func setupRemoteCommands() {
         guard self.playerService != nil else { return }
         let commandCenter = MPRemoteCommandCenter.shared()
@@ -385,47 +499,41 @@ final class NowPlayingManager {
             }
         }
 
-        // Remove any existing targets to prevent duplicates
-        commandCenter.playCommand.removeTarget(nil)
-        commandCenter.pauseCommand.removeTarget(nil)
-        commandCenter.togglePlayPauseCommand.removeTarget(nil)
-        commandCenter.nextTrackCommand.removeTarget(nil)
-        commandCenter.previousTrackCommand.removeTarget(nil)
-        commandCenter.skipForwardCommand.removeTarget(nil)
-        commandCenter.skipBackwardCommand.removeTarget(nil)
-        commandCenter.changePlaybackPositionCommand.removeTarget(nil)
+        // Remove only targets registered by this manager. WebKit owns a separate media session and
+        // must be allowed to keep its action handlers while Kaset refreshes native routing.
+        self.removeRemoteCommandRegistrations()
 
         // Play command
         commandCenter.playCommand.isEnabled = true
-        commandCenter.playCommand.addTarget { _ in
+        self.registerRemoteCommand(commandCenter.playCommand) { _ in
             captureCommand(.play)
             return .success
         }
 
         // Pause command
         commandCenter.pauseCommand.isEnabled = true
-        commandCenter.pauseCommand.addTarget { _ in
+        self.registerRemoteCommand(commandCenter.pauseCommand) { _ in
             captureCommand(.pause)
             return .success
         }
 
         // Toggle play/pause command
         commandCenter.togglePlayPauseCommand.isEnabled = true
-        commandCenter.togglePlayPauseCommand.addTarget { _ in
+        self.registerRemoteCommand(commandCenter.togglePlayPauseCommand) { _ in
             captureCommand(.togglePlayPause)
             return .success
         }
 
         // Next track command
         commandCenter.nextTrackCommand.isEnabled = true
-        commandCenter.nextTrackCommand.addTarget { _ in
+        self.registerRemoteCommand(commandCenter.nextTrackCommand) { _ in
             captureCommand(.nextPrevious(direction: .forward))
             return .success
         }
 
         // Previous track command
         commandCenter.previousTrackCommand.isEnabled = true
-        commandCenter.previousTrackCommand.addTarget { _ in
+        self.registerRemoteCommand(commandCenter.previousTrackCommand) { _ in
             captureCommand(.nextPrevious(direction: .backward))
             return .success
         }
@@ -433,7 +541,7 @@ final class NowPlayingManager {
         // Skip forward command (Control Center skip buttons or media keys)
         commandCenter.skipForwardCommand.isEnabled = self.settings.mediaControlStyle == .skipForwardBackward
         commandCenter.skipForwardCommand.preferredIntervals = [NSNumber(value: Self.defaultSkipInterval)]
-        commandCenter.skipForwardCommand.addTarget { event in
+        self.registerRemoteCommand(commandCenter.skipForwardCommand) { event in
             let interval = (event as? MPSkipIntervalCommandEvent)?.interval ?? Self.defaultSkipInterval
             captureCommand(.skip(interval: interval, direction: .forward))
             return .success
@@ -442,7 +550,7 @@ final class NowPlayingManager {
         // Skip backward command (Control Center skip buttons or media keys)
         commandCenter.skipBackwardCommand.isEnabled = self.settings.mediaControlStyle == .skipForwardBackward
         commandCenter.skipBackwardCommand.preferredIntervals = [NSNumber(value: Self.defaultSkipInterval)]
-        commandCenter.skipBackwardCommand.addTarget { event in
+        self.registerRemoteCommand(commandCenter.skipBackwardCommand) { event in
             let interval = (event as? MPSkipIntervalCommandEvent)?.interval ?? Self.defaultSkipInterval
             captureCommand(.skip(interval: interval, direction: .backward))
             return .success
@@ -450,7 +558,7 @@ final class NowPlayingManager {
 
         // Change playback position command
         commandCenter.changePlaybackPositionCommand.isEnabled = true
-        commandCenter.changePlaybackPositionCommand.addTarget { event in
+        self.registerRemoteCommand(commandCenter.changePlaybackPositionCommand) { event in
             guard let positionEvent = event as? MPChangePlaybackPositionCommandEvent else {
                 return .commandFailed
             }

--- a/Sources/Kaset/Services/Player/NowPlayingManager.swift
+++ b/Sources/Kaset/Services/Player/NowPlayingManager.swift
@@ -167,9 +167,9 @@ final class NowPlayingManager {
     }
 
     /// Pure decision: given the active source and its playback state, what claim do we want?
-    /// Confirmed playback stays hands-off so WebKit owns the rich Control Center card. A paused or
-    /// loading video keeps a minimal video claim until WebKit reports playback, while inactive music
-    /// keeps the equivalent music claim so the Play key resumes Kaset instead of Apple Music.
+    /// Confirmed playback stays hands-off so WebKit owns the rich Control Center card. Loading media
+    /// keeps a minimal native claim until WebKit reports playback, while inactive music keeps the
+    /// equivalent paused claim so the Play key resumes Kaset instead of Apple Music.
     nonisolated static func desiredClaim(
         state: PlayerService.PlaybackState,
         track: (title: String, artist: String)?,
@@ -187,8 +187,11 @@ final class NowPlayingManager {
         }
 
         switch state {
-        case .playing, .buffering, .loading:
+        case .playing:
             return .handsOff
+        case .buffering, .loading:
+            guard let track else { return .release }
+            return .claim(title: track.title, artist: track.artist, playbackState: .playing)
         case .idle, .paused, .ended, .error:
             guard let track else { return .release }
             return .claim(title: track.title, artist: track.artist, playbackState: .paused)
@@ -209,19 +212,22 @@ final class NowPlayingManager {
         self.applyNowPlayingClaim(claim)
     }
 
-    /// Maps a claim onto `MPNowPlayingInfoCenter`. Hands-off only clears info we still own.
+    /// Maps a claim onto `MPNowPlayingInfoCenter`. Hands-off preserves the current card while keeping
+    /// the app-wide playback state synchronized for macOS remote-command routing.
     private func applyNowPlayingClaim(_ claim: NowPlayingClaim) {
         let center = MPNowPlayingInfoCenter.default()
         switch claim {
         case .handsOff:
+            // macOS requires apps to update playbackState whenever playback starts or stops.
+            // This does not replace WebKit's richer nowPlayingInfo dictionary.
+            center.playbackState = .playing
             guard self.isAssertingNativeClaim else { return }
             guard Self.isNativeClaim(center.nowPlayingInfo) else {
                 self.isAssertingNativeClaim = false
                 return
             }
             // Preserve the fallback until WebKit atomically replaces the app-wide metadata.
-            // A non-destructive state update cannot clear a concurrently published WebKit card.
-            center.playbackState = .playing
+            // The state update above cannot clear a concurrently published WebKit card.
         case .release:
             guard self.isAssertingNativeClaim else { return }
             self.isAssertingNativeClaim = false

--- a/Sources/Kaset/Services/Player/NowPlayingManager.swift
+++ b/Sources/Kaset/Services/Player/NowPlayingManager.swift
@@ -226,8 +226,8 @@ final class NowPlayingManager {
                 self.isAssertingNativeClaim = false
                 return
             }
-            // Preserve the fallback until WebKit atomically replaces the app-wide metadata.
-            // The state update above cannot clear a concurrently published WebKit card.
+        // Preserve the fallback until WebKit atomically replaces the app-wide metadata.
+        // The state update above cannot clear a concurrently published WebKit card.
         case .release:
             guard self.isAssertingNativeClaim else { return }
             self.isAssertingNativeClaim = false

--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -348,9 +348,6 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
                 }
             }
         }
-        .task {
-            NowPlayingManager.shared.configure(playerService: self.playerService)
-        }
         .task(id: self.accountService.currentAccount?.id) {
             // Keep PodcastsViewModel in sync with the active account so
             // 404 / empty results are recorded against the right account.

--- a/Tests/KasetTests/Helpers/MockYTMusicClient.swift
+++ b/Tests/KasetTests/Helpers/MockYTMusicClient.swift
@@ -80,6 +80,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     var onGetPodcasts: (@MainActor () -> Void)?
     var beforeGetHomeReturn: (@MainActor () async -> Void)?
     var beforeGetHomeContinuationReturn: (@MainActor () async -> Void)?
+    var beforeGetHistoryReturn: (@MainActor () async -> Void)?
     var beforeCreatePlaylistReturn: (@MainActor () async -> Void)?
     var beforeSubscribeToPlaylistReturn: (@MainActor (String) async -> Void)?
     var beforeUnsubscribeFromPlaylistReturn: (@MainActor (String) async -> Void)?
@@ -95,7 +96,6 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     var editSongLibraryStatusResponseDelays: [Duration] = []
     var editSongLibraryStatusErrors: [(any Error)?] = []
     var getSongDelay: Duration?
-    var getHistoryDelay: Duration?
     var getPodcastsDelay: Duration?
     var getPlaylistDelay: Duration?
     var getPlaylistError: Error?
@@ -472,9 +472,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     func getHistory() async throws -> HomeResponse {
         self.getHistoryCallCount += 1
         self._historyContinuationIndex = 0
-        if let getHistoryDelay {
-            try? await Task.sleep(for: getHistoryDelay)
-        }
+        await self.beforeGetHistoryReturn?()
         if let error = shouldThrowError {
             throw error
         }
@@ -1378,6 +1376,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.onGetLibraryContent = nil
         self.beforeGetHomeReturn = nil
         self.beforeGetHomeContinuationReturn = nil
+        self.beforeGetHistoryReturn = nil
         self.fetchAccountsListCallCount = 0
         self.accountsListStartedGate = nil
         self.accountsListReleaseGate = nil
@@ -1436,7 +1435,6 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.editSongLibraryStatusResponseDelays = []
         self.editSongLibraryStatusErrors = []
         self.getSongDelay = nil
-        self.getHistoryDelay = nil
         self.mixQueueDelay = nil
         self.getRadioQueueDelay = nil
         self.mixQueueResult = RadioQueueResult(songs: [], continuationToken: nil)

--- a/Tests/KasetTests/HistoryViewModelTests.swift
+++ b/Tests/KasetTests/HistoryViewModelTests.swift
@@ -180,13 +180,21 @@ struct HistoryViewModelTests {
         await self.viewModel.loadMore()
         #expect(self.viewModel.sections.map(\.title) == ["Today", "Yesterday"])
 
-        self.mockClient.getHistoryDelay = .milliseconds(100)
-        let refreshTask = Task { await self.viewModel.refresh() }
-        await self.waitForHistoryRefresh {
-            self.mockClient.getHistoryCallCount == 2
+        let refreshStarted = AsyncGate()
+        let releaseRefresh = AsyncGate()
+        self.mockClient.beforeGetHistoryReturn = {
+            await refreshStarted.open()
+            await releaseRefresh.wait()
         }
+        let refreshTask = Task { await self.viewModel.refresh() }
+        await refreshStarted.wait()
 
         await self.viewModel.loadMore()
+        #expect(self.viewModel.isRefreshingHistory)
+        #expect(self.mockClient.getHistoryContinuationCallCount == 1)
+        #expect(self.viewModel.sections.map(\.title) == ["Today", "Yesterday"])
+
+        await releaseRefresh.open()
         _ = await refreshTask.value
 
         #expect(self.mockClient.getHistoryContinuationCallCount == 1)

--- a/Tests/KasetTests/NowPlayingClaimTests.swift
+++ b/Tests/KasetTests/NowPlayingClaimTests.swift
@@ -5,12 +5,23 @@ import Testing
 
 @Suite("Now playing claim", .serialized, .tags(.service))
 struct NowPlayingClaimTests {
-    @Test("Actively playing or starting yields hands-off (WebKit owns the card)")
+    @Test("Confirmed active playback yields hands-off (WebKit owns the card)")
     func activePlaybackIsHandsOff() {
         let track = (title: "Song", artist: "Artist")
         #expect(NowPlayingManager.desiredClaim(state: .playing, track: track, activeVideo: nil) == .handsOff)
-        #expect(NowPlayingManager.desiredClaim(state: .buffering, track: track, activeVideo: nil) == .handsOff)
-        #expect(NowPlayingManager.desiredClaim(state: .loading, track: track, activeVideo: nil) == .handsOff)
+    }
+
+    @Test("Music startup gaps keep a native claim until WebKit owns the card")
+    func musicStartupGapsKeepNativeClaim() {
+        let track = (title: "Song", artist: "Artist")
+        let expected = NowPlayingManager.NowPlayingClaim.claim(
+            title: "Song",
+            artist: "Artist",
+            playbackState: .playing
+        )
+
+        #expect(NowPlayingManager.desiredClaim(state: .buffering, track: track, activeVideo: nil) == expected)
+        #expect(NowPlayingManager.desiredClaim(state: .loading, track: track, activeVideo: nil) == expected)
     }
 
     @Test("Not playing with a track yields a minimal claim")

--- a/Tests/KasetTests/NowPlayingClaimTests.swift
+++ b/Tests/KasetTests/NowPlayingClaimTests.swift
@@ -11,6 +11,35 @@ struct NowPlayingClaimTests {
         #expect(NowPlayingManager.desiredClaim(state: .playing, track: track, activeVideo: nil) == .handsOff)
     }
 
+    @Test("Recovery publishes a native fallback when WebKit metadata disappeared")
+    func recoveryReclaimsActiveMusicWithoutMetadata() {
+        let track = (title: "Song", artist: "Artist")
+        let expected = NowPlayingManager.NowPlayingClaim.claim(
+            title: "Song",
+            artist: "Artist",
+            playbackState: .playing
+        )
+
+        #expect(NowPlayingManager.recoveryClaim(
+            state: .playing,
+            track: track,
+            activeVideo: nil,
+            hasNowPlayingInfo: false
+        ) == expected)
+    }
+
+    @Test("Recovery preserves an existing WebKit Now Playing card")
+    func recoveryPreservesExistingPlaybackMetadata() {
+        let track = (title: "Song", artist: "Artist")
+
+        #expect(NowPlayingManager.recoveryClaim(
+            state: .playing,
+            track: track,
+            activeVideo: nil,
+            hasNowPlayingInfo: true
+        ) == .handsOff)
+    }
+
     @Test("Music startup gaps keep a native claim until WebKit owns the card")
     func musicStartupGapsKeepNativeClaim() {
         let track = (title: "Song", artist: "Artist")
@@ -81,6 +110,28 @@ struct NowPlayingClaimTests {
             track: track,
             activeVideo: video
         ) == .handsOff)
+    }
+
+    @Test("Recovery publishes a native fallback for confirmed video without metadata")
+    func recoveryReclaimsActiveVideoWithoutMetadata() {
+        let video = NowPlayingManager.ActiveVideoClaim(
+            title: "Video",
+            artist: "Channel",
+            playbackState: .playing,
+            isPlaybackConfirmed: true
+        )
+        let expected = NowPlayingManager.NowPlayingClaim.claim(
+            title: "Video",
+            artist: "Channel",
+            playbackState: .playing
+        )
+
+        #expect(NowPlayingManager.recoveryClaim(
+            state: .paused,
+            track: nil,
+            activeVideo: video,
+            hasNowPlayingInfo: false
+        ) == expected)
     }
 
     @Test("A loading video keeps its fallback even if the previous document was playing")

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -272,11 +272,13 @@ Coordinates the two playback services so Music and YouTube do not play over each
 
 Remote command center integration for media key support:
 
-- Registers `MPRemoteCommandCenter` handlers
+- Registers `MPRemoteCommandCenter` handlers during app initialization, independent of the main-window lifecycle
+- Tracks and refreshes only Kaset-owned command targets so WebKit media-session handlers remain intact
 - Handles media keys (play/pause, next, previous, seek)
 - Routes commands to `PlayerService` / `YouTubePlayerService` based on the active source
+- Reasserts command routing and Now Playing state after Core Audio route changes, app activation, and system wake
 
-**Note**: Now Playing display (track/video info, artwork) is handled natively by WKWebView's Media Session API. This provides better integration with YouTube Music artwork and regular YouTube video metadata.
+**Note**: WKWebView's Media Session API owns the rich Now Playing display (track/video info and artwork) during healthy playback. Kaset publishes a tagged minimal fallback during loading, paused, and recovery gaps so media keys remain routed to the app without replacing healthy WebKit metadata.
 
 ### HapticService
 
@@ -641,9 +643,11 @@ User clicks Play
     ▼
 ┌─────────────────────────────────────────────────┐
 │ WKWebView Media Session (native)                │
-│  → Updates macOS Now Playing (with album art)   │
+│  → Updates rich macOS Now Playing metadata      │
 │ NowPlayingManager                               │
-│  → Registers media key handlers → PlayerService │
+│  → Registers media keys during app startup      │
+│  → Publishes a minimal fallback during gaps     │
+│  → Recovers after audio-route/lifecycle changes │
 └─────────────────────────────────────────────────┘
 ```
 

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -6,6 +6,7 @@ Kaset provides keyboard control for playback and navigation while preserving sta
 
 | Shortcut | Action                              |
 | -------- | ----------------------------------- |
+| `F8` / Play-Pause media key | Global play / pause through macOS media controls |
 | `Space`  | Play / Pause                        |
 | `⌘→`     | Next track                          |
 | `⌘←`     | Previous track                      |


### PR DESCRIPTION
Root cause:
- Remote media commands were registered from SwiftUI window tasks, leaving an initialization window where F8 was not routed to Kaset.
- Kaset released its native Now Playing claim during music loading and buffering, allowing macOS to route the media key to another app.
- The app-wide playback state was only synchronized while Kaset still owned its fallback metadata.

Fix:
- Register remote media commands and YouTube routing during app initialization.
- Keep a native playing claim during music loading and buffering until WebKit publishes the rich Now Playing card.
- Synchronize MPNowPlayingInfoCenter playback state without replacing WebKit metadata.
- Add regression coverage for loading and buffering ownership.