### PR TITLE
docs: add ADOPTERS.md with Droppy integration

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,19 @@
+# Adopters
+
+This page lists apps, tools, and projects that integrate with, build upon, or support **Kaset**.
+
+If you are using or integrating Kaset in your project or application, please consider adding yourself to this list by opening a pull request!
+
+## Integrations & Ecosystem Apps
+
+| Project / App | Description | Link |
+| :--- | :--- | :--- |
+| **Droppy** | Dynamic Island and notch utility for macOS featuring a first-party extension to integrate and play YouTube Music through Kaset. | [getdroppy.app](https://getdroppy.app/) |
+
+## Adding Your Project
+
+We welcome integrations from the community! To add your project:
+
+1. Fork the repository.
+2. Add your entry to the list above in alphabetical order.
+3. Submit a pull request describing how your project integrates with Kaset.


### PR DESCRIPTION
## Description

This PR introduces an `ADOPTERS.md` file to track apps, tools, and projects that integrate with or build upon Kaset, listing Droppy as an initial adopter.

Droppy (https://getdroppy.app/) provides a first-party extension to integrate and play YouTube Music through Kaset.

## Type of Change

- [x] 📚 Documentation update

## Changes Made

- Created `ADOPTERS.md` with guidelines for community projects to add themselves.
- Added Droppy (https://getdroppy.app/) to the adopters list with details on its first-party Kaset integration.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have updated documentation if needed