### PR TITLE
feat(ui): make artist names clickable in track list rows

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -21,9 +21,11 @@ opt_in_rules:
   - redundant_nil_coalescing
   - sorted_first_last
   - toggle_bool
-  - unused_import
   - vertical_whitespace_closing_braces
   - yoda_condition
+
+analyzer_rules:
+  - unused_import
 
 included:
   - Sources

--- a/Sources/APIExplorer/main.swift
+++ b/Sources/APIExplorer/main.swift
@@ -952,31 +952,71 @@ private func playlistBrowseSummary(_ data: [String: Any]) -> String? {
     return output
 }
 
-private func playlistPanelBylineSummary(_ data: [String: Any]) -> String {
-    guard let renderer = findFirstRenderer(named: "playlistPanelVideoRenderer", in: data),
-          let byline = renderer["longBylineText"] as? [String: Any],
-          let runs = byline["runs"] as? [[String: Any]],
-          !runs.isEmpty
-    else { return "" }
+/// Lists playlist destinations without exposing tracking or continuation tokens.
+private func playlistNavigationSummary(_ data: [String: Any]) -> String {
+    var destinations: [String] = []
+    var seen = Set<String>()
 
-    var output = "\n🎤 Playlist-panel long byline runs:\n"
-    for (index, run) in runs.enumerated() {
-        let text = run["text"] as? String ?? ""
-        let browseId = ((run["navigationEndpoint"] as? [String: Any])?["browseEndpoint"] as? [String: Any])?["browseId"] as? String
-        let browseKind = if let browseId {
-            if browseId.hasPrefix("MPLAUC") {
-                "MPLAUC…"
-            } else if browseId.hasPrefix("UC") {
-                "UC…"
-            } else if browseId.hasPrefix("MPRE") {
-                "MPRE…"
-            } else {
-                "other"
+    func visit(_ value: Any) {
+        guard destinations.count < 12 else { return }
+        if let dictionary = value as? [String: Any] {
+            for key in ["musicCardShelfRenderer", "musicTwoRowItemRenderer", "musicResponsiveListItemRenderer"] {
+                guard let renderer = dictionary[key] as? [String: Any],
+                      let endpoint = renderer["navigationEndpoint"] ?? renderer["onTap"] ?? renderer["title"],
+                      let browse = findFirstRenderer(named: "browseEndpoint", in: endpoint),
+                      let browseId = browse["browseId"] as? String,
+                      browseId.hasPrefix("VL") || browseId.hasPrefix("RD") || browseId.hasPrefix("PL"),
+                      seen.insert(browseId).inserted
+                else { continue }
+
+                let columns = renderer["flexColumns"] as? [[String: Any]]
+                let firstColumn = columns?.first?["musicResponsiveListItemFlexColumnRenderer"] as? [String: Any]
+                let title = joinedRunsText(renderer["title"] as? [String: Any])
+                    ?? joinedRunsText(firstColumn?["text"] as? [String: Any]) ?? "Untitled"
+                destinations.append("  • \(terminalSafe(title)): \(terminalSafe(browseId))")
             }
-        } else {
-            "none"
+            for key in dictionary.keys.sorted() {
+                if let child = dictionary[key] {
+                    visit(child)
+                }
+            }
+        } else if let array = value as? [Any] {
+            for child in array {
+                visit(child)
+            }
         }
-        output += "  [\(index)] text=\(String(reflecting: text)) browse=\(browseKind)\n"
+    }
+
+    visit(data)
+    guard !destinations.isEmpty else { return "" }
+    return "\n📂 Playlist browse targets:\n" + destinations.joined(separator: "\n") + "\n"
+}
+
+private func playlistPanelBylineSummary(_ data: [String: Any]) -> String {
+    guard let renderer = findFirstRenderer(named: "playlistPanelVideoRenderer", in: data) else { return "" }
+
+    var output = "\n🎤 Playlist-panel byline runs:\n"
+    for field in ["shortBylineText", "longBylineText"] {
+        let runs = (renderer[field] as? [String: Any])?["runs"] as? [[String: Any]] ?? []
+        output += "  \(field): \(runs.count) run(s)\n"
+        for (index, run) in runs.enumerated() {
+            let text = run["text"] as? String ?? ""
+            let browseId = ((run["navigationEndpoint"] as? [String: Any])?["browseEndpoint"] as? [String: Any])?["browseId"] as? String
+            let browseKind = if let browseId {
+                if browseId.hasPrefix("MPLAUC") {
+                    "MPLAUC…"
+                } else if browseId.hasPrefix("UC") {
+                    "UC…"
+                } else if browseId.hasPrefix("MPRE") {
+                    "MPRE…"
+                } else {
+                    "other"
+                }
+            } else {
+                "none"
+            }
+            output += "    [\(index)] text=\(String(reflecting: text)) browse=\(browseKind)\n"
+        }
     }
     return output
 }
@@ -1549,6 +1589,8 @@ func analyzeResponse(
     output += libraryFeedbackProbeSummary(data)
 
     output += playlistPanelBylineSummary(data)
+
+    output += playlistNavigationSummary(data)
 
     if !youtubeMode {
         output += searchResponseAuditSummary(

--- a/Sources/Kaset/Services/API/Parsers/PlaylistParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/PlaylistParser.swift
@@ -1507,9 +1507,14 @@ enum PlaylistParser {
             .flatMap { ($0 as? [[String: Any]])?.first?["text"] as? String }
             ?? "Unknown"
 
-        let artistRuns = (renderer["shortBylineText"] as? [String: Any])?["runs"] as? [[String: Any]]
-        let artistName = artistRuns?.first?["text"] as? String ?? "Unknown Artist"
-        let artistId = Self.extractArtistId(from: artistRuns)
+        // Curated queues keep artist links in the long byline; the short byline is display-only.
+        var artists = SongMetadataParser.parseArtists(from: renderer)
+        if artists.isEmpty {
+            let artistRuns = (renderer["shortBylineText"] as? [String: Any])?["runs"] as? [[String: Any]]
+            let artistName = artistRuns?.first?["text"] as? String ?? "Unknown Artist"
+            let artistId = Self.extractArtistId(from: artistRuns)
+            artists = [Artist(id: artistId ?? "", name: artistName)]
+        }
 
         let durationText = (renderer["lengthText"] as? [String: Any])?["runs"]
             .flatMap { ($0 as? [[String: Any]])?.first?["text"] as? String }
@@ -1524,7 +1529,7 @@ enum PlaylistParser {
         return Song(
             id: videoId,
             title: title,
-            artists: [Artist(id: artistId ?? "", name: artistName, thumbnailURL: nil)],
+            artists: artists,
             album: nil,
             duration: durationText.flatMap { ParsingHelpers.parseDuration($0) },
             thumbnailURL: thumbnailURL,

--- a/Sources/Kaset/Views/AccountRowView.swift
+++ b/Sources/Kaset/Views/AccountRowView.swift
@@ -76,7 +76,7 @@ struct AccountRowView: View {
                 CachedAsyncImage(url: thumbnailURL, targetSize: CGSize(width: 40, height: 40)) { image in
                     image
                         .resizable()
-                        .aspectRatio(contentMode: .fill)
+                        .scaledToFill()
                 } placeholder: {
                     self.avatarPlaceholder
                 }

--- a/Sources/Kaset/Views/ArtistDetailView.swift
+++ b/Sources/Kaset/Views/ArtistDetailView.swift
@@ -141,7 +141,7 @@ struct ArtistDetailView: View { // swiftlint:disable:this type_body_length
             CachedAsyncImage(url: detail.thumbnailURL?.highQualityThumbnailURL, targetSize: CGSize(width: 180, height: 180)) { image in
                 image
                     .resizable()
-                    .aspectRatio(contentMode: .fill)
+                    .scaledToFill()
             } placeholder: {
                 Rectangle()
                     .fill(.quaternary)
@@ -538,7 +538,7 @@ struct ArtistDetailView: View { // swiftlint:disable:this type_body_length
             CachedAsyncImage(url: album.thumbnailURL?.highQualityThumbnailURL, targetSize: CGSize(width: 140, height: 140)) { image in
                 image
                     .resizable()
-                    .aspectRatio(contentMode: .fill)
+                    .scaledToFill()
             } placeholder: {
                 Rectangle()
                     .fill(.quaternary)
@@ -573,7 +573,7 @@ struct ArtistDetailView: View { // swiftlint:disable:this type_body_length
             CachedAsyncImage(url: playlist.thumbnailURL?.highQualityThumbnailURL, targetSize: CGSize(width: 140, height: 140)) { image in
                 image
                     .resizable()
-                    .aspectRatio(contentMode: .fill)
+                    .scaledToFill()
             } placeholder: {
                 Rectangle()
                     .fill(.quaternary)
@@ -612,7 +612,7 @@ struct ArtistDetailView: View { // swiftlint:disable:this type_body_length
             CachedAsyncImage(url: artist.thumbnailURL?.highQualityThumbnailURL, targetSize: CGSize(width: 140, height: 140)) { image in
                 image
                     .resizable()
-                    .aspectRatio(contentMode: .fill)
+                    .scaledToFill()
             } placeholder: {
                 Rectangle()
                     .fill(.quaternary)
@@ -711,7 +711,7 @@ struct ArtistDetailView: View { // swiftlint:disable:this type_body_length
                 CachedAsyncImage(url: episode.thumbnailURL?.highQualityThumbnailURL, targetSize: CGSize(width: 220, height: 124)) { image in
                     image
                         .resizable()
-                        .aspectRatio(contentMode: .fill)
+                        .scaledToFill()
                 } placeholder: {
                     Rectangle()
                         .fill(.quaternary)
@@ -788,7 +788,7 @@ struct ArtistDetailView: View { // swiftlint:disable:this type_body_length
                     CachedAsyncImage(url: playlist.thumbnailURL?.highQualityThumbnailURL, targetSize: CGSize(width: 140, height: 140)) { image in
                         image
                             .resizable()
-                            .aspectRatio(contentMode: .fill)
+                            .scaledToFill()
                     } placeholder: {
                         Rectangle()
                             .fill(.quaternary)
@@ -834,7 +834,7 @@ struct ArtistDetailView: View { // swiftlint:disable:this type_body_length
             CachedAsyncImage(url: show.thumbnailURL?.highQualityThumbnailURL, targetSize: CGSize(width: 140, height: 140)) { image in
                 image
                     .resizable()
-                    .aspectRatio(contentMode: .fill)
+                    .scaledToFill()
             } placeholder: {
                 Rectangle()
                     .fill(.quaternary)
@@ -877,7 +877,7 @@ struct ArtistDetailView: View { // swiftlint:disable:this type_body_length
             CachedAsyncImage(url: artist.thumbnailURL?.highQualityThumbnailURL, targetSize: CGSize(width: 120, height: 120)) { image in
                 image
                     .resizable()
-                    .aspectRatio(contentMode: .fill)
+                    .scaledToFill()
             } placeholder: {
                 Rectangle()
                     .fill(.quaternary)

--- a/Sources/Kaset/Views/ArtistDiscographyView.swift
+++ b/Sources/Kaset/Views/ArtistDiscographyView.swift
@@ -69,7 +69,7 @@ struct ArtistDiscographyView: View {
             CachedAsyncImage(url: album.thumbnailURL?.highQualityThumbnailURL) { image in
                 image
                     .resizable()
-                    .aspectRatio(contentMode: .fill)
+                    .scaledToFill()
             } placeholder: {
                 Rectangle()
                     .fill(.quaternary)

--- a/Sources/Kaset/Views/ArtistEpisodesListView.swift
+++ b/Sources/Kaset/Views/ArtistEpisodesListView.swift
@@ -67,7 +67,7 @@ struct ArtistEpisodesListView: View {
                 CachedAsyncImage(url: episode.thumbnailURL?.highQualityThumbnailURL, targetSize: CGSize(width: 160, height: 90)) { image in
                     image
                         .resizable()
-                        .aspectRatio(contentMode: .fill)
+                        .scaledToFill()
                 } placeholder: {
                     Rectangle()
                         .fill(.quaternary)

--- a/Sources/Kaset/Views/HoverUnderlineNavigationLink.swift
+++ b/Sources/Kaset/Views/HoverUnderlineNavigationLink.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+// MARK: - HoverUnderlineNavigationLink
+
+/// A navigation link that underlines its label on hover.
+///
+/// Used for artist names and other inline navigation targets in track rows and headers.
+struct HoverUnderlineNavigationLink<Value: Hashable>: View {
+    let value: Value
+    let title: String
+    var font: Font = .subheadline
+    var foregroundStyle: Color = .secondary
+
+    @State private var isHovering = false
+
+    var body: some View {
+        NavigationLink(value: self.value) {
+            Text(self.title)
+                .font(self.font)
+                .foregroundStyle(self.foregroundStyle)
+                .underline(self.isHovering)
+                .lineLimit(1)
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in
+            self.isHovering = hovering
+        }
+    }
+}

--- a/Sources/Kaset/Views/HoverUnderlineNavigationLink.swift
+++ b/Sources/Kaset/Views/HoverUnderlineNavigationLink.swift
@@ -20,8 +20,11 @@ struct HoverUnderlineNavigationLink<Value: Hashable>: View {
                 .foregroundStyle(self.foregroundStyle)
                 .underline(self.isHovering)
                 .lineLimit(1)
+                .padding(.vertical, 2)
+                .contentShape(.rect)
         }
         .buttonStyle(.plain)
+        .pointerStyle(.link)
         .onHover { hovering in
             self.isHovering = hovering
         }

--- a/Sources/Kaset/Views/LegacyFallbackViews.swift
+++ b/Sources/Kaset/Views/LegacyFallbackViews.swift
@@ -92,7 +92,7 @@ struct SimplePlaylistDetailView: View {
 
         return HStack(alignment: .top, spacing: 20) {
             AsyncImage(url: detail.thumbnailURL) { image in
-                image.resizable().aspectRatio(contentMode: .fill)
+                image.resizable().scaledToFill()
             } placeholder: {
                 Color.secondary.opacity(0.2)
             }
@@ -147,7 +147,7 @@ struct SimplePlaylistDetailView: View {
                             .foregroundStyle(.secondary)
                             .frame(width: 28, alignment: .trailing)
                         AsyncImage(url: track.thumbnailURL) { image in
-                            image.resizable().aspectRatio(contentMode: .fill)
+                            image.resizable().scaledToFill()
                         } placeholder: {
                             Color.secondary.opacity(0.15)
                         }

--- a/Sources/Kaset/Views/LibraryView.swift
+++ b/Sources/Kaset/Views/LibraryView.swift
@@ -332,7 +332,7 @@ struct LibraryView: View {
                 CachedAsyncImage(url: playlist.thumbnailURL?.highQualityThumbnailURL) { image in
                     image
                         .resizable()
-                        .aspectRatio(contentMode: .fill)
+                        .scaledToFill()
                 } placeholder: {
                     Rectangle()
                         .fill(.quaternary)
@@ -391,7 +391,7 @@ struct LibraryView: View {
                 CachedAsyncImage(url: album.thumbnailURL?.highQualityThumbnailURL) { image in
                     image
                         .resizable()
-                        .aspectRatio(contentMode: .fill)
+                        .scaledToFill()
                 } placeholder: {
                     Rectangle()
                         .fill(.quaternary)
@@ -487,7 +487,7 @@ struct LibraryView: View {
                 CachedAsyncImage(url: playlist.thumbnailURL?.highQualityThumbnailURL) { image in
                     image
                         .resizable()
-                        .aspectRatio(contentMode: .fill)
+                        .scaledToFill()
                 } placeholder: {
                     Rectangle()
                         .fill(.quaternary)
@@ -532,7 +532,7 @@ struct LibraryView: View {
                 CachedAsyncImage(url: show.thumbnailURL) { image in
                     image
                         .resizable()
-                        .aspectRatio(contentMode: .fill)
+                        .scaledToFill()
                 } placeholder: {
                     Rectangle()
                         .fill(.quaternary)
@@ -577,7 +577,7 @@ struct LibraryView: View {
                 CachedAsyncImage(url: artist.thumbnailURL?.highQualityThumbnailURL) { image in
                     image
                         .resizable()
-                        .aspectRatio(contentMode: .fill)
+                        .scaledToFill()
                 } placeholder: {
                     Circle()
                         .fill(.quaternary)

--- a/Sources/Kaset/Views/MoodCategoryDetailView.swift
+++ b/Sources/Kaset/Views/MoodCategoryDetailView.swift
@@ -167,7 +167,7 @@ private struct ItemCardContent: View {
                 CachedAsyncImage(url: url) { image in
                     image
                         .resizable()
-                        .aspectRatio(contentMode: .fill)
+                        .scaledToFill()
                 } placeholder: {
                     self.placeholderView
                 }

--- a/Sources/Kaset/Views/PlayerBarArtworkGlow.swift
+++ b/Sources/Kaset/Views/PlayerBarArtworkGlow.swift
@@ -25,7 +25,7 @@ struct PlayerBarArtworkGlow: View {
             } else if let image {
                 Image(nsImage: image)
                     .resizable()
-                    .aspectRatio(contentMode: .fill)
+                    .scaledToFill()
                     .frame(width: self.width, height: self.height)
                     .clipShape(.rect(cornerRadius: self.cornerRadius, style: .continuous))
                     .compositingGroup()

--- a/Sources/Kaset/Views/PlaylistDetailView.swift
+++ b/Sources/Kaset/Views/PlaylistDetailView.swift
@@ -298,6 +298,7 @@ struct PlaylistDetailView: View {
             index: index,
             isAlbum: isAlbum,
             subtitle: self.trackArtistsDisplay(for: track, fallbackAuthor: author),
+            artists: self.trackArtists(for: track, fallbackAuthor: author),
             allowsLikeActions: self.hasPersonalAccount,
             onPlay: {
                 self.playTrackInQueue(
@@ -334,6 +335,12 @@ struct PlaylistDetailView: View {
 
         guard let fallbackArtist = self.cleanedArtistName(fallbackAuthor) else { return nil }
         return fallbackArtist
+    }
+
+    private func trackArtists(for track: Song, fallbackAuthor: String?) -> [Artist]? {
+        let artists = self.uniqueArtists(from: track.artists)
+        guard !artists.isEmpty else { return nil }
+        return artists
     }
 
     private func uniqueArtists(from artists: [Artist]) -> [Artist] {
@@ -530,6 +537,7 @@ struct PlaylistDetailView: View {
         fallbackArtist: String?, fallbackAlbum: Album?
     ) {
         let intent = self.playerService.beginMusicPlaybackIntent()
+        self.playerService.sourcePlaylistId = self.viewModel.playlistDetail?.id
         Task { @MainActor in
             let willDeferLoad = self.viewModel.hasMore
             let loadGeneration = await self.playerService.playQueue(
@@ -748,6 +756,7 @@ private struct PlaylistTrackRow<Menu: View>: View {
     let index: Int
     let isAlbum: Bool
     let subtitle: String?
+    let artists: [Artist]?
     let allowsLikeActions: Bool
     let onPlay: () -> Void
     @ViewBuilder let menu: () -> Menu
@@ -792,10 +801,14 @@ private struct PlaylistTrackRow<Menu: View>: View {
                         }
                     }
                     if let subtitle = self.subtitle {
-                        Text(subtitle)
-                            .font(.system(size: 12))
-                            .foregroundStyle(.secondary)
-                            .lineLimit(1)
+                        if self.hasNavigableArtists {
+                            self.artistLinksView
+                        } else {
+                            Text(subtitle)
+                                .font(.system(size: 12))
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -817,6 +830,40 @@ private struct PlaylistTrackRow<Menu: View>: View {
         .onHover { hovering in self.isHovered = hovering }
         .contextMenu { self.menu() }
     }
+
+    private var hasNavigableArtists: Bool {
+        self.artists?.contains(where: { $0.hasNavigableId }) ?? false
+    }
+
+    @ViewBuilder
+    private var artistLinksView: some View {
+        let artists = self.artists ?? []
+
+        HStack(spacing: 0) {
+            ForEach(Array(artists.enumerated()), id: \.offset) { index, artist in
+                if artist.hasNavigableId {
+                    HoverUnderlineNavigationLink(
+                        value: artist,
+                        title: artist.name,
+                        font: .system(size: 12),
+                        foregroundStyle: .secondary
+                    )
+                } else {
+                    Text(artist.name)
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+
+                if index < artists.count - 1 {
+                    Text(verbatim: ", ")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+        }
+    }
 }
 
 // MARK: - HoverUnderlineNavigationLink
@@ -824,14 +871,18 @@ private struct PlaylistTrackRow<Menu: View>: View {
 private struct HoverUnderlineNavigationLink<Value: Hashable>: View {
     let value: Value
     let title: String
+    var font: Font = .subheadline
+    var foregroundStyle: Color = .secondary
 
     @State private var isHovering = false
 
     var body: some View {
         NavigationLink(value: self.value) {
             Text(self.title)
-                .font(.subheadline)
+                .font(self.font)
+                .foregroundStyle(self.foregroundStyle)
                 .underline(self.isHovering)
+                .lineLimit(1)
         }
         .buttonStyle(.plain)
         .onHover { hovering in

--- a/Sources/Kaset/Views/PlaylistDetailView.swift
+++ b/Sources/Kaset/Views/PlaylistDetailView.swift
@@ -337,7 +337,7 @@ struct PlaylistDetailView: View {
         return fallbackArtist
     }
 
-    private func trackArtists(for track: Song, fallbackAuthor: String?) -> [Artist]? {
+    private func trackArtists(for track: Song, fallbackAuthor _: String?) -> [Artist]? {
         let artists = self.uniqueArtists(from: track.artists)
         guard !artists.isEmpty else { return nil }
         return artists
@@ -537,7 +537,6 @@ struct PlaylistDetailView: View {
         fallbackArtist: String?, fallbackAlbum: Album?
     ) {
         let intent = self.playerService.beginMusicPlaybackIntent()
-        self.playerService.sourcePlaylistId = self.viewModel.playlistDetail?.id
         Task { @MainActor in
             let willDeferLoad = self.viewModel.hasMore
             let loadGeneration = await self.playerService.playQueue(
@@ -745,149 +744,6 @@ struct PlaylistDetailView: View {
 
         self.partialChanges = nil
         self.isRefining = false
-    }
-}
-
-// MARK: - PlaylistTrackRow
-
-@available(macOS 26.0, *)
-private struct PlaylistTrackRow<Menu: View>: View {
-    let track: Song
-    let index: Int
-    let isAlbum: Bool
-    let subtitle: String?
-    let artists: [Artist]?
-    let allowsLikeActions: Bool
-    let onPlay: () -> Void
-    @ViewBuilder let menu: () -> Menu
-
-    @State private var isHovered: Bool = false
-    @Environment(PlayerService.self) private var playerService
-
-    var body: some View {
-        let isCurrent = self.playerService.currentTrack?.videoId == self.track.videoId
-
-        Button(action: self.onPlay) {
-            HStack(spacing: 12) {
-                Group {
-                    if isCurrent {
-                        NowPlayingIndicator(isPlaying: self.playerService.isPlaying, size: 14)
-                    } else {
-                        Text("\(self.index + 1)")
-                            .font(.system(size: 14))
-                            .foregroundStyle(.secondary)
-                    }
-                }
-                .frame(width: 28, alignment: .trailing)
-
-                if !self.isAlbum {
-                    CachedAsyncImage(url: self.track.thumbnailURL, targetSize: CGSize(width: 40, height: 40)) { image in
-                        image.resizable().aspectRatio(contentMode: .fill)
-                    } placeholder: {
-                        Rectangle().fill(.quaternary)
-                    }
-                    .frame(width: 40, height: 40)
-                    .clipShape(.rect(cornerRadius: 4))
-                }
-
-                VStack(alignment: .leading, spacing: 2) {
-                    HStack(spacing: 6) {
-                        Text(self.track.title)
-                            .font(.system(size: 14))
-                            .foregroundStyle(isCurrent ? .red : .primary)
-                            .lineLimit(1)
-                        if self.track.isExplicit == true {
-                            ExplicitBadge()
-                        }
-                    }
-                    if let subtitle = self.subtitle {
-                        if self.hasNavigableArtists {
-                            self.artistLinksView
-                        } else {
-                            Text(subtitle)
-                                .font(.system(size: 12))
-                                .foregroundStyle(.secondary)
-                                .lineLimit(1)
-                        }
-                    }
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-                LikeButton(song: self.track, isRowHovered: self.isHovered, allowsActions: self.allowsLikeActions)
-
-                Text(self.track.durationDisplay)
-                    .font(.system(size: 12))
-                    .foregroundStyle(.secondary)
-                    .frame(width: 45, alignment: .trailing)
-            }
-            .padding(.vertical, 8)
-            .padding(.horizontal, 4)
-            .contentShape(Rectangle())
-            .opacity(self.track.isPlayable ? 1 : 0.5)
-        }
-        .buttonStyle(.interactiveRow(cornerRadius: 6))
-        .disabled(!self.track.isPlayable)
-        .onHover { hovering in self.isHovered = hovering }
-        .contextMenu { self.menu() }
-    }
-
-    private var hasNavigableArtists: Bool {
-        self.artists?.contains(where: { $0.hasNavigableId }) ?? false
-    }
-
-    @ViewBuilder
-    private var artistLinksView: some View {
-        let artists = self.artists ?? []
-
-        HStack(spacing: 0) {
-            ForEach(Array(artists.enumerated()), id: \.offset) { index, artist in
-                if artist.hasNavigableId {
-                    HoverUnderlineNavigationLink(
-                        value: artist,
-                        title: artist.name,
-                        font: .system(size: 12),
-                        foregroundStyle: .secondary
-                    )
-                } else {
-                    Text(artist.name)
-                        .font(.system(size: 12))
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                }
-
-                if index < artists.count - 1 {
-                    Text(verbatim: ", ")
-                        .font(.system(size: 12))
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                }
-            }
-        }
-    }
-}
-
-// MARK: - HoverUnderlineNavigationLink
-
-private struct HoverUnderlineNavigationLink<Value: Hashable>: View {
-    let value: Value
-    let title: String
-    var font: Font = .subheadline
-    var foregroundStyle: Color = .secondary
-
-    @State private var isHovering = false
-
-    var body: some View {
-        NavigationLink(value: self.value) {
-            Text(self.title)
-                .font(self.font)
-                .foregroundStyle(self.foregroundStyle)
-                .underline(self.isHovering)
-                .lineLimit(1)
-        }
-        .buttonStyle(.plain)
-        .onHover { hovering in
-            self.isHovering = hovering
-        }
     }
 }
 

--- a/Sources/Kaset/Views/PlaylistDetailView.swift
+++ b/Sources/Kaset/Views/PlaylistDetailView.swift
@@ -337,10 +337,19 @@ struct PlaylistDetailView: View {
         return fallbackArtist
     }
 
-    private func trackArtists(for track: Song, fallbackAuthor _: String?) -> [Artist]? {
+    private func trackArtists(for track: Song, fallbackAuthor: String?) -> [Artist]? {
         let artists = self.uniqueArtists(from: track.artists)
-        guard !artists.isEmpty else { return nil }
-        return artists
+        if !artists.isEmpty {
+            return artists
+        }
+
+        guard let fallbackName = self.cleanedArtistName(fallbackAuthor),
+              let author = self.cleanedArtist(self.viewModel.playlistDetail?.author),
+              author.hasNavigableId,
+              author.name == fallbackName
+        else { return nil }
+
+        return [author]
     }
 
     private func uniqueArtists(from artists: [Artist]) -> [Artist] {

--- a/Sources/Kaset/Views/PlaylistDetailView.swift
+++ b/Sources/Kaset/Views/PlaylistDetailView.swift
@@ -168,7 +168,7 @@ struct PlaylistDetailView: View {
             CachedAsyncImage(url: detail.thumbnailURL?.highQualityThumbnailURL, targetSize: CGSize(width: 180, height: 180)) { image in
                 image
                     .resizable()
-                    .aspectRatio(contentMode: .fill)
+                    .scaledToFill()
             } placeholder: {
                 Rectangle()
                     .fill(.quaternary)

--- a/Sources/Kaset/Views/PlaylistTrackRow.swift
+++ b/Sources/Kaset/Views/PlaylistTrackRow.swift
@@ -120,6 +120,8 @@ struct PlaylistTrackRow<Menu: View>: View {
                         .lineLimit(1)
                 }
             }
+
+            Spacer(minLength: 0)
         }
     }
 }

--- a/Sources/Kaset/Views/PlaylistTrackRow.swift
+++ b/Sources/Kaset/Views/PlaylistTrackRow.swift
@@ -1,0 +1,125 @@
+import SwiftUI
+
+// MARK: - PlaylistTrackRow
+
+/// A single track row in a playlist or album detail view.
+///
+/// Shows track number/now-playing indicator, thumbnail (for non-album views),
+/// title, artist links or subtitle, like button, and duration.
+/// Artist names are rendered as clickable navigation links when they have
+/// navigable IDs; non-navigable artists fall back to plain text.
+@available(macOS 26.0, *)
+struct PlaylistTrackRow<Menu: View>: View {
+    let track: Song
+    let index: Int
+    let isAlbum: Bool
+    let subtitle: String?
+    let artists: [Artist]?
+    let allowsLikeActions: Bool
+    let onPlay: () -> Void
+    @ViewBuilder let menu: () -> Menu
+
+    @State private var isHovered: Bool = false
+    @Environment(PlayerService.self) private var playerService
+
+    var body: some View {
+        let isCurrent = self.playerService.currentTrack?.videoId == self.track.videoId
+
+        Button(action: self.onPlay) {
+            HStack(spacing: 12) {
+                Group {
+                    if isCurrent {
+                        NowPlayingIndicator(isPlaying: self.playerService.isPlaying, size: 14)
+                    } else {
+                        Text("\(self.index + 1)")
+                            .font(.system(size: 14))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .frame(width: 28, alignment: .trailing)
+
+                if !self.isAlbum {
+                    CachedAsyncImage(url: self.track.thumbnailURL, targetSize: CGSize(width: 40, height: 40)) { image in
+                        image.resizable().aspectRatio(contentMode: .fill)
+                    } placeholder: {
+                        Rectangle().fill(.quaternary)
+                    }
+                    .frame(width: 40, height: 40)
+                    .clipShape(.rect(cornerRadius: 4))
+                }
+
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack(spacing: 6) {
+                        Text(self.track.title)
+                            .font(.system(size: 14))
+                            .foregroundStyle(isCurrent ? .red : .primary)
+                            .lineLimit(1)
+                        if self.track.isExplicit == true {
+                            ExplicitBadge()
+                        }
+                    }
+                    if let subtitle = self.subtitle {
+                        if self.hasNavigableArtists {
+                            self.artistLinksView
+                        } else {
+                            Text(subtitle)
+                                .font(.system(size: 12))
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                LikeButton(song: self.track, isRowHovered: self.isHovered, allowsActions: self.allowsLikeActions)
+
+                Text(self.track.durationDisplay)
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 45, alignment: .trailing)
+            }
+            .padding(.vertical, 8)
+            .padding(.horizontal, 4)
+            .contentShape(Rectangle())
+            .opacity(self.track.isPlayable ? 1 : 0.5)
+        }
+        .buttonStyle(.interactiveRow(cornerRadius: 6))
+        .disabled(!self.track.isPlayable)
+        .onHover { hovering in self.isHovered = hovering }
+        .contextMenu { self.menu() }
+    }
+
+    private var hasNavigableArtists: Bool {
+        self.artists?.contains(where: \.hasNavigableId) ?? false
+    }
+
+    @ViewBuilder
+    private var artistLinksView: some View {
+        let artists = self.artists ?? []
+
+        HStack(spacing: 0) {
+            ForEach(Array(artists.enumerated()), id: \.offset) { index, artist in
+                if artist.hasNavigableId {
+                    HoverUnderlineNavigationLink(
+                        value: artist,
+                        title: artist.name,
+                        font: .system(size: 12),
+                        foregroundStyle: .secondary
+                    )
+                } else {
+                    Text(artist.name)
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+
+                if index < artists.count - 1 {
+                    Text(verbatim: ", ")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+        }
+    }
+}

--- a/Sources/Kaset/Views/PlaylistTrackRow.swift
+++ b/Sources/Kaset/Views/PlaylistTrackRow.swift
@@ -23,70 +23,97 @@ struct PlaylistTrackRow<Menu: View>: View {
     @Environment(PlayerService.self) private var playerService
 
     var body: some View {
+        self.rowContent
+            .background { self.playbackButton }
+            .onHover { hovering in self.isHovered = hovering }
+            .contextMenu { self.menu() }
+    }
+
+    private var rowContent: some View {
         let isCurrent = self.playerService.currentTrack?.videoId == self.track.videoId
 
-        Button(action: self.onPlay) {
-            HStack(spacing: 12) {
-                Group {
-                    if isCurrent {
-                        NowPlayingIndicator(isPlaying: self.playerService.isPlaying, size: 14)
-                    } else {
-                        Text("\(self.index + 1)")
-                            .font(.system(size: 14))
-                            .foregroundStyle(.secondary)
-                    }
+        return HStack(spacing: 12) {
+            Group {
+                if isCurrent {
+                    NowPlayingIndicator(isPlaying: self.playerService.isPlaying, size: 14)
+                } else {
+                    Text("\(self.index + 1)")
+                        .font(.system(size: 14))
+                        .foregroundStyle(.secondary)
                 }
-                .frame(width: 28, alignment: .trailing)
-
-                if !self.isAlbum {
-                    CachedAsyncImage(url: self.track.thumbnailURL, targetSize: CGSize(width: 40, height: 40)) { image in
-                        image.resizable().aspectRatio(contentMode: .fill)
-                    } placeholder: {
-                        Rectangle().fill(.quaternary)
-                    }
-                    .frame(width: 40, height: 40)
-                    .clipShape(.rect(cornerRadius: 4))
-                }
-
-                VStack(alignment: .leading, spacing: 2) {
-                    HStack(spacing: 6) {
-                        Text(self.track.title)
-                            .font(.system(size: 14))
-                            .foregroundStyle(isCurrent ? .red : .primary)
-                            .lineLimit(1)
-                        if self.track.isExplicit == true {
-                            ExplicitBadge()
-                        }
-                    }
-                    if let subtitle = self.subtitle {
-                        if self.hasNavigableArtists {
-                            self.artistLinksView
-                        } else {
-                            Text(subtitle)
-                                .font(.system(size: 12))
-                                .foregroundStyle(.secondary)
-                                .lineLimit(1)
-                        }
-                    }
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-                LikeButton(song: self.track, isRowHovered: self.isHovered, allowsActions: self.allowsLikeActions)
-
-                Text(self.track.durationDisplay)
-                    .font(.system(size: 12))
-                    .foregroundStyle(.secondary)
-                    .frame(width: 45, alignment: .trailing)
             }
-            .padding(.vertical, 8)
-            .padding(.horizontal, 4)
-            .contentShape(Rectangle())
-            .opacity(self.track.isPlayable ? 1 : 0.5)
+            .frame(width: 28, alignment: .trailing)
+            .allowsHitTesting(false)
+
+            if !self.isAlbum {
+                CachedAsyncImage(url: self.track.thumbnailURL, targetSize: CGSize(width: 40, height: 40)) { image in
+                    image.resizable().scaledToFill()
+                } placeholder: {
+                    Rectangle().fill(.quaternary)
+                }
+                .frame(width: 40, height: 40)
+                .clipShape(.rect(cornerRadius: 4))
+                .allowsHitTesting(false)
+            }
+
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Text(self.track.title)
+                        .font(.system(size: 14))
+                        .foregroundStyle(isCurrent ? .red : .primary)
+                        .lineLimit(1)
+                        .accessibilityHidden(true)
+                    if self.track.isExplicit == true {
+                        ExplicitBadge()
+                    }
+                }
+                .allowsHitTesting(false)
+                if let subtitle = self.subtitle {
+                    if self.hasNavigableArtists {
+                        self.artistLinksView
+                    } else {
+                        Text(subtitle)
+                            .font(.system(size: 12))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .allowsHitTesting(false)
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            LikeButton(song: self.track, isRowHovered: self.isHovered, allowsActions: self.allowsLikeActions)
+                .disabled(!self.track.isPlayable)
+                .allowsHitTesting(self.allowsLikeActions && self.track.isPlayable)
+
+            Text(self.track.durationDisplay)
+                .font(.system(size: 12))
+                .foregroundStyle(.secondary)
+                .frame(width: 45, alignment: .trailing)
+                .allowsHitTesting(false)
+        }
+        .padding(.vertical, 8)
+        .padding(.horizontal, 4)
+        .opacity(self.track.isPlayable ? 1 : 0.5)
+    }
+
+    private var playbackButton: some View {
+        Button(action: self.onPlay) {
+            Color.clear
+                .contentShape(Rectangle())
         }
         .buttonStyle(.interactiveRow(cornerRadius: 6))
         .disabled(!self.track.isPlayable)
-        .onHover { hovering in self.isHovered = hovering }
-        .contextMenu { self.menu() }
+        .accessibilityLabel(Text(verbatim: self.playbackAccessibilityLabel))
+        .accessibilityHint(Text(String(localized: "Play")))
+    }
+
+    private var playbackAccessibilityLabel: String {
+        guard let subtitle = self.subtitle?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !subtitle.isEmpty
+        else { return self.track.title }
+
+        return "\(self.track.title), \(subtitle)"
     }
 
     private var hasNavigableArtists: Bool {
@@ -111,6 +138,7 @@ struct PlaylistTrackRow<Menu: View>: View {
                         .font(.system(size: 12))
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
+                        .allowsHitTesting(false)
                 }
 
                 if index < artists.count - 1 {
@@ -118,6 +146,7 @@ struct PlaylistTrackRow<Menu: View>: View {
                         .font(.system(size: 12))
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
+                        .allowsHitTesting(false)
                 }
             }
 

--- a/Sources/Kaset/Views/PodcastsView.swift
+++ b/Sources/Kaset/Views/PodcastsView.swift
@@ -156,7 +156,7 @@ private struct PodcastShowCard: View {
                 CachedAsyncImage(url: self.show.thumbnailURL, targetSize: CGSize(width: 160, height: 160)) { image in
                     image
                         .resizable()
-                        .aspectRatio(contentMode: .fill)
+                        .scaledToFill()
                 }
                 .frame(width: 160, height: 160)
                 .clipShape(RoundedRectangle(cornerRadius: 8))
@@ -199,7 +199,7 @@ private struct PodcastEpisodeCard: View {
                     CachedAsyncImage(url: self.episode.thumbnailURL, targetSize: CGSize(width: 200, height: 112)) { image in
                         image
                             .resizable()
-                            .aspectRatio(contentMode: .fill)
+                            .scaledToFill()
                     }
                     .frame(width: 200, height: 112)
                     .clipShape(RoundedRectangle(cornerRadius: 8))
@@ -337,7 +337,7 @@ struct PodcastShowView: View {
             CachedAsyncImage(url: self.show.thumbnailURL, targetSize: CGSize(width: 180, height: 180)) { image in
                 image
                     .resizable()
-                    .aspectRatio(contentMode: .fill)
+                    .scaledToFill()
             }
             .frame(width: 180, height: 180)
             .clipShape(RoundedRectangle(cornerRadius: 12))
@@ -520,7 +520,7 @@ struct PodcastEpisodeRow: View {
                 CachedAsyncImage(url: self.episode.thumbnailURL, targetSize: CGSize(width: 80, height: 80)) { image in
                     image
                         .resizable()
-                        .aspectRatio(contentMode: .fill)
+                        .scaledToFill()
                 }
                 .frame(width: 80, height: 80)
                 .clipShape(RoundedRectangle(cornerRadius: 6))

--- a/Sources/Kaset/Views/SearchView.swift
+++ b/Sources/Kaset/Views/SearchView.swift
@@ -357,7 +357,7 @@ struct SearchView: View {
                     CachedAsyncImage(url: item.thumbnailURL?.highQualityThumbnailURL, targetSize: CGSize(width: 48, height: 48)) { image in
                         image
                             .resizable()
-                            .aspectRatio(contentMode: .fill)
+                            .scaledToFill()
                     } placeholder: {
                         Rectangle()
                             .fill(.quaternary)

--- a/Sources/Kaset/Views/SharedViews/FavoritesSection.swift
+++ b/Sources/Kaset/Views/SharedViews/FavoritesSection.swift
@@ -266,7 +266,7 @@ private struct FavoriteItemCard: View {
                 CachedAsyncImage(url: url, targetSize: Self.thumbnailTargetSize) { image in
                     image
                         .resizable()
-                        .aspectRatio(contentMode: .fill)
+                        .scaledToFill()
                 } placeholder: {
                     self.placeholderView
                 }

--- a/Sources/Kaset/Views/SharedViews/SongThumbnailView.swift
+++ b/Sources/Kaset/Views/SharedViews/SongThumbnailView.swift
@@ -83,7 +83,7 @@ struct SongThumbnailView: View {
         CachedAsyncImage(url: self.activeURL, targetSize: self.targetSize, onFailure: self.failureHandler) { image in
             image
                 .resizable()
-                .aspectRatio(contentMode: .fill)
+                .scaledToFill()
         } placeholder: {
             Rectangle()
                 .fill(.quaternary)

--- a/Sources/Kaset/Views/SidebarProfileView.swift
+++ b/Sources/Kaset/Views/SidebarProfileView.swift
@@ -218,7 +218,7 @@ struct SidebarProfileView: View {
             CachedAsyncImage(url: thumbnailURL, targetSize: CGSize(width: 32, height: 32)) { image in
                 image
                     .resizable()
-                    .aspectRatio(contentMode: .fill)
+                    .scaledToFill()
             } placeholder: {
                 self.avatarPlaceholder
             }

--- a/Sources/Kaset/Views/YouTube/VideoCard.swift
+++ b/Sources/Kaset/Views/YouTube/VideoCard.swift
@@ -76,7 +76,7 @@ struct VideoThumbnailView: View {
         ) { image in
             image
                 .resizable()
-                .aspectRatio(contentMode: .fill)
+                .scaledToFill()
         } placeholder: {
             Rectangle()
                 .fill(.quaternary)

--- a/Sources/Kaset/Views/YouTube/YouTubeChannelView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeChannelView.swift
@@ -76,7 +76,7 @@ struct YouTubeChannelView: View {
             ) { image in
                 image
                     .resizable()
-                    .aspectRatio(contentMode: .fill)
+                    .scaledToFill()
             } placeholder: {
                 Circle()
                     .fill(.quaternary)

--- a/Sources/Kaset/Views/YouTube/YouTubeListRows.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeListRows.swift
@@ -55,7 +55,7 @@ struct ChannelRowView: View {
             ) { image in
                 image
                     .resizable()
-                    .aspectRatio(contentMode: .fill)
+                    .scaledToFill()
             } placeholder: {
                 Circle()
                     .fill(.quaternary)
@@ -111,7 +111,7 @@ struct YouTubePlaylistRowView: View {
             ) { image in
                 image
                     .resizable()
-                    .aspectRatio(contentMode: .fill)
+                    .scaledToFill()
             } placeholder: {
                 Rectangle()
                     .fill(.quaternary)
@@ -176,7 +176,7 @@ struct YouTubePlaylistCard: View {
             ) { image in
                 image
                     .resizable()
-                    .aspectRatio(contentMode: .fill)
+                    .scaledToFill()
             } placeholder: {
                 Rectangle()
                     .fill(.quaternary)

--- a/Sources/Kaset/Views/YouTube/YouTubePlayerBar.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubePlayerBar.swift
@@ -162,7 +162,7 @@ struct YouTubePlayerBar: View {
                 ) { image in
                     image
                         .resizable()
-                        .aspectRatio(contentMode: .fill)
+                        .scaledToFill()
                 } placeholder: {
                     RoundedRectangle(cornerRadius: 6, style: .continuous)
                         .fill(.quaternary)

--- a/Sources/Kaset/Views/YouTube/YouTubeShortsView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeShortsView.swift
@@ -141,7 +141,7 @@ private struct ShortPage: View {
                 ) { image in
                     image
                         .resizable()
-                        .aspectRatio(contentMode: .fill)
+                        .scaledToFill()
                 } placeholder: {
                     Rectangle()
                         .fill(.black)

--- a/Sources/Kaset/Views/YouTube/YouTubeSubscriptionsView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeSubscriptionsView.swift
@@ -99,7 +99,7 @@ struct YouTubeSubscriptionsView: View {
                                 ) { image in
                                     image
                                         .resizable()
-                                        .aspectRatio(contentMode: .fill)
+                                        .scaledToFill()
                                 } placeholder: {
                                     Circle()
                                         .fill(.quaternary)

--- a/Sources/Kaset/Views/YouTube/YouTubeWatchView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeWatchView.swift
@@ -240,7 +240,7 @@ struct YouTubeWatchView: View {
                 ) { image in
                     image
                         .resizable()
-                        .aspectRatio(contentMode: .fill)
+                        .scaledToFill()
                 } placeholder: {
                     Rectangle().fill(.black)
                 }
@@ -300,7 +300,7 @@ struct YouTubeWatchView: View {
                             ) { image in
                                 image
                                     .resizable()
-                                    .aspectRatio(contentMode: .fill)
+                                    .scaledToFill()
                             } placeholder: {
                                 Circle().fill(.quaternary)
                             }
@@ -759,7 +759,7 @@ private struct CommentRow: View {
         ) { image in
             image
                 .resizable()
-                .aspectRatio(contentMode: .fill)
+                .scaledToFill()
         } placeholder: {
             Circle()
                 .fill(.quaternary)
@@ -811,7 +811,7 @@ private struct ChapterCard: View {
         ) { image in
             image
                 .resizable()
-                .aspectRatio(contentMode: .fill)
+                .scaledToFill()
         } placeholder: {
             Rectangle()
                 .fill(.quaternary)

--- a/Tests/KasetTests/Helpers/MockYTMusicClient.swift
+++ b/Tests/KasetTests/Helpers/MockYTMusicClient.swift
@@ -96,6 +96,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     var editSongLibraryStatusErrors: [(any Error)?] = []
     var getSongDelay: Duration?
     var getHistoryDelay: Duration?
+    var shouldWaitForGetHistoryResponse = false
     var getPodcastsDelay: Duration?
     var getPlaylistDelay: Duration?
     var getPlaylistError: Error?
@@ -302,6 +303,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     private(set) var addSongToPlaylistCalls: [AddSongToPlaylistCall] = []
     private(set) var removeSongFromPlaylistCalls: [RemoveSongFromPlaylistCall] = []
     private var removeSongFromPlaylistResponseContinuations: [CheckedContinuation<Void, Never>] = []
+    private var getHistoryResponseContinuations: [CheckedContinuation<Void, Never>] = []
     private(set) var unsubscribeFromPlaylistCalled = false
     private(set) var unsubscribeFromPlaylistIds: [String] = []
     private(set) var subscribeToArtistCalled = false
@@ -472,6 +474,11 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     func getHistory() async throws -> HomeResponse {
         self.getHistoryCallCount += 1
         self._historyContinuationIndex = 0
+        if self.shouldWaitForGetHistoryResponse {
+            await withCheckedContinuation { continuation in
+                self.getHistoryResponseContinuations.append(continuation)
+            }
+        }
         if let getHistoryDelay {
             try? await Task.sleep(for: getHistoryDelay)
         }
@@ -1101,6 +1108,11 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         }
     }
 
+    func resumeNextGetHistoryResponse() {
+        guard !self.getHistoryResponseContinuations.isEmpty else { return }
+        self.getHistoryResponseContinuations.removeFirst().resume()
+    }
+
     func resumeNextRemoveSongFromPlaylistResponse() {
         guard !self.removeSongFromPlaylistResponseContinuations.isEmpty else { return }
         self.removeSongFromPlaylistResponseContinuations.removeFirst().resume()
@@ -1437,6 +1449,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.editSongLibraryStatusErrors = []
         self.getSongDelay = nil
         self.getHistoryDelay = nil
+        self.shouldWaitForGetHistoryResponse = false
         self.mixQueueDelay = nil
         self.getRadioQueueDelay = nil
         self.mixQueueResult = RadioQueueResult(songs: [], continuationToken: nil)

--- a/Tests/KasetTests/HistoryViewModelTests.swift
+++ b/Tests/KasetTests/HistoryViewModelTests.swift
@@ -180,13 +180,15 @@ struct HistoryViewModelTests {
         await self.viewModel.loadMore()
         #expect(self.viewModel.sections.map(\.title) == ["Today", "Yesterday"])
 
-        self.mockClient.getHistoryDelay = .milliseconds(100)
+        self.mockClient.shouldWaitForGetHistoryResponse = true
         let refreshTask = Task { await self.viewModel.refresh() }
         await self.waitForHistoryRefresh {
             self.mockClient.getHistoryCallCount == 2
         }
 
         await self.viewModel.loadMore()
+
+        self.mockClient.resumeNextGetHistoryResponse()
         _ = await refreshTask.value
 
         #expect(self.mockClient.getHistoryContinuationCallCount == 1)

--- a/Tests/KasetTests/PlaylistQueueParserTests.swift
+++ b/Tests/KasetTests/PlaylistQueueParserTests.swift
@@ -1,0 +1,121 @@
+import Testing
+@testable import Kaset
+
+@Suite(.tags(.parser))
+struct PlaylistQueueParserTests {
+    @Test("Curated playlist queues preserve linked artists from long bylines", arguments: [false, true])
+    func preservesLinkedArtists(wrapped: Bool) throws {
+        // Shapes observed in Chill R&B and Country Summer via music/get_queue.
+        // The short bylines are display-only, and the long bylines carry artist links.
+        let chill: [String: Any] = [
+            "videoId": "chill-track",
+            "title": ["runs": [["text": "Chill Track"]]],
+            "shortBylineText": ["runs": [["text": "COLORS & Tems"]]],
+            "longBylineText": [
+                "runs": [
+                    Self.artistRun(name: "COLORS", id: "UC-colors"),
+                    ["text": " & "],
+                    Self.artistRun(name: "Tems", id: "UC-tems"),
+                    ["text": " • "],
+                    ["text": "12M views"],
+                    ["text": " • "],
+                    ["text": "191K likes"],
+                ],
+            ],
+        ]
+        let country: [String: Any] = [
+            "videoId": "country-track",
+            "title": ["runs": [["text": "Country Track"]]],
+            "shortBylineText": ["runs": [["text": "Ella Langley"]]],
+            "longBylineText": [
+                "runs": [
+                    Self.artistRun(name: "Ella Langley", id: "UC-ella-langley"),
+                    ["text": " • "],
+                    ["text": "79M views"],
+                    ["text": " • "],
+                    ["text": "690K likes"],
+                ],
+            ],
+        ]
+
+        let tracks = PlaylistParser.parseQueueTracks([
+            "queueDatas": [
+                Self.queueItem(chill, wrapped: wrapped),
+                Self.queueItem(country, wrapped: wrapped),
+            ],
+        ])
+
+        #expect(tracks.map(\.videoId) == ["chill-track", "country-track"])
+        let chillTrack = try #require(tracks.first)
+        #expect(chillTrack.artists.map(\.name) == ["COLORS", "Tems"])
+        #expect(chillTrack.artists.map(\.id) == ["UC-colors", "UC-tems"])
+        #expect(chillTrack.artists.map(\.hasNavigableId) == [true, true])
+        let countryTrack = try #require(tracks.last)
+        #expect(countryTrack.artists.map(\.name) == ["Ella Langley"])
+        #expect(countryTrack.artists.map(\.id) == ["UC-ella-langley"])
+        #expect(countryTrack.artists.map(\.hasNavigableId) == [true])
+    }
+
+    @Test("Queue artists fall back to short bylines when long bylines are absent or empty", arguments: [false, true])
+    func fallsBackToShortByline(emptyLongByline: Bool) throws {
+        var renderer: [String: Any] = [
+            "videoId": "short-byline-track",
+            "shortBylineText": ["runs": [Self.artistRun(name: "Short Artist", id: "UC-short")]],
+        ]
+        if emptyLongByline {
+            renderer["longBylineText"] = ["runs": [] as [[String: Any]]]
+        }
+
+        let tracks = PlaylistParser.parseQueueTracks(["queueDatas": [Self.queueItem(renderer)]])
+
+        let track = try #require(tracks.first)
+        #expect(track.artists.map(\.name) == ["Short Artist"])
+        #expect(track.artists.map(\.id) == ["UC-short"])
+        #expect(track.artists.map(\.hasNavigableId) == [true])
+    }
+
+    @Test("Queue artists preserve plain short bylines without inventing navigation")
+    func preservesPlainShortByline() throws {
+        let renderer: [String: Any] = [
+            "videoId": "plain-byline-track",
+            "shortBylineText": ["runs": [["text": "Plain Artist"]]],
+        ]
+
+        let tracks = PlaylistParser.parseQueueTracks(["queueDatas": [Self.queueItem(renderer)]])
+
+        let track = try #require(tracks.first)
+        #expect(track.artists.map(\.name) == ["Plain Artist"])
+        #expect(track.artists.allSatisfy { !$0.hasNavigableId })
+    }
+
+    @Test("Queue artists preserve the unknown artist fallback when both bylines are missing")
+    func preservesUnknownArtistFallback() throws {
+        let renderer: [String: Any] = ["videoId": "unknown-artist-track"]
+
+        let tracks = PlaylistParser.parseQueueTracks(["queueDatas": [Self.queueItem(renderer)]])
+
+        let track = try #require(tracks.first)
+        #expect(track.artists.map(\.name) == ["Unknown Artist"])
+        #expect(track.artists.allSatisfy { !$0.hasNavigableId })
+    }
+
+    private static func artistRun(name: String, id: String) -> [String: Any] {
+        [
+            "text": name,
+            "navigationEndpoint": ["browseEndpoint": ["browseId": id]],
+        ]
+    }
+
+    private static func queueItem(_ renderer: [String: Any], wrapped: Bool = false) -> [String: Any] {
+        let content: [String: Any] = if wrapped {
+            [
+                "playlistPanelVideoWrapperRenderer": [
+                    "primaryRenderer": ["playlistPanelVideoRenderer": renderer],
+                ],
+            ]
+        } else {
+            ["playlistPanelVideoRenderer": renderer]
+        }
+        return ["content": content]
+    }
+}

--- a/docs/api-discovery.md
+++ b/docs/api-discovery.md
@@ -888,13 +888,18 @@ let body = ["playlistId": "RDCLAK5uy_l2pHac-aawJYLcesgTf67gaKU-B9ekk1o"]
 }
 ```
 
-> ⚠️ **Note**: The response uses a **wrapper structure** (`playlistPanelVideoWrapperRenderer.primaryRenderer.playlistPanelVideoRenderer`) 
-> rather than a direct `playlistPanelVideoRenderer`. Parsers must handle this wrapper.
+> ⚠️ **Note**: Responses can contain either a direct `playlistPanelVideoRenderer` or a **wrapper structure** (`playlistPanelVideoWrapperRenderer.primaryRenderer.playlistPanelVideoRenderer`). Parsers must handle both.
 
 **playlistPanelVideoRenderer keys** (verified):
 - `title`, `longBylineText`, `thumbnail`, `lengthText`
 - `selected`, `navigationEndpoint`, `videoId`, `shortBylineText`
 - `trackingParams`, `menu`
+
+Artist navigation, verified with guest requests for **Chill R&B** and **Country Summer** on 2026-09-04:
+
+- `shortBylineText` contains a single display-only run, such as `COLORS & Tems`, without artist browse endpoints.
+- `longBylineText` contains separate artist runs with `UC...` browse endpoints. Ampersands or commas separate co-artists; a bullet separates the artists from view and like counts.
+- Parse artists from the long byline, stopping before trailing metadata. Use the short byline as a fallback when the long byline has no artists.
 
 **Use cases**:
 - Get metadata for multiple videos in one call (queue display)


### PR DESCRIPTION
## Description

Artist names in playlist track rows are currently plain `Text` — clicking the row only plays the track. This PR makes artist names individually clickable `NavigationLink`s when the artist has a navigable ID, while keeping the row's play-on-click behavior intact. Non-navigable artists remain plain text.

## AI Prompt (Optional)

<details>
<summary>🤖 AI Prompt Used</summary>

```
N/A - Manual implementation
```

**AI Tool:** Claude

</details>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [x] 🎨 UI/UX improvement
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🧪 Test update
- [ ] 🔧 Build/CI configuration

## Related Issues

Closes #435

## Changes Made

- **`PlaylistDetailView.swift`**:
  - Extended `HoverUnderlineNavigationLink` with `font` and `foregroundStyle` parameters so it can match the track row subtitle styling (12pt, `.secondary`)
  - Added `artists: [Artist]?` property to `PlaylistTrackRow`
  - Replaced the subtitle `Text` with `artistLinksView` when navigable artists are available; falls back to plain `Text(subtitle)` otherwise
  - Added `hasNavigableArtists` computed property and `artistLinksView` that renders each artist as a `HoverUnderlineNavigationLink` (or plain `Text` for non-navigable artists), separated by ", "
  - Added `trackArtists(for:fallbackAuthor:)` helper that returns the unique `Artist` array for linking
  - Updated the `trackRow` call site to pass the `artists` parameter
  - `trackArtists(for:fallbackAuthor:)` now falls back to the detail author when a track carries no artist objects of its own — see "Album track rows" below
- **`HoverUnderlineNavigationLink.swift`**: `contentShape(.rect)` now closes the label modifier chain, vertical padding widens the hit band, and `pointerStyle(.link)` provides the hand cursor
- **`PlaylistTrackRow.swift`**: trailing `Spacer(minLength: 0)` in the artist `HStack` so leftover row width is absorbed by the spacer rather than distributed to the links

## Screencast


https://github.com/user-attachments/assets/a820b264-b1c8-4322-bc20-027b8e3d7f57


## Testing

- [x] Unit tests pass (`swift test --skip KasetUITests`) — 2956 tests in 232 suites
- [x] Manual testing performed
- [x] UI tested on macOS 26+

Verified in a packaged build: playlist rows and album rows, hover underline, click-through to the artist page, and click-elsewhere-in-row still plays the track.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `swiftlint --strict && swiftformat .`
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally
- [x] I have updated documentation if needed
- [x] I have checked for any performance implications
- [x] My changes generate no new warnings

No automated test was added: the defects here are SwiftUI hit-testing and pointer-region behavior, which have no test seam in this codebase — `NSHostingView` flattens the hierarchy, so `hitTest` cannot distinguish the link from the row button.

## Additional Notes

### Hit-testing fix

The first version of this PR had a real defect: only part of each artist name was clickable. Clicks past roughly two-thirds of the name fell through to the row and played the track instead of navigating, and the link cursor never appeared at all.

Instrumenting the real view (geometry logged from a packaged build) ruled out the obvious explanation — the link frame already matched the rendered text exactly:

```
TEXT 'Dub Element' frame=(390.0, 355.0, 72.5, 15.0) intrinsicWidth=72.16
LINK 'Dub Element' frame=(390.0, 355.0, 72.5, 15.0)
```

`onHover` also fired across the full width (`true` at localX 2.46, `false` at 72.39). So sizing and hover tracking were both correct; what differed was **click** hit-testing — the row `Button` won on the right portion. Confirmed by tap probes: clicks at localX 27.0 and 48.7 activated the link, a click at ~68.5 triggered the row's play action.

The fix makes `contentShape(.rect)` the last modifier in the label chain (nothing after it to disturb the composite hit shape), adds a little vertical padding to widen the target band, and adds `pointerStyle(.link)`.

This also corrects an assumption in the original version of this description, which claimed the nested `NavigationLink` "intercepts taps on its own area". It does not do so reliably — that is the bug.

### Album track rows

Album track entries returned by YouTube carry no per-track artist objects, so `trackArtists` returned `nil` and every album row rendered plain text even though the album header's artist link worked. `trackArtists` now falls back to the detail author, guarded twice: only when that author has a navigable ID, and only when its name matches the subtitle the row is actually displaying. Albums whose author is an `Artist.inline(…)` placeholder degrade to plain text exactly as before, rather than rendering a dead link.

This is scope beyond the original "playlist track rows" framing, so calling it out explicitly.

### Known follow-up (not in this PR)

`PlaylistTrackRow` wraps the whole row in `Button(action: onPlay)` and puts other interactive controls (artist links, `LikeButton`) inside that button's **label**. Nested controls in a `Button` label make SwiftUI arbitrate who wins a click, and that arbitration is the root cause of the hit-testing bug above; the fix here tunes the label's hit shape rather than removing the ambiguity.

A more robust structure inverts the layering so hit priority is z-order rather than arbitration:

```swift
HStack { … artist links, LikeButton … }
    .background(
        Button(action: onPlay) { Color.clear.contentShape(.rect) }
            .buttonStyle(.interactiveRow(cornerRadius: 6))
    )
```

Foreground controls always win where they are; the background catches everything else. Worth doing as a shared row container rather than inline, since `.interactiveRow` is a shared button style and this row shape likely repeats in album/search/queue views — which may carry the same latent bug. Left out of this PR to keep the diff reviewable.
