### PR TITLE
fix(dev): default compile-and-run to debug

### DIFF
--- a/.agents/skills/dev-loop-packaging/SKILL.md
+++ b/.agents/skills/dev-loop-packaging/SKILL.md
@@ -29,7 +29,7 @@ Scripts/compile_and_run.sh --wait
 ## What The Scripts Do
 
 - `Scripts/build-app.sh` builds the app and assembles `.build/app/Kaset.app`.
-- `Scripts/compile_and_run.sh` kills existing Kaset processes, optionally runs tests and linting, packages the app, relaunches it, and checks that it stays running.
+- `Scripts/compile_and_run.sh` kills existing Kaset processes, optionally runs tests and linting, packages a debug app by default, relaunches it, and checks that it stays running. Pass `--release` for a release build.
 - `Scripts/compile_and_run.sh --test` runs the SwiftPM test target before packaging; it does not invoke the separate Xcode UI-test project.
 - `Scripts/build-app.sh` can also build for custom architectures via `ARCHES`.
 

--- a/Scripts/compile_and_run.sh
+++ b/Scripts/compile_and_run.sh
@@ -14,7 +14,7 @@ LOCK_PID_FILE="${LOCK_DIR}/pid"
 WAIT_FOR_LOCK=0
 RUN_TESTS=0
 RUN_LINT=0
-BUILD_CONFIG="release"
+BUILD_CONFIG="debug"
 
 log()  { printf '%s\n' "$*"; }
 fail() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
@@ -112,8 +112,8 @@ for arg in "$@"; do
       log "  --wait, -w    Wait if another compile is in progress"
       log "  --test, -t    Run tests before packaging"
       log "  --lint, -l    Run swiftformat and swiftlint before building"
-      log "  --debug, -d   Package a debug app bundle (shows DEBUG-only settings)"
-      log "  --release, -r Package a release app bundle (default)"
+      log "  --debug, -d   Package a debug app bundle (default; shows DEBUG-only settings)"
+      log "  --release, -r Package a release app bundle"
       exit 0
       ;;
     *)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -40,6 +40,9 @@ Scripts/build-app.sh
 Scripts/compile_and_run.sh
 ```
 
+The dev loop packages a debug build by default. Pass `--release` when testing
+release-only behavior.
+
 ### Lint & Format
 
 ```bash


### PR DESCRIPTION
## Description

Make the packaged development loop use a debug build by default. Debug builds use the file-backed cookie archive, so local rebuilds and separate worktrees can reuse the same login session. Release builds remain available through `--release`.

## Type of Change

- [x] Bug fix
- [x] Documentation update
- [x] Build configuration

## Changes Made

- Default `Scripts/compile_and_run.sh` to debug builds.
- Keep `--release` as an explicit override.
- Update command help and development workflow documentation.

## Testing

- [x] `bash -n Scripts/compile_and_run.sh`
- [x] Verified `Scripts/compile_and_run.sh --help`
- [x] Verified `--release` overrides the debug default
- [x] `git diff --check`

## Additional Notes

The app was not launched, and no UI tests were run.