### PR TITLE
feat(api-explorer): add read-only API discovery

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -73,6 +73,11 @@ let package = Package(
                 .swiftLanguageMode(.v6),
             ]
         ),
+        .testTarget(
+            name: "APIExplorerTests",
+            dependencies: ["APIExplorer"],
+            swiftSettings: [.swiftLanguageMode(.v6)]
+        ),
         // Shared Foundation-only YouTube Ask parsing and safety core
         .target(
             name: "YouTubeAskCore",

--- a/Sources/APIExplorer/DiscoveryAudit.swift
+++ b/Sources/APIExplorer/DiscoveryAudit.swift
@@ -1,0 +1,666 @@
+import Foundation
+
+func discoveryHelp() -> String {
+    var lines = [
+        "Usage: discover <endpoint> <body-json> [--guest] [--follow N] [-v] [-o report.txt]",
+        "Use --body-file <mode-0600-path|-> for private IDs or opaque request parameters.",
+        "Supported read-only endpoints and fields:",
+    ]
+    for endpoint in DiscoveryRequest.allowedFields.keys.sorted() {
+        lines.append("  " + endpoint + ": " + (DiscoveryRequest.allowedFields[endpoint] ?? []).sorted().joined(separator: ", "))
+    }
+    lines += [
+        "Navigation indices are local to each response. Repeat --follow for up to five hops.",
+        "Responses can reorder between runs. Inspect the selected route at each step.",
+        "Authentication is reused for every hop when Kaset cookies exist; --guest suppresses it.",
+        "-v adds field/type paths, never raw values. -o saves only the redacted report.",
+        "--ios-music or --android-music uses that mobile profile on every hop, with no web API key.",
+        "--mobile-web-key adds the resolved web API key to mobile discovery for auth comparison.",
+        "--mobile-cookie-only omits SAPISIDHASH on mobile discovery while retaining saved cookies.",
+        "--mobile-token-file <mode-0600-path> uses a mobile OAuth access token instead of web cookies.",
+        "Token files must be owned by you, have mode 0600 and no extended ACL, and not be symlinks.",
+        "Do not put tokens in command arguments, reports, or chat. Token acquisition is separate.",
+        "Web-cookie mobile probes were rejected; cookie-only probes returned a guest session.",
+        "A content envelope or HTTP 200 alone does not prove a feature works or auth succeeded.",
+        "Only FEmusic_charts accepts formData, with one two-letter country in selectedValues.",
+        "Examples:",
+        "  swift run api-explorer discover browse '{\"browseId\":\"FEmusic_charts\"}' --guest",
+        "  swift run api-explorer discover next '{\"videoId\":\"dQw4w9WgXcQ\"}' --guest",
+        "  swift run api-explorer discover browse '{\"browseId\":\"FEmusic_home\"}' --guest --follow 0",
+        "  swift run api-explorer discover browse '{\"browseId\":\"FEmusic_home\"}' --ios-music --guest -v",
+    ]
+    return lines.joined(separator: "\n")
+}
+
+// MARK: - DiscoveryRequest
+
+/// A small read-only subset of InnerTube. In particular, browse + formData can
+/// update a taste profile, so checking the endpoint alone is not sufficient.
+/// Charts country selection is the only supported form, constrained separately.
+struct DiscoveryRequest {
+    let endpoint: String
+    let body: [String: Any]
+
+    static let allowedFields: [String: Set<String>] = [
+        "browse": ["browseId", "params", "continuation"],
+        "search": ["query", "params", "continuation"],
+        "next": [
+            "videoId", "playlistId", "params", "continuation", "index", "playlistSetVideoId",
+            "isAudioOnly", "enablePersistentPlaylistPanel", "tunerSettingValue",
+        ],
+        "player": ["videoId"],
+        "music/get_queue": ["videoIds", "playlistId"],
+        "music/get_search_suggestions": ["input"],
+        "get_transcript": ["params"],
+    ]
+
+    init(endpoint: String, body: [String: Any]) throws {
+        guard var allowed = Self.allowedFields[endpoint] else { throw DiscoveryError.unsupportedRequest }
+        if endpoint == "browse", body["browseId"] as? String == "FEmusic_charts" {
+            allowed.insert("formData")
+        }
+        guard Set(body.keys).isSubset(of: allowed), !body.isEmpty,
+              JSONSerialization.isValidJSONObject(body)
+        else { throw DiscoveryError.unsupportedRequest }
+
+        for (key, value) in body {
+            switch key {
+            case "formData":
+                guard let form = value as? [String: Any], Set(form.keys) == ["selectedValues"],
+                      let countries = form["selectedValues"] as? [String], countries.count == 1,
+                      countries.allSatisfy(Self.isCountryCode)
+                else { throw DiscoveryError.unsupportedRequest }
+            case "videoIds":
+                guard let ids = value as? [String], !ids.isEmpty, ids.count <= 50,
+                      ids.allSatisfy({ !$0.isEmpty && $0.count <= 128 })
+                else { throw DiscoveryError.unsupportedRequest }
+            case "index":
+                guard let number = value as? Int, (0 ... 100_000).contains(number) else {
+                    throw DiscoveryError.unsupportedRequest
+                }
+            case "isAudioOnly", "enablePersistentPlaylistPanel":
+                guard value is Bool else { throw DiscoveryError.unsupportedRequest }
+            default:
+                guard let text = value as? String, !text.isEmpty, text.utf8.count <= 32768 else {
+                    throw DiscoveryError.unsupportedRequest
+                }
+            }
+        }
+        let required: [String: Set<String>] = [
+            "browse": ["browseId", "continuation"],
+            "search": ["query", "continuation"],
+            "next": ["videoId", "playlistId", "continuation"],
+            "player": ["videoId"],
+            "music/get_queue": ["videoIds", "playlistId"],
+            "music/get_search_suggestions": ["input"],
+            "get_transcript": ["params"],
+        ]
+        guard let requiredKeys = required[endpoint], !requiredKeys.isDisjoint(with: body.keys) else {
+            throw DiscoveryError.unsupportedRequest
+        }
+        self.endpoint = endpoint
+        self.body = body
+    }
+
+    static func isCountryCode(_ value: String) -> Bool {
+        value.utf8.count == 2 && value.unicodeScalars.allSatisfy { (65 ... 90).contains($0.value) }
+    }
+
+    var identity: Data {
+        (try? JSONSerialization.data(
+            withJSONObject: ["endpoint": self.endpoint, "body": self.body], options: [.sortedKeys]
+        )) ?? Data()
+    }
+
+    var summary: String {
+        let destination = (self.body["browseId"] as? String).map { " " + DiscoveryAudit.browseFamily($0) } ?? ""
+        let country = ((self.body["formData"] as? [String: Any])?["selectedValues"] as? [String])?.first
+        let selection = country.map { " country=" + $0 } ?? ""
+        return self.endpoint + destination + selection + " fields=[" + self.body.keys.sorted().joined(separator: ", ") + "]"
+    }
+}
+
+// MARK: - DiscoveryError
+
+enum DiscoveryError: Error {
+    case unsupportedRequest
+}
+
+// MARK: - DiscoveryNavigation
+
+struct DiscoveryNavigation {
+    let request: DiscoveryRequest
+    let source: String
+    let label: String?
+
+    var summary: String {
+        self.request.summary + " via " + self.source + (self.label.map { " label=" + $0 } ?? "")
+    }
+
+    var priority: Int {
+        if self.request.endpoint == "get_transcript" {
+            return 0
+        }
+        if self.request.body["formData"] != nil {
+            return 3
+        }
+        if let browseID = self.request.body["browseId"] as? String {
+            if browseID.hasPrefix("MPTC") {
+                return 0
+            }
+            if browseID.hasPrefix("MPTR") {
+                return 1
+            }
+            if browseID.hasPrefix("MPLY") {
+                return 2
+            }
+        }
+        if self.source.contains("chip") || self.source.contains("Chip") {
+            return 3
+        }
+        if self.source.contains("dropdown") || self.source.contains("Dropdown") {
+            return 4
+        }
+        if self.request.body["continuation"] != nil {
+            return 5
+        }
+        return self.request.endpoint == "browse" ? 6 : 7
+    }
+}
+
+// MARK: - DiscoveryAudit
+
+/// Stores replayable values only in memory. Reports contain schema names, counts,
+/// fixed UI labels, and browse-ID families, never response text or opaque values.
+struct DiscoveryAudit {
+    private(set) var navigation: [DiscoveryNavigation] = []
+    private(set) var renderers: [String: Int] = [:]
+    private(set) var rendererFields: [String: Set<String>] = [:]
+    private(set) var schema: Set<String> = []
+    private(set) var labels: [String: Int] = [:]
+    private(set) var pageTypes: [String: Int] = [:]
+    private(set) var observedCommands: [String: Int] = [:]
+    private(set) var counterpartCount = 0
+    private(set) var creditSectionCount = 0
+    private(set) var populatedCreditSectionCount = 0
+    private(set) var chartCountryCount = 0
+    private(set) var selectedChartCountries: [String] = []
+    private(set) var selectedChips: Set<String> = []
+    private(set) var speedDialItemCount = 0
+    private(set) var speedDialShortcutCount = 0
+    private(set) var homeShelves: [String] = []
+    private(set) var truncated = false
+    private(set) var schemaTruncated = false
+    let serverLoggedOut: Bool?
+    let hasAPIError: Bool
+    let apiErrorSummary: String?
+    let hasContent: Bool
+    private var identities: Set<Data> = []
+    private var visitedNodes = 0
+
+    private static let safeLabels: Set<String> = [
+        "All", "Albums", "Artists", "Songs", "Videos", "Playlists", "Podcasts", "Episodes", "Profiles",
+        "Featured playlists", "Community playlists", "Uploads", "Your library", "Downloads",
+        "Recently added", "Recently played", "A to Z", "Z to A", "Popular", "Newest first",
+        "Speed dial", "Speed Dial", "Listen again", "Quick picks",
+        "Workout", "Focus", "Relax", "Commute", "Energize", "Sleep", "Party", "Romance", "Feel good", "Sad",
+        "Discover", "Familiar", "New releases", "Deep cuts", "Upbeat", "Downbeat", "Chill",
+        "Song credits", "View song credits", "Performed by", "Written by", "Produced by", "Music metadata provided by",
+        "Lyrics", "Related", "Up next", "Start radio", "Create a radio", "Tune your music",
+        "You might also like", "Recommended playlists", "Similar artists", "About the artist", "Other versions",
+        "More from the artist", "From the album", "Featured on", "Music videos", "Recommended music videos",
+        "Not interested", "Don't recommend channel", "Remove from history", "Pin to Listen again", "Unpin from Listen again",
+        "Artist variety", "Song selection", "Low", "Medium", "High", "Blend", "Familiarity", "Popularity",
+        "United States", "United Kingdom", "Turkey", "Türkiye", "Japan", "Global", "Top songs", "Top music videos",
+    ]
+
+    init(response: [String: Any], request: DiscoveryRequest) {
+        let context = response["responseContext"] as? [String: Any]
+        let webContext = context?["mainAppWebResponseContext"] as? [String: Any]
+        let services = context?["serviceTrackingParams"] as? [[String: Any]] ?? []
+        let loginFlags = services.flatMap { $0["params"] as? [[String: Any]] ?? [] }
+            .filter { ["logged_in", "yt_li"].contains($0["key"] as? String ?? "") }
+            .map { $0["value"] as? String ?? "" }
+        let inferredLoggedOut: Bool? = switch Set(loginFlags) {
+        case ["0"]: true
+        case ["1"]: false
+        default: nil
+        }
+        self.serverLoggedOut = (webContext?["loggedOut"] as? Bool) ?? inferredLoggedOut
+        self.hasAPIError = response["error"] != nil
+        self.apiErrorSummary = Self.describeAPIError(response["error"] as? [String: Any])
+        self.hasContent = ["contents", "continuationContents", "onResponseReceivedActions", "onResponseReceivedEndpoints", "actions", "videoDetails", "queueDatas"]
+            .contains { key in
+                if let object = response[key] as? [String: Any] {
+                    return !object.isEmpty
+                }
+                if let array = response[key] as? [Any] {
+                    return !array.isEmpty
+                }
+                return false
+            }
+        self.collectChartCountries(response, request: request)
+        self.walk(response, path: "$", source: "root", label: nil, request: request, depth: 0)
+        self.navigation = self.navigation.enumerated().sorted {
+            $0.element.priority == $1.element.priority
+                ? $0.offset < $1.offset
+                : $0.element.priority < $1.element.priority
+        }.map(\.element)
+    }
+
+    static func schemaKey(_ key: String) -> String {
+        guard !key.isEmpty, key.count <= 100,
+              key.first?.isASCII == true, key.first?.isLowercase == true,
+              key.unicodeScalars.allSatisfy({ (65 ... 90).contains($0.value) || (97 ... 122).contains($0.value) })
+        else { return "<key>" }
+        return key
+    }
+
+    /// Only fixed error categories may leave the response. Server messages can
+    /// echo credentials or account data, including on failed requests.
+    private static func describeAPIError(_ error: [String: Any]?) -> String? {
+        guard let error else { return nil }
+        let statuses: Set = [
+            "INVALID_ARGUMENT", "UNAUTHENTICATED", "PERMISSION_DENIED", "NOT_FOUND",
+            "FAILED_PRECONDITION", "RESOURCE_EXHAUSTED", "INTERNAL", "UNAVAILABLE",
+        ]
+        let status = error["status"] as? String ?? ""
+        let messages: [String: String] = [
+            "Request contains an invalid argument.": "invalid argument",
+            "API key not valid. Please pass a valid API key.": "invalid API key",
+            "Request had invalid authentication credentials.": "invalid authentication",
+            "Login Required": "login required",
+        ]
+        let category = (error["message"] as? String).flatMap { messages[$0] } ?? "message hidden"
+        return (statuses.contains(status) ? status : "unrecognized status") + "; " + category
+    }
+
+    static func browseFamily(_ value: String) -> String {
+        if value.hasPrefix("FEmusic_"), value.count <= 90,
+           value.dropFirst(8).unicodeScalars.allSatisfy({ (97 ... 122).contains($0.value) || $0.value == 95 })
+        {
+            return value
+        }
+        for family in ["MPLA", "MPTC", "MPTR", "MPLY", "MPRE", "MPSP", "VL", "UC"] where value.hasPrefix(family) {
+            return family + "…"
+        }
+        return "<browse-id>"
+    }
+
+    private static func knownLabel(in dictionary: [String: Any]) -> String? {
+        for key in ["title", "text", "label"] {
+            if let value = dictionary[key] as? String, safeLabels.contains(value) {
+                return value
+            }
+            if let text = dictionary[key] as? [String: Any] {
+                let value: String? = (text["simpleText"] as? String)
+                    ?? (text["runs"] as? [[String: Any]])?.compactMap { $0["text"] as? String }.joined()
+                if let value, Self.safeLabels.contains(value) {
+                    return value
+                }
+            }
+        }
+        return nil
+    }
+
+    private mutating func append(
+        endpoint: String, body: [String: Any], source: String, label: String?
+    ) {
+        guard let request = try? DiscoveryRequest(endpoint: endpoint, body: body) else { return }
+        guard self.navigation.count < 2000 else {
+            self.truncated = true
+            return
+        }
+        if self.identities.insert(request.identity).inserted {
+            self.navigation.append(DiscoveryNavigation(request: request, source: source, label: label))
+        }
+    }
+
+    private mutating func collectNavigation(
+        _ dictionary: [String: Any], source: String, label: String?, request: DiscoveryRequest
+    ) {
+        self.collectTranscript(dictionary)
+        // Never execute service endpoints, form submissions, or command batches.
+        // Only these navigation payloads are projected onto known read-only fields.
+        for key in ["browseEndpoint", "browseSectionListReloadEndpoint", "searchEndpoint", "watchEndpoint", "watchPlaylistEndpoint"] {
+            guard let payload = dictionary[key] as? [String: Any], payload["formData"] == nil else { continue }
+            let endpoint = key == "searchEndpoint" ? "search" : (key.hasPrefix("watch") ? "next" : "browse")
+            let fields = DiscoveryRequest.allowedFields[endpoint] ?? []
+            var body = payload.filter { fields.contains($0.key) }
+            if endpoint == "next", request.endpoint == "next" {
+                for contextKey in ["isAudioOnly", "enablePersistentPlaylistPanel", "tunerSettingValue"] where body[contextKey] == nil {
+                    body[contextKey] = request.body[contextKey]
+                }
+            }
+            self.append(endpoint: endpoint, body: body, source: source, label: label)
+        }
+        for key in ["nextContinuationData", "nextRadioContinuationData", "reloadContinuationData", "continuationCommand"] {
+            guard let payload = dictionary[key] as? [String: Any],
+                  let continuation = (payload["continuation"] ?? payload["token"]) as? String
+            else { continue }
+            // Retain the seed's context, especially video/playlist IDs for next.
+            var body = request.body
+            body["continuation"] = continuation
+            self.append(endpoint: request.endpoint, body: body, source: key, label: label)
+        }
+    }
+
+    private mutating func collectTranscript(_ dictionary: [String: Any]) {
+        guard let payload = dictionary["getTranscriptEndpoint"] as? [String: Any],
+              let params = payload["params"] as? String
+        else { return }
+        // Extract only the read-only request from any surrounding UI command
+        // batch. No other command in that batch is executed.
+        self.append(endpoint: "get_transcript", body: ["params": params], source: "getTranscriptEndpoint", label: nil)
+    }
+
+    private mutating func collectChartCountries(_ response: [String: Any], request: DiscoveryRequest) {
+        guard request.endpoint == "browse", request.body["browseId"] as? String == "FEmusic_charts",
+              let updates = response["frameworkUpdates"] as? [String: Any],
+              let batch = updates["entityBatchUpdate"] as? [String: Any],
+              let mutations = batch["mutations"] as? [[String: Any]]
+        else { return }
+        var countries: Set<String> = []
+        for mutation in mutations {
+            guard let payload = mutation["payload"] as? [String: Any],
+                  let choice = payload["musicFormBooleanChoice"] as? [String: Any],
+                  let country = choice["opaqueToken"] as? String,
+                  DiscoveryRequest.isCountryCode(country)
+            else { continue }
+            if choice["selected"] as? Bool == true, !self.selectedChartCountries.contains(country) {
+                self.selectedChartCountries.append(country)
+            }
+            guard countries.insert(country).inserted else { continue }
+            self.append(
+                endpoint: "browse",
+                body: ["browseId": "FEmusic_charts", "formData": ["selectedValues": [country]]],
+                source: "musicFormBooleanChoice", label: "Charts country " + country
+            )
+        }
+        self.chartCountryCount = countries.count
+    }
+
+    private mutating func walk(
+        _ value: Any, path: String, source: String, label: String?, request: DiscoveryRequest, depth: Int
+    ) {
+        guard depth <= 70, self.visitedNodes < 100_000 else {
+            self.truncated = true
+            return
+        }
+        self.visitedNodes += 1
+        if let dictionary = value as? [String: Any] {
+            let ownsLabel = ["title", "text", "label"].contains { dictionary[$0] != nil }
+            let localLabel = ownsLabel ? Self.knownLabel(in: dictionary) : label
+            if let ownLabel = Self.knownLabel(in: dictionary) {
+                self.labels[ownLabel, default: 0] += 1
+            }
+            self.collectNavigation(dictionary, source: source, label: localLabel, request: request)
+            for key in dictionary.keys.sorted() {
+                guard let nested = dictionary[key] else { continue }
+                let safeKey = Self.schemaKey(key)
+                let nestedPath = path + "." + safeKey
+                if self.schema.count < 1500 {
+                    self.schema.insert(nestedPath + ": " + Self.valueKind(nested))
+                } else {
+                    self.schemaTruncated = true
+                }
+                var nestedSource = source
+                if key.hasSuffix("Renderer") || key.hasSuffix("ViewModel") || (key.hasPrefix("music") && key.hasSuffix("Model")) {
+                    self.renderers[safeKey, default: 0] += 1
+                    if let renderer = nested as? [String: Any] {
+                        self.rendererFields[safeKey, default: []].formUnion(renderer.keys.map(Self.schemaKey))
+                    }
+                    nestedSource = safeKey
+                }
+                if key.hasSuffix("Endpoint") || key.hasSuffix("Command") {
+                    self.observedCommands[safeKey, default: 0] += 1
+                }
+                if key == "counterpart" || key == "counterpartRenderer" {
+                    self.counterpartCount += 1
+                }
+                if key == "musicSpeedDialShelfModel",
+                   let model = nested as? [String: Any],
+                   let data = model["data"] as? [String: Any],
+                   let items = data["items"] as? [[String: Any]]
+                {
+                    self.speedDialItemCount += items.count
+                    self.speedDialShortcutCount += items.count(where: { $0["isShortcut"] as? Bool == true })
+                }
+                if key == "musicCarouselShelfRenderer", let shelf = nested as? [String: Any] {
+                    let header = shelf["header"] as? [String: Any]
+                    let basicHeader = header?["musicCarouselShelfBasicHeaderRenderer"] as? [String: Any] ?? [:]
+                    let title = Self.knownLabel(in: basicHeader) ?? "<label>"
+                    let count = (shelf["contents"] as? [Any])?.count ?? 0
+                    self.homeShelves.append("label=\(title); items=\(count)")
+                }
+                if key == "dismissableDialogContentSectionRenderer" {
+                    self.creditSectionCount += 1
+                    if let section = nested as? [String: Any],
+                       let subtitle = section["subtitle"] as? [String: Any],
+                       let runs = subtitle["runs"] as? [[String: Any]],
+                       runs.contains(where: { ($0["text"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false })
+                    {
+                        self.populatedCreditSectionCount += 1
+                    }
+                }
+                if key == "chipCloudChipRenderer", let chip = nested as? [String: Any],
+                   chip["isSelected"] as? Bool == true
+                {
+                    self.selectedChips.insert(Self.knownLabel(in: chip) ?? "<label>")
+                }
+                if ["pageType", "musicVideoType"].contains(key), let type = nested as? String,
+                   type.hasPrefix("MUSIC_"), type.count <= 100,
+                   type.unicodeScalars.allSatisfy({ (65 ... 90).contains($0.value) || $0.value == 95 })
+                {
+                    self.pageTypes[type, default: 0] += 1
+                }
+                // Only the explicit transcript read is extracted from service
+                // wrappers. Other embedded commands remain schema-only.
+                if ["serviceEndpoint", "defaultServiceEndpoint", "toggledServiceEndpoint", "commandExecutorCommand", "formData", "submitEndpoint", "onDeselectedCommand"].contains(key) {
+                    self.walkSchemaOnly(nested, path: nestedPath, depth: depth + 1)
+                } else {
+                    self.walk(nested, path: nestedPath, source: nestedSource, label: localLabel, request: request, depth: depth + 1)
+                }
+            }
+        } else if let array = value as? [Any] {
+            for nested in array.prefix(2000) {
+                self.walk(nested, path: path + "[]", source: source, label: label, request: request, depth: depth + 1)
+            }
+            if array.count > 2000 {
+                self.truncated = true
+            }
+        }
+    }
+
+    private mutating func walkSchemaOnly(_ value: Any, path: String, depth: Int) {
+        guard depth <= 70, self.visitedNodes < 100_000 else {
+            self.truncated = true
+            return
+        }
+        self.visitedNodes += 1
+        if let dictionary = value as? [String: Any] {
+            self.collectTranscript(dictionary)
+            for key in dictionary.keys.sorted() {
+                guard let nested = dictionary[key] else { continue }
+                let safeKey = Self.schemaKey(key)
+                let nestedPath = path + "." + safeKey
+                if self.schema.count < 1500 {
+                    self.schema.insert(nestedPath + ": " + Self.valueKind(nested))
+                } else {
+                    self.schemaTruncated = true
+                }
+                if key.hasSuffix("Endpoint") || key.hasSuffix("Command") {
+                    self.observedCommands[safeKey, default: 0] += 1
+                }
+                self.walkSchemaOnly(nested, path: nestedPath, depth: depth + 1)
+            }
+        } else if let array = value as? [Any] {
+            for nested in array.prefix(2000) {
+                self.walkSchemaOnly(nested, path: path + "[]", depth: depth + 1)
+            }
+            if array.count > 2000 {
+                self.truncated = true
+            }
+        }
+    }
+
+    private static func valueKind(_ value: Any) -> String {
+        if value is [String: Any] {
+            return "object"
+        }
+        if value is [Any] {
+            return "array"
+        }
+        if value is String {
+            return "string"
+        }
+        if value is NSNull {
+            return "null"
+        }
+        return "scalar"
+    }
+
+    func rendered(limit: Int = 40, verbose: Bool = false) -> String {
+        var lines = [
+            "Server session: " + (self.serverLoggedOut.map { $0 ? "guest" : "signed-in" } ?? "unconfirmed"),
+            "Response: " + (self.hasAPIError ? "API error" : (self.hasContent ? "content envelope present, inspect counts below" : "no content envelope")),
+        ]
+        if let apiErrorSummary = self.apiErrorSummary {
+            lines.append("API error category: " + apiErrorSummary)
+        }
+        lines.append("Renderers and models:")
+        for key in self.renderers.keys.sorted() {
+            let fields = verbose ? " fields=[" + (self.rendererFields[key] ?? []).sorted().joined(separator: ", ") + "]" : ""
+            lines.append("  \(key): \(self.renderers[key, default: 0])\(fields)")
+        }
+        for (title, values) in [("Recognized UI labels", self.labels), ("Content types", self.pageTypes), ("Observed command kinds", self.observedCommands)] where !values.isEmpty {
+            lines.append(title + ":")
+            for key in values.keys.sorted() {
+                lines.append("  \(key): \(values[key, default: 0])")
+            }
+        }
+        lines.append("Counterpart fields: \(self.counterpartCount); credit sections: \(self.creditSectionCount)")
+        lines.append("Speed dial models: \(self.renderers["musicSpeedDialShelfModel", default: 0]); items: \(self.speedDialItemCount); shortcuts: \(self.speedDialShortcutCount)")
+        if !self.homeShelves.isEmpty {
+            lines.append("Web carousel shelves:")
+            lines.append(contentsOf: self.homeShelves.map { "  " + $0 })
+        }
+        if self.creditSectionCount > 0 {
+            lines.append("Credit sections containing text: \(self.populatedCreditSectionCount)")
+        }
+        if self.chartCountryCount > 0 {
+            lines.append("Chart country choices: \(self.chartCountryCount)")
+        }
+        if !self.selectedChartCountries.isEmpty {
+            lines.append("Selected chart countries: " + self.selectedChartCountries.joined(separator: ", "))
+        }
+        if !self.selectedChips.isEmpty {
+            lines.append("Selected chips: " + self.selectedChips.sorted().joined(separator: ", "))
+        }
+        lines.append("Read-only navigation (\(self.navigation.count)):")
+        for (index, entry) in self.navigation.prefix(limit).enumerated() {
+            lines.append("  [\(index)] \(entry.summary)")
+        }
+        if self.navigation.count > limit {
+            lines.append("  Use --limit \(min(self.navigation.count, 500)) to show more entries.")
+        }
+        if self.truncated {
+            lines.append("Audit limits reached; counts and navigation may be incomplete.")
+        }
+        if verbose {
+            lines.append("Schema (all scalar values hidden):")
+            lines.append(contentsOf: self.schema.sorted().map { "  " + $0 })
+            if self.schemaTruncated {
+                lines.append("Schema output capped at 1500 paths; navigation traversal continues independently.")
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+}
+
+func discoverAPI(
+    endpoint: String, bodyJSON: String, followIndices: [Int], limit: Int,
+    verbose: Bool, outputFile: String?, mobileClient: MusicMobileRequestProfile.Client? = nil,
+    mobileWebKey: Bool = false,
+    mobileCookieOnly: Bool = false, mobileTokenFile: String? = nil
+) async -> Bool {
+    var reports: [String] = []
+    var succeeded = true
+    func record(_ report: String) {
+        print(report)
+        reports.append(report)
+    }
+    do {
+        guard let data = bodyJSON.data(using: .utf8),
+              let body = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { throw DiscoveryError.unsupportedRequest }
+        var request = try DiscoveryRequest(endpoint: endpoint, body: body)
+        let mobileAccessToken = try mobileTokenFile.map { try loadMobileAccessToken(from: $0) }
+        let authenticated = mobileAccessToken == nil && hasUsableAuthMaterial()
+        let authentication = mobileAccessToken != nil
+            ? "mobile OAuth supplied on every hop"
+            : (authenticated ? "web cookies supplied on every hop" : "guest")
+        record("Read-only discovery. Response values, account IDs, and tokens stay hidden.")
+        record("Client: \(mobileClient?.rawValue ?? activeClientName); authentication: \(authentication)")
+        if let mobileClient {
+            let profile = MusicMobileRequestProfile(client: mobileClient, version: clientVersionWasForced ? cachedClientVersion : nil)
+            record("Mobile profile version: \(profile.version); source: \(clientVersionWasForced ? "override" : "configured default")")
+            record("Mobile web API key: \(mobileWebKey ? "resolved from web configuration" : "omitted")")
+            let authorization = mobileAccessToken != nil ? "Bearer" : (authenticated && !mobileCookieOnly ? "SAPISIDHASH" : "omitted")
+            record("Mobile authorization header: \(authorization)")
+        }
+        if mobileClient != nil, authenticated {
+            record("Mobile web-cookie authentication must be confirmed by the server session, not credential presence.")
+        }
+        record("Captured: " + ISO8601DateFormatter().string(from: Date()))
+
+        for step in 0 ... followIndices.count {
+            let wire = try await makeWireRequest(
+                endpoint: request.endpoint, body: request.body, authenticated: authenticated, mobileClient: mobileClient,
+                mobileWebKey: mobileWebKey, mobileCookieOnly: mobileCookieOnly,
+                mobileAccessToken: mobileAccessToken
+            )
+            guard let response = try? JSONSerialization.jsonObject(with: wire.data) as? [String: Any] else {
+                record("Step \(step): \(request.summary)\nHTTP \(wire.statusCode); response is not a JSON object. Use wire-action to inspect its format.")
+                succeeded = false
+                break
+            }
+            let audit = DiscoveryAudit(response: response, request: request)
+            let report = "Step \(step): \(request.summary)\nHTTP \(wire.statusCode); bytes=\(wire.data.count)\n" + audit.rendered(limit: limit, verbose: verbose)
+            record(report)
+            guard (200 ... 299).contains(wire.statusCode), !audit.hasAPIError else {
+                succeeded = false
+                break
+            }
+            if step < followIndices.count {
+                let index = followIndices[step]
+                guard audit.navigation.indices.contains(index) else {
+                    record("Selected navigation index is absent in this response. Re-run discover to inspect current entries.")
+                    succeeded = false
+                    break
+                }
+                let entry = audit.navigation[index]
+                record("Following [\(index)] \(entry.summary)")
+                request = entry.request
+            }
+        }
+    } catch is DiscoveryError {
+        record("Unsupported discovery request. See discover help for allowed endpoints and fields; only the chart country form is accepted.")
+        succeeded = false
+    } catch {
+        // URLSession errors can embed a URL containing the API key. Never print
+        // the underlying error or arbitrary server-provided error messages here.
+        record("Discovery failed while reading the request or contacting YouTube. Sensitive error details are hidden.")
+        succeeded = false
+    }
+    if let outputFile {
+        do {
+            try writePrivateOutput(Data((reports.joined(separator: "\n\n") + "\n").utf8), to: outputFile)
+            print("Saved a redacted discovery report with owner-only permissions.")
+        } catch {
+            print("Could not save the discovery report with owner-only permissions.")
+            succeeded = false
+        }
+    }
+    return succeeded
+}

--- a/Sources/APIExplorer/DiscoveryAudit.swift
+++ b/Sources/APIExplorer/DiscoveryAudit.swift
@@ -23,6 +23,8 @@ func discoveryHelp() -> String {
         "Web-cookie mobile probes were rejected; cookie-only probes returned a guest session.",
         "A content envelope or HTTP 200 alone does not prove a feature works or auth succeeded.",
         "Only FEmusic_charts accepts formData, with one two-letter country in selectedValues.",
+        "Library chips and sort menus expose only their browse reads; bundled state changes stay hidden.",
+        "Taste-profile acceptance buttons are inspected without exposing a replayable action.",
         "Examples:",
         "  swift run api-explorer discover browse '{\"browseId\":\"FEmusic_charts\"}' --guest",
         "  swift run api-explorer discover next '{\"videoId\":\"dQw4w9WgXcQ\"}' --guest",
@@ -158,7 +160,7 @@ struct DiscoveryNavigation {
         if self.source.contains("chip") || self.source.contains("Chip") {
             return 3
         }
-        if self.source.contains("dropdown") || self.source.contains("Dropdown") {
+        if self.source == "musicMultiSelectMenuItemRenderer" || self.source.contains("dropdown") || self.source.contains("Dropdown") {
             return 4
         }
         if self.request.body["continuation"] != nil {
@@ -186,6 +188,7 @@ struct DiscoveryAudit {
     private(set) var chartCountryCount = 0
     private(set) var selectedChartCountries: [String] = []
     private(set) var selectedChips: Set<String> = []
+    private(set) var sortMenuTitles: Set<String> = []
     private(set) var speedDialItemCount = 0
     private(set) var speedDialShortcutCount = 0
     private(set) var homeShelves: [String] = []
@@ -199,9 +202,9 @@ struct DiscoveryAudit {
     private var visitedNodes = 0
 
     private static let safeLabels: Set<String> = [
-        "All", "Albums", "Artists", "Songs", "Videos", "Playlists", "Podcasts", "Episodes", "Profiles",
+        "All", "Albums", "Artists", "Songs", "Videos", "Playlists", "Podcasts", "Episodes", "Profiles", "Channels",
         "Featured playlists", "Community playlists", "Uploads", "Your library", "Downloads",
-        "Recently added", "Recently played", "A to Z", "Z to A", "Popular", "Newest first",
+        "Recently added", "Recently saved", "Recently played", "A to Z", "Z to A", "Popular", "Newest first",
         "Speed dial", "Speed Dial", "Listen again", "Quick picks",
         "Workout", "Focus", "Relax", "Commute", "Energize", "Sleep", "Party", "Romance", "Feel good", "Sad",
         "Discover", "Familiar", "New releases", "Deep cuts", "Upbeat", "Downbeat", "Chill",
@@ -320,6 +323,7 @@ struct DiscoveryAudit {
         _ dictionary: [String: Any], source: String, label: String?, request: DiscoveryRequest
     ) {
         self.collectTranscript(dictionary)
+        self.collectBrowseSelection(dictionary, source: source, label: label, request: request)
         // Never execute service endpoints, form submissions, or command batches.
         // Only these navigation payloads are projected onto known read-only fields.
         for key in ["browseEndpoint", "browseSectionListReloadEndpoint", "searchEndpoint", "watchEndpoint", "watchPlaylistEndpoint"] {
@@ -342,6 +346,44 @@ struct DiscoveryAudit {
             var body = request.body
             body["continuation"] = continuation
             self.append(endpoint: request.endpoint, body: body, source: key, label: label)
+        }
+    }
+
+    /// Signed-in Library selections bundle a browse read with persistence or
+    /// checkbox commands. Extract only the direct read from these UI wrappers.
+    private mutating func collectBrowseSelection(
+        _ dictionary: [String: Any], source: String, label: String?, request: DiscoveryRequest
+    ) {
+        guard request.endpoint == "browse" else { return }
+        let selection: [String: Any]?
+        switch source {
+        case "chipCloudChipRenderer":
+            selection = dictionary["navigationEndpoint"] as? [String: Any]
+        case "musicMultiSelectMenuItemRenderer":
+            selection = dictionary["selectedCommand"] as? [String: Any]
+        default:
+            return
+        }
+        guard let batch = selection?["commandExecutorCommand"] as? [String: Any],
+              let commands = batch["commands"] as? [[String: Any]]
+        else { return }
+        for command in commands.prefix(2000) {
+            if let browse = command["browseEndpoint"] as? [String: Any], browse["formData"] == nil {
+                let fields = DiscoveryRequest.allowedFields["browse"] ?? []
+                self.append(endpoint: "browse", body: browse.filter { fields.contains($0.key) }, source: source, label: label)
+            }
+            if let reload = command["browseSectionListReloadEndpoint"] as? [String: Any], reload["formData"] == nil,
+               let continuation = reload["continuation"] as? [String: Any],
+               let data = continuation["reloadContinuationData"] as? [String: Any],
+               let value = data["continuation"] as? String
+            {
+                var body = request.body
+                body["continuation"] = value
+                self.append(endpoint: "browse", body: body, source: source, label: label)
+            }
+        }
+        if commands.count > 2000 {
+            self.truncated = true
         }
     }
 
@@ -448,15 +490,19 @@ struct DiscoveryAudit {
                 {
                     self.selectedChips.insert(Self.knownLabel(in: chip) ?? "<label>")
                 }
+                if key == "musicSortFilterButtonRenderer", let button = nested as? [String: Any] {
+                    self.sortMenuTitles.insert(Self.knownLabel(in: button) ?? "<label>")
+                }
                 if ["pageType", "musicVideoType"].contains(key), let type = nested as? String,
                    type.hasPrefix("MUSIC_"), type.count <= 100,
                    type.unicodeScalars.allSatisfy({ (65 ... 90).contains($0.value) || $0.value == 95 })
                 {
                     self.pageTypes[type, default: 0] += 1
                 }
-                // Only the explicit transcript read is extracted from service
-                // wrappers. Other embedded commands remain schema-only.
-                if ["serviceEndpoint", "defaultServiceEndpoint", "toggledServiceEndpoint", "commandExecutorCommand", "formData", "submitEndpoint", "onDeselectedCommand"].contains(key) {
+                // Browse selections are extracted at their owning UI renderer.
+                // Other batch and service commands stay schema-only, except
+                // explicit transcript reads.
+                if ["serviceEndpoint", "defaultServiceEndpoint", "toggledServiceEndpoint", "commandExecutorCommand", "formData", "submitEndpoint", "acceptButton", "onDeselectedCommand"].contains(key) {
                     self.walkSchemaOnly(nested, path: nestedPath, depth: depth + 1)
                 } else {
                     self.walk(nested, path: nestedPath, source: nestedSource, label: localLabel, request: request, depth: depth + 1)
@@ -556,6 +602,9 @@ struct DiscoveryAudit {
         }
         if !self.selectedChips.isEmpty {
             lines.append("Selected chips: " + self.selectedChips.sorted().joined(separator: ", "))
+        }
+        if !self.sortMenuTitles.isEmpty {
+            lines.append("Sort menu titles: " + self.sortMenuTitles.sorted().joined(separator: ", "))
         }
         lines.append("Read-only navigation (\(self.navigation.count)):")
         for (index, entry) in self.navigation.prefix(limit).enumerated() {

--- a/Sources/APIExplorer/DiscoveryAudit.swift
+++ b/Sources/APIExplorer/DiscoveryAudit.swift
@@ -20,7 +20,7 @@ func discoveryHelp() -> String {
         "--mobile-cookie-only omits SAPISIDHASH on mobile discovery while retaining saved cookies.",
         "--mobile-token-file <mode-0600-path> uses a mobile OAuth access token instead of web cookies.",
         "Token files must be owned by you, have mode 0600 and no extended ACL, and not be symlinks.",
-        "The report destination must not refer to the token file or request-body file.",
+        "The report destination must not refer to the cookie archive, token file, or request-body file, including redirected stdin.",
         "Do not put tokens in command arguments, reports, or chat. Token acquisition is separate.",
         "Web-cookie mobile probes were rejected; cookie-only probes returned a guest session.",
         "A content envelope or HTTP 200 alone does not prove a feature works or auth succeeded.",
@@ -264,6 +264,8 @@ struct DiscoveryAudit {
         "FEmusic_recently_played", "FEmusic_offline", "FEmusic_library_privately_owned_landing", "FEmusic_library_privately_owned_tracks",
         "FEmusic_library_privately_owned_albums", "FEmusic_library_privately_owned_releases", "FEmusic_library_privately_owned_artists",
         "FEsubscriptions", "FElibrary", "FEhistory", "FEplaylist_aggregation",
+        "FEwhat_to_watch", "FEgaming_destination", "FEnews_destination", "FEsports_destination",
+        "FElive_destination", "FEfashion_destination", "FElearning_destination",
     ]
 
     private static let safePageTypes: Set<String> = [
@@ -702,6 +704,15 @@ struct DiscoveryAudit {
     }
 }
 
+func discoveryOutputOverwritesInput(
+    _ outputFile: String, bodyFile: String?, mobileTokenFile: String?, cookieBackupFile: URL?,
+    standardInput: Int32 = STDIN_FILENO
+) -> Bool {
+    let inputFiles = [mobileTokenFile, bodyFile == "-" ? nil : bodyFile, cookieBackupFile?.path].compactMap(\.self)
+    return inputFiles.contains { pathsReferToSameFile($0, outputFile) }
+        || (bodyFile == "-" && fileDescriptorRefersToFile(standardInput, path: outputFile))
+}
+
 func discoverAPI(
     endpoint: String, bodyJSON: String, followIndices: [Int], limit: Int,
     verbose: Bool, outputFile: String?, mobileClient: MusicMobileRequestProfile.Client? = nil,
@@ -714,9 +725,11 @@ func discoverAPI(
         print(report)
         reports.append(report)
     }
-    let inputFiles = [mobileTokenFile, bodyFile == "-" ? nil : bodyFile].compactMap(\.self)
-    if let outputFile, inputFiles.contains(where: { pathsReferToSameFile($0, outputFile) }) {
-        record("The discovery report destination must differ from --body-file and --mobile-token-file.")
+    let cookieFile = selectedCookieBackupFile()
+    if let outputFile, discoveryOutputOverwritesInput(
+        outputFile, bodyFile: bodyFile, mobileTokenFile: mobileTokenFile, cookieBackupFile: cookieFile
+    ) {
+        record("The discovery report destination must differ from the cookie archive, --body-file, and --mobile-token-file, including redirected stdin.")
         return false
     }
     do {
@@ -725,10 +738,12 @@ func discoverAPI(
         else { throw DiscoveryError.unsupportedRequest }
         var request = try DiscoveryRequest(endpoint: endpoint, body: body)
         let mobileAccessToken = try mobileTokenFile.map { try loadMobileAccessToken(from: $0) }
-        let mobileCookieHeader = mobileCookieOnly && mobileAccessToken == nil
-            ? loadCookiesFromAppBackup().flatMap { buildCookieHeader(from: $0) }
-            : nil
-        let authenticated = mobileAccessToken == nil && hasUsableAuthMaterial()
+        // Freeze the cookie identity for the whole chain, including web configuration
+        // reads. An empty snapshot keeps a guest run from acquiring cookies later.
+        let cookies = mobileAccessToken == nil ? loadCookiesFromAppBackup(from: cookieFile) ?? [] : []
+        let cookieHeader = buildCookieHeader(from: cookies)
+        let mobileCookieHeader = mobileCookieOnly ? cookieHeader : nil
+        let authenticated = getSAPISID(from: cookies) != nil && cookieHeader != nil
         let authentication = mobileAccessToken != nil
             ? "mobile OAuth supplied on every hop"
             : (authenticated || mobileCookieHeader != nil ? "web cookies supplied on every hop" : "guest")
@@ -748,7 +763,8 @@ func discoverAPI(
 
         for step in 0 ... followIndices.count {
             let wire = try await makeWireRequest(
-                endpoint: request.endpoint, body: request.body, authenticated: authenticated, mobileClient: mobileClient,
+                endpoint: request.endpoint, body: request.body, authenticated: authenticated,
+                cookieSnapshot: cookies, mobileClient: mobileClient,
                 mobileWebKey: mobileWebKey, mobileCookieOnly: mobileCookieOnly,
                 mobileAccessToken: mobileAccessToken, mobileCookieHeader: mobileCookieHeader
             )

--- a/Sources/APIExplorer/DiscoveryAudit.swift
+++ b/Sources/APIExplorer/DiscoveryAudit.swift
@@ -20,7 +20,7 @@ func discoveryHelp() -> String {
         "--mobile-cookie-only omits SAPISIDHASH on mobile discovery while retaining saved cookies.",
         "--mobile-token-file <mode-0600-path> uses a mobile OAuth access token instead of web cookies.",
         "Token files must be owned by you, have mode 0600 and no extended ACL, and not be symlinks.",
-        "The report destination must not refer to the token file.",
+        "The report destination must not refer to the token file or request-body file.",
         "Do not put tokens in command arguments, reports, or chat. Token acquisition is separate.",
         "Web-cookie mobile probes were rejected; cookie-only probes returned a guest session.",
         "A content envelope or HTTP 200 alone does not prove a feature works or auth succeeded.",
@@ -213,7 +213,7 @@ struct DiscoveryAudit {
     private static let safeSchemaKeys: Set<String> = [
         "responseContext", "mainAppWebResponseContext", "loggedOut", "serviceTrackingParams", "service", "params",
         "key", "value", "visitorData", "trackingParams", "clickTrackingParams", "error", "code", "status", "message",
-        "contents", "content", "continuationContents", "onResponseReceivedActions", "onResponseReceivedEndpoints",
+        "contents", "content", "continuationContents", "continuationItems", "onResponseReceivedActions", "onResponseReceivedEndpoints", "onResponseReceivedCommands",
         "actions", "videoDetails", "queueDatas", "tabs", "header", "footer", "items", "options", "menu", "data",
         "title", "subtitle", "secondSubtitle", "text", "label", "simpleText", "runs", "secondaryText",
         "browseId", "videoId", "videoIds", "playlistId", "playlistSetVideoId", "query", "input", "index",
@@ -311,7 +311,7 @@ struct DiscoveryAudit {
         self.serverLoggedOut = (webContext?["loggedOut"] as? Bool) ?? inferredLoggedOut
         self.hasAPIError = response["error"] != nil
         self.apiErrorSummary = Self.describeAPIError(response["error"] as? [String: Any])
-        self.hasContent = ["contents", "continuationContents", "onResponseReceivedActions", "onResponseReceivedEndpoints", "actions", "videoDetails", "queueDatas"]
+        self.hasContent = ["contents", "continuationContents", "onResponseReceivedActions", "onResponseReceivedEndpoints", "onResponseReceivedCommands", "actions", "videoDetails", "queueDatas"]
             .contains { key in
                 if let object = response[key] as? [String: Any] {
                     return !object.isEmpty
@@ -706,7 +706,7 @@ func discoverAPI(
     endpoint: String, bodyJSON: String, followIndices: [Int], limit: Int,
     verbose: Bool, outputFile: String?, mobileClient: MusicMobileRequestProfile.Client? = nil,
     mobileWebKey: Bool = false,
-    mobileCookieOnly: Bool = false, mobileTokenFile: String? = nil
+    mobileCookieOnly: Bool = false, mobileTokenFile: String? = nil, bodyFile: String? = nil
 ) async -> Bool {
     var reports: [String] = []
     var succeeded = true
@@ -714,8 +714,9 @@ func discoverAPI(
         print(report)
         reports.append(report)
     }
-    if let mobileTokenFile, let outputFile, pathsReferToSameFile(mobileTokenFile, outputFile) {
-        record("The discovery report destination must not refer to the mobile access-token file.")
+    let inputFiles = [mobileTokenFile, bodyFile == "-" ? nil : bodyFile].compactMap(\.self)
+    if let outputFile, inputFiles.contains(where: { pathsReferToSameFile($0, outputFile) }) {
+        record("The discovery report destination must differ from --body-file and --mobile-token-file.")
         return false
     }
     do {
@@ -724,10 +725,13 @@ func discoverAPI(
         else { throw DiscoveryError.unsupportedRequest }
         var request = try DiscoveryRequest(endpoint: endpoint, body: body)
         let mobileAccessToken = try mobileTokenFile.map { try loadMobileAccessToken(from: $0) }
+        let mobileCookieHeader = mobileCookieOnly && mobileAccessToken == nil
+            ? loadCookiesFromAppBackup().flatMap { buildCookieHeader(from: $0) }
+            : nil
         let authenticated = mobileAccessToken == nil && hasUsableAuthMaterial()
         let authentication = mobileAccessToken != nil
             ? "mobile OAuth supplied on every hop"
-            : (authenticated ? "web cookies supplied on every hop" : "guest")
+            : (authenticated || mobileCookieHeader != nil ? "web cookies supplied on every hop" : "guest")
         record("Read-only discovery. Response values, account IDs, and tokens stay hidden.")
         record("Client: \(mobileClient?.rawValue ?? activeClientName); authentication: \(authentication)")
         if let mobileClient {
@@ -737,7 +741,7 @@ func discoverAPI(
             let authorization = mobileAccessToken != nil ? "Bearer" : (authenticated && !mobileCookieOnly ? "SAPISIDHASH" : "omitted")
             record("Mobile authorization header: \(authorization)")
         }
-        if mobileClient != nil, authenticated {
+        if mobileClient != nil, authenticated || mobileCookieHeader != nil {
             record("Mobile web-cookie authentication must be confirmed by the server session, not credential presence.")
         }
         record("Captured: " + ISO8601DateFormatter().string(from: Date()))
@@ -746,7 +750,7 @@ func discoverAPI(
             let wire = try await makeWireRequest(
                 endpoint: request.endpoint, body: request.body, authenticated: authenticated, mobileClient: mobileClient,
                 mobileWebKey: mobileWebKey, mobileCookieOnly: mobileCookieOnly,
-                mobileAccessToken: mobileAccessToken
+                mobileAccessToken: mobileAccessToken, mobileCookieHeader: mobileCookieHeader
             )
             guard let response = try? JSONSerialization.jsonObject(with: wire.data) as? [String: Any] else {
                 record("Step \(step): \(request.summary)\nHTTP \(wire.statusCode); response is not a JSON object. Use wire-action to inspect its format.")

--- a/Sources/APIExplorer/DiscoveryAudit.swift
+++ b/Sources/APIExplorer/DiscoveryAudit.swift
@@ -1,3 +1,4 @@
+import CoreFoundation
 import Foundation
 
 func discoveryHelp() -> String {
@@ -19,6 +20,7 @@ func discoveryHelp() -> String {
         "--mobile-cookie-only omits SAPISIDHASH on mobile discovery while retaining saved cookies.",
         "--mobile-token-file <mode-0600-path> uses a mobile OAuth access token instead of web cookies.",
         "Token files must be owned by you, have mode 0600 and no extended ACL, and not be symlinks.",
+        "The report destination must not refer to the token file.",
         "Do not put tokens in command arguments, reports, or chat. Token acquisition is separate.",
         "Web-cookie mobile probes were rejected; cookie-only probes returned a guest session.",
         "A content envelope or HTTP 200 alone does not prove a feature works or auth succeeded.",
@@ -77,11 +79,15 @@ struct DiscoveryRequest {
                       ids.allSatisfy({ !$0.isEmpty && $0.count <= 128 })
                 else { throw DiscoveryError.unsupportedRequest }
             case "index":
-                guard let number = value as? Int, (0 ... 100_000).contains(number) else {
+                guard let scalar = value as? NSNumber, CFGetTypeID(scalar) != CFBooleanGetTypeID(),
+                      let number = value as? Int, (0 ... 100_000).contains(number)
+                else {
                     throw DiscoveryError.unsupportedRequest
                 }
             case "isAudioOnly", "enablePersistentPlaylistPanel":
-                guard value is Bool else { throw DiscoveryError.unsupportedRequest }
+                guard let scalar = value as? NSNumber, CFGetTypeID(scalar) == CFBooleanGetTypeID() else {
+                    throw DiscoveryError.unsupportedRequest
+                }
             default:
                 guard let text = value as? String, !text.isEmpty, text.utf8.count <= 32768 else {
                     throw DiscoveryError.unsupportedRequest
@@ -124,8 +130,9 @@ struct DiscoveryRequest {
 
 // MARK: - DiscoveryError
 
-enum DiscoveryError: Error {
+enum DiscoveryError: Error, Equatable {
     case unsupportedRequest
+    case invalidMobileToken
 }
 
 // MARK: - DiscoveryNavigation
@@ -201,6 +208,78 @@ struct DiscoveryAudit {
     private var identities: Set<Data> = []
     private var visitedNodes = 0
 
+    /// Response dictionaries can be keyed by private IDs, even all-letter ones.
+    /// Extend this list only with verified, static schema names.
+    private static let safeSchemaKeys: Set<String> = [
+        "responseContext", "mainAppWebResponseContext", "loggedOut", "serviceTrackingParams", "service", "params",
+        "key", "value", "visitorData", "trackingParams", "clickTrackingParams", "error", "code", "status", "message",
+        "contents", "content", "continuationContents", "onResponseReceivedActions", "onResponseReceivedEndpoints",
+        "actions", "videoDetails", "queueDatas", "tabs", "header", "footer", "items", "options", "menu", "data",
+        "title", "subtitle", "secondSubtitle", "text", "label", "simpleText", "runs", "secondaryText",
+        "browseId", "videoId", "videoIds", "playlistId", "playlistSetVideoId", "query", "input", "index",
+        "isAudioOnly", "enablePersistentPlaylistPanel", "tunerSettingValue", "continuation", "continuations", "token",
+        "nextContinuationData", "nextRadioContinuationData", "reloadContinuationData", "isSelected", "selected",
+        "formData", "selectedValues", "opaqueToken", "selectionFormValue", "formItemEntityKey", "newCheckedState",
+        "frameworkUpdates", "entityBatchUpdate", "mutations", "payload", "musicFormBooleanChoice",
+        "pageType", "musicVideoType", "browseEndpointContextSupportedConfigs", "browseEndpointContextMusicConfig",
+        "thumbnail", "thumbnails", "image", "sources", "url", "width", "height", "icon", "iconType", "badges",
+        "flexColumns", "fixedColumns", "playlistItemData", "overlay", "shelfId", "counterpart", "isShortcut",
+        "newElement", "type", "componentType", "model", "onTap", "onLongPress", "commands", "command", "acceptButton",
+        "feedbackToken", "feedbackTokens", "dismissalToken", "accessToken", "accountId",
+        "browseEndpoint", "browseSectionListReloadEndpoint", "searchEndpoint", "watchEndpoint", "watchPlaylistEndpoint",
+        "navigationEndpoint", "navigationCommand", "playNavigationEndpoint", "startPlaybackCommand", "innertubeCommand",
+        "serviceEndpoint", "defaultServiceEndpoint", "toggledServiceEndpoint", "submitEndpoint", "feedbackEndpoint",
+        "getTranscriptEndpoint", "continuationEndpoint", "continuationCommand", "commandExecutorCommand", "serialCommand",
+        "selectedCommand", "onDeselectedCommand", "musicLibraryPersistLaunchNavigationCommand", "musicCheckboxFormItemMutatedCommand",
+        "musicBrowseFormBinderCommand", "reloadContinuationItemsCommand", "appendContinuationItemsAction",
+        "singleColumnBrowseResultsRenderer", "twoColumnBrowseResultsRenderer", "singleColumnMusicWatchNextResultsRenderer",
+        "tabbedSearchResultsRenderer", "twoColumnSearchResultsRenderer", "tabRenderer", "tabbedRenderer",
+        "watchNextTabbedResultsRenderer", "sectionListRenderer", "itemSectionRenderer", "gridRenderer", "gridHeaderRenderer",
+        "musicShelfRenderer", "musicPlaylistShelfRenderer", "musicCardShelfRenderer", "musicCardShelfHeaderBasicRenderer",
+        "musicCarouselShelfRenderer", "musicCarouselShelfBasicHeaderRenderer", "musicImmersiveCarouselShelfRenderer",
+        "musicDescriptionShelfRenderer", "musicTwoRowItemRenderer", "musicResponsiveListItemRenderer", "musicMultiRowListItemRenderer",
+        "musicResponsiveListItemFlexColumnRenderer", "musicResponsiveListItemFixedColumnRenderer", "musicResponsiveHeaderRenderer",
+        "musicDetailHeaderRenderer", "musicEditablePlaylistDetailHeaderRenderer", "musicImmersiveHeaderRenderer", "musicVisualHeaderRenderer",
+        "musicQueueRenderer", "playlistPanelRenderer", "playlistPanelVideoRenderer", "playlistPanelVideoWrapperRenderer",
+        "chipCloudRenderer", "chipCloudChipRenderer", "feedFilterChipBarRenderer", "musicSortFilterButtonRenderer",
+        "musicMultiSelectMenuRenderer", "musicMultiSelectMenuItemRenderer", "musicNavigationButtonRenderer",
+        "menuRenderer", "menuNavigationItemRenderer", "menuServiceItemRenderer", "toggleMenuServiceItemRenderer",
+        "musicMenuTitleRenderer", "buttonRenderer", "toggleButtonRenderer", "musicPlayButtonRenderer", "likeButtonRenderer",
+        "musicThumbnailRenderer", "musicItemThumbnailOverlayRenderer", "musicInlineBadgeRenderer", "metadataBadgeRenderer",
+        "continuationItemRenderer", "counterpartRenderer", "dismissableDialogContentSectionRenderer",
+        "tastebuilderRenderer", "tastebuilderItemRenderer", "messageRenderer", "notificationTextRenderer",
+        "elementRenderer", "musicSpeedDialShelfModel", "musicGridItemCarouselModel", "musicListItemCarouselModel",
+        "musicQuickPicksModel", "timedLyricsModel", "searchSuggestionsSectionRenderer", "searchSuggestionRenderer",
+        "historySuggestionRenderer", "transcriptRenderer", "transcriptSearchPanelRenderer", "transcriptSegmentListRenderer",
+        "transcriptSegmentRenderer", "transcriptSectionHeaderRenderer", "engagementPanelSectionListRenderer",
+    ]
+
+    private static let publicBrowseIDs: Set<String> = [
+        "FEmusic_home", "FEmusic_explore", "FEmusic_charts", "FEmusic_moods_and_genres", "FEmusic_moods_and_genres_category",
+        "FEmusic_new_releases", "FEmusic_podcasts", "FEmusic_radio_builder",
+        "FEmusic_liked_playlists", "FEmusic_liked_albums", "FEmusic_liked_videos", "FEmusic_history",
+        "FEmusic_library_landing", "FEmusic_library_artists", "FEmusic_library_corpus_artists", "FEmusic_library_corpus_track_artists",
+        "FEmusic_library_songs", "FEmusic_library_non_music_audio_list", "FEmusic_library_non_music_audio_channels_list",
+        "FEmusic_library_user_profile_channels_list", "FEmusic_tastebuilder", "FEmusic_listening_review",
+        "FEmusic_recently_played", "FEmusic_offline", "FEmusic_library_privately_owned_landing", "FEmusic_library_privately_owned_tracks",
+        "FEmusic_library_privately_owned_albums", "FEmusic_library_privately_owned_releases", "FEmusic_library_privately_owned_artists",
+        "FEsubscriptions", "FElibrary", "FEhistory", "FEplaylist_aggregation",
+    ]
+
+    private static let safePageTypes: Set<String> = [
+        "MUSIC_PAGE_TYPE_ALBUM", "MUSIC_PAGE_TYPE_AUDIOBOOK", "MUSIC_PAGE_TYPE_ARTIST", "MUSIC_PAGE_TYPE_LIBRARY_ARTIST",
+        "MUSIC_PAGE_TYPE_ARTIST_DISCOGRAPHY", "MUSIC_PAGE_TYPE_USER_CHANNEL", "MUSIC_PAGE_TYPE_PLAYLIST",
+        "MUSIC_PAGE_TYPE_PODCAST_SHOW_DETAIL_PAGE", "MUSIC_PAGE_TYPE_TRACK_CREDITS", "MUSIC_PAGE_TYPE_TRACK_RELATED",
+        "MUSIC_VIDEO_TYPE_ATV", "MUSIC_VIDEO_TYPE_OMV", "MUSIC_VIDEO_TYPE_UGC", "MUSIC_VIDEO_TYPE_OFFICIAL_SOURCE_MUSIC",
+        "MUSIC_VIDEO_TYPE_PODCAST_EPISODE",
+    ]
+
+    private static let uiLabelRenderers: Set<String> = [
+        "chipCloudChipRenderer", "tabRenderer", "menuNavigationItemRenderer", "menuServiceItemRenderer",
+        "toggleMenuServiceItemRenderer", "musicMultiSelectMenuItemRenderer", "musicSortFilterButtonRenderer",
+        "musicCarouselShelfBasicHeaderRenderer", "musicCardShelfHeaderBasicRenderer", "dismissableDialogContentSectionRenderer",
+    ]
+
     private static let safeLabels: Set<String> = [
         "All", "Albums", "Artists", "Songs", "Videos", "Playlists", "Podcasts", "Episodes", "Profiles", "Channels",
         "Featured playlists", "Community playlists", "Uploads", "Your library", "Downloads",
@@ -252,11 +331,7 @@ struct DiscoveryAudit {
     }
 
     static func schemaKey(_ key: String) -> String {
-        guard !key.isEmpty, key.count <= 100,
-              key.first?.isASCII == true, key.first?.isLowercase == true,
-              key.unicodeScalars.allSatisfy({ (65 ... 90).contains($0.value) || (97 ... 122).contains($0.value) })
-        else { return "<key>" }
-        return key
+        self.safeSchemaKeys.contains(key) ? key : "<key>"
     }
 
     /// Only fixed error categories may leave the response. Server messages can
@@ -279,12 +354,10 @@ struct DiscoveryAudit {
     }
 
     static func browseFamily(_ value: String) -> String {
-        if value.hasPrefix("FEmusic_"), value.count <= 90,
-           value.dropFirst(8).unicodeScalars.allSatisfy({ (97 ... 122).contains($0.value) || $0.value == 95 })
-        {
+        if self.publicBrowseIDs.contains(value) {
             return value
         }
-        for family in ["MPLA", "MPTC", "MPTR", "MPLY", "MPRE", "MPSP", "VL", "UC"] where value.hasPrefix(family) {
+        for family in ["FEmusic_", "MPLA", "MPTC", "MPTR", "MPLY", "MPRE", "MPSP", "VL", "UC"] where value.hasPrefix(family) {
             return family + "…"
         }
         return "<browse-id>"
@@ -431,12 +504,7 @@ struct DiscoveryAudit {
         }
         self.visitedNodes += 1
         if let dictionary = value as? [String: Any] {
-            let ownsLabel = ["title", "text", "label"].contains { dictionary[$0] != nil }
-            let localLabel = ownsLabel ? Self.knownLabel(in: dictionary) : label
-            if let ownLabel = Self.knownLabel(in: dictionary) {
-                self.labels[ownLabel, default: 0] += 1
-            }
-            self.collectNavigation(dictionary, source: source, label: localLabel, request: request)
+            self.collectNavigation(dictionary, source: source, label: label, request: request)
             for key in dictionary.keys.sorted() {
                 guard let nested = dictionary[key] else { continue }
                 let safeKey = Self.schemaKey(key)
@@ -447,10 +515,18 @@ struct DiscoveryAudit {
                     self.schemaTruncated = true
                 }
                 var nestedSource = source
+                var nestedLabel = label
                 if key.hasSuffix("Renderer") || key.hasSuffix("ViewModel") || (key.hasPrefix("music") && key.hasSuffix("Model")) {
                     self.renderers[safeKey, default: 0] += 1
+                    // Labels belong to UI metadata on this renderer only. A new
+                    // content renderer must not inherit its parent's heading.
+                    nestedLabel = nil
                     if let renderer = nested as? [String: Any] {
                         self.rendererFields[safeKey, default: []].formUnion(renderer.keys.map(Self.schemaKey))
+                        if Self.uiLabelRenderers.contains(key), let ownLabel = Self.knownLabel(in: renderer) {
+                            nestedLabel = ownLabel
+                            self.labels[ownLabel, default: 0] += 1
+                        }
                     }
                     nestedSource = safeKey
                 }
@@ -494,8 +570,7 @@ struct DiscoveryAudit {
                     self.sortMenuTitles.insert(Self.knownLabel(in: button) ?? "<label>")
                 }
                 if ["pageType", "musicVideoType"].contains(key), let type = nested as? String,
-                   type.hasPrefix("MUSIC_"), type.count <= 100,
-                   type.unicodeScalars.allSatisfy({ (65 ... 90).contains($0.value) || $0.value == 95 })
+                   Self.safePageTypes.contains(type)
                 {
                     self.pageTypes[type, default: 0] += 1
                 }
@@ -505,7 +580,7 @@ struct DiscoveryAudit {
                 if ["serviceEndpoint", "defaultServiceEndpoint", "toggledServiceEndpoint", "commandExecutorCommand", "formData", "submitEndpoint", "acceptButton", "onDeselectedCommand"].contains(key) {
                     self.walkSchemaOnly(nested, path: nestedPath, depth: depth + 1)
                 } else {
-                    self.walk(nested, path: nestedPath, source: nestedSource, label: localLabel, request: request, depth: depth + 1)
+                    self.walk(nested, path: nestedPath, source: nestedSource, label: nestedLabel, request: request, depth: depth + 1)
                 }
             }
         } else if let array = value as? [Any] {
@@ -639,6 +714,10 @@ func discoverAPI(
         print(report)
         reports.append(report)
     }
+    if let mobileTokenFile, let outputFile, pathsReferToSameFile(mobileTokenFile, outputFile) {
+        record("The discovery report destination must not refer to the mobile access-token file.")
+        return false
+    }
     do {
         guard let data = bodyJSON.data(using: .utf8),
               let body = try JSONSerialization.jsonObject(with: data) as? [String: Any]
@@ -693,7 +772,10 @@ func discoverAPI(
                 request = entry.request
             }
         }
-    } catch is DiscoveryError {
+    } catch DiscoveryError.invalidMobileToken {
+        record("Invalid mobile access-token file. Use a raw token of 1-8192 bytes in a mode-0600 regular file owned by you, without a symlink or extended ACL.")
+        succeeded = false
+    } catch DiscoveryError.unsupportedRequest {
         record("Unsupported discovery request. See discover help for allowed endpoints and fields; only the chart country form is accepted.")
         succeeded = false
     } catch {

--- a/Sources/APIExplorer/main.swift
+++ b/Sources/APIExplorer/main.swift
@@ -649,6 +649,13 @@ func extractConfigInteger(named name: String, from html: String) -> Int? {
     return Int(html[range])
 }
 
+func isValidClientVersion(_ value: String) -> Bool {
+    !value.isEmpty && value.utf8.count <= 64
+        && value.split(separator: ".", omittingEmptySubsequences: false).allSatisfy { component in
+            !component.isEmpty && component.utf8.allSatisfy { (48 ... 57).contains($0) }
+        }
+}
+
 // MARK: - MusicMobileRequestProfile
 
 /// Mobile Home uses element models that the WEB_REMIX client does not request.
@@ -3883,9 +3890,7 @@ func runMain() async {
             }
             index += 1
             let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !value.isEmpty, value.utf8.count <= 64,
-                  value.unicodeScalars.allSatisfy({ (48 ... 57).contains($0.value) || $0.value == 46 })
-            else {
+            guard isValidClientVersion(value) else {
                 print("❌ Invalid --client-version value: provide a version such as 1.20231204.01.00")
                 return
             }

--- a/Sources/APIExplorer/main.swift
+++ b/Sources/APIExplorer/main.swift
@@ -694,7 +694,7 @@ struct MusicMobileRequestProfile {
             ]) { _, value in value }
         case .android:
             context.merge([
-                "osName": "Android", "osVersion": "13", "androidSdkVersion": 36,
+                "osName": "Android", "osVersion": "13", "androidSdkVersion": 33,
                 "clientFormFactor": "SMALL_FORM_FACTOR",
             ]) { _, value in value }
         }
@@ -2236,15 +2236,29 @@ func loadPrivatePrompt(from promptFile: String) throws -> String {
 /// Reuses the owner, mode, ACL, symlink, and bounded-read checks for private input.
 /// Only a regular file is accepted so a token can never be echoed by a terminal.
 func loadMobileAccessToken(from path: String) throws -> String {
-    guard path != "-" else { throw DiscoveryError.unsupportedRequest }
-    let token = try loadPrivatePrompt(from: path)
-    guard token.utf8.count <= 8192,
+    guard path != "-", let token = try? loadPrivatePrompt(from: path),
+          token.utf8.count <= 8192,
           token.unicodeScalars.allSatisfy({ scalar in
               (65 ... 90).contains(scalar.value) || (97 ... 122).contains(scalar.value)
                   || (48 ... 57).contains(scalar.value) || "-._~+/=".unicodeScalars.contains(scalar)
           })
-    else { throw DiscoveryError.unsupportedRequest }
+    else { throw DiscoveryError.invalidMobileToken }
     return token
+}
+
+/// Prevents discovery reports from replacing their credential input, including
+/// relative paths, symlinked directories, and existing hard-link aliases.
+func pathsReferToSameFile(_ firstPath: String, _ secondPath: String) -> Bool {
+    let first = URL(fileURLWithPath: NSString(string: firstPath).expandingTildeInPath).resolvingSymlinksInPath().standardizedFileURL
+    let second = URL(fileURLWithPath: NSString(string: secondPath).expandingTildeInPath).resolvingSymlinksInPath().standardizedFileURL
+    if first == second {
+        return true
+    }
+    var firstStatus = stat()
+    var secondStatus = stat()
+    return first.path.withCString { Darwin.lstat($0, &firstStatus) } == 0
+        && second.path.withCString { Darwin.lstat($0, &secondStatus) } == 0
+        && firstStatus.st_dev == secondStatus.st_dev && firstStatus.st_ino == secondStatus.st_ino
 }
 
 func loadRequestBodyJSON(inlineBody: String?, bodyFile: String?) throws -> String {

--- a/Sources/APIExplorer/main.swift
+++ b/Sources/APIExplorer/main.swift
@@ -13,6 +13,7 @@
 //    browse <browseId> [params]    - Explore a browse endpoint
 //    action <endpoint> <body>      - Explore a JSON action endpoint (body as JSON)
 //    wire-action <endpoint> <body> - Safely inspect JSON, streaming, or opaque responses
+//    discover <endpoint> <body>    - Inspect and follow read-only navigation, with values redacted
 //    ask-video-audit <videoId>     - Audit YouTube Ask Gemini / YouChat API surfaces
 //    ask-video-parity <videoId>    - Compare read-only Ask request profiles
 //    ask-video-live-test <videoId> - Replay server-issued summary/follow-up suggestions
@@ -26,8 +27,8 @@
 //    help                          - Show this help message
 //
 //  Options:
-//    -v, --verbose                 - Show raw JSON, or expanded search-audit samples
-//    -o, --output <file>           - Save raw JSON response to a file
+//    -v, --verbose                 - Show raw JSON, or redacted audit schemas/samples
+//    -o, --output <file>           - Save a response; discover saves only a redacted report
 //    --client-version <version>    - Override the resolved InnerTube client version
 //    --confirm-live-ai             - Required acknowledgement for live AI requests
 //    --prompt-file <path|->         - Read a private free-text prompt from a mode-0600 file or stdin
@@ -35,7 +36,12 @@
 //    --follow-up                   - Replay one server-issued follow-up suggestion
 //    --youtube, --yt               - Target regular YouTube (www.youtube.com, WEB client)
 //                                    instead of YouTube Music
+//    --ios-music, --android-music  - Use a mobile Music request profile with discover
+//    --mobile-web-key             - Add the resolved web API key to mobile discovery
+//    --mobile-cookie-only         - Omit the authorization header for mobile comparison
+//    --mobile-token-file <path>   - Read a mobile OAuth access token from a private file
 //    --no-auth, --guest            - Force unauthenticated requests even if Kaset cookies exist
+//    --follow <index>              - Follow a discover navigation entry; repeat for deeper pages
 //
 //  Examples:
 //    swift run api-explorer browse FEmusic_home
@@ -643,7 +649,82 @@ func extractConfigInteger(named name: String, from html: String) -> Int? {
     return Int(html[range])
 }
 
-// MARK: - Request Builder
+// MARK: - MusicMobileRequestProfile
+
+/// Mobile Home uses element models that the WEB_REMIX client does not request.
+/// This profile is scoped to read-only discovery, not production playback.
+struct MusicMobileRequestProfile {
+    enum Client: String {
+        case ios = "IOS_MUSIC"
+        case android = "ANDROID_MUSIC"
+
+        var defaultVersion: String {
+            switch self {
+            case .ios: "9.06.4"
+            case .android: "5.34.51"
+            }
+        }
+
+        var headerID: String {
+            switch self {
+            case .ios: "26"
+            case .android: "21"
+            }
+        }
+    }
+
+    let client: Client
+    let version: String
+
+    init(client: Client, version: String? = nil) {
+        self.client = client
+        self.version = version ?? client.defaultVersion
+    }
+
+    func clientContext(language: String) -> [String: Any] {
+        var context: [String: Any] = [
+            "clientName": self.client.rawValue, "clientVersion": self.version,
+            "hl": language, "gl": "US", "platform": "MOBILE",
+        ]
+        switch self.client {
+        case .ios:
+            context.merge([
+                "osName": "iOS", "osVersion": "26.2.1",
+                "deviceMake": "Apple", "deviceModel": "iPhone18,4",
+            ]) { _, value in value }
+        case .android:
+            context.merge([
+                "osName": "Android", "osVersion": "13", "androidSdkVersion": 36,
+                "clientFormFactor": "SMALL_FORM_FACTOR",
+            ]) { _, value in value }
+        }
+        return context
+    }
+
+    var userAgent: String {
+        switch self.client {
+        case .ios:
+            "com.google.ios.youtubemusic/\(self.version) iSL/3.4 iPhone/26.2.1 hw/iPhone18_4 (gzip)"
+        case .android:
+            "com.google.android.apps.youtube.music/\(self.version) (Linux; U; Android 13; en_US) gzip"
+        }
+    }
+
+    /// Keeps the body, client headers, and user agent on the same identity.
+    func applyHeaders(to request: inout URLRequest, cookieOnly: Bool, accessToken: String?) {
+        request.setValue(self.userAgent, forHTTPHeaderField: "User-Agent")
+        request.setValue(self.client.headerID, forHTTPHeaderField: "X-Youtube-Client-Name")
+        request.setValue(self.version, forHTTPHeaderField: "X-Youtube-Client-Version")
+        if let accessToken {
+            request.setValue("Bearer " + accessToken, forHTTPHeaderField: "Authorization")
+            for field in ["Cookie", "X-Goog-AuthUser", "X-Goog-PageId", "X-Origin", "Origin", "Referer"] {
+                request.setValue(nil, forHTTPHeaderField: field)
+            }
+        } else if cookieOnly {
+            request.setValue(nil, forHTTPHeaderField: "Authorization")
+        }
+    }
+}
 
 func buildContext(brandAccountId: String? = nil) -> [String: Any] {
     var userDict: [String: Any] = [
@@ -779,16 +860,28 @@ func canonicalAPIEndpoint(_ endpoint: String) throws -> String {
     return endpoint
 }
 
-func makeWireRequest(endpoint: String, body: [String: Any], authenticated: Bool = false) async throws
+func makeWireRequest(
+    endpoint: String, body: [String: Any], authenticated: Bool = false,
+    mobileClient: MusicMobileRequestProfile.Client? = nil,
+    mobileWebKey: Bool = false, mobileCookieOnly: Bool = false,
+    mobileAccessToken: String? = nil
+) async throws
     -> APIWireResponse
 {
     let endpoint = try canonicalAPIEndpoint(endpoint)
-    let apiKey = try await resolveAPIKey(authenticated: authenticated)
+    let mobileProfile = mobileClient.map {
+        MusicMobileRequestProfile(client: $0, version: clientVersionWasForced ? cachedClientVersion : nil)
+    }
+    guard mobileAccessToken == nil || (mobileProfile != nil && !authenticated && !mobileCookieOnly && !youtubeMode) else {
+        throw DiscoveryError.unsupportedRequest
+    }
     var components = URLComponents(string: "\(activeBaseURL)/\(endpoint)")
-    components?.queryItems = [
-        URLQueryItem(name: "key", value: apiKey),
-        URLQueryItem(name: "prettyPrint", value: "false"),
-    ]
+    var queryItems = [URLQueryItem(name: "prettyPrint", value: "false")]
+    if mobileProfile == nil || mobileWebKey {
+        let apiKey = try await resolveAPIKey(authenticated: authenticated)
+        queryItems.insert(URLQueryItem(name: "key", value: apiKey), at: 0)
+    }
+    components?.queryItems = queryItems
     guard let url = components?.url else {
         throw NSError(
             domain: "APIExplorer", code: -1, userInfo: [NSLocalizedDescriptionKey: "Invalid URL"]
@@ -801,9 +894,16 @@ func makeWireRequest(endpoint: String, body: [String: Any], authenticated: Bool 
     for (key, value) in buildHeaders(authenticated: authenticated) {
         request.setValue(value, forHTTPHeaderField: key)
     }
+    if let mobileProfile {
+        mobileProfile.applyHeaders(to: &request, cookieOnly: mobileCookieOnly, accessToken: mobileAccessToken)
+    }
 
     var fullBody = body
-    fullBody["context"] = buildContext()
+    var context = buildContext()
+    if let mobileProfile {
+        context["client"] = mobileProfile.clientContext(language: globalHl)
+    }
+    fullBody["context"] = context
     request.httpBody = try JSONSerialization.data(withJSONObject: fullBody)
 
     let (data, response) = try await boundedResponseData(
@@ -1823,9 +1923,13 @@ func exploreAction(
     }
 }
 
-private let maximumPrivateBodyBytes = 2 * 1024 * 1024
-private let maximumPrivatePromptBytes = 64 * 1024
-private let maximumPrivatePromptCharacters = 16000
+// MARK: - PrivateInputLimits
+
+private enum PrivateInputLimits {
+    static let bodyBytes = 2 * 1024 * 1024
+    static let promptBytes = 64 * 1024
+    static let promptCharacters = 16000
+}
 
 private func posixError(_ description: String, code: Int32 = errno) -> NSError {
     NSError(
@@ -1982,7 +2086,7 @@ func writePrivateOutput(_ data: Data, to path: String) throws {
 
 private func readBoundedData(
     fileDescriptor: Int32,
-    maximumBytes: Int = maximumPrivateBodyBytes,
+    maximumBytes: Int = PrivateInputLimits.bodyBytes,
     contentDescription: String = "Request body"
 ) throws -> Data {
     var result = Data()
@@ -2041,7 +2145,7 @@ func loadPrivatePrompt(from promptFile: String) throws -> String {
         }
         data = try readBoundedData(
             fileDescriptor: STDIN_FILENO,
-            maximumBytes: maximumPrivatePromptBytes,
+            maximumBytes: PrivateInputLimits.promptBytes,
             contentDescription: "Prompt"
         )
     } else {
@@ -2088,7 +2192,7 @@ func loadPrivatePrompt(from promptFile: String) throws -> String {
             )
         }
         guard status.st_size >= 0,
-              status.st_size <= off_t(maximumPrivatePromptBytes)
+              status.st_size <= off_t(PrivateInputLimits.promptBytes)
         else {
             throw NSError(
                 domain: "APIExplorer",
@@ -2098,7 +2202,7 @@ func loadPrivatePrompt(from promptFile: String) throws -> String {
         }
         data = try readBoundedData(
             fileDescriptor: fileDescriptor,
-            maximumBytes: maximumPrivatePromptBytes,
+            maximumBytes: PrivateInputLimits.promptBytes,
             contentDescription: "Prompt"
         )
     }
@@ -2111,17 +2215,31 @@ func loadPrivatePrompt(from promptFile: String) throws -> String {
         )
     }
     prompt = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard !prompt.isEmpty, prompt.count <= maximumPrivatePromptCharacters else {
+    guard !prompt.isEmpty, prompt.count <= PrivateInputLimits.promptCharacters else {
         throw NSError(
             domain: "APIExplorer",
             code: -1,
             userInfo: [
                 NSLocalizedDescriptionKey:
-                    "Prompt must contain 1-\(maximumPrivatePromptCharacters) characters",
+                    "Prompt must contain 1-\(PrivateInputLimits.promptCharacters) characters",
             ]
         )
     }
     return prompt
+}
+
+/// Reuses the owner, mode, ACL, symlink, and bounded-read checks for private input.
+/// Only a regular file is accepted so a token can never be echoed by a terminal.
+func loadMobileAccessToken(from path: String) throws -> String {
+    guard path != "-" else { throw DiscoveryError.unsupportedRequest }
+    let token = try loadPrivatePrompt(from: path)
+    guard token.utf8.count <= 8192,
+          token.unicodeScalars.allSatisfy({ scalar in
+              (65 ... 90).contains(scalar.value) || (97 ... 122).contains(scalar.value)
+                  || (48 ... 57).contains(scalar.value) || "-._~+/=".unicodeScalars.contains(scalar)
+          })
+    else { throw DiscoveryError.unsupportedRequest }
+    return token
 }
 
 func loadRequestBodyJSON(inlineBody: String?, bodyFile: String?) throws -> String {
@@ -2188,7 +2306,7 @@ func loadRequestBodyJSON(inlineBody: String?, bodyFile: String?) throws -> Strin
             )
         }
         guard status.st_size >= 0,
-              status.st_size <= off_t(maximumPrivateBodyBytes)
+              status.st_size <= off_t(PrivateInputLimits.bodyBytes)
         else {
             throw NSError(
                 domain: "APIExplorer",
@@ -3260,6 +3378,8 @@ func listEndpoints() {
         FEmusic_moods_and_genres      Browse by mood (Chill, Focus) or genre (Pop, Rock)
         FEmusic_new_releases          Recently released albums, singles, videos
         FEmusic_podcasts              Podcast discovery
+        FEmusic_radio_builder         Radio controls and form entities (creation unverified)
+        FEmusic_listening_review      Recap probe (guest response has no content)
 
         🔐 AUTHENTICATED (Requires Sign-in)
         ───────────────────────────────────────────────────────────────────────────────
@@ -3268,6 +3388,7 @@ func listEndpoints() {
         FEmusic_liked_videos          Liked songs (returns playlist format)
         FEmusic_history               Listening history (organized by time)
         FEmusic_library_landing       Library overview page
+        FEmusic_tastebuilder          Recommendation onboarding (guest gets sign-in prompt)
         FEmusic_library_artists       Rejected with HTTP 400 in current sessions
         FEmusic_library_corpus_artists Followed artists (returns public UC... pages)
         FEmusic_library_corpus_track_artists  Artists chip from Library (returns MPLAUC... pages)
@@ -3289,6 +3410,8 @@ func listEndpoints() {
         MPLAUC{libraryArtistId}       Library artist detail (from Artists chip, requires auth)
         MPREb_{albumId}               Album detail
         MPLYt_{lyricsId}              Lyrics content
+        MPTC{creditsId}               Song credits dialog (use server-issued browseId)
+        MPTR{relatedId}               Related tracks, playlists, artists (from next tabs)
         FEmusic_moods_and_genres_category   Mood/Genre category (with params)
 
         ═══════════════════════════════════════════════════════════════════════════════
@@ -3419,6 +3542,8 @@ func listEndpoints() {
         Audit a video:                swift run api-explorer ask-video-audit <VIDEO_ID>
         Compare Ask request profiles: swift run api-explorer ask-video-parity <VIDEO_ID>
         Inspect wire format:          swift run api-explorer --youtube wire-action <ep> '{}'
+        Discover read-only routes:    swift run api-explorer discover help
+        Transcript navigation:       next may issue getTranscriptEndpoint; guest replay returned 400
 
         ═══════════════════════════════════════════════════════════════════════════════
         💡 USAGE TIPS
@@ -3451,6 +3576,7 @@ func showHelp() {
           browse <browseId> [params]     Explore a browse endpoint
           action <endpoint> [body]       Explore a JSON action endpoint
           wire-action <endpoint> [body]  Safely inspect JSON, streaming, or opaque responses
+          discover <endpoint> [body]     Inspect read-only navigation, filters, and response shapes
           ask-video-audit <videoId>      Audit Ask Gemini / YouChat without sending a prompt
           ask-video-parity <videoId>     Compare ordered read-only Ask request profiles
           ask-video-live-test <videoId>  Replay the server-issued summary suggestion
@@ -3473,12 +3599,14 @@ func showHelp() {
 
         Options:
           -v, --verbose                  Show raw JSON for browse/action/continuation; expand audits
-          -o, --output <file>            Save raw output with owner-only permissions (mode 0600)
+          -o, --output <file>            Save raw output, or discover's redacted report (mode 0600)
           --body-file <path|->           Read a sensitive JSON body from a chmod-600 file or stdin
           --prompt-file <path|->         Read a private prompt from a mode-0600 file or stdin
           --confirm-live-ai              Required acknowledgement for live Ask commands
           --fresh-chats N                Run 1-3 independent summary chats (default: 1)
           --follow-up                    Replay the first server-issued follow-up suggestion
+          --follow <index>               Follow a numbered discover entry, repeat up to 5 times
+          --limit N                      Show 1-500 discover entries (default: 40)
           --authuser N                   Use Google account at index N (for multi-account)
           --brand <ID>                   Use brand account ID (21-digit number)
           --client-version <version>     Override the resolved InnerTube client version
@@ -3487,6 +3615,11 @@ func showHelp() {
                                          code localizes real responses.
           --youtube, --yt                Target regular YouTube (www.youtube.com, WEB client)
                                          instead of YouTube Music
+          --ios-music                    Use IOS_MUSIC with discover, including mobile Home models
+          --android-music                Use ANDROID_MUSIC with discover
+          --mobile-web-key               Add the resolved web API key to mobile discovery
+          --mobile-cookie-only           Omit SAPISIDHASH while retaining cookies for comparison
+          --mobile-token-file <path>     Read a mobile OAuth access token from a mode-0600 file
           --no-auth, --guest             Force signed-out requests even if Kaset cookies exist
 
         YouTube mode examples:
@@ -3596,6 +3729,13 @@ func runMain() async {
     var outputFile: String?
     var bodyFile: String?
     var promptFile: String?
+    var discoveryFollowIndices: [Int] = []
+    var discoveryLimit = 40
+    var discoveryLimitWasSpecified = false
+    var mobileClient: MusicMobileRequestProfile.Client?
+    var mobileWebKey = false
+    var mobileCookieOnly = false
+    var mobileTokenFile: String?
     var filteredArgs: [String] = []
 
     var index = 0
@@ -3606,12 +3746,49 @@ func runMain() async {
             verbose = true
         case "--youtube", "--yt":
             activateYouTubeMode()
+        case "--ios-music", "--android-music":
+            guard mobileClient == nil else {
+                print("❌ Select only one mobile client profile")
+                exit(1)
+            }
+            mobileClient = argument == "--ios-music" ? .ios : .android
+        case "--mobile-web-key":
+            mobileWebKey = true
+        case "--mobile-cookie-only":
+            mobileCookieOnly = true
+        case "--mobile-token-file":
+            guard let value = commandLineOptionValue(after: index, in: args) else {
+                print("❌ --mobile-token-file requires a private regular file path")
+                exit(1)
+            }
+            mobileTokenFile = value
+            index += 1
         case "--no-auth", "--guest":
             forceUnauthenticatedRequests = true
         case "--confirm-live-ai":
             confirmLiveAI = true
         case "--follow-up":
             includeAskFollowUp = true
+        case "--follow":
+            guard let rawValue = commandLineOptionValue(after: index, in: args),
+                  let value = Int(rawValue), value >= 0,
+                  discoveryFollowIndices.count < 5
+            else {
+                print("❌ --follow requires a nonnegative entry index, at most 5 times")
+                exit(1)
+            }
+            discoveryFollowIndices.append(value)
+            index += 1
+        case "--limit":
+            guard let rawValue = commandLineOptionValue(after: index, in: args),
+                  let value = Int(rawValue), (1 ... 500).contains(value)
+            else {
+                print("❌ --limit requires an integer between 1 and 500")
+                exit(1)
+            }
+            discoveryLimit = value
+            discoveryLimitWasSpecified = true
+            index += 1
         case "-o", "--output":
             guard let value = commandLineOptionValue(
                 after: index,
@@ -3682,7 +3859,9 @@ func runMain() async {
             }
             index += 1
             let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !value.isEmpty, !value.hasPrefix("-") else {
+            guard !value.isEmpty, value.utf8.count <= 64,
+                  value.unicodeScalars.allSatisfy({ (48 ... 57).contains($0.value) || $0.value == 46 })
+            else {
                 print("❌ Invalid --client-version value: provide a version such as 1.20231204.01.00")
                 return
             }
@@ -3716,8 +3895,56 @@ func runMain() async {
         print("❌ --prompt-file is supported only by ask-video-free-text-test")
         return
     }
+    guard command == "discover" || (discoveryFollowIndices.isEmpty && !discoveryLimitWasSpecified) else {
+        print("❌ --follow and --limit are supported only by discover")
+        exit(1)
+    }
+    guard mobileClient == nil || (command == "discover" && !youtubeMode) else {
+        print("❌ Mobile profiles are supported only by discover and cannot be combined with --youtube")
+        exit(1)
+    }
+    guard (!mobileWebKey && !mobileCookieOnly) || mobileClient != nil else {
+        print("❌ --mobile-web-key and --mobile-cookie-only require a discover mobile profile")
+        exit(1)
+    }
+    guard mobileTokenFile == nil || (command == "discover" && mobileClient != nil
+        && !forceUnauthenticatedRequests && !mobileCookieOnly
+        && globalBrandAccountId == nil && !authUserOptionWasSpecified)
+    else {
+        print("❌ --mobile-token-file requires mobile discover and cannot mix with guest, cookie-only, or web account selection")
+        exit(1)
+    }
 
     switch command {
+    case "discover":
+        if filteredArgs.count == 2, filteredArgs[1] == "help" {
+            print(discoveryHelp())
+            return
+        }
+        guard (2 ... 3).contains(filteredArgs.count) else {
+            print("❌ Usage: discover <endpoint> [body-json] [--body-file <path|->] [--follow N]")
+            exit(1)
+        }
+        do {
+            let bodyJSON = try loadRequestBodyJSON(
+                inlineBody: filteredArgs.count == 3 ? filteredArgs[2] : nil,
+                bodyFile: bodyFile
+            )
+            let succeeded = await discoverAPI(
+                endpoint: filteredArgs[1], bodyJSON: bodyJSON,
+                followIndices: discoveryFollowIndices, limit: discoveryLimit,
+                verbose: verbose, outputFile: outputFile, mobileClient: mobileClient,
+                mobileWebKey: mobileWebKey, mobileCookieOnly: mobileCookieOnly,
+                mobileTokenFile: mobileTokenFile
+            )
+            if !succeeded {
+                exit(1)
+            }
+        } catch {
+            print("❌ Could not read the discovery request body")
+            exit(1)
+        }
+
     case "browse":
         guard filteredArgs.count >= 2 else {
             print("❌ Usage: browse <browseId> [params]")

--- a/Sources/APIExplorer/main.swift
+++ b/Sources/APIExplorer/main.swift
@@ -724,12 +724,15 @@ struct MusicMobileRequestProfile {
         request.setValue(self.version, forHTTPHeaderField: "X-Youtube-Client-Version")
         if let accessToken {
             request.setValue("Bearer " + accessToken, forHTTPHeaderField: "Authorization")
-            for field in ["Cookie", "X-Goog-AuthUser", "X-Goog-PageId", "X-Origin", "Origin", "Referer"] {
-                request.setValue(nil, forHTTPHeaderField: field)
-            }
+            request.setValue(nil, forHTTPHeaderField: "Cookie")
         } else if cookieOnly {
             request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
             request.setValue(nil, forHTTPHeaderField: "Authorization")
+        }
+        if request.value(forHTTPHeaderField: "Cookie") == nil {
+            for field in ["X-Goog-AuthUser", "X-Goog-PageId", "X-Origin", "Origin", "Referer"] {
+                request.setValue(nil, forHTTPHeaderField: field)
+            }
         }
     }
 }

--- a/Sources/APIExplorer/main.swift
+++ b/Sources/APIExplorer/main.swift
@@ -319,30 +319,42 @@ private final class BoundedResponseDataDelegate: NSObject, URLSessionDataDelegat
 
 // MARK: - Cookie Management
 
-/// Reads cookies from Kaset app's backup file in Application Support.
-/// This allows the standalone tool to make authenticated API requests.
-func loadCookiesFromAppBackup() -> [HTTPCookie]? {
-    guard !forceUnauthenticatedRequests else {
-        return nil
-    }
-
-    guard let appSupport = FileManager.default.urls(
+/// Locates the authoritative cookie archive without reading its contents.
+func selectedCookieBackupFile(
+    appSupport: URL? = FileManager.default.urls(
         for: .applicationSupportDirectory,
         in: .userDomainMask
-    ).first
-    else {
-        return nil
-    }
+    ).first,
+    homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+) -> URL? {
+    guard let appSupport else { return nil }
 
     let legacyCookieFile =
         appSupport
             .appendingPathComponent("Kaset", isDirectory: true)
             .appendingPathComponent("cookies.dat")
 
-    let containerCookieFile = FileManager.default.homeDirectoryForCurrentUser
+    let containerCookieFile = homeDirectory
         .appendingPathComponent("Library/Containers/com.sertacozercan.Kaset/Data", isDirectory: true)
         .appendingPathComponent("Library/Application Support/Kaset", isDirectory: true)
         .appendingPathComponent("cookies.dat")
+
+    // Once the sandboxed app has created its Application Support directory, its
+    // container export is authoritative. Never resurrect the legacy host archive
+    // after logout, account switching, expiry, corruption, or a cleared export.
+    if FileManager.default.fileExists(atPath: containerCookieFile.path) {
+        return containerCookieFile
+    }
+    if FileManager.default.fileExists(atPath: containerCookieFile.deletingLastPathComponent().path) {
+        return nil
+    }
+    return FileManager.default.fileExists(atPath: legacyCookieFile.path) ? legacyCookieFile : nil
+}
+
+/// Reads cookies from Kaset app's backup file in Application Support.
+/// This allows the standalone tool to make authenticated API requests.
+func loadCookiesFromAppBackup(from cookieFile: URL? = selectedCookieBackupFile()) -> [HTTPCookie]? {
+    guard !forceUnauthenticatedRequests, let cookieFile else { return nil }
 
     func decodeCookies(at cookieFile: URL) -> [HTTPCookie]? {
         guard let data = try? Data(contentsOf: cookieFile) else {
@@ -381,22 +393,7 @@ func loadCookiesFromAppBackup() -> [HTTPCookie]? {
         return cookies.isEmpty ? nil : cookies
     }
 
-    // Once the sandboxed app has created its Application Support directory, its
-    // container export is authoritative. Never resurrect the legacy host archive
-    // after logout, account switching, expiry, corruption, or a cleared export.
-    if FileManager.default.fileExists(atPath: containerCookieFile.path) {
-        return decodeCookies(at: containerCookieFile)
-    }
-
-    let containerStorageDirectory = containerCookieFile.deletingLastPathComponent()
-    if FileManager.default.fileExists(atPath: containerStorageDirectory.path) {
-        return nil
-    }
-
-    guard FileManager.default.fileExists(atPath: legacyCookieFile.path) else {
-        return nil
-    }
-    return decodeCookies(at: legacyCookieFile)
+    return decodeCookies(at: cookieFile)
 }
 
 /// Filters cookies to those that match the active API host
@@ -499,21 +496,21 @@ private func webClientConfigurationRequest(timeout: TimeInterval? = nil) -> URLR
     return request
 }
 
-private func webClientConfiguration(authenticated: Bool) -> URLSessionConfiguration {
+func webClientConfiguration(authenticated: Bool, cookieSnapshot: [HTTPCookie]? = nil) -> URLSessionConfiguration {
     let configuration = URLSessionConfiguration.ephemeral
-    if authenticated, let cookies = loadCookiesFromAppBackup(), !cookies.isEmpty {
-        let storage = HTTPCookieStorage()
+    if authenticated, let cookies = cookieSnapshot ?? loadCookiesFromAppBackup(), !cookies.isEmpty,
+       let storage = configuration.httpCookieStorage
+    {
         for cookie in cookies {
             storage.setCookie(cookie)
         }
-        configuration.httpCookieStorage = storage
         configuration.httpShouldSetCookies = true
         configuration.httpCookieAcceptPolicy = .always
     }
     return configuration
 }
 
-func resolveAPIKey(authenticated: Bool = false) async throws -> String {
+func resolveAPIKey(authenticated: Bool = false, cookieSnapshot: [HTTPCookie]? = nil) async throws -> String {
     if let cachedAPIKey {
         return cachedAPIKey
     }
@@ -523,13 +520,13 @@ func resolveAPIKey(authenticated: Bool = false) async throws -> String {
     {
         let trimmed = override.trimmingCharacters(in: .whitespacesAndNewlines)
         cachedAPIKey = trimmed
-        await resolveLiveClientVersionIfNeeded(authenticated: authenticated)
+        await resolveLiveClientVersionIfNeeded(authenticated: authenticated, cookieSnapshot: cookieSnapshot)
         return trimmed
     }
 
     let request = webClientConfigurationRequest()
     let (data, response) = try await boundedResponseData(
-        configuration: webClientConfiguration(authenticated: authenticated),
+        configuration: webClientConfiguration(authenticated: authenticated, cookieSnapshot: cookieSnapshot),
         request: request,
         maximumBytes: maximumConfigurationResponseBytes
     )
@@ -567,7 +564,7 @@ func resolveAPIKey(authenticated: Bool = false) async throws -> String {
 /// Resolves only the live client version when the API key came from an explicit
 /// environment override. Failure is non-fatal: callers can still use the
 /// configured fallback, and search-audit labels that source explicitly.
-func resolveLiveClientVersionIfNeeded(authenticated: Bool = false) async {
+func resolveLiveClientVersionIfNeeded(authenticated: Bool = false, cookieSnapshot: [HTTPCookie]? = nil) async {
     guard cachedClientVersion == nil else { return }
 
     let request = webClientConfigurationRequest(timeout: 5)
@@ -575,7 +572,7 @@ func resolveLiveClientVersionIfNeeded(authenticated: Bool = false) async {
     let response: URLResponse
     do {
         (data, response) = try await boundedResponseData(
-            configuration: webClientConfiguration(authenticated: authenticated),
+            configuration: webClientConfiguration(authenticated: authenticated, cookieSnapshot: cookieSnapshot),
             request: request,
             maximumBytes: maximumConfigurationResponseBytes
         )
@@ -769,7 +766,7 @@ func buildContext(brandAccountId: String? = nil) -> [String: Any] {
     ]
 }
 
-func buildHeaders(authenticated: Bool = false, authUserIndex: Int? = nil) -> [String: String] {
+func buildHeaders(authenticated: Bool = false, authUserIndex: Int? = nil, cookieSnapshot: [HTTPCookie]? = nil) -> [String: String] {
     var headers: [String: String] = [
         "Content-Type": "application/json",
         "User-Agent":
@@ -777,7 +774,7 @@ func buildHeaders(authenticated: Bool = false, authUserIndex: Int? = nil) -> [St
         "Origin": activeOrigin,
         "Referer": "\(activeOrigin)/",
     ]
-    if authenticated, let cookies = loadCookiesFromAppBackup() {
+    if authenticated, let cookies = cookieSnapshot ?? loadCookiesFromAppBackup() {
         if let authorization = buildSIDAuthorizationHeader(
             from: cookies,
             includeAllAvailableProofs: false
@@ -873,6 +870,7 @@ func canonicalAPIEndpoint(_ endpoint: String) throws -> String {
 
 func makeWireRequest(
     endpoint: String, body: [String: Any], authenticated: Bool = false,
+    cookieSnapshot: [HTTPCookie]? = nil,
     mobileClient: MusicMobileRequestProfile.Client? = nil,
     mobileWebKey: Bool = false, mobileCookieOnly: Bool = false,
     mobileAccessToken: String? = nil, mobileCookieHeader: String? = nil
@@ -889,7 +887,7 @@ func makeWireRequest(
     var components = URLComponents(string: "\(activeBaseURL)/\(endpoint)")
     var queryItems = [URLQueryItem(name: "prettyPrint", value: "false")]
     if mobileProfile == nil || mobileWebKey {
-        let apiKey = try await resolveAPIKey(authenticated: authenticated)
+        let apiKey = try await resolveAPIKey(authenticated: authenticated, cookieSnapshot: cookieSnapshot)
         queryItems.insert(URLQueryItem(name: "key", value: apiKey), at: 0)
     }
     components?.queryItems = queryItems
@@ -902,7 +900,7 @@ func makeWireRequest(
     var request = URLRequest(url: url)
     request.httpMethod = "POST"
 
-    for (key, value) in buildHeaders(authenticated: authenticated) {
+    for (key, value) in buildHeaders(authenticated: authenticated, cookieSnapshot: cookieSnapshot) {
         request.setValue(value, forHTTPHeaderField: key)
     }
     if let mobileProfile {
@@ -2270,6 +2268,17 @@ func pathsReferToSameFile(_ firstPath: String, _ secondPath: String) -> Bool {
     return first.path.withCString { Darwin.lstat($0, &firstStatus) } == 0
         && second.path.withCString { Darwin.lstat($0, &secondStatus) } == 0
         && firstStatus.st_dev == secondStatus.st_dev && firstStatus.st_ino == secondStatus.st_ino
+}
+
+/// Shell redirection can make stdin another alias of an output file.
+func fileDescriptorRefersToFile(_ fileDescriptor: Int32, path: String) -> Bool {
+    var inputStatus = stat()
+    var outputStatus = stat()
+    let output = URL(fileURLWithPath: NSString(string: path).expandingTildeInPath).resolvingSymlinksInPath().standardizedFileURL
+    return fstat(fileDescriptor, &inputStatus) == 0
+        && (inputStatus.st_mode & S_IFMT) == S_IFREG
+        && output.path.withCString { Darwin.lstat($0, &outputStatus) } == 0
+        && inputStatus.st_dev == outputStatus.st_dev && inputStatus.st_ino == outputStatus.st_ino
 }
 
 func loadRequestBodyJSON(inlineBody: String?, bodyFile: String?) throws -> String {

--- a/Sources/APIExplorer/main.swift
+++ b/Sources/APIExplorer/main.swift
@@ -718,7 +718,7 @@ struct MusicMobileRequestProfile {
     }
 
     /// Keeps the body, client headers, and user agent on the same identity.
-    func applyHeaders(to request: inout URLRequest, cookieOnly: Bool, accessToken: String?) {
+    func applyHeaders(to request: inout URLRequest, cookieOnly: Bool, accessToken: String?, cookieHeader: String? = nil) {
         request.setValue(self.userAgent, forHTTPHeaderField: "User-Agent")
         request.setValue(self.client.headerID, forHTTPHeaderField: "X-Youtube-Client-Name")
         request.setValue(self.version, forHTTPHeaderField: "X-Youtube-Client-Version")
@@ -728,6 +728,7 @@ struct MusicMobileRequestProfile {
                 request.setValue(nil, forHTTPHeaderField: field)
             }
         } else if cookieOnly {
+            request.setValue(cookieHeader, forHTTPHeaderField: "Cookie")
             request.setValue(nil, forHTTPHeaderField: "Authorization")
         }
     }
@@ -871,7 +872,7 @@ func makeWireRequest(
     endpoint: String, body: [String: Any], authenticated: Bool = false,
     mobileClient: MusicMobileRequestProfile.Client? = nil,
     mobileWebKey: Bool = false, mobileCookieOnly: Bool = false,
-    mobileAccessToken: String? = nil
+    mobileAccessToken: String? = nil, mobileCookieHeader: String? = nil
 ) async throws
     -> APIWireResponse
 {
@@ -902,7 +903,7 @@ func makeWireRequest(
         request.setValue(value, forHTTPHeaderField: key)
     }
     if let mobileProfile {
-        mobileProfile.applyHeaders(to: &request, cookieOnly: mobileCookieOnly, accessToken: mobileAccessToken)
+        mobileProfile.applyHeaders(to: &request, cookieOnly: mobileCookieOnly, accessToken: mobileAccessToken, cookieHeader: mobileCookieHeader)
     }
 
     var fullBody = body
@@ -2253,7 +2254,7 @@ func loadMobileAccessToken(from path: String) throws -> String {
     return token
 }
 
-/// Prevents discovery reports from replacing their credential input, including
+/// Prevents discovery reports from replacing an input file, including
 /// relative paths, symlinked directories, and existing hard-link aliases.
 func pathsReferToSameFile(_ firstPath: String, _ secondPath: String) -> Bool {
     let first = URL(fileURLWithPath: NSString(string: firstPath).expandingTildeInPath).resolvingSymlinksInPath().standardizedFileURL
@@ -3964,7 +3965,7 @@ func runMain() async {
                 followIndices: discoveryFollowIndices, limit: discoveryLimit,
                 verbose: verbose, outputFile: outputFile, mobileClient: mobileClient,
                 mobileWebKey: mobileWebKey, mobileCookieOnly: mobileCookieOnly,
-                mobileTokenFile: mobileTokenFile
+                mobileTokenFile: mobileTokenFile, bodyFile: bodyFile
             )
             if !succeeded {
                 exit(1)

--- a/Sources/APIExplorer/main.swift
+++ b/Sources/APIExplorer/main.swift
@@ -1718,11 +1718,16 @@ let authRequiredEndpoints = Set([
     "FEmusic_library_corpus_track_artists",
     "FEmusic_library_songs",
     "FEmusic_library_non_music_audio_list",
+    "FEmusic_library_non_music_audio_channels_list",
+    "FEmusic_library_user_profile_channels_list",
+    "FEmusic_tastebuilder",
+    "FEmusic_listening_review",
     "FEmusic_recently_played",
     "FEmusic_offline",
     "FEmusic_library_privately_owned_landing",
     "FEmusic_library_privately_owned_tracks",
     "FEmusic_library_privately_owned_albums",
+    "FEmusic_library_privately_owned_releases",
     "FEmusic_library_privately_owned_artists",
 ])
 
@@ -3379,7 +3384,6 @@ func listEndpoints() {
         FEmusic_new_releases          Recently released albums, singles, videos
         FEmusic_podcasts              Podcast discovery
         FEmusic_radio_builder         Radio controls and form entities (creation unverified)
-        FEmusic_listening_review      Recap probe (guest response has no content)
 
         🔐 AUTHENTICATED (Requires Sign-in)
         ───────────────────────────────────────────────────────────────────────────────
@@ -3388,11 +3392,15 @@ func listEndpoints() {
         FEmusic_liked_videos          Liked songs (returns playlist format)
         FEmusic_history               Listening history (organized by time)
         FEmusic_library_landing       Library overview page
-        FEmusic_tastebuilder          Recommendation onboarding (guest gets sign-in prompt)
+        FEmusic_tastebuilder          Artist-selection data; acceptance is not replayable in discover
+        FEmusic_listening_review      Recap probe (signed-in sample returned a message only)
         FEmusic_library_artists       Rejected with HTTP 400 in current sessions
         FEmusic_library_corpus_artists Followed artists (returns public UC... pages)
         FEmusic_library_corpus_track_artists  Artists chip from Library (returns MPLAUC... pages)
-        FEmusic_library_songs         All songs in library (requires params*)
+        FEmusic_library_songs         Unverified legacy ID; the Songs chip issues FEmusic_liked_videos
+        FEmusic_library_non_music_audio_list       Dedicated podcast library
+        FEmusic_library_non_music_audio_channels_list Podcast library channel filter (preserve params)
+        FEmusic_library_user_profile_channels_list Profiles filter (preserve issued params)
         FEmusic_recently_played       Recently played content
         FEmusic_offline               Downloaded content (may not work on desktop)
 
@@ -3400,7 +3408,8 @@ func listEndpoints() {
         ───────────────────────────────────────────────────────────────────────────────
         FEmusic_library_privately_owned_landing   Uploads landing page
         FEmusic_library_privately_owned_tracks    User-uploaded songs
-        FEmusic_library_privately_owned_albums    User-uploaded albums
+        FEmusic_library_privately_owned_releases  Upload Albums chip (empty signed-in sample verified)
+        FEmusic_library_privately_owned_albums    Rejected legacy probe; use the issued releases route
         FEmusic_library_privately_owned_artists   Artists from user uploads
 
         🌐 DYNAMIC BROWSE IDs (Pattern-based)
@@ -3543,6 +3552,7 @@ func listEndpoints() {
         Compare Ask request profiles: swift run api-explorer ask-video-parity <VIDEO_ID>
         Inspect wire format:          swift run api-explorer --youtube wire-action <ep> '{}'
         Discover read-only routes:    swift run api-explorer discover help
+        Signed-in Library filters:   swift run api-explorer discover browse '{"browseId":"FEmusic_library_landing"}'
         Transcript navigation:       next may issue getTranscriptEndpoint; guest replay returned 400
 
         ═══════════════════════════════════════════════════════════════════════════════

--- a/Tests/APIExplorerTests/DiscoveryAuditTests.swift
+++ b/Tests/APIExplorerTests/DiscoveryAuditTests.swift
@@ -1,0 +1,455 @@
+import Foundation
+import Testing
+@testable import APIExplorer
+
+@Suite("Read-only API discovery")
+struct DiscoveryAuditTests {
+    @Test("The mobile profile keeps its version and device identity consistent")
+    func mobileRequestProfile() {
+        let profile = MusicMobileRequestProfile(client: .ios, version: "9.07.1")
+        let context = profile.clientContext(language: "tr")
+        #expect(context["clientName"] as? String == "IOS_MUSIC")
+        #expect(context["clientVersion"] as? String == "9.07.1")
+        #expect(context["platform"] as? String == "MOBILE")
+        #expect(context["hl"] as? String == "tr")
+        #expect(context["browserName"] == nil)
+        #expect(context["browserVersion"] == nil)
+        #expect(profile.userAgent.contains("/9.07.1 "))
+        #expect(MusicMobileRequestProfile(client: .ios).version == MusicMobileRequestProfile.Client.ios.defaultVersion)
+    }
+
+    @Test("Android identity and mobile authentication headers remain consistent")
+    func androidProfileAndHeaders() throws {
+        let profile = MusicMobileRequestProfile(client: .android, version: "7.21.50")
+        let context = profile.clientContext(language: "en")
+        #expect(context["clientName"] as? String == "ANDROID_MUSIC")
+        #expect(context["osName"] as? String == "Android")
+        #expect(context["androidSdkVersion"] as? Int == 36)
+        #expect(context["platform"] as? String == "MOBILE")
+        #expect(context["deviceModel"] == nil)
+
+        var request = try URLRequest(url: #require(URL(string: "https://music.youtube.com/youtubei/v1/browse")))
+        request.setValue("test-cookie", forHTTPHeaderField: "Cookie")
+        request.setValue("SAPISIDHASH mock-proof", forHTTPHeaderField: "Authorization")
+        request.setValue("1", forHTTPHeaderField: "X-Goog-AuthUser")
+        request.setValue("test-account", forHTTPHeaderField: "X-Goog-PageId")
+        request.setValue("https://music.youtube.com", forHTTPHeaderField: "X-Origin")
+        request.setValue("https://music.youtube.com", forHTTPHeaderField: "Origin")
+        request.setValue("https://music.youtube.com/", forHTTPHeaderField: "Referer")
+        profile.applyHeaders(to: &request, cookieOnly: false, accessToken: nil)
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "SAPISIDHASH mock-proof")
+        #expect(request.value(forHTTPHeaderField: "User-Agent")?.contains("/7.21.50 ") == true)
+        #expect(request.value(forHTTPHeaderField: "X-Youtube-Client-Name") == "21")
+        #expect(request.value(forHTTPHeaderField: "X-Youtube-Client-Version") == "7.21.50")
+
+        profile.applyHeaders(to: &request, cookieOnly: true, accessToken: nil)
+        #expect(request.value(forHTTPHeaderField: "Authorization") == nil)
+        #expect(request.value(forHTTPHeaderField: "Cookie") == "test-cookie")
+
+        profile.applyHeaders(to: &request, cookieOnly: false, accessToken: "mock-access-token")
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer mock-access-token")
+        for field in ["Cookie", "X-Goog-AuthUser", "X-Goog-PageId", "X-Origin", "Origin", "Referer"] {
+            #expect(request.value(forHTTPHeaderField: field) == nil)
+        }
+    }
+
+    @Test("Mobile OAuth requires a private regular file and cannot inject headers")
+    func mobileTokenFile() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let file = directory.appendingPathComponent("access-token")
+        #expect(FileManager.default.createFile(atPath: file.path, contents: Data("mock-access-token\n".utf8), attributes: [.posixPermissions: 0o600]))
+        #expect(try loadMobileAccessToken(from: file.path) == "mock-access-token")
+
+        try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: file.path)
+        #expect(throws: (any Error).self) { try loadMobileAccessToken(from: file.path) }
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: file.path)
+        let link = directory.appendingPathComponent("link")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: file)
+        #expect(throws: (any Error).self) { try loadMobileAccessToken(from: link.path) }
+        #expect(throws: (any Error).self) { try loadMobileAccessToken(from: "-") }
+
+        for invalid in ["", "Bearer mock-token", "mock-token\r\nCookie: test-cookie", String(repeating: "x", count: 8193)] {
+            try Data(invalid.utf8).write(to: file)
+            #expect(throws: (any Error).self) { try loadMobileAccessToken(from: file.path) }
+        }
+    }
+
+    @Test("Mobile OAuth cannot be sent through a web profile")
+    func mobileTokenDestination() async {
+        await #expect(throws: DiscoveryError.self) {
+            try await makeWireRequest(endpoint: "browse", body: ["browseId": "FEmusic_home"], mobileAccessToken: "mock-token")
+        }
+    }
+
+    @Test("Service metadata distinguishes an authenticated mobile response from guest content", arguments: ["0", "1"])
+    func serviceLoginFlags(flag: String) throws {
+        let request = try DiscoveryRequest(endpoint: "browse", body: ["browseId": "FEmusic_home"])
+        let response: [String: Any] = ["responseContext": ["serviceTrackingParams": [
+            ["service": "GFEEDBACK", "params": [["key": "logged_in", "value": flag], ["key": "account", "value": "private-account"]]],
+            ["service": "CSI", "params": [["key": "yt_li", "value": flag]]],
+        ]]]
+        let audit = DiscoveryAudit(response: response, request: request)
+        #expect(audit.serverLoggedOut == (flag == "0"))
+        #expect(!audit.rendered(verbose: true).contains("private-account"))
+    }
+
+    @Test("Conflicting or unfamiliar login flags do not establish authentication")
+    func inconclusiveServiceLoginFlags() throws {
+        let request = try DiscoveryRequest(endpoint: "browse", body: ["browseId": "FEmusic_home"])
+        for flags in [["0", "1"], ["private-value"], ["1", "false"], ["0", "private-value"], []] {
+            let params = flags.map { ["key": "logged_in", "value": $0] }
+            let audit = DiscoveryAudit(response: ["responseContext": ["serviceTrackingParams": [["params": params]]]], request: request)
+            #expect(audit.serverLoggedOut == nil)
+        }
+        let invalidFlags: [Any] = [1, true, NSNull()]
+        for invalid in invalidFlags {
+            let params: [[String: Any]] = [["key": "logged_in", "value": "1"], ["key": "yt_li", "value": invalid]]
+            let audit = DiscoveryAudit(response: ["responseContext": ["serviceTrackingParams": [["params": params]]]], request: request)
+            #expect(audit.serverLoggedOut == nil)
+        }
+    }
+
+    @Test("Error categories and web shelf summaries hide arbitrary response values")
+    func errorAndShelfRedaction() throws {
+        let request = try DiscoveryRequest(endpoint: "browse", body: ["browseId": "FEmusic_home"])
+        let response: [String: Any] = [
+            "error": ["status": "INVALID_ARGUMENT", "message": "Request contains an invalid argument."],
+            "contents": ["musicCarouselShelfRenderer": [
+                "shelfId": "private-shelf-id",
+                "header": ["musicCarouselShelfBasicHeaderRenderer": ["title": ["runs": [["text": "Listen again"]]]]],
+                "contents": [["title": "Private item"]],
+            ]],
+        ]
+        let audit = DiscoveryAudit(response: response, request: request)
+        #expect(audit.apiErrorSummary == "INVALID_ARGUMENT; invalid argument")
+        #expect(audit.homeShelves == ["label=Listen again; items=1"])
+        #expect(audit.speedDialItemCount == 0)
+        let report = audit.rendered(verbose: true)
+        #expect(!report.contains("private-shelf-id"))
+        #expect(!report.contains("Private item"))
+        let unknown = DiscoveryAudit(response: ["error": ["status": "private-status", "message": "mock-token"]], request: request)
+        #expect(unknown.apiErrorSummary == "unrecognized status; message hidden")
+    }
+
+    @Test("Mobile Speed dial models expose counts and read commands without private values")
+    func mobileSpeedDial() throws {
+        let request = try DiscoveryRequest(endpoint: "browse", body: ["browseId": "FEmusic_home"])
+        let model: [String: Any] = ["musicSpeedDialShelfModel": ["data": ["items": [
+            [
+                "title": "Private song title",
+                "startPlaybackCommand": ["serialCommand": ["commands": [
+                    ["innertubeCommand": ["watchEndpoint": [
+                        "videoId": "test-video", "playlistId": "test-radio", "params": "mock-play",
+                    ]]],
+                    ["innertubeCommand": ["feedbackEndpoint": ["feedbackToken": "mock-feedback"]]],
+                ]]],
+            ],
+            [
+                "title": "Private playlist title",
+                "navigationCommand": ["innertubeCommand": ["browseEndpoint": [
+                    "browseId": "VLtest-playlist", "params": "mock-browse",
+                ]]],
+            ],
+            ["isShortcut": true],
+        ]]]]
+        let audit = DiscoveryAudit(response: ["contents": ["itemSectionRenderer": ["contents": [
+            ["elementRenderer": ["newElement": ["type": ["componentType": ["model": model]]]]],
+        ]]]], request: request)
+
+        #expect(audit.renderers["musicSpeedDialShelfModel"] == 1)
+        #expect(audit.speedDialItemCount == 3)
+        #expect(audit.speedDialShortcutCount == 1)
+        #expect(audit.navigation.count == 2)
+        let playRead = try #require(audit.navigation.first { $0.request.endpoint == "next" })
+        #expect(playRead.request.body["params"] as? String == "mock-play")
+        #expect(playRead.request.body["playlistId"] as? String == "test-radio")
+        #expect(audit.observedCommands["feedbackEndpoint"] == 1)
+        let report = audit.rendered(verbose: true)
+        #expect(report.contains("Speed dial models: 1; items: 3; shortcuts: 1"))
+        for privateValue in ["Private", "test-video", "test-radio", "test-playlist", "mock-"] {
+            #expect(!report.contains(privateValue))
+        }
+    }
+
+    @Test("A Speed dial label or an empty model does not imply populated Speed dial items")
+    func speedDialPresence() throws {
+        let request = try DiscoveryRequest(endpoint: "browse", body: ["browseId": "FEmusic_home"])
+        let audit = DiscoveryAudit(response: ["contents": [
+            "musicSpeedDialShelfModel": ["data": [:]],
+            "musicGridItemCarouselModel": ["data": [
+                "title": "Speed dial", "items": [["title": "Private item"]],
+            ]],
+        ]], request: request)
+        #expect(audit.renderers["musicSpeedDialShelfModel"] == 1)
+        #expect(audit.renderers["musicGridItemCarouselModel"] == 1)
+        #expect(audit.speedDialItemCount == 0)
+        #expect(audit.speedDialShortcutCount == 0)
+    }
+
+    @Test("Seeds reject mutations even when sent through browse", arguments: [
+        "feedback", "playlist/create", "browse/edit_playlist", "subscription/subscribe", "get_answer",
+    ])
+    func rejectsMutationEndpoints(endpoint: String) {
+        #expect(throws: DiscoveryError.self) {
+            try DiscoveryRequest(endpoint: endpoint, body: ["videoId": "test-video"])
+        }
+    }
+
+    @Test("Browse forms cannot update recommendation preferences")
+    func rejectsBrowseFormData() {
+        #expect(throws: DiscoveryError.self) {
+            try DiscoveryRequest(endpoint: "browse", body: [
+                "browseId": "FEmusic_home", "formData": ["selectedValues": ["mock-token"]],
+            ])
+        }
+        #expect(throws: DiscoveryError.self) {
+            try DiscoveryRequest(endpoint: "browse", body: ["browseId": ["formData": "mock-token"]])
+        }
+        #expect(throws: DiscoveryError.self) {
+            try DiscoveryRequest(endpoint: "next", body: ["params": "mock-token"])
+        }
+    }
+
+    @Test("Only the chart country form is accepted")
+    func chartFormBoundary() throws {
+        let request = try DiscoveryRequest(endpoint: "browse", body: [
+            "browseId": "FEmusic_charts", "formData": ["selectedValues": ["JP"]],
+        ])
+        #expect(request.endpoint == "browse")
+        for form: [String: Any] in [
+            ["selectedValues": ["mock-token"]],
+            ["selectedValues": ["JP", "US"]],
+            ["selectedValues": ["JP"], "impressionValues": ["mock-token"]],
+            ["selectedValues": []],
+        ] {
+            #expect(throws: DiscoveryError.self) {
+                try DiscoveryRequest(endpoint: "browse", body: ["browseId": "FEmusic_charts", "formData": form])
+            }
+        }
+    }
+
+    @Test("Chart choices are extracted only from chart responses")
+    func chartChoices() throws {
+        let response: [String: Any] = ["frameworkUpdates": ["entityBatchUpdate": ["mutations": [
+            ["payload": ["musicFormBooleanChoice": ["opaqueToken": "JP", "selected": true]]],
+            ["payload": ["musicFormBooleanChoice": ["opaqueToken": "US"]]],
+            ["payload": ["musicFormBooleanChoice": ["opaqueToken": "JP"]]],
+            ["payload": ["musicFormBooleanChoice": ["opaqueToken": "mock-token"]]],
+        ]]]]
+        let chart = try DiscoveryRequest(endpoint: "browse", body: ["browseId": "FEmusic_charts"])
+        let home = try DiscoveryRequest(endpoint: "browse", body: ["browseId": "FEmusic_home"])
+        let audit = DiscoveryAudit(response: response, request: chart)
+        #expect(audit.chartCountryCount == 2)
+        #expect(audit.navigation.count == 2)
+        #expect(audit.selectedChartCountries == ["JP"])
+        let form = try #require(audit.navigation.first?.request.body["formData"] as? [String: Any])
+        #expect(form["selectedValues"] as? [String] == ["JP"])
+        #expect(DiscoveryAudit(response: response, request: home).navigation.isEmpty)
+        #expect(!audit.rendered(verbose: true).contains("mock-token"))
+    }
+
+    @Test("Transcript retrieval is extracted without executing sibling commands")
+    func transcriptInServiceBatch() throws {
+        let request = try DiscoveryRequest(endpoint: "next", body: ["videoId": "test-video"])
+        let audit = DiscoveryAudit(response: ["serviceEndpoint": ["commandExecutorCommand": ["commands": [
+            ["getTranscriptEndpoint": ["params": "mock-transcript"]],
+            ["feedbackEndpoint": ["feedbackToken": "mock-feedback"]],
+            ["browseEndpoint": ["browseId": "FEmusic_home"]],
+        ]]]], request: request)
+        #expect(audit.navigation.count == 1)
+        #expect(audit.navigation.first?.request.endpoint == "get_transcript")
+        #expect(audit.navigation.first?.request.body["params"] as? String == "mock-transcript")
+        #expect(!audit.rendered(verbose: true).contains("mock-"))
+    }
+
+    @Test("Credits, related content, chips, and search preserve issued parameters without printing them")
+    func harvestsNavigation() throws {
+        let request = try DiscoveryRequest(endpoint: "next", body: ["videoId": "test-video"])
+        let response: [String: Any] = [
+            "contents": [
+                "musicQueueRenderer": [
+                    "items": [
+                        ["menuNavigationItemRenderer": [
+                            "text": ["runs": [["text": "Song credits"]]],
+                            "navigationEndpoint": [
+                                "clickTrackingParams": "mock-tracking",
+                                "browseEndpoint": ["browseId": "MPTC-private-id", "params": "mock-credits"],
+                            ],
+                        ]],
+                        ["tabRenderer": [
+                            "title": "Related",
+                            "endpoint": ["browseEndpoint": ["browseId": "MPTR-private-id"]],
+                        ]],
+                        ["chipCloudChipRenderer": [
+                            "text": ["simpleText": "Focus"],
+                            "navigationEndpoint": ["browseSectionListReloadEndpoint": [
+                                "browseId": "FEmusic_home", "params": "mock-focus",
+                            ]],
+                        ]],
+                        ["chipCloudChipRenderer": [
+                            "text": ["runs": [["text": "Albums"]]],
+                            "navigationEndpoint": ["searchEndpoint": ["query": "private-query", "params": "mock-filter"]],
+                        ]],
+                    ],
+                ],
+            ],
+        ]
+        let audit = DiscoveryAudit(response: response, request: request)
+        #expect(audit.navigation.count == 4)
+        #expect(audit.navigation[0].label == "Song credits")
+        #expect(audit.navigation[0].request.body["params"] as? String == "mock-credits")
+        #expect(audit.navigation[1].request.body["browseId"] as? String == "MPTR-private-id")
+        #expect(audit.navigation[2].request.body["params"] as? String == "mock-focus")
+        #expect(audit.navigation[3].request.endpoint == "search")
+        #expect(audit.navigation[3].request.body["query"] as? String == "private-query")
+        #expect(audit.rendered().contains("MPTC…"))
+        #expect(!audit.rendered(verbose: true).contains("private-id"))
+        #expect(!audit.rendered(verbose: true).contains("mock-"))
+        #expect(!audit.rendered(verbose: true).contains("private-query"))
+    }
+
+    @Test("Continuation retains next's queue context and uses next routing", arguments: [
+        "nextContinuationData", "nextRadioContinuationData", "reloadContinuationData",
+    ])
+    func continuationContext(key: String) throws {
+        let request = try DiscoveryRequest(endpoint: "next", body: [
+            "videoId": "test-video", "playlistId": "test-playlist", "isAudioOnly": true,
+        ])
+        let audit = DiscoveryAudit(response: [
+            "continuations": [[key: ["continuation": "mock-continuation"]]],
+        ], request: request)
+        let continuation = try #require(audit.navigation.first?.request)
+        #expect(continuation.endpoint == "next")
+        #expect(continuation.body["videoId"] as? String == "test-video")
+        #expect(continuation.body["playlistId"] as? String == "test-playlist")
+        #expect(continuation.body["continuation"] as? String == "mock-continuation")
+        #expect(continuation.body["isAudioOnly"] as? Bool == true)
+    }
+
+    @Test("Queue filter navigation retains audio and persistent-panel configuration")
+    func queueFilterContext() throws {
+        let request = try DiscoveryRequest(endpoint: "next", body: [
+            "videoId": "test-video", "playlistId": "test-playlist", "isAudioOnly": true,
+            "enablePersistentPlaylistPanel": true,
+        ])
+        let audit = DiscoveryAudit(response: ["chipCloudChipRenderer": [
+            "text": ["simpleText": "Popular"], "isSelected": true,
+            "navigationEndpoint": ["watchPlaylistEndpoint": ["playlistId": "test-radio", "params": "mock-filter"]],
+        ]], request: request)
+        let filter = try #require(audit.navigation.first?.request)
+        #expect(filter.endpoint == "next")
+        #expect(filter.body["isAudioOnly"] as? Bool == true)
+        #expect(filter.body["enablePersistentPlaylistPanel"] as? Bool == true)
+        #expect(filter.body["videoId"] == nil)
+        #expect(filter.body["params"] as? String == "mock-filter")
+        #expect(audit.selectedChips == ["Popular"])
+    }
+
+    @Test("Deselect actions do not masquerade as a filter selection")
+    func ignoresDeselectAction() throws {
+        let request = try DiscoveryRequest(endpoint: "browse", body: ["browseId": "FEmusic_home"])
+        let audit = DiscoveryAudit(response: ["chipCloudChipRenderer": [
+            "text": ["simpleText": "Focus"],
+            "navigationEndpoint": ["browseEndpoint": ["browseId": "FEmusic_home", "params": "mock-focus"]],
+            "onDeselectedCommand": ["browseEndpoint": ["browseId": "FEmusic_home", "params": "mock-reset"]],
+        ]], request: request)
+        #expect(audit.navigation.count == 1)
+        #expect(audit.navigation.first?.request.body["params"] as? String == "mock-focus")
+    }
+
+    @Test("Credit headings alone are distinguished from populated sections")
+    func populatedCredits() throws {
+        let request = try DiscoveryRequest(endpoint: "browse", body: ["browseId": "MPTC-test"])
+        let audit = DiscoveryAudit(response: ["contents": [
+            ["dismissableDialogContentSectionRenderer": [
+                "title": ["simpleText": "Performed by"], "subtitle": ["runs": [["text": "Test performer"]]],
+            ]],
+            ["dismissableDialogContentSectionRenderer": ["title": ["simpleText": "Written by"]]],
+        ]], request: request)
+        #expect(audit.creditSectionCount == 2)
+        #expect(audit.populatedCreditSectionCount == 1)
+        #expect(!audit.rendered(verbose: true).contains("Test performer"))
+    }
+
+    @Test("Service commands and form submissions are inspected but never replayable")
+    func excludesSideEffects() throws {
+        let endpoint: [String: Any] = ["browseEndpoint": ["browseId": "FEmusic_home"]]
+        let request = try DiscoveryRequest(endpoint: "browse", body: ["browseId": "FEmusic_radio_builder"])
+        let audit = DiscoveryAudit(response: [
+            "serviceEndpoint": endpoint,
+            "commandExecutorCommand": ["commands": [endpoint]],
+            "submitEndpoint": endpoint,
+            "formData": endpoint,
+            "navigationEndpoint": ["browseEndpoint": [
+                "browseId": "FEmusic_home", "formData": ["selectedValues": ["mock-token"]],
+            ]],
+        ], request: request)
+        #expect(audit.navigation.isEmpty)
+        #expect(audit.observedCommands["browseEndpoint"] == 5)
+        #expect(!audit.rendered(verbose: true).contains("mock-token"))
+    }
+
+    @Test("Only known UI labels and schema names appear in a report")
+    func redactsValuesAndDynamicKeys() throws {
+        let request = try DiscoveryRequest(endpoint: "browse", body: ["browseId": "UC-private-account"])
+        let audit = DiscoveryAudit(response: [
+            "responseContext": ["visitorData": "mock-visitor", "mainAppWebResponseContext": ["loggedOut": false]],
+            "error": ["message": "private-error", "code": 400],
+            "contents": ["musicShelfRenderer": [
+                "title": ["runs": [["text": "Private playlist title"]]],
+                "accountId": "private-account",
+                "mock-key-123": "mock-token",
+                "accessToken": "mock-access",
+                "text": "\u{001B}[31mPrivate text",
+                "browseEndpoint": ["browseId": "UC-private-account"],
+            ]],
+        ], request: request)
+        let report = audit.rendered(verbose: true)
+        #expect(audit.serverLoggedOut == false)
+        #expect(audit.hasAPIError)
+        #expect(report.contains("musicShelfRenderer"))
+        #expect(report.contains("<key>"))
+        #expect(report.contains("UC…"))
+        for value in ["private-account", "Private", "private-error", "mock-", "\u{001B}"] {
+            #expect(!report.contains(value))
+        }
+        #expect(!request.summary.contains("private-account"))
+    }
+
+    @Test("An HTTP 200 responseContext-only payload does not imply feature content")
+    func emptyResponse() throws {
+        let request = try DiscoveryRequest(endpoint: "browse", body: ["browseId": "FEmusic_listening_review"])
+        let audit = DiscoveryAudit(response: ["responseContext": [:], "trackingParams": "mock-tracking"], request: request)
+        #expect(!audit.hasContent)
+        #expect(audit.serverLoggedOut == nil)
+        #expect(audit.navigation.isEmpty)
+        #expect(audit.rendered().contains("no content envelope"))
+    }
+
+    @Test("Duplicate destinations keep distinct params and deterministic order")
+    func deduplication() throws {
+        let request = try DiscoveryRequest(endpoint: "browse", body: ["browseId": "FEmusic_home"])
+        let audit = DiscoveryAudit(response: ["contents": [
+            ["browseEndpoint": ["browseId": "FEmusic_home", "params": "mock-first"]],
+            ["browseEndpoint": ["browseId": "FEmusic_home", "params": "mock-first"]],
+            ["browseEndpoint": ["browseId": "FEmusic_home", "params": "mock-second"]],
+        ]], request: request)
+        #expect(audit.navigation.count == 2)
+        #expect(audit.navigation[0].request.body["params"] as? String == "mock-first")
+        #expect(audit.navigation[1].request.body["params"] as? String == "mock-second")
+    }
+
+    @Test("Deep payloads stop at the audit limit")
+    func traversalBound() throws {
+        let request = try DiscoveryRequest(endpoint: "browse", body: ["browseId": "FEmusic_home"])
+        var response: [String: Any] = ["browseEndpoint": ["browseId": "FEmusic_charts"]]
+        for _ in 0 ..< 90 {
+            response = ["nested": response]
+        }
+        let audit = DiscoveryAudit(response: response, request: request)
+        #expect(audit.truncated)
+        #expect(audit.navigation.isEmpty)
+    }
+}

--- a/Tests/APIExplorerTests/DiscoveryAuditTests.swift
+++ b/Tests/APIExplorerTests/DiscoveryAuditTests.swift
@@ -640,15 +640,21 @@ extension DiscoveryAuditTests {
 
     @Test("Only known public browse routes are printed")
     func redactsUnknownBrowseRoutes() throws {
-        for browseID in ["FEmusic_private_account", "FEmusic_privatetoken", "privateaccount"] {
+        for browseID in ["FEmusic_private_account", "FEmusic_privatetoken", "FEprivate_destination", "privateaccount"] {
             let request = try DiscoveryRequest(endpoint: "browse", body: ["browseId": browseID])
             let audit = DiscoveryAudit(response: ["navigationEndpoint": ["browseEndpoint": ["browseId": browseID]]], request: request)
             #expect(!request.summary.contains(browseID))
             #expect(!audit.rendered(verbose: true).contains(browseID))
         }
-        for browseID in ["FEmusic_home", "FEmusic_library_corpus_track_artists", "FEmusic_charts"] {
+        for browseID in [
+            "FEmusic_home", "FEmusic_library_corpus_track_artists", "FEmusic_charts", "FEwhat_to_watch",
+            "FEgaming_destination", "FEnews_destination", "FEsports_destination", "FElive_destination",
+            "FEfashion_destination", "FElearning_destination",
+        ] {
             let request = try DiscoveryRequest(endpoint: "browse", body: ["browseId": browseID])
+            let audit = DiscoveryAudit(response: ["navigationEndpoint": ["browseEndpoint": ["browseId": browseID]]], request: request)
             #expect(request.summary.contains(browseID))
+            #expect(audit.rendered().contains(browseID))
         }
     }
 
@@ -711,16 +717,7 @@ extension DiscoveryAuditTests {
         let file = directory.appendingPathComponent("private-input")
         let original = Data((mobileInput ? "mock-access-token" : #"{"params":"mock-private-params"}"#).utf8)
         #expect(FileManager.default.createFile(atPath: file.path, contents: original, attributes: [.posixPermissions: 0o600]))
-        let link = directory.appendingPathComponent("token-link")
-        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: file)
-        let directoryLink = directory.appendingPathComponent("directory-link")
-        try FileManager.default.createSymbolicLink(at: directoryLink, withDestinationURL: directory)
-        let hardLink = directory.appendingPathComponent("hard-link")
-        try FileManager.default.linkItem(at: file, to: hardLink)
-        let parentDepth = FileManager.default.currentDirectoryPath.split(separator: "/").count
-        let relativePath = String(repeating: "../", count: parentDepth) + file.path.dropFirst()
-        let aliases = [file.path, directory.path + "/./private-input", relativePath, link.path, directoryLink.path + "/private-input", hardLink.path]
-        for outputPath in aliases {
+        for outputPath in try self.outputAliases(for: file) {
             let succeeded = await discoverAPI(
                 endpoint: "browse", bodyJSON: "{}", followIndices: [], limit: 1,
                 verbose: false, outputFile: outputPath, mobileClient: mobileInput ? .ios : nil,
@@ -738,5 +735,84 @@ extension DiscoveryAuditTests {
         )
         #expect(!succeeded)
         #expect(!FileManager.default.fileExists(atPath: missing.path))
+    }
+
+    @Test("Discovery protects cookie archives and redirected stdin aliases", arguments: [false, true])
+    func implicitInputOutputAliases(redirectedInput: Bool) throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let file = directory.appendingPathComponent("cookies.dat")
+        #expect(FileManager.default.createFile(atPath: file.path, contents: Data("test-cookie".utf8), attributes: [.posixPermissions: 0o600]))
+        let input = try FileHandle(forReadingFrom: file)
+        defer { try? input.close() }
+        for outputPath in try self.outputAliases(for: file) {
+            #expect(discoveryOutputOverwritesInput(
+                outputPath, bodyFile: redirectedInput ? "-" : nil, mobileTokenFile: nil,
+                cookieBackupFile: redirectedInput ? nil : file, standardInput: input.fileDescriptor
+            ))
+        }
+        #expect(!discoveryOutputOverwritesInput(
+            directory.appendingPathComponent("report.txt").path, bodyFile: redirectedInput ? "-" : nil,
+            mobileTokenFile: nil, cookieBackupFile: redirectedInput ? nil : file, standardInput: input.fileDescriptor
+        ))
+        let pipe = Pipe()
+        #expect(!discoveryOutputOverwritesInput(
+            file.path, bodyFile: "-", mobileTokenFile: nil, cookieBackupFile: nil,
+            standardInput: pipe.fileHandleForReading.fileDescriptor
+        ))
+    }
+
+    @Test("Cookie archive selection preserves container authority after logout")
+    func cookieBackupSelection() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let appSupport = directory.appendingPathComponent("Library/Application Support")
+        let legacy = appSupport.appendingPathComponent("Kaset/cookies.dat")
+        let container = directory.appendingPathComponent("Library/Containers/com.sertacozercan.Kaset/Data/Library/Application Support/Kaset/cookies.dat")
+        try FileManager.default.createDirectory(at: legacy.deletingLastPathComponent(), withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        #expect(selectedCookieBackupFile(appSupport: appSupport, homeDirectory: directory) == nil)
+        #expect(FileManager.default.createFile(atPath: legacy.path, contents: Data("test-cookie".utf8)))
+        #expect(selectedCookieBackupFile(appSupport: appSupport, homeDirectory: directory) == legacy)
+        try FileManager.default.createDirectory(at: container.deletingLastPathComponent(), withIntermediateDirectories: true)
+        #expect(selectedCookieBackupFile(appSupport: appSupport, homeDirectory: directory) == nil)
+        #expect(FileManager.default.createFile(atPath: container.path, contents: Data("test-cookie".utf8)))
+        #expect(selectedCookieBackupFile(appSupport: appSupport, homeDirectory: directory) == container)
+        try FileManager.default.removeItem(at: container)
+        #expect(selectedCookieBackupFile(appSupport: appSupport, homeDirectory: directory) == nil)
+    }
+
+    @Test("Configuration requests use the supplied cookie snapshot, including an empty guest snapshot")
+    func configurationCookieSnapshot() throws {
+        let cookie = try #require(HTTPCookie(properties: [
+            .domain: ".youtube.com", .path: "/", .name: "test-session", .value: "test-cookie",
+        ]))
+        let cookies = [cookie]
+        let first = webClientConfiguration(authenticated: true, cookieSnapshot: cookies)
+        let firstCookieCount = first.httpCookieStorage?.cookies?.count ?? 0
+        #expect(firstCookieCount == 1)
+        first.httpCookieStorage?.deleteCookie(cookie)
+        let next = webClientConfiguration(authenticated: true, cookieSnapshot: cookies)
+        let preservedSnapshot = next.httpCookieStorage?.cookies?.contains {
+            $0.name == "test-session" && $0.value == "test-cookie"
+        } == true
+        #expect(preservedSnapshot)
+        let guest = webClientConfiguration(authenticated: true, cookieSnapshot: [])
+        let guestHasNoCookies = guest.httpCookieStorage?.cookies?.isEmpty != false
+        #expect(guestHasNoCookies)
+    }
+
+    private func outputAliases(for file: URL) throws -> [String] {
+        let directory = file.deletingLastPathComponent()
+        let link = directory.appendingPathComponent("input-link")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: file)
+        let directoryLink = directory.appendingPathComponent("directory-link")
+        try FileManager.default.createSymbolicLink(at: directoryLink, withDestinationURL: directory)
+        let hardLink = directory.appendingPathComponent("hard-link")
+        try FileManager.default.linkItem(at: file, to: hardLink)
+        let parentDepth = FileManager.default.currentDirectoryPath.split(separator: "/").count
+        let relativePath = String(repeating: "../", count: parentDepth) + file.path.dropFirst()
+        return [file.path, directory.path + "/./" + file.lastPathComponent, relativePath, link.path,
+                directoryLink.appendingPathComponent(file.lastPathComponent).path, hardLink.path]
     }
 }

--- a/Tests/APIExplorerTests/DiscoveryAuditTests.swift
+++ b/Tests/APIExplorerTests/DiscoveryAuditTests.swift
@@ -46,7 +46,7 @@ struct DiscoveryAuditTests {
         #expect(request.value(forHTTPHeaderField: "X-Youtube-Client-Name") == "21")
         #expect(request.value(forHTTPHeaderField: "X-Youtube-Client-Version") == "7.21.50")
 
-        profile.applyHeaders(to: &request, cookieOnly: true, accessToken: nil)
+        profile.applyHeaders(to: &request, cookieOnly: true, accessToken: nil, cookieHeader: "test-cookie")
         #expect(request.value(forHTTPHeaderField: "Authorization") == nil)
         #expect(request.value(forHTTPHeaderField: "Cookie") == "test-cookie")
 
@@ -536,6 +536,43 @@ struct DiscoveryAuditTests {
 }
 
 extension DiscoveryAuditTests {
+    @Test("Mobile cookie-only probes retain cookies without a signing cookie")
+    func cookieOnlyWithoutSigningCookie() throws {
+        let cookie = try #require(HTTPCookie(properties: [
+            .name: "VISITOR_INFO1_LIVE", .value: "test-cookie", .domain: ".youtube.com", .path: "/",
+        ]))
+        let cookieHeader = try #require(HTTPCookie.requestHeaderFields(with: [cookie])["Cookie"])
+        let profile = MusicMobileRequestProfile(client: .ios)
+        var request = try URLRequest(url: #require(URL(string: "https://music.youtube.com/youtubei/v1/browse")))
+        profile.applyHeaders(to: &request, cookieOnly: true, accessToken: nil, cookieHeader: cookieHeader)
+        #expect(request.value(forHTTPHeaderField: "Cookie") == "VISITOR_INFO1_LIVE=test-cookie")
+        #expect(request.value(forHTTPHeaderField: "Authorization") == nil)
+
+        profile.applyHeaders(to: &request, cookieOnly: true, accessToken: nil)
+        #expect(request.value(forHTTPHeaderField: "Cookie") == nil)
+        #expect(request.value(forHTTPHeaderField: "Authorization") == nil)
+    }
+
+    @Test("Command continuations are reported as content without exposing their values")
+    func commandContinuationContent() throws {
+        let request = try DiscoveryRequest(endpoint: "search", body: ["query": "test-query", "continuation": "mock-page"])
+        let response: [String: Any] = ["onResponseReceivedCommands": [["appendContinuationItemsAction": [
+            "continuationItems": [["musicResponsiveListItemRenderer": [
+                "title": "Private result", "navigationEndpoint": ["watchEndpoint": ["videoId": "test-video"]],
+            ]]],
+        ]]]]
+        let audit = DiscoveryAudit(response: response, request: request)
+        #expect(audit.hasContent)
+        #expect(audit.renderers["musicResponsiveListItemRenderer"] == 1)
+        #expect(audit.navigation.count == 1)
+        let report = audit.rendered(verbose: true)
+        #expect(report.contains("content envelope present"))
+        #expect(report.contains("onResponseReceivedCommands"))
+        #expect(!report.contains("Private result"))
+        #expect(!report.contains("mock-page"))
+        #expect(!DiscoveryAudit(response: ["onResponseReceivedCommands": []], request: request).hasContent)
+    }
+
     @Test("Client version overrides reject empty or nonnumeric components", arguments: [
         "", ".", "1..2", "1.", ".1", "1...2", "1.a.2", "1.2\r\nInjected", "１.２", String(repeating: "1", count: 65),
     ])
@@ -644,36 +681,38 @@ extension DiscoveryAuditTests {
         #expect(!output.contains(token.path))
     }
 
-    @Test("Discovery never replaces its token input, even when request validation fails")
-    func tokenOutputAliases() async throws {
+    @Test("Discovery never replaces an input file, even when request validation fails", arguments: [false, true])
+    func inputOutputAliases(mobileInput: Bool) async throws {
         let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
         defer { try? FileManager.default.removeItem(at: directory) }
-        let token = directory.appendingPathComponent("access-token")
-        let original = Data("mock-access-token".utf8)
-        #expect(FileManager.default.createFile(atPath: token.path, contents: original, attributes: [.posixPermissions: 0o600]))
+        let file = directory.appendingPathComponent("private-input")
+        let original = Data((mobileInput ? "mock-access-token" : #"{"params":"mock-private-params"}"#).utf8)
+        #expect(FileManager.default.createFile(atPath: file.path, contents: original, attributes: [.posixPermissions: 0o600]))
         let link = directory.appendingPathComponent("token-link")
-        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: token)
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: file)
         let directoryLink = directory.appendingPathComponent("directory-link")
         try FileManager.default.createSymbolicLink(at: directoryLink, withDestinationURL: directory)
         let hardLink = directory.appendingPathComponent("hard-link")
-        try FileManager.default.linkItem(at: token, to: hardLink)
+        try FileManager.default.linkItem(at: file, to: hardLink)
         let parentDepth = FileManager.default.currentDirectoryPath.split(separator: "/").count
-        let relativePath = String(repeating: "../", count: parentDepth) + token.path.dropFirst()
-        let aliases = [token.path, directory.path + "/./access-token", relativePath, link.path, directoryLink.path + "/access-token", hardLink.path]
+        let relativePath = String(repeating: "../", count: parentDepth) + file.path.dropFirst()
+        let aliases = [file.path, directory.path + "/./private-input", relativePath, link.path, directoryLink.path + "/private-input", hardLink.path]
         for outputPath in aliases {
             let succeeded = await discoverAPI(
                 endpoint: "browse", bodyJSON: "{}", followIndices: [], limit: 1,
-                verbose: false, outputFile: outputPath, mobileClient: .ios, mobileTokenFile: token.path
+                verbose: false, outputFile: outputPath, mobileClient: mobileInput ? .ios : nil,
+                mobileTokenFile: mobileInput ? file.path : nil, bodyFile: mobileInput ? nil : file.path
             )
             #expect(!succeeded)
-            #expect(try Data(contentsOf: token) == original)
+            #expect(try Data(contentsOf: file) == original)
             #expect(try Data(contentsOf: URL(fileURLWithPath: outputPath)) == original)
         }
-        let missing = directory.appendingPathComponent("missing-token")
+        let missing = directory.appendingPathComponent("missing-input")
         let succeeded = await discoverAPI(
             endpoint: "browse", bodyJSON: "{}", followIndices: [], limit: 1,
-            verbose: false, outputFile: missing.path, mobileClient: .ios, mobileTokenFile: missing.path
+            verbose: false, outputFile: missing.path, mobileClient: mobileInput ? .ios : nil,
+            mobileTokenFile: mobileInput ? missing.path : nil, bodyFile: mobileInput ? nil : missing.path
         )
         #expect(!succeeded)
         #expect(!FileManager.default.fileExists(atPath: missing.path))

--- a/Tests/APIExplorerTests/DiscoveryAuditTests.swift
+++ b/Tests/APIExplorerTests/DiscoveryAuditTests.swift
@@ -359,6 +359,79 @@ struct DiscoveryAuditTests {
         #expect(audit.navigation.first?.request.body["params"] as? String == "mock-focus")
     }
 
+    @Test("Library chips extract direct browse reads without bundled persistence or form commands")
+    func libraryChipCommands() throws {
+        let request = try DiscoveryRequest(endpoint: "browse", body: ["browseId": "FEmusic_library_landing"])
+        let response: [String: Any] = ["contents": ["chipCloudChipRenderer": [
+            "text": ["runs": [["text": "Artists"]]],
+            "navigationEndpoint": ["commandExecutorCommand": ["commands": [
+                ["browseEndpoint": ["browseId": "FEmusic_library_corpus_track_artists", "params": "mock-filter"]],
+                ["musicLibraryPersistLaunchNavigationCommand": ["command": ["browseEndpoint": ["browseId": "private-persisted-route"]]]],
+                ["browseEndpoint": ["browseId": "FEmusic_home", "formData": ["selectedValues": ["mock-selection"]]]],
+                ["feedbackEndpoint": ["feedbackTokens": ["mock-feedback"]]],
+            ]]],
+            "onDeselectedCommand": ["commandExecutorCommand": ["commands": [
+                ["browseEndpoint": ["browseId": "FEmusic_library_landing"]],
+            ]]],
+        ]]]
+        let audit = DiscoveryAudit(response: response, request: request)
+        #expect(audit.navigation.count == 1)
+        let entry = try #require(audit.navigation.first)
+        #expect(entry.request.endpoint == "browse")
+        #expect(entry.request.body["browseId"] as? String == "FEmusic_library_corpus_track_artists")
+        #expect(entry.request.body["params"] as? String == "mock-filter")
+        #expect(entry.label == "Artists")
+        #expect(entry.source == "chipCloudChipRenderer")
+        for hidden in ["mock-filter", "private-persisted-route", "mock-selection", "mock-feedback"] {
+            #expect(!audit.rendered(verbose: true).contains(hidden))
+        }
+    }
+
+    @Test("Library sort reads preserve filter context and replace the prior continuation")
+    func librarySortCommands() throws {
+        let request = try DiscoveryRequest(endpoint: "browse", body: [
+            "browseId": "FEmusic_library_landing", "params": "mock-filter", "continuation": "mock-old-page",
+        ])
+        let option: [String: Any] = ["musicMultiSelectMenuItemRenderer": [
+            "title": ["runs": [["text": "A to Z"]]],
+            "selectedCommand": ["commandExecutorCommand": ["commands": [
+                ["browseSectionListReloadEndpoint": ["continuation": ["reloadContinuationData": ["continuation": "mock-sort-page"]]]],
+                ["musicCheckboxFormItemMutatedCommand": ["formItemEntityKey": "mock-choice", "newCheckedState": true]],
+            ]]],
+        ]]
+        let response: [String: Any] = ["contents": ["musicSortFilterButtonRenderer": [
+            "title": ["runs": [["text": "Recently played"]]],
+            "menu": ["musicMultiSelectMenuRenderer": ["options": [option]]],
+        ]]]
+        let audit = DiscoveryAudit(response: response, request: request)
+        #expect(audit.navigation.count == 1)
+        let entry = try #require(audit.navigation.first)
+        #expect(entry.request.endpoint == "browse")
+        #expect(entry.request.body["browseId"] as? String == "FEmusic_library_landing")
+        #expect(entry.request.body["params"] as? String == "mock-filter")
+        #expect(entry.request.body["continuation"] as? String == "mock-sort-page")
+        #expect(entry.label == "A to Z")
+        #expect(entry.source == "musicMultiSelectMenuItemRenderer")
+        #expect(audit.sortMenuTitles == ["Recently played"])
+        #expect(!audit.rendered(verbose: true).contains("mock-sort-page"))
+        #expect(!audit.rendered(verbose: true).contains("mock-choice"))
+    }
+
+    @Test("Taste-profile acceptance buttons are never replayable discovery routes")
+    func tasteProfileAcceptanceIsNotNavigation() throws {
+        let request = try DiscoveryRequest(endpoint: "browse", body: ["browseId": "FEmusic_tastebuilder"])
+        let response: [String: Any] = ["contents": ["tastebuilderRenderer": [
+            "acceptButton": ["buttonRenderer": ["navigationEndpoint": ["browseEndpoint": [
+                "browseId": "FEmusic_home", "params": "mock-submit",
+            ]]]],
+            "contents": [["tastebuilderItemRenderer": ["selectionFormValue": "mock-selection"]]],
+        ]]]
+        let audit = DiscoveryAudit(response: response, request: request)
+        #expect(audit.navigation.isEmpty)
+        #expect(audit.observedCommands["browseEndpoint"] == 1)
+        #expect(!audit.rendered(verbose: true).contains("mock-submit"))
+    }
+
     @Test("Credit headings alone are distinguished from populated sections")
     func populatedCredits() throws {
         let request = try DiscoveryRequest(endpoint: "browse", body: ["browseId": "MPTC-test"])

--- a/Tests/APIExplorerTests/DiscoveryAuditTests.swift
+++ b/Tests/APIExplorerTests/DiscoveryAuditTests.swift
@@ -2,6 +2,8 @@ import Foundation
 import Testing
 @testable import APIExplorer
 
+// MARK: - DiscoveryAuditTests
+
 @Suite("Read-only API discovery")
 struct DiscoveryAuditTests {
     @Test("The mobile profile keeps its version and device identity consistent")
@@ -24,7 +26,8 @@ struct DiscoveryAuditTests {
         let context = profile.clientContext(language: "en")
         #expect(context["clientName"] as? String == "ANDROID_MUSIC")
         #expect(context["osName"] as? String == "Android")
-        #expect(context["androidSdkVersion"] as? Int == 36)
+        #expect(context["osVersion"] as? String == "13")
+        #expect(context["androidSdkVersion"] as? Int == 33)
         #expect(context["platform"] as? String == "MOBILE")
         #expect(context["deviceModel"] == nil)
 
@@ -39,6 +42,7 @@ struct DiscoveryAuditTests {
         profile.applyHeaders(to: &request, cookieOnly: false, accessToken: nil)
         #expect(request.value(forHTTPHeaderField: "Authorization") == "SAPISIDHASH mock-proof")
         #expect(request.value(forHTTPHeaderField: "User-Agent")?.contains("/7.21.50 ") == true)
+        #expect(request.value(forHTTPHeaderField: "User-Agent")?.contains("Android 13;") == true)
         #expect(request.value(forHTTPHeaderField: "X-Youtube-Client-Name") == "21")
         #expect(request.value(forHTTPHeaderField: "X-Youtube-Client-Version") == "7.21.50")
 
@@ -63,16 +67,16 @@ struct DiscoveryAuditTests {
         #expect(try loadMobileAccessToken(from: file.path) == "mock-access-token")
 
         try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: file.path)
-        #expect(throws: (any Error).self) { try loadMobileAccessToken(from: file.path) }
+        #expect(throws: DiscoveryError.invalidMobileToken) { try loadMobileAccessToken(from: file.path) }
         try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: file.path)
         let link = directory.appendingPathComponent("link")
         try FileManager.default.createSymbolicLink(at: link, withDestinationURL: file)
-        #expect(throws: (any Error).self) { try loadMobileAccessToken(from: link.path) }
-        #expect(throws: (any Error).self) { try loadMobileAccessToken(from: "-") }
+        #expect(throws: DiscoveryError.invalidMobileToken) { try loadMobileAccessToken(from: link.path) }
+        #expect(throws: DiscoveryError.invalidMobileToken) { try loadMobileAccessToken(from: "-") }
 
         for invalid in ["", "Bearer mock-token", "mock-token\r\nCookie: test-cookie", String(repeating: "x", count: 8193)] {
             try Data(invalid.utf8).write(to: file)
-            #expect(throws: (any Error).self) { try loadMobileAccessToken(from: file.path) }
+            #expect(throws: DiscoveryError.invalidMobileToken) { try loadMobileAccessToken(from: file.path) }
         }
     }
 
@@ -474,6 +478,10 @@ struct DiscoveryAuditTests {
                 "title": ["runs": [["text": "Private playlist title"]]],
                 "accountId": "private-account",
                 "mock-key-123": "mock-token",
+                "privateaccount": ["privatetoken": "mock-token"],
+                "privateRenderer": ["privateCommand": ["privateEndpoint": [:]]],
+                "musicPrivateModel": ["browseEndpoint": ["browseId": "FEmusic_private_account"]],
+                "pageType": "MUSIC_PRIVATE_ACCOUNT",
                 "accessToken": "mock-access",
                 "text": "\u{001B}[31mPrivate text",
                 "browseEndpoint": ["browseId": "UC-private-account"],
@@ -485,7 +493,7 @@ struct DiscoveryAuditTests {
         #expect(report.contains("musicShelfRenderer"))
         #expect(report.contains("<key>"))
         #expect(report.contains("UC…"))
-        for value in ["private-account", "Private", "private-error", "mock-", "\u{001B}"] {
+        for value in ["private-account", "privateaccount", "privatetoken", "privateRenderer", "privateCommand", "privateEndpoint", "private_account", "Private", "MUSIC_PRIVATE_ACCOUNT", "private-error", "mock-", "\u{001B}"] {
             #expect(!report.contains(value))
         }
         #expect(!request.summary.contains("private-account"))
@@ -524,5 +532,136 @@ struct DiscoveryAuditTests {
         let audit = DiscoveryAudit(response: response, request: request)
         #expect(audit.truncated)
         #expect(audit.navigation.isEmpty)
+    }
+}
+
+extension DiscoveryAuditTests {
+    @Test("Request validation rejects JSON boolean and numeric coercion", arguments: [
+        #"{"videoId":"test-video","index":true}"#,
+        #"{"videoId":"test-video","index":false}"#,
+        #"{"videoId":"test-video","index":1.5}"#,
+        #"{"videoId":"test-video","index":-1}"#,
+        #"{"videoId":"test-video","index":100001}"#,
+        #"{"videoId":"test-video","isAudioOnly":1}"#,
+        #"{"videoId":"test-video","isAudioOnly":0}"#,
+        #"{"videoId":"test-video","enablePersistentPlaylistPanel":1}"#,
+        #"{"videoId":"test-video","enablePersistentPlaylistPanel":0}"#,
+    ])
+    func rejectsCoercedJSONScalars(bodyJSON: String) throws {
+        let body = try #require(JSONSerialization.jsonObject(with: Data(bodyJSON.utf8)) as? [String: Any])
+        #expect(throws: DiscoveryError.unsupportedRequest) {
+            try DiscoveryRequest(endpoint: "next", body: body)
+        }
+    }
+
+    @Test("Request validation accepts JSON indices and booleans", arguments: [
+        #"{"videoId":"test-video","index":0,"isAudioOnly":true,"enablePersistentPlaylistPanel":false}"#,
+        #"{"videoId":"test-video","index":1,"isAudioOnly":false,"enablePersistentPlaylistPanel":true}"#,
+        #"{"videoId":"test-video","index":100000}"#,
+    ])
+    func acceptsJSONScalars(bodyJSON: String) throws {
+        let body = try #require(JSONSerialization.jsonObject(with: Data(bodyJSON.utf8)) as? [String: Any])
+        let request = try DiscoveryRequest(endpoint: "next", body: body)
+        #expect(request.endpoint == "next")
+    }
+
+    @Test("Only known public browse routes are printed")
+    func redactsUnknownBrowseRoutes() throws {
+        for browseID in ["FEmusic_private_account", "FEmusic_privatetoken", "privateaccount"] {
+            let request = try DiscoveryRequest(endpoint: "browse", body: ["browseId": browseID])
+            let audit = DiscoveryAudit(response: ["navigationEndpoint": ["browseEndpoint": ["browseId": browseID]]], request: request)
+            #expect(!request.summary.contains(browseID))
+            #expect(!audit.rendered(verbose: true).contains(browseID))
+        }
+        for browseID in ["FEmusic_home", "FEmusic_library_corpus_track_artists", "FEmusic_charts"] {
+            let request = try DiscoveryRequest(endpoint: "browse", body: ["browseId": browseID])
+            #expect(request.summary.contains(browseID))
+        }
+    }
+
+    @Test("Content named like a UI label stays hidden, including inside a labeled header")
+    func contentTitlesAreNotLabels() throws {
+        let request = try DiscoveryRequest(endpoint: "browse", body: ["browseId": "FEmusic_home"])
+        let audit = DiscoveryAudit(response: ["contents": [
+            "musicCarouselShelfBasicHeaderRenderer": [
+                "title": ["simpleText": "Listen again"],
+                "contents": [["musicTwoRowItemRenderer": [
+                    "title": ["runs": [["text": "Focus"]]],
+                    "navigationEndpoint": ["browseEndpoint": ["browseId": "VLtest-playlist"]],
+                ]]],
+            ],
+            "musicResponsiveListItemRenderer": [
+                "text": "Popular",
+                "navigationEndpoint": ["watchEndpoint": ["videoId": "test-video"]],
+            ],
+            "musicSpeedDialShelfModel": ["data": ["items": [[
+                "title": "Chill",
+                "navigationCommand": ["browseEndpoint": ["browseId": "UCtest-artist"]],
+            ]]]],
+        ]], request: request)
+        #expect(audit.labels == ["Listen again": 1])
+        #expect(audit.navigation.count == 3)
+        #expect(audit.navigation.allSatisfy { $0.label == nil })
+        let report = audit.rendered(verbose: true)
+        for title in ["Focus", "Popular", "Chill"] {
+            #expect(!report.contains(title))
+        }
+    }
+
+    @Test("Invalid token files get a separate redacted diagnostic")
+    func invalidTokenDiagnostic() async throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let token = directory.appendingPathComponent("access-token")
+        let report = directory.appendingPathComponent("report.txt")
+        #expect(FileManager.default.createFile(atPath: token.path, contents: Data("Bearer mock-token".utf8), attributes: [.posixPermissions: 0o600]))
+
+        let succeeded = await discoverAPI(
+            endpoint: "browse", bodyJSON: #"{"browseId":"FEmusic_home"}"#,
+            followIndices: [], limit: 1, verbose: true, outputFile: report.path,
+            mobileClient: .ios, mobileTokenFile: token.path
+        )
+        #expect(!succeeded)
+        let output = try String(contentsOf: report, encoding: .utf8)
+        #expect(output.contains("Invalid mobile access-token file"))
+        #expect(!output.contains("Unsupported discovery request"))
+        #expect(!output.contains("mock-token"))
+        #expect(!output.contains(token.path))
+    }
+
+    @Test("Discovery never replaces its token input, even when request validation fails")
+    func tokenOutputAliases() async throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let token = directory.appendingPathComponent("access-token")
+        let original = Data("mock-access-token".utf8)
+        #expect(FileManager.default.createFile(atPath: token.path, contents: original, attributes: [.posixPermissions: 0o600]))
+        let link = directory.appendingPathComponent("token-link")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: token)
+        let directoryLink = directory.appendingPathComponent("directory-link")
+        try FileManager.default.createSymbolicLink(at: directoryLink, withDestinationURL: directory)
+        let hardLink = directory.appendingPathComponent("hard-link")
+        try FileManager.default.linkItem(at: token, to: hardLink)
+        let parentDepth = FileManager.default.currentDirectoryPath.split(separator: "/").count
+        let relativePath = String(repeating: "../", count: parentDepth) + token.path.dropFirst()
+        let aliases = [token.path, directory.path + "/./access-token", relativePath, link.path, directoryLink.path + "/access-token", hardLink.path]
+        for outputPath in aliases {
+            let succeeded = await discoverAPI(
+                endpoint: "browse", bodyJSON: "{}", followIndices: [], limit: 1,
+                verbose: false, outputFile: outputPath, mobileClient: .ios, mobileTokenFile: token.path
+            )
+            #expect(!succeeded)
+            #expect(try Data(contentsOf: token) == original)
+            #expect(try Data(contentsOf: URL(fileURLWithPath: outputPath)) == original)
+        }
+        let missing = directory.appendingPathComponent("missing-token")
+        let succeeded = await discoverAPI(
+            endpoint: "browse", bodyJSON: "{}", followIndices: [], limit: 1,
+            verbose: false, outputFile: missing.path, mobileClient: .ios, mobileTokenFile: missing.path
+        )
+        #expect(!succeeded)
+        #expect(!FileManager.default.fileExists(atPath: missing.path))
     }
 }

--- a/Tests/APIExplorerTests/DiscoveryAuditTests.swift
+++ b/Tests/APIExplorerTests/DiscoveryAuditTests.swift
@@ -536,6 +536,20 @@ struct DiscoveryAuditTests {
 }
 
 extension DiscoveryAuditTests {
+    @Test("Client version overrides reject empty or nonnumeric components", arguments: [
+        "", ".", "1..2", "1.", ".1", "1...2", "1.a.2", "1.2\r\nInjected", "１.２", String(repeating: "1", count: 65),
+    ])
+    func rejectsMalformedClientVersion(version: String) {
+        #expect(!isValidClientVersion(version))
+    }
+
+    @Test("Client version overrides accept numeric components", arguments: [
+        "1", "9.06.4", "7.21.50", "1.20231204.01.00", String(repeating: "1", count: 64),
+    ])
+    func acceptsClientVersion(version: String) {
+        #expect(isValidClientVersion(version))
+    }
+
     @Test("Request validation rejects JSON boolean and numeric coercion", arguments: [
         #"{"videoId":"test-video","index":true}"#,
         #"{"videoId":"test-video","index":false}"#,

--- a/Tests/APIExplorerTests/DiscoveryAuditTests.swift
+++ b/Tests/APIExplorerTests/DiscoveryAuditTests.swift
@@ -45,10 +45,14 @@ struct DiscoveryAuditTests {
         #expect(request.value(forHTTPHeaderField: "User-Agent")?.contains("Android 13;") == true)
         #expect(request.value(forHTTPHeaderField: "X-Youtube-Client-Name") == "21")
         #expect(request.value(forHTTPHeaderField: "X-Youtube-Client-Version") == "7.21.50")
+        #expect(request.value(forHTTPHeaderField: "Origin") == "https://music.youtube.com")
+        #expect(request.value(forHTTPHeaderField: "Referer") == "https://music.youtube.com/")
 
         profile.applyHeaders(to: &request, cookieOnly: true, accessToken: nil, cookieHeader: "test-cookie")
         #expect(request.value(forHTTPHeaderField: "Authorization") == nil)
         #expect(request.value(forHTTPHeaderField: "Cookie") == "test-cookie")
+        #expect(request.value(forHTTPHeaderField: "Origin") == "https://music.youtube.com")
+        #expect(request.value(forHTTPHeaderField: "Referer") == "https://music.youtube.com/")
 
         profile.applyHeaders(to: &request, cookieOnly: false, accessToken: "mock-access-token")
         #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer mock-access-token")
@@ -536,6 +540,24 @@ struct DiscoveryAuditTests {
 }
 
 extension DiscoveryAuditTests {
+    @Test("Guest mobile profiles omit web headers", arguments: [MusicMobileRequestProfile.Client.ios, .android])
+    func guestMobileHeaders(client: MusicMobileRequestProfile.Client) throws {
+        let profile = MusicMobileRequestProfile(client: client)
+        for cookieOnly in [false, true] {
+            var request = try URLRequest(url: #require(URL(string: "https://music.youtube.com/youtubei/v1/browse")))
+            let webHeaders = ["X-Goog-AuthUser", "X-Goog-PageId", "X-Origin", "Origin", "Referer"]
+            for field in webHeaders {
+                request.setValue("mock-value", forHTTPHeaderField: field)
+            }
+            profile.applyHeaders(to: &request, cookieOnly: cookieOnly, accessToken: nil)
+            for field in webHeaders + ["Cookie", "Authorization"] {
+                #expect(request.value(forHTTPHeaderField: field) == nil)
+            }
+            #expect(request.value(forHTTPHeaderField: "X-Youtube-Client-Name") == client.headerID)
+            #expect(request.value(forHTTPHeaderField: "User-Agent") == profile.userAgent)
+        }
+    }
+
     @Test("Mobile cookie-only probes retain cookies without a signing cookie")
     func cookieOnlyWithoutSigningCookie() throws {
         let cookie = try #require(HTTPCookie(properties: [

--- a/docs/api-discovery.md
+++ b/docs/api-discovery.md
@@ -1,8 +1,10 @@
 # YouTube Music and YouTube API Reference
 
-> **Complete documentation of YouTube Music and regular YouTube InnerTube endpoints for Kaset development.**
+> **Working reference for YouTube Music and regular YouTube InnerTube endpoints used by Kaset.**
 >
 > This document catalogs known YouTube Music API endpoints, their authentication requirements, implementation status, and usage patterns. The same `api-explorer` tool also supports regular YouTube via `--youtube`; see [YouTube Mode](youtube.md) for the video-source architecture.
+
+The [implementation status](#implementation-status) records what Kaset supports, what is missing, and the evidence from the latest probes. Results are dated because endpoint behavior can change.
 
 ## Table of Contents
 
@@ -11,16 +13,16 @@
   - [Brand Account Support](#brand-account-support)
 - [Browse Endpoints](#browse-endpoints)
   - [Implemented](#implemented-browse-endpoints)
-  - [Available (Not Implemented)](#available-browse-endpoints)
+  - [Not implemented](#not-implemented-browse-endpoints)
 - [Action Endpoints](#action-endpoints)
   - [Implemented](#implemented-action-endpoints)
-  - [Available (Not Implemented)](#available-action-endpoints)
+  - [Not implemented](#not-implemented-action-endpoints)
 - [Undocumented Endpoints](#undocumented-endpoints)
 - [Request Patterns](#request-patterns)
 - [Response Parsing](#response-parsing)
 - [Parsers Reference](#parsers-reference)
 - [Error Handling](#error-handling)
-- [Implementation Priorities](#implementation-priorities)
+- [Implementation status](#implementation-status)
 - [Using the API Explorer](#using-the-api-explorer)
 
 ---
@@ -203,12 +205,14 @@ Browse endpoints use `POST /browse` with a `browseId` parameter.
 |-----------|------|------|-------------|--------|
 | `FEmusic_home` | Home | 🌐 | Personalized recommendations, mixes, quick picks | `HomeResponseParser` |
 | `FEmusic_explore` | Explore | 🌐 | New releases, charts, moods shortcuts | `HomeResponseParser` |
-| `FEmusic_charts` | Charts | 🌐 | Top songs, albums by country/genre | `HomeResponseParser` |
+| `FEmusic_charts` | Charts | 🌐 | Chart sections; country selection is not implemented | `HomeResponseParser` |
 | `FEmusic_moods_and_genres` | Moods & Genres | 🌐 | Browse by mood/genre grids | `HomeResponseParser` |
 | `FEmusic_new_releases` | New Releases | 🌐 | Recent albums, singles, videos | `HomeResponseParser` |
+| `FEmusic_history` | History | 🔐 | Recently played tracks, grouped by time | `HomeResponseParser` |
 | `FEmusic_library_landing` | Library Landing | 🔐 | Library content previews (playlists, albums, podcasts, artists) | `PlaylistParser.parseLibraryContent` |
 | `FEmusic_liked_playlists` | Library Playlists | 🔐 | User's saved/created playlists | `PlaylistParser` |
 | `FEmusic_liked_albums` | Library Albums | 🔐 | User's saved albums | `PlaylistParser.parseLibraryAlbumsPage` / `parseLibraryAlbumsContinuation` |
+| `FEmusic_library_corpus_artists` | Followed Artists | 🔐 | Followed artists with public channel browse IDs | `PlaylistParser.parseLibraryArtists` |
 | `FEmusic_library_privately_owned_tracks` | Uploaded Songs | 🔐 | User-uploaded songs with playlist-style rows and continuation | `PlaylistParser` |
 | `VLLM` | Liked Songs | 🔐 | All songs user has liked (with pagination) | `PlaylistParser` |
 | `VL{playlistId}` | Playlist Detail | 🌐 | Playlist tracks and metadata | `PlaylistParser` |
@@ -305,26 +309,30 @@ let body = ["browseId": "VLLM"]
 
 ---
 
-### Available Browse Endpoints
+### Not implemented browse endpoints
 
-These endpoints are functional but not yet implemented in Kaset.
+These browse paths have no dedicated integration in Kaset. The notes distinguish usable responses from sign-in prompts and failed probes.
 
-| Browse ID | Name | Auth | Priority | Notes |
-|-----------|------|------|----------|-------|
-| `FEmusic_history` | History | 🔐 | **High** | Recently played tracks |
-| `FEmusic_library_non_music_audio_list` | Subscribed Podcasts | 🔐 | Medium | User's subscribed podcast shows |
-| `FEmusic_library_corpus_track_artists` | Library Artists (Artists chip) | 🔐 | Medium | Sign-in backed; returns `MPLAUC...` library artist pages |
-| `FEmusic_library_artists` | Library Artists (param-based) | 🔐 | Medium | Requires auth + params*; distinct from the Artists chip |
-| `FEmusic_library_songs` | Library Songs | 🔐 | Low | Requires auth + params* |
-| `FEmusic_recently_played` | Recently Played | 🔐 | Medium | Requires auth |
-| `FEmusic_library_privately_owned_landing` | Uploads | 🔐 | Low | User-uploaded content |
-| `FEmusic_library_privately_owned_albums` | Uploaded Albums | 🔐 | Low | Uploaded albums |
+| Browse ID | Name | Auth | Notes |
+|-----------|------|------|-------|
+| `FEmusic_library_non_music_audio_list` | Subscribed Podcasts | 🔐 | Dedicated filtered endpoint; the app already displays podcasts from Library landing |
+| `FEmusic_library_corpus_track_artists` | Library Artists | 🔐 | Returns `MPLAUC...` library artist pages; followed artists use the implemented `FEmusic_library_corpus_artists` endpoint |
+| `FEmusic_library_artists` | Library Artists, legacy route | 🔐 | Returned HTTP 400 even with full authentication; no working request established |
+| `FEmusic_library_songs` | Library Songs | 🔐 | Historical probe returned HTTP 400; required request context remains unverified |
+| `FEmusic_recently_played` | Recently Played | 🔐 | Historical probe returned HTTP 400; History is implemented through `FEmusic_history` |
+| `FEmusic_library_privately_owned_landing` | Uploads landing | 🔐 | No dedicated landing page; Uploaded Songs is implemented separately |
+| `FEmusic_library_privately_owned_albums` | Uploaded Albums | 🔐 | Guest request returned HTTP 400 on 2026-09-04; authenticated behavior was not checked |
+| Server-issued `MPTC...` | Song credits | 🌐 | Four populated credit sections returned on 2026-09-04 |
+| Server-issued `MPTR...` | Related Music content | 🌐 | Recommendations, playlists, and artists returned on 2026-09-04 |
+| `FEmusic_radio_builder` | Radio builder | 🌐 | Form schema returned; station creation and saving were not tested |
+| `FEmusic_tastebuilder` | Taste profile | 🔐 | Guest response contained a sign-in prompt, with no artist choices |
+| `FEmusic_listening_review` | Recap | Unverified | Guest response contained context/tracking only; usable content remains unverified |
 
 > `FEmusic_library_corpus_track_artists` is the browseId behind the Library landing Artists chip. With authentication it returns `musicResponsiveListItemRenderer` rows whose `browseId` values look like `MPLAUC...` and use `pageType = MUSIC_PAGE_TYPE_LIBRARY_ARTIST`. Without authentication it still returns HTTP 200, but only with a sign-in prompt.
 >
 > `FEmusic_library_albums` is a legacy browse ID that currently returns HTTP 400. Saved albums use `FEmusic_liked_albums`; optional sorting params are not required for the default order.
->
-> \* `FEmusic_library_artists` and `FEmusic_library_songs` are separate param-based library endpoints. They return HTTP 400 without authentication and the correct `params` value.
+
+### Additional browse response details
 
 #### Uploaded Songs (`FEmusic_library_privately_owned_tracks`)
 
@@ -417,12 +425,24 @@ let body = ["browseId": "FEmusic_charts"]
 - Top albums chart
 - Trending videos
 - Genre-specific charts
-- Country-specific charts (via params)
+- Country-specific charts via `formData.selectedValues`, revalidated 2026-09-04
 
-**Implementation suggestion**:
-```swift
-func getCharts(country: String? = nil) async throws -> ChartsResponse
+The country menu exposes `musicMultiSelectMenuItemRenderer` entries backed by
+`frameworkUpdates.entityBatchUpdate.mutations[].payload.musicFormBooleanChoice`.
+The observed `opaqueToken` values are two-letter country codes, including `ZZ`
+for Global. A Japan request returned HTTP 200 with `JP` selected:
+
+```json
+{"browseId":"FEmusic_charts","formData":{"selectedValues":["JP"]}}
 ```
+
+This chart selection is separate from the client's `context.client.gl` value.
+Do not generalize chart form handling to other browse IDs: tastebuilder forms
+can change recommendation preferences.
+
+**Kaset status**: Chart sections and pagination are implemented. Country choices,
+selection requests, and a country picker are not implemented. See the
+[country discovery details](#chart-countries) for the observed menu and response.
 
 ---
 
@@ -482,6 +502,7 @@ Action endpoints perform operations or fetch specific data.
 | `search` | Search | 🌐 | Search songs, videos, albums/audiobooks, artists/profiles, playlists, podcasts, and episodes |
 | `music/get_search_suggestions` | Suggestions | 🌐 | Autocomplete for search |
 | `next` | Now Playing | 🌐 | Track info, lyrics ID, radio queue |
+| `music/get_queue` | Get Queue | 🌐 | Metadata for video IDs and playlist queues |
 | `like/like` | Like | 🔐 | Like a song/album/playlist |
 | `like/dislike` | Dislike | 🔐 | Dislike a song |
 | `like/removelike` | Remove Like | 🔐 | Remove like/dislike rating |
@@ -490,6 +511,11 @@ Action endpoints perform operations or fetch specific data.
 | `subscription/unsubscribe` | Unsubscribe | 🔐 | Unsubscribe from artist |
 | `account/accounts_list` | Accounts List | 🔐 | List all accounts (primary + brand) |
 | `account/account_menu` | Account Menu | 🔐 | Current account info and settings |
+| `playlist/get_add_to_playlist` | Add-to-Playlist Menu | 🔐 | Playlist choices cached with library TTL |
+| `browse/edit_playlist` | Edit Playlist | 🔐 | Add/remove tracks and invalidate affected caches |
+| `playlist/create` | Create Playlist | 🔐 | Create a playlist, optionally with seed videos |
+| `playlist/delete` | Delete Playlist | 🔐 | Delete a user-owned playlist when the response exposes that action |
+| `guide` | YouTube Guide | 🔐 | Regular YouTube subscriptions; no Music sidebar integration |
 
 ---
 
@@ -784,20 +810,16 @@ _ = try await request("like/removelike", body: body)
 
 ---
 
-### Available Action Endpoints
+### Not implemented action endpoints
 
-| Endpoint | Name | Auth | Priority | Notes |
-|----------|------|------|----------|-------|
-| `player` | Player | 🌐 | Medium | Video metadata, streaming URLs |
-| `music/get_queue` | Get Queue | 🌐 | **High** | Queue data for video IDs |
-| `playlist/get_add_to_playlist` | Add to Playlist | 🔐 | Medium | Get playlists for "Add to" menu; cached with library TTL |
-| `browse/edit_playlist` | Edit Playlist | 🔐 | Medium | Add/remove playlist tracks; invalidates library/menu caches |
-| `playlist/create` | Create Playlist | 🔐 | Medium | Create new playlist; supports optional seed `videoIds` |
-| `playlist/delete` | Delete Playlist | 🔐 | Low | Delete a user-owned playlist when delete affordance is present |
-| `guide` | Guide | 🌐 | Low | Sidebar structure |
-| `account/account_menu` | Account Menu | 🔐 | Low | Account settings |
+| Endpoint | Name | Auth | Notes |
+|----------|------|------|-------|
+| `player` | Player | 🌐 | No direct native-client integration; playback uses WebView. Guest responses can be `UNPLAYABLE` without streaming data |
+| `get_transcript` | YouTube Transcript | Unverified | Server-issued commands found, but both guest replays returned HTTP 400 on 2026-09-04. Captions are implemented separately |
 
 ---
+
+### Additional action response details
 
 #### Player (`player`)
 
@@ -805,7 +827,9 @@ _ = try await request("like/removelike", body: body)
 let body = ["videoId": "dQw4w9WgXcQ"]
 ```
 
-**Response** (works WITHOUT auth!):
+**Historical response example**: The 2024 probe included streaming data. On
+2026-07-01, guest Music and YouTube requests instead returned `UNPLAYABLE`
+without `streamingData`. HTTP 200 alone does not establish playability.
 ```json
 {
   "playabilityStatus": { "status": "OK" },
@@ -1036,8 +1060,8 @@ These endpoints were discovered through API exploration (2024-12-22) but are not
 
 | Endpoint | Type | Auth | Parameters | Description |
 |----------|------|------|------------|-------------|
-| `FEmusic_radio_builder` | Browse | 🌐 | - | Radio station builder UI data (form fields, artist selection) |
-| `FEmusic_liked_videos` | Browse | 🔐 | - | User's liked videos (alternative to `FEmusic_liked_videos`) |
+| `FEmusic_radio_builder` | Browse | 🌐 | - | Form dialog and chips verified on 2026-09-04; station creation/saving not tested or implemented |
+| `FEmusic_liked_videos` | Browse | 🔐 | - | Limited liked-song list; Kaset uses `VLLM` for pagination |
 
 ### Infrastructure/Internal Endpoints
 
@@ -1060,7 +1084,7 @@ These endpoints exist but return HTTP 400 without proper parameters:
 | `comment/create_comment` | Action | 🔐 | 400 | Needs `videoId`, `commentText` |
 | `comment/perform_comment_action` | Action | 🔐 | 400 | Needs action params |
 | `share/get_share_panel` | Action | 🌐 | 400 | Needs `videoId` |
-| `get_transcript` | Action | 🌐 | 400 | Needs `videoId`, `params` |
+| `get_transcript` | Action | Unverified | 400 | Server-issued WEB `next` params also returned HTTP 400 on 2026-09-04; a working request context remains unverified |
 | `live_chat/send_message` | Action | 🔐 | 400 | Needs chat params |
 | `notification/get_unseen_count` | Action | 🔐 | 400 | Needs user context |
 
@@ -1268,31 +1292,255 @@ let result = try await RetryPolicy.execute(
 
 ---
 
-## Implementation Priorities
+## Implementation status
 
-### Phase 1: High-Impact Features
+Checked against the app source on 2026-09-04. Status refers to Kaset integration,
+not API Explorer support. Partial means the existing behavior and missing parts
+are listed separately in the same row.
 
-| Feature | Endpoint | Effort | Impact |
-|---------|----------|--------|--------|
-| History | `FEmusic_history` | Medium | High |
-| Charts | `FEmusic_charts` | Low | High |
-| Moods & Genres | `FEmusic_moods_and_genres` | Low | High |
-| Queue Display | `music/get_queue` | Low | High |
+| Capability | Kaset status | Implemented and missing behavior |
+|------------|--------------|----------------------------------|
+| Home, Explore, Moods & Genres, New Releases | Implemented | Browse pages and section parsing exist; Home activity chips are listed separately below |
+| Listening history | Implemented | Recently played tracks grouped by time |
+| Saved albums | Implemented | Album collection with grid pagination |
+| Library content-type filtering | Implemented | Filters for the existing library content |
+| Library playlists and followed artists | Partial | Dedicated loads display the initial page; complete collection pagination and sorting are not implemented |
+| Uploaded Songs | Implemented | Library tile, playlist-style track rows, and track pagination |
+| Playlist creation, track editing, and deletion | Implemented | Add/remove tracks, create playlists, and delete playlists with ownership checks |
+| Podcasts | Partial | Discovery, show pages, episode progress, and played-state display exist; explicit Resume and Start Over controls are not implemented |
+| Captions | Implemented | Playback captions exist; a native transcript panel is separate |
+| Music video type parsing | Implemented | Includes `MUSIC_VIDEO_TYPE_OFFICIAL_SOURCE_MUSIC` |
+| Video quality selection | Partial | Regular YouTube has a WebView-backed quality picker; a Music video resolution picker is not implemented |
+| Charts | Partial | Chart sections and pagination exist; country selection is not implemented |
+| Radio and mix queues | Partial | Song/artist radio, mixes, queue display, and continuation exist; radio filter chips are not implemented |
+| Song credits | Not implemented | No credits parser or sheet |
+| Home activity chips | Not implemented | No chip model, selection requests, or filter row |
+| Mobile Speed dial | Not implemented | Known `IOS_MUSIC` Home model; web-cookie authentication returned HTTP 400 on mobile clients. Requires a verified mobile OAuth session before replacing Favorites |
+| Related content for the current Music track | Not implemented | No Music Related view |
+| Full radio builder | Not implemented | No form-driven station creation or saving |
+| Native YouTube transcript | Not implemented | No working transcript request or native panel |
+| Recommendation dismissal | Not implemented | Dislike and library add/remove feedback exist; Not interested for recommendations does not |
+| Taste profile onboarding | Not implemented | No artist-selection onboarding |
+| Uploaded albums/artists and library sorting | Not implemented | Uploaded Songs and content-type filtering do not cover these features |
+| Recap | Not implemented | No Recap page or parser |
+| Audio/video counterpart switch | Not implemented | The existing video button changes presentation, not the recording |
 
-### Phase 2: Library Enhancements
+The initial probes ran on 2026-09-04 in guest mode before an authentication
+export was available. The later Speed dial investigation also tested the new
+web login; each result below identifies its authentication mode. Counts describe
+individual responses, not fixed limits. No account mutations or playback
+behavior were tested.
 
-| Feature | Endpoint | Effort | Impact |
-|---------|----------|--------|--------|
-| Library Albums | `FEmusic_liked_albums` | Implemented | Medium |
-| Library Artists | `FEmusic_library_corpus_track_artists` | Medium | Medium |
-| Add to Playlist | `playlist/get_add_to_playlist` + `browse/edit_playlist` | Implemented | Medium |
+### Song credits
 
-### Phase 3: Discovery
+Searching for `Daft Punk Get Lucky` exposed a server-issued `MPTC...` browse ID
+in a row menu. Following it returned HTTP 200 with page type
+`MUSIC_PAGE_TYPE_TRACK_CREDITS`. A `dismissableDialogRenderer` contained four
+populated `dismissableDialogContentSectionRenderer` sections. Each had a title
+and nonempty subtitle runs. The roles were Performed by, Written by, Produced
+by, and Music metadata provided by.
 
-| Feature | Endpoint | Effort | Impact |
-|---------|----------|--------|--------|
-| New Releases | `FEmusic_new_releases` | Low | Medium |
-| Create Playlist | `playlist/create` | Implemented | Medium |
+Kaset's [Song model](../Sources/Kaset/Models/Song.swift),
+[SongMetadataParser](../Sources/Kaset/Services/API/Parsers/SongMetadataParser.swift),
+and [song context menus](../Sources/Kaset/Views/SharedViews/SongContextMenus.swift)
+do not expose credits. The browse ID comes from navigation and cannot be
+constructed from the video ID. Credit titles can be localized or unfamiliar;
+the observed four roles are not an exhaustive schema. Credits require a
+separate detail request, which can be deferred until the user opens them.
+
+### Home activity chips
+
+Guest Home returned 11 chips: Podcasts, Energize, Relax, Workout, Feel good,
+Commute, Sleep, Romance, Party, Focus, and Sad. Following Focus with its issued
+`FEmusic_home` browse params returned HTTP 200, `isSelected=true` for Focus,
+and three shelves instead of two. These chips are distinct from the existing
+Moods & Genres destination pages.
+
+[HomeResponse](../Sources/Kaset/Models/HomeResponse.swift) stores sections but
+no chips, and [HomeResponseParser](../Sources/Kaset/Services/API/Parsers/HomeResponseParser.swift)
+does not parse the filter bar. [YTMusicClient](../Sources/Kaset/Services/API/YTMusicClient.swift)
+owns continuation state by page type; it has no separate Home filter cache or
+continuation identity. Selecting a chip changes the request params and the
+content to which subsequent continuations belong.
+
+### Mobile Speed dial
+
+Speed dial is exposed by an existing client through the Home browse request,
+using `clientName: IOS_MUSIC`. It is not a separate known browse ID. The
+[client's Home parser](https://github.com/itsnebulalol/resonance-addons/blob/a9a6ac6d1adfd7c36da83d086bfad6840296eff9/packages/youtubemusic-addon/src/routes/catalog.ts)
+reads this path:
+
+```text
+contents.singleColumnBrowseResultsRenderer.tabs[].tabRenderer.content
+  .sectionListRenderer.contents[].itemSectionRenderer.contents[]
+  .elementRenderer.newElement.type.componentType.model
+  .musicSpeedDialShelfModel.data.items[]
+```
+
+The associated [request implementation](https://github.com/itsnebulalol/resonance-addons/blob/a9a6ac6d1adfd7c36da83d086bfad6840296eff9/packages/youtubemusic-addon/src/auth.ts)
+sends `POST https://music.youtube.com/youtubei/v1/browse?prettyPrint=false` with
+`browseId: FEmusic_home`. Its profile uses version `9.06.4`, platform `MOBILE`,
+iOS `26.2.1`, and device `iPhone18,4`. It authenticates with mobile OAuth.
+
+Verified locally on 2026-09-04:
+
+| Probe | Result |
+|-------|--------|
+| Guest `WEB_REMIX` Home | HTTP 200 with two `musicCarouselShelfRenderer` sections; no Speed dial model |
+| Guest `IOS_MUSIC` Home | HTTP 200 with mobile `elementRenderer` models. One response contained `musicGridItemCarouselModel`, `musicListItemCarouselModel`, and Quick picks; no Speed dial model |
+| Signed-in `WEB_REMIX` Home | HTTP 200; `logged_in=1` and `yt_li=1`. Returned Listen again with 20 items, but no Speed dial model |
+| `IOS_MUSIC` with web cookies and SAPISIDHASH | HTTP 400 `INVALID_ARGUMENT`. Repeated with matching client headers and with the resolved web API key; same rejection |
+| `IOS_MUSIC` with cookies but no Authorization header | HTTP 200, explicitly guest in service metadata; no Speed dial model. Adding the web API key did not authenticate it |
+| `ANDROID_MUSIC` with SAPISIDHASH | Versions `5.34.51` and `7.21.50` returned HTTP 400 `INVALID_ARGUMENT` |
+| Guest `ANDROID_MUSIC` Home | Both tested versions returned HTTP 200 with a `messageRenderer`, not a populated Home feed |
+| Mobile OAuth Home | Not tested; Kaset has no mobile OAuth session or token export |
+
+The Home request and guest iOS response format are verified. The current Kaset
+login authenticates the web client, but did not authenticate any tested mobile
+profile. A response body or HTTP 200 alone is insufficient: the cookie-only
+mobile response explicitly reported a guest session. The linked client's
+[authentication configuration](https://github.com/itsnebulalol/resonance-addons/blob/a9a6ac6d1adfd7c36da83d086bfad6840296eff9/packages/youtubemusic-addon/src/index.ts)
+requires a Google OAuth refresh token, which its request implementation exchanges
+for a mobile access token. Kaset currently has no such exchange or login flow.
+
+The Speed dial item shape below comes from that client implementation, not a
+locally captured signed-in response:
+
+| Item field | Purpose in the linked parser |
+|------------|------------------------------|
+| `title`, `thumbnail.image.sources` | Tile label and artwork |
+| `navigationCommand.innertubeCommand.browseEndpoint` | Playlist, album, or artist navigation |
+| `startPlaybackCommand.innertubeCommand.watchEndpoint` | Playback seed and playlist context |
+| `startPlaybackCommand.serialCommand.commands[].innertubeCommand.watchEndpoint` | Playback seed inside a command sequence |
+| `onLongPress.innertubeCommand.menuEndpoint.menu.menuRenderer.title.musicMenuTitleRenderer.secondaryText` | Additional metadata in the long-press menu |
+| `isShortcut` | Marks a shortcut tile; it does not establish ordinary song semantics |
+
+An artist tile can carry both browse navigation and a radio playback command.
+Those are distinct actions. Preserve issued commands rather than reducing every
+tile to a song or synthesizing a Speed dial browse ID.
+
+**App status: Not implemented.** Favorites remains unchanged. Listen again is
+not used as a substitute for the requested mobile Speed dial section. The next
+step is to establish mobile OAuth authentication and capture a populated
+`musicSpeedDialShelfModel` before implementing its parser and interface.
+
+Kaset currently requests `WEB_REMIX`, and
+[HomeResponseParser](../Sources/Kaset/Services/API/Parsers/HomeResponseParser.swift)
+does not parse `elementRenderer` mobile models. Speed dial has no dedicated app
+model or interface. API Explorer reports mobile model names, Speed dial item
+and shortcut counts, redacted read navigation, fixed API error categories, and
+server login flags from `responseContext.serviceTrackingParams`. It also reports
+web shelf labels and item counts separately, so Listen again cannot be mistaken
+for a mobile Speed dial model.
+
+**Explorer status: Implemented.** iOS and Android request profiles, web-cookie
+comparison options, and private-file OAuth input are available:
+
+```bash
+swift run api-explorer discover browse '{"browseId":"FEmusic_home"}' --ios-music --guest
+swift run api-explorer discover browse '{"browseId":"FEmusic_home"}' --ios-music -v -o /tmp/mobile-home.txt
+swift run api-explorer discover browse '{"browseId":"FEmusic_home"}' --ios-music --mobile-cookie-only
+swift run api-explorer discover browse '{"browseId":"FEmusic_home"}' --android-music --client-version 7.21.50 --guest
+swift run api-explorer discover browse '{"browseId":"FEmusic_home"}' --ios-music --mobile-token-file /path/to/private-access-token -o /tmp/mobile-oauth-home.txt
+```
+
+Without `--mobile-token-file`, mobile discovery uses saved web cookies if
+available, or guest mode when `--guest` is supplied. `--mobile-cookie-only`
+retains cookies but removes SAPISIDHASH for comparison. `--mobile-web-key` adds
+the resolved web API key; it did not fix the iOS authentication rejection.
+
+The token-file option reads an existing OAuth **access token**, not a refresh
+token. The file must be owned by the current user, have mode 0600 and no extended
+ACL, and be a regular file rather than a symlink. Its value stays in memory and
+is sent only to mobile discovery requests as Bearer authorization; web cookies
+and account-selection headers are omitted. It cannot be combined with guest
+mode, cookie-only mode, or web account selection. Do not put credentials in
+command arguments, documentation, fixtures, or chat. This option does not obtain,
+refresh, or validate a mobile credential by itself; a populated signed-in
+response still needs live verification.
+
+Both mobile profiles are restricted to `discover`, cannot be combined with
+`--youtube` or each other, and stay active on every followed request. They omit
+the web API-key lookup by default and send matching client headers and user
+agents. `--client-version` overrides the configured version. The Android default
+`5.34.51` comes from the
+[YouTube.js client definitions](https://github.com/LuanRT/YouTube.js/blob/a480854c501406cf55c9eb7ad5b540ab36a65b56/src/utils/Constants.ts)
+and is a diagnostic baseline, not a verified Home feed profile. The model and
+item counts distinguish an absent shelf from an empty one without exposing
+listening history.
+
+### Chart countries
+
+Charts exposed 69 distinct country choices across 70 menu items, including one
+duplicate. The menu uses `musicMultiSelectMenuItemRenderer` and
+`musicBrowseFormBinderCommand`. Its choices are backed by
+`frameworkUpdates.entityBatchUpdate.mutations[].payload.musicFormBooleanChoice`.
+The observed `opaqueToken` values were public two-letter country codes,
+including `ZZ` for Global.
+
+The [Japan request](#charts-femusic_charts) returned HTTP 200, explicitly
+selected `JP`, 40 list rows, and two carousels. Country selection is separate
+from `context.client.gl`, which the app currently sets to US.
+[ChartsViewModel](../Sources/Kaset/ViewModels/ChartsViewModel.swift) and
+[ChartsView](../Sources/Kaset/Views/ChartsView.swift) have no country selection;
+`getCharts` has no country argument or country-specific state.
+
+The read-only form handling verified here applies only to Charts. Home and
+tastebuilder forms can update recommendation preferences.
+
+### Related Music content
+
+For `dQw4w9WgXcQ`, `next` returned a Related tab with an `MPTR...` browse ID
+alongside the `MPLY...` Lyrics tab. Following the issued Related navigation
+returned HTTP 200, five carousels, 28 track rows, and an artist description.
+Recognized sections included You might also like, Recommended playlists,
+Similar artists, and About the artist. The page type is
+`MUSIC_PAGE_TYPE_TRACK_RELATED`. The page uses the shelf structure
+already handled by [HomeResponseParser](../Sources/Kaset/Services/API/Parsers/HomeResponseParser.swift),
+but Kaset does not load or display this tab. Preserve the issued browse ID.
+
+A recommendation is not evidence of an audio/video counterpart. None of the
+sampled queues exposed explicit counterpart fields. A recording switch remains
+unverified even though Related browsing works.
+
+### Radio queue filters
+
+A `next` request with a video seed, its `RDAMVM...` playlist, `isAudioOnly=true`,
+and `enablePersistentPlaylistPanel=true` returned 50 queue entries and eight
+chips. Recognized labels included All, Popular, Discover, Deep cuts, and Party.
+Following the issued Popular command returned HTTP 200 and 24 queue entries.
+That response did not repeat the full filter bar.
+
+[RadioQueueResult](../Sources/Kaset/Services/API/Parsers/RadioQueueParser.swift)
+stores songs and a continuation, but no filter commands. The commands carry
+server-issued playlist IDs and params. API Explorer retains the seed's audio
+and persistent-panel flags when following them.
+
+An unfiltered `nextRadioContinuationData` replay also returned HTTP 200 and 49
+entries. These probes establish queue reads, not filtered or infinite
+pagination, selected-chip persistence, or in-app playback behavior. The app's
+continuation request sends fewer fields than Explorer; comparing different
+request contexts does not establish a parser defect.
+
+### Other discovery results and limits
+
+| Area | API evidence and remaining limits |
+|------|-----------------------------------|
+| Full radio builder | `FEmusic_radio_builder` returned HTTP 200, a dialog, two chip groups, five choices, `musicWatchFormBinderCommand`, and form entities. Familiar, Popular, and Discover controls were present. Multiple artist seeds and station creation/saving were not verified. |
+| Native YouTube transcript | WEB `next` exposed `getTranscriptEndpoint` for `aircAruvnKk` and `jNQXAC9IVRw`. Both exact server-params replays to `get_transcript` returned HTTP 400. Request context and authenticated behavior remain unverified. Existing captions do not establish transcript support. |
+| Recommendation dismissal | Guest Home cards exposed Not interested and `feedbackEndpoint`. No mutation was sent. Signed-in action semantics and responses remain unverified; live validation requires an authorized disposable target. Library add/remove feedback is a separate implemented use of the same endpoint. |
+| Taste profile | `FEmusic_tastebuilder` returned HTTP 200 with a sign-in prompt and no artist choices. Authenticated content was not checked. Selection submission changes recommendation preferences. |
+| Uploaded albums/artists and library sorting | `FEmusic_library_privately_owned_albums` returned HTTP 400 as a guest. This does not establish that the endpoint is invalid. Authenticated upload menus, sorting commands, and collection continuations remain unchecked. Sorting an initial page alone would not sort the full library. |
+| Recap | `FEmusic_listening_review` returned HTTP 200 with only response context and tracking fields. No usable guest Recap response or current account entry point was established. |
+| Podcast resume | Source inspection only: episode models and UI carry progress, but conversion to `Song` drops it. WebView may already restore progress, so runtime instrumentation is needed before calling this a playback bug. `PodcastParser` currently accepts integer percentages, marks progress of at least 95% as played, and recognizes the literal English word `played`. |
+
+The [probe commands](#repeat-the-discovery-probes) reproduce the read requests.
+Upstream source helped identify candidates: ytmusicapi's
+[credits and Related methods](https://github.com/sigma67/ytmusicapi/blob/master/ytmusicapi/mixins/browsing.py),
+[country form request](https://github.com/sigma67/ytmusicapi/blob/master/ytmusicapi/mixins/charts.py),
+and [watch queue parameters](https://github.com/sigma67/ytmusicapi/blob/master/ytmusicapi/mixins/watch.py).
+These are independent client implementations, not an official API contract;
+the response claims above come from the live probes.
 
 ---
 
@@ -1324,6 +1572,71 @@ swift run api-explorer action search '{"query":"manifest"}' -o /tmp/search.json
 swift run api-explorer action search '{"query":"never gonna give you up"}'
 swift run api-explorer action player '{"videoId":"dQw4w9WgXcQ"}'
 ```
+
+### Read-only discovery
+
+`discover` inventories renderer and mobile model types, recognized UI labels, command kinds,
+and replayable navigation. It keeps opaque request parameters in memory and
+prints browse-ID families instead of content or account identifiers. Unknown
+labels and all free-form response text remain hidden. `-v` adds schema paths
+and value types, never raw response values.
+
+#### Repeat the discovery probes
+
+Start with `swift run api-explorer auth` and `swift run api-explorer list`.
+These commands reproduce the September discoveries:
+
+```bash
+swift run api-explorer discover help
+
+# Credits. Inspect the current MPTC entry before choosing its index.
+swift run api-explorer discover search '{"query":"Daft Punk Get Lucky"}' --guest
+swift run api-explorer discover search '{"query":"Daft Punk Get Lucky"}' --guest --follow 0
+
+# Home. Inspect the Focus entry, then select it with --follow N.
+swift run api-explorer discover browse '{"browseId":"FEmusic_home"}' --guest
+
+# Mobile Home. Speed dial requires a populated shelf to confirm availability.
+swift run api-explorer discover browse '{"browseId":"FEmusic_home"}' --ios-music --guest
+
+# Chart menu and a country selection, saved as a redacted report.
+swift run api-explorer discover browse '{"browseId":"FEmusic_charts"}' --guest --limit 100
+swift run api-explorer discover browse '{"browseId":"FEmusic_charts","formData":{"selectedValues":["JP"]}}' --guest -o /tmp/charts-discovery.txt
+
+# Related. Entry 0 was the Related tab in the sampled response.
+swift run api-explorer discover next '{"videoId":"dQw4w9WgXcQ"}' --guest --follow 0
+
+# Radio queue with filter commands and continuation options.
+swift run api-explorer discover next '{"videoId":"dQw4w9WgXcQ","playlistId":"RDAMVMdQw4w9WgXcQ","isAudioOnly":true,"enablePersistentPlaylistPanel":true}' --guest
+
+# Radio form schema, without submission or station creation.
+swift run api-explorer discover browse '{"browseId":"FEmusic_radio_builder"}' --guest -v
+
+# Transcript commands. Entry 0 was get_transcript in both samples.
+swift run api-explorer discover next '{"videoId":"aircAruvnKk"}' --youtube --guest --follow 0
+swift run api-explorer discover next '{"videoId":"jNQXAC9IVRw"}' --youtube --guest --follow 0
+```
+
+Indices can change when YouTube reorders content. Check each printed hop before
+using it as evidence. Repeat `--follow` for up to five hops; each index selects
+from the preceding response. Explorer reports the selected route even when its
+index is beyond the displayed `--limit`. A `get_transcript` entry is an observed read
+command, not a promise that its replay works. The September probes returned
+HTTP 400. Discovery returns a nonzero exit status on a failed request, and `-o`
+saves a redacted report even for failed HTTP responses.
+
+The allowlist includes `browse`, `search`, `next`, `player`, `music/get_queue`,
+`music/get_search_suggestions`, and `get_transcript`. Discovery refuses mutation
+endpoints and request fields. The only form exception is a single two-letter
+country selection for `FEmusic_charts`. Service command batches are inspected,
+with only the explicit transcript retrieval extracted for replay.
+
+Authentication stays consistent across hops. Cookies are used when available;
+`--guest` suppresses them. The report distinguishes the requested auth mode from
+the server's explicit session marker. Music responses often omit that marker.
+HTTP 200 and a content envelope alone do not establish authenticated content.
+Use `--body-file` for private request IDs or opaque parameters. Reports use
+owner-only file permissions and never contain raw payloads.
 
 ### Regular YouTube Mode
 
@@ -1675,6 +1988,7 @@ The `--brand` flag sets `context.user.onBehalfOfUser` in the request body. See [
 | `browse <id> [params]` | Explore a browse endpoint |
 | `action <endpoint> <json>` | Explore an action endpoint that returns a top-level JSON object |
 | `wire-action <endpoint> <json>` | Safely inspect object, array, streaming, or opaque wire responses without printing raw values |
+| `discover <endpoint> <json>` | Inventory and follow read-only navigation; `discover help` lists the supported request fields |
 | `ask-video-audit <videoId>` | Run a redacted, read-only Ask Gemini / YouChat audit without sending a prompt |
 | `ask-video-parity <videoId>` | Test ordered read-only Ask request profiles using only `next` and initial `get_panel`; never submits a chip |
 | `ask-video-live-test <videoId>` | With `--confirm-live-ai`, replay the server-issued summary chip; optionally add `--follow-up` or `--fresh-chats N` |
@@ -1692,7 +2006,13 @@ The `--brand` flag sets `context.user.onBehalfOfUser` in the request body. See [
 | Option | Description |
 |--------|-------------|
 | `-v, --verbose` | Show full raw JSON for browse/action/continuation commands; expand audit and search samples |
-| `-o, --output <file>` | Save raw output with owner-only permissions; `ask-video-audit` ignores this option |
+| `-o, --output <file>` | Save raw output with owner-only permissions; `discover` saves only a redacted report, and `ask-video-audit` ignores this option |
+| `--follow N` | Follow a numbered `discover` navigation entry; repeat for up to five hops |
+| `--limit N` | Show 1-500 `discover` entries, default 40 |
+| `--ios-music`, `--android-music` | Select one mobile Music profile for `discover`; web-cookie authentication was rejected in tested profiles |
+| `--mobile-web-key` | Include the resolved web API key in mobile discovery for request comparison |
+| `--mobile-cookie-only` | Keep web cookies but omit SAPISIDHASH in mobile discovery; tested iOS responses were guest sessions |
+| `--mobile-token-file <path>` | Use an existing OAuth access token from an owner-only mode-0600 regular file; mobile discovery only, without web cookies or web account selection |
 | `--authuser N` | Use Google account at index N |
 | `--brand <ID>` | Use brand account (21-digit ID) |
 | `--client-version <version>` | Override the resolved InnerTube client version for compatibility probes |
@@ -1720,6 +2040,9 @@ The `--brand` flag sets `context.user.onBehalfOfUser` in the request body. See [
 
 | Date | Changes |
 |------|---------|
+| 2026-09-04 | Located the mobile Speed dial Home model in an existing client; verified guest `IOS_MUSIC` Home requests, added a read-only mobile profile and model/item counts to Explorer, and recorded the missing signed-in validation |
+| 2026-09-04 | Confirmed the new web login works while tested mobile clients reject SAPISIDHASH; cookie-only iOS responses explicitly report guest. Added Android comparison, server login/error diagnostics, and private OAuth input to Explorer. Actual Speed dial remains blocked on mobile authentication; Favorites was not replaced with Listen again |
+| 2026-09-04 | Added redacted `discover` traversal, chart form selection, transcript-command inspection, and behavioral tests; verified credits, Home chips, country charts, Related content, and radio filter reads; consolidated findings, guest-only limits, and [implementation status](#implementation-status) in this reference |
 | 2026-08-03 | Live-validated two free-text prompts in one chat; retained the validated composer command across successful bound revisions, enforced one action per revision, and preserved stale-revision rejection/no-retry behavior |
 | 2026-08-02 | Browser-validated the `get_panel` free-text request and response shape; added the guarded `ask-video-free-text-test`; selected the first content-equivalent mirrored YouChat panel; documented and implemented `sendUserQueryCommand` provenance from the watch footer `chatInputViewModel`, an eligible YouChat item, or prompt-free initial `get_panel`; added redacted parity capability reporting; deduplicated repeated visible suggestions; retained server-chip follow-ups |
 | 2026-08-01 | Revalidated an eligible signed-in production watch response; added strict support for the observed local user-turn/loading `onClick` mutation, preserved direct chips while discarding ambiguous panel-only commands, and added one bounded read-only retry for internal identity-fence cancellation |
@@ -1749,14 +2072,19 @@ This section documents API functionality for the floating video window feature. 
 
 The `musicVideoType` field distinguishes between actual music videos and audio-only tracks. This is available in both `player` and `next` endpoint responses.
 
-| Video Type | Constant | Description | Has Video Content |
+| Video Type | Constant | Description | Kaset video toggle |
 |------------|----------|-------------|-------------------|
 | Official Music Video | `MUSIC_VIDEO_TYPE_OMV` | Full video from artist/label | ✅ Yes |
 | Audio Track Video | `MUSIC_VIDEO_TYPE_ATV` | Static image or visualizer | ❌ No |
-| User Generated Content | `MUSIC_VIDEO_TYPE_UGC` | Fan-made or unofficial | ⚠️ Varies |
+| User Generated Content | `MUSIC_VIDEO_TYPE_UGC` | Fan-made or unofficial | ❌ No |
+| Official-source music | `MUSIC_VIDEO_TYPE_OFFICIAL_SOURCE_MUSIC` | Official-source video search result | ❌ No |
 | Podcast Episode | `MUSIC_VIDEO_TYPE_PODCAST_EPISODE` | Audio podcast | ❌ No |
 
+All listed constants are parsed. `hasVideoContent` enables the video toggle
+only for `.omv`; `isSearchVideo` also includes `.ugc` and `.officialSourceMusic`.
+
 **Implementation**: The `MusicVideoType` enum and parsing are implemented in:
+
 - [Sources/Kaset/Models/MusicVideoType.swift](../Sources/Kaset/Models/MusicVideoType.swift) - Enum definition
 - [Sources/Kaset/Models/Song.swift](../Sources/Kaset/Models/Song.swift) - `musicVideoType` property
 - [Sources/Kaset/Services/API/Parsers/SongMetadataParser.swift](../Sources/Kaset/Services/API/Parsers/SongMetadataParser.swift) - Parsing logic
@@ -1782,13 +2110,21 @@ if song.musicVideoType?.hasVideoContent == true {
 
 ---
 
-### Video Quality Options (Future Enhancement)
+### Video quality selection
 
-The `player` endpoint returns video streaming data in `streamingData.adaptiveFormats`. This could enable a video quality selector feature.
+Regular YouTube quality selection is implemented in
+[YouTubePlayerBar](../Sources/Kaset/Views/YouTube/YouTubePlayerBar.swift) and
+[YouTubeWatchWebView](../Sources/Kaset/Views/YouTube/YouTubeWatchWebView+Scripts.swift).
+The picker reads the WebView player's available quality levels and requests
+the chosen level through `setPlaybackQualityRange`, with a
+`setPlaybackQuality` fallback. A Music video resolution picker is not implemented.
 
-> ⚠️ **Not Implemented**: Due to DRM requirements, Kaset uses WebView for playback. Direct URL streaming would bypass DRM protection. Quality selection would need to be implemented via WebView JavaScript.
+Historical `player` responses exposed formats in `streamingData.adaptiveFormats`.
+Kaset uses WebView playback rather than those URLs. Guest responses may omit
+streaming data, and the formats below are sample observations, not guaranteed
+quality choices for every video.
 
-**Available Qualities** (from `adaptiveFormats`):
+**Historical format sample** from `adaptiveFormats`:
 
 | Quality | Resolution | Codec Options |
 |---------|------------|---------------|
@@ -1820,35 +2156,26 @@ The `player` endpoint returns video streaming data in `streamingData.adaptiveFor
 }
 ```
 
-**Future Implementation Path**:
-1. Inject JavaScript into WebView to access player API
-2. Use `player.setPlaybackQuality()` or similar YouTube player methods
-3. Or: Parse available qualities and let WebView auto-select
-
 ---
 
-### Related Content / Video Alternatives (Future Enhancement)
+### Audio/video counterparts
 
-The `next` endpoint returns a Related tab that can find song/video counterparts.
+A switch between paired audio and video recordings is not implemented. The
+existing Music video button changes the presentation of the current recording.
 
-> ⚠️ **Not Implemented**: Could be used to find video version of audio-only tracks or vice versa.
-
-**Related Tab browseId Pattern**: `MPTRt_{trackId}`
-
-**Example**: For song `DyDfgMOUjCI`, the Related tab browseId is `MPTRt_5OAD9vk2OaS`
-
-**Page Type**: `MUSIC_PAGE_TYPE_TRACK_RELATED`
-
-**Use Cases**:
-- "Watch Video" button for ATV tracks that have an OMV version
-- "Listen to Audio" for users who prefer audio-only playback
-- Finding alternative versions (live, remix, etc.)
+[Related Music content](#related-music-content) was verified on 2026-09-04,
+but its recommendations do not establish a pairing. No explicit counterpart
+fields appeared in the sampled queues. Related browse IDs are server-issued
+navigation values, not values to construct from a track ID.
 
 ---
 
 ## Verification Summary
 
-The following endpoints were tested without authentication on 2024-12-21. `FEmusic_library_corpus_track_artists` was re-validated on 2026-03-24:
+The table below records historical probes from 2024-12-21, with later library
+checks noted in the rows and endpoint sections. `FEmusic_library_corpus_track_artists`
+was revalidated on 2026-03-24. See [implementation status](#implementation-status)
+for the 2026-09-04 discoveries and their verification limits.
 
 ### ✅ Working Without Auth
 
@@ -1862,7 +2189,7 @@ The following endpoints were tested without authentication on 2024-12-21. `FEmus
 | `FEmusic_podcasts` | HTTP 200 | Full response |
 | `FEmusic_library_landing` | HTTP 200 | Returns login prompt (no content) |
 | `FEmusic_library_corpus_track_artists` | HTTP 200 | Returns sign-in prompt (no artist rows) |
-| `player` | HTTP 200 | Full metadata + streaming info |
+| `player` | HTTP 200 | Streaming data appeared in the 2024 sample; 2026-07-01 guest probes returned `UNPLAYABLE` without streaming data |
 | `music/get_queue` | HTTP 200 | Full queue data |
 | `search` | HTTP 200 | Full results |
 
@@ -1884,11 +2211,11 @@ The following endpoints were tested without authentication on 2024-12-21. `FEmus
 | `FEmusic_library_albums` | HTTP 400 | Legacy saved-albums browse ID; use `FEmusic_liked_albums` |
 | `FEmusic_library_artists` | HTTP 400 | Rejected as invalid argument in current authenticated sessions |
 | `FEmusic_library_corpus_artists` | HTTP 200* | Returns followed artists with full auth and public `UC...` browseIds |
-| `FEmusic_library_songs` | HTTP 400 | Needs auth + specific `params` value |
-| `FEmusic_recently_played` | HTTP 400 | Needs auth |
+| `FEmusic_library_songs` | HTTP 400 | No working request established; required context remains unverified |
+| `FEmusic_recently_played` | HTTP 400 | No working request established; Kaset uses `FEmusic_history` |
 | `playlist/get_add_to_playlist` | HTTP 401 | Needs full auth; app caches with `APICache.TTL.library` |
 | `playlist/create` | HTTP 401 | Needs full auth; response playlist ID may be top-level or nested |
-| `browse/edit_playlist` | HTTP 401 | Needs full auth; app uses `ACTION_ADD_VIDEO` for adding tracks |
+| `browse/edit_playlist` | HTTP 401 | Needs full auth; app uses `ACTION_ADD_VIDEO` and `ACTION_REMOVE_VIDEO` for track edits |
 | `playlist/delete` | HTTP 401 | Needs full auth and user-owned playlist |
 
 > **Note on Library Artists endpoints**: `FEmusic_library_corpus_track_artists` is the sign-in-backed Artists chip browseId and returns `MPLAUC...` library artist pages. Those `MPLAUC...` pages also require authentication when browsed directly. In current authenticated sessions, the library chip also exposes `FEmusic_library_corpus_artists` with `params=ggMCCAU=`; that endpoint returns followed artists with public `UC...` browseIds and is a better source for navigation. By contrast, `FEmusic_library_artists` currently returns HTTP 400 invalid argument even with full SAPISIDHASH authentication.

--- a/docs/api-discovery.md
+++ b/docs/api-discovery.md
@@ -315,18 +315,22 @@ These browse paths have no dedicated integration in Kaset. The notes distinguish
 
 | Browse ID | Name | Auth | Notes |
 |-----------|------|------|-------|
-| `FEmusic_library_non_music_audio_list` | Subscribed Podcasts | 🔐 | Dedicated filtered endpoint; the app already displays podcasts from Library landing |
+| `FEmusic_library_non_music_audio_list` | Podcast library | 🔐 | Signed-in request returned nine grid items; the app uses the Library landing preview instead |
+| `FEmusic_library_non_music_audio_channels_list` | Podcast Channels filter | 🔐 | Issued params returned 25 channel rows, then 21 more through continuation |
+| `FEmusic_library_user_profile_channels_list` | Library Profiles filter | 🔐 | Issued params returned one user-channel row and a message; no dedicated app integration |
 | `FEmusic_library_corpus_track_artists` | Library Artists | 🔐 | Returns `MPLAUC...` library artist pages; followed artists use the implemented `FEmusic_library_corpus_artists` endpoint |
 | `FEmusic_library_artists` | Library Artists, legacy route | 🔐 | Returned HTTP 400 even with full authentication; no working request established |
-| `FEmusic_library_songs` | Library Songs | 🔐 | Historical probe returned HTTP 400; required request context remains unverified |
+| `FEmusic_library_songs` | Library Songs, legacy route | 🔐 | Historical probe returned HTTP 400; the current Library Songs chip issues `FEmusic_liked_videos` |
 | `FEmusic_recently_played` | Recently Played | 🔐 | Historical probe returned HTTP 400; History is implemented through `FEmusic_history` |
 | `FEmusic_library_privately_owned_landing` | Uploads landing | 🔐 | No dedicated landing page; Uploaded Songs is implemented separately |
-| `FEmusic_library_privately_owned_albums` | Uploaded Albums | 🔐 | Guest request returned HTTP 400 on 2026-09-04; authenticated behavior was not checked |
+| `FEmusic_library_privately_owned_releases` | Uploaded Albums | 🔐 | Server-issued Albums chip returned a signed-in empty-state response; populated album rows remain unverified |
+| `FEmusic_library_privately_owned_artists` | Uploaded Artists | 🔐 | Server-issued Artists chip returned a signed-in empty-state response; populated artist rows remain unverified |
+| `FEmusic_library_privately_owned_albums` | Uploaded Albums, legacy probe | 🔐 | Guest and signed-in requests returned HTTP 400; the issued Albums route uses `privately_owned_releases` |
 | Server-issued `MPTC...` | Song credits | 🌐 | Four populated credit sections returned on 2026-09-04 |
 | Server-issued `MPTR...` | Related Music content | 🌐 | Recommendations, playlists, and artists returned on 2026-09-04 |
 | `FEmusic_radio_builder` | Radio builder | 🌐 | Form schema returned; station creation and saving were not tested |
-| `FEmusic_tastebuilder` | Taste profile | 🔐 | Guest response contained a sign-in prompt, with no artist choices |
-| `FEmusic_listening_review` | Recap | Unverified | Guest response contained context/tracking only; usable content remains unverified |
+| `FEmusic_tastebuilder` | Taste profile | 🔐 | Signed-in response contained 1,700 item renderers across 120 lists; acceptance and selection submission were not sent |
+| `FEmusic_listening_review` | Recap | 🔐 | Signed-in request returned a message, without usable Recap content |
 
 > `FEmusic_library_corpus_track_artists` is the browseId behind the Library landing Artists chip. With authentication it returns `musicResponsiveListItemRenderer` rows whose `browseId` values look like `MPLAUC...` and use `pageType = MUSIC_PAGE_TYPE_LIBRARY_ARTIST`. Without authentication it still returns HTTP 200, but only with a sign-in prompt.
 >
@@ -357,10 +361,10 @@ let body = ["browseId": "FEmusic_library_landing"]
 ```
 
 **Response structure**:
-- Returns all library content in a single `gridRenderer`
+- Returns mixed library items in a paginated `gridRenderer`
 - Includes: Playlists (`VL*`), Podcasts (`MPSPP*`), artist/profile tiles (`UC*`), Profiles, Auto playlists
 - Contains filter chips for: Playlists, Podcasts, Songs, Albums, Artists, Profiles
-- Each chip's `browseEndpoint.browseId` provides the filtered endpoint
+- Each chip's `browseEndpoint.browseId` provides the filtered endpoint; signed-in selections can wrap it in `commandExecutorCommand.commands`
 - The landing grid may expose artist tiles as `UC*`, but the filtered Artists chip returns library-artist browse IDs instead
 
 **Filter chip endpoints discovered**:
@@ -1073,7 +1077,7 @@ These endpoints exist but are primarily for YouTube's internal use:
 | `reel/reel_item_watch` | Action | 🌐 | `{}` | Returns status tracking params (YouTube Shorts related) |
 | `log_event` | Action | 🌐 | `{}` | Analytics/telemetry logging endpoint |
 | `att/get` | Action | 🌐 | `{}` | Anti-bot/botguard challenge data |
-| `FEmusic_listening_review` | Browse | 🌐 | - | Returns only responseContext (Year in Review?) |
+| `FEmusic_listening_review` | Browse | 🔐 | - | Signed-in sample returned a message; usable Recap content remains unverified |
 
 ### Endpoints Requiring Parameters
 
@@ -1303,11 +1307,13 @@ are listed separately in the same row.
 | Home, Explore, Moods & Genres, New Releases | Implemented | Browse pages and section parsing exist; Home activity chips are listed separately below |
 | Listening history | Implemented | Recently played tracks grouped by time |
 | Saved albums | Implemented | Album collection with grid pagination |
-| Library content-type filtering | Implemented | Filters for the existing library content |
+| Library content-type filtering | Partial | Local filters cover the existing collections; the server's Songs, Profiles, and podcast Channels filters are not integrated |
 | Library playlists and followed artists | Partial | Dedicated loads display the initial page; complete collection pagination and sorting are not implemented |
+| Library sorting | Not implemented | Signed-in Library and playlist sort reloads are verified; no native sorting controls or sort-specific continuation state |
+| Library Profiles | Not implemented | The server-issued Profiles route works; no dedicated profile collection or Library filter |
 | Uploaded Songs | Implemented | Library tile, playlist-style track rows, and track pagination |
 | Playlist creation, track editing, and deletion | Implemented | Add/remove tracks, create playlists, and delete playlists with ownership checks |
-| Podcasts | Partial | Discovery, show pages, episode progress, and played-state display exist; explicit Resume and Start Over controls are not implemented |
+| Podcasts | Partial | Discovery, show pages, episode progress, and played-state display exist; dedicated Library/Channels requests and explicit Resume and Start Over controls are not implemented |
 | Captions | Implemented | Playback captions exist; a native transcript panel is separate |
 | Music video type parsing | Implemented | Includes `MUSIC_VIDEO_TYPE_OFFICIAL_SOURCE_MUSIC` |
 | Video quality selection | Partial | Regular YouTube has a WebView-backed quality picker; a Music video resolution picker is not implemented |
@@ -1321,15 +1327,85 @@ are listed separately in the same row.
 | Native YouTube transcript | Not implemented | No working transcript request or native panel |
 | Recommendation dismissal | Not implemented | Dislike and library add/remove feedback exist; Not interested for recommendations does not |
 | Taste profile onboarding | Not implemented | No artist-selection onboarding |
-| Uploaded albums/artists and library sorting | Not implemented | Uploaded Songs and content-type filtering do not cover these features |
+| Uploaded albums/artists | Not implemented | Their issued browse routes return signed-in empty states; Uploaded Songs is implemented separately |
 | Recap | Not implemented | No Recap page or parser |
 | Audio/video counterpart switch | Not implemented | The existing video button changes presentation, not the recording |
 
 The initial probes ran on 2026-09-04 in guest mode before an authentication
-export was available. The later Speed dial investigation also tested the new
-web login; each result below identifies its authentication mode. Counts describe
-individual responses, not fixed limits. No account mutations or playback
-behavior were tested.
+export was available. Later Speed dial and account discovery used the saved web
+login. Each result below identifies its authentication mode. Counts describe
+renderers in individual responses, not unique records or fixed limits. No account
+mutations or playback behavior were tested.
+
+### Authenticated Library and account discovery
+
+Verified on 2026-09-04 with saved Kaset cookies and the `WEB_REMIX` client.
+Home, Library, and the successful account-specific requests explicitly reported
+a signed-in server session. Credentials and personalized response values stayed
+out of reports. These probes used the web session; they do not establish mobile
+OAuth authentication.
+
+| Read | Verified response |
+|------|-------------------|
+| Library landing | HTTP 200, 25 grid items, six content chips, and three sort choices. Its next-page request returned eight more items. |
+| Library sorting | Following the issued Recently saved reload returned HTTP 200, 25 grid items, and a sort-menu title of Recently saved. |
+| Playlist sorting | The dedicated playlist page offered Recently saved, A to Z, and Z to A. Following A to Z returned HTTP 200, 20 grid items, and a matching sort-menu title. |
+| Playlist pagination | Following the default playlist page's next continuation returned HTTP 200 with no additional item renderers or next-page navigation. |
+| Podcast library | Following Podcasts returned HTTP 200 and nine grid items through `FEmusic_library_non_music_audio_list`. |
+| Podcast Channels | The Channels chip issued `FEmusic_library_non_music_audio_channels_list` with params. It returned 25 user-channel rows and selected both Podcasts and Channels. The next continuation returned 21 more channel rows. |
+| Profiles | The Profiles chip issued `FEmusic_library_user_profile_channels_list` with params. It returned HTTP 200, one user-channel row, a message, and three sort choices. |
+| Upload Albums and Artists | Their issued routes returned HTTP 200 with selected filter chips and a message, without album or artist rows. The Albums route is `FEmusic_library_privately_owned_releases`; the older `privately_owned_albums` probe still returned HTTP 400 while signed in. |
+| Listening history | HTTP 200 with 199 track rows across four shelves. Removal commands were observed but not sent. |
+| Taste profile | HTTP 200 with `tastebuilderRenderer`, 120 item lists, and 1,700 item renderers containing selection and impression form fields. No acceptance or selection submission was sent. |
+| Recap | HTTP 200 with a signed-in session and a `messageRenderer`, without Recap data. |
+| YouTube transcript | Signed-in WEB `next` issued `getTranscriptEndpoint` for `jNQXAC9IVRw`; replaying its exact params returned HTTP 400 `FAILED_PRECONDITION`. Authentication alone did not make this request work. |
+
+The six Library chips target Playlists, Podcasts, Songs, Albums, Artists, and
+Profiles. Songs currently issues `FEmusic_liked_videos`. The issued Profiles and
+podcast Channels requests include params; this investigation did not establish
+an equivalent params-free request.
+
+Library selection commands differ from the direct browse navigation seen in
+guest Home. A chip's read is under
+`chipCloudChipRenderer.navigationEndpoint.commandExecutorCommand.commands[].browseEndpoint`.
+The batch also contains `musicLibraryPersistLaunchNavigationCommand`.
+Sort options use
+`musicMultiSelectMenuItemRenderer.selectedCommand.commandExecutorCommand.commands[]`
+with a `browseSectionListReloadEndpoint.continuation.reloadContinuationData`
+read and checkbox-update siblings. Explorer extracts the browse read, retains
+the current filter context for reloads, and does not execute the other commands.
+Returned sort-menu titles confirm the selected sort. Sorting across every page
+and native UI ordering remain untested.
+
+The taste builder's `acceptButton` is inspected as schema only. Its browse-like
+shape does not make acceptance an ordinary discovery route. Selection values
+remain private, and discovery does not expose an acceptance navigation entry.
+
+Kaset's [Library view](../Sources/Kaset/Views/LibraryView.swift) filters already
+loaded collections locally. Its
+[Library loader](../Sources/Kaset/Services/API/YTMusicClient.swift) reads podcast
+shows from the landing preview and has no dedicated podcast Channels or Profiles
+load. Library sorting, full collection pagination, and those dedicated reads
+are concrete additions supported by these responses. Uploaded album/artist
+parsers still need a populated account fixture before implementation.
+
+**Explorer status: Implemented.** Bundled chip reads, sort reloads, redacted
+sort-menu titles, and non-replayable taste acceptance are covered by tests.
+**App status:** The missing integrations remain as listed in the table above.
+
+```bash
+swift run api-explorer auth
+swift run api-explorer discover browse '{"browseId":"FEmusic_library_landing"}' --limit 20
+
+# Inspect current indices before following these sampled selections.
+swift run api-explorer discover browse '{"browseId":"FEmusic_library_landing"}' --follow 7
+swift run api-explorer discover browse '{"browseId":"FEmusic_liked_playlists"}' --follow 3
+swift run api-explorer discover browse '{"browseId":"FEmusic_library_landing"}' --follow 1 --follow 2 --follow 6
+swift run api-explorer discover browse '{"browseId":"FEmusic_library_landing"}' --follow 5
+swift run api-explorer discover browse '{"browseId":"FEmusic_library_privately_owned_landing"}' --follow 2
+swift run api-explorer discover browse '{"browseId":"FEmusic_tastebuilder"}'
+swift run api-explorer discover browse '{"browseId":"FEmusic_listening_review"}'
+```
 
 ### Song credits
 
@@ -1527,11 +1603,11 @@ request contexts does not establish a parser defect.
 | Area | API evidence and remaining limits |
 |------|-----------------------------------|
 | Full radio builder | `FEmusic_radio_builder` returned HTTP 200, a dialog, two chip groups, five choices, `musicWatchFormBinderCommand`, and form entities. Familiar, Popular, and Discover controls were present. Multiple artist seeds and station creation/saving were not verified. |
-| Native YouTube transcript | WEB `next` exposed `getTranscriptEndpoint` for `aircAruvnKk` and `jNQXAC9IVRw`. Both exact server-params replays to `get_transcript` returned HTTP 400. Request context and authenticated behavior remain unverified. Existing captions do not establish transcript support. |
-| Recommendation dismissal | Guest Home cards exposed Not interested and `feedbackEndpoint`. No mutation was sent. Signed-in action semantics and responses remain unverified; live validation requires an authorized disposable target. Library add/remove feedback is a separate implemented use of the same endpoint. |
-| Taste profile | `FEmusic_tastebuilder` returned HTTP 200 with a sign-in prompt and no artist choices. Authenticated content was not checked. Selection submission changes recommendation preferences. |
-| Uploaded albums/artists and library sorting | `FEmusic_library_privately_owned_albums` returned HTTP 400 as a guest. This does not establish that the endpoint is invalid. Authenticated upload menus, sorting commands, and collection continuations remain unchecked. Sorting an initial page alone would not sort the full library. |
-| Recap | `FEmusic_listening_review` returned HTTP 200 with only response context and tracking fields. No usable guest Recap response or current account entry point was established. |
+| Native YouTube transcript | WEB `next` exposed `getTranscriptEndpoint` for `aircAruvnKk` and `jNQXAC9IVRw`. Guest exact-params replays returned HTTP 400. The signed-in replay for `jNQXAC9IVRw` also returned HTTP 400 `FAILED_PRECONDITION`. A working request remains unverified; existing captions do not establish transcript support. |
+| Recommendation dismissal | Guest and signed-in Home cards exposed Not interested and `feedbackEndpoint`; signed-in Home also exposed Don't recommend channel. No mutation was sent, so action semantics and responses remain unverified. Library add/remove feedback is a separate implemented use of the same endpoint. |
+| Taste profile | Signed-in content is verified in [account discovery](#authenticated-library-and-account-discovery). Artist choices exist; acceptance and submission remain untested. |
+| Uploaded albums/artists and library sorting | [Account discovery](#authenticated-library-and-account-discovery) verified the issued upload routes with empty states, populated sort reloads, and collection continuations. Populated upload records and sorting across all pages remain unverified. |
+| Recap | Guest `FEmusic_listening_review` returned context/tracking only; the signed-in request returned a message. Neither response established usable Recap data. |
 | Podcast resume | Source inspection only: episode models and UI carry progress, but conversion to `Song` drops it. WebView may already restore progress, so runtime instrumentation is needed before calling this a playback bug. `PodcastParser` currently accepts integer percentages, marks progress of at least 95% as played, and recognizes the literal English word `played`. |
 
 The [probe commands](#repeat-the-discovery-probes) reproduce the read requests.
@@ -1628,8 +1704,10 @@ saves a redacted report even for failed HTTP responses.
 The allowlist includes `browse`, `search`, `next`, `player`, `music/get_queue`,
 `music/get_search_suggestions`, and `get_transcript`. Discovery refuses mutation
 endpoints and request fields. The only form exception is a single two-letter
-country selection for `FEmusic_charts`. Service command batches are inspected,
-with only the explicit transcript retrieval extracted for replay.
+country selection for `FEmusic_charts`. It extracts direct browse reads from
+Library chip and sort-selection batches, without executing persistence or
+checkbox-update siblings. Other service commands remain schema-only, except
+explicit transcript reads. Taste-profile acceptance is not replayable.
 
 Authentication stays consistent across hops. Cookies are used when available;
 `--guest` suppresses them. The report distinguishes the requested auth mode from
@@ -2040,6 +2118,7 @@ The `--brand` flag sets `context.user.onBehalfOfUser` in the request body. See [
 
 | Date | Changes |
 |------|---------|
+| 2026-09-04 | Verified signed-in Library filters, sort reloads, pagination, podcast Channels, Profiles, upload empty states, and taste-builder data. Added safe selection-read extraction and blocked taste acceptance in Explorer; recorded Recap and authenticated transcript limits |
 | 2026-09-04 | Located the mobile Speed dial Home model in an existing client; verified guest `IOS_MUSIC` Home requests, added a read-only mobile profile and model/item counts to Explorer, and recorded the missing signed-in validation |
 | 2026-09-04 | Confirmed the new web login works while tested mobile clients reject SAPISIDHASH; cookie-only iOS responses explicitly report guest. Added Android comparison, server login/error diagnostics, and private OAuth input to Explorer. Actual Speed dial remains blocked on mobile authentication; Favorites was not replaced with Listen again |
 | 2026-09-04 | Added redacted `discover` traversal, chart form selection, transcript-command inspection, and behavioral tests; verified credits, Home chips, country charts, Related content, and radio filter reads; consolidated findings, guest-only limits, and [implementation status](#implementation-status) in this reference |

--- a/docs/api-discovery.md
+++ b/docs/api-discovery.md
@@ -514,7 +514,6 @@ Action endpoints perform operations or fetch specific data.
 | `subscription/subscribe` | Subscribe | 🔐 | Subscribe to artist |
 | `subscription/unsubscribe` | Unsubscribe | 🔐 | Unsubscribe from artist |
 | `account/accounts_list` | Accounts List | 🔐 | List all accounts (primary + brand) |
-| `account/account_menu` | Account Menu | 🔐 | Current account info and settings |
 | `playlist/get_add_to_playlist` | Add-to-Playlist Menu | 🔐 | Playlist choices cached with library TTL |
 | `browse/edit_playlist` | Edit Playlist | 🔐 | Add/remove tracks and invalidate affected caches |
 | `playlist/create` | Create Playlist | 🔐 | Create a playlist, optionally with seed videos |
@@ -1073,7 +1072,7 @@ These endpoints exist but are primarily for YouTube's internal use:
 
 | Endpoint | Type | Auth | Parameters | Notes |
 |----------|------|------|------------|-------|
-| `account/account_menu` | Action | 🌐/🔐 | `{}` | Returns account menu structure (settings, premium promo) |
+| `account/account_menu` | Action | 🌐/🔐 | `{}` | Not implemented; allowlisted for authentication but has no app caller or parser. Account selection uses `account/accounts_list` |
 | `reel/reel_item_watch` | Action | 🌐 | `{}` | Returns status tracking params (YouTube Shorts related) |
 | `log_event` | Action | 🌐 | `{}` | Analytics/telemetry logging endpoint |
 | `att/get` | Action | 🌐 | `{}` | Anti-bot/botguard challenge data |
@@ -1327,6 +1326,7 @@ are listed separately in the same row.
 | Native YouTube transcript | Not implemented | No working transcript request or native panel |
 | Recommendation dismissal | Not implemented | Dislike and library add/remove feedback exist; Not interested for recommendations does not |
 | Taste profile onboarding | Not implemented | No artist-selection onboarding |
+| Account menu | Not implemented | No `account/account_menu` caller or parser; account selection uses the implemented `account/accounts_list` endpoint |
 | Uploaded albums/artists | Not implemented | Their issued browse routes return signed-in empty states; Uploaded Songs is implemented separately |
 | Recap | Not implemented | No Recap page or parser |
 | Audio/video counterpart switch | Not implemented | The existing video button changes presentation, not the recording |
@@ -1458,7 +1458,8 @@ sends `POST https://music.youtube.com/youtubei/v1/browse?prettyPrint=false` with
 `browseId: FEmusic_home`. Its profile uses version `9.06.4`, platform `MOBILE`,
 iOS `26.2.1`, and device `iPhone18,4`. It authenticates with mobile OAuth.
 
-Verified locally on 2026-09-04:
+Verified locally on 2026-09-04, with the Android rows rechecked on 2026-09-05
+using a matching Android 13 / API level 33 profile:
 
 | Probe | Result |
 |-------|--------|
@@ -1530,15 +1531,19 @@ token. The file must be owned by the current user, have mode 0600 and no extende
 ACL, and be a regular file rather than a symlink. Its value stays in memory and
 is sent only to mobile discovery requests as Bearer authorization; web cookies
 and account-selection headers are omitted. It cannot be combined with guest
-mode, cookie-only mode, or web account selection. Do not put credentials in
-command arguments, documentation, fixtures, or chat. This option does not obtain,
+mode, cookie-only mode, or web account selection. A report destination that refers
+to the token file is rejected before loading credentials or making requests.
+Invalid token files produce a separate diagnostic without printing their contents.
+Do not put credentials in command arguments, documentation, fixtures, or chat.
+This option does not obtain,
 refresh, or validate a mobile credential by itself; a populated signed-in
 response still needs live verification.
 
 Both mobile profiles are restricted to `discover`, cannot be combined with
 `--youtube` or each other, and stay active on every followed request. They omit
 the web API-key lookup by default and send matching client headers and user
-agents. `--client-version` overrides the configured version. The Android default
+agents. The Android profile pairs Android 13 with SDK level 33; its user agent
+also declares Android 13. `--client-version` overrides the configured version. The Android default
 `5.34.51` comes from the
 [YouTube.js client definitions](https://github.com/LuanRT/YouTube.js/blob/a480854c501406cf55c9eb7ad5b540ab36a65b56/src/utils/Constants.ts)
 and is a diagnostic baseline, not a verified Home feed profile. The model and
@@ -1653,9 +1658,11 @@ swift run api-explorer action player '{"videoId":"dQw4w9WgXcQ"}'
 
 `discover` inventories renderer and mobile model types, recognized UI labels, command kinds,
 and replayable navigation. It keeps opaque request parameters in memory and
-prints browse-ID families instead of content or account identifiers. Unknown
-labels and all free-form response text remain hidden. `-v` adds schema paths
-and value types, never raw response values.
+prints browse-ID families instead of content or account identifiers. Only known
+schema names, public routes, and content types are printed; unknown names are
+redacted. Labels are recognized only on specific chip, header, and menu renderers,
+so a song or playlist named Focus does not become a UI label. `-v` adds schema
+paths and value types, never raw response values.
 
 #### Repeat the discovery probes
 
@@ -1713,6 +1720,8 @@ Authentication stays consistent across hops. Cookies are used when available;
 `--guest` suppresses them. The report distinguishes the requested auth mode from
 the server's explicit session marker. Music responses often omit that marker.
 HTTP 200 and a content envelope alone do not establish authenticated content.
+Rechecked on 2026-09-05 with saved cookies available: a guest Home request and
+its followed chip request both explicitly reported guest sessions.
 Use `--body-file` for private request IDs or opaque parameters. Reports use
 owner-only file permissions and never contain raw payloads.
 
@@ -2118,6 +2127,7 @@ The `--brand` flag sets `context.user.onBehalfOfUser` in the request body. See [
 
 | Date | Changes |
 |------|---------|
+| 2026-09-05 | Tightened discovery redaction, JSON scalar validation, and token-file diagnostics and overwrite protection. Rechecked Android with a consistent OS/SDK profile and verified guest hops; corrected Account menu implementation status |
 | 2026-09-04 | Verified signed-in Library filters, sort reloads, pagination, podcast Channels, Profiles, upload empty states, and taste-builder data. Added safe selection-read extraction and blocked taste acceptance in Explorer; recorded Recap and authenticated transcript limits |
 | 2026-09-04 | Located the mobile Speed dial Home model in an existing client; verified guest `IOS_MUSIC` Home requests, added a read-only mobile profile and model/item counts to Explorer, and recorded the missing signed-in validation |
 | 2026-09-04 | Confirmed the new web login works while tested mobile clients reject SAPISIDHASH; cookie-only iOS responses explicitly report guest. Added Android comparison, server login/error diagnostics, and private OAuth input to Explorer. Actual Speed dial remains blocked on mobile authentication; Favorites was not replaced with Listen again |

--- a/docs/api-discovery.md
+++ b/docs/api-discovery.md
@@ -1458,13 +1458,14 @@ sends `POST https://music.youtube.com/youtubei/v1/browse?prettyPrint=false` with
 `browseId: FEmusic_home`. Its profile uses version `9.06.4`, platform `MOBILE`,
 iOS `26.2.1`, and device `iPhone18,4`. It authenticates with mobile OAuth.
 
-Verified locally on 2026-09-04, with the Android rows rechecked on 2026-09-05
-using a matching Android 13 / API level 33 profile:
+Initial probes ran on 2026-09-04. The guest mobile rows and Android web-cookie
+comparisons were rechecked on 2026-09-05. Guest mobile probes omit browser
+headers; Android uses a matching Android 13 / API level 33 profile.
 
 | Probe | Result |
 |-------|--------|
 | Guest `WEB_REMIX` Home | HTTP 200 with two `musicCarouselShelfRenderer` sections; no Speed dial model |
-| Guest `IOS_MUSIC` Home | HTTP 200 with mobile `elementRenderer` models. One response contained `musicGridItemCarouselModel`, `musicListItemCarouselModel`, and Quick picks; no Speed dial model |
+| Guest `IOS_MUSIC` Home | HTTP 200, explicitly guest, with mobile `elementRenderer` and `musicGridItemCarouselModel` content; no Speed dial model |
 | Signed-in `WEB_REMIX` Home | HTTP 200; `logged_in=1` and `yt_li=1`. Returned Listen again with 20 items, but no Speed dial model |
 | `IOS_MUSIC` with web cookies and SAPISIDHASH | HTTP 400 `INVALID_ARGUMENT`. Repeated with matching client headers and with the resolved web API key; same rejection |
 | `IOS_MUSIC` with cookies but no Authorization header | HTTP 200, explicitly guest in service metadata; no Speed dial model. Adding the web API key did not authenticate it |
@@ -1543,7 +1544,9 @@ response still needs live verification.
 Both mobile profiles are restricted to `discover`, cannot be combined with
 `--youtube` or each other, and stay active on every followed request. They omit
 the web API-key lookup by default and send matching client headers and user
-agents. The Android profile pairs Android 13 with SDK level 33; its user agent
+agents. Guest and OAuth requests omit `Origin`, `Referer`, `X-Origin`, and web
+account-selection headers. These headers are retained for web-cookie comparisons.
+The Android profile pairs Android 13 with SDK level 33; its user agent
 also declares Android 13. `--client-version` overrides the configured version. The Android default
 `5.34.51` comes from the
 [YouTube.js client definitions](https://github.com/LuanRT/YouTube.js/blob/a480854c501406cf55c9eb7ad5b540ab36a65b56/src/utils/Constants.ts)

--- a/docs/api-discovery.md
+++ b/docs/api-discovery.md
@@ -1523,7 +1523,8 @@ swift run api-explorer discover browse '{"browseId":"FEmusic_home"}' --ios-music
 
 Without `--mobile-token-file`, mobile discovery uses saved web cookies if
 available, or guest mode when `--guest` is supplied. `--mobile-cookie-only`
-retains cookies but removes SAPISIDHASH for comparison. `--mobile-web-key` adds
+retains available cookies even when no signing cookie is present, but omits
+SAPISIDHASH for comparison. `--mobile-web-key` adds
 the resolved web API key; it did not fix the iOS authentication rejection.
 
 The token-file option reads an existing OAuth **access token**, not a refresh
@@ -1724,6 +1725,9 @@ Rechecked on 2026-09-05 with saved cookies available: a guest Home request and
 its followed chip request both explicitly reported guest sessions.
 Use `--body-file` for private request IDs or opaque parameters. Reports use
 owner-only file permissions and never contain raw payloads.
+Discovery rejects report paths that alias either the request-body file or mobile
+token file, including symlink and hard-link aliases. Standard input via
+`--body-file -` is not a file destination.
 
 ### Regular YouTube Mode
 

--- a/docs/api-discovery.md
+++ b/docs/api-discovery.md
@@ -1523,7 +1523,9 @@ swift run api-explorer discover browse '{"browseId":"FEmusic_home"}' --ios-music
 ```
 
 Without `--mobile-token-file`, mobile discovery uses saved web cookies if
-available, or guest mode when `--guest` is supplied. `--mobile-cookie-only`
+available, or guest mode when `--guest` is supplied. Discovery captures cookies
+once and reuses them for every followed request and web configuration lookup.
+`--mobile-cookie-only`
 retains available cookies even when no signing cookie is present, but omits
 SAPISIDHASH for comparison. `--mobile-web-key` adds
 the resolved web API key; it did not fix the iOS authentication rejection.
@@ -1534,7 +1536,9 @@ ACL, and be a regular file rather than a symlink. Its value stays in memory and
 is sent only to mobile discovery requests as Bearer authorization; web cookies
 and account-selection headers are omitted. It cannot be combined with guest
 mode, cookie-only mode, or web account selection. A report destination that refers
-to the token file is rejected before loading credentials or making requests.
+to the token file, selected cookie archive, or request-body file is rejected
+before loading credentials or making requests. This includes symlink and
+hard-link aliases and a regular file redirected into `--body-file -`.
 Invalid token files produce a separate diagnostic without printing their contents.
 Do not put credentials in command arguments, documentation, fixtures, or chat.
 This option does not obtain,


### PR DESCRIPTION
## Description

API Explorer can now follow server-issued read-only routes and report response structure without printing raw values. `docs/api-discovery.md` collects guest and authenticated findings and marks Kaset capabilities as implemented, partial, or not implemented.

## Type of Change

- [x] New feature
- [x] Documentation update
- [x] Test update

## Changes Made

- Add `discover` with an endpoint and field allowlist, bounded traversal, repeatable `--follow` navigation, and redacted schema/report output.
- Extract browse reads from authenticated Library chip and sort-selection commands while excluding persistence, checkbox updates, and taste-profile acceptance from replay.
- Add iOS and Android Music probes, server authentication diagnostics, and existing OAuth access-token input from private files. Keep mobile client and device headers consistent, reject malformed client-version overrides, and omit web origin and account-selection headers for guest and OAuth probes.
- Reject report destinations that alias request-body files, OAuth token files, or the selected cookie archive, including symlinks, hard links, and files redirected into stdin.
- Capture saved cookies once per discovery chain and reuse them for every followed request and web configuration lookup.
- Document verified credits, Home activity chips, chart countries, Related content, and radio queue reads. Add signed-in Library sorting and pagination, podcast Channels, Profiles, upload empty states, and taste-profile data, with the remaining Recap and transcript limits.

Actual mobile Speed dial remains **not implemented in Kaset**. Web credentials authenticate web Home but fail to authenticate the tested mobile clients. A populated mobile OAuth response is still needed before replacing Favorites.

## Testing

- `swift build`
- `swift test --skip KasetUITests --filter 'DiscoveryAuditTests|APIExplorerActionRoutingTests'`: 44 tests passed.
- `swiftlint --strict --quiet`, SwiftFormat on the changed Swift files, and `git diff --check`.
- Read-only live probes with guest and signed-in web sessions, including Library selections and continuations. Mobile authentication comparisons did not establish a working mobile OAuth session.
- CLI regression check confirms redirected request input remains unchanged when used as the report destination.

## Checklist

- [x] Changes follow the project's formatting and lint rules.
- [x] Tests cover mutation rejection, Library selection replay, traversal, redaction, mobile headers and version validation, private-file handling, output aliases, and cookie snapshots.
- [x] Discovery documentation includes implementation status and verification limits.
- [x] Review findings are resolved.

