### PR TITLE
fix(ui): correct sidebar highlight spacing

### DIFF
--- a/Sources/Kaset/Views/SharedViews/KasetSidebarRow.swift
+++ b/Sources/Kaset/Views/SharedViews/KasetSidebarRow.swift
@@ -42,6 +42,8 @@ struct KasetSidebarRow: View {
         if self.isSelected {
             RoundedRectangle(cornerRadius: 8, style: .continuous)
                 .fill(Color.secondary.opacity(0.22))
+                .padding(.horizontal, 8)
+                .padding(.vertical, 2)
         }
     }
 }

--- a/Sources/Kaset/Views/SharedViews/KasetSidebarRow.swift
+++ b/Sources/Kaset/Views/SharedViews/KasetSidebarRow.swift
@@ -21,6 +21,7 @@ struct KasetSidebarRow: View {
             Label {
                 Text(self.title)
                     .lineLimit(1)
+                    .fontWeight(self.isSelected ? .semibold : .regular)
                     .foregroundStyle(.primary)
             } icon: {
                 Image(systemName: self.systemImage)
@@ -28,11 +29,11 @@ struct KasetSidebarRow: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.vertical, 5)
-            .background(self.selectionBackground)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .listRowInsets(EdgeInsets(top: 1, leading: 10, bottom: 1, trailing: 10))
+        .listRowBackground(self.selectionBackground)
         .accessibilityAddTraits(self.isSelected ? .isSelected : [])
     }
 


### PR DESCRIPTION
Give selected sidebar rows a rounded gray highlight with space around the icon and a margin at each sidebar edge. Draw the background on the list row with 8 points of horizontal padding and 2 points of vertical padding, and make the selected title semibold. The shared row applies to Music, YouTube, and pinned items.

## Testing

- `swift build`
- `swift test --skip KasetUITests --filter KasetSidebarRowTests`, with the built Sparkle framework directory added to `DYLD_FRAMEWORK_PATH` for Xcode 27 beta
- `swiftlint --strict --quiet`
- `swiftformat --lint . --quiet`
