### PR TITLE
fix(auth): preserve live WebKit login when archive is unavailable

### DIFF
--- a/Sources/Kaset/KasetApp.swift
+++ b/Sources/Kaset/KasetApp.swift
@@ -225,7 +225,7 @@ struct KasetApp: App {
                 Color.clear
                     .frame(width: 1, height: 1)
             } else {
-                let startupState = self.authService.state
+                let startupState = self.authService.startupState
                 MainWindow(
                     navigationSelection: self.$navigationSelection,
                     youtubeNavigationSelection: self.$youtubeNavigationSelection,
@@ -283,18 +283,22 @@ struct KasetApp: App {
                     }
                 }
                 .task(id: startupState) {
+                    guard let startupState else { return }
                     DiagnosticsLogger.app.info("KasetApp: Root task started")
                     let signOutSequence = self.authService.signOutSequence
                     // Check if user is already logged in from previous session
                     guard await self.authService.checkLoginStatusForStartup(
                         expectedState: startupState
                     ), !Task.isCancelled,
-                    self.authService.state == startupState,
+                    self.authService.startupState == startupState,
                     self.authService.signOutSequence == signOutSequence
                     else { return }
                     DiagnosticsLogger.app.info("KasetApp: Login status check complete")
                     if !self.didCompleteStartupPlaybackCleanup {
-                        if self.authService.state.isLoggedIn {
+                        if self.authService.signOutSequence > 0 {
+                            self.playerService.clearPlaybackForSignOut()
+                            self.youtubePlayerService.stop()
+                        } else if self.authService.state.isLoggedIn {
                             self.playerService.clearGuestPlaybackForAuthenticatedStartup()
                         } else {
                             self.playerService.clearPlaybackForGuestStartup()

--- a/Sources/Kaset/KasetApp.swift
+++ b/Sources/Kaset/KasetApp.swift
@@ -225,6 +225,7 @@ struct KasetApp: App {
                 Color.clear
                     .frame(width: 1, height: 1)
             } else {
+                let startupState = self.authService.state
                 MainWindow(
                     navigationSelection: self.$navigationSelection,
                     youtubeNavigationSelection: self.$youtubeNavigationSelection,
@@ -281,10 +282,16 @@ struct KasetApp: App {
                         self.handleIncomingURL(url)
                     }
                 }
-                .task {
+                .task(id: startupState) {
                     DiagnosticsLogger.app.info("KasetApp: Root task started")
+                    let signOutSequence = self.authService.signOutSequence
                     // Check if user is already logged in from previous session
-                    await self.authService.checkLoginStatus()
+                    guard await self.authService.checkLoginStatusForStartup(
+                        expectedState: startupState
+                    ), !Task.isCancelled,
+                    self.authService.state == startupState,
+                    self.authService.signOutSequence == signOutSequence
+                    else { return }
                     DiagnosticsLogger.app.info("KasetApp: Login status check complete")
                     if !self.didCompleteStartupPlaybackCleanup {
                         if self.authService.state.isLoggedIn {
@@ -297,11 +304,14 @@ struct KasetApp: App {
                     }
                     self.drainPendingIncomingURLsIfReady()
 
-                    // Fetch accounts after login check (for account switcher)
+                    // This task owns account loading for startup, login, and recovery.
+                    self.accountService?.authenticationIdentityDidChange()
                     await self.accountService?.fetchAccounts()
 
                     // Warm up Foundation Models in background (macOS 26+ only)
-                    if !self.settings.useLegacyMacOS15UI, #available(macOS 26.0, *) {
+                    if !self.settings.useLegacyMacOS15UI, #available(macOS 26.0, *),
+                       !FoundationModelsService.shared.isWarmedUp
+                    {
                         await FoundationModelsService.shared.warmup()
                     }
                 }

--- a/Sources/Kaset/Resources/Localizable.xcstrings
+++ b/Sources/Kaset/Resources/Localizable.xcstrings
@@ -12752,6 +12752,112 @@
     },
     "Item %lld": {},
     "Kaset": {},
+    "Kaset could not read saved sign-in data. Retry to restore your session.": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تعذّر على Kaset قراءة بيانات تسجيل الدخول المحفوظة. أعد المحاولة لاستعادة جلستك."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaset konnte die gespeicherten Anmeldedaten nicht lesen. Versuche es erneut, um deine Sitzung wiederherzustellen."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaset could not read saved sign-in data. Retry to restore your session."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaset no pudo leer los datos de inicio de sesión guardados. Reinténtalo para restaurar tu sesión."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaset n'a pas pu lire les données de connexion enregistrées. Réessayez pour restaurer votre session."
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaset tidak dapat membaca data masuk yang tersimpan. Coba lagi untuk memulihkan sesi Anda."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaset non ha potuto leggere i dati di accesso salvati. Riprova per ripristinare la sessione."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaset이 저장된 로그인 데이터를 읽지 못했습니다. 세션을 복원하려면 재시도하세요."
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaset kon de opgeslagen aanmeldgegevens niet lezen. Probeer het opnieuw om je sessie te herstellen."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaset nie mógł odczytać zapisanych danych logowania. Spróbuj ponownie, aby przywrócić sesję."
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "O Kaset não conseguiu ler os dados de início de sessão guardados. Tente novamente para restaurar a sua sessão."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaset не удалось прочитать сохранённые данные для входа. Повторите попытку, чтобы восстановить сеанс."
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaset kunde inte läsa sparade inloggningsdata. Försök igen för att återställa din session."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaset kayıtlı oturum açma verilerini okuyamadı. Oturumunuzu geri yüklemek için tekrar deneyin."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaset не вдалося прочитати збережені дані входу. Повторіть спробу, щоб відновити сеанс."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaset 无法读取已保存的登录数据。请重试以恢复会话。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kaset 無法讀取已儲存的登入資料。請重試以還原工作階段。"
+          }
+        }
+      }
+    },
     "Kaset could not safely clear saved sign-in data. Retry before signing in again.": {
       "localizations": {
         "ar": {
@@ -25173,6 +25279,112 @@
           "stringUnit": {
             "state": "translated",
             "value": "登出"
+          }
+        }
+      }
+    },
+    "Sign-In Temporarily Unavailable": {
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تسجيل الدخول غير متاح مؤقتًا"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anmeldung vorübergehend nicht verfügbar"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sign-In Temporarily Unavailable"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inicio de sesión no disponible temporalmente"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connexion temporairement indisponible"
+          }
+        },
+        "id": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Masuk sementara tidak tersedia"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accesso temporaneamente non disponibile"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "일시적으로 로그인할 수 없음"
+          }
+        },
+        "nl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aanmelden tijdelijk niet beschikbaar"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Logowanie tymczasowo niedostępne"
+          }
+        },
+        "pt": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Início de sessão temporariamente indisponível"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вход временно недоступен"
+          }
+        },
+        "sv": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inloggning tillfälligt otillgänglig"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oturum Açma Geçici Olarak Kullanılamıyor"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вхід тимчасово недоступний"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暂时无法登录"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "暫時無法登入"
           }
         }
       }

--- a/Sources/Kaset/Resources/ar.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/ar.lproj/Localizable.strings
@@ -213,6 +213,8 @@
 "Kaset works without login for public browsing, search, and playback. Sign in to access personal music collections." = "يعمل Kaset من دون تسجيل دخول للتصفح العام والبحث والتشغيل. سجّل الدخول للوصول إلى مجموعات الموسيقى الشخصية.";
 "Kaset works without login for public YouTube search, discovery, and playback. Sign in to access personal video collections." = "يعمل Kaset من دون تسجيل دخول للبحث العام في YouTube والاكتشاف والتشغيل. سجّل الدخول للوصول إلى مجموعات الفيديو الشخصية.";
 "Kaset could not safely clear saved sign-in data. Retry before signing in again." = "تعذّر على Kaset مسح بيانات تسجيل الدخول المحفوظة بأمان. أعد المحاولة قبل تسجيل الدخول مرة أخرى.";
+"Sign-In Temporarily Unavailable" = "تسجيل الدخول غير متاح مؤقتًا";
+"Kaset could not read saved sign-in data. Retry to restore your session." = "تعذّر على Kaset قراءة بيانات تسجيل الدخول المحفوظة. أعد المحاولة لاستعادة جلستك.";
 "Kaset could not remove saved sign-in data. Try signing out again before quitting." = "تعذّر على Kaset إزالة بيانات تسجيل الدخول المحفوظة. حاول تسجيل الخروج مرة أخرى قبل إنهاء التطبيق.";
 "Keep a playing video in a floating window when you leave the page. When off, the video stops instead." = "أبقِ الفيديو الجاري تشغيله في نافذة عائمة عند مغادرة الصفحة. عند إيقافه، سيتوقف الفيديو بدلًا من ذلك.";
 "Keep listening even when the window is closed" = "استمر في الاستماع حتى عند إغلاق النافذة";

--- a/Sources/Kaset/Resources/de.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/de.lproj/Localizable.strings
@@ -213,6 +213,8 @@
 "Kaset works without login for public browsing, search, and playback. Sign in to access personal music collections." = "Kaset funktioniert ohne Anmeldung für öffentliches Browsen, Suchen und Wiedergeben. Melde dich an, um auf persönliche Musiksammlungen zuzugreifen.";
 "Kaset works without login for public YouTube search, discovery, and playback. Sign in to access personal video collections." = "Kaset funktioniert ohne Anmeldung für öffentliche YouTube-Suche, Entdecken und Wiedergabe. Melde dich an, um auf persönliche Videosammlungen zuzugreifen.";
 "Kaset could not safely clear saved sign-in data. Retry before signing in again." = "Kaset konnte die gespeicherten Anmeldedaten nicht sicher löschen. Versuche es erneut, bevor du dich wieder anmeldest.";
+"Sign-In Temporarily Unavailable" = "Anmeldung vorübergehend nicht verfügbar";
+"Kaset could not read saved sign-in data. Retry to restore your session." = "Kaset konnte die gespeicherten Anmeldedaten nicht lesen. Versuche es erneut, um deine Sitzung wiederherzustellen.";
 "Kaset could not remove saved sign-in data. Try signing out again before quitting." = "Kaset konnte die gespeicherten Anmeldedaten nicht entfernen. Versuche vor dem Beenden erneut, dich abzumelden.";
 "Keep a playing video in a floating window when you leave the page. When off, the video stops instead." = "Halte ein laufendes Video in einem schwebenden Fenster, wenn du die Seite verlässt. Ist die Option aus, stoppt das Video stattdessen.";
 "Keep listening even when the window is closed" = "Weiterhören, auch wenn das Fenster geschlossen ist";

--- a/Sources/Kaset/Resources/en.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/en.lproj/Localizable.strings
@@ -17,6 +17,8 @@
 "Kaset could not remove saved sign-in data. Try signing out again before quitting." = "Kaset could not remove saved sign-in data. Try signing out again before quitting.";
 "Sign-In Cleanup Required" = "Sign-In Cleanup Required";
 "Kaset could not safely clear saved sign-in data. Retry before signing in again." = "Kaset could not safely clear saved sign-in data. Retry before signing in again.";
+"Sign-In Temporarily Unavailable" = "Sign-In Temporarily Unavailable";
+"Kaset could not read saved sign-in data. Retry to restore your session." = "Kaset could not read saved sign-in data. Retry to restore your session.";
 
 // YouTube Ask Gemini
 "Ask Gemini" = "Ask Gemini";

--- a/Sources/Kaset/Resources/es.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/es.lproj/Localizable.strings
@@ -213,6 +213,8 @@
 "Kaset works without login for public browsing, search, and playback. Sign in to access personal music collections." = "Kaset funciona sin iniciar sesión para explorar, buscar y reproducir contenido público. Inicia sesión para acceder a tus colecciones personales de música.";
 "Kaset works without login for public YouTube search, discovery, and playback. Sign in to access personal video collections." = "Kaset funciona sin iniciar sesión para la búsqueda pública, el descubrimiento y la reproducción en YouTube. Inicia sesión para acceder a tus colecciones personales de videos.";
 "Kaset could not safely clear saved sign-in data. Retry before signing in again." = "Kaset no pudo borrar de forma segura los datos de inicio de sesión guardados. Reinténtalo antes de volver a iniciar sesión.";
+"Sign-In Temporarily Unavailable" = "Inicio de sesión no disponible temporalmente";
+"Kaset could not read saved sign-in data. Retry to restore your session." = "Kaset no pudo leer los datos de inicio de sesión guardados. Reinténtalo para restaurar tu sesión.";
 "Kaset could not remove saved sign-in data. Try signing out again before quitting." = "Kaset no pudo eliminar los datos de inicio de sesión guardados. Intenta cerrar sesión de nuevo antes de salir.";
 "Keep a playing video in a floating window when you leave the page. When off, the video stops instead." = "Mantén un video en reproducción en una ventana flotante al salir de la página. Si está desactivado, el video se detiene.";
 "Keep listening even when the window is closed" = "Sigue escuchando aunque la ventana esté cerrada";

--- a/Sources/Kaset/Resources/fr.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/fr.lproj/Localizable.strings
@@ -213,6 +213,8 @@
 "Kaset works without login for public browsing, search, and playback. Sign in to access personal music collections." = "Kaset fonctionne sans connexion pour la navigation publique, la recherche et la lecture. Connectez-vous pour accéder à vos collections musicales personnelles.";
 "Kaset works without login for public YouTube search, discovery, and playback. Sign in to access personal video collections." = "Kaset fonctionne sans connexion pour la recherche publique, la découverte et la lecture sur YouTube. Connectez-vous pour accéder à vos collections vidéo personnelles.";
 "Kaset could not safely clear saved sign-in data. Retry before signing in again." = "Kaset n’a pas pu effacer en toute sécurité les données de connexion enregistrées. Réessayez avant de vous reconnecter.";
+"Sign-In Temporarily Unavailable" = "Connexion temporairement indisponible";
+"Kaset could not read saved sign-in data. Retry to restore your session." = "Kaset n'a pas pu lire les données de connexion enregistrées. Réessayez pour restaurer votre session.";
 "Kaset could not remove saved sign-in data. Try signing out again before quitting." = "Kaset n’a pas pu supprimer les données de connexion enregistrées. Essayez de vous déconnecter à nouveau avant de quitter.";
 "Keep a playing video in a floating window when you leave the page. When off, the video stops instead." = "Garde une vidéo en cours de lecture dans une fenêtre flottante quand vous quittez la page. Sinon, la vidéo s'arrête.";
 "Keep listening even when the window is closed" = "Continuer l'écoute même lorsque la fenêtre est fermée";

--- a/Sources/Kaset/Resources/id.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/id.lproj/Localizable.strings
@@ -213,6 +213,8 @@
 "Kaset works without login for public browsing, search, and playback. Sign in to access personal music collections." = "Kaset berfungsi tanpa login untuk penelusuran, pencarian, dan pemutaran publik. Masuk untuk mengakses koleksi musik pribadi.";
 "Kaset works without login for public YouTube search, discovery, and playback. Sign in to access personal video collections." = "Kaset berfungsi tanpa login untuk pencarian, penemuan, dan pemutaran YouTube publik. Masuk untuk mengakses koleksi video pribadi.";
 "Kaset could not safely clear saved sign-in data. Retry before signing in again." = "Kaset tidak dapat menghapus data masuk yang tersimpan dengan aman. Coba lagi sebelum masuk kembali.";
+"Sign-In Temporarily Unavailable" = "Masuk sementara tidak tersedia";
+"Kaset could not read saved sign-in data. Retry to restore your session." = "Kaset tidak dapat membaca data masuk yang tersimpan. Coba lagi untuk memulihkan sesi Anda.";
 "Kaset could not remove saved sign-in data. Try signing out again before quitting." = "Kaset tidak dapat menghapus data masuk yang tersimpan. Coba keluar lagi sebelum menutup aplikasi.";
 "Keep a playing video in a floating window when you leave the page. When off, the video stops instead." = "Pertahankan video yang sedang diputar di jendela mengambang saat Anda meninggalkan halaman. Jika nonaktif, video akan berhenti.";
 "Keep listening even when the window is closed" = "Lanjutkan mendengarkan meski jendela ditutup";

--- a/Sources/Kaset/Resources/it.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/it.lproj/Localizable.strings
@@ -213,6 +213,8 @@
 "Kaset works without login for public browsing, search, and playback. Sign in to access personal music collections." = "Kaset funziona senza accesso per navigazione pubblica, ricerca e riproduzione. Accedi per vedere le tue raccolte musicali personali.";
 "Kaset works without login for public YouTube search, discovery, and playback. Sign in to access personal video collections." = "Kaset funziona senza accesso per ricerca pubblica, scoperta e riproduzione su YouTube. Accedi per vedere le tue raccolte video personali.";
 "Kaset could not safely clear saved sign-in data. Retry before signing in again." = "Kaset non ha potuto eliminare in modo sicuro i dati di accesso salvati. Riprova prima di accedere di nuovo.";
+"Sign-In Temporarily Unavailable" = "Accesso temporaneamente non disponibile";
+"Kaset could not read saved sign-in data. Retry to restore your session." = "Kaset non ha potuto leggere i dati di accesso salvati. Riprova per ripristinare la sessione.";
 "Kaset could not remove saved sign-in data. Try signing out again before quitting." = "Kaset non ha potuto rimuovere i dati di accesso salvati. Prova a disconnetterti di nuovo prima di uscire.";
 "Keep a playing video in a floating window when you leave the page. When off, the video stops instead." = "Mantieni un video in riproduzione in una finestra mobile quando lasci la pagina. Se disattivato, il video si interrompe.";
 "Keep listening even when the window is closed" = "Continua ad ascoltare anche quando la finestra è chiusa";

--- a/Sources/Kaset/Resources/ko.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/ko.lproj/Localizable.strings
@@ -213,6 +213,8 @@
 "Kaset works without login for public browsing, search, and playback. Sign in to access personal music collections." = "Kaset은 로그인 없이 공개 탐색, 검색 및 재생을 사용할 수 있습니다. 개인 음악 모음을 보려면 로그인하세요.";
 "Kaset works without login for public YouTube search, discovery, and playback. Sign in to access personal video collections." = "Kaset은 로그인 없이 공개 YouTube 검색, 탐색 및 재생을 사용할 수 있습니다. 개인 동영상 모음을 보려면 로그인하세요.";
 "Kaset could not safely clear saved sign-in data. Retry before signing in again." = "Kaset이 저장된 로그인 데이터를 안전하게 지우지 못했습니다. 다시 로그인하기 전에 재시도하세요.";
+"Sign-In Temporarily Unavailable" = "일시적으로 로그인할 수 없음";
+"Kaset could not read saved sign-in data. Retry to restore your session." = "Kaset이 저장된 로그인 데이터를 읽지 못했습니다. 세션을 복원하려면 재시도하세요.";
 "Kaset could not remove saved sign-in data. Try signing out again before quitting." = "Kaset이 저장된 로그인 데이터를 제거하지 못했습니다. 앱을 종료하기 전에 다시 로그아웃해 보세요.";
 "Keep a playing video in a floating window when you leave the page. When off, the video stops instead." = "페이지를 벗어나도 재생 중인 비디오를 떠 있는 윈도우에 유지합니다. 끄면 대신 비디오가 중지됩니다.";
 "Keep listening even when the window is closed" = "창이 닫혀도 계속 재생";

--- a/Sources/Kaset/Resources/nl.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/nl.lproj/Localizable.strings
@@ -213,6 +213,8 @@
 "Kaset works without login for public browsing, search, and playback. Sign in to access personal music collections." = "Kaset werkt zonder inloggen voor openbaar bladeren, zoeken en afspelen. Log in voor toegang tot persoonlijke muziekcollecties.";
 "Kaset works without login for public YouTube search, discovery, and playback. Sign in to access personal video collections." = "Kaset werkt zonder inloggen voor openbare YouTube-zoekopdrachten, ontdekking en weergave. Log in voor toegang tot persoonlijke videocollecties.";
 "Kaset could not safely clear saved sign-in data. Retry before signing in again." = "Kaset kon de opgeslagen aanmeldgegevens niet veilig wissen. Probeer het opnieuw voordat je je weer aanmeldt.";
+"Sign-In Temporarily Unavailable" = "Aanmelden tijdelijk niet beschikbaar";
+"Kaset could not read saved sign-in data. Retry to restore your session." = "Kaset kon de opgeslagen aanmeldgegevens niet lezen. Probeer het opnieuw om je sessie te herstellen.";
 "Kaset could not remove saved sign-in data. Try signing out again before quitting." = "Kaset kon de opgeslagen aanmeldgegevens niet verwijderen. Probeer opnieuw af te melden voordat je stopt.";
 "Keep a playing video in a floating window when you leave the page. When off, the video stops instead." = "Houd een afspelende video in een zwevend venster wanneer je de pagina verlaat. Als dit uit staat, stopt de video.";
 "Keep listening even when the window is closed" = "Blijf luisteren, zelfs wanneer het venster is gesloten";

--- a/Sources/Kaset/Resources/pl.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/pl.lproj/Localizable.strings
@@ -213,6 +213,8 @@
 "Kaset works without login for public browsing, search, and playback. Sign in to access personal music collections." = "Kaset działa bez logowania w przypadku publicznego przeglądania, wyszukiwania i odtwarzania. Zaloguj się, aby uzyskać dostęp do osobistych kolekcji muzyki.";
 "Kaset works without login for public YouTube search, discovery, and playback. Sign in to access personal video collections." = "Kaset działa bez logowania w przypadku publicznego wyszukiwania, odkrywania i odtwarzania w YouTube. Zaloguj się, aby uzyskać dostęp do osobistych kolekcji wideo.";
 "Kaset could not safely clear saved sign-in data. Retry before signing in again." = "Kaset nie mógł bezpiecznie usunąć zapisanych danych logowania. Spróbuj ponownie przed kolejnym logowaniem.";
+"Sign-In Temporarily Unavailable" = "Logowanie tymczasowo niedostępne";
+"Kaset could not read saved sign-in data. Retry to restore your session." = "Kaset nie mógł odczytać zapisanych danych logowania. Spróbuj ponownie, aby przywrócić sesję.";
 "Kaset could not remove saved sign-in data. Try signing out again before quitting." = "Kaset nie mógł usunąć zapisanych danych logowania. Spróbuj wylogować się ponownie przed zamknięciem aplikacji.";
 "Keep a playing video in a floating window when you leave the page. When off, the video stops instead." = "Utrzymuj odtwarzany film w pływającym oknie po opuszczeniu strony. Gdy opcja jest wyłączona, film zatrzyma się.";
 "Keep listening even when the window is closed" = "Kontynuuj słuchanie nawet po zamknięciu okna";

--- a/Sources/Kaset/Resources/pt.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/pt.lproj/Localizable.strings
@@ -213,6 +213,8 @@
 "Kaset works without login for public browsing, search, and playback. Sign in to access personal music collections." = "O Kaset funciona sem iniciar sessão para exploração, pesquisa e reprodução públicas. Inicie sessão para aceder a coleções pessoais de música.";
 "Kaset works without login for public YouTube search, discovery, and playback. Sign in to access personal video collections." = "O Kaset funciona sem iniciar sessão para pesquisa, descoberta e reprodução públicas no YouTube. Inicie sessão para aceder a coleções pessoais de vídeos.";
 "Kaset could not safely clear saved sign-in data. Retry before signing in again." = "O Kaset não conseguiu limpar em segurança os dados de início de sessão guardados. Tente novamente antes de iniciar sessão outra vez.";
+"Sign-In Temporarily Unavailable" = "Início de sessão temporariamente indisponível";
+"Kaset could not read saved sign-in data. Retry to restore your session." = "O Kaset não conseguiu ler os dados de início de sessão guardados. Tente novamente para restaurar a sua sessão.";
 "Kaset could not remove saved sign-in data. Try signing out again before quitting." = "O Kaset não conseguiu remover os dados de início de sessão guardados. Tente terminar sessão novamente antes de sair.";
 "Keep a playing video in a floating window when you leave the page. When off, the video stops instead." = "Mantenha um vídeo em reprodução numa janela flutuante quando sair da página. Se estiver desativado, o vídeo para em vez disso.";
 "Keep listening even when the window is closed" = "Continue a ouvir mesmo quando a janela estiver fechada";

--- a/Sources/Kaset/Resources/ru.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/ru.lproj/Localizable.strings
@@ -213,6 +213,8 @@
 "Kaset works without login for public browsing, search, and playback. Sign in to access personal music collections." = "Kaset работает без входа для публичного просмотра, поиска и воспроизведения. Войдите, чтобы получить доступ к личным музыкальным коллекциям.";
 "Kaset works without login for public YouTube search, discovery, and playback. Sign in to access personal video collections." = "Kaset работает без входа для публичного поиска, рекомендаций и воспроизведения на YouTube. Войдите, чтобы получить доступ к личным коллекциям видео.";
 "Kaset could not safely clear saved sign-in data. Retry before signing in again." = "Kaset не удалось безопасно удалить сохранённые данные для входа. Повторите попытку перед новым входом.";
+"Sign-In Temporarily Unavailable" = "Вход временно недоступен";
+"Kaset could not read saved sign-in data. Retry to restore your session." = "Kaset не удалось прочитать сохранённые данные для входа. Повторите попытку, чтобы восстановить сеанс.";
 "Kaset could not remove saved sign-in data. Try signing out again before quitting." = "Kaset не удалось удалить сохранённые данные для входа. Попробуйте выйти ещё раз перед завершением работы.";
 "Keep a playing video in a floating window when you leave the page. When off, the video stops instead." = "Оставляет воспроизводящееся видео в плавающем окне, когда вы покидаете страницу. Если выключено, видео останавливается.";
 "Keep listening even when the window is closed" = "Продолжайте слушать, даже когда окно закрыто";

--- a/Sources/Kaset/Resources/sv.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/sv.lproj/Localizable.strings
@@ -213,6 +213,8 @@
 "Kaset works without login for public browsing, search, and playback. Sign in to access personal music collections." = "Kaset fungerar utan inloggning för offentlig bläddring, sökning och uppspelning. Logga in för att komma åt personliga musiksamlingar.";
 "Kaset works without login for public YouTube search, discovery, and playback. Sign in to access personal video collections." = "Kaset fungerar utan inloggning för offentlig YouTube-sökning, upptäckt och uppspelning. Logga in för att komma åt personliga videosamlingar.";
 "Kaset could not safely clear saved sign-in data. Retry before signing in again." = "Kaset kunde inte rensa sparade inloggningsdata på ett säkert sätt. Försök igen innan du loggar in på nytt.";
+"Sign-In Temporarily Unavailable" = "Inloggning tillfälligt otillgänglig";
+"Kaset could not read saved sign-in data. Retry to restore your session." = "Kaset kunde inte läsa sparade inloggningsdata. Försök igen för att återställa din session.";
 "Kaset could not remove saved sign-in data. Try signing out again before quitting." = "Kaset kunde inte ta bort sparade inloggningsdata. Försök logga ut igen innan du avslutar.";
 "Keep a playing video in a floating window when you leave the page. When off, the video stops instead." = "Behåll en spelande video i ett flytande fönster när du lämnar sidan. När det är av stannar videon i stället.";
 "Keep listening even when the window is closed" = "Fortsätt lyssna även när fönstret är stängt";

--- a/Sources/Kaset/Resources/tr.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/tr.lproj/Localizable.strings
@@ -213,6 +213,8 @@
 "Kaset works without login for public browsing, search, and playback. Sign in to access personal music collections." = "Kaset, herkese açık gezinme, arama ve oynatma için giriş yapmadan çalışır. Kişisel müzik koleksiyonlarına erişmek için giriş yapın.";
 "Kaset works without login for public YouTube search, discovery, and playback. Sign in to access personal video collections." = "Kaset, herkese açık YouTube araması, keşif ve oynatma için giriş yapmadan çalışır. Kişisel video koleksiyonlarına erişmek için giriş yapın.";
 "Kaset could not safely clear saved sign-in data. Retry before signing in again." = "Kaset kayıtlı oturum açma verilerini güvenli bir şekilde temizleyemedi. Yeniden oturum açmadan önce tekrar deneyin.";
+"Sign-In Temporarily Unavailable" = "Oturum Açma Geçici Olarak Kullanılamıyor";
+"Kaset could not read saved sign-in data. Retry to restore your session." = "Kaset kayıtlı oturum açma verilerini okuyamadı. Oturumunuzu geri yüklemek için tekrar deneyin.";
 "Kaset could not remove saved sign-in data. Try signing out again before quitting." = "Kaset kayıtlı oturum açma verilerini kaldıramadı. Uygulamadan çıkmadan önce yeniden çıkış yapmayı deneyin.";
 "Keep a playing video in a floating window when you leave the page. When off, the video stops instead." = "Sayfadan ayrıldığınızda oynatılan videoyu kayan bir pencerede tutar. Kapalıysa video bunun yerine durur.";
 "Keep listening even when the window is closed" = "Pencere kapalıyken bile dinlemeye devam edin";

--- a/Sources/Kaset/Resources/uk.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/uk.lproj/Localizable.strings
@@ -213,6 +213,8 @@
 "Kaset works without login for public browsing, search, and playback. Sign in to access personal music collections." = "Kaset працює без входу для публічного перегляду, пошуку й відтворення. Увійдіть, щоб отримати доступ до особистих музичних колекцій.";
 "Kaset works without login for public YouTube search, discovery, and playback. Sign in to access personal video collections." = "Kaset працює без входу для публічного пошуку, рекомендацій і відтворення на YouTube. Увійдіть, щоб отримати доступ до особистих колекцій відео.";
 "Kaset could not safely clear saved sign-in data. Retry before signing in again." = "Kaset не вдалося безпечно видалити збережені дані входу. Повторіть спробу перед новим входом.";
+"Sign-In Temporarily Unavailable" = "Вхід тимчасово недоступний";
+"Kaset could not read saved sign-in data. Retry to restore your session." = "Kaset не вдалося прочитати збережені дані входу. Повторіть спробу, щоб відновити сеанс.";
 "Kaset could not remove saved sign-in data. Try signing out again before quitting." = "Kaset не вдалося видалити збережені дані входу. Спробуйте вийти ще раз перед завершенням роботи.";
 "Keep a playing video in a floating window when you leave the page. When off, the video stops instead." = "Залишає відео, що відтворюється, у плаваючому вікні, коли ви залишаєте сторінку. Якщо вимкнено, відео зупиняється.";
 "Keep listening even when the window is closed" = "Продовжуйте слухати, навіть коли вікно закрито";

--- a/Sources/Kaset/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/zh-Hans.lproj/Localizable.strings
@@ -218,6 +218,8 @@
 "Kaset can't access its own audio output. Open System Settings → Privacy & Security → Screen & System Audio Recording and enable Kaset, then toggle the equalizer on again." = "Kaset 无法访问自身的音频输出。请打开“系统设置 → 隐私与安全性 → 屏幕与系统音频录制”并启用 Kaset，然后重新打开均衡器。";
 "Kaset could not remove saved sign-in data. Try signing out again before quitting." = "Kaset 无法移除已保存的登录数据。请在退出前重新尝试退出登录。";
 "Kaset could not safely clear saved sign-in data. Retry before signing in again." = "Kaset 无法安全地清除已保存的登录数据。请重试后再登录。";
+"Sign-In Temporarily Unavailable" = "暂时无法登录";
+"Kaset could not read saved sign-in data. Retry to restore your session." = "Kaset 无法读取已保存的登录数据。请重试以恢复会话。";
 "Kaset creates fresh AI sessions per request. Refresh the status if Apple Intelligence finishes downloading or becomes available while the app is open." = "Kaset 会为每个请求创建全新的 AI 会话。如果 Apple Intelligence 在应用运行期间完成下载或变为可用，请刷新状态。";
 "Kaset works without login for public YouTube search, discovery, and playback. Sign in to access personal video collections." = "无需登录即可使用 Kaset 进行公开的 YouTube 搜索、发现和播放。登录后可访问个人视频收藏。";
 "Kaset works without login for public browsing, search, and playback. Sign in to access personal music collections." = "无需登录即可使用 Kaset 进行公开浏览、搜索和播放。登录后可访问个人音乐收藏。";

--- a/Sources/Kaset/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Sources/Kaset/Resources/zh-Hant.lproj/Localizable.strings
@@ -218,6 +218,8 @@
 "Kaset can't access its own audio output. Open System Settings → Privacy & Security → Screen & System Audio Recording and enable Kaset, then toggle the equalizer on again." = "Kaset 無法存取自身的音訊輸出。請開啟「系統設定 → 隱私權與安全性 → 螢幕與系統音訊錄製」並啟用 Kaset，然後重新開啟等化器。";
 "Kaset could not remove saved sign-in data. Try signing out again before quitting." = "Kaset 無法移除已儲存的登入資料。請在結束前重新嘗試登出。";
 "Kaset could not safely clear saved sign-in data. Retry before signing in again." = "Kaset 無法安全地清除已儲存的登入資料。請重試後再登入。";
+"Sign-In Temporarily Unavailable" = "暫時無法登入";
+"Kaset could not read saved sign-in data. Retry to restore your session." = "Kaset 無法讀取已儲存的登入資料。請重試以還原工作階段。";
 "Kaset creates fresh AI sessions per request. Refresh the status if Apple Intelligence finishes downloading or becomes available while the app is open." = "Kaset 會為每個請求建立全新的 AI 工作階段。如果 Apple Intelligence 在應用程式執行期間完成下載或變為可用，請重新整理狀態。";
 "Kaset works without login for public YouTube search, discovery, and playback. Sign in to access personal video collections." = "無需登入即可使用 Kaset 進行公開的 YouTube 搜尋、探索和播放。登入後可存取個人影片收藏。";
 "Kaset works without login for public browsing, search, and playback. Sign in to access personal music collections." = "無需登入即可使用 Kaset 進行公開瀏覽、搜尋和播放。登入後可存取個人音樂收藏。";

--- a/Sources/Kaset/Services/Auth/AuthService.swift
+++ b/Sources/Kaset/Services/Auth/AuthService.swift
@@ -43,6 +43,12 @@ final class AuthService: AuthServiceProtocol {
     /// Whether startup is waiting for saved sign-in data to become readable.
     private(set) var isCookieRestoreUnavailable = false
 
+    /// Suspends startup cleanup while restoration or authentication is unresolved.
+    var startupState: State? {
+        guard !self.isCookieRestoreUnavailable, self.loginCheckTask == nil else { return nil }
+        return self.state
+    }
+
     /// Whether failed-login cleanup still owns the account boundary.
     private(set) var isLoginCleanupInProgress = false
 
@@ -287,6 +293,7 @@ final class AuthService: AuthServiceProtocol {
     /// Checks if the user is logged in based on existing cookies.
     /// Waits for the initial Keychain restore before reading WebKit cookies.
     func checkLoginStatus() async {
+        guard !Task.isCancelled else { return }
         if let signOutTask = self.signOutTask {
             _ = await signOutTask.value
             if self.signOutTask == signOutTask {
@@ -311,19 +318,16 @@ final class AuthService: AuthServiceProtocol {
         let checkGeneration = self.loginCheckGeneration
         let task = Task { @MainActor [weak self] in
             guard let self else { return }
-            let resolvedState = await self.resolveLoginState()
+            let (resolvedState, restoreResult) = await self.resolveLoginState()
             guard !Task.isCancelled,
                   checkGeneration == self.loginCheckGeneration
             else { return }
 
-            guard await self.transitionToResolvedState(
+            _ = await self.transitionToResolvedState(
                 resolvedState,
+                restoreResult: restoreResult,
                 expectedLoginCheckGeneration: checkGeneration
-            ) else { return }
-            if resolvedState.isLoggedIn {
-                self.needsReauth = false
-                self.updateLoginCleanupRequirement(false, requiresReauthentication: false)
-            }
+            )
         }
         self.loginCheckTask = task
         await task.value
@@ -331,9 +335,14 @@ final class AuthService: AuthServiceProtocol {
         self.loginCheckTask = nil
     }
 
+    /// Cancels a pending status check and rejects any result that arrives afterward.
+    func cancelLoginStatusCheck() {
+        self.invalidateLoginCheck()
+    }
+
     /// Runs the initial probe; only a task for a resolved state may finish startup.
     func checkLoginStatusForStartup(expectedState: State) async -> Bool {
-        guard !Task.isCancelled, self.state == expectedState else { return false }
+        guard !Task.isCancelled, self.startupState == expectedState else { return false }
         switch expectedState {
         case .initializing:
             await self.checkLoginStatus()
@@ -369,6 +378,8 @@ final class AuthService: AuthServiceProtocol {
             return await signOutTask.value
         }
         self.logger.info("Signing out user")
+        // Keep pending recovery from publishing login if sign-out intent cannot be saved.
+        self.invalidateLoginCheck()
         guard self.webKitManager.invalidateAuthCookieRestoration() else {
             self.logger.error("Could not persist sign-out intent before account drain")
             return false
@@ -378,7 +389,6 @@ final class AuthService: AuthServiceProtocol {
         self.accountBoundaryWillBegin?()
 
         // Fence authenticated work synchronously before the first suspension.
-        self.invalidateLoginCheck()
         self.activeLoginAttemptID = nil
         self.cancellingLoginAttemptID = nil
         self.advanceAccountIdentityGeneration()
@@ -676,6 +686,7 @@ final class AuthService: AuthServiceProtocol {
 
     private func transitionToResolvedState(
         _ newState: State,
+        restoreResult: CookieRestoreResult,
         expectedLoginCheckGeneration: UInt64
     ) async -> Bool {
         let previousIdentity = self.activeAuthenticationIdentity
@@ -706,9 +717,26 @@ final class AuthService: AuthServiceProtocol {
             self.advanceAccountIdentityGeneration()
             self.clearAPIResponseCaches()
         }
+        let wasCookieRestoreUnavailable = self.isCookieRestoreUnavailable
         self.state = newState
         self.activeLoginAttemptID = nil
         self.cancellingLoginAttemptID = nil
+        // Publish recovery and authentication together so Retry keeps its escape controls.
+        self.isCookieRestoreUnavailable = restoreResult == .unavailable
+        switch restoreResult {
+        case .ready:
+            if wasCookieRestoreUnavailable || newState.isLoggedIn {
+                self.needsReauth = false
+            }
+            if newState.isLoggedIn {
+                self.updateLoginCleanupRequirement(false, requiresReauthentication: false)
+            }
+        case .unavailable:
+            self.needsReauth = true
+        case .failed:
+            self.updateLoginCleanupRequirement(true, requiresReauthentication: true)
+            self.needsReauth = true
+        }
         return true
     }
 
@@ -730,59 +758,51 @@ final class AuthService: AuthServiceProtocol {
         self.loginCheckTask = nil
     }
 
-    private func resolveLoginState() async -> State {
+    private func resolveLoginState() async -> (State, CookieRestoreResult) {
         if UITestConfig.isUITestMode,
            UITestConfig.environmentValue(for: UITestConfig.mockLoggedOutKey) == "true"
         {
             self.logger.info("UI Test mode: forcing logged out state")
-            return .loggedOut
+            return (.loggedOut, .ready)
         }
 
         if UITestConfig.isUITestMode, UITestConfig.shouldSkipAuth {
             self.logger.info("UI Test mode: skipping auth check, assuming logged in")
-            return .loggedIn(sapisid: "mock-sapisid-for-ui-tests")
+            return (.loggedIn(sapisid: "mock-sapisid-for-ui-tests"), .ready)
         }
 
         guard !self.loginCleanupRequired else {
             self.logger.error("Cookie cleanup is pending; resolving authentication as logged out")
-            return .loggedOut
+            return (.loggedOut, .failed)
         }
 
         self.logger.debug("Checking login status from cookies")
         let restoreResult = await self.webKitManager.waitForInitialCookieRestore()
-        guard !Task.isCancelled else { return self.state }
-        guard !self.loginCleanupRequired else { return .loggedOut }
+        guard !Task.isCancelled else { return (self.state, restoreResult) }
+        guard !self.loginCleanupRequired else { return (.loggedOut, .failed) }
         switch restoreResult {
         case .ready:
-            if self.isCookieRestoreUnavailable {
-                self.isCookieRestoreUnavailable = false
-                self.needsReauth = false
-            }
+            break
         case .unavailable:
             self.logger.error("Saved sign-in data is unavailable; preserving the session for retry")
-            self.isCookieRestoreUnavailable = true
-            self.needsReauth = true
-            return .loggedOut
+            return (.loggedOut, .unavailable)
         case .failed:
             self.logger.error("Initial cookie cleanup failed; refusing to evaluate authentication cookies")
-            self.isCookieRestoreUnavailable = false
-            self.updateLoginCleanupRequirement(true, requiresReauthentication: true)
-            self.needsReauth = true
-            return .loggedOut
+            return (.loggedOut, .failed)
         }
         self.logger.debug("Initial cookie restore completed, checking auth cookies")
 
         #if DEBUG
             await self.webKitManager.logAuthCookies()
-            guard !Task.isCancelled else { return self.state }
+            guard !Task.isCancelled else { return (self.state, .ready) }
         #endif
 
         if let sapisid = await self.webKitManager.getSAPISID() {
             self.logger.info("Found SAPISID cookie after initial restore, user is logged in")
-            return .loggedIn(sapisid: sapisid)
+            return (.loggedIn(sapisid: sapisid), .ready)
         }
 
         self.logger.info("No SAPISID cookie found after initial restore, user is logged out")
-        return .loggedOut
+        return (.loggedOut, .ready)
     }
 }

--- a/Sources/Kaset/Services/Auth/AuthService.swift
+++ b/Sources/Kaset/Services/Auth/AuthService.swift
@@ -34,6 +34,15 @@ final class AuthService: AuthServiceProtocol {
     /// Whether a failed login cleanup must be retried before another sign-in.
     private(set) var loginCleanupRequired = false
 
+    /// A new recovery sheet captures the owner of residual cookies, even after cancellation released the active attempt.
+    var loginCleanupAttemptID: LoginAttemptID? {
+        guard self.loginCleanupRequired else { return nil }
+        return self.activeLoginAttemptID ?? LoginAttemptID(rawValue: self.nextLoginAttemptID)
+    }
+
+    /// Whether startup is waiting for saved sign-in data to become readable.
+    private(set) var isCookieRestoreUnavailable = false
+
     /// Whether failed-login cleanup still owns the account boundary.
     private(set) var isLoginCleanupInProgress = false
 
@@ -59,7 +68,7 @@ final class AuthService: AuthServiceProtocol {
     /// Reauth prompts keep the existing account-cookie playback store so active
     /// playback is not torn down while the user re-authenticates.
     var shouldUseCookieFreePlaybackDataStore: Bool {
-        if self.loginCleanupRequired {
+        if self.loginCleanupRequired || self.isCookieRestoreUnavailable {
             return true
         }
         if self.isGuestModeEnabled {
@@ -209,6 +218,14 @@ final class AuthService: AuthServiceProtocol {
         self.state = .loggingIn
     }
 
+    /// Release a presentation attempt so Retry can check unavailable storage
+    /// without clearing cookies or creating the login WebView.
+    func deferLoginForCookieRestore(expectedAttemptID: LoginAttemptID) {
+        guard self.activeLoginAttemptID == expectedAttemptID else { return }
+        self.isCookieRestoreUnavailable = true
+        self.sessionExpired()
+    }
+
     /// Cancels an in-progress login presentation without changing an already
     /// completed authenticated session.
     func cancelLoginIfNeeded(expectedAttemptID: LoginAttemptID? = nil) {
@@ -240,6 +257,14 @@ final class AuthService: AuthServiceProtocol {
         self.state = self.stateBeforeLogin ?? .loggedOut
         self.stateBeforeLogin = nil
         self.logger.info("Login flow cancelled")
+        if self.state.isInitializing {
+            // The early attempt cancelled startup's only status probe. Resume it
+            // unless another login or sign-out has already changed the state.
+            Task { @MainActor [weak self] in
+                guard let self, self.state.isInitializing else { return }
+                await self.checkLoginStatus()
+            }
+        }
     }
 
     /// Registers account-owned WebKit mutation cleanup that every sign-out must await.
@@ -306,6 +331,23 @@ final class AuthService: AuthServiceProtocol {
         self.loginCheckTask = nil
     }
 
+    /// Runs the initial probe; only a task for a resolved state may finish startup.
+    func checkLoginStatusForStartup(expectedState: State) async -> Bool {
+        guard !Task.isCancelled, self.state == expectedState else { return false }
+        switch expectedState {
+        case .initializing:
+            await self.checkLoginStatus()
+            // The state change schedules the root task that owns the result.
+            return false
+        case .loggingIn:
+            return false
+        case .loggedOut:
+            return true
+        case .loggedIn:
+            return self.signOutTask == nil
+        }
+    }
+
     /// Called when a session expires (e.g., 401/403 from API).
     func sessionExpired() {
         self.cancelPendingGuestModeTransition()
@@ -344,6 +386,7 @@ final class AuthService: AuthServiceProtocol {
         self.state = .loggedOut
         self.isGuestModeEnabled = false
         self.needsReauth = false
+        self.isCookieRestoreUnavailable = false
         self.stateBeforeLogin = nil
 
         let preparation = self.signOutPreparation
@@ -622,6 +665,7 @@ final class AuthService: AuthServiceProtocol {
         self.clearAPIResponseCaches()
         self.state = .loggedIn(sapisid: sapisid)
         self.needsReauth = false
+        self.isCookieRestoreUnavailable = false
         self.updateLoginCleanupRequirement(false, requiresReauthentication: false)
         self.stateBeforeLogin = nil
     }
@@ -705,11 +749,23 @@ final class AuthService: AuthServiceProtocol {
         }
 
         self.logger.debug("Checking login status from cookies")
-        let canEvaluateAuthentication = await self.webKitManager.waitForInitialCookieRestore()
+        let restoreResult = await self.webKitManager.waitForInitialCookieRestore()
         guard !Task.isCancelled else { return self.state }
         guard !self.loginCleanupRequired else { return .loggedOut }
-        guard canEvaluateAuthentication else {
+        switch restoreResult {
+        case .ready:
+            if self.isCookieRestoreUnavailable {
+                self.isCookieRestoreUnavailable = false
+                self.needsReauth = false
+            }
+        case .unavailable:
+            self.logger.error("Saved sign-in data is unavailable; preserving the session for retry")
+            self.isCookieRestoreUnavailable = true
+            self.needsReauth = true
+            return .loggedOut
+        case .failed:
             self.logger.error("Initial cookie cleanup failed; refusing to evaluate authentication cookies")
+            self.isCookieRestoreUnavailable = false
             self.updateLoginCleanupRequirement(true, requiresReauthentication: true)
             self.needsReauth = true
             return .loggedOut

--- a/Sources/Kaset/Services/Player/PlayerService+PlaybackBoundaries.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+PlaybackBoundaries.swift
@@ -8,6 +8,7 @@ extension PlayerService {
     /// known to have been created in guest mode. Legacy/unknown sessions are
     /// cleared because they may contain account-owned listening metadata.
     func clearPlaybackForGuestStartup() {
+        self.hasResolvedStartupPlaybackOwnership = true
         self.logger.info("Clearing active playback state for guest startup")
         guard self.restoredPlaybackSessionOwnerScope == Self.playbackSessionScopeGuest else {
             self.clearSavedQueue()
@@ -21,6 +22,7 @@ extension PlayerService {
     /// account. Guest Mode itself is not persisted, so a guest-owned restore must
     /// not silently move onto the authenticated playback store.
     func clearGuestPlaybackForAuthenticatedStartup() {
+        self.hasResolvedStartupPlaybackOwnership = true
         guard self.restoredPlaybackSessionOwnerScope == Self.playbackSessionScopeGuest else { return }
         self.logger.info("Clearing guest-owned playback state for authenticated startup")
         self.clearSavedQueue()
@@ -29,6 +31,7 @@ extension PlayerService {
 
     /// Synchronously clears playback, queue, and WebView state at the sign-out privacy boundary.
     func clearPlaybackForSignOut() {
+        self.hasResolvedStartupPlaybackOwnership = true
         self.logger.info("Clearing playback state for sign-out")
         self.clearPlaybackForPrivacyBoundary(persistEmptyQueue: true)
     }

--- a/Sources/Kaset/Services/Player/PlayerService+Queue.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+Queue.swift
@@ -1127,10 +1127,12 @@ extension PlayerService {
                 ? min(max(self.progress, 0), resolvedDuration)
                 : max(self.progress, 0)
 
-            let isKnownGuestSession = self.authService?.shouldPersistGuestPlaybackState == true
-            let ownerScope = ownerScopeOverride ?? (isKnownGuestSession
-                ? Self.playbackSessionScopeGuest
-                : Self.playbackSessionScopeAuthenticated)
+            let retainedOwnerScope = self.shouldPreserveRestoredPlaybackOwnership
+                ? (self.restoredPlaybackSessionOwnerScope ?? Self.playbackSessionScopeAuthenticated) : nil
+            let ownerScope = retainedOwnerScope ?? ownerScopeOverride
+                ?? (self.authService?.shouldPersistGuestPlaybackState == true
+                    ? Self.playbackSessionScopeGuest : Self.playbackSessionScopeAuthenticated)
+            let isKnownGuestSession = ownerScope == Self.playbackSessionScopeGuest
             let persistedQueue = isKnownGuestSession ? Self.queueWithoutAccountMetadata(persistableQueue) : persistableQueue
             let persistedEntryIndexByID = Dictionary(
                 uniqueKeysWithValues: persistedEntries.enumerated().map { ($0.element.id, $0.offset) }
@@ -1254,6 +1256,8 @@ extension PlayerService {
     /// Re-tags a restored/persisted playback session after crossing a playback
     /// privacy boundary without otherwise changing the queue payload.
     func updateRestoredPlaybackSessionOwnerScope(_ ownerScope: String?) {
+        // A data-store reload can precede the root task's startup privacy decision.
+        guard !self.shouldPreserveRestoredPlaybackOwnership else { return }
         self.restoredPlaybackSessionOwnerScope = ownerScope
 
         guard let sessionData = self.queuePersistenceDefaults.data(forKey: self.savedPlaybackSessionKey) else { return }

--- a/Sources/Kaset/Services/Player/PlayerService.swift
+++ b/Sources/Kaset/Services/Player/PlayerService.swift
@@ -310,6 +310,13 @@ final class PlayerService: NSObject, PlayerServiceProtocol {
     /// `nil` means legacy/unknown and must not be trusted across guest privacy boundaries.
     var restoredPlaybackSessionOwnerScope: String?
 
+    /// Startup must classify the restored queue before authentication can change its ownership.
+    var hasResolvedStartupPlaybackOwnership = false
+
+    var shouldPreserveRestoredPlaybackOwnership: Bool {
+        self.isPendingRestoredLoadDeferred && !self.hasResolvedStartupPlaybackOwnership
+    }
+
     static let playbackSessionScopeGuest = "guest"
     static let playbackSessionScopeAuthenticated = "authenticated"
     var queue: [Song] {

--- a/Sources/Kaset/Services/Protocols.swift
+++ b/Sources/Kaset/Services/Protocols.swift
@@ -81,9 +81,9 @@ protocol WebKitManagerProtocol: AnyObject, Sendable {
         _ transaction: CookieBackupTransaction
     ) async -> CookieBackupRollbackResult
 
-    /// Waits for the startup Keychain-to-WebKit cookie restore to finish.
-    /// Returns whether authentication cookies are safe to evaluate afterward.
-    func waitForInitialCookieRestore() async -> Bool
+    /// Waits for startup restoration, retrying temporary storage failures.
+    /// Only a failed restore requires destructive cleanup; unavailability preserves state.
+    func waitForInitialCookieRestore() async -> CookieRestoreResult
 
     /// Logs all authentication-related cookies for debugging.
     func logAuthCookies() async

--- a/Sources/Kaset/Services/WebKit/WebKitManager+CookieBackup.swift
+++ b/Sources/Kaset/Services/WebKit/WebKitManager+CookieBackup.swift
@@ -266,7 +266,12 @@ extension WebKitManager {
     /// Starts a rollback-safe persistence transaction before the login WebView
     /// can change authentication cookies.
     func beginLoginCookieBackup() async -> CookieBackupTransaction? {
-        guard await self.waitForInitialCookieRestore() else {
+        switch await self.waitForInitialCookieRestore() {
+        case .ready:
+            break
+        case .unavailable:
+            return nil
+        case .failed:
             self.loginCookieBackupSetupRequiresCleanup = true
             return nil
         }
@@ -346,7 +351,9 @@ extension WebKitManager {
 
         let authCookies = allLiveCookies.filter(KeychainCookieStorage.isAuthCookie)
         let loginCookies = allLiveCookies.filter(KeychainCookieStorage.isLoginDomainCookie)
-        if authCookies.isEmpty {
+        // A partial Google session cannot form a native API archive, but its
+        // complete cookie jar still provides a valid in-memory rollback baseline.
+        if case .noPrimarySession = KeychainCookieStorage.makeArchiveResult(from: authCookies) {
             return LoginCookieBackupBaseline(
                 liveBaseline: .empty,
                 authSnapshot: nil,
@@ -675,7 +682,7 @@ extension WebKitManager {
 
     /// Forces an immediate save of a stable YouTube/Google cookie snapshot.
     func forceBackupCookies() async -> Bool {
-        guard !self.isClearingAuthCookies else { return false }
+        guard self.canPersistAuthCookies else { return false }
 
         if let forcedCookieBackupTask {
             // A later caller establishes a newer freshness boundary even if
@@ -709,7 +716,7 @@ extension WebKitManager {
                         self.forcedCookieBackupDirty
                     },
                     canContinue: {
-                        !Task.isCancelled && !self.isClearingAuthCookies
+                        !Task.isCancelled && self.canPersistAuthCookies
                     }
                 )
             )
@@ -768,7 +775,7 @@ extension WebKitManager: WKHTTPCookieStoreObserver {
     func handleObservedCookieChange(in cookieStore: WKHTTPCookieStore) {
         self.recordCookieChange()
 
-        guard !self.isRestoringCookies, !self.isClearingAuthCookies else { return }
+        guard self.canPersistAuthCookies else { return }
         if self.isPreparingLoginCookieBackup
             || self.activeLoginCookieBackupTransaction != nil
             || self.forcedCookieBackupTask != nil
@@ -794,10 +801,10 @@ extension WebKitManager: WKHTTPCookieStoreObserver {
     }
 
     private func performCookieBackup(cookieStore: WKHTTPCookieStore) async {
-        guard !self.isClearingAuthCookies else { return }
+        guard self.canPersistAuthCookies else { return }
         let generation = await self.cookieArchiveQueue.reserveGeneration()
         let cookies = await cookieStore.allCookies()
-        guard !Task.isCancelled, !self.isClearingAuthCookies else { return }
+        guard !Task.isCancelled, self.canPersistAuthCookies else { return }
         let authCookies = cookies.filter(KeychainCookieStorage.isAuthCookie)
         let action = CookieArchiveBackupAction.make(
             from: KeychainCookieStorage.makeArchiveResult(from: authCookies)
@@ -813,7 +820,7 @@ extension WebKitManager: WKHTTPCookieStoreObserver {
         case .retainExisting:
             self.logger.error("Retaining the last authentication-cookie archive after serialization failure")
         case let .persist(data, cookieCount):
-            guard !Task.isCancelled, !self.isClearingAuthCookies else { return }
+            guard !Task.isCancelled, self.canPersistAuthCookies else { return }
             _ = await self.cookieArchiveQueue.save(
                 archiveData: data,
                 cookieCount: cookieCount,

--- a/Sources/Kaset/Services/WebKit/WebKitManager+CookieRestore.swift
+++ b/Sources/Kaset/Services/WebKit/WebKitManager+CookieRestore.swift
@@ -28,10 +28,7 @@ extension WebKitManager {
             )
             return didDeletePersistedCookies && didClearLiveCookies
         case .unavailable:
-            self.logger.error("Cookie restore policy could not be read; preserving the archive for retry")
-            _ = await self.clearLiveLoginSessionCookies(
-                expectedGeneration: expectedGeneration
-            )
+            self.logger.error("Cookie restore policy could not be read; preserving live cookies and the archive for retry")
             return false
         }
 
@@ -52,16 +49,13 @@ extension WebKitManager {
 
         switch archiveResult {
         case .failure:
-            self.logger.error("Cookie backup storage could not be read; preserving it for retry")
-            _ = await self.clearLiveLoginSessionCookies(
-                expectedGeneration: expectedGeneration
-            )
+            self.logger.error("Cookie backup storage could not be read; preserving live cookies and the archive for retry")
             return false
         case .notFound:
-            guard await self.clearLiveLoginSessionCookies(
-                expectedGeneration: expectedGeneration
-            ) else { return false }
-            self.logger.info("No cookies found in archive storage (first run or signed out)")
+            // Explicit invalidation persists a denied restore policy before it
+            // deletes the archive. An allowed policy with no archive is not an
+            // authoritative sign-out signal and may coexist with a live login.
+            self.logger.info("No cookies found in archive storage; preserving the live WebKit session")
             return true
         case let .data(archiveData):
             // The persisted archive is the source of truth for login-session

--- a/Sources/Kaset/Services/WebKit/WebKitManager+CookieRestore.swift
+++ b/Sources/Kaset/Services/WebKit/WebKitManager+CookieRestore.swift
@@ -1,20 +1,70 @@
 import Foundation
 import WebKit
 
+// MARK: - CookieRestoreResult
+
+enum CookieRestoreResult: Equatable, Sendable {
+    case ready
+    case unavailable
+    case failed
+}
+
 // MARK: - Startup Cookie Restoration
 
 extension WebKitManager {
+    var canPersistAuthCookies: Bool {
+        self.initialCookieRestoreResult == .ready
+            && !self.isRestoringCookies
+            && !self.isClearingAuthCookies
+    }
+
+    func startInitialCookieRestore() {
+        guard self.initialCookieRestoreTask == nil,
+              !self.isClearingAuthCookies,
+              !self.authCookieClearCoordinator.isBusy
+        else { return }
+
+        self.initialCookieRestoreResult = .unavailable
+        let pendingBackup = self.cookieDebounceTask
+        let forcedBackup = self.forcedCookieBackupTask
+        pendingBackup?.cancel()
+        forcedBackup?.cancel()
+        self.cookieDebounceTask = nil
+        let restoreGeneration = self.authCookieOperationFence.generation
+        self.initialCookieRestoreTask = Task { @MainActor in
+            await pendingBackup?.value
+            _ = await forcedBackup?.value
+            let result = await self.restoreAuthCookiesFromBackup(
+                expectedGeneration: restoreGeneration
+            )
+            self.initialCookieRestoreResult = result
+            self.initialCookieRestoreTask = nil
+            return result
+        }
+    }
+
+    /// Joins the current restore, or retries a previous non-destructive storage failure.
+    func waitForInitialCookieRestore() async -> CookieRestoreResult {
+        if self.initialCookieRestoreTask == nil, self.initialCookieRestoreResult == .unavailable {
+            self.startInitialCookieRestore()
+        }
+        if let restoreTask = self.initialCookieRestoreTask {
+            return await restoreTask.value
+        }
+        return self.initialCookieRestoreResult
+    }
+
     /// Restores auth cookies from the configured archive storage to WebKit.
     /// Handles migration from legacy file-based storage on first run.
-    func restoreAuthCookiesFromBackup(expectedGeneration: UInt64) async -> Bool {
+    func restoreAuthCookiesFromBackup(expectedGeneration: UInt64) async -> CookieRestoreResult {
         self.isRestoringCookies = true
         defer { self.isRestoringCookies = false }
 
-        guard self.canContinueAuthCookieOperation(expectedGeneration: expectedGeneration) else { return false }
+        guard self.canContinueAuthCookieOperation(expectedGeneration: expectedGeneration) else { return .failed }
 
         // Wait a moment for WebKit to fully initialize
         try? await Task.sleep(for: .milliseconds(100))
-        guard self.canContinueAuthCookieOperation(expectedGeneration: expectedGeneration) else { return false }
+        guard self.canContinueAuthCookieOperation(expectedGeneration: expectedGeneration) else { return .failed }
 
         switch await self.cookieArchiveQueue.restoreDecision() {
         case .allowed:
@@ -22,14 +72,14 @@ extension WebKitManager {
         case .denied:
             self.logger.info("Cookie backup restoration is disabled after explicit invalidation")
             let didDeletePersistedCookies = await self.cookieArchiveQueue.invalidateAndDelete()
-            guard self.canContinueAuthCookieOperation(expectedGeneration: expectedGeneration) else { return false }
+            guard self.canContinueAuthCookieOperation(expectedGeneration: expectedGeneration) else { return .failed }
             let didClearLiveCookies = await self.clearLiveLoginSessionCookies(
                 expectedGeneration: expectedGeneration
             )
-            return didDeletePersistedCookies && didClearLiveCookies
+            return didDeletePersistedCookies && didClearLiveCookies ? .ready : .failed
         case .unavailable:
             self.logger.error("Cookie restore policy could not be read; preserving live cookies and the archive for retry")
-            return false
+            return .unavailable
         }
 
         // Migrate from legacy file-based storage if needed (one-time operation).
@@ -37,36 +87,37 @@ extension WebKitManager {
         _ = await Task(priority: .utility) {
             LegacyCookieMigration.migrateIfNeeded()
         }.value
-        guard self.canContinueAuthCookieOperation(expectedGeneration: expectedGeneration) else { return false }
+        guard self.canContinueAuthCookieOperation(expectedGeneration: expectedGeneration) else { return .failed }
 
         let existingCookies = await self.dataStore.httpCookieStore.allCookies()
-        guard self.canContinueAuthCookieOperation(expectedGeneration: expectedGeneration) else { return false }
+        guard self.canContinueAuthCookieOperation(expectedGeneration: expectedGeneration) else { return .failed }
         self.logger.info("WebKit has \(existingCookies.count) cookies on startup")
 
         // Archive I/O runs on the injected storage queue, never on the main actor.
         let archiveResult = await self.cookieArchiveQueue.loadArchiveResult()
-        guard self.canContinueAuthCookieOperation(expectedGeneration: expectedGeneration) else { return false }
+        guard self.canContinueAuthCookieOperation(expectedGeneration: expectedGeneration) else { return .failed }
 
         switch archiveResult {
         case .failure:
             self.logger.error("Cookie backup storage could not be read; preserving live cookies and the archive for retry")
-            return false
+            return .unavailable
         case .notFound:
             // Explicit invalidation persists a denied restore policy before it
             // deletes the archive. An allowed policy with no archive is not an
             // authoritative sign-out signal and may coexist with a live login.
             self.logger.info("No cookies found in archive storage; preserving the live WebKit session")
-            return true
+            return .ready
         case let .data(archiveData):
             // The persisted archive is the source of truth for login-session
             // state. Preserve unrelated Google/YouTube preference cookies.
             guard await self.clearLiveLoginSessionCookies(
                 expectedGeneration: expectedGeneration
-            ) else { return false }
-            return await self.restoreArchivedAuthCookies(
+            ) else { return .failed }
+            let didRestore = await self.restoreArchivedAuthCookies(
                 archiveData,
                 expectedGeneration: expectedGeneration
             )
+            return didRestore ? .ready : .failed
         }
     }
 
@@ -126,11 +177,6 @@ extension WebKitManager {
         }
         self.logger.info("✓ Auth cookies restored from Keychain (\(cookies.count) total cookies)")
 
-        #if DEBUG
-            if self.canContinueAuthCookieOperation(expectedGeneration: expectedGeneration) {
-                _ = await self.forceBackupCookies()
-            }
-        #endif
         return true
     }
 

--- a/Sources/Kaset/Services/WebKit/WebKitManager.swift
+++ b/Sources/Kaset/Services/WebKit/WebKitManager.swift
@@ -15,12 +15,14 @@ final class WebKitManager: NSObject, WebKitManagerProtocol {
     /// Creates an isolated manager for unit tests. The cookie archive queue is private to the
     /// instance and backed by in-memory storage, so parallel suites cannot clear or overwrite
     /// each other's archive through the process-wide `CookieArchiveWriteQueue.shared`.
-    static func makeTestInstance() -> WebKitManager {
+    static func makeTestInstance(
+        cookieArchiveStorage: CookieArchiveStorage = .inMemory()
+    ) -> WebKitManager {
         WebKitManager(
             dataStore: .nonPersistent(),
             restoresCookies: false,
             loadsExtensions: false,
-            cookieArchiveQueue: CookieArchiveWriteQueue(storage: .inMemory())
+            cookieArchiveQueue: CookieArchiveWriteQueue(storage: cookieArchiveStorage)
         )
     }
 

--- a/Sources/Kaset/Services/WebKit/WebKitManager.swift
+++ b/Sources/Kaset/Services/WebKit/WebKitManager.swift
@@ -67,11 +67,11 @@ final class WebKitManager: NSObject, WebKitManagerProtocol {
     /// Records cookie changes delivered while a forced snapshot is being persisted.
     var forcedCookieBackupDirty = false
 
-    /// Task for the one-time startup restore from Keychain into WebKit.
-    private var initialCookieRestoreTask: Task<Bool, Never>?
+    /// Coalesces startup restoration and retries after temporary storage failures.
+    var initialCookieRestoreTask: Task<CookieRestoreResult, Never>?
 
-    /// Whether startup left authentication cookies safe to evaluate.
-    private var initialCookieRestoreAllowsAuthentication = true
+    /// Authentication and archive writes stay blocked until restoration is resolved.
+    var initialCookieRestoreResult: CookieRestoreResult = .ready
 
     /// Invalidates startup restores and backups that began before an auth-cookie clear.
     var authCookieOperationFence = AuthCookieOperationFence()
@@ -124,15 +124,7 @@ final class WebKitManager: NSObject, WebKitManagerProtocol {
         // Restore auth cookies on startup.
         // Keychain is the source of truth; in DEBUG builds we also export to cookies.dat for tooling.
         if restoresCookies, !UITestConfig.isRunningUnitTests {
-            let restoreGeneration = self.authCookieOperationFence.generation
-            self.initialCookieRestoreTask = Task { @MainActor in
-                let allowsAuthentication = await self.restoreAuthCookiesFromBackup(
-                    expectedGeneration: restoreGeneration
-                )
-                self.initialCookieRestoreAllowsAuthentication = allowsAuthentication
-                self.initialCookieRestoreTask = nil
-                return allowsAuthentication
-            }
+            self.startInitialCookieRestore()
         }
 
         self.logger.info("WebKitManager initialized with persistent data store")
@@ -420,14 +412,6 @@ final class WebKitManager: NSObject, WebKitManagerProtocol {
         return URL(string: normalizedPath, relativeTo: rootURL)?.absoluteURL
     }
 
-    /// Waits for the one-time startup cookie restore to finish.
-    func waitForInitialCookieRestore() async -> Bool {
-        if let restoreTask = self.initialCookieRestoreTask {
-            return await restoreTask.value
-        }
-        return self.initialCookieRestoreAllowsAuthentication
-    }
-
     /// Retrieves all cookies from the HTTP cookie store.
     func getAllCookies() async -> [HTTPCookie] {
         await self.dataStore.httpCookieStore.allCookies()
@@ -566,7 +550,7 @@ final class WebKitManager: NSObject, WebKitManagerProtocol {
         }
 
         let didClear = liveClearResult.didClear && didInvalidatePersistedCookies
-        self.initialCookieRestoreAllowsAuthentication = didClear
+        self.initialCookieRestoreResult = didClear ? .ready : .failed
         self.loginCookieBackupSetupRequiresCleanup = !didClear
         self.cookiesDidChange = Date()
         return didClear
@@ -598,7 +582,7 @@ final class WebKitManager: NSObject, WebKitManagerProtocol {
         let remainingCookies = await self.dataStore.httpCookieStore.allCookies()
         let didClearLiveCookies = !remainingCookies.contains(where: KeychainCookieStorage.isLoginDomainCookie)
         let didClear = didInvalidatePersistedCookies && didClearLiveCookies
-        self.initialCookieRestoreAllowsAuthentication = didClear
+        self.initialCookieRestoreResult = didClear ? .ready : .failed
         self.loginCookieBackupSetupRequiresCleanup = !didClear
         if didClear {
             self.logger.info("WebKit data cleared successfully")

--- a/Sources/Kaset/Views/LoginSheet.swift
+++ b/Sources/Kaset/Views/LoginSheet.swift
@@ -18,7 +18,9 @@ struct LoginSheet: View {
     @State private var pollTask: Task<Void, Never>?
     @State private var loginCheckTask: Task<Void, Never>?
     @State private var recoveryRetryTask: Task<Void, Never>?
+    @State private var signOutTask: Task<Void, Never>?
     @State private var isRetryingRecovery = false
+    @State private var signOutFailurePresented = false
     @State private var isActive = false
 
     var body: some View {
@@ -43,6 +45,20 @@ struct LoginSheet: View {
             }
         }
         .frame(width: 500, height: 650)
+        .alert(
+            String(localized: "Sign Out Incomplete"),
+            isPresented: self.$signOutFailurePresented
+        ) {
+            Button(String(localized: "Retry")) {
+                self.signOutForRecovery()
+            }
+            Button(String(localized: "OK"), role: .cancel) {}
+        } message: {
+            Text(
+                "Kaset could not remove saved sign-in data. Try signing out again before quitting.",
+                comment: "Sign-out durable storage failure message"
+            )
+        }
         .onChange(of: self.webKitManager.cookiesDidChange) { _, _ in
             self.checkForSuccessfulLogin()
         }
@@ -88,16 +104,19 @@ struct LoginSheet: View {
             let pollTask = self.pollTask
             let loginCheckTask = self.loginCheckTask
             let recoveryRetryTask = self.recoveryRetryTask
+            let signOutTask = self.signOutTask
             preparationTask?.cancel()
             pollTask?.cancel()
             loginCheckTask?.cancel()
             recoveryRetryTask?.cancel()
+            signOutTask?.cancel()
 
             Task { @MainActor in
                 await preparationTask?.value
                 await loginCheckTask?.value
                 await pollTask?.value
                 await recoveryRetryTask?.value
+                await signOutTask?.value
 
                 if let transaction = self.cookieBackupTransaction {
                     self.cookieBackupTransaction = nil
@@ -160,7 +179,14 @@ struct LoginSheet: View {
                     Text(String(localized: "Retry"))
                 }
             }
-            .disabled(self.isRetryingRecovery || self.authService.isLoginCleanupInProgress)
+            .disabled(self.isRetryingRecovery || self.signOutTask != nil || self.authService.isLoginCleanupInProgress)
+
+            if self.authService.isCookieRestoreUnavailable {
+                Button(String(localized: "Sign Out"), role: .destructive) {
+                    self.signOutForRecovery()
+                }
+                .disabled(self.signOutTask != nil || self.authService.isLoginCleanupInProgress)
+            }
         }
         .padding(32)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -304,6 +330,7 @@ struct LoginSheet: View {
 
     private func retryLoginRecovery() {
         guard self.recoveryRetryTask == nil,
+              self.signOutTask == nil,
               !self.authService.isLoginCleanupInProgress
         else { return }
         let expectedAttemptID = self.authService.activeLoginAttemptID
@@ -343,6 +370,25 @@ struct LoginSheet: View {
             }
 
             await self.restartLoginAfterRecovery()
+        }
+    }
+
+    private func signOutForRecovery() {
+        guard self.signOutTask == nil,
+              !self.authService.isLoginCleanupInProgress
+        else { return }
+        self.authService.cancelLoginStatusCheck()
+        self.recoveryRetryTask?.cancel()
+        self.signOutTask = Task { @MainActor in
+            defer { self.signOutTask = nil }
+
+            let didSignOut = await self.authService.signOut()
+            guard !Task.isCancelled, self.isActive else { return }
+            if didSignOut {
+                self.dismiss()
+            } else {
+                self.signOutFailurePresented = true
+            }
         }
     }
 

--- a/Sources/Kaset/Views/LoginSheet.swift
+++ b/Sources/Kaset/Views/LoginSheet.swift
@@ -17,8 +17,8 @@ struct LoginSheet: View {
     @State private var preparationTask: Task<Void, Never>?
     @State private var pollTask: Task<Void, Never>?
     @State private var loginCheckTask: Task<Void, Never>?
-    @State private var cleanupRetryTask: Task<Void, Never>?
-    @State private var isRetryingCleanup = false
+    @State private var recoveryRetryTask: Task<Void, Never>?
+    @State private var isRetryingRecovery = false
     @State private var isActive = false
 
     var body: some View {
@@ -30,8 +30,8 @@ struct LoginSheet: View {
 
             // Do not create the login WebView until reauthentication has drained
             // old session mutations and established its cookie baseline.
-            if self.authService.loginCleanupRequired {
-                self.loginCleanupFailureView
+            if self.authService.isCookieRestoreUnavailable || self.authService.loginCleanupRequired {
+                self.loginRecoveryView
             } else if self.didCaptureInitialLoginState {
                 LoginWebView(onNavigationToYouTubeMusic: {
                     self.checkForSuccessfulLogin()
@@ -55,6 +55,7 @@ struct LoginSheet: View {
                 self.authService.startLogin()
             }
             self.loginAttemptID = self.authService.activeLoginAttemptID
+                ?? self.authService.loginCleanupAttemptID
         }
         .task {
             guard !Task.isCancelled, self.isActive else { return }
@@ -86,17 +87,17 @@ struct LoginSheet: View {
             let preparationTask = self.preparationTask
             let pollTask = self.pollTask
             let loginCheckTask = self.loginCheckTask
-            let cleanupRetryTask = self.cleanupRetryTask
+            let recoveryRetryTask = self.recoveryRetryTask
             preparationTask?.cancel()
             pollTask?.cancel()
             loginCheckTask?.cancel()
-            cleanupRetryTask?.cancel()
+            recoveryRetryTask?.cancel()
 
             Task { @MainActor in
                 await preparationTask?.value
                 await loginCheckTask?.value
                 await pollTask?.value
-                await cleanupRetryTask?.value
+                await recoveryRetryTask?.value
 
                 if let transaction = self.cookieBackupTransaction {
                     self.cookieBackupTransaction = nil
@@ -130,35 +131,36 @@ struct LoginSheet: View {
         }
     }
 
-    private var loginCleanupFailureView: some View {
+    private var loginRecoveryView: some View {
         VStack(spacing: 16) {
             Image(systemName: "exclamationmark.triangle.fill")
                 .font(.system(size: 32))
                 .foregroundStyle(.orange)
                 .accessibilityHidden(true)
 
-            Text(String(localized: "Sign-In Cleanup Required"))
+            Text(self.authService.isCookieRestoreUnavailable
+                ? String(localized: "Sign-In Temporarily Unavailable")
+                : String(localized: "Sign-In Cleanup Required"))
                 .font(.headline)
 
-            Text(
-                "Kaset could not safely clear saved sign-in data. Retry before signing in again.",
-                comment: "Failed login cleanup explanation"
-            )
-            .multilineTextAlignment(.center)
-            .foregroundStyle(.secondary)
-            .frame(maxWidth: 340)
+            Text(self.authService.isCookieRestoreUnavailable
+                ? String(localized: "Kaset could not read saved sign-in data. Retry to restore your session.")
+                : String(localized: "Kaset could not safely clear saved sign-in data. Retry before signing in again.", comment: "Failed login cleanup explanation"))
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: 340)
 
             Button {
-                self.retryLoginCleanup()
+                self.retryLoginRecovery()
             } label: {
-                if self.isRetryingCleanup || self.authService.isLoginCleanupInProgress {
+                if self.isRetryingRecovery || self.authService.isLoginCleanupInProgress {
                     ProgressView()
                         .controlSize(.small)
                 } else {
                     Text(String(localized: "Retry"))
                 }
             }
-            .disabled(self.isRetryingCleanup || self.authService.isLoginCleanupInProgress)
+            .disabled(self.isRetryingRecovery || self.authService.isLoginCleanupInProgress)
         }
         .padding(32)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -191,6 +193,14 @@ struct LoginSheet: View {
         guard !self.authService.loginCleanupRequired,
               let loginAttemptID = self.loginAttemptID
         else { return }
+        // Sign In must still reopen the recovery sheet after it is dismissed.
+        // Release its presentation attempt before Retry checks storage.
+        if self.authService.isCookieRestoreUnavailable {
+            self.authService.deferLoginForCookieRestore(expectedAttemptID: loginAttemptID)
+            return
+        }
+
+        guard await self.restoreCookiesBeforeLogin(expectedAttemptID: loginAttemptID) else { return }
 
         if self.authService.needsReauth {
             await self.accountService.prepareForReauthentication()
@@ -208,22 +218,6 @@ struct LoginSheet: View {
                 return
             }
             self.authService.setLoginCleanupRequired(false)
-        }
-
-        let canEvaluateAuthentication = await self.webKitManager.waitForInitialCookieRestore()
-        guard self.authService.activeLoginAttemptID == loginAttemptID else { return }
-        guard canEvaluateAuthentication else {
-            let didClear = await self.authService.clearFailedLoginAfterDraining(
-                expectedAttemptID: loginAttemptID,
-                expectedSignOutSequence: self.authService.signOutSequence,
-                clearCookies: {
-                    await self.webKitManager.clearAllData()
-                }
-            )
-            if didClear == true {
-                await self.restartLoginAfterCleanup()
-            }
-            return
         }
 
         guard !Task.isCancelled,
@@ -280,39 +274,79 @@ struct LoginSheet: View {
         self.startPollingForLogin()
     }
 
-    private func retryLoginCleanup() {
-        guard self.cleanupRetryTask == nil,
-              !self.authService.isLoginCleanupInProgress
-        else { return }
-        let expectedAttemptID = self.authService.activeLoginAttemptID
-            ?? self.loginAttemptID
-            ?? LoginAttemptID(rawValue: 0)
-        let expectedSignOutSequence = self.authService.signOutSequence
-        self.cleanupRetryTask = Task { @MainActor in
-            self.isRetryingCleanup = true
-            defer {
-                self.isRetryingCleanup = false
-                self.cleanupRetryTask = nil
-            }
-
+    private func restoreCookiesBeforeLogin(expectedAttemptID: LoginAttemptID) async -> Bool {
+        let restoreResult = await self.webKitManager.waitForInitialCookieRestore()
+        guard !Task.isCancelled, self.isActive,
+              self.authService.activeLoginAttemptID == expectedAttemptID
+        else { return false }
+        switch restoreResult {
+        case .ready:
+            return true
+        case .unavailable:
+            self.authService.deferLoginForCookieRestore(expectedAttemptID: expectedAttemptID)
+            // Keep the sheet's attempt ID: if a retry reveals an invalid archive,
+            // cleanup must still prove ownership of this logged-out attempt.
+            return false
+        case .failed:
             let didClear = await self.authService.clearFailedLoginAfterDraining(
                 expectedAttemptID: expectedAttemptID,
-                expectedSignOutSequence: expectedSignOutSequence,
+                expectedSignOutSequence: self.authService.signOutSequence,
                 clearCookies: {
                     await self.webKitManager.clearAllData()
                 }
             )
-            guard !Task.isCancelled,
-                  self.isActive,
-                  let didClear
-            else { return }
-            guard didClear else { return }
-
-            await self.restartLoginAfterCleanup()
+            if didClear == true {
+                await self.restartLoginAfterRecovery()
+            }
+            return false
         }
     }
 
-    private func restartLoginAfterCleanup() async {
+    private func retryLoginRecovery() {
+        guard self.recoveryRetryTask == nil,
+              !self.authService.isLoginCleanupInProgress
+        else { return }
+        let expectedAttemptID = self.authService.activeLoginAttemptID
+            ?? self.loginAttemptID
+            ?? self.authService.loginCleanupAttemptID
+        guard let expectedAttemptID else { return }
+        let expectedSignOutSequence = self.authService.signOutSequence
+        self.recoveryRetryTask = Task { @MainActor in
+            self.isRetryingRecovery = true
+            defer {
+                self.isRetryingRecovery = false
+                self.recoveryRetryTask = nil
+            }
+
+            if self.authService.isCookieRestoreUnavailable {
+                await self.authService.checkLoginStatus()
+                guard !Task.isCancelled, self.isActive,
+                      self.authService.signOutSequence == expectedSignOutSequence,
+                      !self.authService.isCookieRestoreUnavailable,
+                      !self.authService.loginCleanupRequired,
+                      self.authService.activeLoginAttemptID == nil
+                else { return }
+                if self.authService.state.isLoggedIn {
+                    self.didCompleteLogin = true
+                    self.dismiss()
+                    return
+                }
+            } else {
+                let didClear = await self.authService.clearFailedLoginAfterDraining(
+                    expectedAttemptID: expectedAttemptID,
+                    expectedSignOutSequence: expectedSignOutSequence,
+                    clearCookies: {
+                        await self.webKitManager.clearAllData()
+                    }
+                )
+                guard !Task.isCancelled, self.isActive, didClear == true else { return }
+            }
+
+            await self.restartLoginAfterRecovery()
+        }
+    }
+
+    private func restartLoginAfterRecovery() async {
         guard self.isActive else { return }
         if self.authService.activeLoginAttemptID == nil {
             self.authService.startLogin()

--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -844,14 +844,8 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
                     await self.presentCurrentWhatsNew()
                 }
             }
-            // KasetApp's root startup task owns the initializing -> logged-in
-            // account fetch. Later login and reauthentication transitions still
-            // need to refresh the account list here.
-            if oldState != .initializing {
-                Task {
-                    await self.accountService.fetchAccounts()
-                }
-            }
+            // KasetApp's state-keyed root task owns account loading for every
+            // authenticated transition, after startup playback cleanup.
             // If we just completed login/reauth, refresh content. This handles
             // the case where cookies were unavailable during initial load and
             // preserved views that may currently hold auth-expired state.

--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -201,7 +201,12 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
     private var windowChrome: some View {
         ZStack(alignment: .bottomTrailing) {
             Group {
-                if self.authService.state.isInitializing {
+                if self.authService.isCookieRestoreUnavailable {
+                    SignInRequiredView(
+                        title: String(localized: "Sign-In Temporarily Unavailable"),
+                        message: String(localized: "Kaset could not read saved sign-in data. Retry to restore your session.")
+                    )
+                } else if self.authService.state.isInitializing {
                     // Show loading while checking login status to avoid guest-content flash
                     self.initializingView
                 } else if self.authService.hasPersonalAccount {
@@ -231,7 +236,7 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
             // Keep it as a hidden 1×1 anchor for audio playback; do not reveal a mini overlay.
             // Keep authenticated Home available while restoration defers watch loading.
             // Let the video window own the visible WebView.
-            if Self.shouldMountPersistentPlayer(
+            if !self.authService.isCookieRestoreUnavailable, Self.shouldMountPersistentPlayer(
                 isLoggedIn: self.authService.state.isLoggedIn,
                 pendingVideoId: self.playerService.pendingPlayVideoId,
                 isPendingRestoredLoadDeferred: self.playerService.isPendingRestoredLoadDeferred,

--- a/Tests/KasetTests/AuthServiceCookieRestoreTests.swift
+++ b/Tests/KasetTests/AuthServiceCookieRestoreTests.swift
@@ -1,0 +1,221 @@
+import Observation
+import Testing
+@testable import Kaset
+
+@Suite("AuthService cookie restore recovery", .serialized, .tags(.service))
+@MainActor
+struct AuthServiceCookieRestoreTests {
+    @Test("Cancelling an early sign-in resumes startup authentication", arguments: [CookieRestoreResult.ready, .unavailable, .failed])
+    func cancellingEarlySignInResumesStartup(restoreResult: CookieRestoreResult) async throws {
+        let manager = MockWebKitManager()
+        manager.waitForInitialCookieRestoreResult = restoreResult
+        manager.sapisidValue = "mock-restored-session"
+        let restoreEntered = AsyncGate()
+        let releaseRestore = AsyncGate()
+        manager.waitForInitialCookieRestoreGate = {
+            await restoreEntered.open()
+            await releaseRestore.wait()
+        }
+        let authService = AuthService(webKitManager: manager)
+        let startup = Task { @MainActor in
+            await authService.checkLoginStatus()
+        }
+        await restoreEntered.wait()
+
+        authService.startLogin()
+        let attemptID = try #require(authService.activeLoginAttemptID)
+        #expect(authService.beginLoginCancellation(expectedAttemptID: attemptID))
+        await releaseRestore.open()
+        await startup.value
+        let rollback = await authService.resolveLoginRollbackAfterDraining(
+            expectedAttemptID: attemptID,
+            prepareRollback: { true },
+            rollback: { _ in .rolledBack }
+        )
+        for _ in 0 ..< 100 where authService.state.isInitializing {
+            await Task.yield()
+        }
+
+        let expectedState: AuthService.State = restoreResult == .ready
+            ? .loggedIn(sapisid: "mock-restored-session")
+            : .loggedOut
+        #expect(rollback == .rolledBack)
+        #expect(authService.state == expectedState)
+        #expect(manager.waitForInitialCookieRestoreCallCount == 2)
+        #expect(authService.isCookieRestoreUnavailable == (restoreResult == .unavailable))
+        #expect(authService.loginCleanupRequired == (restoreResult == .failed))
+
+        if restoreResult == .failed {
+            let cleanupAttemptID = try #require(authService.loginCleanupAttemptID)
+            #expect(cleanupAttemptID == attemptID)
+            let didClear = await authService.clearFailedLoginAfterDraining(
+                expectedAttemptID: cleanupAttemptID,
+                expectedSignOutSequence: authService.signOutSequence,
+                clearCookies: { await manager.clearAllData() }
+            )
+            #expect(didClear == true)
+            #expect(manager.clearAllDataCalled)
+            #expect(!authService.loginCleanupRequired)
+        }
+    }
+
+    @Test("Resolving early sign-in resumes the startup account pipeline", arguments: [true, false])
+    func earlySignInResumesAccountResolution(cancels: Bool) async throws {
+        let manager = MockWebKitManager()
+        manager.sapisidValue = "mock-restored-session"
+        let restoreEntered = AsyncGate()
+        let releaseRestore = AsyncGate()
+        manager.waitForInitialCookieRestoreGate = {
+            await restoreEntered.open()
+            await releaseRestore.wait()
+        }
+        let authService = AuthService(webKitManager: manager)
+        let client = MockYTMusicClient()
+        client.accountsListResponse = AccountsListResponse(
+            googleEmail: "owner@example.test",
+            accounts: [MockUserAccountData.primaryAccount]
+        )
+        let accountService = AccountService(ytMusicClient: client, authService: authService)
+        let initialState = authService.state
+        let startup = Task { @MainActor in
+            guard await authService.checkLoginStatusForStartup(expectedState: initialState) else { return false }
+            await accountService.fetchAccounts()
+            return true
+        }
+        await restoreEntered.wait()
+        authService.startLogin()
+        let attemptID = try #require(authService.activeLoginAttemptID)
+        if cancels {
+            #expect(authService.beginLoginCancellation(expectedAttemptID: attemptID))
+        }
+        Self.observeStartup(authService: authService, accountService: accountService)
+        await releaseRestore.open()
+        #expect(await startup.value == false)
+        #expect(client.fetchAccountsListCallCount == 0)
+
+        if cancels {
+            _ = await authService.resolveLoginRollbackAfterDraining(
+                expectedAttemptID: attemptID,
+                prepareRollback: { true },
+                rollback: { _ in .rolledBack }
+            )
+        } else {
+            authService.completeLogin(sapisid: "mock-restored-session")
+        }
+        for _ in 0 ..< 100 where !accountService.didCompleteAccountResolution {
+            await Task.yield()
+        }
+
+        #expect(authService.state.isLoggedIn)
+        #expect(client.fetchAccountsListCallCount == 1)
+        #expect(accountService.currentAccount?.id == MockUserAccountData.primaryAccount.id)
+        #expect(accountService.didCompleteAccountResolution)
+        #expect(await authService.checkLoginStatusForStartup(expectedState: initialState) == false)
+    }
+
+    @Test("An early sign-in can defer startup and retry without clearing cookies")
+    func earlySignInDefersWithoutCleanup() async throws {
+        let manager = MockWebKitManager()
+        let authService = AuthService(webKitManager: manager)
+        authService.startLogin()
+        let attemptID = try #require(authService.activeLoginAttemptID)
+
+        authService.deferLoginForCookieRestore(expectedAttemptID: attemptID)
+
+        #expect(authService.state == .loggedOut)
+        #expect(authService.activeLoginAttemptID == nil)
+        #expect(authService.isCookieRestoreUnavailable)
+        #expect(authService.shouldUseCookieFreePlaybackDataStore)
+        #expect(!authService.loginCleanupRequired)
+        #expect(!manager.invalidateAuthCookieRestorationCalled)
+
+        authService.startLogin()
+        let reopenedAttemptID = try #require(authService.activeLoginAttemptID)
+        #expect(reopenedAttemptID != attemptID)
+        #expect(authService.state == .loggingIn)
+        #expect(authService.isCookieRestoreUnavailable)
+        authService.deferLoginForCookieRestore(expectedAttemptID: reopenedAttemptID)
+        #expect(authService.activeLoginAttemptID == nil)
+
+        manager.sapisidValue = "mock-restored-session"
+        await authService.checkLoginStatus()
+
+        #expect(authService.state == .loggedIn(sapisid: "mock-restored-session"))
+        #expect(!authService.isCookieRestoreUnavailable)
+        #expect(!manager.clearAllDataCalled)
+        #expect(!manager.clearAuthCookiesCalled)
+    }
+
+    @Test("A queued startup recheck yields to a newer account action", arguments: [true, false])
+    func queuedStartupRecheckHonorsNewerAction(signsOut: Bool) async {
+        let manager = MockWebKitManager()
+        manager.waitForInitialCookieRestoreResult = .unavailable
+        let authService = AuthService(webKitManager: manager)
+        authService.startLogin()
+        authService.cancelLoginIfNeeded()
+
+        if signsOut {
+            #expect(await authService.signOut())
+        } else {
+            authService.startLogin()
+        }
+        for _ in 0 ..< 100 {
+            await Task.yield()
+        }
+
+        #expect(authService.state == (signsOut ? .loggedOut : .loggingIn))
+        #expect(!authService.isCookieRestoreUnavailable)
+        #expect(manager.waitForInitialCookieRestoreCallCount == 0)
+    }
+
+    @Test("A stale unavailable restore cannot cancel a replacement login")
+    func staleRestoreDoesNotCancelReplacementLogin() throws {
+        let authService = AuthService(webKitManager: MockWebKitManager())
+        authService.startLogin()
+        let staleAttemptID = try #require(authService.activeLoginAttemptID)
+        authService.cancelLoginIfNeeded(expectedAttemptID: staleAttemptID)
+        authService.startLogin()
+        let replacementID = try #require(authService.activeLoginAttemptID)
+
+        authService.deferLoginForCookieRestore(expectedAttemptID: staleAttemptID)
+
+        #expect(authService.activeLoginAttemptID == replacementID)
+        #expect(authService.state == .loggingIn)
+        #expect(!authService.isCookieRestoreUnavailable)
+    }
+
+    @Test("Explicit sign-out ends storage recovery")
+    func signOutEndsStorageRecovery() async {
+        let manager = MockWebKitManager()
+        manager.waitForInitialCookieRestoreResult = .unavailable
+        let authService = AuthService(webKitManager: manager)
+        await authService.checkLoginStatus()
+        #expect(authService.isCookieRestoreUnavailable)
+
+        #expect(await authService.signOut())
+
+        #expect(!authService.isCookieRestoreUnavailable)
+        #expect(authService.state == .loggedOut)
+        #expect(!authService.needsReauth)
+        #expect(manager.clearAllDataCalled)
+    }
+
+    private static func observeStartup(authService: AuthService, accountService: AccountService) {
+        let state = withObservationTracking {
+            authService.state
+        } onChange: { [weak authService, weak accountService] in
+            Task { @MainActor in
+                guard let authService, let accountService else { return }
+                Self.observeStartup(authService: authService, accountService: accountService)
+            }
+        }
+        Task { @MainActor [weak authService, weak accountService] in
+            guard let authService, let accountService,
+                  await authService.checkLoginStatusForStartup(expectedState: state),
+                  authService.state == state
+            else { return }
+            accountService.authenticationIdentityDidChange()
+            await accountService.fetchAccounts()
+        }
+    }
+}

--- a/Tests/KasetTests/AuthServiceCookieRestoreTests.swift
+++ b/Tests/KasetTests/AuthServiceCookieRestoreTests.swift
@@ -200,9 +200,138 @@ struct AuthServiceCookieRestoreTests {
         #expect(manager.clearAllDataCalled)
     }
 
+    @Test("Startup waits for recovery to finish publishing authentication", arguments: [true, false])
+    func startupWaitsForRecoveryPublication(restoresSession: Bool) async {
+        let manager = MockWebKitManager()
+        manager.waitForInitialCookieRestoreResult = .unavailable
+        let authService = AuthService(webKitManager: manager)
+        await authService.checkLoginStatus()
+        manager.waitForInitialCookieRestoreResult = .ready
+        manager.sapisidValue = restoresSession ? "mock-restored-session" : nil
+        let cookieReadEntered = AsyncGate()
+        let releaseCookieRead = AsyncGate()
+        manager.getSAPISIDGate = {
+            await cookieReadEntered.open()
+            await releaseCookieRead.wait()
+        }
+
+        let recovery = Task { @MainActor in
+            await authService.checkLoginStatus()
+        }
+        await cookieReadEntered.wait()
+        #expect(authService.isCookieRestoreUnavailable)
+        #expect(authService.state == .loggedOut)
+        #expect(!authService.shouldPersistGuestPlaybackState)
+        #expect(await authService.checkLoginStatusForStartup(expectedState: .loggedOut) == false)
+        await releaseCookieRead.open()
+        await recovery.value
+        #expect(!authService.isCookieRestoreUnavailable)
+        #expect(authService.state.isLoggedIn == restoresSession)
+        #expect(authService.shouldPersistGuestPlaybackState == !restoresSession)
+        #expect(await authService.checkLoginStatusForStartup(expectedState: authService.state))
+    }
+
+    @Test("Sign-out supersedes a pending recovery read", arguments: [true, false], [true, false])
+    func signOutSupersedesPendingRecovery(waitingForCookie: Bool, canInvalidateRestoration: Bool) async {
+        let manager = MockWebKitManager()
+        manager.waitForInitialCookieRestoreResult = .unavailable
+        let authService = AuthService(webKitManager: manager)
+        await authService.checkLoginStatus()
+        manager.waitForInitialCookieRestoreResult = .ready
+        manager.sapisidValue = "mock-restored-session"
+        let readEntered = AsyncGate()
+        let releaseRead = AsyncGate()
+        let readGate: @Sendable () async -> Void = {
+            await readEntered.open()
+            await releaseRead.wait()
+        }
+        if waitingForCookie {
+            manager.getSAPISIDGate = readGate
+        } else {
+            manager.waitForInitialCookieRestoreGate = readGate
+        }
+        let recovery = Task { @MainActor in
+            await authService.checkLoginStatus()
+        }
+        await readEntered.wait()
+        #expect(authService.isCookieRestoreUnavailable)
+        #expect(authService.startupState == nil)
+
+        manager.invalidateAuthCookieRestorationResult = canInvalidateRestoration
+        #expect(await authService.signOut() == canInvalidateRestoration)
+        #expect(authService.isCookieRestoreUnavailable == !canInvalidateRestoration)
+        #expect(authService.startupState == (canInvalidateRestoration ? .loggedOut : nil))
+        #expect(manager.clearAllDataCalled == canInvalidateRestoration)
+
+        await releaseRead.open()
+        await recovery.value
+        #expect(authService.state == .loggedOut)
+        #expect(authService.needsReauth == !canInvalidateRestoration)
+        #expect(authService.isCookieRestoreUnavailable == !canInvalidateRestoration)
+    }
+
+    @Test("Recovery cancellation rejects a cookie result before asynchronous sign-out", arguments: [true, false])
+    func signOutClickFencesPendingRecovery(canInvalidateRestoration: Bool) async {
+        let manager = MockWebKitManager()
+        manager.waitForInitialCookieRestoreResult = .unavailable
+        let authService = AuthService(webKitManager: manager)
+        await authService.checkLoginStatus()
+        manager.waitForInitialCookieRestoreResult = .ready
+        manager.sapisidValue = "mock-restored-session"
+        manager.invalidateAuthCookieRestorationResult = canInvalidateRestoration
+        let cookieReadEntered = AsyncGate()
+        let releaseCookieRead = AsyncGate()
+        manager.getSAPISIDGate = {
+            await cookieReadEntered.open()
+            await releaseCookieRead.wait()
+        }
+        let recovery = Task { @MainActor in
+            await authService.checkLoginStatus()
+        }
+        await cookieReadEntered.wait()
+
+        // The Sign Out action cancels recovery before scheduling its async task.
+        authService.cancelLoginStatusCheck()
+        recovery.cancel()
+        // A queued cookie callback can run before that sign-out task starts.
+        await releaseCookieRead.open()
+        await recovery.value
+        #expect(authService.state == .loggedOut)
+        #expect(authService.isCookieRestoreUnavailable)
+        #expect(authService.startupState == nil)
+
+        #expect(await authService.signOut() == canInvalidateRestoration)
+        #expect(authService.state == .loggedOut)
+        #expect(authService.isCookieRestoreUnavailable == !canInvalidateRestoration)
+    }
+
+    @Test("Cancelled status callers cannot restart cookie recovery")
+    func cancelledStatusCallerDoesNotStartRecovery() async {
+        let manager = MockWebKitManager()
+        manager.waitForInitialCookieRestoreResult = .unavailable
+        let authService = AuthService(webKitManager: manager)
+        await authService.checkLoginStatus()
+        manager.waitForInitialCookieRestoreResult = .ready
+        manager.sapisidValue = "mock-restored-session"
+        let startRetry = AsyncGate()
+        let recovery = Task { @MainActor in
+            await startRetry.wait()
+            await authService.checkLoginStatus()
+        }
+
+        recovery.cancel()
+        await startRetry.open()
+        await recovery.value
+
+        #expect(authService.state == .loggedOut)
+        #expect(authService.isCookieRestoreUnavailable)
+        #expect(manager.waitForInitialCookieRestoreCallCount == 1)
+        #expect(manager.getSAPISIDCallCount == 0)
+    }
+
     private static func observeStartup(authService: AuthService, accountService: AccountService) {
         let state = withObservationTracking {
-            authService.state
+            authService.startupState
         } onChange: { [weak authService, weak accountService] in
             Task { @MainActor in
                 guard let authService, let accountService else { return }
@@ -210,9 +339,9 @@ struct AuthServiceCookieRestoreTests {
             }
         }
         Task { @MainActor [weak authService, weak accountService] in
-            guard let authService, let accountService,
+            guard let state, let authService, let accountService,
                   await authService.checkLoginStatusForStartup(expectedState: state),
-                  authService.state == state
+                  authService.startupState == state
             else { return }
             accountService.authenticationIdentityDidChange()
             await accountService.fetchAccounts()

--- a/Tests/KasetTests/AuthServiceTests.swift
+++ b/Tests/KasetTests/AuthServiceTests.swift
@@ -592,7 +592,7 @@ struct AuthServiceTests {
 
     @Test("Failed startup cleanup refuses surviving authentication cookies")
     func failedStartupCleanupRefusesAuthenticationCookies() async {
-        self.mockWebKitManager.waitForInitialCookieRestoreResult = false
+        self.mockWebKitManager.waitForInitialCookieRestoreResult = .failed
         self.mockWebKitManager.sapisidValue = "surviving-session"
 
         await self.authService.checkLoginStatus()

--- a/Tests/KasetTests/Helpers/MockWebKitManager.swift
+++ b/Tests/KasetTests/Helpers/MockWebKitManager.swift
@@ -27,7 +27,8 @@ final class MockWebKitManager: WebKitManagerProtocol {
     var loginCookieSnapshotChanged = true
     var rollbackLoginCookieBackupResult: CookieBackupRollbackResult = .rolledBack
     var loginCookieBackupSetupRequiresCleanup = false
-    var waitForInitialCookieRestoreResult = true
+    var waitForInitialCookieRestoreResult: CookieRestoreResult = .ready
+    var waitForInitialCookieRestoreGate: (@Sendable () async -> Void)?
 
     /// When set, `switchSessionIdentity` throws this error instead of succeeding.
     var switchSessionIdentityError: Error?
@@ -231,10 +232,11 @@ final class MockWebKitManager: WebKitManagerProtocol {
         return self.rollbackLoginCookieBackupResult
     }
 
-    func waitForInitialCookieRestore() async -> Bool {
+    func waitForInitialCookieRestore() async -> CookieRestoreResult {
         self.waitForInitialCookieRestoreCalled = true
         self.waitForInitialCookieRestoreCallCount += 1
         self.callSequence.append("waitForInitialCookieRestore")
+        await self.waitForInitialCookieRestoreGate?()
         return self.waitForInitialCookieRestoreResult
     }
 
@@ -308,7 +310,8 @@ final class MockWebKitManager: WebKitManagerProtocol {
         self.loginCookieSessionValues = []
         self.rollbackLoginCookieBackupResult = .rolledBack
         self.loginCookieBackupSetupRequiresCleanup = false
-        self.waitForInitialCookieRestoreResult = true
+        self.waitForInitialCookieRestoreResult = .ready
+        self.waitForInitialCookieRestoreGate = nil
         self.beginLoginCookieBackupCallCount = 0
         self.refreshLoginCookieBackupCallCount = 0
         self.commitLoginCookieBackupCallCount = 0

--- a/Tests/KasetTests/LoginCompletionGateTests.swift
+++ b/Tests/KasetTests/LoginCompletionGateTests.swift
@@ -9,6 +9,7 @@ struct LoginCompletionGateTests {
         let webKitManager = MockWebKitManager()
         webKitManager.forceBackupCookiesResult = false
         let authService = AuthService(webKitManager: webKitManager)
+        await authService.checkLoginStatus()
         authService.startLogin()
         guard let attemptID = authService.activeLoginAttemptID else {
             Issue.record("Expected an active login attempt")
@@ -33,7 +34,7 @@ struct LoginCompletionGateTests {
         #expect(webKitManager.forceBackupCookiesCallCount == 1)
         #expect(webKitManager.commitLoginCookieBackupCallCount == 1)
         #expect(webKitManager.finalizeLoginCookieBackupCallCount == 0)
-        #expect(authService.state == .initializing)
+        #expect(authService.state == .loggedOut)
     }
 
     @Test("Cancellation while persistence is in flight rolls back and prevents login completion")
@@ -46,6 +47,7 @@ struct LoginCompletionGateTests {
             await releaseBackup.wait()
         }
         let authService = AuthService(webKitManager: webKitManager)
+        await authService.checkLoginStatus()
         authService.startLogin()
         guard let attemptID = authService.activeLoginAttemptID else {
             Issue.record("Expected an active login attempt")
@@ -73,7 +75,7 @@ struct LoginCompletionGateTests {
         let didComplete = await completionTask.value
         #expect(!didComplete)
         #expect(webKitManager.rollbackLoginCookieBackupCallCount == 1)
-        #expect(authService.state == .initializing)
+        #expect(authService.state == .loggedOut)
     }
 
     @Test("A newer login attempt supersedes detection while persistence is in flight")
@@ -405,6 +407,7 @@ struct LoginCompletionGateTests {
         let webKitManager = MockWebKitManager()
         webKitManager.finalizeLoginCookieBackupResult = false
         let authService = AuthService(webKitManager: webKitManager)
+        await authService.checkLoginStatus()
         authService.startLogin()
         guard let attemptID = authService.activeLoginAttemptID,
               let transaction = await webKitManager.beginLoginCookieBackup()
@@ -425,7 +428,7 @@ struct LoginCompletionGateTests {
         #expect(!didComplete)
         #expect(webKitManager.rollbackLoginCookieBackupCallCount == 1)
         #expect(!webKitManager.clearAllDataCalled)
-        #expect(authService.state == .initializing)
+        #expect(authService.state == .loggedOut)
         #expect(!authService.loginCleanupRequired)
     }
 
@@ -601,6 +604,7 @@ struct LoginCompletionGateTests {
         let webKitManager = MockWebKitManager()
         webKitManager.commitLoginCookieBackupResult = false
         let authService = AuthService(webKitManager: webKitManager)
+        await authService.checkLoginStatus()
         authService.startLogin()
         guard let attemptID = authService.activeLoginAttemptID else {
             Issue.record("Expected an active login attempt")
@@ -627,7 +631,7 @@ struct LoginCompletionGateTests {
         #expect(webKitManager.finalizeLoginCookieBackupCallCount == 0)
         #expect(webKitManager.rollbackLoginCookieBackupCallCount == 1)
         #expect(!webKitManager.clearAllDataCalled)
-        #expect(authService.state == .initializing)
+        #expect(authService.state == .loggedOut)
         #expect(!authService.needsReauth)
     }
 }

--- a/Tests/KasetTests/PlayerServiceQueuePersistenceSyncTests.swift
+++ b/Tests/KasetTests/PlayerServiceQueuePersistenceSyncTests.swift
@@ -3,6 +3,124 @@ import Testing
 @testable import Kaset
 
 extension PlayerServiceQueueTests {
+    @Test("Unavailable cookie restoration preserves playback ownership until startup cleanup", arguments: [true, false], [true, false])
+    func unavailableCookieRestorePreservesPlaybackOwnership(wasGuestQueue: Bool, restoresSession: Bool) async throws {
+        let previousAuth = AuthService(webKitManager: MockWebKitManager())
+        if wasGuestQueue {
+            await previousAuth.checkLoginStatus()
+        } else {
+            previousAuth.completeLogin(sapisid: "mock-personal-session")
+        }
+        self.playerService.setAuthService(previousAuth)
+        let songs = TestFixtures.makeSongs(count: 2)
+        await self.playerService.playQueue(songs, startingAt: 1)
+        self.playerService.saveQueueForPersistence()
+        let savedSession = try #require(UserDefaults.standard.data(forKey: "kaset.saved.playbackSession"))
+        defer { self.playerService.clearSavedQueue() }
+
+        let restoredService = PlayerService()
+        restoredService.setYTMusicClient(self.mockClient)
+        #expect(restoredService.restoreQueueFromPersistence())
+        let manager = MockWebKitManager()
+        manager.waitForInitialCookieRestoreResult = .unavailable
+        manager.sapisidValue = restoresSession ? "mock-personal-session" : nil
+        let authService = AuthService(webKitManager: manager)
+        restoredService.setAuthService(authService)
+        await authService.checkLoginStatus()
+
+        let mayFinishStartup = await authService.checkLoginStatusForStartup(expectedState: authService.state)
+        if mayFinishStartup {
+            restoredService.clearPlaybackForGuestStartup()
+        }
+
+        #expect(!mayFinishStartup)
+        #expect(restoredService.queue.map(\.id) == songs.map(\.id))
+        #expect(restoredService.currentTrack?.id == songs[1].id)
+        restoredService.saveQueueForPersistence()
+        #expect(UserDefaults.standard.data(forKey: "kaset.saved.playbackSession") == savedSession)
+
+        let cookieReadEntered = AsyncGate()
+        let releaseCookieRead = AsyncGate()
+        manager.getSAPISIDGate = {
+            await cookieReadEntered.open()
+            await releaseCookieRead.wait()
+        }
+        manager.waitForInitialCookieRestoreResult = .ready
+        let recovery = Task { @MainActor in
+            await authService.checkLoginStatus()
+        }
+        await cookieReadEntered.wait()
+        // Quitting can save the queue while the recovered cookie read is pending.
+        restoredService.saveQueueForPersistence()
+        #expect(UserDefaults.standard.data(forKey: "kaset.saved.playbackSession") == savedSession)
+        await releaseCookieRead.open()
+        await recovery.value
+        #expect(await authService.checkLoginStatusForStartup(expectedState: authService.state))
+        // Authentication can publish before the root task performs startup cleanup.
+        restoredService.saveQueueForPersistence()
+        #expect(UserDefaults.standard.data(forKey: "kaset.saved.playbackSession") == savedSession)
+        restoredService.reloadCurrentTrackForAuthDataStoreChange(usesCookieFreeDataStore: !restoresSession)
+        #expect(restoredService.restoredPlaybackSessionOwnerScope == (wasGuestQueue
+                ? PlayerService.playbackSessionScopeGuest : PlayerService.playbackSessionScopeAuthenticated))
+        if restoresSession {
+            restoredService.clearGuestPlaybackForAuthenticatedStartup()
+        } else {
+            restoredService.clearPlaybackForGuestStartup()
+        }
+        if wasGuestQueue != restoresSession {
+            #expect(restoredService.queue.map(\.id) == songs.map(\.id))
+            #expect(restoredService.currentTrack?.id == songs[1].id)
+            #expect(UserDefaults.standard.data(forKey: "kaset.saved.playbackSession") != nil)
+            if wasGuestQueue {
+                // After startup, a later explicit login can own the preserved guest queue.
+                authService.completeLogin(sapisid: "mock-later-session")
+                restoredService.saveQueueForPersistence()
+                #expect(restoredService.restoredPlaybackSessionOwnerScope == PlayerService.playbackSessionScopeAuthenticated)
+            }
+        } else {
+            #expect(restoredService.queue.isEmpty)
+            #expect(restoredService.currentTrack == nil)
+            #expect(UserDefaults.standard.data(forKey: "kaset.saved.playbackSession") == nil)
+        }
+    }
+
+    @Test("Legacy restored queues stay private until startup cleanup", arguments: [true, false])
+    func legacyQueueOwnershipWaitsForStartupCleanup(restoresSession: Bool) async {
+        let songs = TestFixtures.makeSongs(count: 2)
+        await self.playerService.playQueue(songs, startingAt: 1)
+        self.playerService.saveQueueForPersistence()
+        self.playerService.updateRestoredPlaybackSessionOwnerScope(nil)
+        self.mockClient.shouldThrowError = URLError(.notConnectedToInternet)
+        defer { self.playerService.clearSavedQueue() }
+
+        let restoredService = PlayerService()
+        restoredService.setYTMusicClient(self.mockClient)
+        #expect(restoredService.restoreQueueFromPersistence())
+        #expect(restoredService.restoredPlaybackSessionOwnerScope == nil)
+        let manager = MockWebKitManager()
+        manager.waitForInitialCookieRestoreResult = .unavailable
+        manager.sapisidValue = restoresSession ? "mock-personal-session" : nil
+        let authService = AuthService(webKitManager: manager)
+        restoredService.setAuthService(authService)
+        await authService.checkLoginStatus()
+        manager.waitForInitialCookieRestoreResult = .ready
+        await authService.checkLoginStatus()
+
+        #expect(authService.state.isLoggedIn == restoresSession)
+        #expect(restoredService.restoredPlaybackSessionOwnerScope == nil)
+        restoredService.saveQueueForPersistence()
+        #expect(restoredService.restoredPlaybackSessionOwnerScope != PlayerService.playbackSessionScopeGuest)
+        if restoresSession {
+            restoredService.clearGuestPlaybackForAuthenticatedStartup()
+            #expect(restoredService.queue.map(\.id) == songs.map(\.id))
+            #expect(UserDefaults.standard.data(forKey: "kaset.saved.playbackSession") != nil)
+        } else {
+            restoredService.clearPlaybackForGuestStartup()
+            #expect(restoredService.queue.isEmpty)
+            #expect(UserDefaults.standard.data(forKey: "kaset.saved.playbackSession") == nil)
+        }
+    }
+
     @Test("Unchanged persistence still synchronizes an ephemeral next entry")
     func unchangedPersistenceStillSynchronizesEphemeralNextEntry() async {
         let songs = TestFixtures.makeSongs(count: 2)

--- a/Tests/KasetTests/WebKitCookieRestoreTests+Recovery.swift
+++ b/Tests/KasetTests/WebKitCookieRestoreTests+Recovery.swift
@@ -95,6 +95,31 @@ extension WebKitCookieRestoreTests {
         #expect(storage.snapshot.deleteCount == 1)
     }
 
+    @Test("Explicit sign-out discards a session behind an unreadable restore policy")
+    func signOutDiscardsUnreadableRestorePolicy() async throws {
+        let storage = CookieRecoveryStorage()
+        storage.update {
+            $0.policy = .unavailable
+            $0.archive = Data("mock-retained-archive".utf8)
+        }
+        let manager = WebKitManager.makeTestInstance(cookieArchiveStorage: storage.interface)
+        try await manager.dataStore.httpCookieStore.setCookie(
+            Self.makeRecoveryCookie(name: "SAPISID", domain: ".youtube.com")
+        )
+        let authService = AuthService(webKitManager: manager)
+        manager.startInitialCookieRestore()
+        await authService.checkLoginStatus()
+        #expect(authService.isCookieRestoreUnavailable)
+
+        #expect(await authService.signOut())
+
+        #expect(!authService.isCookieRestoreUnavailable)
+        #expect(authService.state == .loggedOut)
+        #expect(await manager.getSAPISID() == nil)
+        #expect(storage.snapshot.archive == nil)
+        #expect(storage.snapshot.policy == .denied)
+    }
+
     @Test("Clearing data fences an in-flight startup retry")
     func clearingDataFencesRetry() async throws {
         let storage = CookieRecoveryStorage()

--- a/Tests/KasetTests/WebKitCookieRestoreTests+Recovery.swift
+++ b/Tests/KasetTests/WebKitCookieRestoreTests+Recovery.swift
@@ -1,0 +1,302 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+/// Login transactions share the process-wide restore-policy generation with
+/// quarantine tests, so keep recovery cases in the same serialized suite.
+extension WebKitCookieRestoreTests {
+    @Test("Unavailable startup storage preserves authentication without requiring cleanup", arguments: [true, false])
+    func unavailableStartupDoesNotRequireCleanup(policyUnavailable: Bool) async throws {
+        let storage = CookieRecoveryStorage()
+        storage.update {
+            $0.policy = policyUnavailable ? .unavailable : .allowed
+            $0.readFails = !policyUnavailable
+        }
+        let manager = WebKitManager.makeTestInstance(cookieArchiveStorage: storage.interface)
+        let cookie = try Self.makeRecoveryCookie(name: "SAPISID", domain: ".youtube.com")
+        await manager.dataStore.httpCookieStore.setCookie(cookie)
+        let authService = AuthService(webKitManager: manager)
+
+        manager.startInitialCookieRestore()
+        await authService.checkLoginStatus()
+
+        #expect(!authService.loginCleanupRequired)
+        #expect(authService.isCookieRestoreUnavailable)
+        #expect(authService.shouldUseCookieFreePlaybackDataStore)
+        #expect(await manager.getSAPISID() == "mock-session")
+        #expect(storage.snapshot.deleteCount == 0)
+        manager.cookieDebounceTask?.cancel()
+    }
+
+    @Test("Retry restores the saved session and concurrent callers share the read", arguments: [true, false])
+    func retryRestoresSavedSession(policyUnavailable: Bool) async throws {
+        let storage = CookieRecoveryStorage()
+        let cookie = try Self.makeRecoveryCookie(name: "SAPISID", domain: ".youtube.com")
+        let archive = try #require(KeychainCookieStorage.makeArchiveData(from: [cookie]))
+        storage.update {
+            $0.archive = archive.data
+            $0.policy = policyUnavailable ? .unavailable : .allowed
+            $0.readFails = !policyUnavailable
+        }
+        let manager = WebKitManager.makeTestInstance(cookieArchiveStorage: storage.interface)
+        try await manager.dataStore.httpCookieStore.setCookie(
+            Self.makeRecoveryCookie(name: "SAPISID", domain: ".youtube.com", value: "mock-stale-session")
+        )
+        let authService = AuthService(webKitManager: manager)
+        manager.startInitialCookieRestore()
+        await authService.checkLoginStatus()
+        #expect(authService.isCookieRestoreUnavailable)
+        let readsBeforeRetry = storage.snapshot.loadCount
+        storage.update {
+            $0.policy = .allowed
+            $0.readFails = false
+        }
+
+        async let first: Void = authService.checkLoginStatus()
+        async let second: Void = authService.checkLoginStatus()
+        _ = await (first, second)
+
+        #expect(authService.state == .loggedIn(sapisid: cookie.value))
+        #expect(!authService.isCookieRestoreUnavailable)
+        #expect(!authService.loginCleanupRequired)
+        #expect(!authService.needsReauth)
+        #expect(manager.canPersistAuthCookies)
+        #expect(storage.snapshot.loadCount == readsBeforeRetry + 1)
+        #expect(storage.snapshot.archive == archive.data)
+        #expect(storage.snapshot.deleteCount == 0)
+        #expect(await manager.getSAPISID() == cookie.value)
+        _ = await manager.clearAllData()
+    }
+
+    @Test("Retry honors a newly readable sign-out denial")
+    func retryHonorsDeniedRestore() async throws {
+        let storage = CookieRecoveryStorage()
+        storage.update {
+            $0.policy = .unavailable
+            $0.archive = Data("mock-retained-archive".utf8)
+        }
+        let manager = WebKitManager.makeTestInstance(cookieArchiveStorage: storage.interface)
+        try await manager.dataStore.httpCookieStore.setCookie(
+            Self.makeRecoveryCookie(name: "SAPISID", domain: ".youtube.com")
+        )
+        let authService = AuthService(webKitManager: manager)
+        manager.startInitialCookieRestore()
+        await authService.checkLoginStatus()
+        storage.update { $0.policy = .denied }
+
+        await authService.checkLoginStatus()
+
+        #expect(authService.state == .loggedOut)
+        #expect(!authService.isCookieRestoreUnavailable)
+        #expect(!authService.loginCleanupRequired)
+        #expect(!authService.needsReauth)
+        #expect(await manager.getSAPISID() == nil)
+        #expect(storage.snapshot.archive == nil)
+        #expect(storage.snapshot.deleteCount == 1)
+    }
+
+    @Test("Clearing data fences an in-flight startup retry")
+    func clearingDataFencesRetry() async throws {
+        let storage = CookieRecoveryStorage()
+        storage.update { $0.policy = .unavailable }
+        let manager = WebKitManager.makeTestInstance(cookieArchiveStorage: storage.interface)
+        manager.startInitialCookieRestore()
+        #expect(await manager.waitForInitialCookieRestore() == .unavailable)
+        let cookie = try Self.makeRecoveryCookie(name: "SAPISID", domain: ".youtube.com")
+        let archive = try #require(KeychainCookieStorage.makeArchiveData(from: [cookie]))
+        storage.update {
+            $0.policy = .allowed
+            $0.archive = archive.data
+        }
+
+        manager.startInitialCookieRestore()
+        let retry = try #require(manager.initialCookieRestoreTask)
+        #expect(await manager.clearAllData())
+        _ = await retry.value
+
+        #expect(await manager.waitForInitialCookieRestore() == .ready)
+        #expect(await manager.getAllCookies().isEmpty)
+        #expect(storage.snapshot.archive == nil)
+        #expect(storage.snapshot.policy == .denied)
+    }
+
+    @Test("Recovery cleanup requires the retained deferred attempt identity")
+    func invalidArchiveRecoveryRetainsCleanupOwnership() async throws {
+        let storage = CookieRecoveryStorage()
+        storage.update { $0.policy = .unavailable }
+        let manager = WebKitManager.makeTestInstance(cookieArchiveStorage: storage.interface)
+        let authService = AuthService(webKitManager: manager)
+        manager.startInitialCookieRestore()
+        await authService.checkLoginStatus()
+        authService.startLogin()
+        let attemptID = try #require(authService.activeLoginAttemptID)
+        authService.deferLoginForCookieRestore(expectedAttemptID: attemptID)
+        #expect(authService.activeLoginAttemptID == nil)
+
+        storage.update {
+            $0.policy = .allowed
+            $0.archive = Data("mock-invalid-archive".utf8)
+        }
+        await authService.checkLoginStatus()
+        #expect(!authService.isCookieRestoreUnavailable)
+        #expect(authService.loginCleanupRequired)
+
+        let missingIdentityResult = await authService.clearFailedLoginAfterDraining(
+            expectedAttemptID: LoginAttemptID(rawValue: 0),
+            expectedSignOutSequence: authService.signOutSequence,
+            clearCookies: { await manager.clearAllData() }
+        )
+        #expect(missingIdentityResult == nil)
+        #expect(storage.snapshot.archive != nil)
+
+        let retainedIdentityResult = await authService.clearFailedLoginAfterDraining(
+            expectedAttemptID: attemptID,
+            expectedSignOutSequence: authService.signOutSequence,
+            clearCookies: { await manager.clearAllData() }
+        )
+        #expect(retainedIdentityResult == true)
+        #expect(!authService.loginCleanupRequired)
+        #expect(authService.state == .loggedOut)
+        #expect(storage.snapshot.archive == nil)
+        #expect(manager.canPersistAuthCookies)
+    }
+
+    @Test("Deferred restore blocks observer and forced archive writes", arguments: [true, false])
+    func deferredRestoreBlocksBackups(hasPrimarySession: Bool) async throws {
+        let storage = CookieRecoveryStorage()
+        let originalArchive = Data("mock-retained-archive".utf8)
+        storage.update {
+            $0.policy = .unavailable
+            $0.archive = originalArchive
+        }
+        let manager = WebKitManager.makeTestInstance(cookieArchiveStorage: storage.interface)
+        if hasPrimarySession {
+            try await manager.dataStore.httpCookieStore.setCookie(
+                Self.makeRecoveryCookie(name: "SAPISID", domain: ".youtube.com")
+            )
+        }
+
+        manager.startInitialCookieRestore()
+        _ = await manager.waitForInitialCookieRestore()
+        #expect(await manager.forceBackupCookies() == false)
+        manager.handleObservedCookieChange(in: manager.dataStore.httpCookieStore)
+        await manager.cookieDebounceTask?.value
+
+        #expect(storage.snapshot.archive == originalArchive)
+        #expect(storage.snapshot.saveCount == 0)
+        #expect(storage.snapshot.deleteCount == 0)
+    }
+
+    @Test("A partial Google session survives login preparation and cancellation", arguments: [true, false])
+    func partialSessionCanBeginAndRollbackLogin(startsUnavailable: Bool) async throws {
+        let storage = CookieRecoveryStorage()
+        storage.update { $0.policy = startsUnavailable ? .unavailable : .allowed }
+        let manager = WebKitManager.makeTestInstance(cookieArchiveStorage: storage.interface)
+        let googleCookie = try Self.makeRecoveryCookie(name: "SID", domain: ".google.com")
+        await manager.dataStore.httpCookieStore.setCookie(googleCookie)
+        let authService = AuthService(webKitManager: manager)
+        manager.startInitialCookieRestore()
+        await authService.checkLoginStatus()
+        if startsUnavailable {
+            storage.update { $0.policy = .allowed }
+            await authService.checkLoginStatus()
+        }
+        #expect(authService.state == .loggedOut)
+        #expect(!authService.isCookieRestoreUnavailable)
+        #expect(!authService.needsReauth)
+        authService.startLogin()
+        let attemptID = try #require(authService.activeLoginAttemptID)
+
+        let transaction = await manager.beginLoginCookieBackup()
+        #expect(transaction != nil)
+        #expect(!manager.loginCookieBackupSetupRequiresCleanup)
+        guard let transaction else { return }
+
+        try await manager.dataStore.httpCookieStore.setCookie(
+            Self.makeRecoveryCookie(name: "SAPISID", domain: ".youtube.com")
+        )
+        let rollback = await authService.resolveLoginRollbackAfterDraining(
+            expectedAttemptID: attemptID,
+            prepareRollback: { await manager.prepareLoginCookieBackupRollback(transaction) },
+            rollback: { _ in await manager.rollbackLoginCookieBackup(transaction) }
+        )
+        #expect(rollback == .rolledBack)
+        #expect(authService.state == .loggedOut)
+        #expect(!authService.loginCleanupRequired)
+        let cookies = await manager.getAllCookies()
+        #expect(cookies.count == 1)
+        #expect(cookies.first?.name == googleCookie.name)
+        #expect(cookies.first?.value == googleCookie.value)
+        _ = await manager.clearAllData()
+    }
+
+    private static func makeRecoveryCookie(
+        name: String,
+        domain: String,
+        value: String = "mock-session"
+    ) throws -> HTTPCookie {
+        try #require(HTTPCookie(properties: [
+            .name: name,
+            .value: value,
+            .domain: domain,
+            .path: "/",
+            .expires: Date().addingTimeInterval(3600),
+        ]))
+    }
+}
+
+// MARK: - CookieRecoveryStorage
+
+private final class CookieRecoveryStorage: @unchecked Sendable {
+    struct State {
+        var policy: CookieArchiveRestoreDecision = .allowed
+        var archive: Data?
+        var readFails = false
+        var loadCount = 0
+        var saveCount = 0
+        var deleteCount = 0
+    }
+
+    private let lock = NSLock()
+    private var state = State()
+
+    var snapshot: State {
+        self.lock.withLock { self.state }
+    }
+
+    func update(_ operation: (inout State) -> Void) {
+        self.lock.withLock { operation(&self.state) }
+    }
+
+    var interface: CookieArchiveStorage {
+        CookieArchiveStorage(
+            save: { data, _ in
+                self.update {
+                    $0.archive = data
+                    $0.saveCount += 1
+                }
+                return true
+            },
+            loadResult: {
+                self.lock.withLock {
+                    self.state.loadCount += 1
+                    guard !self.state.readFails else { return .failure }
+                    guard let data = self.state.archive else { return .notFound }
+                    return .data(data)
+                }
+            },
+            delete: {
+                self.update {
+                    $0.archive = nil
+                    $0.deleteCount += 1
+                }
+                return true
+            },
+            restoreDecision: { self.snapshot.policy },
+            setRestoreAllowed: { allowed in
+                self.update { $0.policy = allowed ? .allowed : .denied }
+                return true
+            }
+        )
+    }
+}

--- a/Tests/KasetTests/WebKitCookieRestoreTests.swift
+++ b/Tests/KasetTests/WebKitCookieRestoreTests.swift
@@ -5,6 +5,212 @@ import Testing
 @Suite("WebKit cookie restoration", .serialized, .tags(.service))
 @MainActor
 struct WebKitCookieRestoreTests {
+    @Test("Missing archive preserves a valid live primary session")
+    func missingArchivePreservesValidLivePrimarySession() async throws {
+        let livePrimaryCookie = try #require(HTTPCookie(properties: [
+            .name: "SAPISID",
+            .value: "mock-live-primary-session",
+            .domain: ".youtube.com",
+            .path: "/",
+            .expires: Date().addingTimeInterval(3600),
+        ]))
+        let webKitManager = WebKitManager.makeTestInstance()
+
+        await webKitManager.dataStore.httpCookieStore.setCookie(livePrimaryCookie)
+
+        let allowsAuthentication = await webKitManager.restoreAuthCookiesFromBackup(
+            expectedGeneration: webKitManager.authCookieOperationFence.generation
+        )
+        let cookies = await webKitManager.dataStore.httpCookieStore.allCookies()
+        _ = await webKitManager.clearAllData()
+
+        #expect(allowsAuthentication)
+        #expect(cookies.first { $0.name == "SAPISID" }?.value == "mock-live-primary-session")
+    }
+
+    @Test("Missing archive without a live session allows signed-out startup")
+    func missingArchiveWithoutLiveSessionAllowsSignedOutStartup() async {
+        let webKitManager = WebKitManager.makeTestInstance()
+
+        let allowsAuthentication = await webKitManager.restoreAuthCookiesFromBackup(
+            expectedGeneration: webKitManager.authCookieOperationFence.generation
+        )
+        let cookies = await webKitManager.dataStore.httpCookieStore.allCookies()
+
+        #expect(allowsAuthentication)
+        #expect(cookies.isEmpty)
+    }
+
+    @Test("Unavailable archive preserves the complete live cookie jar")
+    func unavailableArchivePreservesLiveCookies() async throws {
+        let persistedState = InMemoryCookieArchiveBox()
+        let persistedMarker = Data([0x47])
+        persistedState.store(persistedMarker)
+        let storage = CookieArchiveStorage(
+            save: { _, _ in true },
+            loadResult: { .failure },
+            delete: {
+                persistedState.store(nil)
+                return true
+            }
+        )
+        let webKitManager = WebKitManager.makeTestInstance(cookieArchiveStorage: storage)
+        let liveCookies = try [
+            Self.makeCookie(name: "SAPISID", value: "mock-live-primary-session", domain: ".youtube.com"),
+            Self.makeCookie(name: "LSID", value: "mock-live-login-state", domain: ".google.com"),
+            Self.makeCookie(name: "PREF", value: "mock-preference", domain: ".youtube.com"),
+        ]
+        for cookie in liveCookies {
+            await webKitManager.dataStore.httpCookieStore.setCookie(cookie)
+        }
+
+        let allowsAuthentication = await webKitManager.restoreAuthCookiesFromBackup(
+            expectedGeneration: webKitManager.authCookieOperationFence.generation
+        )
+        let cookies = await webKitManager.dataStore.httpCookieStore.allCookies()
+
+        #expect(!allowsAuthentication)
+        #expect(Self.cookieValues(cookies) == Self.cookieValues(liveCookies))
+        #expect(persistedState.load() == persistedMarker)
+    }
+
+    @Test("Unavailable restore policy preserves live cookies and persisted archive")
+    func unavailableRestorePolicyPreservesLiveAndPersistedState() async throws {
+        let persistedState = InMemoryCookieArchiveBox()
+        let persistedMarker = Data([0x48])
+        persistedState.store(persistedMarker)
+        let storage = CookieArchiveStorage(
+            save: { _, _ in true },
+            loadResult: {
+                guard let data = persistedState.load() else { return .notFound }
+                return .data(data)
+            },
+            delete: {
+                persistedState.store(nil)
+                return true
+            },
+            restoreDecision: { .unavailable }
+        )
+        let webKitManager = WebKitManager.makeTestInstance(cookieArchiveStorage: storage)
+        let liveCookies = try [
+            Self.makeCookie(name: "SAPISID", value: "mock-live-primary-session", domain: ".youtube.com"),
+            Self.makeCookie(name: "PREF", value: "mock-preference", domain: ".youtube.com"),
+        ]
+        for cookie in liveCookies {
+            await webKitManager.dataStore.httpCookieStore.setCookie(cookie)
+        }
+
+        let allowsAuthentication = await webKitManager.restoreAuthCookiesFromBackup(
+            expectedGeneration: webKitManager.authCookieOperationFence.generation
+        )
+        let cookies = await webKitManager.dataStore.httpCookieStore.allCookies()
+
+        #expect(!allowsAuthentication)
+        #expect(Self.cookieValues(cookies) == Self.cookieValues(liveCookies))
+        #expect(await webKitManager.cookieArchiveQueue.persistedArchiveData() == persistedMarker)
+    }
+
+    @Test("Denied restore remains authoritative")
+    func deniedRestoreClearsLoginStateAndArchive() async throws {
+        let persistedState = InMemoryCookieArchiveBox()
+        persistedState.store(Data([0x49]))
+        let storage = CookieArchiveStorage(
+            save: { _, _ in true },
+            loadResult: {
+                guard let data = persistedState.load() else { return .notFound }
+                return .data(data)
+            },
+            delete: {
+                persistedState.store(nil)
+                return true
+            },
+            restoreDecision: { .denied }
+        )
+        let webKitManager = WebKitManager.makeTestInstance(cookieArchiveStorage: storage)
+        let livePrimaryCookie = try Self.makeCookie(
+            name: "SAPISID",
+            value: "mock-live-primary-session",
+            domain: ".youtube.com"
+        )
+        let preferenceCookie = try Self.makeCookie(
+            name: "PREF",
+            value: "mock-preference",
+            domain: ".youtube.com"
+        )
+        await webKitManager.dataStore.httpCookieStore.setCookie(livePrimaryCookie)
+        await webKitManager.dataStore.httpCookieStore.setCookie(preferenceCookie)
+
+        let allowsAuthentication = await webKitManager.restoreAuthCookiesFromBackup(
+            expectedGeneration: webKitManager.authCookieOperationFence.generation
+        )
+        let cookies = await webKitManager.dataStore.httpCookieStore.allCookies()
+
+        #expect(allowsAuthentication)
+        #expect(!cookies.contains { $0.name == "SAPISID" })
+        #expect(cookies.first { $0.name == "PREF" }?.value == "mock-preference")
+        #expect(await webKitManager.cookieArchiveQueue.persistedArchiveData() == nil)
+    }
+
+    @Test("Denied restore clears residual login state when the archive is missing")
+    func deniedRestoreWithMissingArchiveClearsResidualLoginState() async throws {
+        let storage = CookieArchiveStorage(
+            save: { _, _ in true },
+            loadResult: { .notFound },
+            delete: { true },
+            restoreDecision: { .denied }
+        )
+        let webKitManager = WebKitManager.makeTestInstance(cookieArchiveStorage: storage)
+        let livePrimaryCookie = try Self.makeCookie(
+            name: "SAPISID",
+            value: "mock-residual-primary-session",
+            domain: ".youtube.com"
+        )
+        await webKitManager.dataStore.httpCookieStore.setCookie(livePrimaryCookie)
+
+        let allowsAuthentication = await webKitManager.restoreAuthCookiesFromBackup(
+            expectedGeneration: webKitManager.authCookieOperationFence.generation
+        )
+        let cookies = await webKitManager.dataStore.httpCookieStore.allCookies()
+
+        #expect(allowsAuthentication)
+        #expect(!cookies.contains { $0.name == "SAPISID" })
+    }
+
+    @Test("Invalid archive is quarantined through startup restoration")
+    func invalidArchiveIsQuarantinedThroughRestoreEntryPoint() async throws {
+        let webKitManager = WebKitManager.makeTestInstance()
+        let generation = await webKitManager.cookieArchiveQueue.reserveGeneration()
+        #expect(await webKitManager.cookieArchiveQueue.save(
+            archiveData: Data([0x4A]),
+            cookieCount: 1,
+            generation: generation
+        ).isPersisted)
+        let livePrimaryCookie = try Self.makeCookie(
+            name: "SAPISID",
+            value: "mock-live-primary-session",
+            domain: ".youtube.com"
+        )
+        let preferenceCookie = try Self.makeCookie(
+            name: "PREF",
+            value: "mock-preference",
+            domain: ".youtube.com"
+        )
+        await webKitManager.dataStore.httpCookieStore.setCookie(livePrimaryCookie)
+        await webKitManager.dataStore.httpCookieStore.setCookie(preferenceCookie)
+        let restorePolicyGeneration = CookieArchiveRestorePolicy.generation
+
+        let allowsAuthentication = await webKitManager.restoreAuthCookiesFromBackup(
+            expectedGeneration: webKitManager.authCookieOperationFence.generation
+        )
+        let cookies = await webKitManager.dataStore.httpCookieStore.allCookies()
+        _ = await webKitManager.clearAllData()
+
+        #expect(!allowsAuthentication)
+        #expect(CookieArchiveRestorePolicy.generation > restorePolicyGeneration)
+        #expect(!cookies.contains { $0.name == "SAPISID" })
+        #expect(cookies.first { $0.name == "PREF" }?.value == "mock-preference")
+    }
+
     @Test("Clearing one manager's data leaves another manager's cookie archive intact")
     func clearingOneManagerPreservesAnotherManagersArchive() async {
         let archiveOwner = WebKitManager.makeTestInstance()
@@ -65,13 +271,13 @@ struct WebKitCookieRestoreTests {
         await webKitManager.dataStore.httpCookieStore.setCookie(staleGAIA)
         await webKitManager.dataStore.httpCookieStore.setCookie(publicPreference)
 
-        let restored = await webKitManager.restoreAuthCookiesFromBackup(
+        let allowsAuthentication = await webKitManager.restoreAuthCookiesFromBackup(
             expectedGeneration: webKitManager.authCookieOperationFence.generation
         )
         let cookies = await webKitManager.dataStore.httpCookieStore.allCookies()
         _ = await webKitManager.clearAllData()
 
-        #expect(restored)
+        #expect(allowsAuthentication)
         #expect(cookies.first { $0.name == "__Secure-3PAPISID" }?.value == "isolated-restore-session")
         #expect(cookies.contains { $0.name == "SAPISID" } == false)
         #expect(cookies.contains { $0.name == "LSID" } == false)
@@ -345,5 +551,25 @@ struct WebKitCookieRestoreTests {
             expectedLoginCookies: [primaryCookie, baselineCompanion],
             currentCookies: [primaryCookie, refreshedCompanion]
         ))
+    }
+
+    private static func makeCookie(
+        name: String,
+        value: String,
+        domain: String
+    ) throws -> HTTPCookie {
+        try #require(HTTPCookie(properties: [
+            .name: name,
+            .value: value,
+            .domain: domain,
+            .path: "/",
+            .expires: Date().addingTimeInterval(3600),
+        ]))
+    }
+
+    private static func cookieValues(_ cookies: [HTTPCookie]) -> [String] {
+        cookies.map { cookie in
+            "\(cookie.domain)|\(cookie.path)|\(cookie.name)|\(cookie.value)"
+        }.sorted()
     }
 }

--- a/Tests/KasetTests/WebKitCookieRestoreTests.swift
+++ b/Tests/KasetTests/WebKitCookieRestoreTests.swift
@@ -18,13 +18,13 @@ struct WebKitCookieRestoreTests {
 
         await webKitManager.dataStore.httpCookieStore.setCookie(livePrimaryCookie)
 
-        let allowsAuthentication = await webKitManager.restoreAuthCookiesFromBackup(
+        let result = await webKitManager.restoreAuthCookiesFromBackup(
             expectedGeneration: webKitManager.authCookieOperationFence.generation
         )
         let cookies = await webKitManager.dataStore.httpCookieStore.allCookies()
         _ = await webKitManager.clearAllData()
 
-        #expect(allowsAuthentication)
+        #expect(result == .ready)
         #expect(cookies.first { $0.name == "SAPISID" }?.value == "mock-live-primary-session")
     }
 
@@ -32,12 +32,12 @@ struct WebKitCookieRestoreTests {
     func missingArchiveWithoutLiveSessionAllowsSignedOutStartup() async {
         let webKitManager = WebKitManager.makeTestInstance()
 
-        let allowsAuthentication = await webKitManager.restoreAuthCookiesFromBackup(
+        let result = await webKitManager.restoreAuthCookiesFromBackup(
             expectedGeneration: webKitManager.authCookieOperationFence.generation
         )
         let cookies = await webKitManager.dataStore.httpCookieStore.allCookies()
 
-        #expect(allowsAuthentication)
+        #expect(result == .ready)
         #expect(cookies.isEmpty)
     }
 
@@ -64,12 +64,12 @@ struct WebKitCookieRestoreTests {
             await webKitManager.dataStore.httpCookieStore.setCookie(cookie)
         }
 
-        let allowsAuthentication = await webKitManager.restoreAuthCookiesFromBackup(
+        let result = await webKitManager.restoreAuthCookiesFromBackup(
             expectedGeneration: webKitManager.authCookieOperationFence.generation
         )
         let cookies = await webKitManager.dataStore.httpCookieStore.allCookies()
 
-        #expect(!allowsAuthentication)
+        #expect(result == .unavailable)
         #expect(Self.cookieValues(cookies) == Self.cookieValues(liveCookies))
         #expect(persistedState.load() == persistedMarker)
     }
@@ -100,12 +100,12 @@ struct WebKitCookieRestoreTests {
             await webKitManager.dataStore.httpCookieStore.setCookie(cookie)
         }
 
-        let allowsAuthentication = await webKitManager.restoreAuthCookiesFromBackup(
+        let result = await webKitManager.restoreAuthCookiesFromBackup(
             expectedGeneration: webKitManager.authCookieOperationFence.generation
         )
         let cookies = await webKitManager.dataStore.httpCookieStore.allCookies()
 
-        #expect(!allowsAuthentication)
+        #expect(result == .unavailable)
         #expect(Self.cookieValues(cookies) == Self.cookieValues(liveCookies))
         #expect(await webKitManager.cookieArchiveQueue.persistedArchiveData() == persistedMarker)
     }
@@ -140,12 +140,12 @@ struct WebKitCookieRestoreTests {
         await webKitManager.dataStore.httpCookieStore.setCookie(livePrimaryCookie)
         await webKitManager.dataStore.httpCookieStore.setCookie(preferenceCookie)
 
-        let allowsAuthentication = await webKitManager.restoreAuthCookiesFromBackup(
+        let result = await webKitManager.restoreAuthCookiesFromBackup(
             expectedGeneration: webKitManager.authCookieOperationFence.generation
         )
         let cookies = await webKitManager.dataStore.httpCookieStore.allCookies()
 
-        #expect(allowsAuthentication)
+        #expect(result == .ready)
         #expect(!cookies.contains { $0.name == "SAPISID" })
         #expect(cookies.first { $0.name == "PREF" }?.value == "mock-preference")
         #expect(await webKitManager.cookieArchiveQueue.persistedArchiveData() == nil)
@@ -167,12 +167,12 @@ struct WebKitCookieRestoreTests {
         )
         await webKitManager.dataStore.httpCookieStore.setCookie(livePrimaryCookie)
 
-        let allowsAuthentication = await webKitManager.restoreAuthCookiesFromBackup(
+        let result = await webKitManager.restoreAuthCookiesFromBackup(
             expectedGeneration: webKitManager.authCookieOperationFence.generation
         )
         let cookies = await webKitManager.dataStore.httpCookieStore.allCookies()
 
-        #expect(allowsAuthentication)
+        #expect(result == .ready)
         #expect(!cookies.contains { $0.name == "SAPISID" })
     }
 
@@ -199,13 +199,13 @@ struct WebKitCookieRestoreTests {
         await webKitManager.dataStore.httpCookieStore.setCookie(preferenceCookie)
         let restorePolicyGeneration = CookieArchiveRestorePolicy.generation
 
-        let allowsAuthentication = await webKitManager.restoreAuthCookiesFromBackup(
+        let result = await webKitManager.restoreAuthCookiesFromBackup(
             expectedGeneration: webKitManager.authCookieOperationFence.generation
         )
         let cookies = await webKitManager.dataStore.httpCookieStore.allCookies()
         _ = await webKitManager.clearAllData()
 
-        #expect(!allowsAuthentication)
+        #expect(result == .failed)
         #expect(CookieArchiveRestorePolicy.generation > restorePolicyGeneration)
         #expect(!cookies.contains { $0.name == "SAPISID" })
         #expect(cookies.first { $0.name == "PREF" }?.value == "mock-preference")
@@ -271,13 +271,13 @@ struct WebKitCookieRestoreTests {
         await webKitManager.dataStore.httpCookieStore.setCookie(staleGAIA)
         await webKitManager.dataStore.httpCookieStore.setCookie(publicPreference)
 
-        let allowsAuthentication = await webKitManager.restoreAuthCookiesFromBackup(
+        let result = await webKitManager.restoreAuthCookiesFromBackup(
             expectedGeneration: webKitManager.authCookieOperationFence.generation
         )
         let cookies = await webKitManager.dataStore.httpCookieStore.allCookies()
         _ = await webKitManager.clearAllData()
 
-        #expect(allowsAuthentication)
+        #expect(result == .ready)
         #expect(cookies.first { $0.name == "__Secure-3PAPISID" }?.value == "isolated-restore-session")
         #expect(cookies.contains { $0.name == "SAPISID" } == false)
         #expect(cookies.contains { $0.name == "LSID" } == false)

--- a/docs/adr/0037-deferred-cookie-restoration.md
+++ b/docs/adr/0037-deferred-cookie-restoration.md
@@ -28,12 +28,28 @@ A partial Google session without a primary YouTube authentication cookie can
 start login. Its native archive baseline is empty, while rollback retains the
 complete live Google and YouTube cookie jar captured before login.
 
-The root task follows authentication state and owns account loading for startup,
-sign-in, and recovery. Initializing or active-login tasks cannot continue into
-playback cleanup. Cancelling an early sign-in resumes the status check; its
-resolved state starts the task that performs cleanup and account loading. A
-newly presented cleanup sheet captures the last login attempt's identity so
-Retry retains ownership after cancellation releases the active attempt.
+The root task follows startup readiness and authentication state and owns account
+loading for startup, sign-in, and recovery. Unavailable storage and pending
+authentication checks defer playback cleanup, preserving the saved queue and
+current track throughout recovery. Resolving storage restarts startup even when
+authentication remains logged out. Saves and data-store reloads preserve the
+restored queue's guest or personal ownership until startup cleanup decides which
+session to retain. Legacy sessions without an ownership marker remain private.
+Explicit sign-out clears either kind of queue.
+
+Recovery status and authentication publish together. The window keeps playback
+hidden and offers a recovery entry point while restoration is unresolved. The
+recovery sheet offers Retry and an explicit Sign Out to discard the saved session.
+Sign Out cancels the pending authentication check synchronously when clicked,
+before scheduling asynchronous sign-out. Cancelled status callers cannot start
+another recovery check. A failed sign-out write leaves recovery and the failure
+alert available for another attempt.
+
+Initializing or active-login tasks cannot continue into playback cleanup.
+Cancelling an early sign-in resumes the status check; its resolved state starts
+the task that performs cleanup and account loading. A newly presented cleanup
+sheet captures the last login attempt's identity so Retry retains ownership
+after cancellation releases the active attempt.
 
 ## Consequences
 

--- a/docs/adr/0037-deferred-cookie-restoration.md
+++ b/docs/adr/0037-deferred-cookie-restoration.md
@@ -1,0 +1,43 @@
+# ADR-0037: Deferred cookie restoration
+
+## Status
+
+Accepted
+
+## Context
+
+WebKit can retain a valid Google session when the native cookie archive is
+missing. Archive storage or its restore policy can also be temporarily
+unreadable. Treating these states as failed cleanup makes a storage retry erase
+the session. Allowing backups during that delay can overwrite the retained
+archive with an older live cookie jar.
+
+## Decision
+
+Startup restoration returns `ready`, `unavailable`, or `failed`.
+`unavailable` preserves both stores and blocks authentication, login WebView
+creation, and cookie backups. Retry joins one restoration task and reads the
+policy and archive again. Only `failed` requires the existing cleanup flow.
+Explicit sign-out still fences pending restoration and invalidates both stores.
+
+An allowed policy with no archive preserves the live WebKit session. A denied
+policy clears it. A readable archive remains authoritative, and invalid archive
+contents retain the existing quarantine behavior.
+
+A partial Google session without a primary YouTube authentication cookie can
+start login. Its native archive baseline is empty, while rollback retains the
+complete live Google and YouTube cookie jar captured before login.
+
+The root task follows authentication state and owns account loading for startup,
+sign-in, and recovery. Initializing or active-login tasks cannot continue into
+playback cleanup. Cancelling an early sign-in resumes the status check; its
+resolved state starts the task that performs cleanup and account loading. A
+newly presented cleanup sheet captures the last login attempt's identity so
+Retry retains ownership after cancellation releases the active attempt.
+
+## Consequences
+
+Temporary storage failures keep a recoverable session intact across repeated
+sign-in attempts. Authentication stays unavailable until a storage read succeeds
+or the user explicitly signs out. Observer and forced backups share the same
+restoration gate so neither can replace an archive before that decision.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -71,3 +71,4 @@ What becomes easier or more difficult because of this change?
 | [0034](0034-replace-playback-navigation.md) | Replace Playback Documents Without Growing History | Accepted |
 | [0035](0035-gapless-playback-native-queue.md) | Gapless Playback via YouTube Music Native Queue | Accepted |
 | [0036](0036-music-audio-output-continuity.md) | Music audio output continuity | Accepted |
+| [0037](0037-deferred-cookie-restoration.md) | Deferred cookie restoration | Accepted |


### PR DESCRIPTION
## Description

Kaset now preserves a live WebKit login when its native cookie archive is missing. If the archive or restore policy is temporarily unreadable, sign-in shows a recovery message and Retry checks storage again without deleting the session.

Observer and forced backups stay blocked until restoration resolves, protecting the retained archive from stale live cookies. Concurrent retries share one restore task. Partial Google sessions can start login and roll back to their complete original cookie jar.

Playback cleanup waits until storage and authentication resolve, preserving the saved queue and current track during recovery. Saves and WebView reloads retain the restored queue's guest or personal ownership until startup cleanup; older queues without an ownership marker remain private. Startup resumes even when recovery confirms a guest session, then applies the appropriate playback privacy boundary.

The recovery screen remains reachable after dismissal and offers Retry and Sign Out. Sign Out cancels pending authentication as soon as it is requested, and cancelled Retry tasks cannot start another check. Successful sign-out clears saved and live sign-in data, including an unreadable restore policy. If saving sign-out intent fails, recovery and the failure alert remain available for another attempt.

Cancelling or completing an early sign-in resumes account loading without duplicate requests. Cleanup remains retryable if a restore failure reopens the sign-in sheet after cancellation.

Readable archives remain authoritative, and invalid archives retain the existing quarantine behavior. Recovery messages are localized in all 17 supported locales, with the storage decision documented in ADR-0037.

Fixes #475.

## Validation

- `swift build`
- `swift test --skip KasetUITests --disable-xctest --no-parallel`, all 3,378 unit tests passed
- Regression tests cover unavailable archive and policy reads, concurrent recovery, successful and failed sign-out during pending archive or cookie reads, recovery finishing before asynchronous sign-out begins, cancelled Retry tasks starting late, explicit sign-out with an unreadable policy, suppressed backups, partial-session rollback, and early sign-in cancellation and completion
- Playback tests cover guest and personal queues recovering into either authentication state, saves and WebView reloads before startup cleanup, and legacy queues while metadata requests fail offline
- Localization catalog and runtime mirror parity passed
- `swiftlint --strict` and `swiftformat --lint .`

Local UI tests were not run.
