### PR TITLE
fix(player): pass playerBarNavigationAction to sidebar playlist views

### DIFF
--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -758,6 +758,10 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
             }
             .id(item.contentId)
             .navigationDestinations(client: client)
+            .playerBarMusicNavigation(path: Binding(
+                get: { self.pinnedNavigationPaths[item.contentId, default: NavigationPath()] },
+                set: { self.pinnedNavigationPaths[item.contentId] = $0 }
+            ))
         }
         .environment(\.libraryViewModel, self.libraryViewModel)
         .environment(\.onPlaylistDeleted) {

--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -727,14 +727,26 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
         )
     }
 
+    private func pinnedItemNavigationPath(for contentId: String) -> Binding<NavigationPath> {
+        Binding(
+            get: { self.pinnedNavigationPaths[contentId, default: NavigationPath()] },
+            set: { self.pinnedNavigationPaths[contentId] = $0 }
+        )
+    }
+
+    private func pinnedItemPlayerBarNavigationAction(for contentId: String) -> PlayerBarNavigationAction {
+        PlayerBarNavigationAction(
+            openArtist: { self.pinnedNavigationPaths[contentId, default: NavigationPath()].append($0) },
+            openAlbum: { self.pinnedNavigationPaths[contentId, default: NavigationPath()].append($0) }
+        )
+    }
+
     private func viewForSidebarPinnedItem(
         _ item: SidebarPinnedItem,
         client: any YTMusicClientProtocol
     ) -> some View {
-        NavigationStack(path: Binding(
-            get: { self.pinnedNavigationPaths[item.contentId, default: NavigationPath()] },
-            set: { self.pinnedNavigationPaths[item.contentId] = $0 }
-        )) {
+        let playerBarNavigationAction = self.pinnedItemPlayerBarNavigationAction(for: item.contentId)
+        return NavigationStack(path: self.pinnedItemNavigationPath(for: item.contentId)) {
             Group {
                 if !self.usesLegacyMacOS15UI, #available(macOS 26.0, *) {
                     PlaylistDetailView(
@@ -742,7 +754,8 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
                         viewModel: PlaylistDetailViewModel(
                             playlist: item.playlistRoute,
                             client: client
-                        )
+                        ),
+                        playerBarNavigationAction: playerBarNavigationAction
                     )
                     .environment(\.libraryViewModel, self.libraryViewModel)
                 } else {
@@ -751,17 +764,18 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
                         viewModel: PlaylistDetailViewModel(
                             playlist: item.playlistRoute,
                             client: client
-                        )
+                        ),
+                        playerBarNavigationAction: playerBarNavigationAction
                     )
                     .environment(\.libraryViewModel, self.libraryViewModel)
                 }
             }
             .id(item.contentId)
-            .navigationDestinations(client: client)
-            .playerBarMusicNavigation(path: Binding(
-                get: { self.pinnedNavigationPaths[item.contentId, default: NavigationPath()] },
-                set: { self.pinnedNavigationPaths[item.contentId] = $0 }
-            ))
+            .navigationDestinations(
+                client: client,
+                playerBarNavigationAction: playerBarNavigationAction
+            )
+            .playerBarMusicNavigation(path: self.pinnedItemNavigationPath(for: item.contentId))
         }
         .environment(\.libraryViewModel, self.libraryViewModel)
         .environment(\.onPlaylistDeleted) {

--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -665,14 +665,26 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
         )
     }
 
+    private func pinnedItemNavigationPath(for contentId: String) -> Binding<NavigationPath> {
+        Binding(
+            get: { self.pinnedNavigationPaths[contentId, default: NavigationPath()] },
+            set: { self.pinnedNavigationPaths[contentId] = $0 }
+        )
+    }
+
+    private func pinnedItemPlayerBarNavigationAction(for contentId: String) -> PlayerBarNavigationAction {
+        PlayerBarNavigationAction(
+            openArtist: { self.pinnedNavigationPaths[contentId, default: NavigationPath()].append($0) },
+            openAlbum: { self.pinnedNavigationPaths[contentId, default: NavigationPath()].append($0) }
+        )
+    }
+
     private func viewForSidebarPinnedItem(
         _ item: SidebarPinnedItem,
         client: any YTMusicClientProtocol
     ) -> some View {
-        NavigationStack(path: Binding(
-            get: { self.pinnedNavigationPaths[item.contentId, default: NavigationPath()] },
-            set: { self.pinnedNavigationPaths[item.contentId] = $0 }
-        )) {
+        let playerBarNavigationAction = self.pinnedItemPlayerBarNavigationAction(for: item.contentId)
+        return NavigationStack(path: self.pinnedItemNavigationPath(for: item.contentId)) {
             Group {
                 if !self.usesLegacyMacOS15UI, #available(macOS 26.0, *) {
                     PlaylistDetailView(
@@ -680,7 +692,8 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
                         viewModel: PlaylistDetailViewModel(
                             playlist: item.playlistRoute,
                             client: client
-                        )
+                        ),
+                        playerBarNavigationAction: playerBarNavigationAction
                     )
                     .environment(\.libraryViewModel, self.libraryViewModel)
                 } else {
@@ -689,17 +702,18 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
                         viewModel: PlaylistDetailViewModel(
                             playlist: item.playlistRoute,
                             client: client
-                        )
+                        ),
+                        playerBarNavigationAction: playerBarNavigationAction
                     )
                     .environment(\.libraryViewModel, self.libraryViewModel)
                 }
             }
             .id(item.contentId)
-            .navigationDestinations(client: client)
-            .playerBarMusicNavigation(path: Binding(
-                get: { self.pinnedNavigationPaths[item.contentId, default: NavigationPath()] },
-                set: { self.pinnedNavigationPaths[item.contentId] = $0 }
-            ))
+            .navigationDestinations(
+                client: client,
+                playerBarNavigationAction: playerBarNavigationAction
+            )
+            .playerBarMusicNavigation(path: self.pinnedItemNavigationPath(for: item.contentId))
         }
         .environment(\.libraryViewModel, self.libraryViewModel)
         .environment(\.onPlaylistDeleted) {

--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -696,6 +696,10 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
             }
             .id(item.contentId)
             .navigationDestinations(client: client)
+            .playerBarMusicNavigation(path: Binding(
+                get: { self.pinnedNavigationPaths[item.contentId, default: NavigationPath()] },
+                set: { self.pinnedNavigationPaths[item.contentId] = $0 }
+            ))
         }
         .environment(\.libraryViewModel, self.libraryViewModel)
         .environment(\.onPlaylistDeleted) {


### PR DESCRIPTION
## Description

When playing a track from a sidebar playlist (not Liked Music), the artist and album names in the player bar were not clickable.

`viewForSidebarPinnedItem` created `PlaylistDetailView` without a `playerBarNavigationAction`, so it defaulted to `.disabled`. The `PlayerBar` inside then saw `navigationAction.openArtist == nil`, making `canOpenCurrentArtist` false and rendering the artist name disabled.

**Correction from the first revision of this PR:** the fix cannot be done with `.playerBarMusicNavigation(path:)` on the enclosing `NavigationStack` alone. `PlaylistDetailView` sets the environment value directly on its own `PlayerBar`:

```swift
PlayerBar()
    .environment(\.playerBarNavigationAction, self.playerBarNavigationAction)
```

That write is closer to the `PlayerBar` than the modifier on the stack, so it wins — and since the view was constructed without the argument, it stayed `.disabled`. The modifier-only version was verified by inspection but never actually worked when built and run.

Liked Music works because it passes the action **into the view's initializer** (`MainWindow.swift:606`), not just via the outer modifier. This PR applies that same shape to sidebar playlists.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #437

## Changes Made

- Add `pinnedItemPlayerBarNavigationAction(for:)`, mirroring `likedMusicPlayerBarNavigationAction` but keyed on the per-item `contentId` path.
- Pass it into `PlaylistDetailView` and `SimplePlaylistDetailView` — this is what actually fixes the bug.
- Pass it to `navigationDestinations(client:playerBarNavigationAction:)` so the player bar stays clickable after pushing to an artist or album page, matching Liked Music (`MainWindow.swift:618-620`).
- Extract `pinnedItemNavigationPath(for:)` for the path binding that was duplicated inline.

## Testing

- [x] Unit tests pass (`swift test --skip KasetUITests`) — 2956 tests in 232 suites
- [x] `swiftlint --strict && swiftformat .` clean
- [x] Manual testing performed on a packaged build
- [x] UI tested on macOS 26+

Verified in a running packaged build: playing a track from a sidebar playlist and clicking the artist name in the player bar now navigates to the artist page, and Liked Music continues to work.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `swiftlint --strict && swiftformat .`
- [x] New and existing unit tests pass locally
- [x] I have checked for any performance implications
- [x] My changes generate no new warnings

## Additional Notes

While testing this, an unrelated pre-existing bug surfaced: the player bar's album artwork flickers on every view switch. It reproduces in released builds and is **not** caused by this PR — instrumentation showed the whole `PlayerBar` is remounted per navigation because each content view constructs its own via `.safeAreaInset`. Filed separately with the trace data, since the structural fix there would retire this entire class of bug.
