### PR TITLE
fix(player): mount shared PlayerBar via music navigation coordinator

### DIFF
--- a/Sources/Kaset/Utilities/MusicNavigationCoordinator.swift
+++ b/Sources/Kaset/Utilities/MusicNavigationCoordinator.swift
@@ -19,6 +19,7 @@ final class MusicNavigationCoordinator {
 
     var activeTab: NavigationItem?
     var activePinnedContentID: String?
+    private(set) var activeRouteHasNavigationStack = false
 
     var routeArtistID: String?
     var routeAlbumID: String?
@@ -55,12 +56,14 @@ final class MusicNavigationCoordinator {
         )
     }
 
-    func updateActiveRoute(tab: NavigationItem?, pinnedContentID: String?) {
+    func updateActiveRoute(tab: NavigationItem?, pinnedContentID: String?, hasNavigationStack: Bool = true) {
         self.activeTab = tab
         self.activePinnedContentID = pinnedContentID
+        self.activeRouteHasNavigationStack = hasNavigationStack
     }
 
     func activeNavigationPathBinding() -> Binding<NavigationPath>? {
+        guard self.activeRouteHasNavigationStack else { return nil }
         if let contentID = self.activePinnedContentID {
             return self.pinnedPathBinding(for: contentID)
         }
@@ -71,7 +74,8 @@ final class MusicNavigationCoordinator {
     }
 
     var playerBarNavigationAction: PlayerBarNavigationAction {
-        guard let binding = self.activeNavigationPathBinding() else { return .disabled }
+        guard self.activeRouteHasNavigationStack,
+              let binding = self.activeNavigationPathBinding() else { return .disabled }
         return PlayerBarNavigationAction(
             openArtist: { artist in binding.wrappedValue.append(artist) },
             openAlbum: { album in binding.wrappedValue.append(album) }

--- a/Sources/Kaset/Utilities/MusicNavigationCoordinator.swift
+++ b/Sources/Kaset/Utilities/MusicNavigationCoordinator.swift
@@ -1,0 +1,104 @@
+import SwiftUI
+
+// MARK: - MusicNavigationCoordinator
+
+/// Owns music sidebar navigation paths and the active route used by the shared PlayerBar.
+@Observable @MainActor
+final class MusicNavigationCoordinator {
+    var homeNavigationPath = NavigationPath()
+    var exploreNavigationPath = NavigationPath()
+    var searchNavigationPath = NavigationPath()
+    var chartsNavigationPath = NavigationPath()
+    var moodsAndGenresNavigationPath = NavigationPath()
+    var newReleasesNavigationPath = NavigationPath()
+    var podcastsNavigationPath = NavigationPath()
+    var likedMusicNavigationPath = NavigationPath()
+    var libraryNavigationPath = NavigationPath()
+    var historyNavigationPath = NavigationPath()
+    var pinnedNavigationPaths: [String: NavigationPath] = [:]
+
+    var activeTab: NavigationItem?
+    var activePinnedContentID: String?
+
+    var routeArtistID: String?
+    var routeAlbumID: String?
+
+    func navigationPathBinding(for item: NavigationItem) -> Binding<NavigationPath> {
+        switch item {
+        case .home:
+            Binding(get: { self.homeNavigationPath }, set: { self.homeNavigationPath = $0 })
+        case .explore:
+            Binding(get: { self.exploreNavigationPath }, set: { self.exploreNavigationPath = $0 })
+        case .search:
+            Binding(get: { self.searchNavigationPath }, set: { self.searchNavigationPath = $0 })
+        case .charts:
+            Binding(get: { self.chartsNavigationPath }, set: { self.chartsNavigationPath = $0 })
+        case .moodsAndGenres:
+            Binding(get: { self.moodsAndGenresNavigationPath }, set: { self.moodsAndGenresNavigationPath = $0 })
+        case .newReleases:
+            Binding(get: { self.newReleasesNavigationPath }, set: { self.newReleasesNavigationPath = $0 })
+        case .podcasts:
+            Binding(get: { self.podcastsNavigationPath }, set: { self.podcastsNavigationPath = $0 })
+        case .likedMusic:
+            Binding(get: { self.likedMusicNavigationPath }, set: { self.likedMusicNavigationPath = $0 })
+        case .library:
+            Binding(get: { self.libraryNavigationPath }, set: { self.libraryNavigationPath = $0 })
+        case .history:
+            Binding(get: { self.historyNavigationPath }, set: { self.historyNavigationPath = $0 })
+        }
+    }
+
+    func pinnedPathBinding(for contentID: String) -> Binding<NavigationPath> {
+        Binding(
+            get: { self.pinnedNavigationPaths[contentID, default: NavigationPath()] },
+            set: { self.pinnedNavigationPaths[contentID] = $0 }
+        )
+    }
+
+    func updateActiveRoute(tab: NavigationItem?, pinnedContentID: String?) {
+        self.activeTab = tab
+        self.activePinnedContentID = pinnedContentID
+    }
+
+    func activeNavigationPathBinding() -> Binding<NavigationPath>? {
+        if let contentID = self.activePinnedContentID {
+            return self.pinnedPathBinding(for: contentID)
+        }
+        if let tab = self.activeTab {
+            return self.navigationPathBinding(for: tab)
+        }
+        return nil
+    }
+
+    var playerBarNavigationAction: PlayerBarNavigationAction {
+        guard let binding = self.activeNavigationPathBinding() else { return .disabled }
+        return PlayerBarNavigationAction(
+            openArtist: { artist in binding.wrappedValue.append(artist) },
+            openAlbum: { album in binding.wrappedValue.append(album) }
+        )
+    }
+
+    func resetAllNavigationPaths() {
+        self.homeNavigationPath = NavigationPath()
+        self.exploreNavigationPath = NavigationPath()
+        self.searchNavigationPath = NavigationPath()
+        self.chartsNavigationPath = NavigationPath()
+        self.moodsAndGenresNavigationPath = NavigationPath()
+        self.newReleasesNavigationPath = NavigationPath()
+        self.podcastsNavigationPath = NavigationPath()
+        self.likedMusicNavigationPath = NavigationPath()
+        self.libraryNavigationPath = NavigationPath()
+        self.historyNavigationPath = NavigationPath()
+        self.pinnedNavigationPaths = [:]
+        self.routeArtistID = nil
+        self.routeAlbumID = nil
+    }
+
+    func setRouteAlbumID(_ albumID: String?) {
+        self.routeAlbumID = albumID
+    }
+
+    func setRouteArtistID(_ artistID: String?) {
+        self.routeArtistID = artistID
+    }
+}

--- a/Sources/Kaset/Utilities/MusicNavigationCoordinator.swift
+++ b/Sources/Kaset/Utilities/MusicNavigationCoordinator.swift
@@ -102,6 +102,16 @@ final class MusicNavigationCoordinator {
         self.routeAlbumID = albumID
     }
 
+    func showAlbumRoute(for playlist: Playlist) {
+        guard playlist.isAlbum else { return }
+        self.routeAlbumID = playlist.id
+    }
+
+    func hideAlbumRoute(for playlist: Playlist) {
+        guard playlist.isAlbum, self.routeAlbumID == playlist.id else { return }
+        self.routeAlbumID = nil
+    }
+
     func setRouteArtistID(_ artistID: String?) {
         self.routeArtistID = artistID
     }

--- a/Sources/Kaset/Views/ArtistDetailView.swift
+++ b/Sources/Kaset/Views/ArtistDetailView.swift
@@ -5,20 +5,18 @@ import SwiftUI
 /// Detail view for an artist showing their songs and albums.
 struct ArtistDetailView: View { // swiftlint:disable:this type_body_length
     let artist: Artist
-    var playerBarNavigationAction: PlayerBarNavigationAction = .disabled
     @State var viewModel: ArtistDetailViewModel
     @Environment(PlayerService.self) private var playerService
     @Environment(AuthService.self) private var authService
     @Environment(FavoritesManager.self) private var favoritesManager
     @Environment(SongLikeStatusManager.self) private var likeStatusManager
+    @Environment(MusicNavigationCoordinator.self) private var musicNavigation
 
     init(
         artist: Artist,
-        viewModel: ArtistDetailViewModel,
-        playerBarNavigationAction: PlayerBarNavigationAction = .disabled
+        viewModel: ArtistDetailViewModel
     ) {
         self.artist = artist
-        self.playerBarNavigationAction = playerBarNavigationAction
         _viewModel = State(initialValue: viewModel)
     }
 
@@ -44,11 +42,12 @@ struct ArtistDetailView: View { // swiftlint:disable:this type_body_length
         .accentBackground(from: self.viewModel.artistDetail?.thumbnailURL?.highQualityThumbnailURL)
         .navigationTitle(self.artist.name)
         .toolbarBackgroundVisibility(.hidden, for: .automatic)
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            if case .error = self.viewModel.loadingState {} else {
-                PlayerBar()
-                    .environment(\.playerBarNavigationAction, self.playerBarNavigationAction)
-                    .environment(\.playerBarCurrentArtistID, self.artist.id)
+        .onAppear {
+            self.musicNavigation.setRouteArtistID(self.artist.id)
+        }
+        .onDisappear {
+            if self.musicNavigation.routeArtistID == self.artist.id {
+                self.musicNavigation.setRouteArtistID(nil)
             }
         }
         .task {

--- a/Sources/Kaset/Views/ArtistDiscographyView.swift
+++ b/Sources/Kaset/Views/ArtistDiscographyView.swift
@@ -24,11 +24,6 @@ struct ArtistDiscographyView: View {
         .navigationTitle(self.viewModel.destination.sectionTitle)
         .toolbarBackgroundVisibility(.hidden, for: .automatic)
         .topFade()
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            if case .error = self.viewModel.loadingState {} else {
-                PlayerBar()
-            }
-        }
         .task {
             if self.viewModel.loadingState == .idle {
                 await self.viewModel.load()

--- a/Sources/Kaset/Views/ArtistEpisodesListView.swift
+++ b/Sources/Kaset/Views/ArtistEpisodesListView.swift
@@ -32,11 +32,6 @@ struct ArtistEpisodesListView: View {
         .navigationTitle(self.viewModel.destination.sectionTitle)
         .toolbarBackgroundVisibility(.hidden, for: .automatic)
         .topFade()
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            if case .error = self.viewModel.loadingState {} else {
-                PlayerBar()
-            }
-        }
         .task {
             if self.viewModel.loadingState == .idle {
                 await self.viewModel.load()

--- a/Sources/Kaset/Views/ChartsView.swift
+++ b/Sources/Kaset/Views/ChartsView.swift
@@ -33,9 +33,7 @@ struct ChartsView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .localizedNavigationTitle("Charts")
             .navigationDestinations(client: self.viewModel.client)
-            .playerBarMusicNavigation(path: self.musicNavigation.navigationPathBinding(for: .charts))
         }
-        .playerBarMusicNavigation(path: self.musicNavigation.navigationPathBinding(for: .charts))
         .onAppear {
             if self.viewModel.loadingState == .idle {
                 Task {

--- a/Sources/Kaset/Views/ChartsView.swift
+++ b/Sources/Kaset/Views/ChartsView.swift
@@ -3,12 +3,12 @@ import SwiftUI
 /// Charts view displaying top songs, albums, and trending charts.
 struct ChartsView: View {
     @State var viewModel: ChartsViewModel
+    @Environment(MusicNavigationCoordinator.self) private var musicNavigation
     @Environment(PlayerService.self) private var playerService
-    @State private var navigationPath = NavigationPath()
     @State private var networkMonitor = NetworkMonitor.shared
 
     var body: some View {
-        NavigationStack(path: self.$navigationPath) {
+        NavigationStack(path: self.musicNavigation.navigationPathBinding(for: .charts)) {
             Group {
                 if !self.networkMonitor.isConnected {
                     ErrorView(
@@ -32,17 +32,10 @@ struct ChartsView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .localizedNavigationTitle("Charts")
-            .navigationDestinations(
-                client: self.viewModel.client,
-                playerBarNavigationAction: self.playerBarNavigationAction
-            )
-            .playerBarMusicNavigation(path: self.$navigationPath)
+            .navigationDestinations(client: self.viewModel.client)
+            .playerBarMusicNavigation(path: self.musicNavigation.navigationPathBinding(for: .charts))
         }
-        .playerBarMusicNavigation(path: self.$navigationPath)
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            PlayerBar()
-                .playerBarMusicNavigation(path: self.$navigationPath)
-        }
+        .playerBarMusicNavigation(path: self.musicNavigation.navigationPathBinding(for: .charts))
         .onAppear {
             if self.viewModel.loadingState == .idle {
                 Task {
@@ -53,15 +46,9 @@ struct ChartsView: View {
         .refreshable {
             await self.viewModel.refresh()
         }
-        .popsNavigationStackOnSidebarReselect(path: self.$navigationPath, for: .charts)
+        .popsNavigationStackOnSidebarReselect(path: self.musicNavigation.navigationPathBinding(for: .charts), for: .charts)
     }
 
-    private var playerBarNavigationAction: PlayerBarNavigationAction {
-        PlayerBarNavigationAction(
-            openArtist: { self.navigationPath.append($0) },
-            openAlbum: { self.navigationPath.append($0) }
-        )
-    }
 
     // MARK: - Views
 
@@ -137,7 +124,7 @@ struct ChartsView: View {
                 await self.playerService.playWithRadio(song: song)
             }
         case let .playlist(playlist):
-            self.navigationPath.append(playlist)
+            self.musicNavigation.chartsNavigationPath.append(playlist)
         case let .album(album):
             let playlist = Playlist(
                 id: album.id,
@@ -147,9 +134,9 @@ struct ChartsView: View {
                 trackCount: album.trackCount,
                 author: Artist.inline(name: album.artistsDisplay, namespace: "album-artist")
             )
-            self.navigationPath.append(playlist)
+            self.musicNavigation.chartsNavigationPath.append(playlist)
         case let .artist(artist):
-            self.navigationPath.append(artist)
+            self.musicNavigation.chartsNavigationPath.append(artist)
         }
     }
 }

--- a/Sources/Kaset/Views/ChartsView.swift
+++ b/Sources/Kaset/Views/ChartsView.swift
@@ -47,7 +47,6 @@ struct ChartsView: View {
         .popsNavigationStackOnSidebarReselect(path: self.musicNavigation.navigationPathBinding(for: .charts), for: .charts)
     }
 
-
     // MARK: - Views
 
     private var contentView: some View {

--- a/Sources/Kaset/Views/ExploreView.swift
+++ b/Sources/Kaset/Views/ExploreView.swift
@@ -47,7 +47,6 @@ struct ExploreView: View {
         .popsNavigationStackOnSidebarReselect(path: self.musicNavigation.navigationPathBinding(for: .explore), for: .explore)
     }
 
-
     // MARK: - Views
 
     private var contentView: some View {

--- a/Sources/Kaset/Views/ExploreView.swift
+++ b/Sources/Kaset/Views/ExploreView.swift
@@ -33,9 +33,7 @@ struct ExploreView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .localizedNavigationTitle("Explore")
             .navigationDestinations(client: self.viewModel.client)
-            .playerBarMusicNavigation(path: self.musicNavigation.navigationPathBinding(for: .explore))
         }
-        .playerBarMusicNavigation(path: self.musicNavigation.navigationPathBinding(for: .explore))
         .onAppear {
             if self.viewModel.loadingState == .idle {
                 Task {

--- a/Sources/Kaset/Views/ExploreView.swift
+++ b/Sources/Kaset/Views/ExploreView.swift
@@ -3,12 +3,12 @@ import SwiftUI
 /// Explore view displaying new releases, charts, and moods & genres.
 struct ExploreView: View {
     @State var viewModel: ExploreViewModel
+    @Environment(MusicNavigationCoordinator.self) private var musicNavigation
     @Environment(PlayerService.self) private var playerService
-    @State private var navigationPath = NavigationPath()
     @State private var networkMonitor = NetworkMonitor.shared
 
     var body: some View {
-        NavigationStack(path: self.$navigationPath) {
+        NavigationStack(path: self.musicNavigation.navigationPathBinding(for: .explore)) {
             Group {
                 if !self.networkMonitor.isConnected {
                     ErrorView(
@@ -32,17 +32,10 @@ struct ExploreView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .localizedNavigationTitle("Explore")
-            .navigationDestinations(
-                client: self.viewModel.client,
-                playerBarNavigationAction: self.playerBarNavigationAction
-            )
-            .playerBarMusicNavigation(path: self.$navigationPath)
+            .navigationDestinations(client: self.viewModel.client)
+            .playerBarMusicNavigation(path: self.musicNavigation.navigationPathBinding(for: .explore))
         }
-        .playerBarMusicNavigation(path: self.$navigationPath)
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            PlayerBar()
-                .playerBarMusicNavigation(path: self.$navigationPath)
-        }
+        .playerBarMusicNavigation(path: self.musicNavigation.navigationPathBinding(for: .explore))
         .onAppear {
             if self.viewModel.loadingState == .idle {
                 Task {
@@ -53,15 +46,9 @@ struct ExploreView: View {
         .refreshable {
             await self.viewModel.refresh()
         }
-        .popsNavigationStackOnSidebarReselect(path: self.$navigationPath, for: .explore)
+        .popsNavigationStackOnSidebarReselect(path: self.musicNavigation.navigationPathBinding(for: .explore), for: .explore)
     }
 
-    private var playerBarNavigationAction: PlayerBarNavigationAction {
-        PlayerBarNavigationAction(
-            openArtist: { self.navigationPath.append($0) },
-            openAlbum: { self.navigationPath.append($0) }
-        )
-    }
 
     // MARK: - Views
 
@@ -139,7 +126,7 @@ struct ExploreView: View {
                 await self.playerService.playWithRadio(song: song)
             }
         case let .playlist(playlist):
-            self.navigationPath.append(playlist)
+            self.musicNavigation.exploreNavigationPath.append(playlist)
         case let .album(album):
             let playlist = Playlist(
                 id: album.id,
@@ -149,9 +136,9 @@ struct ExploreView: View {
                 trackCount: album.trackCount,
                 author: Artist.inline(name: album.artistsDisplay, namespace: "album-artist")
             )
-            self.navigationPath.append(playlist)
+            self.musicNavigation.exploreNavigationPath.append(playlist)
         case let .artist(artist):
-            self.navigationPath.append(artist)
+            self.musicNavigation.exploreNavigationPath.append(artist)
         }
     }
 }

--- a/Sources/Kaset/Views/HistoryView.swift
+++ b/Sources/Kaset/Views/HistoryView.swift
@@ -71,7 +71,6 @@ struct HistoryView: View {
         .popsNavigationStackOnSidebarReselect(path: self.musicNavigation.navigationPathBinding(for: .history), for: .history)
     }
 
-
     /// Refreshes with visual feedback: spinning icon → data swap.
     @discardableResult
     private func performRefresh() async -> Bool {

--- a/Sources/Kaset/Views/HistoryView.swift
+++ b/Sources/Kaset/Views/HistoryView.swift
@@ -4,14 +4,14 @@ import SwiftUI
 /// Fetches history from the API and displays songs grouped by time period.
 struct HistoryView: View {
     @State var viewModel: HistoryViewModel
+    @Environment(MusicNavigationCoordinator.self) private var musicNavigation
     @Environment(PlayerService.self) private var playerService
     @Environment(FavoritesManager.self) private var favoritesManager
-    @State private var navigationPath = NavigationPath()
     @State private var networkMonitor = NetworkMonitor.shared
     @State private var isRefreshing = false
 
     var body: some View {
-        NavigationStack(path: self.$navigationPath) {
+        NavigationStack(path: self.musicNavigation.navigationPathBinding(for: .history)) {
             Group {
                 if !self.networkMonitor.isConnected {
                     ErrorView(
@@ -51,17 +51,10 @@ struct HistoryView: View {
                     .disabled(self.isRefreshing)
                 }
             }
-            .navigationDestinations(
-                client: self.viewModel.client,
-                playerBarNavigationAction: self.playerBarNavigationAction
-            )
-            .playerBarMusicNavigation(path: self.$navigationPath)
+            .navigationDestinations(client: self.viewModel.client)
+            .playerBarMusicNavigation(path: self.musicNavigation.navigationPathBinding(for: .history))
         }
-        .playerBarMusicNavigation(path: self.$navigationPath)
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            PlayerBar()
-                .playerBarMusicNavigation(path: self.$navigationPath)
-        }
+        .playerBarMusicNavigation(path: self.musicNavigation.navigationPathBinding(for: .history))
         .task {
             if self.viewModel.loadingState == .idle {
                 await self.viewModel.load()
@@ -77,15 +70,9 @@ struct HistoryView: View {
         .refreshable {
             await self.performRefresh()
         }
-        .popsNavigationStackOnSidebarReselect(path: self.$navigationPath, for: .history)
+        .popsNavigationStackOnSidebarReselect(path: self.musicNavigation.navigationPathBinding(for: .history), for: .history)
     }
 
-    private var playerBarNavigationAction: PlayerBarNavigationAction {
-        PlayerBarNavigationAction(
-            openArtist: { self.navigationPath.append($0) },
-            openAlbum: { self.navigationPath.append($0) }
-        )
-    }
 
     /// Refreshes with visual feedback: spinning icon → data swap.
     @discardableResult

--- a/Sources/Kaset/Views/HistoryView.swift
+++ b/Sources/Kaset/Views/HistoryView.swift
@@ -52,9 +52,7 @@ struct HistoryView: View {
                 }
             }
             .navigationDestinations(client: self.viewModel.client)
-            .playerBarMusicNavigation(path: self.musicNavigation.navigationPathBinding(for: .history))
         }
-        .playerBarMusicNavigation(path: self.musicNavigation.navigationPathBinding(for: .history))
         .task {
             if self.viewModel.loadingState == .idle {
                 await self.viewModel.load()

--- a/Sources/Kaset/Views/HomeView.swift
+++ b/Sources/Kaset/Views/HomeView.swift
@@ -7,11 +7,11 @@ struct HomeView: View {
     @Environment(FavoritesManager.self) private var favoritesManager
     @Environment(SongLikeStatusManager.self) private var likeStatusManager
     @Environment(AuthService.self) private var authService
-    @State private var navigationPath = NavigationPath()
+    @Environment(MusicNavigationCoordinator.self) private var musicNavigation
     @State private var networkMonitor = NetworkMonitor.shared
 
     var body: some View {
-        NavigationStack(path: self.$navigationPath) {
+        NavigationStack(path: self.musicNavigation.navigationPathBinding(for: .home)) {
             Group {
                 if !self.networkMonitor.isConnected {
                     ErrorView(
@@ -35,17 +35,10 @@ struct HomeView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .localizedNavigationTitle("Home")
-            .navigationDestinations(
-                client: self.viewModel.client,
-                playerBarNavigationAction: self.playerBarNavigationAction
-            )
-            .playerBarMusicNavigation(path: self.$navigationPath)
+            .navigationDestinations(client: self.viewModel.client)
+            .playerBarMusicNavigation(path: self.musicNavigation.navigationPathBinding(for: .home))
         }
-        .playerBarMusicNavigation(path: self.$navigationPath)
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            PlayerBar()
-                .playerBarMusicNavigation(path: self.$navigationPath)
-        }
+        .playerBarMusicNavigation(path: self.musicNavigation.navigationPathBinding(for: .home))
         .onAppear {
             if self.viewModel.loadingState == .idle {
                 Task {
@@ -53,13 +46,9 @@ struct HomeView: View {
                 }
             }
         }
-        .popsNavigationStackOnSidebarReselect(path: self.$navigationPath, for: .home)
-    }
-
-    private var playerBarNavigationAction: PlayerBarNavigationAction {
-        PlayerBarNavigationAction(
-            openArtist: { self.navigationPath.append($0) },
-            openAlbum: { self.navigationPath.append($0) }
+        .popsNavigationStackOnSidebarReselect(
+            path: self.musicNavigation.navigationPathBinding(for: .home),
+            for: .home
         )
     }
 
@@ -73,11 +62,11 @@ struct HomeView: View {
                     FavoritesSection(
                         onNavigate: { destination in
                             if let playlist = destination as? Playlist {
-                                self.navigationPath.append(playlist)
+                                self.musicNavigation.homeNavigationPath.append(playlist)
                             } else if let artist = destination as? Artist {
-                                self.navigationPath.append(artist)
+                                self.musicNavigation.homeNavigationPath.append(artist)
                             } else if let podcastShow = destination as? PodcastShow {
-                                self.navigationPath.append(podcastShow)
+                                self.musicNavigation.homeNavigationPath.append(podcastShow)
                             }
                         },
                         contentInset: DetailContentLayout.horizontalInset
@@ -270,7 +259,7 @@ struct HomeView: View {
 
         case let .playlist(playlist):
             Button {
-                self.navigationPath.append(playlist)
+                self.musicNavigation.homeNavigationPath.append(playlist)
             } label: {
                 Label(String(localized: "View Playlist"), systemImage: "music.note.list")
             }
@@ -285,7 +274,7 @@ struct HomeView: View {
 
         case let .artist(artist):
             Button {
-                self.navigationPath.append(artist)
+                self.musicNavigation.homeNavigationPath.append(artist)
             } label: {
                 Label(String(localized: "View Artist"), systemImage: "person")
             }
@@ -327,7 +316,7 @@ struct HomeView: View {
             }
         case let .playlist(playlist):
             // Navigate to playlist detail
-            self.navigationPath.append(playlist)
+            self.musicNavigation.homeNavigationPath.append(playlist)
         case let .album(album):
             // For now, we'll create a playlist-like navigation for albums
             // In a full implementation, we'd have an AlbumDetailView
@@ -339,10 +328,10 @@ struct HomeView: View {
                 trackCount: album.trackCount,
                 author: Artist.inline(name: album.artistsDisplay, namespace: "album-artist")
             )
-            self.navigationPath.append(playlist)
+            self.musicNavigation.homeNavigationPath.append(playlist)
         case let .artist(artist):
             // Navigate to artist detail
-            self.navigationPath.append(artist)
+            self.musicNavigation.homeNavigationPath.append(artist)
         }
     }
 }

--- a/Sources/Kaset/Views/HomeView.swift
+++ b/Sources/Kaset/Views/HomeView.swift
@@ -36,9 +36,7 @@ struct HomeView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .localizedNavigationTitle("Home")
             .navigationDestinations(client: self.viewModel.client)
-            .playerBarMusicNavigation(path: self.musicNavigation.navigationPathBinding(for: .home))
         }
-        .playerBarMusicNavigation(path: self.musicNavigation.navigationPathBinding(for: .home))
         .onAppear {
             if self.viewModel.loadingState == .idle {
                 Task {

--- a/Sources/Kaset/Views/LegacyFallbackViews.swift
+++ b/Sources/Kaset/Views/LegacyFallbackViews.swift
@@ -15,7 +15,6 @@ struct SimplePlaylistDetailView: View {
     @State var viewModel: PlaylistDetailViewModel
     @Environment(PlayerService.self) private var playerService
     @Environment(SongLikeStatusManager.self) private var likeStatusManager
-    @Environment(MusicNavigationCoordinator.self) private var musicNavigation
 
     init(
         playlist: Playlist,
@@ -48,16 +47,7 @@ struct SimplePlaylistDetailView: View {
             }
         }
         .navigationTitle(self.playlist.title)
-        .onAppear {
-            if self.playlist.isAlbum {
-                self.musicNavigation.setRouteAlbumID(self.playlist.id)
-            }
-        }
-        .onDisappear {
-            if self.playlist.isAlbum, self.musicNavigation.routeAlbumID == self.playlist.id {
-                self.musicNavigation.setRouteAlbumID(nil)
-            }
-        }
+        .playerBarAlbumRoute(for: self.playlist)
         .task {
             if self.viewModel.loadingState == .idle {
                 await self.viewModel.load()

--- a/Sources/Kaset/Views/LegacyFallbackViews.swift
+++ b/Sources/Kaset/Views/LegacyFallbackViews.swift
@@ -12,18 +12,16 @@ import SwiftUI
 /// Minimal playlist view used on macOS 15 (no Liquid Glass, no AI refine).
 struct SimplePlaylistDetailView: View {
     let playlist: Playlist
-    let playerBarNavigationAction: PlayerBarNavigationAction
     @State var viewModel: PlaylistDetailViewModel
     @Environment(PlayerService.self) private var playerService
     @Environment(SongLikeStatusManager.self) private var likeStatusManager
+    @Environment(MusicNavigationCoordinator.self) private var musicNavigation
 
     init(
         playlist: Playlist,
-        viewModel: PlaylistDetailViewModel,
-        playerBarNavigationAction: PlayerBarNavigationAction = .disabled
+        viewModel: PlaylistDetailViewModel
     ) {
         self.playlist = playlist
-        self.playerBarNavigationAction = playerBarNavigationAction
         self._viewModel = State(initialValue: viewModel)
     }
 
@@ -50,12 +48,14 @@ struct SimplePlaylistDetailView: View {
             }
         }
         .navigationTitle(self.playlist.title)
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            if case .error = self.viewModel.loadingState {
-            } else {
-                PlayerBar()
-                    .environment(\.playerBarNavigationAction, self.playerBarNavigationAction)
-                    .environment(\.playerBarCurrentAlbumID, self.playlist.isAlbum ? self.playlist.id : nil)
+        .onAppear {
+            if self.playlist.isAlbum {
+                self.musicNavigation.setRouteAlbumID(self.playlist.id)
+            }
+        }
+        .onDisappear {
+            if self.playlist.isAlbum, self.musicNavigation.routeAlbumID == self.playlist.id {
+                self.musicNavigation.setRouteAlbumID(nil)
             }
         }
         .task {

--- a/Sources/Kaset/Views/LibraryView.swift
+++ b/Sources/Kaset/Views/LibraryView.swift
@@ -128,9 +128,7 @@ struct LibraryView: View {
             .navigationDestination(for: PodcastShow.self) { show in
                 PodcastShowView(show: show, client: self.viewModel.client)
             }
-            .playerBarMusicNavigation(path: self.musicNavigation.navigationPathBinding(for: .library))
         }
-        .playerBarMusicNavigation(path: self.musicNavigation.navigationPathBinding(for: .library))
         .environment(\.libraryViewModel, self.viewModel)
         .task {
             if self.viewModel.loadingState == .idle {

--- a/Sources/Kaset/Views/LibraryView.swift
+++ b/Sources/Kaset/Views/LibraryView.swift
@@ -146,7 +146,6 @@ struct LibraryView: View {
         .popsNavigationStackOnSidebarReselect(path: self.musicNavigation.navigationPathBinding(for: .library), for: .library)
     }
 
-
     // MARK: - Views
 
     private var contentView: some View {

--- a/Sources/Kaset/Views/LibraryView.swift
+++ b/Sources/Kaset/Views/LibraryView.swift
@@ -49,12 +49,12 @@ enum LibraryFilter: String, CaseIterable, Identifiable {
 /// Library view displaying the user's saved music and followed content.
 struct LibraryView: View {
     @State var viewModel: LibraryViewModel
+    @Environment(MusicNavigationCoordinator.self) private var musicNavigation
     @Environment(PlayerService.self) private var playerService
     @Environment(FavoritesManager.self) private var favoritesManager
     @Environment(\.usesLegacyMacOS15UI) private var usesLegacyMacOS15UI
     @State private var networkMonitor = NetworkMonitor.shared
 
-    @State private var navigationPath = NavigationPath()
     @State private var selectedFilter: LibraryFilter = .all
 
     private let libraryItemSize: CGFloat = 160
@@ -62,7 +62,7 @@ struct LibraryView: View {
     private let libraryItemCardHeight: CGFloat = 222
 
     var body: some View {
-        NavigationStack(path: self.$navigationPath) {
+        NavigationStack(path: self.musicNavigation.navigationPathBinding(for: .library)) {
             Group {
                 if !self.networkMonitor.isConnected {
                     ErrorView(
@@ -93,8 +93,7 @@ struct LibraryView: View {
                         viewModel: PlaylistDetailViewModel(
                             playlist: playlist,
                             client: self.viewModel.client
-                        ),
-                        playerBarNavigationAction: self.playerBarNavigationAction
+                        )
                     )
                     .environment(\.libraryViewModel, self.viewModel)
                 } else {
@@ -103,8 +102,7 @@ struct LibraryView: View {
                         viewModel: PlaylistDetailViewModel(
                             playlist: playlist,
                             client: self.viewModel.client
-                        ),
-                        playerBarNavigationAction: self.playerBarNavigationAction
+                        )
                     )
                     .environment(\.libraryViewModel, self.viewModel)
                 }
@@ -116,8 +114,7 @@ struct LibraryView: View {
                         artist: artist,
                         client: self.viewModel.client,
                         libraryViewModel: self.viewModel
-                    ),
-                    playerBarNavigationAction: self.playerBarNavigationAction
+                    )
                 )
             }
             .navigationDestination(for: TopSongsDestination.self) { destination in
@@ -131,36 +128,26 @@ struct LibraryView: View {
             .navigationDestination(for: PodcastShow.self) { show in
                 PodcastShowView(show: show, client: self.viewModel.client)
             }
-            .playerBarMusicNavigation(path: self.$navigationPath)
+            .playerBarMusicNavigation(path: self.musicNavigation.navigationPathBinding(for: .library))
         }
-        .playerBarMusicNavigation(path: self.$navigationPath)
+        .playerBarMusicNavigation(path: self.musicNavigation.navigationPathBinding(for: .library))
         .environment(\.libraryViewModel, self.viewModel)
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            PlayerBar()
-                .playerBarMusicNavigation(path: self.$navigationPath)
-        }
         .task {
             if self.viewModel.loadingState == .idle {
                 await self.viewModel.load()
             }
             await self.viewModel.reloadIfNeededOnActivation()
         }
-        .task(id: "\(self.navigationPath.count)-\(self.viewModel.activationReloadGeneration)") {
-            guard self.navigationPath.isEmpty else { return }
+        .task(id: "\(self.musicNavigation.libraryNavigationPath.count)-\(self.viewModel.activationReloadGeneration)") {
+            guard self.musicNavigation.libraryNavigationPath.isEmpty else { return }
             await self.viewModel.reloadIfNeededOnActivation()
         }
         .refreshable {
             await self.viewModel.refresh()
         }
-        .popsNavigationStackOnSidebarReselect(path: self.$navigationPath, for: .library)
+        .popsNavigationStackOnSidebarReselect(path: self.musicNavigation.navigationPathBinding(for: .library), for: .library)
     }
 
-    private var playerBarNavigationAction: PlayerBarNavigationAction {
-        PlayerBarNavigationAction(
-            openArtist: { self.navigationPath.append($0) },
-            openAlbum: { self.navigationPath.append($0) }
-        )
-    }
 
     // MARK: - Views
 
@@ -325,7 +312,7 @@ struct LibraryView: View {
 
     private func playlistCard(_ playlist: Playlist) -> some View {
         Button {
-            self.navigationPath.append(playlist)
+            self.musicNavigation.libraryNavigationPath.append(playlist)
         } label: {
             VStack(alignment: .leading, spacing: 8) {
                 // Thumbnail
@@ -385,7 +372,7 @@ struct LibraryView: View {
             .joined(separator: " • ")
 
         return Button {
-            self.navigationPath.append(self.playlist(from: album))
+            self.musicNavigation.libraryNavigationPath.append(self.playlist(from: album))
         } label: {
             VStack(alignment: .leading, spacing: 8) {
                 CachedAsyncImage(url: album.thumbnailURL?.highQualityThumbnailURL) { image in
@@ -421,7 +408,7 @@ struct LibraryView: View {
         .buttonStyle(.plain)
         .contextMenu {
             Button {
-                self.navigationPath.append(self.playlist(from: album))
+                self.musicNavigation.libraryNavigationPath.append(self.playlist(from: album))
             } label: {
                 Label("View Album", systemImage: "square.stack")
             }
@@ -481,7 +468,7 @@ struct LibraryView: View {
 
     private func uploadedSongsCard(_ playlist: Playlist) -> some View {
         Button {
-            self.navigationPath.append(playlist)
+            self.musicNavigation.libraryNavigationPath.append(playlist)
         } label: {
             VStack(alignment: .leading, spacing: 8) {
                 CachedAsyncImage(url: playlist.thumbnailURL?.highQualityThumbnailURL) { image in
@@ -525,7 +512,7 @@ struct LibraryView: View {
 
     private func podcastCard(_ show: PodcastShow) -> some View {
         Button {
-            self.navigationPath.append(show)
+            self.musicNavigation.libraryNavigationPath.append(show)
         } label: {
             VStack(alignment: .leading, spacing: 8) {
                 // Thumbnail
@@ -571,7 +558,7 @@ struct LibraryView: View {
 
     private func artistCard(_ artist: Artist) -> some View {
         Button {
-            self.navigationPath.append(artist)
+            self.musicNavigation.libraryNavigationPath.append(artist)
         } label: {
             VStack(alignment: .leading, spacing: 8) {
                 CachedAsyncImage(url: artist.thumbnailURL?.highQualityThumbnailURL) { image in

--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -73,11 +73,8 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
     @State private var libraryViewModel: LibraryViewModel?
     @State private var historyViewModel: HistoryViewModel?
 
-    /// Navigation path for the Liked Music route.
-    @State private var likedMusicNavigationPath = NavigationPath()
-
-    /// Navigation paths for pinned sidebar playlists/albums keyed by content ID.
-    @State private var pinnedNavigationPaths: [String: NavigationPath] = [:]
+    /// Music sidebar navigation paths and active route for the shared PlayerBar.
+    @State private var musicNavigation = MusicNavigationCoordinator()
 
     /// Column visibility state for NavigationSplitView - persisted to fix restoration from dock.
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
@@ -288,12 +285,30 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
                     self.showWhatsNew.wrappedValue = false
                 }
             }
+            .onAppear {
+                self.musicNavigation.updateActiveRoute(
+                    tab: self.navigationSelection,
+                    pinnedContentID: self.selectedSidebarPinnedItem?.contentId
+                )
+            }
             .modifier(PinnedNavigationPathLifecycleModifier(
                 navigationSelection: self.$navigationSelection,
                 selectedPinnedItem: self.$selectedSidebarPinnedItem,
-                navigationPaths: self.$pinnedNavigationPaths,
+                musicNavigation: self.musicNavigation,
                 committedRemovalGenerations: self.sidebarPinnedItemsManager.committedRemovalGenerations
             ))
+            .onChange(of: self.navigationSelection) { _, newValue in
+                self.musicNavigation.updateActiveRoute(
+                    tab: newValue,
+                    pinnedContentID: self.selectedSidebarPinnedItem?.contentId
+                )
+            }
+            .onChange(of: self.selectedSidebarPinnedItem?.contentId) { _, newValue in
+                self.musicNavigation.updateActiveRoute(
+                    tab: self.navigationSelection,
+                    pinnedContentID: newValue
+                )
+            }
             .onChange(of: self.authService.state) { oldState, newState in
                 self.handleAuthStateChange(oldState: oldState, newState: newState)
             }
@@ -454,8 +469,8 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
                             }
                         },
                         onReselectPinnedItem: { item in
-                            guard !(self.pinnedNavigationPaths[item.contentId]?.isEmpty ?? true) else { return }
-                            self.pinnedNavigationPaths[item.contentId] = NavigationPath()
+                            guard !(self.musicNavigation.pinnedNavigationPaths[item.contentId]?.isEmpty ?? true) else { return }
+                            self.musicNavigation.pinnedNavigationPaths[item.contentId] = NavigationPath()
                         }
                     )
                 } else {
@@ -467,21 +482,35 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
                     )
                 }
             } detail: {
-                if self.settings.appSource == .music {
-                    self.detailView(
-                        for: self.navigationSelection,
-                        pinnedItem: self.selectedSidebarPinnedItem,
-                        client: self.client
-                    )
-                } else {
-                    YouTubeContentView(
-                        selection: self.youtubeNavigationSelection,
-                        store: self.youtubeStore
-                    )
+                Group {
+                    if self.settings.appSource == .music {
+                        self.detailView(
+                            for: self.navigationSelection,
+                            pinnedItem: self.selectedSidebarPinnedItem,
+                            client: self.client
+                        )
+                    } else {
+                        YouTubeContentView(
+                            selection: self.youtubeNavigationSelection,
+                            store: self.youtubeStore
+                        )
+                    }
+                }
+                .safeAreaInset(edge: .bottom, spacing: 0) {
+                    if self.settings.appSource == .music {
+                        PlayerBar()
+                            .environment(
+                                \.playerBarNavigationAction,
+                                self.musicNavigation.playerBarNavigationAction
+                            )
+                            .environment(\.playerBarCurrentArtistID, self.musicNavigation.routeArtistID)
+                            .environment(\.playerBarCurrentAlbumID, self.musicNavigation.routeAlbumID)
+                    }
                 }
             }
             .id(self.contentResetID)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .environment(self.musicNavigation)
             .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)) { _ in
                 // Ensure the sidebar returns when the app is re-activated from the Dock or app switcher.
                 if self.columnVisibility != .all {
@@ -630,32 +659,29 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
                 if self.requiresSignIn(item) {
                     self.signInRequiredView(for: item)
                 } else if let vm = likedMusicViewModel {
-                    NavigationStack(path: self.$likedMusicNavigationPath) {
+                    NavigationStack(path: self.musicNavigation.navigationPathBinding(for: .likedMusic)) {
                         Group {
                             if !self.usesLegacyMacOS15UI, #available(macOS 26.0, *) {
                                 PlaylistDetailView(
                                     playlist: LikedMusicPlaylist.playlist,
-                                    viewModel: vm,
-                                    playerBarNavigationAction: self.likedMusicPlayerBarNavigationAction
+                                    viewModel: vm
                                 )
                                 .environment(\.libraryViewModel, self.libraryViewModel)
                             } else {
                                 SimplePlaylistDetailView(
                                     playlist: LikedMusicPlaylist.playlist,
-                                    viewModel: vm,
-                                    playerBarNavigationAction: self.likedMusicPlayerBarNavigationAction
+                                    viewModel: vm
                                 )
                                 .environment(\.libraryViewModel, self.libraryViewModel)
                             }
                         }
-                        .navigationDestinations(
-                            client: self.client,
-                            playerBarNavigationAction: self.likedMusicPlayerBarNavigationAction
+                        .navigationDestinations(client: self.client)
+                        .playerBarMusicNavigation(
+                            path: self.musicNavigation.navigationPathBinding(for: .likedMusic)
                         )
-                        .playerBarMusicNavigation(path: self.$likedMusicNavigationPath)
                     }
                     .popsNavigationStackOnSidebarReselect(
-                        path: self.$likedMusicNavigationPath,
+                        path: self.musicNavigation.navigationPathBinding(for: .likedMusic),
                         for: .likedMusic
                     )
                 }
@@ -691,21 +717,11 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
         )
     }
 
-    private var likedMusicPlayerBarNavigationAction: PlayerBarNavigationAction {
-        PlayerBarNavigationAction(
-            openArtist: { self.likedMusicNavigationPath.append($0) },
-            openAlbum: { self.likedMusicNavigationPath.append($0) }
-        )
-    }
-
     private func viewForSidebarPinnedItem(
         _ item: SidebarPinnedItem,
         client: any YTMusicClientProtocol
     ) -> some View {
-        NavigationStack(path: Binding(
-            get: { self.pinnedNavigationPaths[item.contentId, default: NavigationPath()] },
-            set: { self.pinnedNavigationPaths[item.contentId] = $0 }
-        )) {
+        NavigationStack(path: self.musicNavigation.pinnedPathBinding(for: item.contentId)) {
             Group {
                 if !self.usesLegacyMacOS15UI, #available(macOS 26.0, *) {
                     PlaylistDetailView(
@@ -869,8 +885,7 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
         )
         self.libraryViewModel = libraryViewModel
         self.historyViewModel = HistoryViewModel(client: self.client)
-        self.likedMusicNavigationPath = NavigationPath()
-        self.pinnedNavigationPaths = [:]
+        self.musicNavigation.resetAllNavigationPaths()
         self.contentResetID = UUID()
     }
 
@@ -977,7 +992,7 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
 private struct PinnedNavigationPathLifecycleModifier: ViewModifier {
     @Binding var navigationSelection: NavigationItem?
     @Binding var selectedPinnedItem: SidebarPinnedItem?
-    @Binding var navigationPaths: [String: NavigationPath]
+    var musicNavigation: MusicNavigationCoordinator
     let committedRemovalGenerations: [String: UInt]
 
     func body(content: Content) -> some View {
@@ -989,11 +1004,11 @@ private struct PinnedNavigationPathLifecycleModifier: ViewModifier {
             }
             .onChange(of: self.selectedPinnedItem?.contentId) { oldContentId, newContentId in
                 guard oldContentId != newContentId, let oldContentId else { return }
-                self.navigationPaths.removeValue(forKey: oldContentId)
+                self.musicNavigation.pinnedNavigationPaths.removeValue(forKey: oldContentId)
             }
             .onChange(of: self.committedRemovalGenerations) { oldValue, newValue in
                 for (contentId, generation) in newValue where oldValue[contentId] != generation {
-                    self.navigationPaths.removeValue(forKey: contentId)
+                    self.musicNavigation.pinnedNavigationPaths.removeValue(forKey: contentId)
                 }
             }
     }

--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -676,9 +676,6 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
                             }
                         }
                         .navigationDestinations(client: self.client)
-                        .playerBarMusicNavigation(
-                            path: self.musicNavigation.navigationPathBinding(for: .likedMusic)
-                        )
                     }
                     .popsNavigationStackOnSidebarReselect(
                         path: self.musicNavigation.navigationPathBinding(for: .likedMusic),

--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -286,10 +286,7 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
                 }
             }
             .onAppear {
-                self.musicNavigation.updateActiveRoute(
-                    tab: self.navigationSelection,
-                    pinnedContentID: self.selectedSidebarPinnedItem?.contentId
-                )
+                self.refreshMusicNavigationRoute()
             }
             .modifier(PinnedNavigationPathLifecycleModifier(
                 navigationSelection: self.$navigationSelection,
@@ -298,16 +295,10 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
                 committedRemovalGenerations: self.sidebarPinnedItemsManager.committedRemovalGenerations
             ))
             .onChange(of: self.navigationSelection) { _, newValue in
-                self.musicNavigation.updateActiveRoute(
-                    tab: newValue,
-                    pinnedContentID: self.selectedSidebarPinnedItem?.contentId
-                )
+                self.refreshMusicNavigationRoute(tab: newValue)
             }
             .onChange(of: self.selectedSidebarPinnedItem?.contentId) { _, newValue in
-                self.musicNavigation.updateActiveRoute(
-                    tab: self.navigationSelection,
-                    pinnedContentID: newValue
-                )
+                self.refreshMusicNavigationRoute(pinnedContentID: newValue)
             }
             .onChange(of: self.authService.state) { oldState, newState in
                 self.handleAuthStateChange(oldState: oldState, newState: newState)
@@ -707,6 +698,30 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
         item.requiresSignIn && !self.hasPersonalAccount
     }
 
+    private func musicNavigationStackIsMounted(tab: NavigationItem?, pinnedContentID: String?) -> Bool {
+        if pinnedContentID != nil {
+            return true
+        }
+        guard let tab else { return false }
+        return !self.requiresSignIn(tab)
+    }
+
+    private func refreshMusicNavigationRoute(
+        tab: NavigationItem? = nil,
+        pinnedContentID: String?? = nil
+    ) {
+        let resolvedTab = tab ?? self.navigationSelection
+        let resolvedPinnedContentID = pinnedContentID ?? self.selectedSidebarPinnedItem?.contentId
+        self.musicNavigation.updateActiveRoute(
+            tab: resolvedTab,
+            pinnedContentID: resolvedPinnedContentID,
+            hasNavigationStack: self.musicNavigationStackIsMounted(
+                tab: resolvedTab,
+                pinnedContentID: resolvedPinnedContentID
+            )
+        )
+    }
+
     private func signInRequiredView(for item: NavigationItem) -> some View {
         SignInRequiredView(
             title: String(localized: "Sign in to use \(item.displayName)"),
@@ -829,6 +844,7 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
                 }
             }
         }
+        self.refreshMusicNavigationRoute()
     }
 
     private func handleGuestModeChange(isGuestModeEnabled: Bool) {
@@ -857,6 +873,7 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
                 await self.refreshAuthenticatedContent()
             }
         }
+        self.refreshMusicNavigationRoute()
     }
 
     private func rebuildMusicViewModels(accountId: String? = nil) {

--- a/Sources/Kaset/Views/MoodCategoryDetailView.swift
+++ b/Sources/Kaset/Views/MoodCategoryDetailView.swift
@@ -24,11 +24,6 @@ struct MoodCategoryDetailView: View {
             }
         }
         .navigationTitle(self.viewModel.category.title)
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            if case .error = self.viewModel.loadingState {} else {
-                PlayerBar()
-            }
-        }
         .onAppear {
             if self.viewModel.loadingState == .idle {
                 Task {

--- a/Sources/Kaset/Views/MoodsAndGenresView.swift
+++ b/Sources/Kaset/Views/MoodsAndGenresView.swift
@@ -47,7 +47,6 @@ struct MoodsAndGenresView: View {
         .popsNavigationStackOnSidebarReselect(path: self.musicNavigation.navigationPathBinding(for: .moodsAndGenres), for: .moodsAndGenres)
     }
 
-
     // MARK: - Views
 
     @ViewBuilder

--- a/Sources/Kaset/Views/MoodsAndGenresView.swift
+++ b/Sources/Kaset/Views/MoodsAndGenresView.swift
@@ -33,9 +33,7 @@ struct MoodsAndGenresView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .localizedNavigationTitle("Moods & Genres")
             .navigationDestinations(client: self.viewModel.client)
-            .playerBarMusicNavigation(path: self.musicNavigation.navigationPathBinding(for: .moodsAndGenres))
         }
-        .playerBarMusicNavigation(path: self.musicNavigation.navigationPathBinding(for: .moodsAndGenres))
         .onAppear {
             if self.viewModel.loadingState == .idle {
                 Task {

--- a/Sources/Kaset/Views/MoodsAndGenresView.swift
+++ b/Sources/Kaset/Views/MoodsAndGenresView.swift
@@ -3,12 +3,12 @@ import SwiftUI
 /// Moods & Genres view for browsing music by mood or genre.
 struct MoodsAndGenresView: View {
     @State var viewModel: MoodsAndGenresViewModel
+    @Environment(MusicNavigationCoordinator.self) private var musicNavigation
     @Environment(PlayerService.self) private var playerService
-    @State private var navigationPath = NavigationPath()
     @State private var networkMonitor = NetworkMonitor.shared
 
     var body: some View {
-        NavigationStack(path: self.$navigationPath) {
+        NavigationStack(path: self.musicNavigation.navigationPathBinding(for: .moodsAndGenres)) {
             Group {
                 if !self.networkMonitor.isConnected {
                     ErrorView(
@@ -32,17 +32,10 @@ struct MoodsAndGenresView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .localizedNavigationTitle("Moods & Genres")
-            .navigationDestinations(
-                client: self.viewModel.client,
-                playerBarNavigationAction: self.playerBarNavigationAction
-            )
-            .playerBarMusicNavigation(path: self.$navigationPath)
+            .navigationDestinations(client: self.viewModel.client)
+            .playerBarMusicNavigation(path: self.musicNavigation.navigationPathBinding(for: .moodsAndGenres))
         }
-        .playerBarMusicNavigation(path: self.$navigationPath)
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            PlayerBar()
-                .playerBarMusicNavigation(path: self.$navigationPath)
-        }
+        .playerBarMusicNavigation(path: self.musicNavigation.navigationPathBinding(for: .moodsAndGenres))
         .onAppear {
             if self.viewModel.loadingState == .idle {
                 Task {
@@ -53,15 +46,9 @@ struct MoodsAndGenresView: View {
         .refreshable {
             await self.viewModel.refresh()
         }
-        .popsNavigationStackOnSidebarReselect(path: self.$navigationPath, for: .moodsAndGenres)
+        .popsNavigationStackOnSidebarReselect(path: self.musicNavigation.navigationPathBinding(for: .moodsAndGenres), for: .moodsAndGenres)
     }
 
-    private var playerBarNavigationAction: PlayerBarNavigationAction {
-        PlayerBarNavigationAction(
-            openArtist: { self.navigationPath.append($0) },
-            openAlbum: { self.navigationPath.append($0) }
-        )
-    }
 
     // MARK: - Views
 
@@ -158,7 +145,7 @@ struct MoodsAndGenresView: View {
                 await self.playerService.playWithRadio(song: song)
             }
         case let .playlist(playlist):
-            self.navigationPath.append(playlist)
+            self.musicNavigation.moodsAndGenresNavigationPath.append(playlist)
         case let .album(album):
             let playlist = Playlist(
                 id: album.id,
@@ -168,9 +155,9 @@ struct MoodsAndGenresView: View {
                 trackCount: album.trackCount,
                 author: Artist.inline(name: album.artistsDisplay, namespace: "album-artist")
             )
-            self.navigationPath.append(playlist)
+            self.musicNavigation.moodsAndGenresNavigationPath.append(playlist)
         case let .artist(artist):
-            self.navigationPath.append(artist)
+            self.musicNavigation.moodsAndGenresNavigationPath.append(artist)
         }
     }
 }

--- a/Sources/Kaset/Views/NewReleasesView.swift
+++ b/Sources/Kaset/Views/NewReleasesView.swift
@@ -33,9 +33,7 @@ struct NewReleasesView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .localizedNavigationTitle("New Releases")
             .navigationDestinations(client: self.viewModel.client)
-            .playerBarMusicNavigation(path: self.musicNavigation.navigationPathBinding(for: .newReleases))
         }
-        .playerBarMusicNavigation(path: self.musicNavigation.navigationPathBinding(for: .newReleases))
         .onAppear {
             if self.viewModel.loadingState == .idle {
                 Task {

--- a/Sources/Kaset/Views/NewReleasesView.swift
+++ b/Sources/Kaset/Views/NewReleasesView.swift
@@ -47,7 +47,6 @@ struct NewReleasesView: View {
         .popsNavigationStackOnSidebarReselect(path: self.musicNavigation.navigationPathBinding(for: .newReleases), for: .newReleases)
     }
 
-
     // MARK: - Views
 
     private var contentView: some View {

--- a/Sources/Kaset/Views/NewReleasesView.swift
+++ b/Sources/Kaset/Views/NewReleasesView.swift
@@ -3,12 +3,12 @@ import SwiftUI
 /// New Releases view displaying recently released music.
 struct NewReleasesView: View {
     @State var viewModel: NewReleasesViewModel
+    @Environment(MusicNavigationCoordinator.self) private var musicNavigation
     @Environment(PlayerService.self) private var playerService
-    @State private var navigationPath = NavigationPath()
     @State private var networkMonitor = NetworkMonitor.shared
 
     var body: some View {
-        NavigationStack(path: self.$navigationPath) {
+        NavigationStack(path: self.musicNavigation.navigationPathBinding(for: .newReleases)) {
             Group {
                 if !self.networkMonitor.isConnected {
                     ErrorView(
@@ -32,17 +32,10 @@ struct NewReleasesView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .localizedNavigationTitle("New Releases")
-            .navigationDestinations(
-                client: self.viewModel.client,
-                playerBarNavigationAction: self.playerBarNavigationAction
-            )
-            .playerBarMusicNavigation(path: self.$navigationPath)
+            .navigationDestinations(client: self.viewModel.client)
+            .playerBarMusicNavigation(path: self.musicNavigation.navigationPathBinding(for: .newReleases))
         }
-        .playerBarMusicNavigation(path: self.$navigationPath)
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            PlayerBar()
-                .playerBarMusicNavigation(path: self.$navigationPath)
-        }
+        .playerBarMusicNavigation(path: self.musicNavigation.navigationPathBinding(for: .newReleases))
         .onAppear {
             if self.viewModel.loadingState == .idle {
                 Task {
@@ -53,15 +46,9 @@ struct NewReleasesView: View {
         .refreshable {
             await self.viewModel.refresh()
         }
-        .popsNavigationStackOnSidebarReselect(path: self.$navigationPath, for: .newReleases)
+        .popsNavigationStackOnSidebarReselect(path: self.musicNavigation.navigationPathBinding(for: .newReleases), for: .newReleases)
     }
 
-    private var playerBarNavigationAction: PlayerBarNavigationAction {
-        PlayerBarNavigationAction(
-            openArtist: { self.navigationPath.append($0) },
-            openAlbum: { self.navigationPath.append($0) }
-        )
-    }
 
     // MARK: - Views
 
@@ -137,7 +124,7 @@ struct NewReleasesView: View {
                 await self.playerService.playWithRadio(song: song)
             }
         case let .playlist(playlist):
-            self.navigationPath.append(playlist)
+            self.musicNavigation.newReleasesNavigationPath.append(playlist)
         case let .album(album):
             let playlist = Playlist(
                 id: album.id,
@@ -147,9 +134,9 @@ struct NewReleasesView: View {
                 trackCount: album.trackCount,
                 author: Artist.inline(name: album.artistsDisplay, namespace: "album-artist")
             )
-            self.navigationPath.append(playlist)
+            self.musicNavigation.newReleasesNavigationPath.append(playlist)
         case let .artist(artist):
-            self.navigationPath.append(artist)
+            self.musicNavigation.newReleasesNavigationPath.append(artist)
         }
     }
 }

--- a/Sources/Kaset/Views/PlayerBarNavigationAction.swift
+++ b/Sources/Kaset/Views/PlayerBarNavigationAction.swift
@@ -15,6 +15,23 @@ extension EnvironmentValues {
     @Entry var playerBarCurrentArtistID: String?
 }
 
+// MARK: - PlayerBarAlbumRouteModifier
+
+private struct PlayerBarAlbumRouteModifier: ViewModifier {
+    let playlist: Playlist
+    @Environment(MusicNavigationCoordinator.self) private var musicNavigation
+
+    func body(content: Content) -> some View {
+        content
+            .onAppear {
+                self.musicNavigation.showAlbumRoute(for: self.playlist)
+            }
+            .onDisappear {
+                self.musicNavigation.hideAlbumRoute(for: self.playlist)
+            }
+    }
+}
+
 // MARK: - SidebarReselectNavigationModifier
 
 private struct SidebarReselectNavigationModifier: ViewModifier {
@@ -31,6 +48,10 @@ private struct SidebarReselectNavigationModifier: ViewModifier {
 }
 
 extension View {
+    func playerBarAlbumRoute(for playlist: Playlist) -> some View {
+        self.modifier(PlayerBarAlbumRouteModifier(playlist: playlist))
+    }
+
     func popsNavigationStackOnSidebarReselect(
         path: Binding<NavigationPath>,
         for navigationItem: NavigationItem

--- a/Sources/Kaset/Views/PlayerBarNavigationAction.swift
+++ b/Sources/Kaset/Views/PlayerBarNavigationAction.swift
@@ -15,30 +15,6 @@ extension EnvironmentValues {
     @Entry var playerBarCurrentArtistID: String?
 }
 
-// MARK: - PlayerBarMusicNavigationModifier
-
-private struct PlayerBarMusicNavigationModifier: ViewModifier {
-    @Binding var navigationPath: NavigationPath
-
-    func body(content: Content) -> some View {
-        content
-            .environment(\.playerBarNavigationAction, PlayerBarNavigationAction(
-                openArtist: { artist in
-                    self.navigationPath.append(artist)
-                },
-                openAlbum: { album in
-                    self.navigationPath.append(album)
-                }
-            ))
-    }
-}
-
-extension View {
-    func playerBarMusicNavigation(path: Binding<NavigationPath>) -> some View {
-        self.modifier(PlayerBarMusicNavigationModifier(navigationPath: path))
-    }
-}
-
 // MARK: - SidebarReselectNavigationModifier
 
 private struct SidebarReselectNavigationModifier: ViewModifier {

--- a/Sources/Kaset/Views/PlaylistDetailView.swift
+++ b/Sources/Kaset/Views/PlaylistDetailView.swift
@@ -7,13 +7,13 @@ import SwiftUI
 @available(macOS 26.0, *)
 struct PlaylistDetailView: View {
     let playlist: Playlist
-    let playerBarNavigationAction: PlayerBarNavigationAction
     @State var viewModel: PlaylistDetailViewModel
     @Environment(PlayerService.self) var playerService
     @Environment(AuthService.self) private var authService
     @Environment(FavoritesManager.self) private var favoritesManager
     @Environment(SidebarPinnedItemsManager.self) var sidebarPinnedItemsManager: SidebarPinnedItemsManager?
     @Environment(SongLikeStatusManager.self) private var likeStatusManager
+    @Environment(MusicNavigationCoordinator.self) private var musicNavigation
     @Environment(\.libraryViewModel) var libraryViewModel: LibraryViewModel?
     @Environment(\.dismiss) var dismiss
     @Environment(\.onPlaylistDeleted) var onPlaylistDeleted
@@ -52,11 +52,9 @@ struct PlaylistDetailView: View {
 
     init(
         playlist: Playlist,
-        viewModel: PlaylistDetailViewModel,
-        playerBarNavigationAction: PlayerBarNavigationAction = .disabled
+        viewModel: PlaylistDetailViewModel
     ) {
         self.playlist = playlist
-        self.playerBarNavigationAction = playerBarNavigationAction
         _viewModel = State(initialValue: viewModel)
     }
 
@@ -87,12 +85,14 @@ struct PlaylistDetailView: View {
         )
         .navigationTitle(self.playlist.title)
         .toolbarBackgroundVisibility(.hidden, for: .automatic)
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            if case .error = self.viewModel.loadingState {
-            } else {
-                PlayerBar()
-                    .environment(\.playerBarNavigationAction, self.playerBarNavigationAction)
-                    .environment(\.playerBarCurrentAlbumID, self.playlist.isAlbum ? self.playlist.id : nil)
+        .onAppear {
+            if self.playlist.isAlbum {
+                self.musicNavigation.setRouteAlbumID(self.playlist.id)
+            }
+        }
+        .onDisappear {
+            if self.playlist.isAlbum, self.musicNavigation.routeAlbumID == self.playlist.id {
+                self.musicNavigation.setRouteAlbumID(nil)
             }
         }
         .task {

--- a/Sources/Kaset/Views/PlaylistDetailView.swift
+++ b/Sources/Kaset/Views/PlaylistDetailView.swift
@@ -13,7 +13,6 @@ struct PlaylistDetailView: View {
     @Environment(FavoritesManager.self) private var favoritesManager
     @Environment(SidebarPinnedItemsManager.self) var sidebarPinnedItemsManager: SidebarPinnedItemsManager?
     @Environment(SongLikeStatusManager.self) private var likeStatusManager
-    @Environment(MusicNavigationCoordinator.self) private var musicNavigation
     @Environment(\.libraryViewModel) var libraryViewModel: LibraryViewModel?
     @Environment(\.dismiss) var dismiss
     @Environment(\.onPlaylistDeleted) var onPlaylistDeleted
@@ -85,16 +84,7 @@ struct PlaylistDetailView: View {
         )
         .navigationTitle(self.playlist.title)
         .toolbarBackgroundVisibility(.hidden, for: .automatic)
-        .onAppear {
-            if self.playlist.isAlbum {
-                self.musicNavigation.setRouteAlbumID(self.playlist.id)
-            }
-        }
-        .onDisappear {
-            if self.playlist.isAlbum, self.musicNavigation.routeAlbumID == self.playlist.id {
-                self.musicNavigation.setRouteAlbumID(nil)
-            }
-        }
+        .playerBarAlbumRoute(for: self.playlist)
         .task {
             await self.viewModel.ensureLoaded()
         }

--- a/Sources/Kaset/Views/PodcastsView.swift
+++ b/Sources/Kaset/Views/PodcastsView.swift
@@ -5,13 +5,13 @@ import SwiftUI
 /// Podcasts discovery view displaying podcast shows and episodes.
 struct PodcastsView: View {
     @State var viewModel: PodcastsViewModel
+    @Environment(MusicNavigationCoordinator.self) private var musicNavigation
     @Environment(PlayerService.self) private var playerService
     @Environment(FavoritesManager.self) private var favoritesManager
-    @State private var navigationPath = NavigationPath()
     @State private var networkMonitor = NetworkMonitor.shared
 
     var body: some View {
-        NavigationStack(path: self.$navigationPath) {
+        NavigationStack(path: self.musicNavigation.navigationPathBinding(for: .podcasts)) {
             Group {
                 if !self.networkMonitor.isConnected {
                     ErrorView(
@@ -38,15 +38,8 @@ struct PodcastsView: View {
             .navigationDestination(for: PodcastShow.self) { show in
                 PodcastShowView(show: show, client: self.viewModel.client)
             }
-            .navigationDestinations(
-                client: self.viewModel.client,
-                playerBarNavigationAction: self.playerBarNavigationAction
-            )
-            .playerBarMusicNavigation(path: self.$navigationPath)
-        }
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            PlayerBar()
-                .playerBarMusicNavigation(path: self.$navigationPath)
+            .navigationDestinations(client: self.viewModel.client)
+            .playerBarMusicNavigation(path: self.musicNavigation.navigationPathBinding(for: .podcasts))
         }
         .onAppear {
             if self.viewModel.loadingState == .idle {
@@ -58,15 +51,9 @@ struct PodcastsView: View {
         .refreshable {
             await self.viewModel.refresh()
         }
-        .popsNavigationStackOnSidebarReselect(path: self.$navigationPath, for: .podcasts)
+        .popsNavigationStackOnSidebarReselect(path: self.musicNavigation.navigationPathBinding(for: .podcasts), for: .podcasts)
     }
 
-    private var playerBarNavigationAction: PlayerBarNavigationAction {
-        PlayerBarNavigationAction(
-            openArtist: { self.navigationPath.append($0) },
-            openAlbum: { self.navigationPath.append($0) }
-        )
-    }
 
     // MARK: - Views
 
@@ -114,7 +101,7 @@ struct PodcastsView: View {
         switch item {
         case let .show(show):
             PodcastShowCard(show: show, favoritesManager: self.favoritesManager) {
-                self.navigationPath.append(show)
+                self.musicNavigation.podcastsNavigationPath.append(show)
             }
         case let .episode(episode):
             PodcastEpisodeCard(episode: episode) {
@@ -259,6 +246,7 @@ struct PodcastShowView: View {
     let show: PodcastShow
     let client: any YTMusicClientProtocol
     @Environment(AuthService.self) private var authService
+    @Environment(MusicNavigationCoordinator.self) private var musicNavigation
     @Environment(PlayerService.self) private var playerService
     @Environment(FavoritesManager.self) private var favoritesManager
     @Environment(\.libraryViewModel) private var libraryViewModel: LibraryViewModel?
@@ -307,9 +295,6 @@ struct PodcastShowView: View {
                 continuationToken: self.continuationToken,
                 client: self.client
             )
-        }
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            PlayerBar()
         }
         .task {
             await self.loadShow()
@@ -635,9 +620,6 @@ struct AllEpisodesView: View {
         .contentMargins(.horizontal, DetailContentLayout.horizontalInset, for: .scrollContent)
         .accentBackground(from: self.show.thumbnailURL)
         .localizedNavigationTitle("All Episodes")
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            PlayerBar()
-        }
         .onAppear {
             // Initialize with episodes passed from parent
             if self.episodes.isEmpty {

--- a/Sources/Kaset/Views/PodcastsView.swift
+++ b/Sources/Kaset/Views/PodcastsView.swift
@@ -39,7 +39,6 @@ struct PodcastsView: View {
                 PodcastShowView(show: show, client: self.viewModel.client)
             }
             .navigationDestinations(client: self.viewModel.client)
-            .playerBarMusicNavigation(path: self.musicNavigation.navigationPathBinding(for: .podcasts))
         }
         .onAppear {
             if self.viewModel.loadingState == .idle {

--- a/Sources/Kaset/Views/PodcastsView.swift
+++ b/Sources/Kaset/Views/PodcastsView.swift
@@ -53,7 +53,6 @@ struct PodcastsView: View {
         .popsNavigationStackOnSidebarReselect(path: self.musicNavigation.navigationPathBinding(for: .podcasts), for: .podcasts)
     }
 
-
     // MARK: - Views
 
     private var contentView: some View {

--- a/Sources/Kaset/Views/SearchView.swift
+++ b/Sources/Kaset/Views/SearchView.swift
@@ -41,9 +41,7 @@ struct SearchView: View {
             }
             .localizedNavigationTitle("Search")
             .navigationDestinations(client: self.viewModel.client)
-            .playerBarMusicNavigation(path: self.musicNavigation.navigationPathBinding(for: .search))
         }
-        .playerBarMusicNavigation(path: self.musicNavigation.navigationPathBinding(for: .search))
         .onAppear {
             self.isSearchFieldFocused = true
         }

--- a/Sources/Kaset/Views/SearchView.swift
+++ b/Sources/Kaset/Views/SearchView.swift
@@ -9,8 +9,8 @@ struct SearchView: View {
     @Environment(FavoritesManager.self) private var favoritesManager
     @Environment(SongLikeStatusManager.self) private var likeStatusManager
     @Environment(AuthService.self) private var authService
+    @Environment(MusicNavigationCoordinator.self) private var musicNavigation
     @Environment(\.libraryViewModel) private var libraryViewModel: LibraryViewModel?
-    @State private var navigationPath = NavigationPath()
     @State private var networkMonitor = NetworkMonitor.shared
 
     /// External trigger for focusing the search field (from keyboard shortcut).
@@ -28,7 +28,7 @@ struct SearchView: View {
     }
 
     var body: some View {
-        NavigationStack(path: self.$navigationPath) {
+        NavigationStack(path: self.musicNavigation.navigationPathBinding(for: .search)) {
             VStack(spacing: 0) {
                 // Search bar
                 self.searchBar
@@ -40,17 +40,10 @@ struct SearchView: View {
                 self.contentView
             }
             .localizedNavigationTitle("Search")
-            .navigationDestinations(
-                client: self.viewModel.client,
-                playerBarNavigationAction: self.playerBarNavigationAction
-            )
-            .playerBarMusicNavigation(path: self.$navigationPath)
+            .navigationDestinations(client: self.viewModel.client)
+            .playerBarMusicNavigation(path: self.musicNavigation.navigationPathBinding(for: .search))
         }
-        .playerBarMusicNavigation(path: self.$navigationPath)
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            PlayerBar()
-                .playerBarMusicNavigation(path: self.$navigationPath)
-        }
+        .playerBarMusicNavigation(path: self.musicNavigation.navigationPathBinding(for: .search))
         .onAppear {
             self.isSearchFieldFocused = true
         }
@@ -60,15 +53,9 @@ struct SearchView: View {
                 self.focusTrigger = false
             }
         }
-        .popsNavigationStackOnSidebarReselect(path: self.$navigationPath, for: .search)
+        .popsNavigationStackOnSidebarReselect(path: self.musicNavigation.navigationPathBinding(for: .search), for: .search)
     }
 
-    private var playerBarNavigationAction: PlayerBarNavigationAction {
-        PlayerBarNavigationAction(
-            openArtist: { self.navigationPath.append($0) },
-            openAlbum: { self.navigationPath.append($0) }
-        )
-    }
 
     // MARK: - Search Bar
 
@@ -527,7 +514,7 @@ struct SearchView: View {
                 trackCount: album.trackCount,
                 author: Artist.inline(name: album.artistsDisplay, namespace: "album-artist")
             )
-            self.navigationPath.append(playlist)
+            self.musicNavigation.searchNavigationPath.append(playlist)
         } label: {
             Label(viewTitle, systemImage: icon)
         }
@@ -575,7 +562,7 @@ struct SearchView: View {
     @ViewBuilder
     private func artistContextMenu(_ artist: Artist) -> some View {
         Button {
-            self.navigationPath.append(artist)
+            self.musicNavigation.searchNavigationPath.append(artist)
         } label: {
             Label(
                 artist.profileKind == .profile
@@ -619,7 +606,7 @@ struct SearchView: View {
         Divider()
 
         Button {
-            self.navigationPath.append(playlist)
+            self.musicNavigation.searchNavigationPath.append(playlist)
         } label: {
             Label(String(localized: "View Playlist"), systemImage: "music.note.list")
         }
@@ -628,7 +615,7 @@ struct SearchView: View {
     @ViewBuilder
     private func podcastShowContextMenu(_ show: PodcastShow) -> some View {
         Button {
-            self.navigationPath.append(show)
+            self.musicNavigation.searchNavigationPath.append(show)
         } label: {
             Label(String(localized: "View Podcast"), systemImage: "mic.fill")
         }
@@ -661,7 +648,7 @@ struct SearchView: View {
             Divider()
 
             Button {
-                self.navigationPath.append(PodcastShow(
+                self.musicNavigation.searchNavigationPath.append(PodcastShow(
                     id: showBrowseId,
                     title: showTitle,
                     author: nil,
@@ -708,7 +695,7 @@ struct SearchView: View {
                 await self.playerService.playWithRadio(song: song)
             }
         case let .artist(artist), let .profile(artist):
-            self.navigationPath.append(artist)
+            self.musicNavigation.searchNavigationPath.append(artist)
         case let .album(album), let .audiobook(album):
             // Navigate as playlist for now
             let playlist = Playlist(
@@ -719,11 +706,11 @@ struct SearchView: View {
                 trackCount: album.trackCount,
                 author: Artist.inline(name: album.artistsDisplay, namespace: "album-artist")
             )
-            self.navigationPath.append(playlist)
+            self.musicNavigation.searchNavigationPath.append(playlist)
         case let .playlist(playlist):
-            self.navigationPath.append(playlist)
+            self.musicNavigation.searchNavigationPath.append(playlist)
         case let .podcastShow(show):
-            self.navigationPath.append(show)
+            self.musicNavigation.searchNavigationPath.append(show)
         case let .podcastEpisode(episode):
             Task {
                 await self.playerService.play(song: episode.playbackSong)

--- a/Sources/Kaset/Views/SearchView.swift
+++ b/Sources/Kaset/Views/SearchView.swift
@@ -54,7 +54,6 @@ struct SearchView: View {
         .popsNavigationStackOnSidebarReselect(path: self.musicNavigation.navigationPathBinding(for: .search), for: .search)
     }
 
-
     // MARK: - Search Bar
 
     private var searchBar: some View {

--- a/Sources/Kaset/Views/SharedViews/NavigationDestinationsModifier.swift
+++ b/Sources/Kaset/Views/SharedViews/NavigationDestinationsModifier.swift
@@ -6,7 +6,6 @@ import SwiftUI
 /// Note: Lyrics sidebar is handled globally in MainWindow, outside the NavigationSplitView.
 struct NavigationDestinationsModifier: ViewModifier {
     let client: any YTMusicClientProtocol
-    let playerBarNavigationAction: PlayerBarNavigationAction
     @Environment(\.libraryViewModel) private var libraryViewModel: LibraryViewModel?
     @Environment(\.usesLegacyMacOS15UI) private var usesLegacyMacOS15UI
 
@@ -36,8 +35,7 @@ struct NavigationDestinationsModifier: ViewModifier {
                                 viewModel: PlaylistDetailViewModel(
                                     playlist: playlist,
                                     client: self.client
-                                ),
-                                playerBarNavigationAction: self.playerBarNavigationAction
+                                )
                             )
                             .environment(\.libraryViewModel, self.libraryViewModel)
                         } else {
@@ -46,8 +44,7 @@ struct NavigationDestinationsModifier: ViewModifier {
                                 viewModel: PlaylistDetailViewModel(
                                     playlist: playlist,
                                     client: self.client
-                                ),
-                                playerBarNavigationAction: self.playerBarNavigationAction
+                                )
                             )
                             .environment(\.libraryViewModel, self.libraryViewModel)
                         }
@@ -59,8 +56,7 @@ struct NavigationDestinationsModifier: ViewModifier {
                             viewModel: PlaylistDetailViewModel(
                                 playlist: playlist,
                                 client: self.client
-                            ),
-                            playerBarNavigationAction: self.playerBarNavigationAction
+                            )
                         )
                         .environment(\.libraryViewModel, self.libraryViewModel)
                     } else {
@@ -69,8 +65,7 @@ struct NavigationDestinationsModifier: ViewModifier {
                             viewModel: PlaylistDetailViewModel(
                                 playlist: playlist,
                                 client: self.client
-                            ),
-                            playerBarNavigationAction: self.playerBarNavigationAction
+                            )
                         )
                         .environment(\.libraryViewModel, self.libraryViewModel)
                     }
@@ -91,8 +86,7 @@ struct NavigationDestinationsModifier: ViewModifier {
                         artist: artist,
                         client: self.client,
                         libraryViewModel: self.libraryViewModel
-                    ),
-                    playerBarNavigationAction: self.playerBarNavigationAction
+                    )
                 )
             }
             .navigationDestination(for: TopSongsDestination.self) { destination in
@@ -129,13 +123,7 @@ struct NavigationDestinationsModifier: ViewModifier {
 
 extension View {
     /// Adds common navigation destinations for Playlist, Artist, MoodCategory, and TopSongsDestination.
-    func navigationDestinations(
-        client: any YTMusicClientProtocol,
-        playerBarNavigationAction: PlayerBarNavigationAction = .disabled
-    ) -> some View {
-        modifier(NavigationDestinationsModifier(
-            client: client,
-            playerBarNavigationAction: playerBarNavigationAction
-        ))
+    func navigationDestinations(client: any YTMusicClientProtocol) -> some View {
+        modifier(NavigationDestinationsModifier(client: client))
     }
 }

--- a/Sources/Kaset/Views/TopSongsView.swift
+++ b/Sources/Kaset/Views/TopSongsView.swift
@@ -39,11 +39,6 @@ struct TopSongsView: View {
         .navigationTitle(self.viewModel.title)
         .toolbarBackgroundVisibility(.hidden, for: .automatic)
         .topFade()
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            if case .error = self.viewModel.loadingState {} else {
-                PlayerBar()
-            }
-        }
         .task {
             if self.viewModel.loadingState == .idle {
                 await self.viewModel.load()

--- a/Tests/KasetTests/MusicNavigationCoordinatorTests.swift
+++ b/Tests/KasetTests/MusicNavigationCoordinatorTests.swift
@@ -1,0 +1,72 @@
+import SwiftUI
+import Testing
+@testable import Kaset
+
+// MARK: - MusicNavigationCoordinatorTests
+
+@Suite(.tags(.model))
+@MainActor
+struct MusicNavigationCoordinatorTests {
+    @Test("playerBarNavigationAction routes artist pushes to the active tab stack")
+    func routesArtistToActiveTab() {
+        let coordinator = MusicNavigationCoordinator()
+        coordinator.updateActiveRoute(tab: .home, pinnedContentID: nil)
+
+        let artist = TestFixtures.makeArtist(id: "UC-home-artist", name: "Home Artist")
+        coordinator.playerBarNavigationAction.openArtist?(artist)
+
+        #expect(coordinator.homeNavigationPath.count == 1)
+        #expect(coordinator.searchNavigationPath.isEmpty)
+    }
+
+    @Test("playerBarNavigationAction follows sidebar route changes without resetting other stacks")
+    func followsActiveRouteChanges() {
+        let coordinator = MusicNavigationCoordinator()
+        coordinator.updateActiveRoute(tab: .home, pinnedContentID: nil)
+        coordinator.playerBarNavigationAction.openArtist?(TestFixtures.makeArtist(id: "UC-1", name: "One"))
+
+        coordinator.updateActiveRoute(tab: .search, pinnedContentID: nil)
+        coordinator.playerBarNavigationAction.openArtist?(TestFixtures.makeArtist(id: "UC-2", name: "Two"))
+
+        #expect(coordinator.homeNavigationPath.count == 1)
+        #expect(coordinator.searchNavigationPath.count == 1)
+    }
+
+    @Test("playerBarNavigationAction routes album pushes to the active pinned playlist stack")
+    func routesAlbumToPinnedStack() {
+        let coordinator = MusicNavigationCoordinator()
+        coordinator.updateActiveRoute(tab: .home, pinnedContentID: "pinned-playlist-1")
+
+        let album = TestFixtures.makePlaylist(id: "MPRE-pinned-album", title: "Pinned Album")
+        coordinator.playerBarNavigationAction.openAlbum?(album)
+
+        #expect(coordinator.pinnedNavigationPaths["pinned-playlist-1"]?.count == 1)
+        #expect(coordinator.homeNavigationPath.isEmpty)
+    }
+
+    @Test("resetAllNavigationPaths clears every stack and route context")
+    func resetClearsStacksAndRouteContext() {
+        let coordinator = MusicNavigationCoordinator()
+        coordinator.updateActiveRoute(tab: .library, pinnedContentID: nil)
+        coordinator.setRouteArtistID("artist-on-screen")
+        coordinator.setRouteAlbumID("album-on-screen")
+        coordinator.libraryNavigationPath.append(TestFixtures.makeArtist(id: "UC-lib", name: "Library Artist"))
+        coordinator.pinnedNavigationPaths["pin-1"] = NavigationPath()
+
+        coordinator.resetAllNavigationPaths()
+
+        #expect(coordinator.libraryNavigationPath.isEmpty)
+        #expect(coordinator.pinnedNavigationPaths.isEmpty)
+        #expect(coordinator.routeArtistID == nil)
+        #expect(coordinator.routeAlbumID == nil)
+    }
+
+    @Test("active route binding returns nil when no tab or pin is selected")
+    func disabledNavigationWhenNoActiveRoute() {
+        let coordinator = MusicNavigationCoordinator()
+
+        #expect(coordinator.activeNavigationPathBinding() == nil)
+        #expect(coordinator.playerBarNavigationAction.openArtist == nil)
+        #expect(coordinator.playerBarNavigationAction.openAlbum == nil)
+    }
+}

--- a/Tests/KasetTests/MusicNavigationCoordinatorTests.swift
+++ b/Tests/KasetTests/MusicNavigationCoordinatorTests.swift
@@ -44,6 +44,25 @@ struct MusicNavigationCoordinatorTests {
         #expect(coordinator.homeNavigationPath.isEmpty)
     }
 
+    @Test("album route lifecycle ignores playlists and does not clear a newer album")
+    func albumRouteLifecycle() {
+        let coordinator = MusicNavigationCoordinator()
+        let playlist = TestFixtures.makePlaylist(id: "VL-playlist")
+        let firstAlbum = TestFixtures.makePlaylist(id: "MPRE-first-album")
+        let secondAlbum = TestFixtures.makePlaylist(id: "MPRE-second-album")
+
+        coordinator.showAlbumRoute(for: playlist)
+        #expect(coordinator.routeAlbumID == nil)
+
+        coordinator.showAlbumRoute(for: firstAlbum)
+        coordinator.showAlbumRoute(for: secondAlbum)
+        coordinator.hideAlbumRoute(for: firstAlbum)
+        #expect(coordinator.routeAlbumID == secondAlbum.id)
+
+        coordinator.hideAlbumRoute(for: secondAlbum)
+        #expect(coordinator.routeAlbumID == nil)
+    }
+
     @Test("resetAllNavigationPaths clears every stack and route context")
     func resetClearsStacksAndRouteContext() {
         let coordinator = MusicNavigationCoordinator()

--- a/Tests/KasetTests/MusicNavigationCoordinatorTests.swift
+++ b/Tests/KasetTests/MusicNavigationCoordinatorTests.swift
@@ -61,6 +61,27 @@ struct MusicNavigationCoordinatorTests {
         #expect(coordinator.routeAlbumID == nil)
     }
 
+    @Test("playerBarNavigationAction is disabled when active route has no mounted navigation stack")
+    func disabledWhenNoMountedStack() {
+        let coordinator = MusicNavigationCoordinator()
+        coordinator.updateActiveRoute(tab: .library, pinnedContentID: nil, hasNavigationStack: false)
+
+        #expect(coordinator.playerBarNavigationAction.openArtist == nil)
+        #expect(coordinator.playerBarNavigationAction.openAlbum == nil)
+        #expect(coordinator.activeNavigationPathBinding() == nil)
+    }
+
+    @Test("guest-gated tabs disable navigation for liked music, library, and history")
+    func disabledForGuestGatedTabs() {
+        let coordinator = MusicNavigationCoordinator()
+        for tab in [NavigationItem.likedMusic, .library, .history] {
+            coordinator.updateActiveRoute(tab: tab, pinnedContentID: nil, hasNavigationStack: false)
+
+            #expect(coordinator.playerBarNavigationAction.openArtist == nil)
+            #expect(coordinator.playerBarNavigationAction.openAlbum == nil)
+        }
+    }
+
     @Test("active route binding returns nil when no tab or pin is selected")
     func disabledNavigationWhenNoActiveRoute() {
         let coordinator = MusicNavigationCoordinator()

--- a/docs/adr/0033-music-navigation-coordinator.md
+++ b/docs/adr/0033-music-navigation-coordinator.md
@@ -24,8 +24,8 @@ re-derived `PlayerBarNavigationAction` plumbing across ~18 call sites.
    `playerBarCurrentArtistID`) is updated by detail views through the coordinator on
    appear/disappear.
 4. Remove per-view `PlayerBar` instances and `playerBarNavigationAction` init parameters;
-   navigation destinations read `playerBarNavigationAction` from the environment set by
-   `.playerBarMusicNavigation(path:)`.
+   the shared bar in `MainWindow` reads `playerBarNavigationAction` from
+   `MusicNavigationCoordinator`.
 
 ## Consequences
 

--- a/docs/adr/0033-music-navigation-coordinator.md
+++ b/docs/adr/0033-music-navigation-coordinator.md
@@ -1,0 +1,38 @@
+# ADR 0033: Music navigation coordinator and shared PlayerBar
+
+## Status
+
+Accepted
+
+## Context
+
+Each music content view mounted its own `PlayerBar` via `.safeAreaInset`, so navigation
+switched destroyed and recreated the bar. That reset `@State`, re-ran `.task` work, and
+caused artwork flicker (#445). Each view also owned a private `navigationPath` and
+re-derived `PlayerBarNavigationAction` plumbing across ~18 call sites.
+
+`MainWindow` already centralized paths for liked music and pinned sidebar playlists
+(`pinnedNavigationPaths`).
+
+## Decision
+
+1. Introduce `MusicNavigationCoordinator`, an `@Observable` owner for all music sidebar
+   navigation paths and the active route (tab or pinned playlist).
+2. Mount a single `PlayerBar` on the music detail column in `MainWindow`, outside every
+   `NavigationStack`.
+3. Route-level album/artist context for the bar (`playerBarCurrentAlbumID`,
+   `playerBarCurrentArtistID`) is updated by detail views through the coordinator on
+   appear/disappear.
+4. Remove per-view `PlayerBar` instances and `playerBarNavigationAction` init parameters;
+   navigation destinations read `playerBarNavigationAction` from the environment set by
+   `.playerBarMusicNavigation(path:)`.
+
+## Consequences
+
+- `PlayerBar` identity is stable across sidebar navigation; seek, volume, and resolved
+  targets persist.
+- Navigation targeting for artist/album buttons lives in one coordinator instead of
+  per-view copies.
+- `#439`-class missing wiring bugs become unrepresentable for the shared bar.
+- `popsNavigationStackOnSidebarReselect` and pinned path lifecycle stay per-stack; only
+  ownership moves to the coordinator.


### PR DESCRIPTION
## Description

Mount one `PlayerBar` in `MainWindow` and route its artist and album actions through `MusicNavigationCoordinator`, so switching music sidebar views does not recreate player-bar state.

Album route lifecycle is shared by the macOS 26 and macOS 15 playlist detail views. A disappearing older album view cannot clear the route for a newer album.

Fixes #445

## Testing

- `swift build --target Kaset`
- `swift test --filter 'KasetTests.MusicNavigationCoordinatorTests'`
- `swiftformat . --lint`
- `swiftlint --strict`
