### PR TITLE
fix: keep YouTube audio playing after closing window

### DIFF
--- a/Sources/Kaset/AppDelegate.swift
+++ b/Sources/Kaset/AppDelegate.swift
@@ -57,12 +57,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             NSApplication.shared.activate(ignoringOtherApps: true)
         }
 
-        // Set up window delegate to intercept close and hide instead
-        Task { @MainActor in
-            try? await Task.sleep(for: .milliseconds(500))
-            self.setupWindowDelegate()
-        }
-
         // Register for system sleep/wake notifications
         self.registerForSleepWakeNotifications()
 
@@ -159,18 +153,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         self.showMainWindowIfNeeded()
     }
 
-    private func setupWindowDelegate() {
-        DiagnosticsLogger.app.info("AppDelegate: setupWindowDelegate starting")
-        for window in NSApplication.shared.windows where window.canBecomeMain {
-            // Skip auxiliary/player and non-primary scene windows; only the regular app window should be hidden-on-close.
-            if self.isAuxiliaryPlayerWindow(window) || !MainWindowLayout.isPrimaryWindow(window) {
-                continue
-            }
-            window.delegate = self
-            MainWindowLayout.configure(window)
-            // Store reference to main window for reliable reopen
-            self.mainWindow = window
+    /// Registers the primary SwiftUI window as soon as its root view joins the
+    /// AppKit hierarchy. Window titles follow navigation state, so discovering
+    /// the main window later by title can miss it before the autosave name is set.
+    /// `KasetApp` owns this through a singleton `Window` scene, not a `WindowGroup`.
+    func registerMainWindow(_ window: NSWindow) {
+        guard !self.isAuxiliaryPlayerWindow(window) else { return }
+        window.delegate = self
+        MainWindowLayout.configureKnownPrimaryWindow(window)
+        self.mainWindow = window
+    }
+
+    /// Releases a detached primary scene without disturbing a newer window.
+    func unregisterMainWindow(_ window: NSWindow) {
+        guard self.mainWindow === window else { return }
+        if window.delegate === self {
+            window.delegate = nil
         }
+        self.mainWindow = nil
     }
 
     // MARK: - Dock Menu

--- a/Sources/Kaset/KasetApp.swift
+++ b/Sources/Kaset/KasetApp.swift
@@ -254,6 +254,16 @@ struct KasetApp: App {
                 .environment(\.showCommandBar, self.$showCommandBar)
                 .environment(\.showWhatsNew, self.$showWhatsNew)
                 .environment(\.usesLegacyMacOS15UI, self.settings.useLegacyMacOS15UI)
+                .background {
+                    MainWindowRegistrationView(
+                        register: { [weak appDelegate = self.appDelegate] window in
+                            appDelegate?.registerMainWindow(window)
+                        },
+                        unregister: { [weak appDelegate = self.appDelegate] window in
+                            appDelegate?.unregisterMainWindow(window)
+                        }
+                    )
+                }
                 .onAppear {
                     DiagnosticsLogger.app.info("KasetApp: App content appeared")
                     self.textInputFocusState.startMonitoring()

--- a/Sources/Kaset/Utilities/MainWindowLayout.swift
+++ b/Sources/Kaset/Utilities/MainWindowLayout.swift
@@ -37,6 +37,13 @@ enum MainWindowLayout {
     static func configure(_ window: NSWindow) {
         guard self.isPrimaryWindow(window) else { return }
 
+        self.configureKnownPrimaryWindow(window)
+    }
+
+    /// Applies the primary-window contract when the caller already owns the
+    /// main SwiftUI scene and does not need title-based discovery.
+    @MainActor
+    static func configureKnownPrimaryWindow(_ window: NSWindow) {
         if window.frameAutosaveName.isEmpty {
             window.setFrameAutosaveName(self.autosaveName)
         }

--- a/Sources/Kaset/Views/MainWindowRegistrationView.swift
+++ b/Sources/Kaset/Views/MainWindowRegistrationView.swift
@@ -1,0 +1,58 @@
+import AppKit
+import SwiftUI
+
+// MARK: - MainWindowRegistrationView
+
+/// Reports the underlying AppKit window when SwiftUI attaches the main scene.
+struct MainWindowRegistrationView: NSViewRepresentable {
+    let register: @MainActor (NSWindow) -> Void
+    let unregister: @MainActor (NSWindow) -> Void
+
+    func makeNSView(context _: Context) -> MainWindowRegistrationNSView {
+        let view = MainWindowRegistrationNSView(frame: .zero)
+        view.windowDidChange = self.register
+        view.windowDidDetach = self.unregister
+        return view
+    }
+
+    func updateNSView(_ view: MainWindowRegistrationNSView, context _: Context) {
+        view.windowDidChange = self.register
+        view.windowDidDetach = self.unregister
+        view.registerCurrentWindowIfNeeded()
+    }
+
+    static func dismantleNSView(_ view: MainWindowRegistrationNSView, coordinator _: Void) {
+        view.unregisterCurrentWindow()
+        view.windowDidChange = nil
+        view.windowDidDetach = nil
+    }
+}
+
+// MARK: - MainWindowRegistrationNSView
+
+@MainActor
+final class MainWindowRegistrationNSView: NSView {
+    var windowDidChange: (@MainActor (NSWindow) -> Void)?
+    var windowDidDetach: (@MainActor (NSWindow) -> Void)?
+    private weak var registeredWindow: NSWindow?
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        self.registerCurrentWindowIfNeeded()
+    }
+
+    func registerCurrentWindowIfNeeded() {
+        guard self.registeredWindow !== self.window else { return }
+        self.unregisterCurrentWindow()
+        self.registeredWindow = self.window
+        if let window = self.window {
+            self.windowDidChange?(window)
+        }
+    }
+
+    func unregisterCurrentWindow() {
+        guard let registeredWindow else { return }
+        self.registeredWindow = nil
+        self.windowDidDetach?(registeredWindow)
+    }
+}

--- a/Tests/KasetTests/AppDelegateWindowLifecycleTests.swift
+++ b/Tests/KasetTests/AppDelegateWindowLifecycleTests.swift
@@ -1,0 +1,116 @@
+import AppKit
+import Foundation
+import Testing
+@testable import Kaset
+
+// MARK: - AppDelegateWindowLifecycleTests
+
+@Suite("AppDelegate window lifecycle", .serialized)
+@MainActor
+struct AppDelegateWindowLifecycleTests {
+    @Test("Registration bridge routes red close and reopen without replacing content")
+    func registrationBridgeRoutesCloseAndReopen() {
+        let windowReference = WeakWindowReference()
+        let auxiliaryWindowsBeforeClose = self.auxiliaryPlayerWindowIDs()
+
+        autoreleasepool {
+            self.exerciseRegistrationBridge(windowReference: windowReference)
+        }
+
+        #expect(windowReference.window == nil)
+        #expect(self.auxiliaryPlayerWindowIDs() == auxiliaryWindowsBeforeClose)
+    }
+
+    private func exerciseRegistrationBridge(windowReference: WeakWindowReference) {
+        let delegate = AppDelegate()
+        let frameAutosaveDefaultsKey = "NSWindow Frame \(MainWindowLayout.autosaveName)"
+        let defaults = UserDefaults.standard
+        let previousFrameAutosaveValue = defaults.object(forKey: frameAutosaveDefaultsKey)
+        var registeredWindowID: ObjectIdentifier?
+        let registrationView = MainWindowRegistrationNSView(frame: .zero)
+        registrationView.windowDidChange = { [weak delegate] window in
+            registeredWindowID = ObjectIdentifier(window)
+            delegate?.registerMainWindow(window)
+        }
+        registrationView.windowDidDetach = { [weak delegate] window in
+            delegate?.unregisterMainWindow(window)
+        }
+        let window = MainWindowLifecycleSpy(
+            contentRect: NSRect(x: 0, y: 0, width: 1100, height: 760),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        windowReference.window = window
+        window.title = "Home"
+        // Exercise the concrete NSView used by the SwiftUI representable. Its
+        // viewDidMoveToWindow callback is the registration timing boundary.
+        window.contentView = registrationView
+        defer {
+            registrationView.unregisterCurrentWindow()
+            registrationView.windowDidChange = nil
+            registrationView.windowDidDetach = nil
+            window.setFrameAutosaveName("")
+            if let previousFrameAutosaveValue {
+                defaults.set(previousFrameAutosaveValue, forKey: frameAutosaveDefaultsKey)
+            } else {
+                defaults.removeObject(forKey: frameAutosaveDefaultsKey)
+            }
+        }
+
+        #expect(registeredWindowID == ObjectIdentifier(window))
+        #expect(window.delegate === delegate)
+        #expect(window.contentMinSize == MainWindowLayout.minimumContentSize)
+
+        let originalContentView = window.contentView
+        let shouldClose = delegate.windowShouldClose(window)
+
+        #expect(!shouldClose)
+        #expect(window.orderOutCallCount == 1)
+        #expect(window.contentView === originalContentView)
+
+        let handledReopen = delegate.applicationShouldHandleReopen(
+            NSApplication.shared,
+            hasVisibleWindows: false
+        )
+
+        #expect(handledReopen)
+        #expect(window.makeKeyAndOrderFrontCallCount == 1)
+        #expect(window.contentView === originalContentView)
+    }
+
+    private func auxiliaryPlayerWindowIDs() -> Set<ObjectIdentifier> {
+        Set(
+            NSApplication.shared.windows.compactMap { window in
+                guard AccessibilityID.isAuxiliaryPlayerWindowIdentifier(window.identifier?.rawValue) else {
+                    return nil
+                }
+                return ObjectIdentifier(window)
+            }
+        )
+    }
+}
+
+// MARK: - WeakWindowReference
+
+@MainActor
+private final class WeakWindowReference {
+    weak var window: NSWindow?
+}
+
+// MARK: - MainWindowLifecycleSpy
+
+@MainActor
+private final class MainWindowLifecycleSpy: NSWindow {
+    private(set) var orderOutCallCount = 0
+    private(set) var makeKeyAndOrderFrontCallCount = 0
+
+    override func orderOut(_ sender: Any?) {
+        self.orderOutCallCount += 1
+        super.orderOut(sender)
+    }
+
+    override func makeKeyAndOrderFront(_: Any?) {
+        self.makeKeyAndOrderFrontCallCount += 1
+    }
+}

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -548,6 +548,8 @@ Before releasing:
 - [ ] Playback starts on click
 - [ ] Track changes work
 - [ ] Background audio works (close window)
+- [ ] Inline YouTube playback continues as audio after the red-button close without opening a floating window
+- [ ] Reopening the main window restores the same playing YouTube surface
 - [ ] Media keys work
 - [ ] Re-opening window doesn't duplicate audio
 - [ ] Sign out and re-login works

--- a/docs/youtube.md
+++ b/docs/youtube.md
@@ -213,6 +213,10 @@ Handoff rules:
   appears, and toggling back restores the same watch view (the YouTube
   drill-in path lives in `YouTubeViewModelStore`, which survives source
   switches). A deliberately popped-out window keeps playing.
+- Closing the main window with the red button hides it and keeps an inline
+  video playing as background audio. This never opens the floating window,
+  even when automatic pop-out is enabled. Reopening Kaset restores the same
+  live inline surface.
 - Closing the floating window stops playback.
 
 The pop-out window is aspect-locked to 16:9 (512×288 minimum), shows the


### PR DESCRIPTION
## Summary

- register the primary SwiftUI window as soon as it joins the AppKit hierarchy
- make the red close button hide and reopen the same inline YouTube playback surface, preserving background audio without a floating window
- add lifecycle regression coverage and update the YouTube and testing documentation

## Verification

- swift build passed
- release packaging and launch smoke passed
- 9 focused lifecycle tests passed
- targeted strict lint and SwiftFormat passed
- autoreview completed with no actionable findings
- packaged runtime smoke confirmed playback advanced from 0:49 to 1:39 while closed; reopening restored the same inline player and no floating window appeared

The full non-UI suite was also attempted, but encountered unrelated concurrency timeouts and a test-runner crash. Each implicated test passed when run in isolation. UI tests were not run.