### PR TITLE
fix(playback): detect and label YouTube and YouTube Music ads

### DIFF
--- a/Sources/Kaset/Resources/Localizable.xcstrings
+++ b/Sources/Kaset/Resources/Localizable.xcstrings
@@ -1,6 +1,208 @@
 {
   "sourceLanguage": "en",
   "strings": {
+    "Ad": {
+      "comment": "Compact badge shown during an advertisement",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إعلان"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Werbung"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anuncio"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pub"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iklan"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuncio"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "광고"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Advertentie"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reklama"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anúncio"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Реклама"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annons"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reklam"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Реклама"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "广告"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "廣告"
+          }
+        }
+      }
+    },
+    "Advertisement": {
+      "comment": "Accessibility label for the player bar advertisement indicator",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إعلان"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Werbung"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anuncio"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Publicité"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iklan"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annuncio"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "광고"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Advertentie"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reklama"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anúncio"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Реклама"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Annons"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reklam"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Реклама"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "广告"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "廣告"
+          }
+        }
+      }
+    },
     "Smart Shuffle": {
       "localizations": {
         "ar": {

--- a/Sources/Kaset/Resources/ar.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/ar.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+"Ad" = "إعلان";
+"Advertisement" = "إعلان";
+
 // Localizable.strings
 
 "%lld songs" = "%lld أغنية";

--- a/Sources/Kaset/Resources/de.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/de.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+"Ad" = "Werbung";
+"Advertisement" = "Werbung";
+
 // Localizable.strings
 
 "%lld songs" = "%lld Titel";

--- a/Sources/Kaset/Resources/en.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/en.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+"Ad" = "Ad";
+"Advertisement" = "Advertisement";
+
 "%@ %@" = "%1$@ %2$@";
 "%@, %@, %@" = "%1$@, %2$@, %3$@";
 "Profiles" = "Profiles";

--- a/Sources/Kaset/Resources/es.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/es.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+"Ad" = "Anuncio";
+"Advertisement" = "Anuncio";
+
 // Localizable.strings
 
 "%lld songs" = "%lld canciones";

--- a/Sources/Kaset/Resources/fr.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/fr.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+"Ad" = "Pub";
+"Advertisement" = "Publicité";
+
 // Localizable.strings
 
 "%lld songs" = "%lld morceaux";

--- a/Sources/Kaset/Resources/id.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/id.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+"Ad" = "Iklan";
+"Advertisement" = "Iklan";
+
 // Localizable.strings
 
 "%lld songs" = "%lld lagu";

--- a/Sources/Kaset/Resources/it.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/it.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+"Ad" = "Annuncio";
+"Advertisement" = "Annuncio";
+
 // Localizable.strings
 
 "%lld songs" = "%lld brani";

--- a/Sources/Kaset/Resources/ko.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/ko.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+"Ad" = "광고";
+"Advertisement" = "광고";
+
 // Localizable.strings
 
 "%lld songs" = "%lld곡";

--- a/Sources/Kaset/Resources/nl.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/nl.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+"Ad" = "Advertentie";
+"Advertisement" = "Advertentie";
+
 // Localizable.strings
 
 "%lld songs" = "%lld nummers";

--- a/Sources/Kaset/Resources/pl.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/pl.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+"Ad" = "Reklama";
+"Advertisement" = "Reklama";
+
 // Localizable.strings
 
 "%lld songs" = "%lld utworów";

--- a/Sources/Kaset/Resources/pt.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/pt.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+"Ad" = "Anúncio";
+"Advertisement" = "Anúncio";
+
 // Localizable.strings
 
 "%lld songs" = "%lld músicas";

--- a/Sources/Kaset/Resources/ru.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/ru.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+"Ad" = "Реклама";
+"Advertisement" = "Реклама";
+
 // Localizable.strings
 
 "%lld songs" = "%lld треков";

--- a/Sources/Kaset/Resources/sv.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/sv.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+"Ad" = "Annons";
+"Advertisement" = "Annons";
+
 // Localizable.strings
 
 "%lld songs" = "%lld låtar";

--- a/Sources/Kaset/Resources/tr.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/tr.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+"Ad" = "Reklam";
+"Advertisement" = "Reklam";
+
 // Localizable.strings
 
 "%lld songs" = "%lld şarkı";

--- a/Sources/Kaset/Resources/uk.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/uk.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+"Ad" = "Реклама";
+"Advertisement" = "Реклама";
+
 // Localizable.strings
 
 "%lld songs" = "%lld пісень";

--- a/Sources/Kaset/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/zh-Hans.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+"Ad" = "广告";
+"Advertisement" = "广告";
+
 // Localizable.strings
 
 "\"Live\" shifts the colors as the video plays; the others stay constant" = "“实时”会随视频播放变换颜色，其他样式则保持不变";

--- a/Sources/Kaset/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/zh-Hant.lproj/Localizable.strings
@@ -1,3 +1,6 @@
+"Ad" = "廣告";
+"Advertisement" = "廣告";
+
 // Localizable.strings
 
 "\"Live\" shifts the colors as the video plays; the others stay constant" = "「即時」會隨影片播放變換色彩，其他樣式則維持不變";

--- a/Sources/Kaset/Services/Player/MusicPlaybackIntent.swift
+++ b/Sources/Kaset/Services/Player/MusicPlaybackIntent.swift
@@ -348,7 +348,8 @@ extension PlayerService {
         guard self.remoteMusicTransportBatchGeneration == batchGeneration,
               self.acceptsMusicPlaybackIntent(intent)
         else { return }
-        guard self.queueEntryIDOwningCurrentPlayback == currentQueueEntryID,
+        guard !self.isShowingAd,
+              self.queueEntryIDOwningCurrentPlayback == currentQueueEntryID,
               (self.currentTrack?.videoId ?? self.pendingPlayVideoId) == currentVideoID,
               let playbackSnapshot,
               self.remoteMusicPlaybackSnapshot(playbackSnapshot, matches: currentVideoID)

--- a/Sources/Kaset/Services/Player/MusicPlaybackIntent.swift
+++ b/Sources/Kaset/Services/Player/MusicPlaybackIntent.swift
@@ -156,6 +156,9 @@ extension PlayerService {
         issuedAtMilliseconds: Double
     ) {
         guard issuedAtMilliseconds.isFinite else { return }
+        if case .relativeSeek = command, self.isShowingAd {
+            return
+        }
 
         if let intent = self.remoteMusicTransportIntent,
            self.acceptsMusicRemoteCommand(
@@ -344,11 +347,13 @@ extension PlayerService {
 
         let currentVideoID = self.currentTrack?.videoId ?? self.pendingPlayVideoId
         let currentQueueEntryID = self.queueEntryIDOwningCurrentPlayback
+        let adPlaybackGeneration = self.adPlaybackGeneration
         let playbackSnapshot = await self.currentMusicPlaybackSnapshot()
         guard self.remoteMusicTransportBatchGeneration == batchGeneration,
               self.acceptsMusicPlaybackIntent(intent)
         else { return }
         guard !self.isShowingAd,
+              self.adPlaybackGeneration == adPlaybackGeneration,
               self.queueEntryIDOwningCurrentPlayback == currentQueueEntryID,
               (self.currentTrack?.videoId ?? self.pendingPlayVideoId) == currentVideoID,
               let playbackSnapshot,

--- a/Sources/Kaset/Services/Player/MusicPlaybackIntent.swift
+++ b/Sources/Kaset/Services/Player/MusicPlaybackIntent.swift
@@ -156,8 +156,11 @@ extension PlayerService {
         issuedAtMilliseconds: Double
     ) {
         guard issuedAtMilliseconds.isFinite else { return }
-        if case .relativeSeek = command, self.isShowingAd {
-            return
+        switch command {
+        case .relativeSeek, .absoluteSeek:
+            guard !self.isShowingAd else { return }
+        default:
+            break
         }
 
         if let intent = self.remoteMusicTransportIntent,

--- a/Sources/Kaset/Services/Player/PlayerService+PlaybackControls.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+PlaybackControls.swift
@@ -761,12 +761,13 @@ extension PlayerService {
 
     /// Seeks to a specific time.
     func seek(to time: TimeInterval) async {
+        guard !self.isShowingAd else { return }
         let intent = self.beginMusicPlaybackIntent()
         await self.seek(to: time, intent: intent)
     }
 
     func seek(to time: TimeInterval, intent: MusicPlaybackIntent) async {
-        guard self.acceptsMusicPlaybackIntent(intent) else { return }
+        guard !self.isShowingAd, self.acceptsMusicPlaybackIntent(intent) else { return }
         let clampedTime = self.duration > 0 ? min(max(time, 0), self.duration) : max(time, 0)
         self.logger.debug("Seeking to \(clampedTime)")
 

--- a/Sources/Kaset/Services/Player/PlayerService.swift
+++ b/Sources/Kaset/Services/Player/PlayerService.swift
@@ -161,7 +161,16 @@ final class PlayerService: NSObject, PlayerServiceProtocol {
     }
 
     /// Whether the music playback WebView currently reports an advertisement.
-    var isShowingAd = false
+    var isShowingAd = false {
+        didSet {
+            if self.isShowingAd != oldValue {
+                self.adPlaybackGeneration &+= 1
+            }
+        }
+    }
+
+    /// Invalidates asynchronous snapshots that span an ad transition.
+    @ObservationIgnored private(set) var adPlaybackGeneration: UInt64 = 0
 
     /// Last clock sample known to belong to the requested music content.
     var lastNonAdContentProgress: TimeInterval = 0

--- a/Sources/Kaset/Services/Player/YouTubePlayerService+Seeking.swift
+++ b/Sources/Kaset/Services/Player/YouTubePlayerService+Seeking.swift
@@ -16,6 +16,7 @@ extension YouTubePlayerService {
 
     /// Seeks to a position in seconds.
     func seek(to time: Double) {
+        guard !self.isShowingAd else { return }
         self.beginYouTubePlaybackIntent()
         self.clearRelativeSeekCoalescingTarget()
         self.performSeek(to: time)
@@ -25,7 +26,7 @@ extension YouTubePlayerService {
         to time: Double,
         issuedAtMilliseconds: Double
     ) {
-        guard self.admitYouTubeRemoteCommand(
+        guard !self.isShowingAd, self.admitYouTubeRemoteCommand(
             issuedAtMilliseconds: issuedAtMilliseconds
         ) else { return }
         self.clearRelativeSeekCoalescingTarget()
@@ -99,14 +100,14 @@ extension YouTubePlayerService {
 
     /// Seeks backward by a fixed interval, clamping to the beginning.
     func seekBackward(by seconds: Double = 30) {
-        guard seconds.isFinite, seconds > 0 else { return }
+        guard !self.isShowingAd, seconds.isFinite, seconds > 0 else { return }
         self.beginYouTubePlaybackIntent()
         self.seekRelative(by: -seconds)
     }
 
     /// Seeks forward by a fixed interval, clamping to the known duration.
     func seekForward(by seconds: Double = 30) {
-        guard seconds.isFinite, seconds > 0 else { return }
+        guard !self.isShowingAd, seconds.isFinite, seconds > 0 else { return }
         self.beginYouTubePlaybackIntent()
         self.seekRelative(by: seconds)
     }

--- a/Sources/Kaset/Services/WebKit/PlaybackAdDetectionScript.swift
+++ b/Sources/Kaset/Services/WebKit/PlaybackAdDetectionScript.swift
@@ -56,9 +56,12 @@ enum PlaybackAdDetectionScript {
             // Ad-end signals can precede the return of content media. Share the
             // known creative ID with end-event and recovery-seek scripts too.
             const adVideoId = window.__kasetAdVideoId || '';
+            const video = document.querySelector('#movie_player video') || document.querySelector('video');
+            const boundVideoId = video && video.__kasetBoundVideoId;
+            // Metadata can return before the physical content occurrence does.
             const isAdCreative = adVideoId !== ''
                 && adVideoId !== contentVideoId
-                && (!videoId || videoId === adVideoId);
+                && (!videoId || videoId === adVideoId || boundVideoId === adVideoId);
             if (!isAd && !isAdCreative) delete window.__kasetAdVideoId;
             return isAd || isAdCreative;
         }

--- a/Sources/Kaset/Services/WebKit/PlaybackAdDetectionScript.swift
+++ b/Sources/Kaset/Services/WebKit/PlaybackAdDetectionScript.swift
@@ -58,18 +58,20 @@ enum PlaybackAdDetectionScript {
             const adVideoId = window.__kasetAdVideoId || '';
             const video = document.querySelector('#movie_player video') || document.querySelector('video');
             const boundVideoId = video && video.__kasetBoundVideoId;
-            // Metadata can return before the physical content occurrence does.
-            const isAdCreative = adVideoId !== ''
+            // An ad pod can change creatives while ad signals briefly clear.
+            // Wait for the requested content's metadata and physical media.
+            const awaitingContent = adVideoId !== ''
                 && adVideoId !== contentVideoId
-                && (!videoId || videoId === adVideoId || boundVideoId === adVideoId);
-            if (!isAd && !isAdCreative) delete window.__kasetAdVideoId;
-            return isAd || isAdCreative;
+                && (videoId !== contentVideoId
+                    || (!!boundVideoId && boundVideoId !== contentVideoId));
+            if (!isAd && !awaitingContent) delete window.__kasetAdVideoId;
+            return isAd || awaitingContent;
         }
         """
     }
 
     /// Returns a refresh hook for the bridges' existing player-attachment paths.
-    /// Watches only the player class and ad events; it adds no polling timer.
+    /// Watches player class and ad events, retrying late API hookup for up to ten seconds.
     nonisolated static var observation: String {
         """
         function observeAdStateChanges(onChange) {
@@ -77,6 +79,8 @@ enum PlaybackAdDetectionScript {
             let observedPlayer = null;
             let classObserver = null;
             let observedAPIs = [];
+            let apiRetryCount = 0;
+            let apiRetryTimeoutId = null;
             let lastIsAd = isAdShowing();
 
             function reportChange() {
@@ -96,6 +100,7 @@ enum PlaybackAdDetectionScript {
             return function refreshAdObserver() {
                 const player = document.getElementById('movie_player');
                 if (player !== observedPlayer) {
+                    apiRetryCount = 0;
                     if (classObserver) classObserver.disconnect();
                     classObserver = null;
                     observedPlayer = player;
@@ -108,7 +113,8 @@ enum PlaybackAdDetectionScript {
                     }
                 }
 
-                const apis = adPlayerAPIs().filter(function(api) {
+                const candidates = adPlayerAPIs();
+                const apis = candidates.filter(function(api) {
                     // A bare player div already has DOM addEventListener.
                     // Wait for YouTube's API before subscribing to player events.
                     return typeof api.getPresentingPlayerType === 'function'
@@ -127,6 +133,17 @@ enum PlaybackAdDetectionScript {
                     }
                 }
                 observedAPIs = apis;
+                if (apis.length === candidates.length) {
+                    apiRetryCount = 0;
+                    if (apiRetryTimeoutId !== null) clearTimeout(apiRetryTimeoutId);
+                    apiRetryTimeoutId = null;
+                } else if (apiRetryTimeoutId === null && apiRetryCount < 20) {
+                    apiRetryCount += 1;
+                    apiRetryTimeoutId = setTimeout(function() {
+                        apiRetryTimeoutId = null;
+                        refreshAdObserver();
+                    }, 500);
+                }
                 reportChange();
             };
         }

--- a/Sources/Kaset/Services/WebKit/PlaybackAdDetectionScript.swift
+++ b/Sources/Kaset/Services/WebKit/PlaybackAdDetectionScript.swift
@@ -11,7 +11,7 @@ enum PlaybackAdDetectionScript {
             });
         }
 
-        function isAdShowing() {
+        function hasAdPlayerSignal() {
             const moviePlayer = document.getElementById('movie_player');
             if (moviePlayer && moviePlayer.classList
                 && (moviePlayer.classList.contains('ad-showing')
@@ -29,6 +29,38 @@ enum PlaybackAdDetectionScript {
                 } catch (e) {}
             }
             return false;
+        }
+
+        function isAdShowing() {
+            const isAd = hasAdPlayerSignal();
+            let contentVideoId = '';
+            try {
+                contentVideoId = new URL(window.location.href).searchParams.get('v') || '';
+            } catch (e) {}
+
+            let videoId = '';
+            // Match the bridges' metadata preference: Music API, then movie player.
+            for (const api of adPlayerAPIs().reverse()) {
+                try {
+                    const data = typeof api.getVideoData === 'function' ? api.getVideoData() : null;
+                    const id = data && (data.video_id || data.videoId);
+                    if (typeof id === 'string' && id) {
+                        videoId = id;
+                        break;
+                    }
+                } catch (e) {}
+            }
+            if (isAd && contentVideoId && videoId && videoId !== contentVideoId) {
+                window.__kasetAdVideoId = videoId;
+            }
+            // Ad-end signals can precede the return of content media. Share the
+            // known creative ID with end-event and recovery-seek scripts too.
+            const adVideoId = window.__kasetAdVideoId || '';
+            const isAdCreative = adVideoId !== ''
+                && adVideoId !== contentVideoId
+                && (!videoId || videoId === adVideoId);
+            if (!isAd && !isAdCreative) delete window.__kasetAdVideoId;
+            return isAd || isAdCreative;
         }
         """
     }

--- a/Sources/Kaset/Services/WebKit/PlaybackAdDetectionScript.swift
+++ b/Sources/Kaset/Services/WebKit/PlaybackAdDetectionScript.swift
@@ -133,7 +133,9 @@ enum PlaybackAdDetectionScript {
                     }
                 }
                 observedAPIs = apis;
-                if (apis.length === candidates.length) {
+                const musicPlayer = document.querySelector('ytmusic-player');
+                const hasPendingMusicAPI = musicPlayer && !musicPlayer.playerApi;
+                if (apis.length === candidates.length && !hasPendingMusicAPI) {
                     apiRetryCount = 0;
                     if (apiRetryTimeoutId !== null) clearTimeout(apiRetryTimeoutId);
                     apiRetryTimeoutId = null;

--- a/Sources/Kaset/Services/WebKit/PlaybackAdDetectionScript.swift
+++ b/Sources/Kaset/Services/WebKit/PlaybackAdDetectionScript.swift
@@ -1,0 +1,100 @@
+/// Ad signals shared by the YouTube and YouTube Music playback bridges.
+enum PlaybackAdDetectionScript {
+    nonisolated static var detection: String {
+        """
+        function adPlayerAPIs() {
+            const moviePlayer = document.getElementById('movie_player');
+            const musicPlayer = document.querySelector('ytmusic-player');
+            const musicAPI = musicPlayer && musicPlayer.playerApi;
+            return [moviePlayer, musicAPI].filter(function(api, index, apis) {
+                return api && apis.indexOf(api) === index;
+            });
+        }
+
+        function isAdShowing() {
+            const moviePlayer = document.getElementById('movie_player');
+            if (moviePlayer && moviePlayer.classList
+                && (moviePlayer.classList.contains('ad-showing')
+                    || moviePlayer.classList.contains('ad-interrupting'))) {
+                return true;
+            }
+            for (const api of adPlayerAPIs()) {
+                try {
+                    // Player type 2 is ad media. Passing true also includes
+                    // server-stitched segments when supported by the player.
+                    if (typeof api.getPresentingPlayerType === 'function'
+                        && api.getPresentingPlayerType(true) === 2) {
+                        return true;
+                    }
+                } catch (e) {}
+            }
+            return false;
+        }
+        """
+    }
+
+    /// Returns a refresh hook for the bridges' existing player-attachment paths.
+    /// Watches only the player class and ad events; it adds no polling timer.
+    nonisolated static var observation: String {
+        """
+        function observeAdStateChanges(onChange) {
+            const events = ['onAdStart', 'onAdEnd', 'onAdStateChange'];
+            let observedPlayer = null;
+            let classObserver = null;
+            let observedAPIs = [];
+            let lastIsAd = isAdShowing();
+
+            function reportChange() {
+                const isAd = isAdShowing();
+                if (isAd === lastIsAd) return;
+                lastIsAd = isAd;
+                onChange();
+            }
+
+            function reportAdEvent() {
+                // Media events can report an ad between observer callbacks.
+                // Always sample explicit ad events so an end is not lost.
+                lastIsAd = isAdShowing();
+                onChange();
+            }
+
+            return function refreshAdObserver() {
+                const player = document.getElementById('movie_player');
+                if (player !== observedPlayer) {
+                    if (classObserver) classObserver.disconnect();
+                    classObserver = null;
+                    observedPlayer = player;
+                    if (player && typeof MutationObserver === 'function') {
+                        classObserver = new MutationObserver(reportChange);
+                        classObserver.observe(player, {
+                            attributes: true,
+                            attributeFilter: ['class']
+                        });
+                    }
+                }
+
+                const apis = adPlayerAPIs().filter(function(api) {
+                    // A bare player div already has DOM addEventListener.
+                    // Wait for YouTube's API before subscribing to player events.
+                    return typeof api.getPresentingPlayerType === 'function'
+                        && typeof api.addEventListener === 'function';
+                });
+                for (const api of observedAPIs) {
+                    if (apis.indexOf(api) !== -1) continue;
+                    for (const event of events) {
+                        try { api.removeEventListener(event, reportAdEvent); } catch (e) {}
+                    }
+                }
+                for (const api of apis) {
+                    if (observedAPIs.indexOf(api) !== -1) continue;
+                    for (const event of events) {
+                        try { api.addEventListener(event, reportAdEvent); } catch (e) {}
+                    }
+                }
+                observedAPIs = apis;
+                reportChange();
+            };
+        }
+        """
+    }
+}

--- a/Sources/Kaset/Utilities/AccessibilityIdentifiers.swift
+++ b/Sources/Kaset/Utilities/AccessibilityIdentifiers.swift
@@ -43,6 +43,7 @@ enum AccessibilityID {
         static let videoButton = "playerBar.video"
         static let airplayButton = "playerBar.airplayButton"
         static let mixTracksButton = "playerBar.mixTracks"
+        static let adIndicator = "playerBar.adIndicator"
         static let volumeSlider = "playerBar.volumeSlider"
         static let trackTitle = "playerBar.trackTitle"
         static let trackArtist = "playerBar.trackArtist"

--- a/Sources/Kaset/Views/MiniPlayerToast.swift
+++ b/Sources/Kaset/Views/MiniPlayerToast.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+/// A small toast-style view that appears when mini player is shown.
+/// Uses Liquid Glass materialize transition for smooth appearance.
+struct MiniPlayerToast: View {
+    let videoId: String
+
+    var body: some View {
+        PersistentPlayerView(videoId: self.videoId, isExpanded: true)
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+            .compatGlassTransition(.materialize)
+    }
+}

--- a/Sources/Kaset/Views/MiniPlayerViews.swift
+++ b/Sources/Kaset/Views/MiniPlayerViews.swift
@@ -146,6 +146,11 @@ struct MiniPlayerWindow: View { // swiftlint:disable:this type_body_length
         .onChange(of: self.currentTrackIdentity) { _, _ in
             self.clearSeekHold()
         }
+        .onChange(of: self.playerService.isShowingAd) { _, isShowingAd in
+            if isShowingAd {
+                self.clearSeekHold()
+            }
+        }
         .onChange(of: self.playerService.volume) { _, newValue in
             if !self.isAdjustingVolume {
                 self.volumeValue = newValue

--- a/Sources/Kaset/Views/MiniPlayerViews.swift
+++ b/Sources/Kaset/Views/MiniPlayerViews.swift
@@ -670,7 +670,7 @@ struct MiniPlayerWindow: View { // swiftlint:disable:this type_body_length
             }
             .controlSize(.small)
             .tint(PackageResourceLookup.brandAccent)
-            .disabled(self.playerService.duration <= 0 || self.playerService.isCurrentItemLive)
+            .disabled(self.playerService.duration <= 0 || self.playerService.isCurrentItemLive || self.playerService.isShowingAd)
             .accessibilityIdentifier(AccessibilityID.MiniPlayer.seekSlider)
 
             HStack {
@@ -862,7 +862,7 @@ struct MiniPlayerWindow: View { // swiftlint:disable:this type_body_length
     }
 
     private func performSeek() {
-        guard self.playerService.duration > 0 else { return }
+        guard self.playerService.duration > 0, !self.playerService.isShowingAd else { return }
         let target = self.seekValue * self.playerService.duration
         let holdID = self.seekHold.begin(target: target)
         Task { await self.playerService.seek(to: target) }

--- a/Sources/Kaset/Views/MiniPlayerViews.swift
+++ b/Sources/Kaset/Views/MiniPlayerViews.swift
@@ -72,20 +72,6 @@ struct PersistentPlayerView: NSViewRepresentable {
     }
 }
 
-// MARK: - MiniPlayerToast
-
-/// A small toast-style view that appears when mini player is shown.
-/// Uses Liquid Glass materialize transition for smooth appearance.
-struct MiniPlayerToast: View {
-    let videoId: String
-
-    var body: some View {
-        PersistentPlayerView(videoId: self.videoId, isExpanded: true)
-            .clipShape(RoundedRectangle(cornerRadius: 6))
-            .compatGlassTransition(.materialize)
-    }
-}
-
 // MARK: - MiniPlayerWindow
 
 struct MiniPlayerWindow: View { // swiftlint:disable:this type_body_length

--- a/Sources/Kaset/Views/MiniPlayerWebView+Coordinator.swift
+++ b/Sources/Kaset/Views/MiniPlayerWebView+Coordinator.swift
@@ -680,6 +680,10 @@ private extension SingletonPlayerWebView.Coordinator {
                 }
             }
 
+            // Ad creatives can expose their own metadata and video identity.
+            // Only content may update the track, queue, or track-specific controls.
+            guard !isAd else { return }
+
             // Update video availability
             self.playerService.updateVideoAvailability(hasVideo: hasVideo)
 

--- a/Sources/Kaset/Views/MiniPlayerWebView+Coordinator.swift
+++ b/Sources/Kaset/Views/MiniPlayerWebView+Coordinator.swift
@@ -619,6 +619,7 @@ private extension SingletonPlayerWebView.Coordinator {
         let duration = SingletonPlayerWebView.finitePlaybackBridgeDouble(from: body["duration"]) ?? 0
         let isAd = body["isAd"] as? Bool ?? false
         let hasReadyMedia = body["hasReadyMedia"] as? Bool ?? false
+        let hasContentMetadata = body["hasContentMetadata"] as? Bool ?? true
         let title = body["title"] as? String ?? ""
         let artist = body["artist"] as? String ?? ""
         let thumbnailUrl = SingletonPlayerWebView.playbackBridgeThumbnailURLString(from: body["thumbnailUrl"])
@@ -682,7 +683,7 @@ private extension SingletonPlayerWebView.Coordinator {
 
             // Ad creatives can expose their own metadata and video identity.
             // Only content may update the track, queue, or track-specific controls.
-            guard !isAd else { return }
+            guard !isAd, hasContentMetadata else { return }
 
             // Update video availability
             self.playerService.updateVideoAvailability(hasVideo: hasVideo)

--- a/Sources/Kaset/Views/MiniPlayerWebView+Coordinator.swift
+++ b/Sources/Kaset/Views/MiniPlayerWebView+Coordinator.swift
@@ -619,7 +619,6 @@ private extension SingletonPlayerWebView.Coordinator {
         let duration = SingletonPlayerWebView.finitePlaybackBridgeDouble(from: body["duration"]) ?? 0
         let isAd = body["isAd"] as? Bool ?? false
         let hasReadyMedia = body["hasReadyMedia"] as? Bool ?? false
-        let hasContentMetadata = body["hasContentMetadata"] as? Bool ?? true
         let title = body["title"] as? String ?? ""
         let artist = body["artist"] as? String ?? ""
         let thumbnailUrl = SingletonPlayerWebView.playbackBridgeThumbnailURLString(from: body["thumbnailUrl"])
@@ -683,7 +682,7 @@ private extension SingletonPlayerWebView.Coordinator {
 
             // Ad creatives can expose their own metadata and video identity.
             // Only content may update the track, queue, or track-specific controls.
-            guard !isAd, hasContentMetadata else { return }
+            guard !isAd else { return }
 
             // Update video availability
             self.playerService.updateVideoAvailability(hasVideo: hasVideo)

--- a/Sources/Kaset/Views/PlayerBar.swift
+++ b/Sources/Kaset/Views/PlayerBar.swift
@@ -103,6 +103,11 @@ struct PlayerBar: View { // swiftlint:disable:this type_body_length
         .onChange(of: self.currentSeekIdentity) { _, _ in
             self.clearSeekHold()
         }
+        .onChange(of: self.playerService.isShowingAd) { _, isShowingAd in
+            if isShowingAd {
+                self.clearSeekHold()
+            }
+        }
         .onChange(of: self.playerService.volume) { _, newValue in
             if !self.isAdjustingVolume {
                 self.volumeValue = newValue
@@ -382,6 +387,9 @@ struct PlayerBar: View { // swiftlint:disable:this type_body_length
             if case let .error(message) = playerService.state {
                 self.errorView(message: message)
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if self.playerService.isShowingAd {
+                PlayerBarAdIndicator()
+                    .padding(.top, 18)
             } else {
                 PlayerBarProgressLane(
                     fraction: self.displayFraction,
@@ -639,6 +647,7 @@ struct PlayerBar: View { // swiftlint:disable:this type_body_length
         self.playerService.currentTrack != nil
             && self.playerService.duration > 0
             && !self.playerService.isCurrentItemLive
+            && !self.playerService.isShowingAd
     }
 
     private var isProgressLoading: Bool {
@@ -1182,7 +1191,7 @@ struct PlayerBar: View { // swiftlint:disable:this type_body_length
 
     /// Performs the actual seek operation after slider interaction ends.
     private func performSeek() {
-        guard self.isSeeking, self.playerService.duration > 0 else { return }
+        guard self.isSeeking, self.canSeek else { return }
         let seekTime = self.seekValue * self.playerService.duration
         let holdID = self.seekHold.begin(target: seekTime)
         self.updateFormattedTimes(progress: seekTime, duration: self.playerService.duration)

--- a/Sources/Kaset/Views/PlayerBarAdIndicator.swift
+++ b/Sources/Kaset/Views/PlayerBarAdIndicator.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+/// Replaces the content timeline while either playback WebView is showing an ad.
+struct PlayerBarAdIndicator: View {
+    var body: some View {
+        HStack(spacing: 8) {
+            Text("Ad", comment: "Compact badge shown during an advertisement")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(.black)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 1)
+                .background(.yellow, in: .capsule)
+                .fixedSize()
+
+            Capsule()
+                .fill(.yellow)
+                .frame(height: PlayerBarSliderVisuals.trackThickness)
+        }
+        .frame(height: 30, alignment: .bottom)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(String(localized: "Advertisement"))
+        .accessibilityIdentifier(AccessibilityID.PlayerBar.adIndicator)
+    }
+}

--- a/Sources/Kaset/Views/SingletonPlayerWebView+ObserverScript.swift
+++ b/Sources/Kaset/Views/SingletonPlayerWebView+ObserverScript.swift
@@ -147,6 +147,9 @@ extension SingletonPlayerWebView {
             let trailingUpdateTimeoutId = null;
             const UPDATE_THROTTLE_MS = 500; // Throttle updates to max 2/sec
             const POLL_INTERVAL_MS = 1000; // Poll at 1Hz during playback (reduced from 250ms)
+            \(PlaybackAdDetectionScript.detection)
+            \(PlaybackAdDetectionScript.observation)
+            const refreshAdObserver = observeAdStateChanges(() => sendUpdate(true));
 
             // Volume enforcement: track target volume set by Swift
             // Don't set a default - only enforce when explicitly set by Swift
@@ -232,6 +235,7 @@ extension SingletonPlayerWebView {
             function setupVideoListeners() {
                 // Watch for video element to attach play/pause listeners
                 function attachVideoListeners() {
+                    refreshAdObserver();
                     const video = document.querySelector('video');
                     if (!video) {
                         setTimeout(attachVideoListeners, 500);
@@ -387,6 +391,7 @@ extension SingletonPlayerWebView {
 
                 // Also watch for video element replacement (YouTube may recreate it)
                 const videoObserver = new MutationObserver(() => {
+                    refreshAdObserver();
                     const video = document.querySelector('video');
                     if (video && !video.__kasetListenersAttached) {
                         attachVideoListeners();
@@ -568,12 +573,6 @@ extension SingletonPlayerWebView {
                 sendUpdate(true);
             }
 
-            function isAdShowing() {
-                const moviePlayer = document.getElementById('movie_player');
-                return !!(moviePlayer && moviePlayer.classList
-                    && moviePlayer.classList.contains('ad-showing'));
-            }
-
             function trackEndedPayload(video) {
                 if (!video || video !== document.querySelector('video') || !video.ended) return null;
                 const occurrenceGeneration = video.__kasetEndedOccurrenceGeneration
@@ -698,7 +697,8 @@ extension SingletonPlayerWebView {
                     // Check if track changed
                     const metadataChanged = title !== '' && (title !== lastTitle || artist !== lastArtist);
                     const videoIdChanged = videoId !== '' && videoId !== lastVideoId;
-                    const trackChanged = metadataChanged || videoIdChanged;
+                    // Keep content metadata pending until the ad has finished.
+                    const trackChanged = !isAd && (metadataChanged || videoIdChanged);
                     if (trackChanged) {
                         if (title !== '') {
                             lastTitle = title;

--- a/Sources/Kaset/Views/SingletonPlayerWebView+ObserverScript.swift
+++ b/Sources/Kaset/Views/SingletonPlayerWebView+ObserverScript.swift
@@ -135,6 +135,7 @@ extension SingletonPlayerWebView {
             let lastTitle = '';
             let lastArtist = '';
             let lastVideoId = '';
+            let adVideoId = '';
             let mediaVideoId = '';
             let mediaSource = '';
             let mediaGeneration = 0;
@@ -423,6 +424,10 @@ extension SingletonPlayerWebView {
                     if (playerVideoId) return playerVideoId;
                 }
 
+                return watchVideoId();
+            }
+
+            function watchVideoId() {
                 try {
                     const url = new URL(window.location.href);
                     return url.searchParams.get('v') || '';
@@ -697,8 +702,18 @@ extension SingletonPlayerWebView {
                     // Check if track changed
                     const metadataChanged = title !== '' && (title !== lastTitle || artist !== lastArtist);
                     const videoIdChanged = videoId !== '' && videoId !== lastVideoId;
-                    // Keep content metadata pending until the ad has finished.
-                    const trackChanged = !isAd && (metadataChanged || videoIdChanged);
+                    const contentVideoId = watchVideoId() || lastVideoId;
+                    if (isAd && contentVideoId && videoId && videoId !== contentVideoId) {
+                        adVideoId = videoId;
+                    }
+                    // The ad signal can clear before the player restores the content ID.
+                    // Do not publish that creative as a content transition.
+                    const isAdMetadata = adVideoId !== ''
+                        && adVideoId !== contentVideoId
+                        && videoId === adVideoId;
+                    if (!isAd && !isAdMetadata) adVideoId = '';
+                    const hasContentMetadata = !isAd && !isAdMetadata;
+                    const trackChanged = hasContentMetadata && (metadataChanged || videoIdChanged);
                     if (trackChanged) {
                         if (title !== '') {
                             lastTitle = title;
@@ -735,6 +750,7 @@ extension SingletonPlayerWebView {
                         duration: playbackClock.duration,
                         isAd: isAd,
                         hasReadyMedia: hasReadyMedia,
+                        hasContentMetadata: hasContentMetadata,
                         title: title,
                         artist: artist,
                         videoId: videoId,

--- a/Sources/Kaset/Views/SingletonPlayerWebView+ObserverScript.swift
+++ b/Sources/Kaset/Views/SingletonPlayerWebView+ObserverScript.swift
@@ -135,7 +135,6 @@ extension SingletonPlayerWebView {
             let lastTitle = '';
             let lastArtist = '';
             let lastVideoId = '';
-            let adVideoId = '';
             let mediaVideoId = '';
             let mediaSource = '';
             let mediaGeneration = 0;
@@ -424,10 +423,6 @@ extension SingletonPlayerWebView {
                     if (playerVideoId) return playerVideoId;
                 }
 
-                return watchVideoId();
-            }
-
-            function watchVideoId() {
                 try {
                     const url = new URL(window.location.href);
                     return url.searchParams.get('v') || '';
@@ -702,18 +697,8 @@ extension SingletonPlayerWebView {
                     // Check if track changed
                     const metadataChanged = title !== '' && (title !== lastTitle || artist !== lastArtist);
                     const videoIdChanged = videoId !== '' && videoId !== lastVideoId;
-                    const contentVideoId = watchVideoId() || lastVideoId;
-                    if (isAd && contentVideoId && videoId && videoId !== contentVideoId) {
-                        adVideoId = videoId;
-                    }
-                    // The ad signal can clear before the player restores the content ID.
-                    // Do not publish that creative as a content transition.
-                    const isAdMetadata = adVideoId !== ''
-                        && adVideoId !== contentVideoId
-                        && videoId === adVideoId;
-                    if (!isAd && !isAdMetadata) adVideoId = '';
-                    const hasContentMetadata = !isAd && !isAdMetadata;
-                    const trackChanged = hasContentMetadata && (metadataChanged || videoIdChanged);
+                    // Keep content metadata pending while ad media remains exposed.
+                    const trackChanged = !isAd && (metadataChanged || videoIdChanged);
                     if (trackChanged) {
                         if (title !== '') {
                             lastTitle = title;
@@ -750,7 +735,6 @@ extension SingletonPlayerWebView {
                         duration: playbackClock.duration,
                         isAd: isAd,
                         hasReadyMedia: hasReadyMedia,
-                        hasContentMetadata: hasContentMetadata,
                         title: title,
                         artist: artist,
                         videoId: videoId,

--- a/Sources/Kaset/Views/SingletonPlayerWebView+PlaybackControls.swift
+++ b/Sources/Kaset/Views/SingletonPlayerWebView+PlaybackControls.swift
@@ -198,8 +198,8 @@ extension SingletonPlayerWebView {
         webView.evaluateJavaScript("""
             (function() {
                 if (window.__kasetDocumentGeneration !== \(generation)) return 'stale';
-                const player = document.getElementById('movie_player');
-                const isAd = !!(player && player.classList.contains('ad-showing'));
+                \(PlaybackAdDetectionScript.detection)
+                const isAd = isAdShowing();
                 const video = document.querySelector('video');
                 if (!isAd || !video || !video.currentSrc || video.readyState < 1) return 'not-ready-ad';
                 window.__kasetPlaybackSuppressed = false;

--- a/Sources/Kaset/Views/YouTube/YouTubePlayerBar.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubePlayerBar.swift
@@ -4,9 +4,8 @@ import SwiftUI
 
 /// The Liquid Glass player bar, adapted for YouTube video playback.
 ///
-/// Same capsule, sizing, and interaction patterns as the music `PlayerBar`
-/// (which is untouched); shown instead of it while a YouTube video is
-/// loaded. Differences per the YouTube content model:
+/// Shares the music `PlayerBar` layout and appears when a YouTube video is loaded.
+/// Differences per the YouTube content model:
 /// - No shuffle/repeat — left/right transport controls seek 30 seconds
 ///   back/forward within the current video.
 /// - Center shows the video thumbnail, title, and channel · views.
@@ -108,10 +107,9 @@ struct YouTubePlayerBar: View {
             self.clearSeekHold()
             self.chapterPreviewMarker = nil
         }
-        .onChange(of: self.youtubePlayer.isShowingAd) { _, isShowingAd in
-            if isShowingAd {
-                self.chapterPreviewMarker = nil
-            }
+        .onChange(of: self.youtubePlayer.isShowingAd) { _, _ in
+            self.clearSeekHold()
+            self.chapterPreviewMarker = nil
         }
         .onChange(of: self.youtubePlayer.volume) { _, newValue in
             if !self.isAdjustingVolume {
@@ -299,27 +297,29 @@ struct YouTubePlayerBar: View {
 
     private var youtubeProgressSection: some View {
         ZStack(alignment: .top) {
-            PlayerBarProgressLane(
-                fraction: self.displayFraction,
-                accent: Self.brandAccent,
-                elapsedText: Self.formatTime(self.progressTextValue),
-                remainingText: "-\(Self.formatTime(max(0, self.youtubePlayer.duration - self.progressTextValue)))",
-                markers: self.chapterProgressMarkers,
-                segments: self.chapterProgressSegments,
-                isLive: false,
-                canSeek: self.canSeek,
-                isLoading: self.isProgressLoading,
-                onScrub: { fraction in
-                    self.isSeeking = true
-                    self.seekValue = fraction
-                },
-                onCommit: {
-                    self.performSeek()
-                },
-                onMarkerPreviewChange: { marker in
-                    self.chapterPreviewMarker = marker
+            Group {
+                if self.youtubePlayer.isShowingAd {
+                    PlayerBarAdIndicator()
+                } else {
+                    PlayerBarProgressLane(
+                        fraction: self.displayFraction,
+                        accent: Self.brandAccent,
+                        elapsedText: Self.formatTime(self.progressTextValue),
+                        remainingText: "-\(Self.formatTime(max(0, self.youtubePlayer.duration - self.progressTextValue)))",
+                        markers: self.chapterProgressMarkers,
+                        segments: self.chapterProgressSegments,
+                        isLive: false,
+                        canSeek: self.canSeek,
+                        isLoading: self.isProgressLoading,
+                        onScrub: { fraction in
+                            self.isSeeking = true
+                            self.seekValue = fraction
+                        },
+                        onCommit: self.performSeek,
+                        onMarkerPreviewChange: { self.chapterPreviewMarker = $0 }
+                    )
                 }
-            )
+            }
             .padding(.top, 18)
             // Match the music player's segmented lane layering so chapter tooltips stay above
             // transport controls without intercepting their clicks.
@@ -716,7 +716,7 @@ struct YouTubePlayerBar: View {
     }
 
     private func performSeek() {
-        guard self.isSeeking else { return }
+        guard self.isSeeking, self.canSeek else { return }
         let seekTime = self.seekValue * self.youtubePlayer.duration
         let holdID = self.seekHold.begin(target: seekTime)
         self.isSeeking = false

--- a/Sources/Kaset/Views/YouTube/YouTubeWatchWebView+RecoverySeek.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeWatchWebView+RecoverySeek.swift
@@ -145,8 +145,8 @@ extension YouTubeWatchWebView {
             window.__kasetPendingSeekInFlightAttempt = null;
 
             const video = document.querySelector('video');
-            const player = document.getElementById('movie_player');
-            const isAd = !!(player && player.classList && player.classList.contains('ad-showing'));
+            \(PlaybackAdDetectionScript.detection)
+            const isAd = isAdShowing();
             const expectedVideoId = \(videoIdLiteral);
             if (isAd || !video || video.readyState < 1 || !video.currentSrc) { return 'armed'; }
             if (expectedVideoId && (video.__kasetBoundVideoId || '') !== expectedVideoId) { return 'armed'; }

--- a/Sources/Kaset/Views/YouTube/YouTubeWatchWebView+Scripts.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeWatchWebView+Scripts.swift
@@ -46,6 +46,9 @@ extension YouTubeWatchWebView {
             var attachRetryTimeoutId = null;
             var attachDebounceTimeoutId = null;
             var videoObserver = null;
+            \(PlaybackAdDetectionScript.detection)
+            \(PlaybackAdDetectionScript.observation)
+            const refreshAdObserver = observeAdStateChanges(function() { sendUpdate(true); });
 
             function moviePlayer() {
                 return document.getElementById('movie_player');
@@ -72,11 +75,6 @@ extension YouTubeWatchWebView {
                 const data = videoData();
                 if (data && data.title) { return data.title; }
                 return document.title.replace(/ - YouTube$/, '');
-            }
-
-            function isAdShowing() {
-                const player = moviePlayer();
-                return !!(player && player.classList && player.classList.contains('ad-showing'));
             }
 
             function clearTrailingUpdate() {
@@ -408,6 +406,7 @@ extension YouTubeWatchWebView {
             }
 
             function attach() {
+                refreshAdObserver();
                 disableAutonav();
                 const video = videoEl();
                 if (!video) { return false; }

--- a/Tests/KasetTests/PlaybackAdDetectionTests.swift
+++ b/Tests/KasetTests/PlaybackAdDetectionTests.swift
@@ -292,6 +292,69 @@ struct PlaybackAdDetectionTests {
         #expect(!context.evaluateScript("lastState().trackChanged").toBool())
     }
 
+    @Test("Music waits for content metadata after an early ad-end event", arguments: [false, true], [false, true])
+    func musicAdEndBeforeMetadata(startsDuringAd: Bool, metadataReturnsFirst: Bool) throws {
+        let context = try self.makeContext(isMusic: true)
+        if !startsDuringAd {
+            try self.installObserver(isMusic: true, in: context)
+        }
+        try self.evaluate(
+            """
+            var contentData = currentData;
+            currentData = { video_id: 'creative', title: 'Advertisement', author: 'Advertiser' };
+            musicApi.presentingType = 2;
+            musicApi.fire('onAdStart');
+            """,
+            in: context
+        )
+        if startsDuringAd {
+            try self.installObserver(isMusic: true, in: context)
+        }
+        #expect(context.evaluateScript("lastState().isAd").toBool())
+        #expect(!context.evaluateScript("lastState().trackChanged").toBool())
+
+        if metadataReturnsFirst {
+            try self.evaluate(
+                "currentData.title = contentData.title; currentData.author = contentData.author; fireVideoEvent('waiting');",
+                in: context
+            )
+        }
+        try self.evaluate("musicApi.presentingType = 1; musicApi.fire('onAdEnd');", in: context)
+
+        #expect(!context.evaluateScript("lastState().isAd").toBool())
+        #expect(!context.evaluateScript("lastState().hasContentMetadata").toBool())
+        #expect(!context.evaluateScript("lastState().trackChanged").toBool())
+
+        try self.evaluate("currentData = contentData; fireVideoEvent('waiting');", in: context)
+        #expect(!context.evaluateScript("lastState().isAd").toBool())
+        #expect(context.evaluateScript("lastState().hasContentMetadata").toBool())
+        #expect(context.evaluateScript("lastState().trackChanged").toBool() == startsDuringAd)
+        #expect(context.evaluateScript("lastState().videoId").toString() == "content")
+        #expect(context.evaluateScript("lastState().title").toString() == "Song")
+    }
+
+    @Test("Music accepts requested content when its metadata leads the watch URL during an ad")
+    func musicRequestedMetadataDuringAd() throws {
+        let context = try self.makeContext(isMusic: true)
+        try self.installObserver(isMusic: true, in: context)
+        try self.evaluate(
+            """
+            currentData = { video_id: 'next', title: 'Next song', author: 'Artist' };
+            musicApi.presentingType = 2;
+            musicApi.fire('onAdStart');
+            window.location.href = 'https://music.youtube.com/watch?v=next';
+            musicApi.presentingType = 1;
+            musicApi.fire('onAdEnd');
+            """,
+            in: context
+        )
+
+        #expect(!context.evaluateScript("lastState().isAd").toBool())
+        #expect(context.evaluateScript("lastState().hasContentMetadata").toBool())
+        #expect(context.evaluateScript("lastState().trackChanged").toBool())
+        #expect(context.evaluateScript("lastState().videoId").toString() == "next")
+    }
+
     @Test("Recovery seeks wait for content when only the player API identifies an ad")
     func recoverySeekWaitsForContent() throws {
         let context = try self.makeContext(isMusic: false)
@@ -329,6 +392,8 @@ struct PlaybackAdDetectionTests {
             var console = { log: function() {} };
             window.__kasetDocumentGeneration = 7;
             window.location = { href: 'https://\(isMusic ? "music" : "www").youtube.com/watch?v=content' };
+            // JavaScriptCore has no browser URL API.
+            var URL = function(value) { this.searchParams = { get: key => value.match(new RegExp('[?&]' + key + '=([^&]*)'))?.[1] || null }; };
             var bridge = { postMessage: function(message) { postedMessages.push(message); } };
             window.webkit = { messageHandlers: { singletonPlayer: bridge, youtubePlayer: bridge } };
             function setTimeout(callback) { timers.push(callback); return timers.length; }

--- a/Tests/KasetTests/PlaybackAdDetectionTests.swift
+++ b/Tests/KasetTests/PlaybackAdDetectionTests.swift
@@ -33,7 +33,7 @@ struct PlaybackAdDetectionTests {
         let context = try self.makeContext(isMusic: isMusic)
         try self.evaluate(
             """
-            moviePlayer.getPresentingPlayerType = function(includeStitchedAds) {
+            \(isMusic ? "musicApi" : "moviePlayer").getPresentingPlayerType = function(includeStitchedAds) {
                 return includeStitchedAds === true ? 2 : 1;
             };
             """,
@@ -145,12 +145,14 @@ struct PlaybackAdDetectionTests {
     @Test("Player replacement reconnects ad observation without stale listeners", arguments: [false, true])
     func replacementPlayer(isMusic: Bool) throws {
         let context = try self.makeContext(isMusic: isMusic)
+        let playerAPI = isMusic ? "musicPlayer.playerApi" : "moviePlayer"
         try self.installObserver(isMusic: isMusic, in: context)
         try self.evaluate(
             """
-            var oldPlayer = moviePlayer;
-            moviePlayer = makePlayer();
-            moviePlayer.classes['ad-showing'] = true;
+            var oldPlayer = \(playerAPI);
+            var replacementPlayer = makePlayer();
+            \(playerAPI) = replacementPlayer;
+            replacementPlayer.presentingType = 2;
             notifyChildrenChanged();
             timers.splice(0).forEach(function(callback) { callback(); });
             notifyChildrenChanged();
@@ -159,13 +161,21 @@ struct PlaybackAdDetectionTests {
             in: context
         )
         #expect(context.evaluateScript("lastState().isAd").toBool())
-        #expect(context.evaluateScript("moviePlayer.listeners.onAdStart.length").toInt32() == 1)
+        #expect(context.evaluateScript("replacementPlayer.listeners.onAdStart.length").toInt32() == 1)
 
         try self.evaluate("postedMessages = []; oldPlayer.fire('onAdStart');", in: context)
         #expect(context.evaluateScript("stateCount()").toInt32() == 0)
-        try self.evaluate("delete moviePlayer.classes['ad-showing']; notifyClassChange(moviePlayer);", in: context)
+        try self.evaluate("replacementPlayer.presentingType = 1; replacementPlayer.fire('onAdEnd');", in: context)
         #expect(context.evaluateScript("stateCount()").toInt32() == 1)
         #expect(!context.evaluateScript("lastState().isAd").toBool())
+
+        // Class observation must still follow the current movie-player element.
+        try self.evaluate(
+            "postedMessages = []; moviePlayer.classes['ad-showing'] = true; notifyClassChange(moviePlayer);",
+            in: context
+        )
+        #expect(context.evaluateScript("stateCount()").toInt32() == 1)
+        #expect(context.evaluateScript("lastState().isAd").toBool())
     }
 
     @Test("Ad listeners wait for the player API on an existing element", arguments: [false, true])

--- a/Tests/KasetTests/PlaybackAdDetectionTests.swift
+++ b/Tests/KasetTests/PlaybackAdDetectionTests.swift
@@ -1,0 +1,414 @@
+import JavaScriptCore
+import Testing
+@testable import Kaset
+
+@Suite("Playback ad detection", .tags(.service))
+@MainActor
+struct PlaybackAdDetectionTests {
+    @Test("Both players identify interrupting ads", arguments: [false, true])
+    func interruptingAds(isMusic: Bool) throws {
+        let context = try self.makeContext(isMusic: isMusic)
+        try self.evaluate("moviePlayer.classes['ad-interrupting'] = true;", in: context)
+
+        try self.installObserver(isMusic: isMusic, in: context)
+
+        #expect(context.evaluateScript("lastState().isAd").toBool())
+    }
+
+    @Test("Both players identify ad media without a CSS marker", arguments: [false, true])
+    func presentingAdPlayer(isMusic: Bool) throws {
+        let context = try self.makeContext(isMusic: isMusic)
+        try self.evaluate(
+            isMusic ? "musicApi.presentingType = 2;" : "moviePlayer.presentingType = 2;",
+            in: context
+        )
+
+        try self.installObserver(isMusic: isMusic, in: context)
+
+        #expect(context.evaluateScript("lastState().isAd").toBool())
+    }
+
+    @Test("Both players request server-stitched ad state", arguments: [false, true])
+    func serverStitchedAdState(isMusic: Bool) throws {
+        let context = try self.makeContext(isMusic: isMusic)
+        try self.evaluate(
+            """
+            moviePlayer.getPresentingPlayerType = function(includeStitchedAds) {
+                return includeStitchedAds === true ? 2 : 1;
+            };
+            """,
+            in: context
+        )
+
+        try self.installObserver(isMusic: isMusic, in: context)
+
+        #expect(context.evaluateScript("lastState().isAd").toBool())
+    }
+
+    @Test("Ordinary and remote playback do not become ads", arguments: [false, true])
+    func contentIsNotAnAd(isMusic: Bool) throws {
+        for presentingType in ["1", "3", "undefined", "null", "'2'"] {
+            let context = try self.makeContext(isMusic: isMusic)
+            try self.evaluate(
+                "moviePlayer.presentingType = \(presentingType); musicApi.presentingType = \(presentingType);",
+                in: context
+            )
+
+            try self.installObserver(isMusic: isMusic, in: context)
+
+            #expect(!context.evaluateScript("lastState().isAd").toBool())
+        }
+    }
+
+    @Test("A failing player API preserves CSS ad detection", arguments: [false, true])
+    func failingAPIKeepsDOMFallback(isMusic: Bool) throws {
+        let context = try self.makeContext(isMusic: isMusic)
+        try self.evaluate(
+            """
+            moviePlayer.getPresentingPlayerType = function() { throw new Error('not ready'); };
+            musicApi.getPresentingPlayerType = moviePlayer.getPresentingPlayerType;
+            moviePlayer.classes['ad-showing'] = true;
+            """,
+            in: context
+        )
+
+        try self.installObserver(isMusic: isMusic, in: context)
+
+        #expect(context.evaluateScript("lastState().isAd").toBool())
+    }
+
+    @Test("A failed API probe does not interrupt state updates", arguments: [false, true])
+    func failedAPIProbe(isMusic: Bool) throws {
+        let context = try self.makeContext(isMusic: isMusic)
+        try self.evaluate(
+            """
+            moviePlayer.getPresentingPlayerType = function() { throw new Error('not ready'); };
+            musicApi.presentingType = 2;
+            """,
+            in: context
+        )
+
+        try self.installObserver(isMusic: isMusic, in: context)
+
+        #expect(context.evaluateScript("lastState().isAd").toBool() == isMusic)
+        #expect(context.evaluateScript("lastState().progress").toDouble() == 12)
+    }
+
+    @Test("Paused players report ad class changes without media events", arguments: [false, true])
+    func pausedAdTransitions(isMusic: Bool) throws {
+        let context = try self.makeContext(isMusic: isMusic)
+        try self.installObserver(isMusic: isMusic, in: context)
+        try self.evaluate(
+            """
+            postedMessages = [];
+            moviePlayer.classes['ad-showing'] = true;
+            notifyClassChange(moviePlayer);
+            """,
+            in: context
+        )
+        #expect(context.evaluateScript("stateCount()").toInt32() == 1)
+        #expect(context.evaluateScript("lastState().isAd").toBool())
+
+        try self.evaluate(
+            """
+            notifyClassChange(moviePlayer);
+            delete moviePlayer.classes['ad-showing'];
+            notifyClassChange(moviePlayer);
+            """,
+            in: context
+        )
+        #expect(context.evaluateScript("stateCount()").toInt32() == 2)
+        #expect(!context.evaluateScript("lastState().isAd").toBool())
+    }
+
+    @Test("Ad player events report transitions while paused", arguments: [false, true], ["onAdStart", "onAdStateChange"])
+    func playerAdEvents(isMusic: Bool, event: String) throws {
+        let context = try self.makeContext(isMusic: isMusic)
+        try self.installObserver(isMusic: isMusic, in: context)
+        try self.evaluate(
+            """
+            postedMessages = [];
+            var activeApi = \(isMusic ? "musicApi" : "moviePlayer");
+            activeApi.presentingType = 2;
+            activeApi.fire('\(event)');
+            """,
+            in: context
+        )
+        #expect(context.evaluateScript("stateCount()").toInt32() == 1)
+        #expect(context.evaluateScript("lastState().isAd").toBool())
+
+        try self.evaluate("activeApi.presentingType = 1; activeApi.fire('onAdEnd');", in: context)
+        #expect(context.evaluateScript("stateCount()").toInt32() == 2)
+        #expect(!context.evaluateScript("lastState().isAd").toBool())
+    }
+
+    @Test("Player replacement reconnects ad observation without stale listeners", arguments: [false, true])
+    func replacementPlayer(isMusic: Bool) throws {
+        let context = try self.makeContext(isMusic: isMusic)
+        try self.installObserver(isMusic: isMusic, in: context)
+        try self.evaluate(
+            """
+            var oldPlayer = moviePlayer;
+            moviePlayer = makePlayer();
+            moviePlayer.classes['ad-showing'] = true;
+            notifyChildrenChanged();
+            timers.splice(0).forEach(function(callback) { callback(); });
+            notifyChildrenChanged();
+            timers.splice(0).forEach(function(callback) { callback(); });
+            """,
+            in: context
+        )
+        #expect(context.evaluateScript("lastState().isAd").toBool())
+        #expect(context.evaluateScript("moviePlayer.listeners.onAdStart.length").toInt32() == 1)
+
+        try self.evaluate("postedMessages = []; oldPlayer.fire('onAdStart');", in: context)
+        #expect(context.evaluateScript("stateCount()").toInt32() == 0)
+        try self.evaluate("delete moviePlayer.classes['ad-showing']; notifyClassChange(moviePlayer);", in: context)
+        #expect(context.evaluateScript("stateCount()").toInt32() == 1)
+        #expect(!context.evaluateScript("lastState().isAd").toBool())
+    }
+
+    @Test("Ad listeners wait for the player API on an existing element", arguments: [false, true])
+    func latePlayerAPI(isMusic: Bool) throws {
+        let context = try self.makeContext(isMusic: isMusic)
+        try self.evaluate(
+            """
+            var playerAddEventListener = moviePlayer.addEventListener;
+            var presentingPlayerType = moviePlayer.getPresentingPlayerType;
+            delete moviePlayer.getPresentingPlayerType;
+            moviePlayer.addEventListener = function() {};
+            """,
+            in: context
+        )
+        try self.installObserver(isMusic: isMusic, in: context)
+        try self.evaluate(
+            """
+            moviePlayer.getPresentingPlayerType = presentingPlayerType;
+            moviePlayer.addEventListener = playerAddEventListener;
+            notifyChildrenChanged();
+            timers.splice(0).forEach(function(callback) { callback(); });
+            postedMessages = [];
+            moviePlayer.presentingType = 2;
+            moviePlayer.fire('onAdStart');
+            """,
+            in: context
+        )
+
+        #expect(context.evaluateScript("stateCount()").toInt32() == 1)
+        #expect(context.evaluateScript("lastState().isAd").toBool())
+    }
+
+    @Test("Ad-end events clear ads first observed through media updates", arguments: [false, true])
+    func adEndAfterMediaSample(isMusic: Bool) throws {
+        let context = try self.makeContext(isMusic: isMusic)
+        try self.installObserver(isMusic: isMusic, in: context)
+        try self.evaluate(
+            """
+            var activeApi = \(isMusic ? "musicApi" : "moviePlayer");
+            activeApi.presentingType = 2;
+            fireVideoEvent('waiting');
+            """,
+            in: context
+        )
+        #expect(context.evaluateScript("lastState().isAd").toBool())
+
+        try self.evaluate(
+            """
+            postedMessages = [];
+            activeApi.presentingType = 1;
+            activeApi.fire('onAdEnd');
+            """,
+            in: context
+        )
+        #expect(context.evaluateScript("stateCount()").toInt32() == 1)
+        #expect(!context.evaluateScript("lastState().isAd").toBool())
+    }
+
+    @Test("Ended events retain ad classification", arguments: [false, true])
+    func adEndsAreNotContentEnds(isMusic: Bool) throws {
+        let context = try self.makeContext(isMusic: isMusic)
+        try self.evaluate("moviePlayer.presentingType = 2; musicApi.presentingType = 2;", in: context)
+        try self.installObserver(isMusic: isMusic, in: context)
+        try self.evaluate("postedMessages = []; video.ended = true; fireVideoEvent('ended');", in: context)
+
+        #expect(context.evaluateScript(
+            "postedMessages.filter(function(message) { return message.type === '\(isMusic ? "TRACK_ENDED" : "VIDEO_ENDED")'; })[0].isAd"
+        ).toBool())
+    }
+
+    @Test("Music ad metadata does not consume the first content update")
+    func musicMetadataWaitsForContent() throws {
+        let context = try self.makeContext(isMusic: true)
+        try self.evaluate("moviePlayer.classes['ad-showing'] = true;", in: context)
+        try self.installObserver(isMusic: true, in: context)
+        #expect(!context.evaluateScript("lastState().trackChanged").toBool())
+
+        try self.evaluate(
+            """
+            delete moviePlayer.classes['ad-showing'];
+            fireVideoEvent('waiting');
+            """,
+            in: context
+        )
+        #expect(!context.evaluateScript("lastState().isAd").toBool())
+        #expect(context.evaluateScript("lastState().trackChanged").toBool())
+    }
+
+    @Test("Music ad creatives do not create content metadata transitions")
+    func musicAdCreativeMetadata() throws {
+        let context = try self.makeContext(isMusic: true)
+        try self.installObserver(isMusic: true, in: context)
+        try self.evaluate(
+            """
+            var contentData = currentData;
+            currentData = { video_id: 'creative', title: 'Advertisement', author: 'Advertiser' };
+            moviePlayer.classes['ad-showing'] = true;
+            fireVideoEvent('waiting');
+            """,
+            in: context
+        )
+        #expect(context.evaluateScript("lastState().isAd").toBool())
+        #expect(!context.evaluateScript("lastState().trackChanged").toBool())
+
+        try self.evaluate(
+            """
+            currentData = contentData;
+            delete moviePlayer.classes['ad-showing'];
+            fireVideoEvent('waiting');
+            """,
+            in: context
+        )
+        #expect(!context.evaluateScript("lastState().isAd").toBool())
+        #expect(!context.evaluateScript("lastState().trackChanged").toBool())
+    }
+
+    @Test("Recovery seeks wait for content when only the player API identifies an ad")
+    func recoverySeekWaitsForContent() throws {
+        let context = try self.makeContext(isMusic: false)
+        try self.evaluate("moviePlayer.presentingType = 2; video.__kasetBoundVideoId = 'content';", in: context)
+        let script = YouTubeWatchWebView.seekWithRecoveryScript(
+            documentGeneration: 7,
+            target: 42,
+            videoIdLiteral: "'content'",
+            attemptID: 1
+        )
+
+        try self.evaluate(script, in: context)
+
+        #expect(context.evaluateScript("video.currentTime").toDouble() == 12)
+        #expect(context.evaluateScript("window.__kasetPendingSeek").toDouble() == 42)
+    }
+
+    private func installObserver(isMusic: Bool, in context: JSContext) throws {
+        try self.evaluate(
+            isMusic ? SingletonPlayerWebView.observerScript : YouTubeWatchWebView.observerScript,
+            in: context
+        )
+    }
+
+    private func makeContext(isMusic: Bool) throws -> JSContext {
+        let context = try #require(JSContext())
+        try self.evaluate(
+            """
+            var window = globalThis;
+            var postedMessages = [];
+            var videoListeners = {};
+            var observers = [];
+            var timers = [];
+            var currentData = { video_id: 'content', title: 'Song', author: 'Artist' };
+            var console = { log: function() {} };
+            window.__kasetDocumentGeneration = 7;
+            window.location = { href: 'https://\(isMusic ? "music" : "www").youtube.com/watch?v=content' };
+            var bridge = { postMessage: function(message) { postedMessages.push(message); } };
+            window.webkit = { messageHandlers: { singletonPlayer: bridge, youtubePlayer: bridge } };
+            function setTimeout(callback) { timers.push(callback); return timers.length; }
+            function clearTimeout() {}
+            function setInterval() { return 1; }
+            function clearInterval() {}
+            function lastState() {
+                return postedMessages.filter(function(message) { return message.type === 'STATE_UPDATE'; }).pop() || {};
+            }
+            function stateCount() {
+                return postedMessages.filter(function(message) { return message.type === 'STATE_UPDATE'; }).length;
+            }
+            function fireVideoEvent(name) {
+                (videoListeners[name] || []).forEach(function(handler) { handler({ type: name, currentTarget: video }); });
+            }
+            function makePlayer() {
+                var player = {
+                    classes: {},
+                    listeners: {},
+                    presentingType: 1,
+                    getPresentingPlayerType: function() { return this.presentingType; },
+                    getVideoData: function() { return currentData; },
+                    addEventListener: function(name, handler) {
+                        if (!this.listeners[name]) this.listeners[name] = [];
+                        this.listeners[name].push(handler);
+                    },
+                    removeEventListener: function(name, handler) {
+                        this.listeners[name] = (this.listeners[name] || []).filter(function(item) { return item !== handler; });
+                    },
+                    fire: function(name) { (this.listeners[name] || []).slice().forEach(function(handler) { handler(); }); }
+                };
+                player.classList = { contains: function(name) { return player.classes[name] === true; } };
+                return player;
+            }
+            var moviePlayer = makePlayer();
+            var musicApi = makePlayer();
+            var musicPlayer = { playerApi: musicApi };
+            var playerBar = {};
+            var video = {
+                currentTime: 12, duration: 180, currentSrc: 'https://media.example/content',
+                paused: true, ended: false, readyState: 4, volume: 1, muted: false,
+                seekable: { length: 1, start: function() { return 0; }, end: function() { return 180; } },
+                addEventListener: function(name, handler) {
+                    if (!videoListeners[name]) videoListeners[name] = [];
+                    videoListeners[name].push(handler);
+                }
+            };
+            var document = {
+                title: 'Song - YouTube', readyState: 'complete', body: {}, documentElement: {},
+                getElementById: function(id) { return id === 'movie_player' ? moviePlayer : null; },
+                querySelector: function(selector) {
+                    if (selector === 'video' || selector === '#movie_player video') return video;
+                    if (selector === 'ytmusic-player' && \(isMusic)) return musicPlayer;
+                    if (selector === 'ytmusic-player-bar' && \(isMusic)) return playerBar;
+                    return null;
+                },
+                querySelectorAll: function() { return []; },
+                addEventListener: function() {}
+            };
+            function MutationObserver(callback) {
+                this.callback = callback;
+                observers.push(this);
+            }
+            MutationObserver.prototype.observe = function(target, options) { this.target = target; this.options = options; };
+            MutationObserver.prototype.disconnect = function() { this.target = null; };
+            function notifyClassChange(target) {
+                observers.slice().forEach(function(observer) {
+                    if (observer.target === target && observer.options.attributes
+                        && observer.options.attributeFilter.indexOf('class') !== -1) {
+                        observer.callback([{ type: 'attributes', target: target, attributeName: 'class' }]);
+                    }
+                });
+            }
+            function notifyChildrenChanged() {
+                observers.slice().forEach(function(observer) {
+                    if ((observer.target === document.body || observer.target === document.documentElement)
+                        && observer.options.childList) {
+                        observer.callback([{ type: 'childList', target: observer.target }]);
+                    }
+                });
+            }
+            """,
+            in: context
+        )
+        return context
+    }
+
+    private func evaluate(_ script: String, in context: JSContext) throws {
+        context.exception = nil
+        context.evaluateScript(script)
+        try #require(context.exception == nil, "JavaScript exception: \(context.exception?.toString() ?? "")")
+    }
+}

--- a/Tests/KasetTests/PlaybackAdDetectionTests.swift
+++ b/Tests/KasetTests/PlaybackAdDetectionTests.swift
@@ -234,11 +234,17 @@ struct PlaybackAdDetectionTests {
         #expect(!context.evaluateScript("lastState().isAd").toBool())
     }
 
-    @Test("Ended events retain ad classification", arguments: [false, true])
-    func adEndsAreNotContentEnds(isMusic: Bool) throws {
+    @Test("Ended events retain ad classification", arguments: [false, true], [false, true])
+    func adEndsAreNotContentEnds(isMusic: Bool, signalClearsFirst: Bool) throws {
         let context = try self.makeContext(isMusic: isMusic)
-        try self.evaluate("moviePlayer.presentingType = 2; musicApi.presentingType = 2;", in: context)
+        try self.evaluate(
+            "currentData = { video_id: 'creative', title: 'Advertisement' }; moviePlayer.presentingType = 2; musicApi.presentingType = 2;",
+            in: context
+        )
         try self.installObserver(isMusic: isMusic, in: context)
+        if signalClearsFirst {
+            try self.evaluate("moviePlayer.presentingType = 1; musicApi.presentingType = 1;", in: context)
+        }
         try self.evaluate("postedMessages = []; video.ended = true; fireVideoEvent('ended');", in: context)
 
         #expect(context.evaluateScript(
@@ -321,38 +327,120 @@ struct PlaybackAdDetectionTests {
         }
         try self.evaluate("musicApi.presentingType = 1; musicApi.fire('onAdEnd');", in: context)
 
-        #expect(!context.evaluateScript("lastState().isAd").toBool())
-        #expect(!context.evaluateScript("lastState().hasContentMetadata").toBool())
+        #expect(context.evaluateScript("lastState().isAd").toBool())
         #expect(!context.evaluateScript("lastState().trackChanged").toBool())
 
         try self.evaluate("currentData = contentData; fireVideoEvent('waiting');", in: context)
         #expect(!context.evaluateScript("lastState().isAd").toBool())
-        #expect(context.evaluateScript("lastState().hasContentMetadata").toBool())
         #expect(context.evaluateScript("lastState().trackChanged").toBool() == startsDuringAd)
         #expect(context.evaluateScript("lastState().videoId").toString() == "content")
         #expect(context.evaluateScript("lastState().title").toString() == "Song")
     }
 
-    @Test("Music accepts requested content when its metadata leads the watch URL during an ad")
-    func musicRequestedMetadataDuringAd() throws {
-        let context = try self.makeContext(isMusic: true)
-        try self.installObserver(isMusic: true, in: context)
+    @Test("Both players accept requested content when its metadata leads the watch URL during an ad", arguments: [false, true])
+    func requestedMetadataDuringAd(isMusic: Bool) throws {
+        let context = try self.makeContext(isMusic: isMusic)
+        try self.installObserver(isMusic: isMusic, in: context)
         try self.evaluate(
             """
             currentData = { video_id: 'next', title: 'Next song', author: 'Artist' };
-            musicApi.presentingType = 2;
-            musicApi.fire('onAdStart');
-            window.location.href = 'https://music.youtube.com/watch?v=next';
-            musicApi.presentingType = 1;
-            musicApi.fire('onAdEnd');
+            var activeApi = \(isMusic ? "musicApi" : "moviePlayer");
+            activeApi.presentingType = 2;
+            activeApi.fire('onAdStart');
+            window.location.href = 'https://\(isMusic ? "music" : "www").youtube.com/watch?v=next';
+            activeApi.presentingType = 1;
+            activeApi.fire('onAdEnd');
             """,
             in: context
         )
 
         #expect(!context.evaluateScript("lastState().isAd").toBool())
-        #expect(context.evaluateScript("lastState().hasContentMetadata").toBool())
-        #expect(context.evaluateScript("lastState().trackChanged").toBool())
+        if isMusic {
+            #expect(context.evaluateScript("lastState().trackChanged").toBool())
+        }
         #expect(context.evaluateScript("lastState().videoId").toString() == "next")
+    }
+
+    @Test("Early ad-end events preserve native content state on both players", arguments: [false, true])
+    func earlyAdEndPreservesNativeState(isMusic: Bool) throws {
+        let context = try self.makeContext(isMusic: isMusic)
+        try self.installObserver(isMusic: isMusic, in: context)
+        try self.evaluate(
+            """
+            var contentData = currentData;
+            var activeApi = \(isMusic ? "musicApi" : "moviePlayer");
+            currentData = { video_id: 'creative', title: 'Advertisement', author: 'Advertiser' };
+            video.currentSrc = 'https://media.example/creative';
+            video.currentTime = 0;
+            video.duration = 30;
+            activeApi.presentingType = 2;
+            activeApi.fire('onAdStart');
+            activeApi.presentingType = 1;
+            activeApi.fire('onAdEnd');
+            """,
+            in: context
+        )
+        let isAd = context.evaluateScript("lastState().isAd").toBool()
+        let hasReadyMedia = context.evaluateScript("lastState().hasReadyMedia").toBool()
+        #expect(isAd)
+        let standaloneDetection = """
+        (function() {
+            \(PlaybackAdDetectionScript.detection)
+            return isAdShowing();
+        })();
+        """
+        #expect(context.evaluateScript(standaloneDetection).toBool())
+        if isMusic {
+            #expect(!SingletonPlayerWebView.isAuthoritativePlaybackSample(
+                hasReadyMedia: hasReadyMedia,
+                isShowingAd: isAd
+            ))
+        } else {
+            let controller = MockYouTubeWatchPlaybackController()
+            let player = YouTubePlayerService(playbackController: controller)
+            defer { player.stop() }
+            player.play(video: MockYouTubeClient.makeVideo(videoId: "content"))
+            player.updatePlaybackState(.init(
+                isPlaying: true,
+                progress: 12,
+                duration: 180,
+                hasReadyMedia: true,
+                videoId: "content",
+                boundVideoId: "content"
+            ))
+            player.updatePlaybackState(.init(
+                isPlaying: context.evaluateScript("lastState().isPlaying").toBool(),
+                progress: context.evaluateScript("lastState().progress").toDouble(),
+                duration: context.evaluateScript("lastState().duration").toDouble(),
+                hasReadyMedia: hasReadyMedia,
+                videoId: context.evaluateScript("lastState().videoId").toString(),
+                boundVideoId: context.evaluateScript("lastState().boundVideoId").toString(),
+                title: context.evaluateScript("lastState().title").toString(),
+                isAd: isAd
+            ))
+            let currentVideoId = player.currentVideo?.videoId
+            let isShowingAd = player.isShowingAd
+            #expect(currentVideoId == "content")
+            #expect(isShowingAd)
+            player.reloadCurrentVideoForIdentitySwitch()
+            let recoveryPositions = controller.reloadResumeSeconds
+            #expect(recoveryPositions == [12])
+        }
+
+        try self.evaluate("currentData = null;", in: context)
+        #expect(context.evaluateScript(standaloneDetection).toBool())
+        try self.evaluate(
+            """
+            currentData = contentData;
+            video.currentSrc = 'https://media.example/content';
+            video.currentTime = 12;
+            video.duration = 180;
+            fireVideoEvent('waiting');
+            """,
+            in: context
+        )
+        #expect(!context.evaluateScript("lastState().isAd").toBool())
+        #expect(context.evaluateScript("lastState().videoId").toString() == "content")
     }
 
     @Test("Recovery seeks wait for content when only the player API identifies an ad")

--- a/Tests/KasetTests/PlaybackAdDetectionTests.swift
+++ b/Tests/KasetTests/PlaybackAdDetectionTests.swift
@@ -209,6 +209,27 @@ struct PlaybackAdDetectionTests {
         #expect(context.evaluateScript("lastState().isAd").toBool())
     }
 
+    @Test("Music ad listeners attach when the API object appears without DOM changes")
+    func lateMusicAPIObject() throws {
+        let context = try self.makeContext(isMusic: true)
+        try self.evaluate("delete musicPlayer.playerApi;", in: context)
+        try self.installObserver(isMusic: true, in: context)
+
+        try self.evaluate(
+            """
+            musicPlayer.playerApi = musicApi;
+            timers.splice(0).forEach(function(callback) { callback(); });
+            postedMessages = [];
+            musicApi.presentingType = 2;
+            musicApi.fire('onAdStart');
+            """,
+            in: context
+        )
+
+        #expect(context.evaluateScript("stateCount()").toInt32() == 1)
+        #expect(context.evaluateScript("lastState().isAd").toBool())
+    }
+
     @Test("API hookup retries stop after readiness or the retry limit", arguments: [false, true])
     func apiAttachmentRetriesStop(apiBecomesReady: Bool) throws {
         let context = try self.makeContext(isMusic: false)

--- a/Tests/KasetTests/PlaybackAdDetectionTests.swift
+++ b/Tests/KasetTests/PlaybackAdDetectionTests.swift
@@ -178,34 +178,64 @@ struct PlaybackAdDetectionTests {
         #expect(context.evaluateScript("lastState().isAd").toBool())
     }
 
-    @Test("Ad listeners wait for the player API on an existing element", arguments: [false, true])
-    func latePlayerAPI(isMusic: Bool) throws {
+    @Test("Ad listeners attach when the player API initializes late", arguments: [false, true], [false, true])
+    func latePlayerAPI(isMusic: Bool, notifiesChildren: Bool) throws {
         let context = try self.makeContext(isMusic: isMusic)
         try self.evaluate(
             """
-            var playerAddEventListener = moviePlayer.addEventListener;
-            var presentingPlayerType = moviePlayer.getPresentingPlayerType;
-            delete moviePlayer.getPresentingPlayerType;
-            moviePlayer.addEventListener = function() {};
+            var activeApi = \(isMusic ? "musicApi" : "moviePlayer");
+            var playerAddEventListener = activeApi.addEventListener;
+            var presentingPlayerType = activeApi.getPresentingPlayerType;
+            delete activeApi.getPresentingPlayerType;
+            activeApi.addEventListener = function() {};
             """,
             in: context
         )
         try self.installObserver(isMusic: isMusic, in: context)
         try self.evaluate(
             """
-            moviePlayer.getPresentingPlayerType = presentingPlayerType;
-            moviePlayer.addEventListener = playerAddEventListener;
-            notifyChildrenChanged();
+            activeApi.getPresentingPlayerType = presentingPlayerType;
+            activeApi.addEventListener = playerAddEventListener;
+            if (\(notifiesChildren)) notifyChildrenChanged();
             timers.splice(0).forEach(function(callback) { callback(); });
             postedMessages = [];
-            moviePlayer.presentingType = 2;
-            moviePlayer.fire('onAdStart');
+            activeApi.presentingType = 2;
+            activeApi.fire('onAdStart');
             """,
             in: context
         )
 
         #expect(context.evaluateScript("stateCount()").toInt32() == 1)
         #expect(context.evaluateScript("lastState().isAd").toBool())
+    }
+
+    @Test("API hookup retries stop after readiness or the retry limit", arguments: [false, true])
+    func apiAttachmentRetriesStop(apiBecomesReady: Bool) throws {
+        let context = try self.makeContext(isMusic: false)
+        try self.evaluate(
+            """
+            var presentingPlayerType = moviePlayer.getPresentingPlayerType;
+            delete moviePlayer.getPresentingPlayerType;
+            \(PlaybackAdDetectionScript.detection)
+            \(PlaybackAdDetectionScript.observation)
+            var adChanges = 0;
+            var refresh = observeAdStateChanges(function() { adChanges += 1; });
+            refresh();
+            var retryTurns = 0;
+            while (timers.length && retryTurns < 100) {
+                if (\(apiBecomesReady)) moviePlayer.getPresentingPlayerType = presentingPlayerType;
+                timers.splice(0).forEach(function(callback) { callback(); });
+                retryTurns += 1;
+            }
+            moviePlayer.presentingType = 2;
+            moviePlayer.fire('onAdStart');
+            """,
+            in: context
+        )
+
+        #expect(context.evaluateScript("retryTurns").toInt32() > 0)
+        #expect(context.evaluateScript("timers.length").toInt32() == 0)
+        #expect(context.evaluateScript("adChanges").toInt32() == (apiBecomesReady ? 1 : 0))
     }
 
     @Test("Ad-end events clear ads first observed through media updates", arguments: [false, true])
@@ -458,6 +488,48 @@ struct PlaybackAdDetectionTests {
         )
         #expect(!context.evaluateScript("lastState().isAd").toBool())
         #expect(context.evaluateScript("lastState().videoId").toString() == "content")
+    }
+
+    @Test("Consecutive creatives remain ads between player ad signals", arguments: [false, true])
+    func consecutiveAdCreatives(isMusic: Bool) throws {
+        let context = try self.makeContext(isMusic: isMusic)
+        try self.installObserver(isMusic: isMusic, in: context)
+        try self.evaluate(
+            """
+            var contentData = currentData;
+            var activeApi = \(isMusic ? "musicApi" : "moviePlayer");
+            currentData = { video_id: 'creative-one', title: 'First ad' };
+            video.currentSrc = 'https://media.example/creative-one';
+            video.currentTime = 0;
+            video.duration = 30;
+            activeApi.presentingType = 2;
+            activeApi.fire('onAdStart');
+            activeApi.presentingType = 1;
+            currentData = { video_id: 'creative-two', title: 'Second ad' };
+            video.currentSrc = 'https://media.example/creative-two';
+            activeApi.fire('onAdEnd');
+            """,
+            in: context
+        )
+
+        #expect(context.evaluateScript("video.__kasetBoundVideoId").toString() == "creative-two")
+        #expect(context.evaluateScript("lastState().isAd").toBool())
+        if isMusic {
+            #expect(!context.evaluateScript("lastState().trackChanged").toBool())
+        }
+
+        try self.evaluate(
+            """
+            currentData = contentData;
+            video.currentSrc = 'https://media.example/content';
+            video.currentTime = 12;
+            video.duration = 180;
+            fireVideoEvent('waiting');
+            """,
+            in: context
+        )
+        #expect(!context.evaluateScript("lastState().isAd").toBool())
+        #expect(context.evaluateScript("video.__kasetBoundVideoId").toString() == "content")
     }
 
     @Test("Recovery seeks wait for content when only the player API identifies an ad")

--- a/Tests/KasetTests/PlaybackAdDetectionTests.swift
+++ b/Tests/KasetTests/PlaybackAdDetectionTests.swift
@@ -299,7 +299,7 @@ struct PlaybackAdDetectionTests {
     }
 
     @Test("Music waits for content metadata after an early ad-end event", arguments: [false, true], [false, true])
-    func musicAdEndBeforeMetadata(startsDuringAd: Bool, metadataReturnsFirst: Bool) throws {
+    func musicAdEndBeforeMetadata(startsDuringAd: Bool, textReturnsFirst: Bool) throws {
         let context = try self.makeContext(isMusic: true)
         if !startsDuringAd {
             try self.installObserver(isMusic: true, in: context)
@@ -308,6 +308,9 @@ struct PlaybackAdDetectionTests {
             """
             var contentData = currentData;
             currentData = { video_id: 'creative', title: 'Advertisement', author: 'Advertiser' };
+            video.currentSrc = 'https://media.example/creative';
+            video.currentTime = 0;
+            video.duration = 30;
             musicApi.presentingType = 2;
             musicApi.fire('onAdStart');
             """,
@@ -319,7 +322,7 @@ struct PlaybackAdDetectionTests {
         #expect(context.evaluateScript("lastState().isAd").toBool())
         #expect(!context.evaluateScript("lastState().trackChanged").toBool())
 
-        if metadataReturnsFirst {
+        if textReturnsFirst {
             try self.evaluate(
                 "currentData.title = contentData.title; currentData.author = contentData.author; fireVideoEvent('waiting');",
                 in: context
@@ -330,7 +333,16 @@ struct PlaybackAdDetectionTests {
         #expect(context.evaluateScript("lastState().isAd").toBool())
         #expect(!context.evaluateScript("lastState().trackChanged").toBool())
 
-        try self.evaluate("currentData = contentData; fireVideoEvent('waiting');", in: context)
+        try self.evaluate(
+            """
+            currentData = contentData;
+            video.currentSrc = 'https://media.example/content';
+            video.currentTime = 12;
+            video.duration = 180;
+            fireVideoEvent('waiting');
+            """,
+            in: context
+        )
         #expect(!context.evaluateScript("lastState().isAd").toBool())
         #expect(context.evaluateScript("lastState().trackChanged").toBool() == startsDuringAd)
         #expect(context.evaluateScript("lastState().videoId").toString() == "content")
@@ -361,8 +373,8 @@ struct PlaybackAdDetectionTests {
         #expect(context.evaluateScript("lastState().videoId").toString() == "next")
     }
 
-    @Test("Early ad-end events preserve native content state on both players", arguments: [false, true])
-    func earlyAdEndPreservesNativeState(isMusic: Bool) throws {
+    @Test("Early ad-end events preserve native content state on both players", arguments: [false, true], [false, true])
+    func earlyAdEndPreservesNativeState(isMusic: Bool, contentIDReturnsFirst: Bool) throws {
         let context = try self.makeContext(isMusic: isMusic)
         try self.installObserver(isMusic: isMusic, in: context)
         try self.evaluate(
@@ -375,6 +387,7 @@ struct PlaybackAdDetectionTests {
             video.duration = 30;
             activeApi.presentingType = 2;
             activeApi.fire('onAdStart');
+            if (\(contentIDReturnsFirst)) currentData = contentData;
             activeApi.presentingType = 1;
             activeApi.fire('onAdEnd');
             """,
@@ -382,6 +395,7 @@ struct PlaybackAdDetectionTests {
         )
         let isAd = context.evaluateScript("lastState().isAd").toBool()
         let hasReadyMedia = context.evaluateScript("lastState().hasReadyMedia").toBool()
+        #expect(context.evaluateScript("video.__kasetBoundVideoId").toString() == "creative")
         #expect(isAd)
         let standaloneDetection = """
         (function() {
@@ -422,6 +436,9 @@ struct PlaybackAdDetectionTests {
             let isShowingAd = player.isShowingAd
             #expect(currentVideoId == "content")
             #expect(isShowingAd)
+            player.seek(to: 20)
+            let adSeeks = controller.seeks
+            #expect(adSeeks.isEmpty)
             player.reloadCurrentVideoForIdentitySwitch()
             let recoveryPositions = controller.reloadResumeSeconds
             #expect(recoveryPositions == [12])

--- a/Tests/KasetTests/PlayerServicePlaybackIntentTests.swift
+++ b/Tests/KasetTests/PlayerServicePlaybackIntentTests.swift
@@ -280,6 +280,68 @@ struct PlayerServicePlaybackIntentTests { // swiftlint:disable:this type_body_le
         #expect(playerService.remoteMusicTransportIntent == nil)
     }
 
+    @Test("Music ignores direct and intent-based seeks during ads")
+    func musicSeeksDuringAds() async {
+        let (playerService, _) = self.makePlayerService()
+        defer { self.resetSingletonPlayer() }
+        let song = self.makeSong(id: "ad-seek")
+        await playerService.playQueue([song], startingAt: 0)
+        playerService.progress = 12
+        playerService.duration = 180
+        playerService.updateAdPlaybackState(
+            isShowingAd: true, observedProgress: 0, observedVideoId: song.videoId, isAuthoritativeContent: false
+        )
+        let intent = playerService.currentMusicPlaybackIntent
+
+        await playerService.seek(to: 90)
+        let intentAfterDirectSeek = playerService.currentMusicPlaybackIntent
+        #expect(intentAfterDirectSeek == intent)
+        await playerService.seek(to: 180, intent: playerService.currentMusicPlaybackIntent)
+        let adProgress = playerService.progress
+        #expect(adProgress == 12)
+
+        playerService.updateAdPlaybackState(
+            isShowingAd: false, observedProgress: 12, observedVideoId: song.videoId, isAuthoritativeContent: true
+        )
+        await playerService.seek(to: 60)
+        let contentProgress = playerService.progress
+        #expect(contentProgress == 60)
+    }
+
+    @Test("A remote Music skip cannot apply an ad snapshot")
+    func remoteSkipWhenAdStarts() async {
+        let (playerService, _) = self.makePlayerService()
+        defer { self.resetSingletonPlayer() }
+        let song = self.makeSong(id: "ad-remote-skip")
+        await playerService.playQueue([song], startingAt: 0)
+        playerService.musicPlaybackIntentIssuedAtMilliseconds = 1000
+        playerService.progress = 12
+        playerService.duration = 180
+        let snapshotStarted = AsyncGate()
+        let releaseSnapshot = AsyncGate()
+        playerService.currentMusicPlaybackSnapshot = {
+            await snapshotStarted.open()
+            await releaseSnapshot.wait()
+            return SingletonPlayerWebView.PlaybackSnapshot(progress: 5, duration: 30, videoId: song.videoId)
+        }
+        playerService.enqueueRemoteMusicTransportCommand(
+            .relativeSeek(delta: 15, admittedAt: ContinuousClock.now), issuedAtMilliseconds: 1001
+        )
+        let remoteTask = playerService.remoteMusicTransportTask
+        await snapshotStarted.wait()
+        playerService.updateAdPlaybackState(
+            isShowingAd: true, observedProgress: 5, observedVideoId: song.videoId, isAuthoritativeContent: false
+        )
+
+        await releaseSnapshot.open()
+        await remoteTask?.value
+
+        let progress = playerService.progress
+        let pendingSkipTarget = playerService.remoteMusicSkipTarget
+        #expect(progress == 12)
+        #expect(pendingSkipTarget == nil)
+    }
+
     @Test("A disappeared queue entry cannot claim a playback reservation")
     func disappearedQueueEntryCannotClaimPlaybackReservation() async {
         let playerService = PlayerService()

--- a/Tests/KasetTests/PlayerServicePlaybackIntentTests.swift
+++ b/Tests/KasetTests/PlayerServicePlaybackIntentTests.swift
@@ -308,8 +308,8 @@ struct PlayerServicePlaybackIntentTests { // swiftlint:disable:this type_body_le
         #expect(contentProgress == 60)
     }
 
-    @Test("A remote Music skip cannot apply an ad snapshot")
-    func remoteSkipWhenAdStarts() async {
+    @Test("A remote Music skip cannot apply an ad snapshot", arguments: [false, true])
+    func remoteSkipWhenAdStarts(adEndsBeforeSnapshot: Bool) async {
         let (playerService, _) = self.makePlayerService()
         defer { self.resetSingletonPlayer() }
         let song = self.makeSong(id: "ad-remote-skip")
@@ -332,6 +332,11 @@ struct PlayerServicePlaybackIntentTests { // swiftlint:disable:this type_body_le
         playerService.updateAdPlaybackState(
             isShowingAd: true, observedProgress: 5, observedVideoId: song.videoId, isAuthoritativeContent: false
         )
+        if adEndsBeforeSnapshot {
+            playerService.updateAdPlaybackState(
+                isShowingAd: false, observedProgress: 12, observedVideoId: song.videoId, isAuthoritativeContent: true
+            )
+        }
 
         await releaseSnapshot.open()
         await remoteTask?.value
@@ -340,6 +345,30 @@ struct PlayerServicePlaybackIntentTests { // swiftlint:disable:this type_body_le
         let pendingSkipTarget = playerService.remoteMusicSkipTarget
         #expect(progress == 12)
         #expect(pendingSkipTarget == nil)
+    }
+
+    @Test("Remote Music skips are rejected when admitted during an ad")
+    func remoteSkipDuringAdIsRejected() async {
+        let (playerService, _) = self.makePlayerService()
+        defer { self.resetSingletonPlayer() }
+        let song = self.makeSong(id: "ad-skip-admission")
+        await playerService.playQueue([song], startingAt: 0)
+        playerService.musicPlaybackIntentIssuedAtMilliseconds = 1000
+        playerService.updateAdPlaybackState(
+            isShowingAd: true, observedProgress: 5, observedVideoId: song.videoId, isAuthoritativeContent: false
+        )
+        let intent = playerService.currentMusicPlaybackIntent
+
+        playerService.enqueueRemoteMusicTransportCommand(
+            .relativeSeek(delta: 15, admittedAt: ContinuousClock.now), issuedAtMilliseconds: 1001
+        )
+
+        let pendingTask = playerService.remoteMusicTransportTask
+        let intentAfterSkip = playerService.currentMusicPlaybackIntent
+        #expect(pendingTask == nil)
+        #expect(intentAfterSkip == intent)
+        pendingTask?.cancel()
+        await pendingTask?.value
     }
 
     @Test("A disappeared queue entry cannot claim a playback reservation")

--- a/Tests/KasetTests/PlayerServicePlaybackIntentTests.swift
+++ b/Tests/KasetTests/PlayerServicePlaybackIntentTests.swift
@@ -347,8 +347,8 @@ struct PlayerServicePlaybackIntentTests { // swiftlint:disable:this type_body_le
         #expect(pendingSkipTarget == nil)
     }
 
-    @Test("Remote Music skips are rejected when admitted during an ad")
-    func remoteSkipDuringAdIsRejected() async {
+    @Test("Remote Music seeks are rejected when admitted during an ad", arguments: [false, true])
+    func remoteSeekDuringAdIsRejected(absoluteSeek: Bool) async {
         let (playerService, _) = self.makePlayerService()
         defer { self.resetSingletonPlayer() }
         let song = self.makeSong(id: "ad-skip-admission")
@@ -359,9 +359,10 @@ struct PlayerServicePlaybackIntentTests { // swiftlint:disable:this type_body_le
         )
         let intent = playerService.currentMusicPlaybackIntent
 
-        playerService.enqueueRemoteMusicTransportCommand(
-            .relativeSeek(delta: 15, admittedAt: ContinuousClock.now), issuedAtMilliseconds: 1001
-        )
+        let command: MusicRemoteTransportCommand = absoluteSeek
+            ? .absoluteSeek(position: 60)
+            : .relativeSeek(delta: 15, admittedAt: ContinuousClock.now)
+        playerService.enqueueRemoteMusicTransportCommand(command, issuedAtMilliseconds: 1001)
 
         let pendingTask = playerService.remoteMusicTransportTask
         let intentAfterSkip = playerService.currentMusicPlaybackIntent

--- a/Tests/KasetTests/SyncedLyricsBridgeScriptTests.swift
+++ b/Tests/KasetTests/SyncedLyricsBridgeScriptTests.swift
@@ -271,10 +271,16 @@ struct SyncedLyricsBridgeScriptTests {
         };
         var playerBar = { attributes: {}, childNodes: [] };
         var playerApi = {
-            getVideoData: function() { return { video_id: 'abc', title: 'Title', author: 'Artist' }; }
+            getVideoData: function() { return { video_id: 'abc', title: 'Title', author: 'Artist' }; },
+            getPresentingPlayerType: function() { return 1; },
+            addEventListener: function() {}
         };
         var ytmusicPlayer = { playerApi: playerApi };
-        var moviePlayer = { getVideoData: playerApi.getVideoData };
+        var moviePlayer = {
+            getVideoData: playerApi.getVideoData,
+            getPresentingPlayerType: playerApi.getPresentingPlayerType,
+            addEventListener: function() {}
+        };
         var document = {
             readyState: 'complete',
             body: {},

--- a/Tests/KasetTests/YouTubePlayerServiceTests.swift
+++ b/Tests/KasetTests/YouTubePlayerServiceTests.swift
@@ -1011,6 +1011,42 @@ struct YouTubePlayerServiceTests {
 }
 
 extension YouTubePlayerServiceTests {
+    @Test("YouTube ignores absolute, relative, and remote seeks during ads")
+    func adSeeksAreIgnored() {
+        self.sut.play(video: MockYouTubeClient.makeVideo(videoId: "content"))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true, progress: 12, duration: 180, hasReadyMedia: true,
+            videoId: "content", boundVideoId: "content"
+        ))
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true, progress: 5, duration: 30, hasReadyMedia: true,
+            videoId: "creative", boundVideoId: "creative", isAd: true
+        ))
+        let intent = self.sut.youtubePlaybackIntentGeneration
+
+        self.sut.seek(to: 20)
+        self.sut.seekForward(by: 2)
+        self.sut.seekBackward(by: 2)
+        self.sut.handleRemoteSeek(to: 30, issuedAtMilliseconds: Date().timeIntervalSince1970 * 1000 + 1)
+
+        let seeks = self.controller.seeks
+        let pendingSeeks = self.controller.pendingRecoverySeeks
+        let progress = self.sut.progress
+        let intentAfterSeeks = self.sut.youtubePlaybackIntentGeneration
+        #expect(seeks.isEmpty)
+        #expect(pendingSeeks.isEmpty)
+        #expect(progress == 5)
+        #expect(intentAfterSeeks == intent)
+
+        self.sut.updatePlaybackState(.init(
+            isPlaying: true, progress: 12, duration: 180, hasReadyMedia: true,
+            videoId: "content", boundVideoId: "content"
+        ))
+        self.sut.seekForward(by: 15)
+        let contentSeeks = self.controller.seeks
+        #expect(contentSeeks == [27])
+    }
+
     @Test("Non-authoritative post-roll placeholders survive process termination")
     func loadingPostRollPlaceholderTerminationRecoversNextVideo() {
         for isAd in [true, false] {

--- a/Tests/KasetTests/YouTubeWatchScriptTests.swift
+++ b/Tests/KasetTests/YouTubeWatchScriptTests.swift
@@ -575,8 +575,7 @@ struct YouTubeWatchScriptTests {
                 title: 'Title - YouTube',
                 getElementById: function(id) { return id === 'movie_player' ? player : null; },
                 querySelector: function(selector) {
-                    if (selector === '.ytp-autonav-toggle-button') { return null; }
-                    return video;
+                    return selector === '#movie_player video' || selector === 'video' ? video : null;
                 }
             };
             window.webkit = {

--- a/Tests/KasetTests/YouTubeWatchScriptTests.swift
+++ b/Tests/KasetTests/YouTubeWatchScriptTests.swift
@@ -565,6 +565,7 @@ struct YouTubeWatchScriptTests {
             };
             var player = {
                 classList: { contains: function() { return false; } },
+                getPresentingPlayerType: function() { return 1; }, addEventListener: function() {},
                 getVideoData: function() {
                     return { video_id: currentDataVideoId, title: 'Title' };
                 },
@@ -772,6 +773,7 @@ extension YouTubeWatchScriptTests {
 
             var moviePlayer = {
                 classList: { contains: function() { return false; } },
+                getPresentingPlayerType: function() { return 1; }, addEventListener: function() {},
                 getVideoData: function() { return { video_id: 'abc123', title: 'Test Video' }; },
                 unMute: function() {}
             };

--- a/docs/playback.md
+++ b/docs/playback.md
@@ -115,8 +115,9 @@ that an ad is playing.
 
 Ad samples update transport state while preserving Music's content clock,
 metadata, like status, video availability, and queue. Ad metadata does not consume
-the observer's next content-change notification. Both players use the same
-detector for end events and recovery seek/resume decisions.
+the observer's next content-change notification. If the ad signal clears early,
+Music withholds a known creative's metadata until the player restores a content ID.
+Both players use the same detector for end events and recovery seek/resume decisions.
 
 During ads, both native player bars replace the content timeline with a yellow
 `Ad` badge. Content timestamps and player-bar seeking return when content resumes;

--- a/docs/playback.md
+++ b/docs/playback.md
@@ -116,7 +116,8 @@ that an ad is playing.
 Ad samples update transport state while preserving Music's content clock,
 metadata, like status, video availability, and queue. Ad metadata does not consume
 the observer's next content-change notification. If the ad signal clears early,
-both players keep a known creative classified as an ad until a content ID returns.
+both players keep a known creative classified as an ad until content metadata and
+the physical media binding have moved away from the creative.
 End events and recovery seek/resume decisions use the same detector.
 
 Both playback services ignore user and system seek requests during ads. The Music

--- a/docs/playback.md
+++ b/docs/playback.md
@@ -109,6 +109,8 @@ Both playback WebViews share `PlaybackAdDetectionScript`. It checks
 with `ad-showing` and `ad-interrupting` player classes as fallbacks. The argument
 includes server-stitched ad segments when the player exposes them. Player ad
 events and class mutations report transitions even while playback is paused.
+API hookup retries every half-second during initialization, stopping when the
+API is ready or after ten seconds.
 These are undocumented player signals and require rechecking when YouTube changes
 its player. Ad inventory or the presence of an ad container does not establish
 that an ad is playing.
@@ -116,8 +118,8 @@ that an ad is playing.
 Ad samples update transport state while preserving Music's content clock,
 metadata, like status, video availability, and queue. Ad metadata does not consume
 the observer's next content-change notification. If the ad signal clears early,
-both players keep a known creative classified as an ad until content metadata and
-the physical media binding have moved away from the creative.
+both players retain ad state across subsequent creatives until the requested
+content returns in metadata and the physical media binding.
 End events and recovery seek/resume decisions use the same detector.
 
 Both playback services ignore user and system seek requests during ads. The Music

--- a/docs/playback.md
+++ b/docs/playback.md
@@ -117,13 +117,15 @@ that an ad is playing.
 
 Ad samples update transport state while preserving Music's content clock,
 metadata, like status, video availability, and queue. Ad metadata does not consume
-the observer's next content-change notification. If the ad signal clears early,
-both players retain ad state across subsequent creatives until the requested
-content returns in metadata and the physical media binding.
+the observer's next content-change notification. After observing a distinct
+creative ID, both players retain ad state across subsequent creatives until the
+requested content returns in metadata and the physical media binding. Ads that
+retain the content ID rely on the player's ad signals.
 End events and recovery seek/resume decisions use the same detector.
 
-Both playback services ignore user and system seek requests during ads. The Music
-mini-player also disables its seek slider until content returns.
+Both playback services ignore user and system seek requests during ads. Music
+also rejects a delayed seek snapshot if ad state changed while it was being read.
+The Music mini-player disables its seek slider until content returns.
 
 During ads, both native player bars replace the content timeline with a yellow
 `Ad` badge. Content timestamps and player-bar seeking return when content resumes;

--- a/docs/playback.md
+++ b/docs/playback.md
@@ -116,8 +116,11 @@ that an ad is playing.
 Ad samples update transport state while preserving Music's content clock,
 metadata, like status, video availability, and queue. Ad metadata does not consume
 the observer's next content-change notification. If the ad signal clears early,
-Music withholds a known creative's metadata until the player restores a content ID.
-Both players use the same detector for end events and recovery seek/resume decisions.
+both players keep a known creative classified as an ad until a content ID returns.
+End events and recovery seek/resume decisions use the same detector.
+
+Both playback services ignore user and system seek requests during ads. The Music
+mini-player also disables its seek slider until content returns.
 
 During ads, both native player bars replace the content timeline with a yellow
 `Ad` badge. Content timestamps and player-bar seeking return when content resumes;

--- a/docs/playback.md
+++ b/docs/playback.md
@@ -104,6 +104,24 @@ Swift updates `PlayerService` from every `STATE_UPDATE`, then uses
 `PlayerService+WebQueueSync` to decide whether the reported track matches
 Kaset's queue or whether YouTube autoplay needs to be corrected.
 
+Both playback WebViews share `PlaybackAdDetectionScript`. It checks
+`getPresentingPlayerType(true) === 2` on the movie player and Music's `playerApi`,
+with `ad-showing` and `ad-interrupting` player classes as fallbacks. The argument
+includes server-stitched ad segments when the player exposes them. Player ad
+events and class mutations report transitions even while playback is paused.
+These are undocumented player signals and require rechecking when YouTube changes
+its player. Ad inventory or the presence of an ad container does not establish
+that an ad is playing.
+
+Ad samples update transport state while preserving Music's content clock,
+metadata, like status, video availability, and queue. Ad metadata does not consume
+the observer's next content-change notification. Both players use the same
+detector for end events and recovery seek/resume decisions.
+
+During ads, both native player bars replace the content timeline with a yellow
+`Ad` badge. Content timestamps and player-bar seeking return when content resumes;
+the selected song or video metadata stays visible throughout the ad.
+
 ### 5. Track-End Handling
 
 Natural track completion is handled by a dedicated bridge event:


### PR DESCRIPTION
## Description

Ads could leave the selected song at `0:00` with no indication that an ad was playing. YouTube and YouTube Music now share ad detection and display a localized yellow `Ad` badge in place of the content timeline. Scrubbing is disabled during ads, and the song or video timeline returns when content resumes.

## Type of change

- [x] Bug fix
- [x] UI/UX improvement
- [x] Test and documentation updates

## Changes made

- Combine player API signals with `ad-showing` and `ad-interrupting` classes, and observe ad transitions through the existing player attachment paths. Retry incomplete API hookup for up to ten seconds during initialization.
- Preserve Music's content clock, metadata, like status, video availability, and queue during ads. After observing a distinct creative ID, preserve ad state through early ad-end signals and consecutive creatives until requested content returns. Reuse detection for playback end events and recovery seek/resume decisions.
- Reject ad seeks in both playback services, including system commands. Reject Music remote seeks before changing playback intent. Discard delayed Music seek snapshots that span an ad transition. Disable the Music mini-player slider and clear any pending seek display when an ad starts.
- Add the shared ad indicator, accessible label, and translations to the catalog and all 17 localization mirrors.
- Add JavaScriptCore regression coverage for both playback observers, including paused transitions, player replacement, metadata changes, and recovery seeking.

## Testing

- `swift build` passed.
- 342 focused playback tests passed across 14 suites, including consecutive ads, late API initialization, early ad-end transitions, snapshots spanning an entire ad, lyrics, and direct, relative, and system seeking during ads.
- Initial validation passed 299 tests across 14 suites, including player bars, seek state, and localization parity.
- The initial `KASET_SIGNING=adhoc Scripts/build-app.sh debug` build passed. Verified the bundle signature and ad labels in all 51 packaged localization files.
- Scoped SwiftFormat and strict SwiftLint checks passed for the review fixes. Structured local review found no actionable issues.

## Additional notes

- Local repository-wide SwiftLint 0.65.1 reports 42 existing `legacy_swiftui_aspect_ratio` violations across 21 files. Git blame confirms every flagged line is already on the PR base. This cleanup remains a separate follow-up.
- The ad signals are undocumented upstream player APIs. Live ad playback has not been verified, and local UI tests were not run. Capturing ads that retain the content ID remains a follow-up before adding source-based retention.
