### PR TITLE
fix(playback): bound WebKit memory growth

### DIFF
--- a/Sources/Kaset/Services/Player/PlayerService+Library.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+Library.swift
@@ -166,6 +166,13 @@ extension PlayerService {
 
         // Use API call for reliable library management
         Task {
+            defer {
+                self.finishLibraryMutationTracking(
+                    key: mutationKey,
+                    pendingMutationKey: pendingMutationKey,
+                    mutationRevision: mutationRevision
+                )
+            }
             do {
                 try await request.value.get()
                 guard self.accountSessionGeneration == accountSessionGeneration else { return }
@@ -296,6 +303,22 @@ extension PlayerService {
         } else {
             self.pendingLibraryMutationCountsByKey[key] = count - 1
         }
+    }
+
+    private func finishLibraryMutationTracking(
+        key: String,
+        pendingMutationKey: String,
+        mutationRevision: UInt64
+    ) {
+        // Requests for one track are serialized through libraryMutationTails. Each
+        // request decrements the pending count before its awaiting wrapper resumes,
+        // so the latest wrapper is the only completion that can satisfy both checks.
+        guard self.libraryMutationRevisions[key] == mutationRevision,
+              self.pendingLibraryMutationCountsByKey[pendingMutationKey] == nil
+        else { return }
+
+        self.libraryMutationRevisions.removeValue(forKey: key)
+        self.confirmedLibraryStateByKey.removeValue(forKey: key)
     }
 
     private func isCurrentLibraryMutation(key: String, revision: UInt64) -> Bool {
@@ -493,10 +516,12 @@ extension PlayerService {
                     )
                     if updatesConfirmedLibraryState {
                         let key = activeAccountID + "\u{0}" + videoId
-                        self.confirmedLibraryStateByKey[key] = MusicLibraryConfirmedState(
-                            isInLibrary: self.currentTrackInLibrary,
-                            feedbackTokens: self.currentTrackFeedbackTokens
-                        )
+                        if self.confirmedLibraryStateByKey[key] != nil {
+                            self.confirmedLibraryStateByKey[key] = MusicLibraryConfirmedState(
+                                isInLibrary: self.currentTrackInLibrary,
+                                feedbackTokens: self.currentTrackFeedbackTokens
+                            )
+                        }
                     }
                 }
 

--- a/Sources/Kaset/Services/Player/WebPlaybackDocumentGeneration.swift
+++ b/Sources/Kaset/Services/Player/WebPlaybackDocumentGeneration.swift
@@ -444,6 +444,10 @@ struct WebPlaybackDocumentGeneration: Equatable {
         return literal
     }
 
+    static func locationReplacementScript(for url: URL) -> String {
+        "window.location.replace(\(self.javaScriptStringLiteral(url.absoluteString)));"
+    }
+
     static func isFragmentOnlyNavigation(from currentURL: URL?, to proposedURL: URL?) -> Bool {
         guard var current = currentURL.flatMap({
             URLComponents(url: $0, resolvingAgainstBaseURL: false)

--- a/Sources/Kaset/Services/WebKit/WebExtensionHost.swift
+++ b/Sources/Kaset/Services/WebKit/WebExtensionHost.swift
@@ -104,19 +104,32 @@ enum WebExtensionHostedWebViewRole: String {
             self.activate(tab)
         }
 
-        func deactivate(role: WebExtensionHostedWebViewRole) {
-            guard let tab = self.tabsByRole[role], self.activeTab === tab else { return }
+        func unregister(role: WebExtensionHostedWebViewRole) {
+            guard let tab = self.tabsByRole.removeValue(forKey: role) else { return }
 
-            let fallbackTab = self.window.firstTab(excluding: tab)
-            self.activeTab = nil
-            self.window.activeTab = nil
-            self.controller.didDeselectTabs([tab])
-
-            if let fallbackTab {
-                self.activate(fallbackTab)
-            } else {
-                self.controller.didFocusWindow(self.window)
+            let wasActive = self.activeTab === tab
+            if wasActive {
+                self.activeTab = nil
+                self.window.activeTab = nil
+                self.controller.didDeselectTabs([tab])
             }
+            let windowWillClose = self.tabsByRole.isEmpty
+            self.tabsByWebViewID = self.tabsByWebViewID.filter { $0.value !== tab }
+            self.window.remove(tab)
+            self.controller.didCloseTab(tab, windowIsClosing: windowWillClose)
+            tab.pendingNavigationURL = nil
+            tab.webView = nil
+            tab.window = nil
+
+            if windowWillClose {
+                self.controller.didCloseWindow(self.window)
+                self.controller.didFocusWindow(nil)
+                self.didOpenWindow = false
+            } else if wasActive, let fallbackTab = self.window.firstTab(excluding: tab) {
+                self.activate(fallbackTab)
+            }
+
+            self.logger.info("Unregistered WebExtension tab for \(role.rawValue)")
         }
 
         func noteNavigationFinished(for webView: WKWebView) {
@@ -227,6 +240,13 @@ enum WebExtensionHostedWebViewRole: String {
             self.tabs.append(tab)
             if self.activeTab == nil {
                 self.activeTab = tab
+            }
+        }
+
+        func remove(_ tab: KasetWebExtensionTab) {
+            self.tabs.removeAll { $0 === tab }
+            if self.activeTab === tab {
+                self.activeTab = nil
             }
         }
 

--- a/Sources/Kaset/Services/WebKit/WebKitManager.swift
+++ b/Sources/Kaset/Services/WebKit/WebKitManager.swift
@@ -309,10 +309,10 @@ final class WebKitManager: NSObject, WebKitManagerProtocol {
         #endif
     }
 
-    func extensionHostWebViewDidDeactivate(role: WebExtensionHostedWebViewRole) {
+    func unregisterExtensionHostWebView(role: WebExtensionHostedWebViewRole) {
         #if compiler(>=5.9)
             if #available(macOS 15.4, *) {
-                self.webExtensionHost.deactivate(role: role)
+                self.webExtensionHost.unregister(role: role)
             }
         #endif
     }

--- a/Sources/Kaset/Views/MiniPlayerWebView.swift
+++ b/Sources/Kaset/Views/MiniPlayerWebView.swift
@@ -224,6 +224,11 @@ struct MiniPlayerWebView: NSViewRepresentable {
 final class SingletonPlayerWebView {
     static let shared = SingletonPlayerWebView()
 
+    /// Creates an isolated wrapper for tests that exercise WebView lifecycle state.
+    static func makeTestInstance() -> SingletonPlayerWebView {
+        SingletonPlayerWebView()
+    }
+
     private(set) var webView: WKWebView?
     weak var webKitManager: WebKitManager?
     private weak var currentContainer: NSView?

--- a/Sources/Kaset/Views/MiniPlayerWebView.swift
+++ b/Sources/Kaset/Views/MiniPlayerWebView.swift
@@ -411,8 +411,12 @@ final class SingletonPlayerWebView {
         if let blankURL {
             webView.load(URLRequest(url: blankURL))
         }
+        webView.configuration.userContentController.removeScriptMessageHandler(
+            forName: "singletonPlayer"
+        )
+        webView.navigationDelegate = nil
         webView.removeFromSuperview()
-        self.webKitManager?.extensionHostWebViewDidDeactivate(role: .musicPlayer)
+        self.webKitManager?.unregisterExtensionHostWebView(role: .musicPlayer)
         self.webView = nil
         self.coordinator = nil
         self.cancelledDocumentNavigations.removeAll()
@@ -950,6 +954,28 @@ extension SingletonPlayerWebView {
             return
         }
         guard self.documentGeneration.startNavigation(generation) else { return }
+        if WebPlaybackDocumentGeneration.isExpectedPlaybackURL(
+            webView.url,
+            host: "music.youtube.com"
+        ), let url = request.url {
+            webView.evaluateJavaScript(
+                WebPlaybackDocumentGeneration.locationReplacementScript(for: url)
+            ) { [weak self, weak webView] _, error in
+                guard let self,
+                      let webView,
+                      webView === self.webView,
+                      self.documentGeneration.inFlightGeneration == generation,
+                      self.documentGeneration.pendingGeneration == nil
+                else { return }
+                guard error == nil
+                    || WebPlaybackDocumentGeneration.generation(from: webView.url) == generation
+                else {
+                    self.handleCurrentDocumentNavigationFailure(generation, webView: webView)
+                    return
+                }
+            }
+            return
+        }
         guard let navigation = webView.load(request) else {
             self.handleCurrentDocumentNavigationFailure(generation, webView: webView)
             return

--- a/Sources/Kaset/Views/YouTube/YouTubeWatchWebView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeWatchWebView.swift
@@ -311,8 +311,12 @@ final class YouTubeWatchWebView {
         if let blankURL {
             webView.load(URLRequest(url: blankURL))
         }
+        webView.configuration.userContentController.removeScriptMessageHandler(
+            forName: "youtubePlayer"
+        )
+        webView.navigationDelegate = nil
         webView.removeFromSuperview()
-        self.webKitManager?.extensionHostWebViewDidDeactivate(role: .youtubeWatch)
+        self.webKitManager?.unregisterExtensionHostWebView(role: .youtubeWatch)
         self.webView = nil
         self.coordinator = nil
         self.currentContainer = nil
@@ -383,6 +387,32 @@ extension YouTubeWatchWebView {
         }
         guard self.documentGeneration.startNavigation(generation) else {
             self.logger.debug("YouTube load superseded before navigation; skipping stale \(url.absoluteString)")
+            return
+        }
+        if WebPlaybackDocumentGeneration.isExpectedPlaybackURL(
+            webView.url,
+            host: "www.youtube.com"
+        ) {
+            webView.evaluateJavaScript(
+                WebPlaybackDocumentGeneration.locationReplacementScript(for: url)
+            ) { [weak self, weak webView] _, error in
+                guard let self,
+                      let webView,
+                      webView === self.webView,
+                      self.documentGeneration.inFlightGeneration == generation,
+                      self.documentGeneration.pendingGeneration == nil
+                else { return }
+                guard error == nil
+                    || WebPlaybackDocumentGeneration.generation(from: webView.url) == generation
+                else {
+                    self.handleCurrentDocumentNavigationFailure(
+                        generation,
+                        webView: webView,
+                        resumeAtOverride: pendingSeek
+                    )
+                    return
+                }
+            }
             return
         }
         guard let navigation = webView.load(request) else {

--- a/Sources/Kaset/Views/YouTube/YouTubeWatchWebView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeWatchWebView.swift
@@ -18,6 +18,11 @@ import WebKit
 final class YouTubeWatchWebView {
     static let shared = YouTubeWatchWebView()
 
+    /// Creates an isolated wrapper for tests that exercise WebView lifecycle state.
+    static func makeTestInstance() -> YouTubeWatchWebView {
+        YouTubeWatchWebView()
+    }
+
     private(set) var webView: WKWebView?
     weak var webKitManager: WebKitManager?
     private weak var currentContainer: NSView?

--- a/Tests/KasetTests/PlaybackWebViewTeardownTests.swift
+++ b/Tests/KasetTests/PlaybackWebViewTeardownTests.swift
@@ -1,0 +1,73 @@
+import Testing
+import WebKit
+@testable import Kaset
+
+@Suite("Playback WebView teardown", .serialized, .tags(.service))
+@MainActor
+struct PlaybackWebViewTeardownTests {
+    @Test("Music teardown releases its coordinator while the WebView remains retained")
+    func musicTeardownReleasesCoordinator() {
+        let singleton = SingletonPlayerWebView.shared
+        singleton.tearDown()
+
+        let webKitManager = WebKitManager.makeTestInstance()
+        let playerService = PlayerService()
+        let retainedWebView = singleton.getWebView(
+            webKitManager: webKitManager,
+            playerService: playerService
+        )
+        weak let coordinator = singleton.coordinator
+
+        #expect(coordinator != nil)
+        singleton.tearDown()
+
+        #expect(retainedWebView.navigationDelegate == nil)
+        #expect(coordinator == nil)
+    }
+
+    @Test("YouTube teardown releases its coordinator while the WebView remains retained")
+    func youtubeTeardownReleasesCoordinator() {
+        let singleton = YouTubeWatchWebView.shared
+        singleton.tearDown()
+
+        let webKitManager = WebKitManager.makeTestInstance()
+        let playerService = YouTubePlayerService(webKitManager: webKitManager)
+        let retainedWebView = singleton.getWebView(
+            webKitManager: webKitManager,
+            playerService: playerService
+        )
+        weak let coordinator = singleton.coordinator
+
+        #expect(coordinator != nil)
+        singleton.tearDown()
+
+        #expect(retainedWebView.navigationDelegate == nil)
+        #expect(coordinator == nil)
+    }
+
+    @Test("Extension host unregister closes its tab and window")
+    func extensionHostUnregisterClosesTabAndWindow() {
+        #if compiler(>=5.9)
+            if #available(macOS 15.4, *) {
+                let controller = WKWebExtensionController()
+                let host = KasetWebExtensionHost(controller: controller)
+                let configuration = WKWebViewConfiguration()
+                configuration.websiteDataStore = .nonPersistent()
+                configuration.webExtensionController = controller
+                let webView = WKWebView(
+                    frame: CGRect(x: 0, y: 0, width: 320, height: 180),
+                    configuration: configuration
+                )
+                let tab = host.register(webView: webView, role: .musicPlayer)
+
+                host.unregister(role: .musicPlayer)
+
+                #expect(host.registeredTabCount == 0)
+                #expect(host.openWindows.isEmpty)
+                #expect(host.focusedWindow == nil)
+                #expect(tab?.webView == nil)
+                #expect(tab?.window == nil)
+            }
+        #endif
+    }
+}

--- a/Tests/KasetTests/PlaybackWebViewTeardownTests.swift
+++ b/Tests/KasetTests/PlaybackWebViewTeardownTests.swift
@@ -7,8 +7,7 @@ import WebKit
 struct PlaybackWebViewTeardownTests {
     @Test("Music teardown releases its coordinator while the WebView remains retained")
     func musicTeardownReleasesCoordinator() {
-        let singleton = SingletonPlayerWebView.shared
-        singleton.tearDown()
+        let singleton = SingletonPlayerWebView.makeTestInstance()
 
         let webKitManager = WebKitManager.makeTestInstance()
         let playerService = PlayerService()
@@ -27,8 +26,7 @@ struct PlaybackWebViewTeardownTests {
 
     @Test("YouTube teardown releases its coordinator while the WebView remains retained")
     func youtubeTeardownReleasesCoordinator() {
-        let singleton = YouTubeWatchWebView.shared
-        singleton.tearDown()
+        let singleton = YouTubeWatchWebView.makeTestInstance()
 
         let webKitManager = WebKitManager.makeTestInstance()
         let playerService = YouTubePlayerService(webKitManager: webKitManager)

--- a/Tests/KasetTests/PlayerServiceLibraryTests.swift
+++ b/Tests/KasetTests/PlayerServiceLibraryTests.swift
@@ -584,6 +584,9 @@ struct PlayerServiceLibraryTests { // swiftlint:disable:this type_body_length
         let didFinish = await self.waitUntil {
             self.mockClient.editSongLibraryStatusTokens.count == 2
                 && self.playerService.libraryMutationTails[mutationKey] == nil
+                && self.playerService.libraryMutationRevisions[mutationKey] == nil
+                && self.playerService.confirmedLibraryStateByKey[mutationKey] == nil
+                && self.playerService.pendingLibraryMutationCountsByKey.isEmpty
                 && !self.playerService.currentTrackInLibrary
         }
 
@@ -591,6 +594,9 @@ struct PlayerServiceLibraryTests { // swiftlint:disable:this type_body_length
         #expect(!self.playerService.currentTrackInLibrary)
         #expect(self.playerService.currentTrack?.isInLibrary == false)
         #expect(self.mockClient.editSongLibraryStatusTokens.count == 2)
+        #expect(self.playerService.libraryMutationRevisions[mutationKey] == nil)
+        #expect(self.playerService.confirmedLibraryStateByKey[mutationKey] == nil)
+        #expect(self.playerService.pendingLibraryMutationCountsByKey.isEmpty)
     }
 
     @Test("Overlapping failed library toggles restore the confirmed baseline")
@@ -762,8 +768,8 @@ struct PlayerServiceLibraryTests { // swiftlint:disable:this type_body_length
         #expect(self.playerService.queue[0].feedbackTokens == originalTokens)
     }
 
-    @Test("Successful library refresh preserves server tokens and rollback baseline")
-    func successfulLibraryRefreshPreservesServerTokensAndRollbackBaseline() async {
+    @Test("Successful library refresh preserves server tokens for later rollback")
+    func successfulLibraryRefreshPreservesServerTokensForLaterRollback() async {
         let song = Song(
             id: "rotated-library-token",
             title: "Rotated Library Token",
@@ -802,10 +808,11 @@ struct PlayerServiceLibraryTests { // swiftlint:disable:this type_body_length
         #expect(self.playerService.currentTrackFeedbackTokens == serverTokens)
         #expect(self.playerService.currentTrack?.feedbackTokens == serverTokens)
         #expect(self.playerService.queue[0].feedbackTokens == serverTokens)
-        #expect(self.playerService.confirmedLibraryStateByKey[mutationKey] == MusicLibraryConfirmedState(
-            isInLibrary: true,
-            feedbackTokens: serverTokens
-        ))
+        let didReleaseTracking = await self.waitUntil {
+            self.playerService.confirmedLibraryStateByKey[mutationKey] == nil
+                && self.playerService.libraryMutationRevisions[mutationKey] == nil
+        }
+        #expect(didReleaseTracking)
 
         self.mockClient.beforeGetSongReturn = nil
         self.mockClient.shouldThrowError = YTMusicError.networkError(
@@ -822,6 +829,171 @@ struct PlayerServiceLibraryTests { // swiftlint:disable:this type_body_length
         #expect(self.playerService.currentTrackInLibrary)
         #expect(self.playerService.currentTrackFeedbackTokens == serverTokens)
         #expect(self.playerService.queue[0].feedbackTokens == serverTokens)
+        #expect(self.playerService.confirmedLibraryStateByKey[mutationKey] == nil)
+        #expect(self.playerService.libraryMutationRevisions[mutationKey] == nil)
+    }
+
+    @Test("Metadata fetches do not retain per-track library mutation state")
+    func metadataFetchesDoNotRetainLibraryMutationState() async {
+        for index in 0 ..< 20 {
+            let videoId = "metadata-only-\(index)"
+            let song = Song(
+                id: videoId,
+                title: "Metadata only \(index)",
+                artists: [Artist(id: "artist", name: "Artist")],
+                videoId: videoId,
+                isInLibrary: index.isMultiple(of: 2),
+                feedbackTokens: FeedbackTokens(
+                    add: "add-\(index)",
+                    remove: "remove-\(index)"
+                )
+            )
+            self.playerService.currentTrack = song
+            self.mockClient.songResponses[videoId] = song
+
+            await self.playerService.fetchSongMetadata(videoId: videoId)
+        }
+
+        #expect(self.playerService.confirmedLibraryStateByKey.isEmpty)
+        #expect(self.playerService.libraryMutationRevisions.isEmpty)
+        #expect(self.playerService.pendingLibraryMutationCountsByKey.isEmpty)
+    }
+
+    @Test("Metadata started before a completed library mutation stays stale after cleanup")
+    func metadataStartedBeforeLibraryMutationStaysStaleAfterCleanup() async {
+        let originalTokens = FeedbackTokens(add: "old-add", remove: "old-remove")
+        let staleTokens = FeedbackTokens(add: "stale-add", remove: "stale-remove")
+        let song = Song(
+            id: "pre-mutation-metadata",
+            title: "Pre-Mutation Metadata",
+            artists: [Artist(id: "artist", name: "Artist")],
+            videoId: "pre-mutation-metadata",
+            isInLibrary: false,
+            feedbackTokens: originalTokens
+        )
+        let entryID = UUID()
+        self.playerService.setQueue(entries: [QueueEntry(id: entryID, song: song)])
+        self.playerService.activePlaybackQueueEntryID = entryID
+        self.playerService.currentTrack = song
+        self.playerService.currentTrackInLibrary = false
+        self.playerService.currentTrackFeedbackTokens = originalTokens
+        self.mockClient.songResponses[song.videoId] = Song(
+            id: song.id,
+            title: song.title,
+            artists: song.artists,
+            videoId: song.videoId,
+            isInLibrary: false,
+            feedbackTokens: staleTokens
+        )
+        let metadataStarted = AsyncGate()
+        let releaseMetadata = AsyncGate()
+        self.mockClient.beforeGetSongReturn = { _ in
+            await metadataStarted.open()
+            await releaseMetadata.wait()
+        }
+
+        let metadataTask = Task { @MainActor in
+            await self.playerService.fetchSongMetadata(videoId: song.videoId)
+        }
+        await metadataStarted.wait()
+        self.mockClient.beforeGetSongReturn = nil
+
+        self.playerService.toggleLibraryStatus()
+        let mutationKey = self.playerService.songLikeStatusManager.activeAccountID
+            + "\u{0}" + song.videoId
+        let mutationFinished = await self.waitUntil {
+            self.mockClient.editSongLibraryStatusTokens.count == 1
+                && self.playerService.libraryMutationRevisions[mutationKey] == nil
+                && self.playerService.confirmedLibraryStateByKey[mutationKey] == nil
+                && self.playerService.pendingLibraryMutationCountsByKey.isEmpty
+                && self.playerService.currentTrackInLibrary
+        }
+        #expect(mutationFinished)
+
+        await releaseMetadata.open()
+        await metadataTask.value
+
+        #expect(self.playerService.currentTrackInLibrary)
+        #expect(self.playerService.currentTrack?.isInLibrary == true)
+        #expect(self.playerService.currentTrackFeedbackTokens == originalTokens)
+        #expect(self.playerService.queue[0].isInLibrary == true)
+        #expect(self.playerService.queue[0].feedbackTokens == originalTokens)
+        #expect(self.playerService.libraryMutationRevisions[mutationKey] == nil)
+        #expect(self.playerService.confirmedLibraryStateByKey[mutationKey] == nil)
+    }
+
+    @Test("Metadata started before rapid library toggles stays stale after cleanup")
+    func metadataStartedBeforeRapidLibraryTogglesStaysStaleAfterCleanup() async {
+        let oldPair = FeedbackTokens(add: "old-add", remove: "old-remove")
+        let badPair = FeedbackTokens(add: "stale-add", remove: "stale-remove")
+        let newPair = FeedbackTokens(add: "final-add", remove: "final-remove")
+        let song = Song(
+            id: "pre-rapid-mutation-metadata",
+            title: "Pre-Rapid-Mutation Metadata",
+            artists: [Artist(id: "artist", name: "Artist")],
+            videoId: "pre-rapid-mutation-metadata",
+            isInLibrary: false,
+            feedbackTokens: oldPair
+        )
+        let entryID = UUID()
+        self.playerService.setQueue(entries: [QueueEntry(id: entryID, song: song)])
+        self.playerService.activePlaybackQueueEntryID = entryID
+        self.playerService.currentTrack = song
+        self.playerService.currentTrackInLibrary = false
+        self.playerService.currentTrackFeedbackTokens = oldPair
+        self.mockClient.songResponses[song.videoId] = Song(
+            id: song.id,
+            title: song.title,
+            artists: song.artists,
+            videoId: song.videoId,
+            isInLibrary: false,
+            feedbackTokens: newPair
+        )
+        let metadataStarted = AsyncGate()
+        let releaseMetadata = AsyncGate()
+        self.mockClient.beforeGetSongReturn = { _ in
+            await metadataStarted.open()
+            await releaseMetadata.wait()
+        }
+
+        let metadataTask = Task { @MainActor in
+            await self.playerService.fetchSongMetadata(videoId: song.videoId)
+        }
+        await metadataStarted.wait()
+        self.mockClient.beforeGetSongReturn = nil
+
+        self.playerService.toggleLibraryStatus()
+        self.playerService.toggleLibraryStatus()
+        let mutationKey = self.playerService.songLikeStatusManager.activeAccountID
+            + "\u{0}" + song.videoId
+        let mutationsFinished = await self.waitUntil {
+            self.mockClient.editSongLibraryStatusTokens.count == 2
+                && self.playerService.libraryMutationRevisions[mutationKey] == nil
+                && self.playerService.confirmedLibraryStateByKey[mutationKey] == nil
+                && self.playerService.pendingLibraryMutationCountsByKey.isEmpty
+                && !self.playerService.currentTrackInLibrary
+                && self.playerService.currentTrackFeedbackTokens == newPair
+        }
+        #expect(mutationsFinished)
+
+        self.mockClient.songResponses[song.videoId] = Song(
+            id: song.id,
+            title: song.title,
+            artists: song.artists,
+            videoId: song.videoId,
+            isInLibrary: false,
+            feedbackTokens: badPair
+        )
+        await releaseMetadata.open()
+        await metadataTask.value
+
+        #expect(!self.playerService.currentTrackInLibrary)
+        #expect(self.playerService.currentTrack?.isInLibrary == false)
+        #expect(self.playerService.currentTrackFeedbackTokens == newPair)
+        #expect(self.playerService.queue[0].isInLibrary == false)
+        #expect(self.playerService.queue[0].feedbackTokens == newPair)
+        #expect(self.playerService.libraryMutationRevisions[mutationKey] == nil)
+        #expect(self.playerService.confirmedLibraryStateByKey[mutationKey] == nil)
     }
 
     @Test("toggleLibraryStatus preserves optimistic add when metadata refresh is stale")

--- a/Tests/KasetTests/WebPlaybackDocumentGenerationTests.swift
+++ b/Tests/KasetTests/WebPlaybackDocumentGenerationTests.swift
@@ -14,6 +14,25 @@ struct WebPlaybackDocumentGenerationTests {
         #expect(WebPlaybackDocumentGeneration.javaScriptStringLiteral(nil) == "null")
     }
 
+    @Test("Location replacement serializes the destination as one JavaScript string")
+    func locationReplacementScriptEscapesDestination() throws {
+        let url = try #require(URL(string: "https://music.youtube.com/watch?v=x%27%29%3Balert%281%29"))
+        let script = WebPlaybackDocumentGeneration.locationReplacementScript(for: url)
+        let prefix = "window.location.replace("
+
+        #expect(script.hasPrefix(prefix))
+        #expect(script.hasSuffix(");"))
+        let literalStart = script.index(script.startIndex, offsetBy: prefix.count)
+        let literalEnd = script.index(script.endIndex, offsetBy: -2)
+        let literal = String(script[literalStart ..< literalEnd])
+        let decoded = try JSONSerialization.jsonObject(
+            with: Data(literal.utf8),
+            options: .fragmentsAllowed
+        ) as? String
+        #expect(decoded == url.absoluteString)
+        #expect(!script.contains("replaceState"))
+    }
+
     @Test("Suppression script keeps an invalidated document from restarting media")
     func mediaSuppressionScriptIsPersistent() {
         let script = WebPlaybackDocumentGeneration.mediaSuppressionScript

--- a/docs/adr/0034-replace-playback-navigation.md
+++ b/docs/adr/0034-replace-playback-navigation.md
@@ -1,0 +1,61 @@
+# ADR-0034: Replace Playback Documents Without Growing History
+
+## Status
+
+Accepted
+
+## Context
+
+Kaset plays DRM-protected music and video in persistent `WKWebView` instances.
+Each track change previously called `WKWebView.load`, which added another full
+YouTube watch document to WebKit's navigation history. WebKit retained a large
+amount of page and media state across those navigations even when the current
+document had only one video element and one set of Kaset observers.
+
+A packaged no-extension run reproduced the problem. Repeated music track
+changes grew the WebContent process rapidly while Kaset's own process and live
+DOM stayed nearly flat. Recreating the WebView was worse: WebKit cached one old
+high-water WebContent process while starting a new one, increasing total memory.
+
+## Decision
+
+1. Use `WKWebView.load` for the first playback document and for explicit
+   continuation or recovery loads.
+2. When a committed playback document already exists, navigate with
+   `window.location.replace`. This destroys the outgoing document without
+   adding another back-forward-list entry.
+3. Keep the existing document-generation, response, host, and video-ID checks
+   around the JavaScript-initiated navigation. Delegate callbacks promote only
+   the generation encoded in the requested playback URL.
+4. On teardown, remove script message handlers and navigation delegates, and
+   close the matching WebExtension tab before releasing the WebView.
+
+## Consequences
+
+- In a packaged run with zero extensions loaded, 16 legacy track loads grew the
+  back-forward list from 0 to 15. Replacement navigation kept it at 0. Every
+  requested document committed, and the live YouTube player matched the native
+  track after each change.
+- A separate 10-minute no-extension playback run included one natural track
+  transition. Kaset remained near 190–214 MB RSS. WebContent finished at a
+  351 MB physical footprint with a 521 MB peak, and the GPU process finished at
+  30 MB with a 40 MB peak. Raw WebContent RSS reached about 623 MB because
+  WebKit retained reclaimable allocator pages.
+- Kaset has no user-facing WebView back navigation, so replacing the current
+  history entry removes no product behavior.
+- Replacing the visible URL with `history.replaceState` and then calling
+  `WKWebView.reload` was rejected. Runtime instrumentation showed that WebKit
+  reloaded the old player while displaying the new URL, leaving the new native
+  document generation uncommitted.
+- A controlled extension-enabled A/B used uBlock Origin Lite for Safari
+  2026.825.1619 in its default Optimal mode and the same 17-track sequence.
+  The legacy build's WebContent physical-footprint peak was 851 MB; replacement
+  navigation reduced it to 516 MB. The sampled aggregate peak fell from 855 MB
+  to 476 MB, and the settled single-process footprint fell from 391 MB to
+  346 MB.
+- The uBlock A/B did not reproduce the reported 1.4 GB GPU spike. GPU physical
+  footprint peaked at 42 MB in the legacy build and 41 MB in the patched build.
+  A separate 15-minute patched run with uBlock peaked at 40 MB GPU and 433 MB
+  WebContent while completing three track replacements. This validates the
+  Kaset-side WebContent fix, but not the reporter's GPU-specific symptom on
+  macOS 26; the local run used a newer WebKit build.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -68,3 +68,4 @@ What becomes easier or more difficult because of this change?
 | [0031](0031-saved-album-library-reconciliation.md) | Saved-Album Library Identity and Reconciliation | Accepted |
 | [0032](0032-youtube-ask-gemini.md) | Watch-Scoped YouTube Ask Gemini | Accepted; fixed WEB profile enabled in production |
 | [0033](0033-login-passkey-suppression.md) | Suppress Passkey Detection in the Login WebView | Accepted |
+| [0034](0034-replace-playback-navigation.md) | Replace Playback Documents Without Growing History | Accepted |

--- a/docs/playback.md
+++ b/docs/playback.md
@@ -126,7 +126,8 @@ When user plays a different track:
 1. `pendingPlayVideoId` changes
 2. SwiftUI calls `updateNSView` (not `makeNSView`)
 3. `SingletonPlayerWebView.loadVideo(videoId:)` called
-4. Current audio paused, target volume prepared, new URL loaded
+4. Current audio is suppressed and the target volume is prepared
+5. The first watch URL uses `WKWebView.load`; later tracks navigate with `window.location.replace`
 
 ```swift
 func loadVideo(videoId: String) {
@@ -135,13 +136,25 @@ func loadVideo(videoId: String) {
     // Update ID immediately to prevent duplicate loads
     currentVideoId = videoId
 
-    // Pause current, set the target volume, then load new
-    webView.evaluateJavaScript("document.querySelector('video')?.pause()") { _, _ in
-        webView.evaluateJavaScript("window.__kasetTargetVolume = currentVolume")
-        self.webView?.load(URLRequest(url: watchURL))
+    // Suppress the outgoing document, then replace its history entry.
+    webView.evaluateJavaScript(WebPlaybackDocumentGeneration.mediaSuppressionScript)
+    if WebPlaybackDocumentGeneration.isExpectedPlaybackURL(
+        webView.url,
+        host: "music.youtube.com"
+    ) {
+        webView.evaluateJavaScript(
+            WebPlaybackDocumentGeneration.locationReplacementScript(for: watchURL)
+        )
+    } else {
+        webView.load(URLRequest(url: watchURL))
     }
 }
 ```
+
+Replacement navigation prevents old YouTube watch pages from accumulating in
+WebKit's back-forward/page cache. See
+[ADR-0034](adr/0034-replace-playback-navigation.md) for the measurement and
+tradeoff record.
 
 When the WebView reports a new `videoId`, Kaset treats that as authoritative
 even if the DOM title/artist are still stale. This avoids a race where YouTube


### PR DESCRIPTION
## Summary

- replace repeated playback document loads with `window.location.replace` after the first committed watch page, keeping WebKit's back-forward list bounded
- remove playback script handlers and fully unregister WebExtension tabs during WebView teardown
- release completed per-track library mutation bookkeeping without weakening stale metadata protection
- record the runtime measurements and navigation tradeoffs in ADR-0034

## Measured result

A packaged 17-track A/B without extensions grew the legacy back-forward list from 0 to 15. The patched build stayed at 0 while every requested document committed.

With uBlock Origin Lite for Safari 2026.825.1619 in Optimal mode and the same track sequence:

- WebContent physical-footprint peak: 851 MB to 516 MB
- sampled aggregate peak: 855 MB to 476 MB
- settled single-process footprint: 391 MB to 346 MB

A separate 15-minute patched uBlock run peaked at 40 MB GPU and 433 MB WebContent while completing three replacement navigations. The local WebKit build did not reproduce the reporter's 1.4 GB GPU spike, so this fixes the Kaset-side WebContent growth without claiming that GPU-specific symptom is fully explained.

## Verification

- 82 focused tests passed across playback navigation, WebView teardown, and library mutation state
- the exact pre-mutation metadata plus rapid add/remove race passed
- the library-adjacent test that failed during the full concurrent run passed in isolation
- SwiftFormat and scoped strict SwiftLint passed
- final autoreview reported no accepted or actionable findings

The full concurrent non-UI suite ran 2,935 tests but reported 47 timing-sensitive issues in suites outside the changed code paths. The touched `PlayerServiceLibraryTests` suite passed.

Addresses #456
