### PR TITLE
fix(player): stop the page URL being stored as track artwork

### DIFF
--- a/Sources/Kaset/Views/MiniPlayerWebView+Coordinator.swift
+++ b/Sources/Kaset/Views/MiniPlayerWebView+Coordinator.swift
@@ -24,6 +24,26 @@ extension SingletonPlayerWebView {
         return decoded
     }
 
+    /// Sanitizes the thumbnail URL reported by the playback bridge.
+    ///
+    /// `img.src` resolves relative to the document, so a player-bar image that has not
+    /// yet been assigned a source reports the YouTube Music page URL. That value fetches
+    /// successfully as HTML and then fails to decode, so it must never reach `currentTrack`.
+    nonisolated static func playbackBridgeThumbnailURLString(from value: Any?) -> String {
+        guard let raw = (value as? String)?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !raw.isEmpty,
+              let components = URLComponents(string: raw),
+              let scheme = components.scheme?.lowercased(),
+              scheme == "https" || scheme == "http",
+              let host = components.host,
+              !host.isEmpty,
+              !components.path.isEmpty,
+              components.path != "/"
+        else { return "" }
+
+        return raw
+    }
+
     // MARK: - Coordinator
 
     final class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler {
@@ -601,7 +621,7 @@ private extension SingletonPlayerWebView.Coordinator {
         let hasReadyMedia = body["hasReadyMedia"] as? Bool ?? false
         let title = body["title"] as? String ?? ""
         let artist = body["artist"] as? String ?? ""
-        let thumbnailUrl = body["thumbnailUrl"] as? String ?? ""
+        let thumbnailUrl = SingletonPlayerWebView.playbackBridgeThumbnailURLString(from: body["thumbnailUrl"])
         let trackChanged = body["trackChanged"] as? Bool ?? false
         let likeStatus = Self.likeStatus(from: body["likeStatus"] as? String)
         let hasVideo = body["hasVideo"] as? Bool ?? false

--- a/Sources/Kaset/Views/SingletonPlayerWebView+ObserverScript.swift
+++ b/Sources/Kaset/Views/SingletonPlayerWebView+ObserverScript.swift
@@ -679,7 +679,11 @@ extension SingletonPlayerWebView {
 
                     // Get the thumbnail URL from the image element
                     if (thumbEl) {
-                        thumbnailUrl = thumbEl.src || thumbEl.getAttribute('src') || '';
+                        // `img.src` resolves against the document base URL, so an empty or
+                        // missing attribute reports the YouTube Music page URL instead of ''.
+                        // Gate on the literal attribute before trusting the resolved value.
+                        const rawThumbSrc = (thumbEl.getAttribute('src') || '').trim();
+                        thumbnailUrl = rawThumbSrc ? (thumbEl.src || rawThumbSrc) : '';
                     }
 
                     // Extract like status from the like button renderer

--- a/Tests/KasetTests/AutoplayRecoveryTests.swift
+++ b/Tests/KasetTests/AutoplayRecoveryTests.swift
@@ -778,4 +778,28 @@ struct MusicPlaybackBridgeDecodingTests {
         #expect(SingletonPlayerWebView.finitePlaybackBridgeDouble(from: true) == nil)
         #expect(SingletonPlayerWebView.finitePlaybackBridgeDouble(from: "1.75") == nil)
     }
+
+    @Test("Playback bridge rejects the document URL reported by an unset thumbnail element")
+    func rejectsDocumentURLThumbnail() {
+        #expect(SingletonPlayerWebView.playbackBridgeThumbnailURLString(from: "https://music.youtube.com/").isEmpty)
+        #expect(SingletonPlayerWebView.playbackBridgeThumbnailURLString(from: "https://music.youtube.com").isEmpty)
+    }
+
+    @Test("Playback bridge rejects empty and malformed thumbnail sources")
+    func rejectsInvalidThumbnails() {
+        #expect(SingletonPlayerWebView.playbackBridgeThumbnailURLString(from: "").isEmpty)
+        #expect(SingletonPlayerWebView.playbackBridgeThumbnailURLString(from: "   ").isEmpty)
+        #expect(SingletonPlayerWebView.playbackBridgeThumbnailURLString(from: nil).isEmpty)
+        #expect(SingletonPlayerWebView.playbackBridgeThumbnailURLString(from: 42).isEmpty)
+        #expect(SingletonPlayerWebView.playbackBridgeThumbnailURLString(from: "data:image/png;base64,AAAA").isEmpty)
+    }
+
+    @Test("Playback bridge preserves real artwork sources")
+    func preservesArtworkThumbnails() {
+        let artwork = "https://lh3.googleusercontent.com/abc=w544-h544-l90-rj"
+        #expect(SingletonPlayerWebView.playbackBridgeThumbnailURLString(from: artwork) == artwork)
+
+        let fallback = "https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg"
+        #expect(SingletonPlayerWebView.playbackBridgeThumbnailURLString(from: fallback) == fallback)
+    }
 }


### PR DESCRIPTION
## Description

`currentTrack.thumbnailURL` is sometimes set to `https://music.youtube.com/` — the app's own page URL — instead of artwork.

The observer script read the player-bar image with `thumbEl.src`. That is the IDL property, which resolves against the document base URL, so an `<img>` whose `src` attribute is empty or missing reports the page URL rather than an empty string. YouTube Music leaves the attribute momentarily empty while swapping tracks. Because the resolved value is a non-empty (truthy) string, the existing `thumbEl.getAttribute('src')` fallback never ran:

```javascript
thumbnailUrl = thumbEl.src || thumbEl.getAttribute('src') || '';
```

The value was then written straight into the track model with no validation:

```swift
let thumbnailURL = URL(string: thumbnailUrl)
```

The result is a URL that *fetches successfully* — HTTP 200, ~2 KB of HTML — and then fails to decode as an image. Any surface that renders it without a fallback sits on its loading placeholder forever, because `CachedAsyncImage` has no error branch and simply keeps showing `placeholder()` when the decode returns nil.

This has been masked so far: `SongThumbnailView` recovers by falling back to `i.ytimg.com/vi/<id>/hqdefault.jpg` via its `onFailure` hook, which covers most thumbnails in the app.

Found while testing #440, whose artwork viewer has no such fallback and so spins indefinitely. Fixed here separately because the bad data is written on `main` today and affects every consumer of `currentTrack.thumbnailURL`.

### How it was diagnosed

Temporary instrumentation in the artwork viewer logged the URL plus an independent `GET` of it to the sandbox tmp directory:

```
artworkURL=https://yt3.googleusercontent.com/ugDC…=w544-h544-l90-rj
status=200 bytes=142912          <- first track, real artwork

artworkURL=https://music.youtube.com/
status=200 bytes=2012            <- after a track change, the page URL
```

The instrumentation has been removed.

## AI Prompt (Optional)

<details>
<summary>🤖 AI Prompt Used</summary>

```
N/A - Manual implementation
```

**AI Tool:** Claude

</details>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Refactoring (no functional changes)
- [ ] 🧪 Test update
- [ ] 🔧 Build/CI configuration

## Related Issues

Relates to #440

## Changes Made

- **`SingletonPlayerWebView+ObserverScript.swift`**: Gate on the literal `src` attribute before trusting the resolved `img.src`, so an unset image reports `''` instead of the document URL.
- **`MiniPlayerWebView+Coordinator.swift`**: Added `playbackBridgeThumbnailURLString(from:)` and applied it at the single bridge ingestion point. Rejects empty, non-`http(s)`, hostless, and bare-`/` values so no non-image URL can reach the track model, whatever the DOM reports.
- **`AutoplayRecoveryTests.swift`**: Coverage for the document URL, empty/whitespace/nil/non-string inputs, and pass-through of real artwork and `i.ytimg.com` fallback URLs.

Rejected input yields an empty string, which every existing caller already treats as "keep current artwork" — `keepQueueSongVisible` uses `URL(string:) ?? song.thumbnailURL`, and `updateTrackMetadata` guards `let thumbnailURL` before applying it or falls back to `?? currentTrack.thumbnailURL`. No call site needed changing.

## Testing

- [x] Unit tests pass (`swift test --skip KasetUITests`) — 2959 tests in 232 suites
- [x] Manual testing performed
- [x] UI tested on macOS 26+

Verified in a packaged build: play a track, change tracks, and confirm artwork-dependent surfaces keep real artwork instead of the page URL.

`PlayerServiceQueueTests` failed once during a full-suite run here, then passed 3/3 in isolation and 2/2 on subsequent full-suite runs, with a different subset of tests failing each time. This is the pre-existing parallel-execution flakiness in persisted state (same family as the `FavoritesManagerTests`/`SettingsManagerTests`/`HistoryViewModelTests` flakes seen on other branches); nothing here touches playback persistence.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `swiftlint --strict && swiftformat .` — both clean
- [x] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally
- [x] I have updated documentation if needed
- [x] I have checked for any performance implications
- [x] My changes generate no new warnings

## Additional Notes

The JS change keeps using `thumbEl.src` for the resolved absolute URL when the attribute is genuinely present, so relative artwork sources still resolve correctly. Only the empty/missing case changes behaviour.

The Swift guard is deliberate defence in depth: the DOM is third-party and can change shape without notice, and the failure mode here is a permanent loading state rather than a visible error, which makes it expensive to notice.
