### PR TITLE
fix(player): restore volume slider interaction

### DIFF
--- a/Sources/Kaset/Services/Player/PlayerService+PlaybackControls.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+PlaybackControls.swift
@@ -795,7 +795,7 @@ extension PlayerService {
         let clampedValue = self.storeVolumeValue(value)
 
         if self.pendingPlayVideoId != nil {
-            SingletonPlayerWebView.shared.setVolume(clampedValue)
+            self.applyMusicPlaybackVolume(clampedValue)
         } else {
             await self.evaluatePlayerCommand("setVolume(\(Int(clampedValue * 100)))")
         }
@@ -809,7 +809,7 @@ extension PlayerService {
         let playbackVolume = self.pendingPlayVideoId == nil
             ? Double(Int(clampedValue * 100)) / 100
             : clampedValue
-        SingletonPlayerWebView.shared.setVolume(playbackVolume)
+        self.applyMusicPlaybackVolume(playbackVolume)
     }
 
     private func storeVolumeValue(_ value: Double) -> Double {

--- a/Sources/Kaset/Services/Player/PlayerService+PlaybackControls.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+PlaybackControls.swift
@@ -792,15 +792,31 @@ extension PlayerService {
 
     /// Sets the volume.
     func setVolume(_ value: Double) async {
-        let clampedValue = max(0, min(1, value))
-        self.volume = clampedValue
-        UserDefaults.standard.set(clampedValue, forKey: Self.volumeKey)
+        let clampedValue = self.storeVolumeValue(value)
 
         if self.pendingPlayVideoId != nil {
             SingletonPlayerWebView.shared.setVolume(clampedValue)
         } else {
             await self.evaluatePlayerCommand("setVolume(\(Int(clampedValue * 100)))")
         }
+    }
+
+    /// Sets volume state and dispatches the playback command before returning.
+    /// Interactive controls use this path so rapid updates retain event order.
+    func setVolumeImmediately(_ value: Double) {
+        let clampedValue = self.storeVolumeValue(value)
+
+        let playbackVolume = self.pendingPlayVideoId == nil
+            ? Double(Int(clampedValue * 100)) / 100
+            : clampedValue
+        SingletonPlayerWebView.shared.setVolume(playbackVolume)
+    }
+
+    private func storeVolumeValue(_ value: Double) -> Double {
+        let clampedValue = max(0, min(1, value))
+        self.volume = clampedValue
+        UserDefaults.standard.set(clampedValue, forKey: Self.volumeKey)
+        return clampedValue
     }
 
     /// Toggles mute state. Remembers previous volume for unmuting.

--- a/Sources/Kaset/Services/Player/PlayerService.swift
+++ b/Sources/Kaset/Services/Player/PlayerService.swift
@@ -18,6 +18,10 @@ final class PlayerService: NSObject, PlayerServiceProtocol {
         await SingletonPlayerWebView.shared.currentPlaybackSnapshot()
     }
 
+    @ObservationIgnored var applyMusicPlaybackVolume: @MainActor (Double) -> Void = {
+        SingletonPlayerWebView.shared.setVolume($0)
+    }
+
     @ObservationIgnored var smartShuffleFeatureEnabled: @MainActor () -> Bool = {
         SettingsManager.shared.smartShuffleEnabled
     }

--- a/Sources/Kaset/Views/PlayerBar.swift
+++ b/Sources/Kaset/Views/PlayerBar.swift
@@ -551,7 +551,7 @@ struct PlayerBar: View { // swiftlint:disable:this type_body_length
                     .foregroundStyle(.primary)
                     .contentTransition(.symbolEffect(.replace))
             }
-            .playerBarVolumeOverlay(isPresented: self.showsVolumeOverlay) {
+            .playerBarVolumeOverlay(isPresented: self.$showsVolumeOverlay) {
                 self.volumeOverlay
             }
         }

--- a/Sources/Kaset/Views/PlayerBar.swift
+++ b/Sources/Kaset/Views/PlayerBar.swift
@@ -542,7 +542,8 @@ struct PlayerBar: View { // swiftlint:disable:this type_body_length
 
             PlayerBarIconButton(
                 action: self.toggleVolumePopover,
-                accessibilityLabel: String(localized: "Volume")
+                accessibilityLabel: String(localized: "Volume"),
+                accessibilityValue: "\(Int(self.displayedVolume * 100))%"
             ) {
                 Image(systemName: self.volumeIcon)
                     .font(.system(size: 15, weight: .regular))

--- a/Sources/Kaset/Views/PlayerBar.swift
+++ b/Sources/Kaset/Views/PlayerBar.swift
@@ -550,13 +550,8 @@ struct PlayerBar: View { // swiftlint:disable:this type_body_length
                     .foregroundStyle(.primary)
                     .contentTransition(.symbolEffect(.replace))
             }
-            .overlay(alignment: .top) {
-                if self.showsVolumeOverlay {
-                    self.volumeOverlay
-                        .offset(y: -176)
-                        .transition(.scale(scale: 0.94, anchor: .bottom).combined(with: .opacity))
-                        .zIndex(1)
-                }
+            .playerBarVolumeOverlay(isPresented: self.showsVolumeOverlay) {
+                self.volumeOverlay
             }
         }
     }
@@ -602,9 +597,7 @@ struct PlayerBar: View { // swiftlint:disable:this type_body_length
                     onEditingChanged: { editing in
                         self.isAdjustingVolume = editing
                         if !editing {
-                            Task {
-                                await self.playerService.setVolume(self.volumeValue)
-                            }
+                            self.playerService.setVolumeImmediately(self.volumeValue)
                         }
                     },
                     onValueChanged: { oldValue, newValue in
@@ -612,9 +605,7 @@ struct PlayerBar: View { // swiftlint:disable:this type_body_length
                             if (oldValue > 0 && newValue == 0) || (oldValue < 1 && newValue == 1) {
                                 HapticService.sliderBoundary()
                             }
-                            Task {
-                                await self.playerService.setVolume(newValue)
-                            }
+                            self.playerService.setVolumeImmediately(newValue)
                         }
                     }
                 )
@@ -1257,14 +1248,17 @@ struct PlayerBar: View { // swiftlint:disable:this type_body_length
     }
 
     private var volumeIcon: String {
-        let currentVolume = self.isAdjustingVolume ? self.volumeValue : self.playerService.volume
-        if currentVolume == 0 {
-            return "speaker.slash.fill"
-        } else if currentVolume < 0.5 {
-            return "speaker.wave.1.fill"
+        if self.displayedVolume == 0 {
+            "speaker.slash.fill"
+        } else if self.displayedVolume < 0.5 {
+            "speaker.wave.1.fill"
         } else {
-            return "speaker.wave.2.fill"
+            "speaker.wave.2.fill"
         }
+    }
+
+    private var displayedVolume: Double {
+        self.isAdjustingVolume ? self.volumeValue : self.playerService.volume
     }
 
     private var repeatIconName: String {

--- a/Sources/Kaset/Views/PlayerBarVerticalSlider.swift
+++ b/Sources/Kaset/Views/PlayerBarVerticalSlider.swift
@@ -70,6 +70,7 @@ struct PlayerBarVerticalSlider: View {
             }
         }
         .frame(width: 28, height: 122)
+        .accessibilityElement(children: .ignore)
         .playerBarVerticalSliderAccessibilityIdentifier(self.accessibilityIdentifier)
         .accessibilityLabel(self.accessibilityLabel)
         .accessibilityValue("\(Int(self.clampedValue * 100))%")

--- a/Sources/Kaset/Views/PlayerBarVolumeOverlayHost.swift
+++ b/Sources/Kaset/Views/PlayerBarVolumeOverlayHost.swift
@@ -207,6 +207,22 @@ private final class PlayerBarVolumeOverlayHostingView: NSHostingView<PlayerBarVo
 private final class PlayerBarVolumeOverlayAnchorView: NSView {
     var onGeometryChange: ((PlayerBarVolumeOverlayAnchorView) -> Void)?
 
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        self.postsFrameChangedNotifications = true
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(self.frameDidChange),
+            name: NSView.frameDidChangeNotification,
+            object: self
+        )
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     override func layout() {
         super.layout()
         self.onGeometryChange?(self)
@@ -220,6 +236,14 @@ private final class PlayerBarVolumeOverlayAnchorView: NSView {
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
         self.onGeometryChange?(self)
+    }
+
+    @objc private func frameDidChange(_: Notification) {
+        self.onGeometryChange?(self)
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
 }
 

--- a/Sources/Kaset/Views/PlayerBarVolumeOverlayHost.swift
+++ b/Sources/Kaset/Views/PlayerBarVolumeOverlayHost.swift
@@ -7,7 +7,7 @@ extension View {
     /// Presents the volume capsule in a borderless child panel so it remains
     /// interactive outside the player bar's compact safe-area inset.
     func playerBarVolumeOverlay(
-        isPresented: Bool,
+        isPresented: Binding<Bool>,
         @ViewBuilder overlay: @escaping () -> some View
     ) -> some View {
         self.modifier(
@@ -25,13 +25,13 @@ private struct PlayerBarVolumeOverlayModifier<Overlay: View>: ViewModifier {
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.usesLegacyMacOS15UI) private var usesLegacyMacOS15UI
 
-    let isPresented: Bool
+    @Binding var isPresented: Bool
     @ViewBuilder let overlay: () -> Overlay
 
     func body(content: Content) -> some View {
         content.background {
             PlayerBarVolumeOverlayAnchor(
-                isPresented: self.isPresented,
+                isPresented: self.$isPresented,
                 overlay: AnyView(
                     self.overlay()
                         .environment(\.colorScheme, self.colorScheme)
@@ -46,7 +46,7 @@ private struct PlayerBarVolumeOverlayModifier<Overlay: View>: ViewModifier {
 // MARK: - PlayerBarVolumeOverlayAnchor
 
 private struct PlayerBarVolumeOverlayAnchor: NSViewRepresentable {
-    let isPresented: Bool
+    @Binding var isPresented: Bool
     let overlay: AnyView
 
     func makeCoordinator() -> Coordinator {
@@ -66,7 +66,10 @@ private struct PlayerBarVolumeOverlayAnchor: NSViewRepresentable {
         context.coordinator.update(
             anchorView: anchorView,
             isPresented: self.isPresented,
-            overlay: self.overlay
+            overlay: self.overlay,
+            onDismiss: {
+                self.isPresented = false
+            }
         )
     }
 
@@ -83,12 +86,18 @@ private struct PlayerBarVolumeOverlayAnchor: NSViewRepresentable {
         private var isPresented = false
         private var panel: NSPanel?
         private var hostingView: PlayerBarVolumeOverlayHostingView?
+        private weak var anchorView: PlayerBarVolumeOverlayAnchorView?
+        private var mouseDownMonitor: Any?
+        private var onDismiss: (() -> Void)?
 
         func update(
             anchorView: PlayerBarVolumeOverlayAnchorView,
             isPresented: Bool,
-            overlay: AnyView
+            overlay: AnyView,
+            onDismiss: @escaping () -> Void
         ) {
+            self.anchorView = anchorView
+            self.onDismiss = onDismiss
             self.isPresented = isPresented
             guard isPresented else {
                 self.hideOverlay()
@@ -98,14 +107,19 @@ private struct PlayerBarVolumeOverlayAnchor: NSViewRepresentable {
             let panel = self.overlayPanel(overlay: overlay)
             self.hostingView?.rootView = PlayerBarVolumeOverlayRoot(overlay: overlay)
             self.positionOverlay(relativeTo: anchorView)
+            guard self.isPresented, panel.parent != nil else { return }
             panel.orderFront(nil)
+            self.startMonitoringMouseDown()
         }
 
         func positionOverlay(relativeTo anchorView: PlayerBarVolumeOverlayAnchorView) {
             guard self.isPresented,
-                  let panel = self.panel,
-                  let parentWindow = anchorView.window
+                  let panel = self.panel
             else { return }
+            guard let parentWindow = anchorView.window else {
+                self.dismissOverlay()
+                return
+            }
 
             let anchorTop = NSPoint(
                 x: anchorView.bounds.midX,
@@ -132,6 +146,8 @@ private struct PlayerBarVolumeOverlayAnchor: NSViewRepresentable {
             self.panel?.close()
             self.panel = nil
             self.hostingView = nil
+            self.anchorView = nil
+            self.onDismiss = nil
         }
 
         private func overlayPanel(overlay: AnyView) -> NSPanel {
@@ -168,9 +184,55 @@ private struct PlayerBarVolumeOverlayAnchor: NSViewRepresentable {
         }
 
         private func hideOverlay() {
+            self.stopMonitoringMouseDown()
             guard let panel = self.panel else { return }
             panel.parent?.removeChildWindow(panel)
             panel.orderOut(nil)
+        }
+
+        private func dismissOverlay() {
+            guard self.isPresented else { return }
+            self.isPresented = false
+            self.hideOverlay()
+            self.onDismiss?()
+        }
+
+        private func startMonitoringMouseDown() {
+            guard self.mouseDownMonitor == nil else { return }
+            self.mouseDownMonitor = NSEvent.addLocalMonitorForEvents(
+                matching: [.leftMouseDown, .rightMouseDown, .otherMouseDown]
+            ) { [weak self] event in
+                MainActor.assumeIsolated {
+                    self?.dismissOverlayIfNeeded(for: event)
+                }
+                return event
+            }
+        }
+
+        private func stopMonitoringMouseDown() {
+            guard let mouseDownMonitor = self.mouseDownMonitor else { return }
+            NSEvent.removeMonitor(mouseDownMonitor)
+            self.mouseDownMonitor = nil
+        }
+
+        private func dismissOverlayIfNeeded(for event: NSEvent) {
+            guard let panel = self.panel else { return }
+            let locationOnScreen = event.window?.convertPoint(
+                toScreen: event.locationInWindow
+            ) ?? NSEvent.mouseLocation
+            if panel.frame.contains(locationOnScreen) {
+                return
+            }
+            if let anchorView = self.anchorView,
+               let anchorWindow = anchorView.window
+            {
+                let locationInWindow = anchorWindow.convertPoint(fromScreen: locationOnScreen)
+                let locationInAnchor = anchorView.convert(locationInWindow, from: nil)
+                if anchorView.bounds.contains(locationInAnchor) {
+                    return
+                }
+            }
+            self.dismissOverlay()
         }
     }
 }

--- a/Sources/Kaset/Views/PlayerBarVolumeOverlayHost.swift
+++ b/Sources/Kaset/Views/PlayerBarVolumeOverlayHost.swift
@@ -88,6 +88,7 @@ private struct PlayerBarVolumeOverlayAnchor: NSViewRepresentable {
         private var hostingView: PlayerBarVolumeOverlayHostingView?
         private weak var anchorView: PlayerBarVolumeOverlayAnchorView?
         private var mouseDownMonitor: Any?
+        private var applicationDidResignActiveObserver: NSObjectProtocol?
         private var onDismiss: (() -> Void)?
 
         func update(
@@ -109,7 +110,7 @@ private struct PlayerBarVolumeOverlayAnchor: NSViewRepresentable {
             self.positionOverlay(relativeTo: anchorView)
             guard self.isPresented, panel.parent != nil else { return }
             panel.orderFront(nil)
-            self.startMonitoringMouseDown()
+            self.startMonitoringDismissal()
         }
 
         func positionOverlay(relativeTo anchorView: PlayerBarVolumeOverlayAnchorView) {
@@ -184,7 +185,7 @@ private struct PlayerBarVolumeOverlayAnchor: NSViewRepresentable {
         }
 
         private func hideOverlay() {
-            self.stopMonitoringMouseDown()
+            self.stopMonitoringDismissal()
             guard let panel = self.panel else { return }
             panel.parent?.removeChildWindow(panel)
             panel.orderOut(nil)
@@ -195,6 +196,27 @@ private struct PlayerBarVolumeOverlayAnchor: NSViewRepresentable {
             self.isPresented = false
             self.hideOverlay()
             self.onDismiss?()
+        }
+
+        private func startMonitoringDismissal() {
+            self.startMonitoringMouseDown()
+            guard self.applicationDidResignActiveObserver == nil else { return }
+            self.applicationDidResignActiveObserver = NotificationCenter.default.addObserver(
+                forName: NSApplication.didResignActiveNotification,
+                object: NSApp,
+                queue: .main
+            ) { [weak self] _ in
+                MainActor.assumeIsolated {
+                    self?.dismissOverlay()
+                }
+            }
+        }
+
+        private func stopMonitoringDismissal() {
+            self.stopMonitoringMouseDown()
+            guard let observer = self.applicationDidResignActiveObserver else { return }
+            NotificationCenter.default.removeObserver(observer)
+            self.applicationDidResignActiveObserver = nil
         }
 
         private func startMonitoringMouseDown() {

--- a/Sources/Kaset/Views/PlayerBarVolumeOverlayHost.swift
+++ b/Sources/Kaset/Views/PlayerBarVolumeOverlayHost.swift
@@ -1,0 +1,247 @@
+import AppKit
+import SwiftUI
+
+// MARK: - Player Bar Volume Overlay Host
+
+extension View {
+    /// Presents the volume capsule in a borderless child panel so it remains
+    /// interactive outside the player bar's compact safe-area inset.
+    func playerBarVolumeOverlay(
+        isPresented: Bool,
+        @ViewBuilder overlay: @escaping () -> some View
+    ) -> some View {
+        self.modifier(
+            PlayerBarVolumeOverlayModifier(
+                isPresented: isPresented,
+                overlay: overlay
+            )
+        )
+    }
+}
+
+// MARK: - PlayerBarVolumeOverlayModifier
+
+private struct PlayerBarVolumeOverlayModifier<Overlay: View>: ViewModifier {
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.usesLegacyMacOS15UI) private var usesLegacyMacOS15UI
+
+    let isPresented: Bool
+    @ViewBuilder let overlay: () -> Overlay
+
+    func body(content: Content) -> some View {
+        content.background {
+            PlayerBarVolumeOverlayAnchor(
+                isPresented: self.isPresented,
+                overlay: AnyView(
+                    self.overlay()
+                        .environment(\.colorScheme, self.colorScheme)
+                        .environment(\.usesLegacyMacOS15UI, self.usesLegacyMacOS15UI)
+                )
+            )
+            .allowsHitTesting(false)
+        }
+    }
+}
+
+// MARK: - PlayerBarVolumeOverlayAnchor
+
+private struct PlayerBarVolumeOverlayAnchor: NSViewRepresentable {
+    let isPresented: Bool
+    let overlay: AnyView
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    func makeNSView(context: Context) -> PlayerBarVolumeOverlayAnchorView {
+        let anchorView = PlayerBarVolumeOverlayAnchorView()
+        anchorView.setAccessibilityElement(false)
+        anchorView.onGeometryChange = { [weak coordinator = context.coordinator] anchorView in
+            coordinator?.positionOverlay(relativeTo: anchorView)
+        }
+        return anchorView
+    }
+
+    func updateNSView(_ anchorView: PlayerBarVolumeOverlayAnchorView, context: Context) {
+        context.coordinator.update(
+            anchorView: anchorView,
+            isPresented: self.isPresented,
+            overlay: self.overlay
+        )
+    }
+
+    static func dismantleNSView(
+        _ anchorView: PlayerBarVolumeOverlayAnchorView,
+        coordinator: Coordinator
+    ) {
+        anchorView.onGeometryChange = nil
+        coordinator.removeOverlay()
+    }
+
+    @MainActor
+    final class Coordinator {
+        private var isPresented = false
+        private var panel: NSPanel?
+        private var hostingView: PlayerBarVolumeOverlayHostingView?
+
+        func update(
+            anchorView: PlayerBarVolumeOverlayAnchorView,
+            isPresented: Bool,
+            overlay: AnyView
+        ) {
+            self.isPresented = isPresented
+            guard isPresented else {
+                self.hideOverlay()
+                return
+            }
+
+            let panel = self.overlayPanel(overlay: overlay)
+            self.hostingView?.rootView = PlayerBarVolumeOverlayRoot(overlay: overlay)
+            self.positionOverlay(relativeTo: anchorView)
+            panel.orderFront(nil)
+        }
+
+        func positionOverlay(relativeTo anchorView: PlayerBarVolumeOverlayAnchorView) {
+            guard self.isPresented,
+                  let panel = self.panel,
+                  let parentWindow = anchorView.window
+            else { return }
+
+            let anchorTop = NSPoint(
+                x: anchorView.bounds.midX,
+                y: anchorView.isFlipped ? anchorView.bounds.minY : anchorView.bounds.maxY
+            )
+            let anchorTopInWindow = anchorView.convert(anchorTop, to: nil)
+            let anchorTopOnScreen = parentWindow.convertPoint(toScreen: anchorTopInWindow)
+
+            if panel.parent !== parentWindow {
+                panel.parent?.removeChildWindow(panel)
+                parentWindow.addChildWindow(panel, ordered: .above)
+            }
+
+            panel.setFrame(
+                PlayerBarVolumeOverlayMetrics.hostFrame(anchorTopCenter: anchorTopOnScreen),
+                display: true
+            )
+        }
+
+        func removeOverlay() {
+            self.isPresented = false
+            self.hideOverlay()
+            self.panel?.contentView = nil
+            self.panel?.close()
+            self.panel = nil
+            self.hostingView = nil
+        }
+
+        private func overlayPanel(overlay: AnyView) -> NSPanel {
+            if let panel = self.panel {
+                return panel
+            }
+
+            let rootView = PlayerBarVolumeOverlayRoot(overlay: overlay)
+            let hostingView = PlayerBarVolumeOverlayHostingView(rootView: rootView)
+            hostingView.frame = NSRect(origin: .zero, size: PlayerBarVolumeOverlayMetrics.hostSize)
+            hostingView.autoresizingMask = [.width, .height]
+
+            let panel = NSPanel(
+                contentRect: hostingView.frame,
+                styleMask: [.borderless, .nonactivatingPanel],
+                backing: .buffered,
+                defer: false
+            )
+            panel.contentView = hostingView
+            panel.isReleasedWhenClosed = false
+            panel.isExcludedFromWindowsMenu = true
+            panel.isMovable = false
+            panel.isOpaque = false
+            panel.backgroundColor = .clear
+            panel.hasShadow = false
+            panel.hidesOnDeactivate = false
+            panel.becomesKeyOnlyIfNeeded = true
+            panel.animationBehavior = .none
+            panel.collectionBehavior = [.fullScreenAuxiliary, .transient]
+
+            self.hostingView = hostingView
+            self.panel = panel
+            return panel
+        }
+
+        private func hideOverlay() {
+            guard let panel = self.panel else { return }
+            panel.parent?.removeChildWindow(panel)
+            panel.orderOut(nil)
+        }
+    }
+}
+
+// MARK: - PlayerBarVolumeOverlayRoot
+
+private struct PlayerBarVolumeOverlayRoot: View {
+    let overlay: AnyView
+
+    var body: some View {
+        self.overlay
+            .padding(.horizontal, PlayerBarVolumeOverlayMetrics.horizontalOutset)
+            .padding(.top, PlayerBarVolumeOverlayMetrics.topOutset)
+            .padding(.bottom, PlayerBarVolumeOverlayMetrics.bottomOutset)
+            .frame(
+                width: PlayerBarVolumeOverlayMetrics.hostSize.width,
+                height: PlayerBarVolumeOverlayMetrics.hostSize.height
+            )
+    }
+}
+
+// MARK: - PlayerBarVolumeOverlayHostingView
+
+@MainActor
+private final class PlayerBarVolumeOverlayHostingView: NSHostingView<PlayerBarVolumeOverlayRoot> {
+    override func acceptsFirstMouse(for _: NSEvent?) -> Bool {
+        true
+    }
+}
+
+// MARK: - PlayerBarVolumeOverlayAnchorView
+
+@MainActor
+private final class PlayerBarVolumeOverlayAnchorView: NSView {
+    var onGeometryChange: ((PlayerBarVolumeOverlayAnchorView) -> Void)?
+
+    override func layout() {
+        super.layout()
+        self.onGeometryChange?(self)
+    }
+
+    override func viewDidMoveToSuperview() {
+        super.viewDidMoveToSuperview()
+        self.onGeometryChange?(self)
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        self.onGeometryChange?(self)
+    }
+}
+
+// MARK: - PlayerBarVolumeOverlayMetrics
+
+private enum PlayerBarVolumeOverlayMetrics {
+    static let contentSize = CGSize(width: 46, height: 168)
+    static let horizontalOutset: CGFloat = 22
+    static let topOutset: CGFloat = 22
+    static let bottomOutset: CGFloat = 8
+    static let hostSize = CGSize(
+        width: Self.contentSize.width + Self.horizontalOutset * 2,
+        height: Self.contentSize.height + Self.topOutset + Self.bottomOutset
+    )
+
+    static func hostFrame(anchorTopCenter: NSPoint) -> NSRect {
+        NSRect(
+            origin: NSPoint(
+                x: anchorTopCenter.x - self.hostSize.width / 2,
+                y: anchorTopCenter.y
+            ),
+            size: self.hostSize
+        )
+    }
+}

--- a/Sources/Kaset/Views/YouTube/YouTubePlayerBar.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubePlayerBar.swift
@@ -389,13 +389,8 @@ struct YouTubePlayerBar: View {
                         .contentTransition(.symbolEffect(.replace))
                 }
             )
-            .overlay(alignment: .top) {
-                if self.showsVolumeOverlay {
-                    self.youtubeVolumeOverlay
-                        .offset(y: -176)
-                        .transition(.scale(scale: 0.94, anchor: .bottom).combined(with: .opacity))
-                        .zIndex(1)
-                }
+            .playerBarVolumeOverlay(isPresented: self.showsVolumeOverlay) {
+                self.youtubeVolumeOverlay
             }
         }
     }
@@ -746,14 +741,17 @@ struct YouTubePlayerBar: View {
     }
 
     private var volumeIcon: String {
-        let currentVolume = self.isAdjustingVolume ? self.volumeValue : self.youtubePlayer.volume
-        if currentVolume == 0 {
-            return "speaker.slash.fill"
-        } else if currentVolume < 0.5 {
-            return "speaker.wave.1.fill"
+        if self.displayedVolume == 0 {
+            "speaker.slash.fill"
+        } else if self.displayedVolume < 0.5 {
+            "speaker.wave.1.fill"
         } else {
-            return "speaker.wave.2.fill"
+            "speaker.wave.2.fill"
         }
+    }
+
+    private var displayedVolume: Double {
+        self.isAdjustingVolume ? self.volumeValue : self.youtubePlayer.volume
     }
 
     private func toggleYouTubeVolumeOverlay() {

--- a/Sources/Kaset/Views/YouTube/YouTubePlayerBar.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubePlayerBar.swift
@@ -118,9 +118,7 @@ struct YouTubePlayerBar: View {
                 self.volumeValue = newValue
             }
         }
-        .onChange(of: self.showsVolumeOverlay) { _, isPresented in
-            self.onVolumeOverlayChange(isPresented)
-        }
+        .onChange(of: self.showsVolumeOverlay) { _, isPresented in self.onVolumeOverlayChange(isPresented) }
         .onAppear {
             self.volumeValue = self.youtubePlayer.volume
             if self.youtubePlayer.duration > 0 {

--- a/Sources/Kaset/Views/YouTube/YouTubePlayerBar.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubePlayerBar.swift
@@ -118,6 +118,9 @@ struct YouTubePlayerBar: View {
                 self.volumeValue = newValue
             }
         }
+        .onChange(of: self.showsVolumeOverlay) { _, isPresented in
+            self.onVolumeOverlayChange(isPresented)
+        }
         .onAppear {
             self.volumeValue = self.youtubePlayer.volume
             if self.youtubePlayer.duration > 0 {
@@ -392,7 +395,7 @@ struct YouTubePlayerBar: View {
                         .contentTransition(.symbolEffect(.replace))
                 }
             )
-            .playerBarVolumeOverlay(isPresented: self.showsVolumeOverlay) {
+            .playerBarVolumeOverlay(isPresented: self.$showsVolumeOverlay) {
                 self.youtubeVolumeOverlay
             }
         }
@@ -763,7 +766,6 @@ struct YouTubePlayerBar: View {
         withAnimation(AppAnimation.quick) {
             self.showsVolumeOverlay = isPresented
         }
-        self.onVolumeOverlayChange(isPresented)
     }
 
     private func openYouTubeFullView() {

--- a/Sources/Kaset/Views/YouTube/YouTubePlayerBar.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubePlayerBar.swift
@@ -38,6 +38,7 @@ struct YouTubePlayerBar: View {
     @Environment(\.colorScheme) private var colorScheme
 
     private let isDetachedWindow: Bool
+    private let onVolumeOverlayChange: (Bool) -> Void
 
     /// Namespace for glass effect morphing.
     @Namespace private var playerNamespace
@@ -51,8 +52,9 @@ struct YouTubePlayerBar: View {
     @State private var showsVolumeOverlay = false
     @State private var chapterPreviewMarker: PlayerBarProgressMarker?
 
-    init(isDetachedWindow: Bool) {
+    init(isDetachedWindow: Bool, onVolumeOverlayChange: @escaping (Bool) -> Void = { _ in }) {
         self.isDetachedWindow = isDetachedWindow
+        self.onVolumeOverlayChange = onVolumeOverlayChange
     }
 
     var body: some View {
@@ -756,9 +758,11 @@ struct YouTubePlayerBar: View {
 
     private func toggleYouTubeVolumeOverlay() {
         HapticService.toggle()
+        let isPresented = !self.showsVolumeOverlay
         withAnimation(AppAnimation.quick) {
-            self.showsVolumeOverlay.toggle()
+            self.showsVolumeOverlay = isPresented
         }
+        self.onVolumeOverlayChange(isPresented)
     }
 
     private func openYouTubeFullView() {

--- a/Sources/Kaset/Views/YouTube/YouTubePlayerBar.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubePlayerBar.swift
@@ -383,6 +383,7 @@ struct YouTubePlayerBar: View {
             PlayerBarIconButton(
                 action: self.toggleYouTubeVolumeOverlay,
                 accessibilityLabel: String(localized: "Volume"),
+                accessibilityValue: "\(Int(self.displayedVolume * 100))%",
                 icon: {
                     Image(systemName: self.volumeIcon)
                         .font(.system(size: 15, weight: .regular))

--- a/Sources/Kaset/Views/YouTube/YouTubeVideoWindowController.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeVideoWindowController.swift
@@ -29,6 +29,13 @@ enum YouTubeVideoWindowLevelPolicy {
         isFloating && !isFullscreenOrTransitioning
     }
 
+    static func shouldShowChrome(
+        isWindowHovered: Bool,
+        isVolumeOverlayPresented: Bool
+    ) -> Bool {
+        isWindowHovered || isVolumeOverlayPresented
+    }
+
     static func collectionBehavior(
         preserving current: NSWindow.CollectionBehavior
     ) -> NSWindow.CollectionBehavior {
@@ -554,6 +561,7 @@ private struct YouTubeVideoWindowContent: View {
 
     @State private var settings = SettingsManager.shared
     @State private var isHovering = false
+    @State private var isVolumeOverlayPresented = false
 
     /// Height of the top strip that moves the window. Generous enough to be
     /// an easy grab target; the top of the video carries no YouTube controls
@@ -566,11 +574,16 @@ private struct YouTubeVideoWindowContent: View {
                 YouTubeWatchSurfaceView()
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
 
-                if self.isHovering {
+                if self.showsWindowChrome {
                     // The full player bar — same items as the main window, plus
                     // detached-only window controls owned by YouTubePlayerBar.
-                    YouTubePlayerBar(isDetachedWindow: true)
-                        .transition(.opacity)
+                    YouTubePlayerBar(
+                        isDetachedWindow: true,
+                        onVolumeOverlayChange: { isPresented in
+                            self.isVolumeOverlayPresented = isPresented
+                        }
+                    )
+                    .transition(.opacity)
                 }
             }
 
@@ -580,7 +593,7 @@ private struct YouTubeVideoWindowContent: View {
                 .frame(maxWidth: .infinity)
                 .frame(height: Self.dragStripHeight)
                 .overlay(alignment: .top) {
-                    if self.isHovering {
+                    if self.showsWindowChrome {
                         Capsule()
                             .fill(.white.opacity(0.35))
                             .frame(width: 36, height: 5)
@@ -597,8 +610,22 @@ private struct YouTubeVideoWindowContent: View {
             withAnimation(.easeInOut(duration: 0.18)) {
                 self.isHovering = hovering
             }
-            YouTubeVideoWindowController.shared.setWindowChromeVisible(hovering)
+            YouTubeVideoWindowController.shared.setWindowChromeVisible(
+                hovering || self.isVolumeOverlayPresented
+            )
         }
+        .onChange(of: self.isVolumeOverlayPresented) { _, isPresented in
+            YouTubeVideoWindowController.shared.setWindowChromeVisible(
+                self.isHovering || isPresented
+            )
+        }
+    }
+
+    private var showsWindowChrome: Bool {
+        YouTubeVideoWindowLevelPolicy.shouldShowChrome(
+            isWindowHovered: self.isHovering,
+            isVolumeOverlayPresented: self.isVolumeOverlayPresented
+        )
     }
 }
 

--- a/Tests/KasetTests/PlayerServiceTests.swift
+++ b/Tests/KasetTests/PlayerServiceTests.swift
@@ -181,11 +181,15 @@ struct PlayerServiceTests {
         #expect(self.playerService.volume == 1.0)
     }
 
-    @Test("Immediate volume changes retain the latest value")
+    @Test("Immediate volume commands preserve dispatch order")
     func immediateVolumeChanges() {
+        var appliedVolumes: [Double] = []
+        self.playerService.applyMusicPlaybackVolume = { appliedVolumes.append($0) }
+
         self.playerService.setVolumeImmediately(0.4)
         self.playerService.setVolumeImmediately(0.7)
 
+        #expect(appliedVolumes == [0.4, 0.7])
         #expect(self.playerService.volume == 0.7)
         #expect(UserDefaults.standard.double(forKey: "playerVolume") == 0.7)
     }

--- a/Tests/KasetTests/PlayerServiceTests.swift
+++ b/Tests/KasetTests/PlayerServiceTests.swift
@@ -181,6 +181,15 @@ struct PlayerServiceTests {
         #expect(self.playerService.volume == 1.0)
     }
 
+    @Test("Immediate volume changes retain the latest value")
+    func immediateVolumeChanges() {
+        self.playerService.setVolumeImmediately(0.4)
+        self.playerService.setVolumeImmediately(0.7)
+
+        #expect(self.playerService.volume == 0.7)
+        #expect(UserDefaults.standard.double(forKey: "playerVolume") == 0.7)
+    }
+
     // MARK: - Queue Tests
 
     @Test("Play queue sets queue")

--- a/Tests/KasetTests/YouTubePlayerBarTests.swift
+++ b/Tests/KasetTests/YouTubePlayerBarTests.swift
@@ -51,6 +51,22 @@ struct YouTubePlayerBarTests {
         #expect(pinnedWindowBreakpoint - standardBreakpoint == 34)
     }
 
+    @Test("Detached controls stay visible while the volume overlay is presented")
+    func detachedControlsStayVisibleWhileVolumeOverlayIsPresented() {
+        #expect(!YouTubeVideoWindowLevelPolicy.shouldShowChrome(
+            isWindowHovered: false,
+            isVolumeOverlayPresented: false
+        ))
+        #expect(YouTubeVideoWindowLevelPolicy.shouldShowChrome(
+            isWindowHovered: true,
+            isVolumeOverlayPresented: false
+        ))
+        #expect(YouTubeVideoWindowLevelPolicy.shouldShowChrome(
+            isWindowHovered: false,
+            isVolumeOverlayPresented: true
+        ))
+    }
+
     @Test("Chapter segments resolve explicit, next-chapter, and duration end times")
     func chapterSegmentsResolveEndTimes() throws {
         let chapters = [

--- a/Tests/KasetUITests/KasetUITestCase.swift
+++ b/Tests/KasetUITests/KasetUITestCase.swift
@@ -43,6 +43,7 @@ enum TestAccessibilityID {
     enum PlayerBar {
         static let miniPlayerButton = "playerBar.miniPlayer"
         static let videoButton = "playerBar.video"
+        static let volumeSlider = "playerBar.volumeSlider"
     }
 
     enum VideoWindow {

--- a/Tests/KasetUITests/PlayerBarUITests.swift
+++ b/Tests/KasetUITests/PlayerBarUITests.swift
@@ -208,7 +208,7 @@ final class PlayerBarUITests: KasetUITestCase {
         ].firstMatch
         XCTAssertTrue(waitForHittable(volumeSlider))
 
-        let initialValue = try XCTUnwrap(volumeSlider.value as? String)
+        let initialValue = try XCTUnwrap(volumeButton.value as? String)
         let initialPercent = try XCTUnwrap(
             initialValue.split(whereSeparator: { !$0.isNumber }).first.flatMap { Int($0) },
             "Expected a numeric volume value, got \(initialValue)"
@@ -220,7 +220,7 @@ final class PlayerBarUITests: KasetUITestCase {
 
         let valueChanged = XCTNSPredicateExpectation(
             predicate: NSPredicate(format: "value != %@", initialValue),
-            object: volumeSlider
+            object: volumeButton
         )
         XCTAssertEqual(XCTWaiter().wait(for: [valueChanged], timeout: 5), .completed)
     }

--- a/Tests/KasetUITests/PlayerBarUITests.swift
+++ b/Tests/KasetUITests/PlayerBarUITests.swift
@@ -209,8 +209,10 @@ final class PlayerBarUITests: KasetUITestCase {
         XCTAssertTrue(waitForHittable(volumeSlider))
 
         let initialValue = try XCTUnwrap(volumeSlider.value as? String)
+        let initialPercent = try XCTUnwrap(Int(initialValue.dropLast()))
+        let targetY = initialPercent >= 50 ? 0.8 : 0.2
         volumeSlider.coordinate(
-            withNormalizedOffset: CGVector(dx: 0.5, dy: 0.8)
+            withNormalizedOffset: CGVector(dx: 0.5, dy: targetY)
         ).click()
 
         let valueChanged = XCTNSPredicateExpectation(

--- a/Tests/KasetUITests/PlayerBarUITests.swift
+++ b/Tests/KasetUITests/PlayerBarUITests.swift
@@ -209,7 +209,10 @@ final class PlayerBarUITests: KasetUITestCase {
         XCTAssertTrue(waitForHittable(volumeSlider))
 
         let initialValue = try XCTUnwrap(volumeSlider.value as? String)
-        let initialPercent = try XCTUnwrap(Int(initialValue.dropLast()))
+        let initialPercent = try XCTUnwrap(
+            initialValue.split(whereSeparator: { !$0.isNumber }).first.flatMap { Int($0) },
+            "Expected a numeric volume value, got \(initialValue)"
+        )
         let targetY = initialPercent >= 50 ? 0.8 : 0.2
         volumeSlider.coordinate(
             withNormalizedOffset: CGVector(dx: 0.5, dy: targetY)

--- a/Tests/KasetUITests/PlayerBarUITests.swift
+++ b/Tests/KasetUITests/PlayerBarUITests.swift
@@ -194,6 +194,32 @@ final class PlayerBarUITests: KasetUITestCase {
         XCTAssertNotEqual(repeatButton.value as? String, "Off")
     }
 
+    func testFirstVolumeSliderInteractionChangesValue() throws {
+        launchWithMockPlayer(isPlaying: true)
+
+        navigateToHome()
+
+        let volumeButton = app.buttons["Volume"].firstMatch
+        XCTAssertTrue(waitForHittable(volumeButton))
+        volumeButton.click()
+
+        let volumeSlider = app.descendants(matching: .any)[
+            TestAccessibilityID.PlayerBar.volumeSlider
+        ].firstMatch
+        XCTAssertTrue(waitForHittable(volumeSlider))
+
+        let initialValue = try XCTUnwrap(volumeSlider.value as? String)
+        volumeSlider.coordinate(
+            withNormalizedOffset: CGVector(dx: 0.5, dy: 0.8)
+        ).click()
+
+        let valueChanged = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "value != %@", initialValue),
+            object: volumeSlider
+        )
+        XCTAssertEqual(XCTWaiter().wait(for: [valueChanged], timeout: 5), .completed)
+    }
+
     // MARK: - Player Bar Persistence Across Views
 
     func testPlayerBarPersistsAcrossNavigation() {


### PR DESCRIPTION
## Summary

- restore the top-facing vertical volume overlay without clipping it to the player bar
- accept first-click slider interaction and apply rapid volume changes in event order
- share the fixed overlay host between the Music and YouTube player bars

## Regression

The volume overlay became non-interactive after #327 moved it outside the player bar bounds using a SwiftUI overlay.

## Verification

- `swift build`
- 140 focused unit tests
- packaged runtime drag test confirmed the persisted volume changes
- autoreview completed with no accepted or actionable findings
