### PR TITLE
fix(ui): align sidebar item indentation

### DIFF
--- a/Sources/Kaset/Views/SharedViews/KasetSidebarRow.swift
+++ b/Sources/Kaset/Views/SharedViews/KasetSidebarRow.swift
@@ -27,7 +27,6 @@ struct KasetSidebarRow: View {
                     .foregroundStyle(PackageResourceLookup.brandAccent)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, 10)
             .padding(.vertical, 5)
             .background(self.selectionBackground)
             .contentShape(Rectangle())


### PR DESCRIPTION
## Summary

- Remove the duplicate 10-point horizontal padding from shared sidebar rows.
- Keep the native source-list inset, selection background, and vertical spacing unchanged.
- Apply the corrected alignment to both Music and YouTube sidebars.

## Testing

- swift build
- swift test --skip KasetUITests --filter KasetSidebarRowTests
- swiftlint lint --strict Sources/Kaset/Views/SharedViews/KasetSidebarRow.swift
- swiftformat --lint Sources/Kaset/Views/SharedViews/KasetSidebarRow.swift
- Packaged app visual check on macOS 27

Closes #466