### PR TITLE
fix(playback): route bare Space to play/pause and stop hidden WebView swallowing ⌘←/⌘→

### DIFF
--- a/Sources/Kaset/KasetApp.swift
+++ b/Sources/Kaset/KasetApp.swift
@@ -67,6 +67,9 @@ struct KasetApp: App {
 
     @State private var textInputFocusState = TextInputFocusState()
 
+    /// Delivers the modifier-less Space shortcut, which AppKit never routes to the menu.
+    @State private var playbackSpaceKeyMonitor = PlaybackSpaceKeyMonitor()
+
     @State private var sidebarNavigationReselectGenerations: [NavigationItem: Int] = [:]
 
     /// Current navigation selection for keyboard navigation.
@@ -267,6 +270,10 @@ struct KasetApp: App {
                 .onAppear {
                     DiagnosticsLogger.app.info("KasetApp: App content appeared")
                     self.textInputFocusState.startMonitoring()
+                    self.playbackSpaceKeyMonitor.start(
+                        isPlaybackCommandEnabled: { !self.shouldDisablePlaybackCommand },
+                        onPlayPause: { self.performPlayPause() }
+                    )
                     // Wire up PlayerService to AppDelegate for dock menu and AppleScript actions
                     // This runs synchronously so AppleScript commands can access playerService immediately
                     self.appDelegate.playerService = self.playerService
@@ -378,13 +385,7 @@ struct KasetApp: App {
             CommandMenu("Playback") {
                 // Play/Pause - Space
                 Button(self.activePlayerIsPlaying ? "Pause" : "Play") {
-                    if self.playbackArbiter.routesMediaKeysToVideo {
-                        self.youtubePlayerService.playPause()
-                    } else {
-                        Task {
-                            await self.playerService.playPause()
-                        }
-                    }
+                    self.performPlayPause()
                 }
                 .keyboardShortcut(self.playbackShortcut(.space, modifiers: []))
                 .disabled(self.shouldDisablePlaybackCommand)
@@ -700,6 +701,18 @@ struct KasetApp: App {
     }
 
     /// Whether the currently routed player (video or music) is playing.
+    /// Toggles playback on whichever player is active. Shared by the Playback menu item and
+    /// `PlaybackSpaceKeyMonitor`, so the Space key and the menu can never diverge.
+    private func performPlayPause() {
+        if self.playbackArbiter.routesMediaKeysToVideo {
+            self.youtubePlayerService.playPause()
+        } else {
+            Task {
+                await self.playerService.playPause()
+            }
+        }
+    }
+
     private var activePlayerIsPlaying: Bool {
         if self.playbackArbiter.routesMediaKeysToVideo {
             self.youtubePlayerService.isPlaying

--- a/Sources/Kaset/KasetApp.swift
+++ b/Sources/Kaset/KasetApp.swift
@@ -222,7 +222,7 @@ struct KasetApp: App {
     }
 
     var body: some Scene {
-        Window("Kaset", id: "main") {
+        Window("Kaset", id: MainWindowLayout.sceneIdentifier) {
             // Skip UI during unit tests to prevent window spam
             if UITestConfig.isRunningUnitTests, !UITestConfig.isUITestMode {
                 Color.clear
@@ -639,7 +639,7 @@ struct KasetApp: App {
     private func showMainWindow() {
         guard !self.focusExistingMainWindow() else { return }
 
-        self.openWindow(id: "main")
+        self.openWindow(id: MainWindowLayout.sceneIdentifier)
         NSApplication.shared.activate(ignoringOtherApps: true)
 
         Task { @MainActor in

--- a/Sources/Kaset/KasetApp.swift
+++ b/Sources/Kaset/KasetApp.swift
@@ -67,6 +67,9 @@ struct KasetApp: App {
 
     @State private var textInputFocusState = TextInputFocusState()
 
+    /// Delivers the modifier-less Space shortcut, which AppKit never routes to the menu.
+    @State private var playbackSpaceKeyMonitor = PlaybackSpaceKeyMonitor()
+
     @State private var sidebarNavigationReselectGenerations: [NavigationItem: Int] = [:]
 
     /// Current navigation selection for keyboard navigation.
@@ -253,6 +256,10 @@ struct KasetApp: App {
                 .onAppear {
                     DiagnosticsLogger.app.info("KasetApp: App content appeared")
                     self.textInputFocusState.startMonitoring()
+                    self.playbackSpaceKeyMonitor.start(
+                        isPlaybackCommandEnabled: { !self.shouldDisablePlaybackCommand },
+                        onPlayPause: { self.performPlayPause() }
+                    )
                     // Wire up PlayerService to AppDelegate for dock menu and AppleScript actions
                     // This runs synchronously so AppleScript commands can access playerService immediately
                     self.appDelegate.playerService = self.playerService
@@ -364,13 +371,7 @@ struct KasetApp: App {
             CommandMenu("Playback") {
                 // Play/Pause - Space
                 Button(self.activePlayerIsPlaying ? "Pause" : "Play") {
-                    if self.playbackArbiter.routesMediaKeysToVideo {
-                        self.youtubePlayerService.playPause()
-                    } else {
-                        Task {
-                            await self.playerService.playPause()
-                        }
-                    }
+                    self.performPlayPause()
                 }
                 .keyboardShortcut(self.playbackShortcut(.space, modifiers: []))
                 .disabled(self.shouldDisablePlaybackCommand)
@@ -678,6 +679,18 @@ struct KasetApp: App {
     }
 
     /// Whether the currently routed player (video or music) is playing.
+    /// Toggles playback on whichever player is active. Shared by the Playback menu item and
+    /// `PlaybackSpaceKeyMonitor`, so the Space key and the menu can never diverge.
+    private func performPlayPause() {
+        if self.playbackArbiter.routesMediaKeysToVideo {
+            self.youtubePlayerService.playPause()
+        } else {
+            Task {
+                await self.playerService.playPause()
+            }
+        }
+    }
+
     private var activePlayerIsPlaying: Bool {
         if self.playbackArbiter.routesMediaKeysToVideo {
             self.youtubePlayerService.isPlaying

--- a/Sources/Kaset/Utilities/MainWindowLayout.swift
+++ b/Sources/Kaset/Utilities/MainWindowLayout.swift
@@ -9,6 +9,7 @@ import AppKit
 /// `NSWindow` so live resizing and restored autosaved frames cannot shrink the
 /// window below the point where the sidebar/player controls remain usable.
 enum MainWindowLayout {
+    static let sceneIdentifier = "main"
     static let autosaveName = "KasetMainWindow"
     static let windowTitle = "Kaset"
     static let minimumWidth: CGFloat = 980
@@ -23,13 +24,24 @@ enum MainWindowLayout {
     }
 
     /// Returns true for windows that are known to be the primary app window.
-    static func isPrimaryWindowIdentity(title: String, frameAutosaveName: String) -> Bool {
-        frameAutosaveName == self.autosaveName || title == self.windowTitle
+    static func isPrimaryWindowIdentity(
+        title: String,
+        frameAutosaveName: String,
+        identifier: String? = nil
+    ) -> Bool {
+        identifier == self.sceneIdentifier
+            || frameAutosaveName == self.sceneIdentifier
+            || frameAutosaveName == self.autosaveName
+            || title == self.windowTitle
     }
 
     @MainActor
     static func isPrimaryWindow(_ window: NSWindow) -> Bool {
-        self.isPrimaryWindowIdentity(title: window.title, frameAutosaveName: window.frameAutosaveName)
+        self.isPrimaryWindowIdentity(
+            title: window.title,
+            frameAutosaveName: window.frameAutosaveName,
+            identifier: window.identifier?.rawValue
+        )
     }
 
     /// Applies the primary-window sizing contract to an AppKit window.

--- a/Sources/Kaset/Utilities/PlaybackSpaceKeyMonitor.swift
+++ b/Sources/Kaset/Utilities/PlaybackSpaceKeyMonitor.swift
@@ -1,0 +1,82 @@
+import AppKit
+
+// MARK: - PlaybackSpaceKeyMonitor
+
+/// Routes the modifier-less Space key to the Playback play/pause command.
+///
+/// AppKit never offers a modifier-less key equivalent to the main menu, so the
+/// `Space` shortcut declared on the Playback command menu is registered on the menu
+/// item but is never dispatched: the key window's view hierarchy declines the event
+/// and it dies before the menu is consulted (issue #405). A local key-down monitor
+/// is the standard way to reach a bare-Space shortcut.
+///
+/// Space is only claimed when the native UI holds focus. While a text field is being
+/// edited it must type a space, and while the player WebView holds focus the page's
+/// own handler already toggles playback — claiming it there would toggle twice.
+@MainActor
+final class PlaybackSpaceKeyMonitor {
+    nonisolated static let spaceKeyCode: UInt16 = 49
+
+    private var monitor: Any?
+
+    /// Whether Space should be claimed for play/pause instead of being delivered normally.
+    nonisolated static func handlesSpaceKey(
+        keyCode: UInt16,
+        modifiers: NSEvent.ModifierFlags,
+        isTextInputFocused: Bool,
+        isWebContentFocused: Bool,
+        isPlaybackCommandEnabled: Bool
+    ) -> Bool {
+        guard keyCode == self.spaceKeyCode else { return false }
+        let significantModifiers = modifiers
+            .intersection(.deviceIndependentFlagsMask)
+            .subtracting([.capsLock, .function, .numericPad])
+        guard significantModifiers.isEmpty else { return false }
+        return isPlaybackCommandEnabled && !isTextInputFocused && !isWebContentFocused
+    }
+
+    /// Whether the responder is inside the player WebView, whose page handles Space itself.
+    nonisolated static func isWebContent(_ responderTypeName: String) -> Bool {
+        responderTypeName.contains("WebView") || responderTypeName.contains("WKContent")
+    }
+
+    /// Whether the responder is a text editor that must receive Space as typed input.
+    static func isTextInput(_ responder: NSResponder?) -> Bool {
+        responder is NSTextView || responder is NSTextField
+    }
+
+    func start(
+        isPlaybackCommandEnabled: @escaping @MainActor () -> Bool,
+        onPlayPause: @escaping @MainActor () -> Void
+    ) {
+        guard self.monitor == nil else { return }
+
+        self.monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            let keyCode = event.keyCode
+            let modifiers = event.modifierFlags
+            let responder = NSApp.keyWindow?.firstResponder
+            let responderTypeName = responder.map { String(describing: type(of: $0)) } ?? ""
+
+            guard Self.handlesSpaceKey(
+                keyCode: keyCode,
+                modifiers: modifiers,
+                isTextInputFocused: MainActor.assumeIsolated { Self.isTextInput(responder) },
+                isWebContentFocused: Self.isWebContent(responderTypeName),
+                isPlaybackCommandEnabled: MainActor.assumeIsolated { isPlaybackCommandEnabled() }
+            ) else { return event }
+
+            MainActor.assumeIsolated { onPlayPause() }
+            return nil
+        }
+    }
+
+    func stop() {
+        guard let monitor else { return }
+        NSEvent.removeMonitor(monitor)
+        self.monitor = nil
+    }
+
+    isolated deinit {
+        self.stop()
+    }
+}

--- a/Sources/Kaset/Utilities/PlaybackSpaceKeyMonitor.swift
+++ b/Sources/Kaset/Utilities/PlaybackSpaceKeyMonitor.swift
@@ -1,18 +1,30 @@
 import AppKit
+import WebKit
+
+// MARK: - PlaybackSpaceKeyContext
+
+struct PlaybackSpaceKeyContext {
+    let keyCode: UInt16
+    let modifiers: NSEvent.ModifierFlags
+    let isRepeat: Bool
+    let isPrimaryWindow: Bool
+    let isTextInputFocused: Bool
+    let isWebContentFocused: Bool
+    let isNativeBrowsingContentFocused: Bool
+    let isPlaybackCommandEnabled: Bool
+}
 
 // MARK: - PlaybackSpaceKeyMonitor
 
 /// Routes the modifier-less Space key to the Playback play/pause command.
 ///
-/// AppKit never offers a modifier-less key equivalent to the main menu, so the
-/// `Space` shortcut declared on the Playback command menu is registered on the menu
-/// item but is never dispatched: the key window's view hierarchy declines the event
-/// and it dies before the menu is consulted (issue #405). A local key-down monitor
-/// is the standard way to reach a bare-Space shortcut.
+/// AppKit does not route bare Space through Kaset's main-menu key equivalent when
+/// native navigation content holds focus, so the registered Playback menu shortcut
+/// is never dispatched (issue #405). A local key-down monitor bridges that gap.
 ///
-/// Space is only claimed when the native UI holds focus. While a text field is being
-/// edited it must type a space, and while the player WebView holds focus the page's
-/// own handler already toggles playback — claiming it there would toggle twice.
+/// Only the initial bare-Space event in the primary window is claimed. Text editors,
+/// WebKit content, and controls with standard Space activation retain the event;
+/// auxiliary windows and key-repeat events are also left alone.
 @MainActor
 final class PlaybackSpaceKeyMonitor {
     nonisolated static let spaceKeyCode: UInt16 = 49
@@ -20,29 +32,44 @@ final class PlaybackSpaceKeyMonitor {
     private var monitor: Any?
 
     /// Whether Space should be claimed for play/pause instead of being delivered normally.
-    nonisolated static func handlesSpaceKey(
-        keyCode: UInt16,
-        modifiers: NSEvent.ModifierFlags,
-        isTextInputFocused: Bool,
-        isWebContentFocused: Bool,
-        isPlaybackCommandEnabled: Bool
-    ) -> Bool {
-        guard keyCode == self.spaceKeyCode else { return false }
-        let significantModifiers = modifiers
+    nonisolated static func handlesSpaceKey(_ context: PlaybackSpaceKeyContext) -> Bool {
+        guard context.keyCode == self.spaceKeyCode,
+              !context.isRepeat,
+              context.isPrimaryWindow
+        else { return false }
+
+        let significantModifiers = context.modifiers
             .intersection(.deviceIndependentFlagsMask)
-            .subtracting([.capsLock, .function, .numericPad])
+            .subtracting([.capsLock, .numericPad])
         guard significantModifiers.isEmpty else { return false }
-        return isPlaybackCommandEnabled && !isTextInputFocused && !isWebContentFocused
+        return context.isPlaybackCommandEnabled
+            && !context.isTextInputFocused
+            && !context.isWebContentFocused
+            && context.isNativeBrowsingContentFocused
     }
 
-    /// Whether the responder is inside the player WebView, whose page handles Space itself.
-    nonisolated static func isWebContent(_ responderTypeName: String) -> Bool {
-        responderTypeName.contains("WebView") || responderTypeName.contains("WKContent")
+    /// Whether the responder is inside a WebKit view whose page handles Space itself.
+    static func isWebContent(_ responder: NSResponder?) -> Bool {
+        var currentResponder = responder
+        while let current = currentResponder {
+            if current is WKWebView {
+                return true
+            }
+            currentResponder = current.nextResponder
+        }
+        return false
     }
 
     /// Whether the responder is a text editor that must receive Space as typed input.
     static func isTextInput(_ responder: NSResponder?) -> Bool {
         responder is NSTextView || responder is NSTextField
+    }
+
+    /// Whether the responder is the native browsing surface where Kaset assigns
+    /// Space to playback. Restricting interception to the table itself avoids
+    /// guessing about SwiftUI's private focus bridge types.
+    static func isNativeBrowsingContent(_ responder: NSResponder?) -> Bool {
+        responder is NSTableView
     }
 
     func start(
@@ -54,16 +81,24 @@ final class PlaybackSpaceKeyMonitor {
         self.monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
             let keyCode = event.keyCode
             let modifiers = event.modifierFlags
-            let responder = NSApp.keyWindow?.firstResponder
-            let responderTypeName = responder.map { String(describing: type(of: $0)) } ?? ""
+            let window = event.window ?? NSApp.keyWindow
+            let responder = window?.firstResponder
 
-            guard Self.handlesSpaceKey(
+            let context = PlaybackSpaceKeyContext(
                 keyCode: keyCode,
                 modifiers: modifiers,
+                isRepeat: event.isARepeat,
+                isPrimaryWindow: MainActor.assumeIsolated {
+                    window.map(MainWindowLayout.isPrimaryWindow) ?? false
+                },
                 isTextInputFocused: MainActor.assumeIsolated { Self.isTextInput(responder) },
-                isWebContentFocused: Self.isWebContent(responderTypeName),
+                isWebContentFocused: MainActor.assumeIsolated { Self.isWebContent(responder) },
+                isNativeBrowsingContentFocused: MainActor.assumeIsolated {
+                    Self.isNativeBrowsingContent(responder)
+                },
                 isPlaybackCommandEnabled: MainActor.assumeIsolated { isPlaybackCommandEnabled() }
-            ) else { return event }
+            )
+            guard Self.handlesSpaceKey(context) else { return event }
 
             MainActor.assumeIsolated { onPlayPause() }
             return nil

--- a/Sources/Kaset/Views/KasetWebView.swift
+++ b/Sources/Kaset/Views/KasetWebView.swift
@@ -3,24 +3,41 @@ import WebKit
 
 // MARK: - KasetWebView
 
-/// A WKWebView that suppresses key-equivalent interception when hidden.
+/// A WKWebView that leaves hidden-player navigation shortcuts to the app menu.
 ///
-/// The singleton player WebView lives in the main window's view hierarchy even
-/// during audio-only playback (hidden at 1×1, opacity 0). `NSWindow.performKeyEquivalent`
-/// recursively searches the contentView's subviews, and a stock `WKWebView` returns
-/// `true` for Space and ⌘←/⌘→ because the YouTube Music page has its own handlers.
-/// The event is consumed before the SwiftUI command-menu shortcut fires, leaving
-/// Space unable to toggle play/pause (issue #405).
-///
-/// When the WebView is visible with non-trivial bounds (video mode), key
-/// equivalents are forwarded to the page as normal. When hidden (audio-only),
-/// `performKeyEquivalent` returns `false` so the event falls through to the
-/// menu system. Deriving from live state avoids a manually-synced flag that can
-/// desync after WebView recreation or reparenting; it mirrors the pattern in
-/// `ScrollForwardingWebView`.
+/// The singleton player WebView stays in the main window at 1x1 during audio
+/// playback. WebKit handles Command-Left and Command-Right before SwiftUI's
+/// Playback menu sees them, so Previous and Next would stop working. Bare Space
+/// is handled separately by `PlaybackSpaceKeyMonitor`.
 final class KasetWebView: WKWebView {
+    nonisolated static let leftArrowKeyCode: UInt16 = 123
+    nonisolated static let rightArrowKeyCode: UInt16 = 124
+
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
-        guard self.bounds.width > 1, self.bounds.height > 1 else { return false }
+        let isHidden = self.bounds.width <= 1 || self.bounds.height <= 1
+        if Self.declinesHiddenPlaybackKeyEquivalent(
+            keyCode: event.keyCode,
+            modifiers: event.modifierFlags,
+            isHidden: isHidden
+        ) {
+            return false
+        }
+
         return super.performKeyEquivalent(with: event)
+    }
+
+    nonisolated static func declinesHiddenPlaybackKeyEquivalent(
+        keyCode: UInt16,
+        modifiers: NSEvent.ModifierFlags,
+        isHidden: Bool
+    ) -> Bool {
+        guard isHidden,
+              keyCode == self.leftArrowKeyCode || keyCode == self.rightArrowKeyCode
+        else { return false }
+
+        let significantModifiers = modifiers
+            .intersection(.deviceIndependentFlagsMask)
+            .subtracting([.capsLock, .numericPad])
+        return significantModifiers == .command
     }
 }

--- a/Sources/Kaset/Views/KasetWebView.swift
+++ b/Sources/Kaset/Views/KasetWebView.swift
@@ -3,7 +3,7 @@ import WebKit
 
 // MARK: - KasetWebView
 
-/// A WKWebView subclass that can suppress key-equivalent interception.
+/// A WKWebView that suppresses key-equivalent interception when hidden.
 ///
 /// The singleton player WebView lives in the main window's view hierarchy even
 /// during audio-only playback (hidden at 1×1, opacity 0). `NSWindow.performKeyEquivalent`
@@ -12,17 +12,15 @@ import WebKit
 /// The event is consumed before the SwiftUI command-menu shortcut fires, leaving
 /// Space unable to toggle play/pause (issue #405).
 ///
-/// When `shouldInterceptKeyEquivalents` is `false` (audio-only/hidden), the WebView
-/// returns `false` from `performKeyEquivalent` so key equivalents fall through to
-/// the menu system. In video mode the flag is `true` and the WebView behaves
-/// normally.
+/// When the WebView is visible with non-trivial bounds (video mode), key
+/// equivalents are forwarded to the page as normal. When hidden (audio-only),
+/// `performKeyEquivalent` returns `false` so the event falls through to the
+/// menu system. Deriving from live state avoids a manually-synced flag that can
+/// desync after WebView recreation or reparenting; it mirrors the pattern in
+/// `ScrollForwardingWebView`.
 final class KasetWebView: WKWebView {
-    /// When `false`, key equivalents pass through to the menu system instead of
-    /// being consumed by the web page. Set to `true` only in the visible video window.
-    var shouldInterceptKeyEquivalents = false
-
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
-        guard self.shouldInterceptKeyEquivalents else { return false }
+        guard self.bounds.width > 1, self.bounds.height > 1 else { return false }
         return super.performKeyEquivalent(with: event)
     }
 }

--- a/Sources/Kaset/Views/KasetWebView.swift
+++ b/Sources/Kaset/Views/KasetWebView.swift
@@ -1,0 +1,28 @@
+import AppKit
+import WebKit
+
+// MARK: - KasetWebView
+
+/// A WKWebView subclass that can suppress key-equivalent interception.
+///
+/// The singleton player WebView lives in the main window's view hierarchy even
+/// during audio-only playback (hidden at 1×1, opacity 0). `NSWindow.performKeyEquivalent`
+/// recursively searches the contentView's subviews, and a stock `WKWebView` returns
+/// `true` for Space and ⌘←/⌘→ because the YouTube Music page has its own handlers.
+/// The event is consumed before the SwiftUI command-menu shortcut fires, leaving
+/// Space unable to toggle play/pause (issue #405).
+///
+/// When `shouldInterceptKeyEquivalents` is `false` (audio-only/hidden), the WebView
+/// returns `false` from `performKeyEquivalent` so key equivalents fall through to
+/// the menu system. In video mode the flag is `true` and the WebView behaves
+/// normally.
+final class KasetWebView: WKWebView {
+    /// When `false`, key equivalents pass through to the menu system instead of
+    /// being consumed by the web page. Set to `true` only in the visible video window.
+    var shouldInterceptKeyEquivalents = false
+
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        guard self.shouldInterceptKeyEquivalents else { return false }
+        return super.performKeyEquivalent(with: event)
+    }
+}

--- a/Sources/Kaset/Views/MiniPlayerWebView.swift
+++ b/Sources/Kaset/Views/MiniPlayerWebView.swift
@@ -343,9 +343,12 @@ final class SingletonPlayerWebView {
             nativePlaybackGeneration: playerService.currentNativeMusicPlaybackGeneration
         )
 
-        let newWebView = WKWebView(frame: .zero, configuration: configuration)
+        let newWebView = KasetWebView(frame: .zero, configuration: configuration)
         newWebView.navigationDelegate = self.coordinator
         newWebView.customUserAgent = WebKitManager.userAgent
+        // Key equivalents are suppressed until the WebView enters video mode;
+        // see KasetWebView for the rationale.
+        newWebView.shouldInterceptKeyEquivalents = false
         self.webKitManager = webKitManager
         webKitManager.registerExtensionHostWebView(newWebView, role: .musicPlayer)
 

--- a/Sources/Kaset/Views/MiniPlayerWebView.swift
+++ b/Sources/Kaset/Views/MiniPlayerWebView.swift
@@ -348,9 +348,12 @@ final class SingletonPlayerWebView {
             nativePlaybackGeneration: playerService.currentNativeMusicPlaybackGeneration
         )
 
-        let newWebView = WKWebView(frame: .zero, configuration: configuration)
+        let newWebView = KasetWebView(frame: .zero, configuration: configuration)
         newWebView.navigationDelegate = self.coordinator
         newWebView.customUserAgent = WebKitManager.userAgent
+        // Key equivalents are suppressed until the WebView enters video mode;
+        // see KasetWebView for the rationale.
+        newWebView.shouldInterceptKeyEquivalents = false
         self.webKitManager = webKitManager
         webKitManager.registerExtensionHostWebView(newWebView, role: .musicPlayer)
 

--- a/Sources/Kaset/Views/MiniPlayerWebView.swift
+++ b/Sources/Kaset/Views/MiniPlayerWebView.swift
@@ -346,9 +346,6 @@ final class SingletonPlayerWebView {
         let newWebView = KasetWebView(frame: .zero, configuration: configuration)
         newWebView.navigationDelegate = self.coordinator
         newWebView.customUserAgent = WebKitManager.userAgent
-        // Key equivalents are suppressed until the WebView enters video mode;
-        // see KasetWebView for the rationale.
-        newWebView.shouldInterceptKeyEquivalents = false
         self.webKitManager = webKitManager
         webKitManager.registerExtensionHostWebView(newWebView, role: .musicPlayer)
 

--- a/Sources/Kaset/Views/MiniPlayerWebView.swift
+++ b/Sources/Kaset/Views/MiniPlayerWebView.swift
@@ -351,9 +351,6 @@ final class SingletonPlayerWebView {
         let newWebView = KasetWebView(frame: .zero, configuration: configuration)
         newWebView.navigationDelegate = self.coordinator
         newWebView.customUserAgent = WebKitManager.userAgent
-        // Key equivalents are suppressed until the WebView enters video mode;
-        // see KasetWebView for the rationale.
-        newWebView.shouldInterceptKeyEquivalents = false
         self.webKitManager = webKitManager
         webKitManager.registerExtensionHostWebView(newWebView, role: .musicPlayer)
 

--- a/Sources/Kaset/Views/SingletonPlayerWebView+VideoMode.swift
+++ b/Sources/Kaset/Views/SingletonPlayerWebView+VideoMode.swift
@@ -15,24 +15,15 @@ extension SingletonPlayerWebView {
             // WebView stays in hierarchy but tiny
             webView.frame = CGRect(x: 0, y: 0, width: 1, height: 1)
             self.removeVideoModeCSS()
-            if let kasetWebView = webView as? KasetWebView {
-                kasetWebView.shouldInterceptKeyEquivalents = false
-            }
         case .miniPlayer:
             webView.frame = CGRect(x: 0, y: 0, width: 160, height: 90)
             self.removeVideoModeCSS()
-            if let kasetWebView = webView as? KasetWebView {
-                kasetWebView.shouldInterceptKeyEquivalents = false
-            }
         case .video:
             // Immediately inject blackout CSS to hide web UI while we prepare video
             self.injectBlackoutCSS()
             // Full size - parent container determines size
             // Defer injection until container has valid bounds (SwiftUI layout)
             self.waitForValidBoundsAndInject()
-            if let kasetWebView = webView as? KasetWebView {
-                kasetWebView.shouldInterceptKeyEquivalents = true
-            }
         }
     }
 

--- a/Sources/Kaset/Views/SingletonPlayerWebView+VideoMode.swift
+++ b/Sources/Kaset/Views/SingletonPlayerWebView+VideoMode.swift
@@ -15,15 +15,24 @@ extension SingletonPlayerWebView {
             // WebView stays in hierarchy but tiny
             webView.frame = CGRect(x: 0, y: 0, width: 1, height: 1)
             self.removeVideoModeCSS()
+            if let kasetWebView = webView as? KasetWebView {
+                kasetWebView.shouldInterceptKeyEquivalents = false
+            }
         case .miniPlayer:
             webView.frame = CGRect(x: 0, y: 0, width: 160, height: 90)
             self.removeVideoModeCSS()
+            if let kasetWebView = webView as? KasetWebView {
+                kasetWebView.shouldInterceptKeyEquivalents = false
+            }
         case .video:
             // Immediately inject blackout CSS to hide web UI while we prepare video
             self.injectBlackoutCSS()
             // Full size - parent container determines size
             // Defer injection until container has valid bounds (SwiftUI layout)
             self.waitForValidBoundsAndInject()
+            if let kasetWebView = webView as? KasetWebView {
+                kasetWebView.shouldInterceptKeyEquivalents = true
+            }
         }
     }
 

--- a/Tests/KasetTests/KasetWebViewTests.swift
+++ b/Tests/KasetTests/KasetWebViewTests.swift
@@ -1,0 +1,45 @@
+import AppKit
+import Testing
+@testable import Kaset
+
+@Suite("Kaset WebView")
+struct KasetWebViewTests {
+    @Test("Hidden WebView declines command-arrow playback shortcuts")
+    func hiddenWebViewDeclinesCommandArrows() {
+        for keyCode in [KasetWebView.leftArrowKeyCode, KasetWebView.rightArrowKeyCode] {
+            #expect(KasetWebView.declinesHiddenPlaybackKeyEquivalent(
+                keyCode: keyCode,
+                modifiers: [.command, .numericPad],
+                isHidden: true
+            ))
+        }
+    }
+
+    @Test("Visible WebView keeps command-arrow handling")
+    func visibleWebViewKeepsCommandArrows() {
+        #expect(!KasetWebView.declinesHiddenPlaybackKeyEquivalent(
+            keyCode: KasetWebView.leftArrowKeyCode,
+            modifiers: .command,
+            isHidden: false
+        ))
+    }
+
+    @Test("Hidden WebView keeps unrelated key equivalents")
+    func hiddenWebViewKeepsUnrelatedKeyEquivalents() {
+        #expect(!KasetWebView.declinesHiddenPlaybackKeyEquivalent(
+            keyCode: PlaybackSpaceKeyMonitor.spaceKeyCode,
+            modifiers: [],
+            isHidden: true
+        ))
+        #expect(!KasetWebView.declinesHiddenPlaybackKeyEquivalent(
+            keyCode: KasetWebView.rightArrowKeyCode,
+            modifiers: [.command, .option],
+            isHidden: true
+        ))
+        #expect(!KasetWebView.declinesHiddenPlaybackKeyEquivalent(
+            keyCode: KasetWebView.rightArrowKeyCode,
+            modifiers: [.command, .function],
+            isHidden: true
+        ))
+    }
+}

--- a/Tests/KasetTests/MainWindowLayoutTests.swift
+++ b/Tests/KasetTests/MainWindowLayoutTests.swift
@@ -30,6 +30,20 @@ struct MainWindowLayoutTests {
         #expect(MainWindowLayout.minimumContentSize.height == MainWindowLayout.minimumHeight)
     }
 
+    @Test("Primary window identity follows the SwiftUI scene identifier after navigation changes the title")
+    func primaryWindowIdentityUsesSceneIdentifier() {
+        #expect(MainWindowLayout.isPrimaryWindowIdentity(
+            title: "Home",
+            frameAutosaveName: "main",
+            identifier: MainWindowLayout.sceneIdentifier
+        ))
+        #expect(!MainWindowLayout.isPrimaryWindowIdentity(
+            title: "Settings",
+            frameAutosaveName: "",
+            identifier: "settings"
+        ))
+    }
+
     @Test("Primary window identity excludes other regular scene windows")
     func primaryWindowIdentityExcludesOtherRegularSceneWindows() {
         #expect(MainWindowLayout.isPrimaryWindowIdentity(title: MainWindowLayout.windowTitle, frameAutosaveName: ""))

--- a/Tests/KasetTests/PlaybackSpaceKeyMonitorTests.swift
+++ b/Tests/KasetTests/PlaybackSpaceKeyMonitorTests.swift
@@ -1,0 +1,73 @@
+import AppKit
+import Testing
+@testable import Kaset
+
+@Suite(.tags(.service))
+struct PlaybackSpaceKeyMonitorTests {
+    private static func handles(
+        keyCode: UInt16 = PlaybackSpaceKeyMonitor.spaceKeyCode,
+        modifiers: NSEvent.ModifierFlags = [],
+        isTextInputFocused: Bool = false,
+        isWebContentFocused: Bool = false,
+        isPlaybackCommandEnabled: Bool = true
+    ) -> Bool {
+        PlaybackSpaceKeyMonitor.handlesSpaceKey(
+            keyCode: keyCode,
+            modifiers: modifiers,
+            isTextInputFocused: isTextInputFocused,
+            isWebContentFocused: isWebContentFocused,
+            isPlaybackCommandEnabled: isPlaybackCommandEnabled
+        )
+    }
+
+    @Test("Bare Space over native UI is claimed for play/pause")
+    func bareSpaceOverNativeUIIsClaimed() {
+        #expect(Self.handles())
+    }
+
+    @Test("Keys other than Space are never claimed")
+    func otherKeysAreNotClaimed() {
+        #expect(!Self.handles(keyCode: 123))
+        #expect(!Self.handles(keyCode: 124))
+        #expect(!Self.handles(keyCode: 36))
+    }
+
+    @Test("Space with a modifier is left alone so it stays available as a shortcut")
+    func modifiedSpaceIsNotClaimed() {
+        #expect(!Self.handles(modifiers: .command))
+        #expect(!Self.handles(modifiers: .option))
+        #expect(!Self.handles(modifiers: .shift))
+        #expect(!Self.handles(modifiers: [.command, .shift]))
+    }
+
+    @Test("Caps lock and function flags do not stop Space from being claimed")
+    func incidentalModifiersAreIgnored() {
+        #expect(Self.handles(modifiers: .capsLock))
+        #expect(Self.handles(modifiers: .function))
+        #expect(Self.handles(modifiers: [.capsLock, .numericPad]))
+    }
+
+    @Test("Space types normally while a text field is being edited")
+    func textInputKeepsSpace() {
+        #expect(!Self.handles(isTextInputFocused: true))
+    }
+
+    @Test("Space is left to the page while the player WebView holds focus")
+    func webContentKeepsSpace() {
+        #expect(!Self.handles(isWebContentFocused: true))
+    }
+
+    @Test("Space is not claimed when the playback command is disabled")
+    func disabledPlaybackCommandKeepsSpace() {
+        #expect(!Self.handles(isPlaybackCommandEnabled: false))
+    }
+
+    @Test("WebKit responder class names are recognised as web content")
+    func recognisesWebContentResponders() {
+        #expect(PlaybackSpaceKeyMonitor.isWebContent("KasetWebView"))
+        #expect(PlaybackSpaceKeyMonitor.isWebContent("WKWebView"))
+        #expect(PlaybackSpaceKeyMonitor.isWebContent("WKContentView"))
+        #expect(!PlaybackSpaceKeyMonitor.isWebContent("SwiftUIOutlineListView"))
+        #expect(!PlaybackSpaceKeyMonitor.isWebContent("NSButton"))
+    }
+}

--- a/Tests/KasetTests/PlaybackSpaceKeyMonitorTests.swift
+++ b/Tests/KasetTests/PlaybackSpaceKeyMonitorTests.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Testing
+import WebKit
 @testable import Kaset
 
 @Suite(.tags(.service))
@@ -7,17 +8,23 @@ struct PlaybackSpaceKeyMonitorTests {
     private static func handles(
         keyCode: UInt16 = PlaybackSpaceKeyMonitor.spaceKeyCode,
         modifiers: NSEvent.ModifierFlags = [],
+        isRepeat: Bool = false,
+        isPrimaryWindow: Bool = true,
         isTextInputFocused: Bool = false,
         isWebContentFocused: Bool = false,
+        isNativeBrowsingContentFocused: Bool = true,
         isPlaybackCommandEnabled: Bool = true
     ) -> Bool {
-        PlaybackSpaceKeyMonitor.handlesSpaceKey(
+        PlaybackSpaceKeyMonitor.handlesSpaceKey(PlaybackSpaceKeyContext(
             keyCode: keyCode,
             modifiers: modifiers,
+            isRepeat: isRepeat,
+            isPrimaryWindow: isPrimaryWindow,
             isTextInputFocused: isTextInputFocused,
             isWebContentFocused: isWebContentFocused,
+            isNativeBrowsingContentFocused: isNativeBrowsingContentFocused,
             isPlaybackCommandEnabled: isPlaybackCommandEnabled
-        )
+        ))
     }
 
     @Test("Bare Space over native UI is claimed for play/pause")
@@ -37,14 +44,29 @@ struct PlaybackSpaceKeyMonitorTests {
         #expect(!Self.handles(modifiers: .command))
         #expect(!Self.handles(modifiers: .option))
         #expect(!Self.handles(modifiers: .shift))
+        #expect(!Self.handles(modifiers: .function))
         #expect(!Self.handles(modifiers: [.command, .shift]))
     }
 
-    @Test("Caps lock and function flags do not stop Space from being claimed")
+    @Test("Caps lock and numeric-pad flags do not stop Space from being claimed")
     func incidentalModifiersAreIgnored() {
         #expect(Self.handles(modifiers: .capsLock))
-        #expect(Self.handles(modifiers: .function))
         #expect(Self.handles(modifiers: [.capsLock, .numericPad]))
+    }
+
+    @Test("Space outside the primary playback window is left to that window")
+    func spaceOutsidePrimaryWindowIsNotClaimed() {
+        #expect(!Self.handles(isPrimaryWindow: false))
+    }
+
+    @Test("Repeated Space key-down events are ignored")
+    func repeatedSpaceIsNotClaimed() {
+        #expect(!Self.handles(isRepeat: true))
+    }
+
+    @Test("Space is left to a focused control that uses it for activation")
+    func focusedControlKeepsSpace() {
+        #expect(!Self.handles(isNativeBrowsingContentFocused: false))
     }
 
     @Test("Space types normally while a text field is being edited")
@@ -62,12 +84,26 @@ struct PlaybackSpaceKeyMonitorTests {
         #expect(!Self.handles(isPlaybackCommandEnabled: false))
     }
 
-    @Test("WebKit responder class names are recognised as web content")
+    @Test("Only native table browsing focus is eligible for playback interception")
+    @MainActor
+    func recognisesNativeBrowsingContent() {
+        #expect(PlaybackSpaceKeyMonitor.isNativeBrowsingContent(NSOutlineView(frame: .zero)))
+        #expect(PlaybackSpaceKeyMonitor.isNativeBrowsingContent(NSTableView(frame: .zero)))
+        #expect(!PlaybackSpaceKeyMonitor.isNativeBrowsingContent(NSButton(frame: .zero)))
+        #expect(!PlaybackSpaceKeyMonitor.isNativeBrowsingContent(NSSlider(frame: .zero)))
+        #expect(!PlaybackSpaceKeyMonitor.isNativeBrowsingContent(NSView(frame: .zero)))
+    }
+
+    @Test("Responders inside a WKWebView are recognised as web content")
+    @MainActor
     func recognisesWebContentResponders() {
-        #expect(PlaybackSpaceKeyMonitor.isWebContent("KasetWebView"))
-        #expect(PlaybackSpaceKeyMonitor.isWebContent("WKWebView"))
-        #expect(PlaybackSpaceKeyMonitor.isWebContent("WKContentView"))
-        #expect(!PlaybackSpaceKeyMonitor.isWebContent("SwiftUIOutlineListView"))
-        #expect(!PlaybackSpaceKeyMonitor.isWebContent("NSButton"))
+        let webView = WKWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        let contentView = NSView(frame: .zero)
+        webView.addSubview(contentView)
+
+        #expect(PlaybackSpaceKeyMonitor.isWebContent(webView))
+        #expect(PlaybackSpaceKeyMonitor.isWebContent(contentView))
+        #expect(!PlaybackSpaceKeyMonitor.isWebContent(NSView(frame: .zero)))
+        #expect(!PlaybackSpaceKeyMonitor.isWebContent(NSButton(frame: .zero)))
     }
 }


### PR DESCRIPTION
## Description

Space did not toggle play/pause when the track list (native `NSTableView`) had focus, and ⌘←/⌘→ were swallowed by the hidden audio-only WebView. Two independent mechanisms fix both:

### 1. `PlaybackSpaceKeyMonitor` — bare Space over native UI

AppKit does not route a modifier-less Space key through the main-menu key equivalent when a native navigation content (`NSTableView`/`NSOutlineView`) holds focus, so the Playback menu shortcut is never dispatched. A local `NSEvent` key-down monitor bridges that gap: it claims the initial bare-Space key-down in the primary window when the responder is a native browsing surface, and routes it to the same `performPlayPause()` the menu uses. Text editors, WebKit content, controls with standard Space activation, auxiliary windows, and key-repeat events all keep the event.

### 2. `KasetWebView` — hidden WebView declines ⌘←/⌘→

The singleton `WKWebView` that plays audio lives in the main window's view hierarchy even during audio-only playback (1×1, opacity 0, `allowsHitTesting(false)`). `NSWindow.performKeyEquivalent` recursively searches the contentView's subviews, and a stock `WKWebView` returns `true` for ⌘←/⌘→ because YouTube Music handles those. `KasetWebView` overrides `performKeyEquivalent` to return `false` when its bounds are 1×1 (hidden/audio-only), letting the key equivalent fall through to the menu system. When the WebView has non-trivial bounds (video mode), it forwards keys normally.

### 3. `MainWindowLayout` — scene identifier

Extracts the `"main"` scene identifier as `MainWindowLayout.sceneIdentifier` so window identity follows the SwiftUI scene identifier after navigation changes the window title, not just the autosave name or title string.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #405

## Changes Made

- Added `PlaybackSpaceKeyMonitor`, a local key-down monitor that routes bare Space to `performPlayPause()` when a native browsing surface has focus.
- Extracted `performPlayPause()` on `KasetApp` so the monitor and the Playback menu item share one code path.
- Added `KasetWebView`, a `WKWebView` subclass that declines ⌘←/⌘→ key equivalents when hidden (1×1 bounds). The singleton player WebView now creates a `KasetWebView` instead of a plain `WKWebView`.
- Added `MainWindowLayout.sceneIdentifier` and wired it into `isPrimaryWindowIdentity` so the monitor can reliably identify the primary window regardless of the current navigation title.
- The WebView behavior is derived from live `self.bounds`, not a manually-synced flag, matching the pattern in `ScrollForwardingWebView` (which derives from `self.url`). This avoids desync after WebView recreation or reparenting.

## Testing

- [x] Unit tests pass (`swift test --skip KasetUITests`)
- [ ] Manual testing performed
- [x] UI tests pass on macOS 15 and macOS 26 (CI)

> **Note:** No Swift toolchain was available on the machine that produced this PR. Build, lint, and tests were verified by CI.

**Manual checklist:**
- Play a track, press Space → playback pauses; press Space again → playback resumes
- Play a track, press ⌘← / ⌘→ → previous/next track
- Type in the search bar → Space inserts a space (existing `TextInputFocusState` guard still applies)
- Open a YouTube video in the video window → Space and arrow keys control the video player directly

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `swiftlint --strict && swiftformat .` — *verified by CI*
- [x] I have added tests that prove my fix works (`PlaybackSpaceKeyMonitorTests`, `KasetWebViewTests`, `MainWindowLayoutTests`)
- [x] New and existing unit tests pass locally — *verified by CI (macOS 15 ✓, macOS 26 ✓)*
- [x] I have updated documentation if needed
- [x] I have checked for any performance implications
- [x] My changes generate no new warnings

## Additional Notes

The existing `TextInputFocusState` mechanism (PR #379) is orthogonal and still works: it disables the menu shortcut itself when a text field has focus. This PR fixes the other half — bare Space never reaching the menu in the first place when a native table has focus.

A Claude Code self-review identified and fixed three issues with the initial flag-based approach: flag desync after WebView recreation, a reparenting race between `PersistentPlayerView` and `VideoWebViewContainer`, and triplicated cast blocks. The stateless bounds-check eliminates all three.