### PR TITLE
fix(auth): route Google passkey sign-in to a working fallback (#291)

### DIFF
--- a/Sources/Kaset/Resources/Localizable.xcstrings
+++ b/Sources/Kaset/Resources/Localizable.xcstrings
@@ -18266,102 +18266,102 @@
         }
       }
     },
-    "Note: If passkeys don't work, use \"Try another way\" to sign in with password.": {
+    "Passkey sign-in is not available in this window. Google will ask for your password or another sign-in method instead.": {
       "localizations": {
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "ملاحظة: إذا لم تعمل مفاتيح المرور، فاستخدم \"جرّب طريقة أخرى\" لتسجيل الدخول بكلمة المرور."
+            "value": "تسجيل الدخول بمفتاح المرور غير متاح في هذه النافذة. سيطلب Google كلمة المرور أو طريقة تسجيل دخول أخرى بدلاً من ذلك."
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Hinweis: Wenn Passkeys nicht funktionieren, verwende \"Auf andere Weise versuchen\", um dich mit einem Passwort anzumelden."
+            "value": "Die Anmeldung mit Passkey ist in diesem Fenster nicht verfügbar. Google fragt stattdessen nach deinem Passwort oder einer anderen Anmeldemethode."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nota: si las passkeys no funcionan, usa \"Try another way\" para iniciar sesión con contraseña."
+            "value": "El inicio de sesión con passkeys no está disponible en esta ventana. Google te pedirá la contraseña u otro método de inicio de sesión en su lugar."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Remarque : si les clés d'identification ne fonctionnent pas, utilisez \"Try another way\" pour vous connecter avec un mot de passe."
+            "value": "La connexion par clé d'identification n'est pas disponible dans cette fenêtre. Google vous demandera votre mot de passe ou une autre méthode de connexion à la place."
           }
         },
         "id": {
           "stringUnit": {
             "state": "translated",
-            "value": "Catatan: Jika passkey tidak berfungsi, gunakan \"Try another way\" untuk masuk dengan kata sandi."
+            "value": "Masuk dengan passkey tidak tersedia di jendela ini. Google akan meminta kata sandi Anda atau metode masuk lain sebagai gantinya."
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nota: se le passkey non funzionano, usa \"Try another way\" per accedere con la password."
+            "value": "L'accesso con passkey non è disponibile in questa finestra. Google chiederà invece la password o un altro metodo di accesso."
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "참고: 패스키가 작동하지 않으면 \"Try another way\"를 사용해 비밀번호로 로그인하세요."
+            "value": "이 창에서는 패스키 로그인을 사용할 수 없습니다. 대신 Google에서 비밀번호나 다른 로그인 방법을 요청합니다."
           }
         },
         "nl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Opmerking: als passkeys niet werken, gebruik je \"Try another way\" om met een wachtwoord in te loggen."
+            "value": "Inloggen met een passkey is niet beschikbaar in dit venster. Google vraagt in plaats daarvan om je wachtwoord of een andere inlogmethode."
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Uwaga: jeśli klucze dostępu nie działają, użyj opcji \"Try another way\", aby zalogować się hasłem."
+            "value": "Logowanie kluczem dostępu nie jest dostępne w tym oknie. Google poprosi zamiast tego o hasło lub inną metodę logowania."
           }
         },
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nota: se as chaves de acesso não funcionarem, use \"Try another way\" para iniciar sessão com a palavra-passe."
+            "value": "O início de sessão com chave de acesso não está disponível nesta janela. A Google irá pedir a sua palavra-passe ou outro método de início de sessão."
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Примечание: если ключи доступа не работают, используйте \"Try another way\", чтобы войти с паролем."
+            "value": "Вход с ключом доступа недоступен в этом окне. Вместо этого Google запросит пароль или другой способ входа."
           }
         },
         "sv": {
           "stringUnit": {
             "state": "translated",
-            "value": "Obs! Om lösenkoder inte fungerar kan du använda \"Try another way\" för att logga in med lösenord."
+            "value": "Inloggning med lösenkod är inte tillgänglig i det här fönstret. Google ber i stället om ditt lösenord eller en annan inloggningsmetod."
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Not: Geçiş anahtarları çalışmıyorsa parola ile oturum açmak için \"Try another way\" seçeneğini kullanın."
+            "value": "Bu pencerede geçiş anahtarıyla oturum açılamaz. Google bunun yerine parolanızı veya başka bir oturum açma yöntemini isteyecektir."
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Примітка: якщо ключі доступу не працюють, скористайтеся \"Try another way\", щоб увійти за паролем."
+            "value": "Вхід із ключем доступу недоступний у цьому вікні. Натомість Google запитає пароль або інший спосіб входу."
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "注意：如果通行密钥无法使用，请选择“尝试其他方式”以使用密码登录。"
+            "value": "此窗口不支持通行密钥登录，Google 会改为要求输入密码或使用其他登录方式。"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "注意：如果密碼金鑰無法使用，請選擇「嘗試其他方式」以使用密碼登入。"
+            "value": "此視窗不支援密碼金鑰登入，Google 會改為要求輸入密碼或使用其他登入方式。"
           }
         }
       }

--- a/Sources/Kaset/Resources/ar.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/ar.lproj/Localizable.strings
@@ -312,7 +312,6 @@
 "Not Playing" = "لا يتم التشغيل";
 "Not signed in" = "لم يتم تسجيل الدخول";
 "Not Supported" = "غير مدعوم";
-"Note: If passkeys don't work, use \"Try another way\" to sign in with password." = "ملاحظة: إذا لم تعمل مفاتيح المرور، فاستخدم \"جرّب طريقة أخرى\" لتسجيل الدخول بكلمة المرور.";
 "Nothing here right now" = "لا يوجد شيء هنا الآن";
 "Nothing to show" = "لا يوجد ما يمكن عرضه";
 "Now Playing" = "قيد التشغيل";
@@ -329,6 +328,7 @@
 "Open the command bar to control music with natural language. Try saying \"play something chill\" or \"add jazz to queue\"." = "افتح شريط الأوامر للتحكم في الموسيقى باللغة الطبيعية. جرّب قول \"play something chill\" أو \"add jazz to queue\".";
 "Options…" = "الخيارات…";
 "Output" = "الإخراج";
+"Passkey sign-in is not available in this window. Google will ask for your password or another sign-in method instead." = "تسجيل الدخول بمفتاح المرور غير متاح في هذه النافذة. سيطلب Google كلمة المرور أو طريقة تسجيل دخول أخرى بدلاً من ذلك.";
 "Pause" = "إيقاف مؤقت";
 "Permission needed" = "الإذن مطلوب";
 "Piano" = "بيانو";

--- a/Sources/Kaset/Resources/de.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/de.lproj/Localizable.strings
@@ -312,7 +312,6 @@
 "Not Playing" = "Wird nicht wiedergegeben";
 "Not signed in" = "Nicht angemeldet";
 "Not Supported" = "Nicht unterstützt";
-"Note: If passkeys don't work, use \"Try another way\" to sign in with password." = "Hinweis: Wenn Passkeys nicht funktionieren, verwende \"Auf andere Weise versuchen\", um dich mit einem Passwort anzumelden.";
 "Nothing here right now" = "Hier ist gerade nichts";
 "Nothing to show" = "Nichts anzuzeigen";
 "Now Playing" = "Jetzt läuft";
@@ -329,6 +328,7 @@
 "Open the command bar to control music with natural language. Try saying \"play something chill\" or \"add jazz to queue\"." = "Öffne die Befehlsleiste, um Musik mit natürlicher Sprache zu steuern. Versuche zum Beispiel \"play something chill\" oder \"add jazz to queue\".";
 "Options…" = "Optionen…";
 "Output" = "Ausgabe";
+"Passkey sign-in is not available in this window. Google will ask for your password or another sign-in method instead." = "Die Anmeldung mit Passkey ist in diesem Fenster nicht verfügbar. Google fragt stattdessen nach deinem Passwort oder einer anderen Anmeldemethode.";
 "Pause" = "Pause";
 "Permission needed" = "Berechtigung erforderlich";
 "Piano" = "Piano";

--- a/Sources/Kaset/Resources/es.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/es.lproj/Localizable.strings
@@ -312,7 +312,6 @@
 "Not Playing" = "No se está reproduciendo";
 "Not signed in" = "Sin iniciar sesión";
 "Not Supported" = "No compatible";
-"Note: If passkeys don't work, use \"Try another way\" to sign in with password." = "Nota: si las passkeys no funcionan, usa \"Try another way\" para iniciar sesión con contraseña.";
 "Nothing here right now" = "No hay nada aquí ahora mismo";
 "Nothing to show" = "Nada para mostrar";
 "Now Playing" = "En reproducción";
@@ -329,6 +328,7 @@
 "Open the command bar to control music with natural language. Try saying \"play something chill\" or \"add jazz to queue\"." = "Abre la barra de comandos para controlar la música con lenguaje natural. Prueba a decir \"play something chill\" o \"add jazz to queue\".";
 "Options…" = "Opciones…";
 "Output" = "Salida";
+"Passkey sign-in is not available in this window. Google will ask for your password or another sign-in method instead." = "El inicio de sesión con passkeys no está disponible en esta ventana. Google te pedirá la contraseña u otro método de inicio de sesión en su lugar.";
 "Pause" = "Pausar";
 "Permission needed" = "Se necesita permiso";
 "Piano" = "Piano";

--- a/Sources/Kaset/Resources/fr.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/fr.lproj/Localizable.strings
@@ -312,7 +312,6 @@
 "Not Playing" = "Pas en lecture";
 "Not signed in" = "Non connecté";
 "Not Supported" = "Non pris en charge";
-"Note: If passkeys don't work, use \"Try another way\" to sign in with password." = "Remarque : si les clés d'identification ne fonctionnent pas, utilisez \"Try another way\" pour vous connecter avec un mot de passe.";
 "Nothing here right now" = "Rien ici pour le moment";
 "Nothing to show" = "Rien à afficher";
 "Now Playing" = "En lecture";
@@ -329,6 +328,7 @@
 "Open the command bar to control music with natural language. Try saying \"play something chill\" or \"add jazz to queue\"." = "Ouvrez la barre de commandes pour contrôler la musique en langage naturel. Essayez par exemple \"play something chill\" ou \"add jazz to queue\".";
 "Options…" = "Options…";
 "Output" = "Sortie";
+"Passkey sign-in is not available in this window. Google will ask for your password or another sign-in method instead." = "La connexion par clé d'identification n'est pas disponible dans cette fenêtre. Google vous demandera votre mot de passe ou une autre méthode de connexion à la place.";
 "Pause" = "Pause";
 "Permission needed" = "Autorisation requise";
 "Piano" = "Piano";

--- a/Sources/Kaset/Resources/id.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/id.lproj/Localizable.strings
@@ -312,7 +312,6 @@
 "Not Playing" = "Tidak Memutar";
 "Not signed in" = "Belum masuk";
 "Not Supported" = "Tidak Didukung";
-"Note: If passkeys don't work, use \"Try another way\" to sign in with password." = "Catatan: Jika passkey tidak berfungsi, gunakan \"Try another way\" untuk masuk dengan kata sandi.";
 "Nothing here right now" = "Tidak ada apa-apa di sini saat ini";
 "Nothing to show" = "Tidak ada yang ditampilkan";
 "Now Playing" = "Sedang Diputar";
@@ -329,6 +328,7 @@
 "Open the command bar to control music with natural language. Try saying \"play something chill\" or \"add jazz to queue\"." = "Buka Command Bar untuk mengontrol musik dengan bahasa alami. Coba ucapkan \"play something chill\" atau \"add jazz to queue\".";
 "Options…" = "Opsi…";
 "Output" = "Keluaran";
+"Passkey sign-in is not available in this window. Google will ask for your password or another sign-in method instead." = "Masuk dengan passkey tidak tersedia di jendela ini. Google akan meminta kata sandi Anda atau metode masuk lain sebagai gantinya.";
 "Pause" = "Jeda";
 "Permission needed" = "Izin diperlukan";
 "Piano" = "Piano";

--- a/Sources/Kaset/Resources/it.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/it.lproj/Localizable.strings
@@ -312,7 +312,6 @@
 "Not Playing" = "Non in riproduzione";
 "Not signed in" = "Accesso non effettuato";
 "Not Supported" = "Non supportato";
-"Note: If passkeys don't work, use \"Try another way\" to sign in with password." = "Nota: se le passkey non funzionano, usa \"Try another way\" per accedere con la password.";
 "Nothing here right now" = "Qui non c'è nulla al momento";
 "Nothing to show" = "Nulla da mostrare";
 "Now Playing" = "In riproduzione";
@@ -329,6 +328,7 @@
 "Open the command bar to control music with natural language. Try saying \"play something chill\" or \"add jazz to queue\"." = "Apri la barra dei comandi per controllare la musica in linguaggio naturale. Prova a dire \"play something chill\" o \"add jazz to queue\".";
 "Options…" = "Opzioni…";
 "Output" = "Uscita";
+"Passkey sign-in is not available in this window. Google will ask for your password or another sign-in method instead." = "L'accesso con passkey non è disponibile in questa finestra. Google chiederà invece la password o un altro metodo di accesso.";
 "Pause" = "Pausa";
 "Permission needed" = "Autorizzazione necessaria";
 "Piano" = "Piano";

--- a/Sources/Kaset/Resources/ko.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/ko.lproj/Localizable.strings
@@ -312,7 +312,6 @@
 "Not Playing" = "재생 중 아님";
 "Not signed in" = "로그인되지 않음";
 "Not Supported" = "지원되지 않음";
-"Note: If passkeys don't work, use \"Try another way\" to sign in with password." = "참고: 패스키가 작동하지 않으면 \"Try another way\"를 사용해 비밀번호로 로그인하세요.";
 "Nothing here right now" = "지금은 여기에 아무것도 없습니다";
 "Nothing to show" = "표시할 내용이 없습니다";
 "Now Playing" = "지금 재생 중";
@@ -329,6 +328,7 @@
 "Open the command bar to control music with natural language. Try saying \"play something chill\" or \"add jazz to queue\"." = "자연어로 음악을 제어하려면 명령 막대를 여세요. \"play something chill\" 또는 \"add jazz to queue\"라고 말해 보세요.";
 "Options…" = "옵션…";
 "Output" = "출력";
+"Passkey sign-in is not available in this window. Google will ask for your password or another sign-in method instead." = "이 창에서는 패스키 로그인을 사용할 수 없습니다. 대신 Google에서 비밀번호나 다른 로그인 방법을 요청합니다.";
 "Pause" = "일시중지";
 "Permission needed" = "권한 필요";
 "Piano" = "피아노";

--- a/Sources/Kaset/Resources/nl.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/nl.lproj/Localizable.strings
@@ -312,7 +312,6 @@
 "Not Playing" = "Speelt niet af";
 "Not signed in" = "Niet ingelogd";
 "Not Supported" = "Niet ondersteund";
-"Note: If passkeys don't work, use \"Try another way\" to sign in with password." = "Opmerking: als passkeys niet werken, gebruik je \"Try another way\" om met een wachtwoord in te loggen.";
 "Nothing here right now" = "Hier staat nu niets";
 "Nothing to show" = "Niets om weer te geven";
 "Now Playing" = "Speelt nu";
@@ -329,6 +328,7 @@
 "Open the command bar to control music with natural language. Try saying \"play something chill\" or \"add jazz to queue\"." = "Open de opdrachtbalk om muziek met natuurlijke taal te bedienen. Probeer bijvoorbeeld \"play something chill\" of \"add jazz to queue\".";
 "Options…" = "Opties…";
 "Output" = "Uitvoer";
+"Passkey sign-in is not available in this window. Google will ask for your password or another sign-in method instead." = "Inloggen met een passkey is niet beschikbaar in dit venster. Google vraagt in plaats daarvan om je wachtwoord of een andere inlogmethode.";
 "Pause" = "Pauze";
 "Permission needed" = "Toestemming vereist";
 "Piano" = "Piano";

--- a/Sources/Kaset/Resources/pl.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/pl.lproj/Localizable.strings
@@ -312,7 +312,6 @@
 "Not Playing" = "Nie odtwarza";
 "Not signed in" = "Nie zalogowano";
 "Not Supported" = "Nieobsługiwane";
-"Note: If passkeys don't work, use \"Try another way\" to sign in with password." = "Uwaga: jeśli klucze dostępu nie działają, użyj opcji \"Try another way\", aby zalogować się hasłem.";
 "Nothing here right now" = "Na razie nic tu nie ma";
 "Nothing to show" = "Nie ma nic do pokazania";
 "Now Playing" = "Teraz odtwarzane";
@@ -329,6 +328,7 @@
 "Open the command bar to control music with natural language. Try saying \"play something chill\" or \"add jazz to queue\"." = "Otwórz pasek poleceń, aby sterować muzyką językiem naturalnym. Spróbuj powiedzieć \"play something chill\" albo \"add jazz to queue\".";
 "Options…" = "Opcje…";
 "Output" = "Wyjście";
+"Passkey sign-in is not available in this window. Google will ask for your password or another sign-in method instead." = "Logowanie kluczem dostępu nie jest dostępne w tym oknie. Google poprosi zamiast tego o hasło lub inną metodę logowania.";
 "Pause" = "Wstrzymaj";
 "Permission needed" = "Wymagane uprawnienie";
 "Piano" = "Piano";

--- a/Sources/Kaset/Resources/pt.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/pt.lproj/Localizable.strings
@@ -312,7 +312,6 @@
 "Not Playing" = "Nada em reprodução";
 "Not signed in" = "Sessão não iniciada";
 "Not Supported" = "Não suportado";
-"Note: If passkeys don't work, use \"Try another way\" to sign in with password." = "Nota: se as chaves de acesso não funcionarem, use \"Try another way\" para iniciar sessão com a palavra-passe.";
 "Nothing here right now" = "Não há nada aqui neste momento";
 "Nothing to show" = "Nada para mostrar";
 "Now Playing" = "Em reprodução";
@@ -329,6 +328,7 @@
 "Open the command bar to control music with natural language. Try saying \"play something chill\" or \"add jazz to queue\"." = "Abra a barra de comandos para controlar a música com linguagem natural. Experimente dizer \"play something chill\" ou \"add jazz to queue\".";
 "Options…" = "Opções…";
 "Output" = "Saída";
+"Passkey sign-in is not available in this window. Google will ask for your password or another sign-in method instead." = "O início de sessão com chave de acesso não está disponível nesta janela. A Google irá pedir a sua palavra-passe ou outro método de início de sessão.";
 "Pause" = "Pausar";
 "Permission needed" = "Permissão necessária";
 "Piano" = "Piano";

--- a/Sources/Kaset/Resources/ru.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/ru.lproj/Localizable.strings
@@ -312,7 +312,6 @@
 "Not Playing" = "Не воспроизводится";
 "Not signed in" = "Вход не выполнен";
 "Not Supported" = "Не поддерживается";
-"Note: If passkeys don't work, use \"Try another way\" to sign in with password." = "Примечание: если ключи доступа не работают, используйте \"Try another way\", чтобы войти с паролем.";
 "Nothing here right now" = "Сейчас здесь ничего нет";
 "Nothing to show" = "Нечего показывать";
 "Now Playing" = "Сейчас играет";
@@ -329,6 +328,7 @@
 "Open the command bar to control music with natural language. Try saying \"play something chill\" or \"add jazz to queue\"." = "Откройте панель команд, чтобы управлять музыкой естественным языком. Попробуйте сказать \"play something chill\" или \"add jazz to queue\".";
 "Options…" = "Параметры…";
 "Output" = "Выход";
+"Passkey sign-in is not available in this window. Google will ask for your password or another sign-in method instead." = "Вход с ключом доступа недоступен в этом окне. Вместо этого Google запросит пароль или другой способ входа.";
 "Pause" = "Пауза";
 "Permission needed" = "Требуется разрешение";
 "Piano" = "Piano";

--- a/Sources/Kaset/Resources/sv.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/sv.lproj/Localizable.strings
@@ -312,7 +312,6 @@
 "Not Playing" = "Spelar inte";
 "Not signed in" = "Inte inloggad";
 "Not Supported" = "Stöds inte";
-"Note: If passkeys don't work, use \"Try another way\" to sign in with password." = "Obs! Om lösenkoder inte fungerar kan du använda \"Try another way\" för att logga in med lösenord.";
 "Nothing here right now" = "Det finns inget här just nu";
 "Nothing to show" = "Inget att visa";
 "Now Playing" = "Spelas nu";
@@ -329,6 +328,7 @@
 "Open the command bar to control music with natural language. Try saying \"play something chill\" or \"add jazz to queue\"." = "Öppna kommandofältet för att styra musik med naturligt språk. Prova att säga \"play something chill\" eller \"add jazz to queue\".";
 "Options…" = "Alternativ…";
 "Output" = "Utgång";
+"Passkey sign-in is not available in this window. Google will ask for your password or another sign-in method instead." = "Inloggning med lösenkod är inte tillgänglig i det här fönstret. Google ber i stället om ditt lösenord eller en annan inloggningsmetod.";
 "Pause" = "Pausa";
 "Permission needed" = "Behörighet krävs";
 "Piano" = "Piano";

--- a/Sources/Kaset/Resources/tr.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/tr.lproj/Localizable.strings
@@ -312,7 +312,6 @@
 "Not Playing" = "Çalmıyor";
 "Not signed in" = "Oturum açık değil";
 "Not Supported" = "Desteklenmiyor";
-"Note: If passkeys don't work, use \"Try another way\" to sign in with password." = "Not: Geçiş anahtarları çalışmıyorsa parola ile oturum açmak için \"Try another way\" seçeneğini kullanın.";
 "Nothing here right now" = "Şu anda burada hiçbir şey yok";
 "Nothing to show" = "Gösterilecek bir şey yok";
 "Now Playing" = "Şimdi Çalıyor";
@@ -329,6 +328,7 @@
 "Open the command bar to control music with natural language. Try saying \"play something chill\" or \"add jazz to queue\"." = "Müziği doğal dille kontrol etmek için Komut Çubuğu'nu açın. \"play something chill\" veya \"add jazz to queue\" demeyi deneyin.";
 "Options…" = "Seçenekler…";
 "Output" = "Çıkış";
+"Passkey sign-in is not available in this window. Google will ask for your password or another sign-in method instead." = "Bu pencerede geçiş anahtarıyla oturum açılamaz. Google bunun yerine parolanızı veya başka bir oturum açma yöntemini isteyecektir.";
 "Pause" = "Duraklat";
 "Permission needed" = "İzin gerekli";
 "Piano" = "Piyano";

--- a/Sources/Kaset/Resources/uk.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/uk.lproj/Localizable.strings
@@ -312,7 +312,6 @@
 "Not Playing" = "Не відтворюється";
 "Not signed in" = "Вхід не виконано";
 "Not Supported" = "Не підтримується";
-"Note: If passkeys don't work, use \"Try another way\" to sign in with password." = "Примітка: якщо ключі доступу не працюють, скористайтеся \"Try another way\", щоб увійти за паролем.";
 "Nothing here right now" = "Зараз тут нічого немає";
 "Nothing to show" = "Нічого показувати";
 "Now Playing" = "Зараз грає";
@@ -329,6 +328,7 @@
 "Open the command bar to control music with natural language. Try saying \"play something chill\" or \"add jazz to queue\"." = "Відкрийте панель команд, щоб керувати музикою природною мовою. Спробуйте сказати \"play something chill\" або \"add jazz to queue\".";
 "Options…" = "Параметри…";
 "Output" = "Вихід";
+"Passkey sign-in is not available in this window. Google will ask for your password or another sign-in method instead." = "Вхід із ключем доступу недоступний у цьому вікні. Натомість Google запитає пароль або інший спосіб входу.";
 "Pause" = "Пауза";
 "Permission needed" = "Потрібен дозвіл";
 "Piano" = "Фортепіано";

--- a/Sources/Kaset/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/zh-Hans.lproj/Localizable.strings
@@ -321,7 +321,6 @@
 "Not disliked" = "未标记不喜欢";
 "Not liked" = "未标记喜欢";
 "Not signed in" = "未登录";
-"Note: If passkeys don't work, use \"Try another way\" to sign in with password." = "注意：如果通行密钥无法使用，请选择“尝试其他方式”以使用密码登录。";
 "Nothing here right now" = "这里暂时什么都没有";
 "Nothing to show" = "暂无内容可显示";
 "Now Playing" = "正在播放";
@@ -338,6 +337,7 @@
 "Open the command bar to control music with natural language. Try saying \"play something chill\" or \"add jazz to queue\"." = "打开命令栏，用自然语言控制音乐。试试说“播放一些舒缓的音乐”或“把爵士加入队列”。";
 "Options…" = "选项…";
 "Output" = "输出";
+"Passkey sign-in is not available in this window. Google will ask for your password or another sign-in method instead." = "此窗口不支持通行密钥登录，Google 会改为要求输入密码或使用其他登录方式。";
 "Pause" = "暂停";
 "Permission needed" = "需要权限";
 "Piano" = "钢琴";

--- a/Sources/Kaset/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/zh-Hant.lproj/Localizable.strings
@@ -321,7 +321,6 @@
 "Not disliked" = "未標記不喜歡";
 "Not liked" = "未標記喜歡";
 "Not signed in" = "未登入";
-"Note: If passkeys don't work, use \"Try another way\" to sign in with password." = "注意：如果密碼金鑰無法使用，請選擇「嘗試其他方式」以使用密碼登入。";
 "Nothing here right now" = "這裡目前什麼都沒有";
 "Nothing to show" = "沒有內容可顯示";
 "Now Playing" = "正在播放";
@@ -338,6 +337,7 @@
 "Open the command bar to control music with natural language. Try saying \"play something chill\" or \"add jazz to queue\"." = "開啟命令列，用自然語言控制音樂。試試說「播放一些舒緩的音樂」或「把爵士加入待播清單」。";
 "Options…" = "選項…";
 "Output" = "輸出";
+"Passkey sign-in is not available in this window. Google will ask for your password or another sign-in method instead." = "此視窗不支援密碼金鑰登入，Google 會改為要求輸入密碼或使用其他登入方式。";
 "Pause" = "暫停";
 "Permission needed" = "需要權限";
 "Piano" = "鋼琴";

--- a/Sources/Kaset/Services/WebKit/LoginPasskeySuppression.swift
+++ b/Sources/Kaset/Services/WebKit/LoginPasskeySuppression.swift
@@ -1,0 +1,77 @@
+import WebKit
+
+// MARK: - LoginPasskeySuppression
+
+/// Hides WebAuthn passkey support from Google sign-in pages loaded in the
+/// login and session-switch WebViews.
+///
+/// WKWebView exposes `window.PublicKeyCredential`, but without the restricted
+/// `com.apple.developer.web-browser.public-key-credential` entitlement (granted
+/// by Apple only to general-purpose browsers) the system rejects every passkey
+/// ceremony before showing any UI. Google's sign-in page detects the API,
+/// offers the passkey flow, and dead-ends on a "Something went wrong" error
+/// instead of falling back to a password. Removing the API up front makes
+/// Google treat the WebView like a browser without WebAuthn support and route
+/// sign-in through flows that can actually succeed. See ADR-0033.
+enum LoginPasskeySuppression {
+    /// JavaScript that removes WebAuthn capability signals before page scripts run.
+    ///
+    /// Two layers, each independently guarded so a WebKit change can never
+    /// break the sign-in page itself:
+    /// 1. Undefines `window.PublicKeyCredential`, which well-behaved relying
+    ///    parties (including Google) feature-detect before offering passkeys.
+    /// 2. Rejects any `navigator.credentials.get/create` call that still asks
+    ///    for a `publicKey` credential with `NotAllowedError`, the same error
+    ///    the platform would eventually produce, but without the misleading
+    ///    cross-device error screen.
+    static let scriptSource = """
+    (function () {
+        "use strict";
+        try {
+            delete window.PublicKeyCredential;
+            Object.defineProperty(window, "PublicKeyCredential", {
+                value: undefined,
+                writable: false,
+                configurable: false,
+            });
+        } catch (error) {}
+        try {
+            var credentials = window.navigator && window.navigator.credentials;
+            if (!credentials) {
+                return;
+            }
+            var prototype = Object.getPrototypeOf(credentials);
+            var wrap = function (original) {
+                if (typeof original !== "function") {
+                    return original;
+                }
+                return function (options) {
+                    if (options && options.publicKey) {
+                        return Promise.reject(new DOMException(
+                            "Passkeys are not available in this app.",
+                            "NotAllowedError"
+                        ));
+                    }
+                    return original.apply(this, arguments);
+                };
+            };
+            prototype.get = wrap(prototype.get);
+            prototype.create = wrap(prototype.create);
+        } catch (error) {}
+    })();
+    """
+
+    /// Builds the user script for the login/session-switch configuration.
+    ///
+    /// Injected at document start so it runs before Google's capability
+    /// detection, and into all frames because parts of the sign-in flow render
+    /// in iframes.
+    @MainActor
+    static func makeUserScript() -> WKUserScript {
+        WKUserScript(
+            source: self.scriptSource,
+            injectionTime: .atDocumentStart,
+            forMainFrameOnly: false
+        )
+    }
+}

--- a/Sources/Kaset/Services/WebKit/WebKitManager.swift
+++ b/Sources/Kaset/Services/WebKit/WebKitManager.swift
@@ -333,13 +333,17 @@ final class WebKitManager: NSObject, WebKitManagerProtocol {
         #endif
     }
 
-    /// Creates the minimal WebView configuration used for hidden account-switch
-    /// navigations. It deliberately shares only the website data store (cookies)
-    /// and does not attach the app's `WKWebExtensionController`, so enabled
-    /// extensions/content scripts cannot observe credential-bearing signin URLs.
+    /// Creates the minimal WebView configuration used for the login sheet and
+    /// hidden account-switch navigations. It deliberately shares only the
+    /// website data store (cookies) and does not attach the app's
+    /// `WKWebExtensionController`, so enabled extensions/content scripts cannot
+    /// observe credential-bearing signin URLs. It also suppresses WebAuthn
+    /// passkey detection so Google's sign-in falls back to flows that can
+    /// succeed in an embedded WebView (ADR-0033).
     func createSessionSwitchWebViewConfiguration() -> WKWebViewConfiguration {
         let configuration = WKWebViewConfiguration()
         configuration.websiteDataStore = self.dataStore
+        configuration.userContentController.addUserScript(LoginPasskeySuppression.makeUserScript())
         return configuration
     }
 

--- a/Sources/Kaset/Views/LoginSheet.swift
+++ b/Sources/Kaset/Views/LoginSheet.swift
@@ -180,7 +180,7 @@ struct LoginSheet: View {
                 }
             }
 
-            Text(String(localized: "Note: If passkeys don't work, use \"Try another way\" to sign in with password."))
+            Text(String(localized: "Passkey sign-in is not available in this window. Google will ask for your password or another sign-in method instead."))
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }

--- a/Tests/KasetTests/LoginPasskeySuppressionTests.swift
+++ b/Tests/KasetTests/LoginPasskeySuppressionTests.swift
@@ -1,0 +1,145 @@
+import Foundation
+import Testing
+import WebKit
+@testable import Kaset
+
+// MARK: - LoginPasskeySuppressionTests
+
+/// Tests for LoginPasskeySuppression.
+@Suite(.serialized, .tags(.service))
+@MainActor
+struct LoginPasskeySuppressionTests {
+    @Test("User script injects at document start into all frames")
+    func userScriptProperties() {
+        let script = LoginPasskeySuppression.makeUserScript()
+        #expect(script.source == LoginPasskeySuppression.scriptSource)
+        #expect(script.injectionTime == .atDocumentStart)
+        #expect(script.isForMainFrameOnly == false)
+    }
+
+    @Test("Session switch WebView configuration attaches the suppression script")
+    func sessionSwitchConfigurationAttachesScript() {
+        let manager = WebKitManager.makeTestInstance()
+        let configuration = manager.createSessionSwitchWebViewConfiguration()
+        let suppressionScript = configuration.userContentController.userScripts
+            .first { $0.source == LoginPasskeySuppression.scriptSource }
+        #expect(suppressionScript != nil)
+        #expect(suppressionScript?.injectionTime == .atDocumentStart)
+        #expect(suppressionScript?.isForMainFrameOnly == false)
+    }
+
+    @Test("WebAuthn API is exposed in a plain WebView", .timeLimit(.minutes(1)))
+    func webAuthnExposedWithoutSuppression() async throws {
+        // Baseline guard: if WKWebView ever stops exposing WebAuthn on its
+        // own, the suppression script becomes redundant and the passkey
+        // handling should be revisited.
+        let configuration = WKWebViewConfiguration()
+        configuration.websiteDataStore = .nonPersistent()
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        try await Self.loadBlankPage(in: webView)
+
+        let credentialType = try await webView.evaluateJavaScript("typeof PublicKeyCredential") as? String
+        #expect(credentialType == "function")
+    }
+
+    @Test("Session-switch configuration hides WebAuthn from pages", .timeLimit(.minutes(1)))
+    func suppressionHidesWebAuthn() async throws {
+        let webView = Self.makeSuppressedWebView()
+        try await Self.loadBlankPage(in: webView)
+
+        let credentialType = try await webView.evaluateJavaScript("typeof PublicKeyCredential") as? String
+        #expect(credentialType == "undefined")
+    }
+
+    @Test("Passkey credential requests are rejected with NotAllowedError", .timeLimit(.minutes(1)))
+    func passkeyRequestsAreRejected() async throws {
+        let webView = Self.makeSuppressedWebView()
+        try await Self.loadBlankPage(in: webView)
+
+        let errorName = try await webView.callAsyncJavaScript(
+            """
+            try {
+                await navigator.credentials.get({ publicKey: { challenge: new Uint8Array(16) } });
+                return "resolved";
+            } catch (error) {
+                return error.name;
+            }
+            """,
+            contentWorld: .page
+        ) as? String
+        #expect(errorName == "NotAllowedError")
+    }
+
+    // MARK: - Helpers
+
+    private static func makeSuppressedWebView() -> WKWebView {
+        let manager = WebKitManager.makeTestInstance()
+        let configuration = manager.createSessionSwitchWebViewConfiguration()
+        return WKWebView(frame: .zero, configuration: configuration)
+    }
+
+    private static func loadBlankPage(in webView: WKWebView) async throws {
+        // WebAuthn is only exposed in secure contexts, so give the local page
+        // an https origin; no network request is made for the page itself.
+        let waiter = NavigationWaiter()
+        try await waiter.waitForLoad(
+            of: webView,
+            html: "<html><body></body></html>",
+            baseURL: URL(string: "https://accounts.google.com/")
+        )
+    }
+}
+
+// MARK: - NavigationWaiter
+
+/// Awaits the completion of a single `loadHTMLString` navigation.
+///
+/// Cancellation-aware so the suite's `timeLimit` trait can end a stuck
+/// navigation instead of suspending the test run indefinitely, and treats
+/// WebContent process termination as a failure rather than waiting forever.
+@MainActor
+private final class NavigationWaiter: NSObject, WKNavigationDelegate {
+    private struct ContentProcessTerminatedError: Error {}
+
+    private var continuation: CheckedContinuation<Void, any Error>?
+
+    func waitForLoad(of webView: WKWebView, html: String, baseURL: URL?) async throws {
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                self.continuation = continuation
+                webView.navigationDelegate = self
+                webView.loadHTMLString(html, baseURL: baseURL)
+            }
+        } onCancel: {
+            Task { @MainActor in
+                self.finish(throwing: CancellationError())
+            }
+        }
+    }
+
+    private func finish(throwing error: (any Error)? = nil) {
+        guard let continuation = self.continuation else { return }
+        self.continuation = nil
+        if let error {
+            continuation.resume(throwing: error)
+        } else {
+            continuation.resume()
+        }
+    }
+
+    func webView(_: WKWebView, didFinish _: WKNavigation!) {
+        self.finish()
+    }
+
+    func webView(_: WKWebView, didFail _: WKNavigation!, withError error: any Error) {
+        self.finish(throwing: error)
+    }
+
+    func webView(_: WKWebView, didFailProvisionalNavigation _: WKNavigation!, withError error: any Error) {
+        self.finish(throwing: error)
+    }
+
+    func webViewWebContentProcessDidTerminate(_: WKWebView) {
+        self.finish(throwing: ContentProcessTerminatedError())
+    }
+}

--- a/Tests/KasetTests/LoginPasskeySuppressionTests.swift
+++ b/Tests/KasetTests/LoginPasskeySuppressionTests.swift
@@ -51,23 +51,23 @@ struct LoginPasskeySuppressionTests {
         #expect(credentialType == "undefined")
     }
 
-    @Test("Passkey credential requests are rejected with NotAllowedError", .timeLimit(.minutes(1)))
+    @Test("Passkey credential requests are rejected by the suppression shim", .timeLimit(.minutes(1)))
     func passkeyRequestsAreRejected() async throws {
         let webView = Self.makeSuppressedWebView()
         try await Self.loadBlankPage(in: webView)
 
-        let errorName = try await webView.callAsyncJavaScript(
+        let errorDescription = try await webView.callAsyncJavaScript(
             """
             try {
                 await navigator.credentials.get({ publicKey: { challenge: new Uint8Array(16) } });
                 return "resolved";
             } catch (error) {
-                return error.name;
+                return error.name + ": " + error.message;
             }
             """,
             contentWorld: .page
         ) as? String
-        #expect(errorName == "NotAllowedError")
+        #expect(errorDescription == "NotAllowedError: Passkeys are not available in this app.")
     }
 
     // MARK: - Helpers

--- a/docs/adr/0033-login-passkey-suppression.md
+++ b/docs/adr/0033-login-passkey-suppression.md
@@ -1,0 +1,99 @@
+# ADR-0033: Suppress Passkey Detection in the Login WebView
+
+## Status
+
+Accepted
+
+## Context
+
+Kaset signs users in by loading `accounts.google.com` in a `WKWebView` and
+capturing the resulting Google session cookies. When an account has passkeys,
+Google's sign-in page offers passkey authentication, and that ceremony can
+never succeed inside Kaset's WebView (issue #291):
+
+- `WKWebView` exposes the WebAuthn API (`window.PublicKeyCredential`), and
+  `PublicKeyCredential.getClientCapabilities()` even reports
+  `hybridTransport: true`, so Google's page treats the WebView as a
+  passkey-capable browser.
+- However, the system authorizes passkey ceremonies only for apps that hold
+  the restricted `com.apple.developer.web-browser.public-key-credential`
+  entitlement, or for relying parties covered by the app's
+  `webcredentials` Associated Domains. Every `navigator.credentials.get()`
+  call from Kaset is rejected almost instantly with `NotAllowedError`, with
+  no system UI and no Bluetooth activity.
+- Google interprets that failure as a broken cross-device (hybrid) attempt
+  and renders the "Something went wrong — check that Bluetooth is on and the
+  devices are close together" error screen. The advice is unsatisfiable; the
+  only escape is "Try another way" and a manual password entry.
+
+Neither supported path to real in-WebView passkeys is available to Kaset:
+
+- The browser entitlement is an Apple-managed capability granted after review
+  only to apps that act as general-purpose web browsers (URL field, search,
+  bookmarks), requested by the Account Holder of an organization developer
+  account, and it must be authorized by an embedded provisioning profile.
+  A YouTube Music client does not meet the criteria, and the profile
+  requirement is incompatible with Kaset's ad-hoc and Apple Development
+  signing fallbacks.
+- Associated Domains would require Google to list Kaset's app identifier in
+  the `google.com` AASA file, which will not happen.
+
+Moving login to the system browser (or `ASWebAuthenticationSession`) does not
+fit either: Kaset needs the Google session cookies to land in its own
+`WKWebsiteDataStore`, an authentication session only returns a callback URL,
+and importing cookies from another browser is both fragile (Google invalidates
+sessions reused across client fingerprints) and indistinguishable from
+credential-stealing behavior.
+
+Shipping WKWebView apps in the same situation (for example the Nook browser
+while awaiting the entitlement, and several Claude/Google wrapper apps)
+converge on the same mitigation: hide WebAuthn from the sign-in page so the
+site never offers a flow that cannot succeed.
+
+## Decision
+
+1. **Hide WebAuthn capability signals in the login and session-switch
+   WebViews.** `WebKitManager.createSessionSwitchWebViewConfiguration()`
+   attaches a `WKUserScript` (`LoginPasskeySuppression`), injected at document
+   start into all frames, that undefines `window.PublicKeyCredential` and
+   rejects `navigator.credentials.get`/`create` calls requesting a
+   `publicKey` credential with `NotAllowedError`. Google's sign-in page
+   feature-detects WebAuthn before offering passkeys, so it routes the
+   account through password (and other non-WebAuthn) challenges instead of
+   the dead-end hybrid flow.
+2. **Scope the suppression to the authentication surface only.** The script
+   is added solely to the configuration used by the login sheet and hidden
+   account-switch navigations. Those WebViews load Google sign-in pages plus
+   the youtube.com/music.youtube.com redirects that complete the flow, none
+   of which need WebAuthn. Playback WebViews use different configurations
+   and are unaffected.
+3. **Keep the login sheet note, updated to describe the actual behavior**
+   ("Passkey sign-in is not available in this window. Google will ask for
+   your password or another sign-in method instead.") so users are not
+   surprised when their passkey is not offered.
+
+## Consequences
+
+- Passkey-enabled Google accounts can sign in without hitting the
+  unrecoverable "Something went wrong" screen; Google falls back to password
+  sign-in on its own instead of requiring users to discover "Try another
+  way".
+- Passkeys still cannot be used to sign in to Kaset. That is a platform
+  restriction, not a regression: the ceremony has never been able to succeed
+  in the embedded WebView. If Apple ever offers a viable path (for example a
+  less restrictive entitlement), the suppression script and this ADR should
+  be revisited.
+- Accounts restricted to passkey-only sign-in (for example by a Workspace
+  policy that disallows passwords) still cannot log in, but they could not
+  before either; with suppression Google at least presents its other
+  verification options rather than the Bluetooth error loop.
+- The suppression script depends on Google feature-detecting WebAuthn. If a
+  page calls the API anyway, the second layer (rejecting `publicKey`
+  requests promptly with `NotAllowedError`) fails the ceremony immediately
+  and deterministically instead of leaving the outcome to the platform; the
+  page may still render an error screen, but sign-in stays recoverable
+  through its non-WebAuthn fallback.
+- `LoginPasskeySuppressionTests` guards both directions: a plain WKWebView
+  must still expose `PublicKeyCredential` (if WebKit changes this, the shim
+  is obsolete), and the session-switch configuration must hide it and reject
+  passkey requests.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -67,3 +67,4 @@ What becomes easier or more difficult because of this change?
 | [0030](0030-account-scoped-favorites.md) | Account-Scoped Favorites Persistence | Accepted |
 | [0031](0031-saved-album-library-reconciliation.md) | Saved-Album Library Identity and Reconciliation | Accepted |
 | [0032](0032-youtube-ask-gemini.md) | Watch-Scoped YouTube Ask Gemini | Accepted; fixed WEB profile enabled in production |
+| [0033](0033-login-passkey-suppression.md) | Suppress Passkey Detection in the Login WebView | Accepted |


### PR DESCRIPTION
## Description

Fixes the passkey sign-in dead-end reported in #291.

When signing in to YouTube Music, Kaset loads `accounts.google.com` in a `WKWebView`. If the account has passkeys, Google offers passkey authentication, but that ceremony can never complete in an un-entitled `WKWebView`: `window.PublicKeyCredential` is exposed (and `getClientCapabilities()` even reports `hybridTransport: true`), yet the OS rejects every `navigator.credentials.get()` almost instantly with `NotAllowedError` and no system UI. Google reads that as a broken cross-device attempt and shows the unrecoverable **"Something went wrong — check that Bluetooth is on and the devices are close together"** screen. The only escape today is "Try another way" plus a manual password.

There is no supported way to make the ceremony actually succeed here: the restricted `com.apple.developer.web-browser.public-key-credential` entitlement is granted by Apple only to general-purpose browsers (and needs an embedded provisioning profile, incompatible with the ad-hoc / Apple Development signing fallbacks), and Associated Domains with `google.com` are impossible.

This PR takes the mitigation shipping in other WKWebView apps in the same spot (e.g. the Nook browser while awaiting the entitlement): **hide WebAuthn from the sign-in page** so Google offers a flow that can succeed. `LoginPasskeySuppression` injects a document-start user script (all frames) into the login / session-switch WebView configuration that:

1. undefines `window.PublicKeyCredential`, which Google feature-detects before offering passkeys, and
2. rejects any `navigator.credentials.get`/`create` call requesting a `publicKey` credential with `NotAllowedError` (a deterministic version of the error the platform would produce anyway, without the misleading cross-device screen).

Google then routes sign-in through password (or another) verification. Passwordless sign-in via passkey still is not possible in the embedded WebView — that is an unchanged platform limitation — but users are no longer stuck on an error loop.

The script is scoped to `createSessionSwitchWebViewConfiguration()`, used only by the login sheet and the hidden account-switch navigations. Playback WebViews are untouched.

## AI Prompt

<details>
<summary>🤖 AI Prompt Used</summary>

```
Fix issue #291 in sozercan/kaset: Google passkey sign-in dead-ends on the
"Something went wrong / check Bluetooth" screen in the login WKWebView.

Research the root cause (WKWebView exposes WebAuthn but the OS rejects every
ceremony without the restricted browser entitlement, so Google falls into the
broken cross-device/hybrid flow), then implement a fix that makes Google fall
back to a working sign-in method. Follow AGENTS.md/CONTRIBUTING.md: no
third-party deps, prefer minimal WebView changes, @MainActor on observable
types, Swift Testing for new tests, update the localization catalog plus all
.lproj mirrors together, add an ADR for the design decision, and pass
swift build / swift test --skip KasetUITests / swiftlint --strict / swiftformat.
Verify the fix against the real accounts.google.com page, not just by reasoning.
```

**AI Tool:** Claude Code

</details>

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #291

## Changes Made

- Add `LoginPasskeySuppression` (`Sources/Kaset/Services/WebKit/`), a document-start / all-frames `WKUserScript` that hides WebAuthn from Google sign-in pages.
- Attach it in `WebKitManager.createSessionSwitchWebViewConfiguration()` (login sheet + account-switch only).
- Update the login sheet caption to describe the actual behavior, localized across all 17 locales.
- Add `LoginPasskeySuppressionTests` (functional WKWebView checks: WebAuthn is exposed in a plain WebView, hidden in the suppressed config, and `publicKey` requests reject with `NotAllowedError`) and a `WebKitManagerTests` guard.
- Add `docs/adr/0033-login-passkey-suppression.md` and its index row.

## Testing

- [x] Unit tests pass (`swift test --skip KasetUITests` — 2986 tests, incl. `LocalizationCatalogParityTests`)
- [x] Manual testing performed
- [x] UI tested on macOS 26+

Verified against the **real** `accounts.google.com` login URL in a `WKWebView` using the shipped script: `typeof PublicKeyCredential` is `"undefined"` (vs `"function"` without the script), the sign-in page renders normally with the email field, and a `publicKey` `get()` rejects with the shim's `NotAllowedError`. `swift build`, the full unit suite, `swiftformat --lint`, and `swiftlint --strict` on the changed files are all clean. The packaged app (`Scripts/compile_and_run.sh`) launches and runs.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `swiftlint --strict && swiftformat .`
- [x] I have added tests that prove my fix works
- [x] New and existing unit tests pass locally
- [x] I have updated documentation if needed (ADR-0033)
- [x] I have checked for any performance implications
- [x] My changes generate no new warnings

## Additional Notes

Heads-up unrelated to this change: the SwiftLint CI job runs an unpinned `brew install swiftlint`, and the current 0.65.1 enables `legacy_swiftui_aspect_ratio` by default, which turns ~42 pre-existing `aspectRatio(contentMode:)` call sites (all in files this PR does not touch, present on `main`) into `--strict` errors. That gate may go red for reasons independent of this PR; happy to send a separate change (disable the rule or migrate the call sites) if useful.
