### PR TITLE
fix(lyrics): prevent Bengali romanizer crash on mixed-script text

### DIFF
--- a/Sources/Kaset/Services/Lyrics/Romanization/Romanizers/BengaliRomanizer.swift
+++ b/Sources/Kaset/Services/Lyrics/Romanization/Romanizers/BengaliRomanizer.swift
@@ -4,6 +4,7 @@ import Foundation
 enum BengaliRomanizer {
     static func romanize(_ text: String) -> String? {
         let cfText = text as CFString
+        let nsText = text as NSString
         let range = CFRangeMake(0, CFStringGetLength(cfText))
         let locale = Locale(identifier: "bn") as CFLocale
 
@@ -31,9 +32,10 @@ enum BengaliRomanizer {
                 result += latin
             } else {
                 let tokenRange = CFStringTokenizerGetCurrentTokenRange(tokenizer)
-                let start = text.index(text.startIndex, offsetBy: tokenRange.location)
-                let end = text.index(start, offsetBy: tokenRange.length)
-                let token = String(text[start ..< end])
+                let token = nsText.substring(with: NSRange(
+                    location: tokenRange.location,
+                    length: tokenRange.length
+                ))
                 result += token
             }
             tokenType = CFStringTokenizerAdvanceToNextToken(tokenizer)

--- a/Tests/KasetTests/RomanizationTests.swift
+++ b/Tests/KasetTests/RomanizationTests.swift
@@ -174,6 +174,51 @@ struct JapaneseRomanizerTests {
     }
 }
 
+// MARK: - BengaliRomanizerTests
+
+struct BengaliRomanizerTests {
+    @Test("Pure Bengali romanizes to non-empty text")
+    func pureBengali() throws {
+        // Control: the fix only touches the no-transcription fallback branch, so a
+        // pure-Bengali input (which is fully transcribed) must keep working. Keep
+        // the assertion as weak as the sibling romanizer tests (non-empty) so it
+        // does not depend on per-OS tokenizer transcription data.
+        let result = try #require(BengaliRomanizer.romanize("নমস্কার"))
+        #expect(!result.isEmpty)
+    }
+
+    @Test("Mixed Bengali and another non-Latin script does not crash")
+    func crossScriptDoesNotCrash() throws {
+        // A non-Latin character the Bengali-locale tokenizer cannot transcribe
+        // (here Thai "ก") is emitted as a token with no Latin transcription, so it
+        // reaches the fallback branch. Before the fix, that branch indexed the
+        // Swift String by grapheme cluster while the token range is measured in
+        // UTF-16 code units; the Bengali matras (combining marks) before the token
+        // make those units diverge, throwing the offset out of bounds and trapping
+        // with "String index is out of bounds". NSString indexing shares the
+        // UTF-16 unit, mirroring the Thai/Japanese romanizers.
+        //
+        // Across macOS versions the tokenizer may transcribe "ก" instead of
+        // passing it through, so this only asserts the crash contract — no trap —
+        // plus an intact Bengali run (verified to crash at HEAD on macOS 26).
+        let bengali = try #require(BengaliRomanizer.romanize("বাংলা"))
+        let mixed = try #require(BengaliRomanizer.romanize("বাংলা ก"))
+
+        // The Bengali portion is still romanized (control is a substring).
+        #expect(mixed.contains(bengali))
+    }
+
+    @Test("Emoji after Bengali text is passed through")
+    func emojiPassthrough() throws {
+        // Regression guard: an emoji after Bengali text must survive in the output.
+        // On macOS 26 the emoji takes the transcription branch (its LatinTranscription
+        // equals itself); should that ever differ on another OS, the now-fixed
+        // fallback branch preserves it too — so the assertion holds either way.
+        let result = try #require(BengaliRomanizer.romanize("নমস্কার❤️"))
+        #expect(result.contains("❤️"))
+    }
+}
+
 // MARK: - TextCanonicalizerTests
 
 struct TextCanonicalizerTests {


### PR DESCRIPTION
## Description

`BengaliRomanizer.romanize(_:)` could trap with `Fatal error: String index is out of bounds` when a line mixed Bengali with another non-Latin script the Bengali-locale tokenizer cannot transcribe (e.g. a Bengali lyric line containing a Thai/CJK/Hangul/Arabic word). The fallback branch indexed the Swift `String` by grapheme cluster (`text.index(_:offsetBy:)`), but `CFStringTokenizer` token ranges are measured in UTF-16 code units. Bengali matras (combining marks) make the grapheme count smaller than the UTF-16 count, so the UTF-16 `location` overshoots `endIndex` and the process traps. This harmonizes the romanizer with its `ThaiRomanizer` / `JapaneseRomanizer` siblings, which already index via `NSString`.

## AI Prompt (Optional)

<details>
<summary>🤖 AI Prompt Used</summary>

```
Investigate and fix an indexing crash/mis-romanization in BengaliRomanizer.
Verify the bug at HEAD before fixing (instrument the real CFStringTokenizer
loop; do not infer from source). Mirror the correct Thai/Japanese romanizers:
add `let nsText = text as NSString` and extract fallback tokens with
`nsText.substring(with: NSRange(...))` so the unit matches the CFRange. Do not
change transliteration tables or the sibling romanizers. Add a pure-logic
Swift Testing case that is RED at HEAD and GREEN after the fix, plus a
pure-Bengali control and an emoji passthrough guard. Run the project gate.
```

**AI Tool:** Claude Code

</details>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Related Issues

<!-- No matching open issue found; crash discovered during lyrics romanization work. -->

## Changes Made

- `BengaliRomanizer.swift`: capture `let nsText = text as NSString` and extract the fallback (non-transliterable) token via `nsText.substring(with: NSRange(location:length:))` instead of grapheme-cluster `String` indexing, matching `ThaiRomanizer`/`JapaneseRomanizer`.
- `RomanizationTests.swift`: add `BengaliRomanizerTests` — a cross-script crash regression (`বাংলা ก`, RED→GREEN), a pure-Bengali control, and an emoji passthrough guard.

## Testing

- [x] Unit tests pass (`swift test --skip KasetUITests`)
- [x] Manual testing performed (instrumented tokenizer to confirm RED crash + GREEN output on macOS 26)
- [ ] UI tested on macOS 26+ (n/a — pure-logic romanization change)

RED (HEAD): `romanize("বাংলা ก")` traps — `Swift/StringCharacterView.swift:158: Fatal error: String index is out of bounds` (signal 5). GREEN (fix): returns `bānlāก`; full suite green.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `swiftlint --strict && swiftformat .`
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally
- [x] I have updated documentation if needed
- [x] I have checked for any performance implications
- [x] My changes generate no new warnings

## Screenshots

n/a — no UI change.

## Additional Notes

- **Crash trigger is cross-script non-Latin text, not emoji/symbols.** An emoji like ❤️/👋 is emitted by `CFStringTokenizer` with a `LatinTranscription` equal to itself, so it takes the transcription branch (not the buggy fallback) and already worked. The crash requires a token that is emitted **without** a Latin transcription — i.e. another non-Latin script the `bn` locale can't transcribe (Thai `ก`, CJK, Hangul, Arabic). Verified empirically by instrumenting the tokenizer.
- The regression test's assertions are deliberately limited to the crash contract (no trap + intact Bengali run) rather than asserting the raw foreign character: `LatinTranscription` availability can vary across macOS versions and CI spans macOS 15 + 26, so asserting the raw glyph would be OS-fragile.
- A separate, intentionally out-of-scope behavior: word-unit tokenization drops non-word symbols like `♪`/`♫`/`★` (they aren't emitted as tokens). That is a tokenizer-emission characteristic, not the indexing bug fixed here, and is left unchanged.
