### PR TITLE
perf: reduce authenticated startup latency

### DIFF
--- a/Sources/Kaset/Services/Auth/AccountService.swift
+++ b/Sources/Kaset/Services/Auth/AccountService.swift
@@ -757,6 +757,8 @@ final class AccountService { // swiftlint:disable:this type_body_length
             if self.verifiedAccountId != self.currentAccount?.id {
                 self.scheduleRestoredSessionPin()
             }
+        } catch is CancellationError {
+            self.logger.debug("AccountService: Account fetch cancelled")
         } catch {
             guard fetchGeneration == self.accountDataGeneration,
                   fetchAuthIdentityGeneration == self.authService.accountIdentityGeneration,

--- a/Sources/Kaset/Services/Auth/AccountService.swift
+++ b/Sources/Kaset/Services/Auth/AccountService.swift
@@ -98,6 +98,11 @@ final class AccountService { // swiftlint:disable:this type_body_length
     /// Whether an account operation is in progress.
     private(set) var isLoading: Bool = false
 
+    /// Whether the first account-list request for the current authenticated
+    /// identity has finished. Personalized views wait for this so a restored
+    /// brand account is selected before they issue requests.
+    private(set) var didCompleteAccountResolution: Bool = false
+
     /// Last error encountered, for toast display.
     private(set) var lastError: Error?
 
@@ -574,6 +579,7 @@ final class AccountService { // swiftlint:disable:this type_body_length
         self.accountsAuthIdentityGeneration = nil
         self.accounts = []
         self.currentAccount = nil
+        self.didCompleteAccountResolution = false
         self.verifiedAccountId = nil
         SongLikeStatusManager.shared.invalidateSession()
         SongLikeStatusManager.shared.clearCache()
@@ -732,6 +738,7 @@ final class AccountService { // swiftlint:disable:this type_body_length
             self.accounts = response.accounts
             self.accountsAuthIdentityGeneration = fetchAuthIdentityGeneration
             self.currentAccount = nextAccount
+            self.didCompleteAccountResolution = true
 
             SongLikeStatusManager.shared.setActiveAccountID(self.currentAccount?.id)
             FavoritesManager.shared.setActiveAccountScopeID(
@@ -765,6 +772,10 @@ final class AccountService { // swiftlint:disable:this type_body_length
             self.lastError = error
             self.lastErrorWasFetch = true
             self.errorSequence += 1
+            // A recoverable fetch failure must not leave the entire app behind
+            // the startup spinner. With no account result, the client retains
+            // its primary-account scope and the existing error UI offers retry.
+            self.didCompleteAccountResolution = true
         }
     }
 
@@ -1526,6 +1537,7 @@ final class AccountService { // swiftlint:disable:this type_body_length
         self.needsAccountFetchAfterManualSwitch = false
         self.accountsAuthIdentityGeneration = nil
         self.currentAccount = nil
+        self.didCompleteAccountResolution = false
         self.verifiedAccountId = nil
         UserDefaults.standard.removeObject(forKey: self.selectedBrandIdKey)
         SongLikeStatusManager.shared.clearCache()

--- a/Sources/Kaset/Services/PodcastsAvailabilityService.swift
+++ b/Sources/Kaset/Services/PodcastsAvailabilityService.swift
@@ -27,19 +27,6 @@ final class PodcastsAvailabilityService {
     /// `.unavailable`).
     private(set) var availability: Availability = .unknown
 
-    /// `true` once the first probe of the session resolves (success,
-    /// 404, transient error) or the timeout fires. `MainWindow` uses
-    /// this as a UI gate — main content renders only after this flips,
-    /// so the sidebar paints with the correct state on first frame.
-    private(set) var didResolveFirstProbe: Bool = false
-
-    /// Maximum time the gate waits for the first probe before failing
-    /// open and letting the sidebar render with `availability` still
-    /// `.unknown` (which displays the same as `.available`). If the
-    /// probe later returns 404, the lazy path
-    /// (`PodcastsViewModel.load`) demotes the state.
-    static let firstProbeGateTimeout: Duration = .seconds(2)
-
     private var accountScope: AccountScope = .unconfigured
     private var generation = 0
 
@@ -61,55 +48,8 @@ final class PodcastsAvailabilityService {
 
     // MARK: - Probing
 
-    /// Runs the first probe of the session and resolves the UI gate.
-    /// Returns when the probe completes OR the timeout fires —
-    /// whichever happens first. The probe always runs to completion in
-    /// the background regardless of the timeout, so a slow-but-definite
-    /// 404 still demotes the tab when it lands.
-    func probeForFirstResolution(
-        for accountId: String?,
-        using client: any YTMusicClientProtocol,
-        timeout: Duration = firstProbeGateTimeout
-    ) async {
-        self.activateAccount(accountId)
-
-        // Spawn the probe as an unstructured task so the timeout race
-        // below can return without waiting on it. `probe(...)` updates
-        // `availability` and `didResolveFirstProbe` itself when it
-        // finishes — even after the timeout has already released the
-        // gate, a late 404 still demotes the tab.
-        let probeTask = Task { [weak self] in
-            _ = await self?.probe(for: accountId, using: client)
-        }
-
-        // Race: the first of (probe finishes) and (timeout fires) wins.
-        // A single-resume latch + checked continuation lets the loser's
-        // task continue running without being awaited.
-        let latch = ResumeLatch()
-        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-            Task { @MainActor in
-                try? await Task.sleep(for: timeout)
-                latch.tryResume(continuation)
-            }
-            Task { @MainActor in
-                _ = await probeTask.value
-                latch.tryResume(continuation)
-            }
-        }
-
-        // If our caller has been cancelled (e.g. logout flipped
-        // `state.isLoggedIn`), tear down the probe and leave the gate
-        // for `reset()` to manage. Otherwise release it only if this
-        // first-resolution request still belongs to the active account.
-        if Task.isCancelled {
-            probeTask.cancel()
-            return
-        }
-        self.resolveFirstProbeGateIfActive(for: accountId)
-    }
-
     /// Calls `client.getPodcasts()` and updates `availability` based on
-    /// the result. Used by `probeForFirstResolution` and by the account
+    /// the result. Used by the background launch probe and by the account
     /// switch flow in `MainWindow`.
     @discardableResult
     func probe(
@@ -131,11 +71,9 @@ final class PodcastsAvailabilityService {
                 // the state alone and let the user-initiated path
                 // (`PodcastsViewModel.load`) confirm.
                 DiagnosticsLogger.api.info("Probe returned 0 sections; leaving availability=\(String(describing: self.availability))")
-                self.didResolveFirstProbe = true
                 return self.availability
             }
             self.availability = .available
-            self.didResolveFirstProbe = true
             return .available
         } catch let YTMusicError.apiError(_, code) where code == 404 {
             guard self.shouldApplyProbeResult(token, outcome: "HTTP 404") else {
@@ -144,7 +82,6 @@ final class PodcastsAvailabilityService {
 
             DiagnosticsLogger.api.info("Probe returned HTTP 404; podcasts unavailable for account=\(label)")
             self.availability = .unavailable
-            self.didResolveFirstProbe = true
             return .unavailable
         } catch is CancellationError {
             // Cancelled (e.g. user logged out before probe completed).
@@ -156,12 +93,9 @@ final class PodcastsAvailabilityService {
                 return self.availability
             }
 
-            // Transient (5xx, network, auth). Don't change state — let
-            // the lazy 404 path or the next session re-evaluate. Still
-            // mark the gate as resolved so the UI doesn't hang behind
-            // a flaky network.
+            // Transient (5xx, network, auth). Don't change state. Let
+            // the lazy 404 path or the next session re-evaluate.
             DiagnosticsLogger.api.debug("Probe inconclusive for account=\(label): \(error.localizedDescription)")
-            self.didResolveFirstProbe = true
             return self.availability
         }
     }
@@ -176,7 +110,6 @@ final class PodcastsAvailabilityService {
 
         self.generation += 1
         self.availability = .unavailable
-        self.didResolveFirstProbe = true
     }
 
     /// Marks podcasts as available based on a user-initiated load that
@@ -186,18 +119,15 @@ final class PodcastsAvailabilityService {
 
         self.generation += 1
         self.availability = .available
-        self.didResolveFirstProbe = true
     }
 
     // MARK: - Lifecycle
 
-    /// Resets state so the next sign-in re-gates the UI and re-probes.
-    /// Called on logout.
+    /// Resets state so the next sign-in re-probes. Called on logout.
     func reset() {
         self.accountScope = .loggedOut
         self.generation += 1
         self.availability = .unknown
-        self.didResolveFirstProbe = false
     }
 
     private func beginProbe(for accountId: String?) -> ProbeToken {
@@ -241,15 +171,6 @@ final class PodcastsAvailabilityService {
         }
     }
 
-    private func resolveFirstProbeGateIfActive(for accountId: String?) {
-        let normalizedAccountId = Self.normalizedAccountId(accountId)
-        guard self.accountScope == .account(normalizedAccountId) else {
-            DiagnosticsLogger.api.debug("Ignoring stale first podcasts probe gate for account=\(normalizedAccountId)")
-            return
-        }
-        self.didResolveFirstProbe = true
-    }
-
     private static func normalizedAccountId(_ accountId: String?) -> String {
         accountId ?? "primary"
     }
@@ -265,22 +186,5 @@ private extension PodcastsAvailabilityService {
     struct ProbeToken: Equatable {
         let accountId: String
         let generation: Int
-    }
-}
-
-// MARK: - ResumeLatch
-
-/// Single-resume gate used by `probeForFirstResolution` to race two
-/// `@MainActor`-isolated tasks (probe completion vs timeout). The loser
-/// observes `tryResume` as a no-op and exits silently. Isolated to the
-/// main actor so the latch needs no additional synchronisation.
-@MainActor
-private final class ResumeLatch {
-    private var resumed = false
-
-    func tryResume(_ continuation: CheckedContinuation<Void, Never>) {
-        guard !self.resumed else { return }
-        self.resumed = true
-        continuation.resume()
     }
 }

--- a/Sources/Kaset/Services/PodcastsAvailabilityService.swift
+++ b/Sources/Kaset/Services/PodcastsAvailabilityService.swift
@@ -11,9 +11,8 @@ import Observation
 ///
 /// State is in-memory only — no persistence. Each app launch re-probes
 /// from scratch so a region change (e.g. enabling a VPN before
-/// relaunching) is reflected without sign-out/in. The owning view
-/// defers rendering main content until `didResolveFirstProbe` flips, so
-/// the user never sees the Podcasts row appear-then-disappear.
+/// relaunching) is reflected without sign-out/in. The sidebar renders
+/// the row while availability is unknown and removes it after a 404.
 @MainActor
 @Observable
 final class PodcastsAvailabilityService {

--- a/Sources/Kaset/VideoWindowController.swift
+++ b/Sources/Kaset/VideoWindowController.swift
@@ -25,7 +25,8 @@ final class VideoWindowController {
     /// Shows the video window.
     func show(
         playerService: PlayerService,
-        webKitManager: WebKitManager
+        webKitManager: WebKitManager,
+        authService: AuthService
     ) {
         // Store reference to sync state on close
         self.playerService = playerService
@@ -45,6 +46,7 @@ final class VideoWindowController {
         let contentView = VideoPlayerWindow()
             .environment(playerService)
             .environment(webKitManager)
+            .environment(authService)
 
         let hostingView = NSHostingView(rootView: AnyView(contentView))
         self.hostingView = hostingView

--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -137,16 +137,14 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
                 )
             }
             .task(id: self.authService.hasPersonalAccount) {
-                // Run the podcasts availability probe whenever the user
-                // becomes logged in (cold start with cached cookies, or
-                // after an explicit sign-in). The result gates `mainContent`
-                // via `didResolveFirstProbe`, so the sidebar paints with the
-                // correct state on first frame — no flicker.
+                // Probe podcasts availability in the background whenever the
+                // user becomes logged in. The sidebar starts with podcasts
+                // visible and removes the row if the endpoint returns 404.
                 guard self.authService.hasPersonalAccount else { return }
                 // Brief delay so post-login cookies have a chance to settle
                 // into the data store the API client reads from. On cold
-                // start cookies are already there; this 200 ms is a small
-                // safety margin and is invisible behind the spinner.
+                // start cookies are already there, and this delay does not
+                // block content rendering.
                 try? await Task.sleep(for: .milliseconds(200))
                 await self.podcastsAvailability.probeForFirstResolution(
                     for: self.accountService.currentAccount?.id,
@@ -179,20 +177,7 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
                     // Show loading while checking login status to avoid guest-content flash
                     self.initializingView
                 } else if self.authService.hasPersonalAccount {
-                    // Skip the probe gate in UI test mode: existing test
-                    // fixtures (e.g. `navigateToSidebarItem`) check
-                    // sidebar element existence synchronously right after
-                    // launch and don't tolerate the ~300 ms gate delay.
-                    // The probe still fires in the background so the
-                    // `MOCK_PODCASTS_REGION_UNAVAILABLE` path works.
-                    if self.podcastsAvailability.didResolveFirstProbe || UITestConfig.isUITestMode {
-                        self.mainContent
-                    } else {
-                        // Hold the same loading view until the podcasts
-                        // probe resolves so the sidebar paints with the
-                        // correct state on first frame.
-                        self.initializingView
-                    }
+                    self.mainContent
                 } else if self.didCompleteStartupPlaybackCleanup {
                     // Guest mode: public browsing/search/playback remains available
                     // without login. Personal routes render sign-in prompts below.
@@ -207,10 +192,12 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
                 DiagnosticsLogger.app.info("MainWindow: UI appeared")
             }
 
-            // Persistent WebView - always present once a video has been requested.
+            // Persistent WebView - present once a video is ready to load.
             // Uses a SINGLETON WebView instance that persists for the app lifetime.
             // Keep it as a hidden 1×1 anchor for audio playback; do not reveal a mini overlay.
-            if let videoId = playerService.pendingPlayVideoId {
+            if let videoId = playerService.pendingPlayVideoId,
+               !self.playerService.isPendingRestoredLoadDeferred
+            {
                 PersistentPlayerView(videoId: videoId, isExpanded: false)
                     .frame(width: 1, height: 1)
                     .opacity(0)
@@ -802,8 +789,13 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
                     await self.presentCurrentWhatsNew()
                 }
             }
-            Task {
-                await self.accountService.fetchAccounts()
+            // KasetApp's root startup task owns the initializing -> logged-in
+            // account fetch. Later login and reauthentication transitions still
+            // need to refresh the account list here.
+            if oldState != .initializing {
+                Task {
+                    await self.accountService.fetchAccounts()
+                }
             }
             // If we just completed login/reauth, refresh content. This handles
             // the case where cookies were unavailable during initial load and

--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -6,6 +6,8 @@ import SwiftUI
 
 /// Main application window with sidebar navigation and player bar.
 struct MainWindow: View { // swiftlint:disable:this type_body_length
+    private static let accountResolutionGateTimeout: Duration = .seconds(2)
+
     private struct PresentedWhatsNew: Identifiable {
         let whatsNew: WhatsNew
         let requestedVersion: WhatsNew.Version
@@ -13,6 +15,11 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
         var id: String {
             "\(self.requestedVersion.description)::\(self.whatsNew.version.description)"
         }
+    }
+
+    private struct PodcastsProbeTaskID: Hashable {
+        let authGeneration: UInt64
+        let accountID: String
     }
 
     @Environment(AuthService.self) private var authService
@@ -59,6 +66,7 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
     @State private var selectedSidebarPinnedItem: SidebarPinnedItem?
     @State private var contentResetID = UUID()
     @State private var guestRefreshTask: Task<Void, Never>?
+    @State private var accountResolutionFailOpenGeneration: UInt64?
 
     // MARK: - Cached ViewModels (persist across tab switches)
 
@@ -136,20 +144,31 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
                     accountId: accountId
                 )
             }
-            .task(id: self.authService.hasPersonalAccount) {
-                // Probe podcasts availability in the background whenever the
-                // user becomes logged in. The sidebar starts with podcasts
-                // visible and removes the row if the endpoint returns 404.
-                guard self.authService.hasPersonalAccount else { return }
+            .task(id: self.podcastsProbeTaskID) {
+                // Probe podcasts availability in the background when the
+                // initial account resolves for an authenticated session.
+                guard self.podcastsProbeTaskID != nil else { return }
                 // Brief delay so post-login cookies have a chance to settle
-                // into the data store the API client reads from. On cold
-                // start cookies are already there, and this delay does not
+                // into the data store the API client reads from. This does not
                 // block content rendering.
                 try? await Task.sleep(for: .milliseconds(200))
-                await self.podcastsAvailability.probeForFirstResolution(
+                guard !Task.isCancelled else { return }
+                await self.podcastsAvailability.probe(
                     for: self.accountService.currentAccount?.id,
                     using: self.client
                 )
+            }
+            .task(id: self.accountResolutionGateTaskID) {
+                self.accountResolutionFailOpenGeneration = nil
+                guard let authGeneration = self.accountResolutionGateTaskID else { return }
+
+                do {
+                    try await Task.sleep(for: Self.accountResolutionGateTimeout)
+                } catch {
+                    return
+                }
+                guard self.accountResolutionGateTaskID == authGeneration else { return }
+                self.accountResolutionFailOpenGeneration = authGeneration
             }
             .onChange(of: self.likeStatusManager.lastLikeEventBatch) { _, batch in
                 guard let batch, batch.accountID == self.likeStatusManager.activeAccountID else { return }
@@ -177,7 +196,13 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
                     // Show loading while checking login status to avoid guest-content flash
                     self.initializingView
                 } else if self.authService.hasPersonalAccount {
-                    self.mainContent
+                    if self.canRenderAuthenticatedContent {
+                        self.mainContent
+                    } else {
+                        // Give the initial account fetch a bounded chance to restore
+                        // the selected primary or brand account before requests start.
+                        self.initializingView
+                    }
                 } else if self.didCompleteStartupPlaybackCleanup {
                     // Guest mode: public browsing/search/playback remains available
                     // without login. Personal routes render sign-in prompts below.
@@ -196,7 +221,8 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
             // Uses a SINGLETON WebView instance that persists for the app lifetime.
             // Keep it as a hidden 1×1 anchor for audio playback; do not reveal a mini overlay.
             if let videoId = playerService.pendingPlayVideoId,
-               !self.playerService.isPendingRestoredLoadDeferred
+               !self.playerService.isPendingRestoredLoadDeferred,
+               !self.playerService.showVideo
             {
                 PersistentPlayerView(videoId: videoId, isExpanded: false)
                     .frame(width: 1, height: 1)
@@ -247,6 +273,28 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
                 .padding(.top, 60)
         }
         .frame(minWidth: MainWindowLayout.minimumWidth, minHeight: MainWindowLayout.minimumHeight)
+    }
+
+    private var podcastsProbeTaskID: PodcastsProbeTaskID? {
+        guard self.authService.hasPersonalAccount,
+              self.accountService.didCompleteAccountResolution
+        else { return nil }
+        return PodcastsProbeTaskID(
+            authGeneration: self.authService.accountIdentityGeneration,
+            accountID: self.accountService.currentAccount?.id ?? "primary"
+        )
+    }
+
+    private var accountResolutionGateTaskID: UInt64? {
+        guard self.authService.hasPersonalAccount,
+              !self.accountService.didCompleteAccountResolution
+        else { return nil }
+        return self.authService.accountIdentityGeneration
+    }
+
+    private var canRenderAuthenticatedContent: Bool {
+        self.accountService.didCompleteAccountResolution
+            || self.accountResolutionFailOpenGeneration == self.authService.accountIdentityGeneration
     }
 
     private var appLifecycleContent: some View {
@@ -302,7 +350,8 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
                 if showVideo {
                     VideoWindowController.shared.show(
                         playerService: self.playerService,
-                        webKitManager: self.webKitManager
+                        webKitManager: self.webKitManager,
+                        authService: self.authService
                     )
                 } else {
                     VideoWindowController.shared.close()
@@ -384,22 +433,14 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
             self.youtubeStore.resetForAccountChange()
 
             // Brand accounts can have a different region than the
-            // primary; re-probe in the background so the sidebar
-            // reflects the new account. We deliberately do NOT
-            // reset the gate (`didResolveFirstProbe`) here — that
-            // would tear down `mainContent` and show the loading
-            // spinner full-screen during the switch. Sidebar may
-            // briefly show the prior account's tab state until the
-            // probe lands.
+            // primary. Re-probe in the background so the sidebar
+            // reflects the new account. The sidebar may briefly show
+            // the prior account's tab state until the probe lands.
             DiagnosticsLogger.auth.info("Account switched, refreshing content and current track metadata...")
 
             await withTaskGroup(of: Void.self) { group in
                 group.addTask {
                     await self.refreshAllContent()
-                }
-
-                group.addTask {
-                    await self.podcastsAvailability.probe(for: newAccountId, using: self.client)
                 }
 
                 if let currentVideoId = self.playerService.currentTrack?.videoId {
@@ -755,8 +796,8 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
                 self.youtubeClient.resetSessionStateForAccountSwitch()
                 self.rebuildMusicViewModels()
                 self.youtubeStore.resetForAccountChange()
-                // Reset podcasts availability so the next sign-in re-gates
-                // the UI and re-probes the endpoint.
+                // Reset podcasts availability so the next sign-in re-probes
+                // the endpoint.
                 self.podcastsAvailability.reset()
             }
             if !isReauthTransition {
@@ -888,7 +929,7 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
 
     private func refreshAuthenticatedContent() async {
         // Parallel initial data fetch for ~40% faster app launch. The podcasts
-        // probe is driven separately by the `.task(id: hasPersonalAccount)` UI gate.
+        // probe is driven separately by the account-keyed task.
         await withTaskGroup(of: Void.self) { group in
             group.addTask { await self.homeViewModel?.refresh() }
             group.addTask { await self.exploreViewModel?.refresh() }
@@ -945,8 +986,7 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
         // The podcasts refresh is gated on the latest availability
         // signal so a brand-account switch into a region without
         // podcasts doesn't fire the spurious 404 the bug is about. The
-        // probe scheduled alongside this group will re-evaluate
-        // availability separately.
+        // account-keyed task re-evaluates availability separately.
         let podcastsAvailable = self.podcastsAvailability.availability != .unavailable
         await withTaskGroup(of: Void.self) { group in
             group.addTask { await self.homeViewModel?.refresh() }

--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -842,13 +842,36 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
             // the case where cookies were unavailable during initial load and
             // preserved views that may currently hold auth-expired state.
             if shouldRefreshAuthenticatedContent {
+                let authGeneration = self.authService.accountIdentityGeneration
                 Task {
-                    // Brief delay to ensure cookies are fully propagated in WebKit
-                    try? await Task.sleep(for: .milliseconds(500))
+                    guard await self.waitForAuthenticatedRefreshReadiness(
+                        authGeneration: authGeneration
+                    ) else { return }
                     await self.refreshAuthenticatedContent()
                 }
             }
         }
+    }
+
+    private func waitForAuthenticatedRefreshReadiness(authGeneration: UInt64) async -> Bool {
+        let clock = ContinuousClock()
+        let accountResolutionDeadline = clock.now + Self.accountResolutionGateTimeout
+
+        do {
+            // Keep the existing post-login cookie propagation delay.
+            try await Task.sleep(for: .milliseconds(500))
+            while !self.accountService.didCompleteAccountResolution,
+                  clock.now < accountResolutionDeadline
+            {
+                try await Task.sleep(for: .milliseconds(50))
+            }
+        } catch {
+            return false
+        }
+
+        return !Task.isCancelled
+            && self.authService.hasPersonalAccount
+            && self.authService.accountIdentityGeneration == authGeneration
     }
 
     private func handleGuestModeChange(isGuestModeEnabled: Bool) {

--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -293,7 +293,8 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
     }
 
     private var canRenderAuthenticatedContent: Bool {
-        self.accountService.didCompleteAccountResolution
+        UITestConfig.isUITestMode
+            || self.accountService.didCompleteAccountResolution
             || self.accountResolutionFailOpenGeneration == self.authService.accountIdentityGeneration
     }
 

--- a/Sources/Kaset/Views/VideoPlayerWindow.swift
+++ b/Sources/Kaset/Views/VideoPlayerWindow.swift
@@ -10,7 +10,7 @@ struct VideoPlayerWindow: View {
     var body: some View {
         // The Window controls the aspect ratio and min size;
         // using .fit here can cause the webview to shrink/be letterboxed incorrectly during fast resize.
-        VideoWebViewContainer()
+        VideoWebViewContainer(videoId: self.playerService.pendingPlayVideoId)
             .background(.black)
             .accessibilityIdentifier(AccessibilityID.VideoWindow.container)
     }
@@ -20,18 +20,41 @@ struct VideoPlayerWindow: View {
 
 /// NSViewRepresentable container for the video WebView.
 struct VideoWebViewContainer: NSViewRepresentable {
+    @Environment(WebKitManager.self) private var webKitManager
+    @Environment(PlayerService.self) private var playerService
+    @Environment(AuthService.self) private var authService
+
+    let videoId: String?
+
     func makeNSView(context _: Context) -> VideoContainerView {
         DiagnosticsLogger.player.info("VideoWebViewContainer.makeNSView called")
         let container = VideoContainerView()
         container.wantsLayer = true
         container.layer?.backgroundColor = NSColor.black.cgColor
+        self.attachPlayerWebView(to: container)
         return container
     }
 
     func updateNSView(_ nsView: VideoContainerView, context _: Context) {
         DiagnosticsLogger.player.debug("VideoWebViewContainer.updateNSView called")
-        // Reparent the WebView into this container for video display
-        SingletonPlayerWebView.shared.ensureInHierarchy(container: nsView)
+        self.attachPlayerWebView(to: nsView)
+    }
+
+    private func attachPlayerWebView(to container: VideoContainerView) {
+        _ = SingletonPlayerWebView.shared.getWebView(
+            webKitManager: self.webKitManager,
+            playerService: self.playerService,
+            usesCookieFreeDataStore: self.authService.shouldUseCookieFreePlaybackDataStore
+        )
+        SingletonPlayerWebView.shared.ensureInHierarchy(container: container)
+        SingletonPlayerWebView.shared.updateDisplayMode(.video)
+
+        if let videoId = self.videoId,
+           self.playerService.shouldAutoloadPendingVideo,
+           SingletonPlayerWebView.shared.currentVideoId != videoId
+        {
+            SingletonPlayerWebView.shared.loadVideo(videoId: videoId)
+        }
     }
 }
 
@@ -79,5 +102,7 @@ final class VideoContainerView: NSView {
 #Preview {
     VideoPlayerWindow()
         .environment(PlayerService())
+        .environment(WebKitManager.shared)
+        .environment(AuthService())
         .frame(width: 480, height: 270)
 }

--- a/Tests/KasetTests/AccountServiceTests.swift
+++ b/Tests/KasetTests/AccountServiceTests.swift
@@ -23,7 +23,20 @@ struct AccountServiceTests {
         #expect(services.account.hasBrandAccounts == false)
         #expect(services.account.currentBrandId == nil)
         #expect(services.account.isLoading == false)
+        #expect(services.account.didCompleteAccountResolution == false)
         #expect(services.account.lastError == nil)
+    }
+
+    @Test @MainActor func accountResolutionTracksCurrentAuthenticationIdentity() async {
+        let services = Self.createService()
+
+        await Self.populateAccounts(services, accounts: [MockUserAccountData.primaryAccount])
+        #expect(services.account.didCompleteAccountResolution == true)
+
+        services.auth.sessionExpired()
+        services.account.authenticationIdentityDidChange()
+
+        #expect(services.account.didCompleteAccountResolution == false)
     }
 
     @Test @MainActor func hasBrandAccountsReturnsFalseForSingleAccount() async {
@@ -1800,6 +1813,7 @@ struct AccountServiceTests {
         await services.account.fetchAccounts()
 
         #expect(services.account.lastError != nil)
+        #expect(services.account.didCompleteAccountResolution == true)
 
         // Clear the error
         services.account.clearError()

--- a/Tests/KasetTests/AccountServiceTests.swift
+++ b/Tests/KasetTests/AccountServiceTests.swift
@@ -1804,6 +1804,18 @@ struct AccountServiceTests {
 
     // MARK: - Error Handling Tests
 
+    @Test @MainActor func cancelledAccountFetchDoesNotResolveOrPublishError() async {
+        let services = Self.createService()
+
+        services.client.shouldThrowError = CancellationError()
+        services.auth.completeLogin(sapisid: "test-sapisid")
+        await services.account.fetchAccounts()
+
+        #expect(services.account.didCompleteAccountResolution == false)
+        #expect(services.account.lastError == nil)
+        #expect(services.account.isLoading == false)
+    }
+
     @Test @MainActor func clearErrorResetsLastError() async {
         let services = Self.createService()
 

--- a/Tests/KasetTests/PodcastsAvailabilityServiceTests.swift
+++ b/Tests/KasetTests/PodcastsAvailabilityServiceTests.swift
@@ -13,7 +13,6 @@ struct PodcastsAvailabilityServiceTests {
     func initialAvailabilityIsUnknown() {
         let service = PodcastsAvailabilityService()
         #expect(service.availability == .unknown)
-        #expect(service.didResolveFirstProbe == false)
     }
 
     // MARK: - Probe outcomes
@@ -30,7 +29,6 @@ struct PodcastsAvailabilityServiceTests {
 
         #expect(result == .available)
         #expect(service.availability == .available)
-        #expect(service.didResolveFirstProbe == true)
     }
 
     @Test
@@ -43,11 +41,10 @@ struct PodcastsAvailabilityServiceTests {
 
         #expect(result == .unavailable)
         #expect(service.availability == .unavailable)
-        #expect(service.didResolveFirstProbe == true)
     }
 
     @Test
-    func probeWithEmptySectionsLeavesAvailabilityUnchangedButResolvesGate() async {
+    func probeWithEmptySectionsLeavesAvailabilityUnchanged() async {
         let client = MockYTMusicClient()
         client.podcastsSections = []
         let service = PodcastsAvailabilityService()
@@ -59,12 +56,10 @@ struct PodcastsAvailabilityServiceTests {
         // load.
         #expect(result == .unknown)
         #expect(service.availability == .unknown)
-        // But the gate releases so the UI doesn't hang.
-        #expect(service.didResolveFirstProbe == true)
     }
 
     @Test
-    func probeWith500LeavesAvailabilityUnchangedButResolvesGate() async {
+    func probeWith500LeavesAvailabilityUnchanged() async {
         let client = MockYTMusicClient()
         client.shouldThrowError = YTMusicError.apiError(message: "HTTP 500", code: 500)
         let service = PodcastsAvailabilityService()
@@ -73,7 +68,6 @@ struct PodcastsAvailabilityServiceTests {
 
         #expect(result == .unknown)
         #expect(service.availability == .unknown)
-        #expect(service.didResolveFirstProbe == true)
     }
 
     @Test
@@ -115,12 +109,10 @@ struct PodcastsAvailabilityServiceTests {
         let currentResult = await service.probe(for: "account-b", using: currentClient)
         #expect(currentResult == .available)
         #expect(service.availability == .available)
-        #expect(service.didResolveFirstProbe == true)
 
         let staleResult = await staleProbe.value
         #expect(staleResult == .available)
         #expect(service.availability == .available)
-        #expect(service.didResolveFirstProbe == true)
     }
 
     @Test
@@ -139,105 +131,43 @@ struct PodcastsAvailabilityServiceTests {
 
         service.reset()
         #expect(service.availability == .unknown)
-        #expect(service.didResolveFirstProbe == false)
 
         let result = await probe.value
         #expect(result == .unknown)
         #expect(service.availability == .unknown)
-        #expect(service.didResolveFirstProbe == false)
-    }
-
-    // MARK: - First-resolution gate
-
-    @Test
-    func probeForFirstResolutionFlipsGateOn404() async {
-        let client = MockYTMusicClient()
-        client.shouldThrowError = YTMusicError.apiError(message: "HTTP 404", code: 404)
-        let service = PodcastsAvailabilityService()
-        #expect(service.didResolveFirstProbe == false)
-
-        await service.probeForFirstResolution(for: "primary", using: client)
-
-        #expect(service.availability == .unavailable)
-        #expect(service.didResolveFirstProbe == true)
-    }
-
-    @Test
-    func probeForFirstResolutionFlipsGateOnSuccess() async {
-        let client = MockYTMusicClient()
-        client.podcastsSections = [
-            PodcastSection(id: UUID().uuidString, title: "Top", items: []),
-        ]
-        let service = PodcastsAvailabilityService()
-
-        await service.probeForFirstResolution(for: "primary", using: client)
-
-        #expect(service.availability == .available)
-        #expect(service.didResolveFirstProbe == true)
-    }
-
-    @Test
-    func probeForFirstResolutionFlipsGateOnTimeoutAndProbeKeepsRunning() async {
-        // Mock client that doesn't return until well after the timeout
-        // and then yields a 404, so we can confirm both that the gate
-        // releases via timeout and that the late 404 still demotes the
-        // tab when it lands.
-        let client = MockYTMusicClient()
-        client.getPodcastsDelay = .milliseconds(500)
-        client.shouldThrowError = YTMusicError.apiError(message: "HTTP 404", code: 404)
-        let service = PodcastsAvailabilityService()
-
-        await service.probeForFirstResolution(
-            for: "primary",
-            using: client,
-            timeout: .milliseconds(50)
-        )
-
-        // Gate releases via timeout; state still unknown so sidebar fails open.
-        #expect(service.didResolveFirstProbe == true)
-        #expect(service.availability == .unknown)
-
-        // The probe is still running in the background — wait for it
-        // and confirm the eventual 404 demotes the tab.
-        try? await Task.sleep(for: .milliseconds(700))
-        #expect(service.availability == .unavailable)
     }
 
     // MARK: - Lazy signals
 
     @Test
-    func markUnavailableUpdatesStateAndResolvesGate() {
+    func markUnavailableUpdatesState() {
         let service = PodcastsAvailabilityService()
 
         service.markUnavailable(for: "primary")
 
         #expect(service.availability == .unavailable)
-        #expect(service.didResolveFirstProbe == true)
     }
 
     @Test
-    func markAvailableUpdatesStateAndResolvesGate() {
+    func markAvailableUpdatesState() {
         let service = PodcastsAvailabilityService()
 
         service.markAvailable(for: "primary")
 
         #expect(service.availability == .available)
-        #expect(service.didResolveFirstProbe == true)
     }
 
     // MARK: - Reset
 
     @Test
-    func resetClearsBothAvailabilityAndGate() {
+    func resetClearsAvailability() {
         let service = PodcastsAvailabilityService()
         service.markUnavailable(for: "primary")
         #expect(service.availability == .unavailable)
-        #expect(service.didResolveFirstProbe == true)
 
         service.reset()
 
         #expect(service.availability == .unknown)
-        #expect(service.didResolveFirstProbe == false)
     }
 }
 

--- a/docs/adr/0019-podcasts-availability.md
+++ b/docs/adr/0019-podcasts-availability.md
@@ -121,8 +121,10 @@ was considered but rejected — see *Alternatives*.
 - **`MainWindow.swift`** renders authenticated content after account
   resolution, or after a 2-second fail-open deadline, without waiting for the
   podcasts probe. A late account result uses the existing account-switch refresh
-  path. The window redirects `navigationSelection = .home` if availability flips
-  to `.unavailable` while the user is on the Podcasts tab.
+  path. Post-login and reauthentication refreshes observe the same deadline so
+  they do not fetch primary-account content while brand restoration is pending.
+  The window redirects `navigationSelection = .home` if availability flips to
+  `.unavailable` while the user is on the Podcasts tab.
 - **`PodcastsViewModel.load()`** on `apiError(code: 404)` calls
   `service.markUnavailable(for:)` and lands on `.loaded` with empty
   sections instead of `.error`. The sidebar row disappears within a frame,

--- a/docs/adr/0019-podcasts-availability.md
+++ b/docs/adr/0019-podcasts-availability.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Implemented
+Implemented, amended 2026-08-29
 
 ## Context
 
@@ -34,10 +34,12 @@ So the fix is scoped to the discovery tab only.
 ## Decision
 
 Add a `PodcastsAvailabilityService` (`@MainActor @Observable`) that probes
-`FEmusic_podcasts` once per session, gates main-window rendering on the
-result, and exposes the resolved state to the sidebar through the SwiftUI
-environment. State is **in-memory only** — every cold launch re-probes from
-scratch.
+`FEmusic_podcasts` once per session and exposes the result to the sidebar
+through the SwiftUI environment. The probe runs after the initial account is
+resolved but does not gate main-window rendering. Authenticated rendering waits
+up to 2 seconds for account resolution, then fails open with the primary-account
+scope while the account request continues. State is **in-memory only** and every
+cold launch re-probes from scratch.
 
 ### State machine
 
@@ -59,12 +61,10 @@ Successful signals can therefore promote `.unavailable` back to
 `.available` after an account/region change; unavailable signals can also
 remove the tab from either `.unknown` or `.available`.
 
-A second observable, `didResolveFirstProbe: Bool`, tracks whether the first
-probe of the session has finished. It flips to `true` on any probe
-completion (success, 404, transient error) **or** when a 2-second timeout
-fires. `MainWindow.body` shows the loading spinner until this flag flips,
-so the sidebar paints with the correct state on first frame — no
-appear-then-disappear flicker.
+While availability is `.unknown`, the sidebar renders the Podcasts row. A
+definitive 404 removes it. This optimistic state keeps the podcasts network
+request off the startup rendering path, at the cost of a brief row removal in
+unsupported regions.
 
 ### No persistence
 
@@ -75,11 +75,9 @@ The service's state lives only in memory. Trade-offs considered:
   invalidate.
 - **+** No schema versioning, no TTL, no per-account cache lifecycle to
   reason about.
-- **−** One extra `browse` request per cold launch. Cost is essentially
-  zero: the request runs in parallel with `homeViewModel.refresh()`
-  etc., warms `APICache` so opening the tab right after launch is
-  instant on available regions, and is hidden behind the spinner on
-  unavailable regions where it ends quickly with 404.
+- **−** One extra `browse` request per cold launch. It runs in parallel with
+  personalized content loads and warms `APICache`, so opening the tab after
+  launch is immediate in available regions.
 
 A persistent cache keyed by `accountId` with a TTL on `.unavailable`
 was considered but rejected — see *Alternatives*.
@@ -93,33 +91,26 @@ was considered but rejected — see *Alternatives*.
 - **Secondary** (lazy path only): a user-initiated load that returns zero
   sections. Empty payloads are noisy from the probe path (cold caches,
   transient YT issues), so we only trust them when the user has actively
-  visited the tab. Background probe with empty sections releases the gate
-  but leaves `availability` untouched.
+  visited the tab. A background probe with empty sections leaves
+  `availability` untouched.
 - **Ignored**: 5xx, network errors, auth errors. Transient failures must
-  never demote a known-good state. They still release the gate so the UI
-  doesn't hang behind a flaky network.
+  never demote a known-good state.
 
 ### Probe lifecycle (in `MainWindow`)
 
-- **First probe**: a `.task(id: authService.state.isLoggedIn)` modifier
-  fires whenever `isLoggedIn` flips to `true` — covering both cold launches
-  with cached cookies (`.initializing → .loggedIn`) and explicit sign-ins
-  (`.loggingIn → .loggedIn`). After a 200 ms cookie-settle delay it calls
-  `service.probeForFirstResolution(...)`, which races the probe against a
-  2-second timeout and flips `didResolveFirstProbe` when either completes.
-  The probe always runs to completion in the background — a slow but
-  definite 404 still demotes the tab when it lands, even if the gate
-  released earlier via timeout.
-- **Account switch**: existing `onChange(of:
-  accountService.currentAccount?.id)` block fires a probe in the same
-  `withTaskGroup` as the other content refreshes. The gate
-  (`didResolveFirstProbe`) is deliberately *not* re-closed here, so
-  `mainContent` stays visible while content refreshes; the sidebar
-  briefly shows the prior account's tab state until the probe returns
-  a definitive answer. We accept this small staleness window in
-  exchange for not tearing down the whole UI on every switch.
-- **Logout**: `service.reset()` clears both `availability` and
-  `didResolveFirstProbe`. The next sign-in re-gates the UI and re-probes.
+- **First probe**: a task keyed to the authentication generation and resolved
+  account ID fires after the account-list request restores the selected primary
+  or brand account. The main window waits up to 2 seconds for that resolution,
+  then renders against the primary-account scope if the request is still pending.
+  After account resolution and a 200 ms cookie-settle delay, the task awaits
+  `service.probe(...)`.
+- **Account switch**: changing the account ID cancels and restarts the same
+  SwiftUI task. `mainContent` stays visible while content refreshes, so the
+  sidebar can briefly show the prior account's tab state until the probe returns
+  a definitive answer. The service's generation check rejects late results from
+  an older account.
+- **Logout**: `service.reset()` clears `availability`. The next sign-in
+  re-probes after account resolution.
 - **`refreshAllContent`**: skips the podcasts viewmodel refresh when
   `availability == .unavailable` to avoid re-firing the spurious 404.
 
@@ -127,12 +118,11 @@ was considered but rejected — see *Alternatives*.
 
 - **`Sidebar.swift`** renders the Podcasts `NavigationLink` only when
   `availability != .unavailable`.
-- **`MainWindow.swift`** holds `mainContent` rendering until
-  `didResolveFirstProbe == true`; until then the existing
-  `initializingView` (cassette icon + spinner) is shown. Also redirects
-  `navigationSelection = .home` if the state flips to `.unavailable`
-  while the user is on the Podcasts tab (handles the lazy-path case
-  during account switches).
+- **`MainWindow.swift`** renders authenticated content after account
+  resolution, or after a 2-second fail-open deadline, without waiting for the
+  podcasts probe. A late account result uses the existing account-switch refresh
+  path. The window redirects `navigationSelection = .home` if availability flips
+  to `.unavailable` while the user is on the Podcasts tab.
 - **`PodcastsViewModel.load()`** on `apiError(code: 404)` calls
   `service.markUnavailable(for:)` and lands on `.loaded` with empty
   sections instead of `.error`. The sidebar row disappears within a frame,
@@ -147,8 +137,9 @@ was considered but rejected — see *Alternatives*.
   dead tab automatically.
 - Region changes via VPN are picked up on the next app launch — no
   account/session manipulation required.
-- No flicker on cold launch in either direction (US-style users see the
-  tab when content paints, TR-style users never see it appear).
+- The podcasts probe no longer delays authenticated content rendering.
+- A stalled account-list request can delay authenticated rendering by at most
+  2 seconds. A late brand-account result refreshes content after it arrives.
 - Other podcast features (library subscriptions, search, artist pages)
   remain fully functional because they're gated separately.
 - No new third-party dependencies. No persistence-layer surface area.
@@ -158,9 +149,8 @@ was considered but rejected — see *Alternatives*.
 - One extra `browse` request per cold launch. Mitigated by parallelism
   with the existing post-login refreshes and by `APICache` warming for
   available regions.
-- Cold-launch first paint is gated on the probe (or 2 s timeout). For
-  available regions this is typically <500 ms and invisible behind the
-  spinner that already covers the auth check.
+- Unsupported regions can briefly see the Podcasts row before the 404 probe
+  removes it.
 
 **Neutral**
 
@@ -174,8 +164,8 @@ was considered but rejected — see *Alternatives*.
 
 - **Lazy-only (no proactive probe)**: simpler, but the Podcasts row
   would show on the first session in an unsupported region until the
-  user clicked it and saw the 404. The first-paint flicker is exactly
-  what we're trying to avoid.
+  user clicked it and saw the 404. The background probe removes the row
+  without requiring that failed interaction.
 - **Probe via a custom HEAD/exists endpoint**: not worth a separate
   code path; reusing `getPodcasts()` warms `APICache` on success.
 - **Persisted cache keyed by `accountId` with a TTL on `.unavailable`**:


### PR DESCRIPTION
## Description

Reduce authenticated cold-start time by moving nonessential work off the content-rendering path.

Instrumented launches improved authenticated content readiness from 3.38 seconds to 1.21 seconds.

## Type of Change

- [x] UI/UX improvement

## Changes Made

- Render authenticated content while the podcasts availability probe runs in the background.
- Key the podcasts probe to the resolved account so restored brand accounts use the correct scope.
- Give account resolution up to 2 seconds to restore the selected account, then fail open while the request continues.
- Skip the duplicate account fetch during the initial authentication transition.
- Delay restored-playback `WKWebView` creation until playback can load.
- Preserve video-window loading when the hidden audio WebView is absent.

## Measured Results

- Authenticated content readiness: 3.38 s to 1.21 s
- Startup account requests: 2 to 1
- Kaset main-thread microhang: 299.66 ms removed
- Deferred restored playback: no `WKWebView` created at launch

## Testing

- [x] 87 focused unit tests passed
- [x] `swift build`
- [x] Release packaging
- [x] SwiftLint passed for the changed files
- [x] Instrumented packaged-app launch verification
- [ ] UI tests, which require explicit approval

## Checklist

- [x] My code follows the project style guidelines
- [x] I checked the performance implications
- [x] My changes generate no new warnings
- [x] Temporary startup instrumentation was removed

## Additional Notes

Repository-wide SwiftLint still reports 42 pre-existing violations outside these files.
