### PR TITLE
fix(tests): eliminate the two cross-suite unit test flakes

### DIFF
--- a/Sources/Kaset/Services/WebKit/WebKitManager+AuthCookieClearing.swift
+++ b/Sources/Kaset/Services/WebKit/WebKitManager+AuthCookieClearing.swift
@@ -1,0 +1,61 @@
+import Foundation
+import WebKit
+
+// MARK: - AuthCookieOperationFence
+
+struct AuthCookieOperationFence {
+    private(set) var generation: UInt64 = 0
+
+    mutating func invalidate() {
+        self.generation &+= 1
+    }
+
+    func isCurrent(_ expectedGeneration: UInt64) -> Bool {
+        expectedGeneration == self.generation
+    }
+}
+
+// MARK: - LiveAuthCookieClearResult
+
+struct LiveAuthCookieClearResult: Equatable {
+    let didClear: Bool
+    let usedCookieStoreFallback: Bool
+}
+
+// MARK: - LiveAuthCookieStoreClearer
+
+@MainActor
+enum LiveAuthCookieStoreClearer {
+    struct Operations {
+        let readCookies: @MainActor () async -> [HTTPCookie]
+        let deleteCookie: @MainActor (HTTPCookie) async -> Void
+        let removeAllCookies: @MainActor () async -> Void
+    }
+
+    static func clear(
+        maximumDeletePasses: Int = 3,
+        operations: Operations
+    ) async -> LiveAuthCookieClearResult {
+        for _ in 0 ..< max(maximumDeletePasses, 0) {
+            let cookies = await operations.readCookies()
+            for cookie in cookies where KeychainCookieStorage.isLoginSessionCookie(cookie) {
+                await operations.deleteCookie(cookie)
+            }
+            let remainingCookies = await operations.readCookies()
+            if !remainingCookies.contains(where: KeychainCookieStorage.isLoginSessionCookie) {
+                return LiveAuthCookieClearResult(
+                    didClear: true,
+                    usedCookieStoreFallback: false
+                )
+            }
+            await Task.yield()
+        }
+
+        await operations.removeAllCookies()
+        let remainingCookies = await operations.readCookies()
+        return LiveAuthCookieClearResult(
+            didClear: !remainingCookies.contains(where: KeychainCookieStorage.isLoginSessionCookie),
+            usedCookieStoreFallback: true
+        )
+    }
+}

--- a/Sources/Kaset/Services/WebKit/WebKitManager+CookieArchiveStorage.swift
+++ b/Sources/Kaset/Services/WebKit/WebKitManager+CookieArchiveStorage.swift
@@ -312,6 +312,26 @@ extension WebKitManager {
     }
 }
 
+// MARK: - InMemoryCookieArchiveBox
+
+/// Backing store for `CookieArchiveStorage.inMemory()`.
+final class InMemoryCookieArchiveBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var archiveData: Data?
+
+    func store(_ data: Data?) {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        self.archiveData = data
+    }
+
+    func load() -> Data? {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.archiveData
+    }
+}
+
 // MARK: - CookieArchiveStorage
 
 struct CookieArchiveStorage: Sendable {
@@ -339,6 +359,28 @@ struct CookieArchiveStorage: Sendable {
         self.setRestoreAllowed = setRestoreAllowed
         self.exportsDebugArchive = exportsDebugArchive
         self.deleteDebugArchive = deleteDebugArchive
+    }
+
+    /// An archive that lives only for the lifetime of its queue. Keeps a manager's cookie
+    /// archive off the process-wide Keychain/`cookies.dat` store so parallel test suites
+    /// stay isolated from each other's invalidations.
+    static func inMemory() -> CookieArchiveStorage {
+        let box = InMemoryCookieArchiveBox()
+        return CookieArchiveStorage(
+            save: { data, _ in
+                box.store(data)
+                return true
+            },
+            load: { box.load() },
+            delete: {
+                box.store(nil)
+                return true
+            },
+            restoreDecision: { .allowed },
+            setRestoreAllowed: { _ in true },
+            exportsDebugArchive: false,
+            deleteDebugArchive: { true }
+        )
     }
 
     static let live = CookieArchiveStorage(

--- a/Sources/Kaset/Services/WebKit/WebKitManager+CookieArchiveStorage.swift
+++ b/Sources/Kaset/Services/WebKit/WebKitManager+CookieArchiveStorage.swift
@@ -336,7 +336,7 @@ final class InMemoryCookieArchiveBox: @unchecked Sendable {
 
 struct CookieArchiveStorage: Sendable {
     let save: @Sendable (Data, Int) -> Bool
-    let load: @Sendable () -> Data?
+    let loadResult: @Sendable () -> CookieArchiveLoadResult
     let delete: @Sendable () -> Bool
     let restoreDecision: @Sendable () -> CookieArchiveRestoreDecision
     let setRestoreAllowed: @Sendable (Bool) -> Bool
@@ -345,7 +345,7 @@ struct CookieArchiveStorage: Sendable {
 
     init(
         save: @escaping @Sendable (Data, Int) -> Bool,
-        load: @escaping @Sendable () -> Data?,
+        loadResult: @escaping @Sendable () -> CookieArchiveLoadResult,
         delete: @escaping @Sendable () -> Bool,
         restoreDecision: @escaping @Sendable () -> CookieArchiveRestoreDecision = { .allowed },
         setRestoreAllowed: @escaping @Sendable (Bool) -> Bool = { _ in true },
@@ -353,12 +353,17 @@ struct CookieArchiveStorage: Sendable {
         deleteDebugArchive: @escaping @Sendable () -> Bool = { true }
     ) {
         self.save = save
-        self.load = load
+        self.loadResult = loadResult
         self.delete = delete
         self.restoreDecision = restoreDecision
         self.setRestoreAllowed = setRestoreAllowed
         self.exportsDebugArchive = exportsDebugArchive
         self.deleteDebugArchive = deleteDebugArchive
+    }
+
+    func load() -> Data? {
+        guard case let .data(data) = self.loadResult() else { return nil }
+        return data
     }
 
     /// An archive that lives only for the lifetime of its queue. Keeps a manager's cookie
@@ -371,7 +376,10 @@ struct CookieArchiveStorage: Sendable {
                 box.store(data)
                 return true
             },
-            load: { box.load() },
+            loadResult: {
+                guard let data = box.load() else { return .notFound }
+                return .data(data)
+            },
             delete: {
                 box.store(nil)
                 return true
@@ -387,7 +395,7 @@ struct CookieArchiveStorage: Sendable {
         save: { data, cookieCount in
             KeychainCookieStorage.saveArchiveData(data, cookieCount: cookieCount)
         },
-        load: { KeychainCookieStorage.loadArchiveData() },
+        loadResult: { KeychainCookieStorage.loadArchiveResult() },
         delete: { KeychainCookieStorage.deleteCookies() },
         restoreDecision: { CookieArchiveRestorePolicy.restoreDecision },
         setRestoreAllowed: { CookieArchiveRestorePolicy.setRestoreAllowed($0) },
@@ -457,6 +465,17 @@ actor CookieArchiveWriteQueue {
     func persistedArchiveData() -> Data? {
         self.storage.load()
     }
+
+    func loadArchiveResult() -> CookieArchiveLoadResult {
+        self.storage.loadResult()
+    }
+
+    #if DEBUG
+        func exportDebugArchiveIfEnabled(_ archiveData: Data) {
+            guard self.storage.exportsDebugArchive else { return }
+            DebugCookieFileExporter.exportAuthCookiesArchiveData(archiveData)
+        }
+    #endif
 
     func consumeLoginTransactionSetupCleanupRequirement() -> Bool {
         let requiresCleanup = self.loginTransactionSetupRequiresCleanup

--- a/Sources/Kaset/Services/WebKit/WebKitManager+CookieBackup.swift
+++ b/Sources/Kaset/Services/WebKit/WebKitManager+CookieBackup.swift
@@ -288,16 +288,16 @@ extension WebKitManager {
         guard let baseline = await self.captureLoginCookieBackupBaseline(
             expectedOperationGeneration: expectedOperationGeneration
         ) else { return nil }
-        guard let transaction = await CookieArchiveWriteQueue.shared.beginLoginTransaction(
+        guard let transaction = await self.cookieArchiveQueue.beginLoginTransaction(
             liveBaseline: baseline.liveBaseline,
             previousLoginCookies: baseline.loginCookies,
             previousLiveSnapshotFingerprint: baseline.authSnapshot?.stabilityFingerprint
         ) else {
-            if await CookieArchiveWriteQueue.shared
+            if await self.cookieArchiveQueue
                 .consumeLoginTransactionSetupCleanupRequirement()
             {
                 self.loginCookieBackupSetupRequiresCleanup = true
-                _ = await CookieArchiveWriteQueue.shared.invalidateAndDelete()
+                _ = await self.cookieArchiveQueue.invalidateAndDelete()
             }
             return nil
         }
@@ -311,13 +311,13 @@ extension WebKitManager {
             } else if self.isClearingAuthCookies
                 || !self.authCookieOperationFence.isCurrent(expectedOperationGeneration)
             {
-                _ = await CookieArchiveWriteQueue.shared.abandonLoginTransaction(transaction)
-            } else if await CookieArchiveWriteQueue.shared.claimLoginTransactionRollback(transaction) {
-                let didRollback = await CookieArchiveWriteQueue.shared
+                _ = await self.cookieArchiveQueue.abandonLoginTransaction(transaction)
+            } else if await self.cookieArchiveQueue.claimLoginTransactionRollback(transaction) {
+                let didRollback = await self.cookieArchiveQueue
                     .rollbackLoginTransaction(transaction)
                 if !didRollback {
                     self.loginCookieBackupSetupRequiresCleanup = true
-                    _ = await CookieArchiveWriteQueue.shared.invalidateAndDelete()
+                    _ = await self.cookieArchiveQueue.invalidateAndDelete()
                 }
             }
             return nil
@@ -386,11 +386,11 @@ extension WebKitManager {
     private func abandonUnstableLoginCookieBackup(
         _ transaction: CookieBackupTransaction
     ) async {
-        let didAbandon = await CookieArchiveWriteQueue.shared
+        let didAbandon = await self.cookieArchiveQueue
             .abandonLoginTransaction(transaction)
         self.loginCookieBackupSetupRequiresCleanup = true
         if !didAbandon {
-            _ = await CookieArchiveWriteQueue.shared.invalidateAndDelete()
+            _ = await self.cookieArchiveQueue.invalidateAndDelete()
         }
     }
 
@@ -409,7 +409,7 @@ extension WebKitManager {
     }
 
     func isLoginCookieBackupActive(_ transaction: CookieBackupTransaction) async -> Bool {
-        let queueOwnsTransaction = await CookieArchiveWriteQueue.shared
+        let queueOwnsTransaction = await self.cookieArchiveQueue
             .isActiveLoginTransaction(transaction)
         return self.isCurrentLoginCookieBackup(transaction) && queueOwnsTransaction
     }
@@ -463,7 +463,7 @@ extension WebKitManager {
                   let postCommitSnapshot = await self.currentCookieArchiveSnapshot(),
                   attempt.snapshot == postCommitSnapshot
             else {
-                _ = await CookieArchiveWriteQueue.shared
+                _ = await self.cookieArchiveQueue
                     .disableLoginTransactionRestore(transaction)
                 return nil
             }
@@ -479,7 +479,7 @@ extension WebKitManager {
     ) async -> String? {
         guard self.isCurrentLoginCookieBackup(transaction),
               !Task.isCancelled,
-              await CookieArchiveWriteQueue.shared
+              await self.cookieArchiveQueue
               .disableLoginTransactionRestore(transaction),
               await self.commitLoginCookieBackup(transaction) != nil
         else {
@@ -506,7 +506,7 @@ extension WebKitManager {
               !Task.isCancelled
         else { return nil }
 
-        let didFinalize = await CookieArchiveWriteQueue.shared.finalizeLoginTransaction(transaction)
+        let didFinalize = await self.cookieArchiveQueue.finalizeLoginTransaction(transaction)
         guard didFinalize,
               self.isCurrentLoginCookieBackup(transaction),
               !self.forcedCookieBackupDirty,
@@ -527,7 +527,7 @@ extension WebKitManager {
         for _ in 0 ..< 3 {
             self.forcedCookieBackupDirty = false
             guard await self.forceBackupCookies(),
-                  let archiveData = await CookieArchiveWriteQueue.shared.persistedArchiveData()
+                  let archiveData = await self.cookieArchiveQueue.persistedArchiveData()
             else {
                 return nil
             }
@@ -544,7 +544,7 @@ extension WebKitManager {
         guard self.isCurrentLoginCookieBackup(transaction) else {
             return true
         }
-        if await CookieArchiveWriteQueue.shared.disableLoginTransactionRestore(transaction) {
+        if await self.cookieArchiveQueue.disableLoginTransactionRestore(transaction) {
             return true
         }
         guard self.isCurrentLoginCookieBackup(transaction) else {
@@ -559,8 +559,8 @@ extension WebKitManager {
         guard self.isCurrentLoginCookieBackup(transaction) else {
             return .superseded
         }
-        guard await CookieArchiveWriteQueue.shared.claimLoginTransactionRollback(transaction) else {
-            let ownership = await CookieArchiveWriteQueue.shared
+        guard await self.cookieArchiveQueue.claimLoginTransactionRollback(transaction) else {
+            let ownership = await self.cookieArchiveQueue
                 .loginTransactionOwnership(transaction)
             return ownership == .none ? .failed : .superseded
         }
@@ -601,7 +601,7 @@ extension WebKitManager {
             )
         }
 
-        let didRollback = await CookieArchiveWriteQueue.shared.rollbackLoginTransaction(transaction)
+        let didRollback = await self.cookieArchiveQueue.rollbackLoginTransaction(transaction)
         guard self.isCurrentLoginCookieBackup(transaction) else { return .superseded }
         guard didRollback else {
             self.isClearingAuthCookies = wasClearingAuthCookies
@@ -617,7 +617,7 @@ extension WebKitManager {
             expirationCutoff: expirationCutoff
         )
         guard postRollbackState == expectedState else {
-            _ = await CookieArchiveWriteQueue.shared.invalidateAndDelete()
+            _ = await self.cookieArchiveQueue.invalidateAndDelete()
             self.isClearingAuthCookies = wasClearingAuthCookies
             self.activeLoginCookieBackupTransaction = nil
             self.logger.error("Authentication cookies changed during login rollback")
@@ -663,7 +663,7 @@ extension WebKitManager {
         _ transaction: CookieBackupTransaction,
         restoringClearingStateTo wasClearingAuthCookies: Bool
     ) async -> CookieBackupRollbackResult {
-        _ = await CookieArchiveWriteQueue.shared.failLoginTransactionRollback(transaction)
+        _ = await self.cookieArchiveQueue.failLoginTransactionRollback(transaction)
         self.isClearingAuthCookies = wasClearingAuthCookies
         self.activeLoginCookieBackupTransaction = nil
         return .failed
@@ -734,7 +734,7 @@ extension WebKitManager {
     }
 
     private func makeCurrentCookieArchiveWriteAttempt() async -> CookieArchiveWriteAttempt? {
-        let generation = await CookieArchiveWriteQueue.shared.reserveGeneration()
+        let generation = await self.cookieArchiveQueue.reserveGeneration()
         guard let snapshot = await self.currentCookieArchiveSnapshot() else { return nil }
         return CookieArchiveWriteAttempt(snapshot: snapshot, generation: generation)
     }
@@ -748,7 +748,7 @@ extension WebKitManager {
     private func persistCookieArchiveAttempt(
         _ attempt: CookieArchiveWriteAttempt
     ) async -> CookieArchiveSaveResult {
-        await CookieArchiveWriteQueue.shared.save(
+        await self.cookieArchiveQueue.save(
             archiveData: attempt.snapshot.data,
             cookieCount: attempt.snapshot.cookieCount,
             generation: attempt.generation
@@ -795,7 +795,7 @@ extension WebKitManager: WKHTTPCookieStoreObserver {
 
     private func performCookieBackup(cookieStore: WKHTTPCookieStore) async {
         guard !self.isClearingAuthCookies else { return }
-        let generation = await CookieArchiveWriteQueue.shared.reserveGeneration()
+        let generation = await self.cookieArchiveQueue.reserveGeneration()
         let cookies = await cookieStore.allCookies()
         guard !Task.isCancelled, !self.isClearingAuthCookies else { return }
         let authCookies = cookies.filter(KeychainCookieStorage.isAuthCookie)
@@ -804,7 +804,7 @@ extension WebKitManager: WKHTTPCookieStoreObserver {
         )
         switch action {
         case .invalidate:
-            let result = await CookieArchiveWriteQueue.shared.invalidateAndDeleteIfLatest(
+            let result = await self.cookieArchiveQueue.invalidateAndDeleteIfLatest(
                 generation: generation
             )
             if result == .failed {
@@ -814,7 +814,7 @@ extension WebKitManager: WKHTTPCookieStoreObserver {
             self.logger.error("Retaining the last authentication-cookie archive after serialization failure")
         case let .persist(data, cookieCount):
             guard !Task.isCancelled, !self.isClearingAuthCookies else { return }
-            _ = await CookieArchiveWriteQueue.shared.save(
+            _ = await self.cookieArchiveQueue.save(
                 archiveData: data,
                 cookieCount: cookieCount,
                 generation: generation

--- a/Sources/Kaset/Services/WebKit/WebKitManager+CookieRestore.swift
+++ b/Sources/Kaset/Services/WebKit/WebKitManager+CookieRestore.swift
@@ -16,12 +16,12 @@ extension WebKitManager {
         try? await Task.sleep(for: .milliseconds(100))
         guard self.canContinueAuthCookieOperation(expectedGeneration: expectedGeneration) else { return false }
 
-        switch await CookieArchiveWriteQueue.shared.restoreDecision() {
+        switch await self.cookieArchiveQueue.restoreDecision() {
         case .allowed:
             break
         case .denied:
             self.logger.info("Cookie backup restoration is disabled after explicit invalidation")
-            let didDeletePersistedCookies = await CookieArchiveWriteQueue.shared.invalidateAndDelete()
+            let didDeletePersistedCookies = await self.cookieArchiveQueue.invalidateAndDelete()
             guard self.canContinueAuthCookieOperation(expectedGeneration: expectedGeneration) else { return false }
             let didClearLiveCookies = await self.clearLiveLoginSessionCookies(
                 expectedGeneration: expectedGeneration

--- a/Sources/Kaset/Services/WebKit/WebKitManager+CookieRestore.swift
+++ b/Sources/Kaset/Services/WebKit/WebKitManager+CookieRestore.swift
@@ -4,7 +4,7 @@ import WebKit
 // MARK: - Startup Cookie Restoration
 
 extension WebKitManager {
-    /// Restores auth cookies from Keychain to WebKit.
+    /// Restores auth cookies from the configured archive storage to WebKit.
     /// Handles migration from legacy file-based storage on first run.
     func restoreAuthCookiesFromBackup(expectedGeneration: UInt64) async -> Bool {
         self.isRestoringCookies = true
@@ -46,11 +46,8 @@ extension WebKitManager {
         guard self.canContinueAuthCookieOperation(expectedGeneration: expectedGeneration) else { return false }
         self.logger.info("WebKit has \(existingCookies.count) cookies on startup")
 
-        // Load cookies from Keychain.
-        // Perform Keychain I/O off the main actor; decode on main actor.
-        let archiveResult = await Task(priority: .utility) {
-            KeychainCookieStorage.loadArchiveResult()
-        }.value
+        // Archive I/O runs on the injected storage queue, never on the main actor.
+        let archiveResult = await self.cookieArchiveQueue.loadArchiveResult()
         guard self.canContinueAuthCookieOperation(expectedGeneration: expectedGeneration) else { return false }
 
         switch archiveResult {
@@ -64,7 +61,7 @@ extension WebKitManager {
             guard await self.clearLiveLoginSessionCookies(
                 expectedGeneration: expectedGeneration
             ) else { return false }
-            self.logger.info("No cookies found in Keychain (first run or signed out)")
+            self.logger.info("No cookies found in archive storage (first run or signed out)")
             return true
         case let .data(archiveData):
             // The persisted archive is the source of truth for login-session
@@ -112,7 +109,7 @@ extension WebKitManager {
         }
 
         #if DEBUG
-            DebugCookieFileExporter.exportAuthCookiesArchiveData(archiveData)
+            await self.cookieArchiveQueue.exportDebugArchiveIfEnabled(archiveData)
         #endif
 
         self.logger.info("Restoring \(keychainCookies.count) auth cookies from Keychain")

--- a/Sources/Kaset/Services/WebKit/WebKitManager.swift
+++ b/Sources/Kaset/Services/WebKit/WebKitManager.swift
@@ -3,65 +3,6 @@ import os
 import Security
 import WebKit
 
-// MARK: - AuthCookieOperationFence
-
-struct AuthCookieOperationFence {
-    private(set) var generation: UInt64 = 0
-
-    mutating func invalidate() {
-        self.generation &+= 1
-    }
-
-    func isCurrent(_ expectedGeneration: UInt64) -> Bool {
-        expectedGeneration == self.generation
-    }
-}
-
-// MARK: - LiveAuthCookieClearResult
-
-struct LiveAuthCookieClearResult: Equatable {
-    let didClear: Bool
-    let usedCookieStoreFallback: Bool
-}
-
-// MARK: - LiveAuthCookieStoreClearer
-
-@MainActor
-enum LiveAuthCookieStoreClearer {
-    struct Operations {
-        let readCookies: @MainActor () async -> [HTTPCookie]
-        let deleteCookie: @MainActor (HTTPCookie) async -> Void
-        let removeAllCookies: @MainActor () async -> Void
-    }
-
-    static func clear(
-        maximumDeletePasses: Int = 3,
-        operations: Operations
-    ) async -> LiveAuthCookieClearResult {
-        for _ in 0 ..< max(maximumDeletePasses, 0) {
-            let cookies = await operations.readCookies()
-            for cookie in cookies where KeychainCookieStorage.isLoginSessionCookie(cookie) {
-                await operations.deleteCookie(cookie)
-            }
-            let remainingCookies = await operations.readCookies()
-            if !remainingCookies.contains(where: KeychainCookieStorage.isLoginSessionCookie) {
-                return LiveAuthCookieClearResult(
-                    didClear: true,
-                    usedCookieStoreFallback: false
-                )
-            }
-            await Task.yield()
-        }
-
-        await operations.removeAllCookies()
-        let remainingCookies = await operations.readCookies()
-        return LiveAuthCookieClearResult(
-            didClear: !remainingCookies.contains(where: KeychainCookieStorage.isLoginSessionCookie),
-            usedCookieStoreFallback: true
-        )
-    }
-}
-
 // MARK: - WebKitManager
 
 /// Manages WebKit data store for persistent cookies and session management.
@@ -71,13 +12,24 @@ final class WebKitManager: NSObject, WebKitManagerProtocol {
     /// Shared singleton instance.
     static let shared = WebKitManager(dataStore: .default(), restoresCookies: true, loadsExtensions: true)
 
-    /// Creates an isolated manager for unit tests.
+    /// Creates an isolated manager for unit tests. The cookie archive queue is private to the
+    /// instance and backed by in-memory storage, so parallel suites cannot clear or overwrite
+    /// each other's archive through the process-wide `CookieArchiveWriteQueue.shared`.
     static func makeTestInstance() -> WebKitManager {
-        WebKitManager(dataStore: .nonPersistent(), restoresCookies: false, loadsExtensions: false)
+        WebKitManager(
+            dataStore: .nonPersistent(),
+            restoresCookies: false,
+            loadsExtensions: false,
+            cookieArchiveQueue: CookieArchiveWriteQueue(storage: .inMemory())
+        )
     }
 
     /// The persistent website data store used across all WebViews.
     let dataStore: WKWebsiteDataStore
+
+    /// Serializes archive reads and writes for this manager's cookies. Defaults to the
+    /// process-wide queue so production keeps a single archive; tests inject their own.
+    let cookieArchiveQueue: CookieArchiveWriteQueue
 
     /// Timestamp of the last cookie change (for observation).
     private(set) var cookiesDidChange: Date = .distantPast
@@ -153,8 +105,14 @@ final class WebKitManager: NSObject, WebKitManagerProtocol {
         )
     #endif
 
-    private init(dataStore: WKWebsiteDataStore, restoresCookies: Bool, loadsExtensions: Bool) {
+    private init(
+        dataStore: WKWebsiteDataStore,
+        restoresCookies: Bool,
+        loadsExtensions: Bool,
+        cookieArchiveQueue: CookieArchiveWriteQueue = .shared
+    ) {
         self.dataStore = dataStore
+        self.cookieArchiveQueue = cookieArchiveQueue
 
         super.init()
 
@@ -576,7 +534,7 @@ final class WebKitManager: NSObject, WebKitManagerProtocol {
         // Invalidate once more after the initial fence so no operation that was
         // already queued before it can leave a durable stale snapshot. All live
         // verification happens after this final persistence suspension.
-        let didInvalidatePersistedCookies = await CookieArchiveWriteQueue.shared.invalidateAndDelete()
+        let didInvalidatePersistedCookies = await self.cookieArchiveQueue.invalidateAndDelete()
 
         let liveClearResult = await LiveAuthCookieStoreClearer.clear(
             operations: LiveAuthCookieStoreClearer.Operations(
@@ -630,7 +588,7 @@ final class WebKitManager: NSObject, WebKitManagerProtocol {
 
         // Repeat the invalidation after WebKit finishes clearing to close the
         // window for any already-enqueued observer or backup work.
-        let didInvalidatePersistedCookies = await CookieArchiveWriteQueue.shared.invalidateAndDelete()
+        let didInvalidatePersistedCookies = await self.cookieArchiveQueue.invalidateAndDelete()
         let remainingCookies = await self.dataStore.httpCookieStore.allCookies()
         let didClearLiveCookies = !remainingCookies.contains(where: KeychainCookieStorage.isLoginDomainCookie)
         let didClear = didInvalidatePersistedCookies && didClearLiveCookies
@@ -656,7 +614,7 @@ final class WebKitManager: NSObject, WebKitManagerProtocol {
         restoreTask?.cancel()
         backupTask?.cancel()
 
-        _ = await CookieArchiveWriteQueue.shared.invalidateAndDelete()
+        _ = await self.cookieArchiveQueue.invalidateAndDelete()
         _ = await restoreTask?.value
         _ = await backupTask?.value
     }

--- a/Tests/KasetTests/Helpers/MockYTMusicClient.swift
+++ b/Tests/KasetTests/Helpers/MockYTMusicClient.swift
@@ -96,6 +96,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     var editSongLibraryStatusErrors: [(any Error)?] = []
     var getSongDelay: Duration?
     var getHistoryDelay: Duration?
+    var shouldWaitForGetHistoryResponse = false
     var getPodcastsDelay: Duration?
     var getPlaylistDelay: Duration?
     var getPlaylistError: Error?
@@ -302,6 +303,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     private(set) var addSongToPlaylistCalls: [AddSongToPlaylistCall] = []
     private(set) var removeSongFromPlaylistCalls: [RemoveSongFromPlaylistCall] = []
     private var removeSongFromPlaylistResponseContinuations: [CheckedContinuation<Void, Never>] = []
+    private var getHistoryResponseContinuations: [CheckedContinuation<Void, Never>] = []
     private(set) var unsubscribeFromPlaylistCalled = false
     private(set) var unsubscribeFromPlaylistIds: [String] = []
     private(set) var subscribeToArtistCalled = false
@@ -472,6 +474,11 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
     func getHistory() async throws -> HomeResponse {
         self.getHistoryCallCount += 1
         self._historyContinuationIndex = 0
+        if self.shouldWaitForGetHistoryResponse {
+            await withCheckedContinuation { continuation in
+                self.getHistoryResponseContinuations.append(continuation)
+            }
+        }
         if let getHistoryDelay {
             try? await Task.sleep(for: getHistoryDelay)
         }
@@ -1101,6 +1108,11 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         }
     }
 
+    func resumeNextGetHistoryResponse() {
+        guard !self.getHistoryResponseContinuations.isEmpty else { return }
+        self.getHistoryResponseContinuations.removeFirst().resume()
+    }
+
     func resumeNextRemoveSongFromPlaylistResponse() {
         guard !self.removeSongFromPlaylistResponseContinuations.isEmpty else { return }
         self.removeSongFromPlaylistResponseContinuations.removeFirst().resume()
@@ -1437,6 +1449,7 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.editSongLibraryStatusErrors = []
         self.getSongDelay = nil
         self.getHistoryDelay = nil
+        self.shouldWaitForGetHistoryResponse = false
         self.mixQueueDelay = nil
         self.getRadioQueueDelay = nil
         self.mixQueueResult = RadioQueueResult(songs: [], continuationToken: nil)

--- a/Tests/KasetTests/Helpers/MockYTMusicClient.swift
+++ b/Tests/KasetTests/Helpers/MockYTMusicClient.swift
@@ -1450,6 +1450,9 @@ final class MockYTMusicClient: YTMusicClientProtocol { // swiftlint:disable:this
         self.getSongDelay = nil
         self.getHistoryDelay = nil
         self.shouldWaitForGetHistoryResponse = false
+        while !self.getHistoryResponseContinuations.isEmpty {
+            self.getHistoryResponseContinuations.removeFirst().resume()
+        }
         self.mixQueueDelay = nil
         self.getRadioQueueDelay = nil
         self.mixQueueResult = RadioQueueResult(songs: [], continuationToken: nil)

--- a/Tests/KasetTests/HistoryViewModelTests.swift
+++ b/Tests/KasetTests/HistoryViewModelTests.swift
@@ -180,13 +180,15 @@ struct HistoryViewModelTests {
         await self.viewModel.loadMore()
         #expect(self.viewModel.sections.map(\.title) == ["Today", "Yesterday"])
 
-        self.mockClient.getHistoryDelay = .milliseconds(100)
+        self.mockClient.shouldWaitForGetHistoryResponse = true
         let refreshTask = Task { await self.viewModel.refresh() }
         await self.waitForHistoryRefresh {
             self.mockClient.getHistoryCallCount == 2
         }
 
         await self.viewModel.loadMore()
+
+        self.mockClient.resumeNextGetHistoryResponse()
         _ = await refreshTask.value
 
         #expect(self.mockClient.getHistoryContinuationCallCount == 1)

--- a/Tests/KasetTests/MockYTMusicClientTests.swift
+++ b/Tests/KasetTests/MockYTMusicClientTests.swift
@@ -1,0 +1,37 @@
+import Testing
+@testable import Kaset
+
+@Suite("Mock YouTube Music client", .serialized, .timeLimit(.minutes(1)))
+@MainActor
+struct MockYTMusicClientTests {
+    @Test("Reset releases suspended history requests")
+    func resetReleasesSuspendedHistoryRequests() async {
+        let client = MockYTMusicClient()
+        client.shouldWaitForGetHistoryResponse = true
+        var didComplete = false
+        let request = Task { @MainActor in
+            _ = try? await client.getHistory()
+            didComplete = true
+        }
+
+        while client.getHistoryCallCount == 0 {
+            await Task.yield()
+        }
+
+        client.reset()
+
+        let clock = ContinuousClock()
+        let deadline = clock.now + .seconds(1)
+        while !didComplete, clock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+
+        let resetReleasedRequest = didComplete
+        if !resetReleasedRequest {
+            client.resumeNextGetHistoryResponse()
+        }
+        await request.value
+
+        #expect(resetReleasedRequest)
+    }
+}

--- a/Tests/KasetTests/WebKitCookieRestoreTests.swift
+++ b/Tests/KasetTests/WebKitCookieRestoreTests.swift
@@ -29,7 +29,7 @@ struct WebKitCookieRestoreTests {
     func persistedArchiveReplacesStaleLiveCookies() async throws {
         let expectedCookie = try #require(HTTPCookie(properties: [
             .name: "__Secure-3PAPISID",
-            .value: "expected-session",
+            .value: "isolated-restore-session",
             .domain: ".youtube.com",
             .path: "/",
         ]))
@@ -52,9 +52,15 @@ struct WebKitCookieRestoreTests {
             .path: "/",
         ]))
         let webKitManager = WebKitManager.makeTestInstance()
+        let archive = try #require(KeychainCookieStorage.makeArchiveData(from: [expectedCookie]))
 
         _ = await webKitManager.clearAllData()
-        KeychainCookieStorage.saveCookies([expectedCookie])
+        let generation = await webKitManager.cookieArchiveQueue.reserveGeneration()
+        #expect(await webKitManager.cookieArchiveQueue.save(
+            archiveData: archive.data,
+            cookieCount: archive.cookieCount,
+            generation: generation
+        ).isPersisted)
         await webKitManager.dataStore.httpCookieStore.setCookie(staleCookie)
         await webKitManager.dataStore.httpCookieStore.setCookie(staleGAIA)
         await webKitManager.dataStore.httpCookieStore.setCookie(publicPreference)
@@ -66,7 +72,7 @@ struct WebKitCookieRestoreTests {
         _ = await webKitManager.clearAllData()
 
         #expect(restored)
-        #expect(cookies.first { $0.name == "__Secure-3PAPISID" }?.value == "expected-session")
+        #expect(cookies.first { $0.name == "__Secure-3PAPISID" }?.value == "isolated-restore-session")
         #expect(cookies.contains { $0.name == "SAPISID" } == false)
         #expect(cookies.contains { $0.name == "LSID" } == false)
         #expect(cookies.first { $0.name == "PREF" }?.value == "preserve-public-state")

--- a/Tests/KasetTests/WebKitCookieRestoreTests.swift
+++ b/Tests/KasetTests/WebKitCookieRestoreTests.swift
@@ -5,6 +5,26 @@ import Testing
 @Suite("WebKit cookie restoration", .serialized, .tags(.service))
 @MainActor
 struct WebKitCookieRestoreTests {
+    @Test("Clearing one manager's data leaves another manager's cookie archive intact")
+    func clearingOneManagerPreservesAnotherManagersArchive() async {
+        let archiveOwner = WebKitManager.makeTestInstance()
+        let clearingManager = WebKitManager.makeTestInstance()
+        let archiveData = Data("archived-cookies".utf8)
+
+        let generation = await archiveOwner.cookieArchiveQueue.reserveGeneration()
+        let saveResult = await archiveOwner.cookieArchiveQueue.save(
+            archiveData: archiveData,
+            cookieCount: 1,
+            generation: generation
+        )
+        #expect(saveResult == .saved)
+
+        _ = await clearingManager.clearAllData()
+
+        #expect(await archiveOwner.cookieArchiveQueue.persistedArchiveData() == archiveData)
+        #expect(await clearingManager.cookieArchiveQueue.persistedArchiveData() == nil)
+    }
+
     @Test("Persisted archive replaces stale live authentication cookies")
     func persistedArchiveReplacesStaleLiveCookies() async throws {
         let expectedCookie = try #require(HTTPCookie(properties: [

--- a/Tests/KasetTests/WebKitManagerTests.swift
+++ b/Tests/KasetTests/WebKitManagerTests.swift
@@ -840,8 +840,11 @@ private final class InMemoryCookieArchiveStorage: @unchecked Sendable {
                 }
                 return self.saveResult
             },
-            load: { [self] in
-                self.lock.withLock { self.data }
+            loadResult: { [self] in
+                self.lock.withLock {
+                    guard let data = self.data else { return .notFound }
+                    return .data(data)
+                }
             },
             delete: { [self] in
                 self.lock.withLock {


### PR DESCRIPTION
## Description

Fixes the two pre-existing flaky unit tests that have been failing `macOS Unit Tests` on unrelated PRs. Both are test-only issues; no production behaviour changes.

### 1. `WebKitCookieRestoreTests` — shared cookie archive (macos-26)

`WebKitManager.clearAllData()` calls `CookieArchiveWriteQueue.shared.invalidateAndDelete()` — a process-wide actor over `KeychainCookieStorage`. Seven test files call `clearAllData()`, and Swift Testing runs their suites concurrently, so one suite deletes the cookie archive another suite has just written. `.serialized` on the individual suites doesn't help: it only orders tests *within* a suite.

Repro on current `main`:

```
swift test --skip KasetUITests --filter WebKit     # fails 5/5
swift test --skip KasetUITests --filter WebKitCookieRestoreTests   # passes 3/3
```

```
✘ "Persisted archive replaces stale live authentication cookies"
  Expectation failed: (cookies.first { $0.name == "__Secure-3PAPISID" }?.value → nil) == "expected-session"
```

### 2. `HistoryViewModelTests` — refresh finishing before `loadMore` (macos-15)

`loadMoreBlockedWhileRefreshRewindsHistoryCursor` simulated an in-flight refresh with a 100ms `getHistory` delay, then polled every 25ms before calling `loadMore()`. On loaded runners the poll returned after refresh had already completed, so the `!isRefreshingHistory` guard no longer blocked `loadMore()`: 3 continuation calls instead of 1, with `"Older"` appended.

Replaced the delay with an explicit continuation gate on the mock, matching the existing `shouldWaitForRemoveSongFromPlaylistResponse` pattern, so refresh cannot finish before `loadMore()` is attempted.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `WebKitManager` takes an injectable `cookieArchiveQueue`, defaulting to `.shared` — production behaviour is unchanged, still a single process-wide archive
- `makeTestInstance()` gets its own `CookieArchiveWriteQueue` over a new `CookieArchiveStorage.inMemory()`, so parallel suites can no longer clear or overwrite each other's archive
- The 30 `CookieArchiveWriteQueue.shared` call sites (all inside `extension WebKitManager`) now go through the injected queue
- New regression test: clearing one manager's data leaves another manager's archive intact — verified to fail without the injection
- Extracted `AuthCookieOperationFence` / `LiveAuthCookieClearResult` / `LiveAuthCookieStoreClearer` into `WebKitManager+AuthCookieClearing.swift` to keep `WebKitManager.swift` under the 900-line `file_length` limit
- Gated the history refresh test on an explicit mock continuation instead of a wall-clock delay

`CookieArchiveStorage.inMemory()` returns `.allowed` from `restoreDecision`, which matches what the live storage already does under unit tests (`CookieArchiveRestorePolicy.restoreDecision` short-circuits on `UITestConfig.isRunningUnitTests`), so no test coverage is weakened.

## Testing

- [x] `swift test --skip KasetUITests` — 6 consecutive full-suite runs, 0 failures
- [x] `swift test --skip KasetUITests --filter WebKit` — 5/5 green (was 5/5 red)
- [x] Cookie flake measured before/after: 8/8 full-suite runs red on `main`, 0/7 red with the fix
- [x] New regression test confirmed red without the fix, green with it
- [x] `swiftlint --strict && swiftformat .` clean

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `swiftlint --strict && swiftformat .`
- [x] I have added tests that prove my fix works
- [x] New and existing unit tests pass locally
- [x] My changes generate no new warnings

## Additional Notes

Production behaviour is unchanged — `WebKitManager.shared` still uses `CookieArchiveWriteQueue.shared`. The injection point exists only so tests stop sharing one global archive.

The `HistoryViewModelTests` fix is cherry-picked from #442, where it was authored as part of an unrelated feature branch. It's shared test infrastructure, so it's carried here to unblock every branch rather than only that one — #442 can drop its copy once this lands.

Unrelated flakes remain in `ScrobblingCoordinator*` and `PlaylistDetailViewModelTests`; those look like separate shared-state issues and aren't touched here.
