### PR TITLE
fix(player): show live status for YouTube streams

### DIFF
--- a/Sources/Kaset/Views/PlayerBarProgressLane.swift
+++ b/Sources/Kaset/Views/PlayerBarProgressLane.swift
@@ -62,14 +62,45 @@ struct PlayerBarProgressLane: View {
     }
 
     var body: some View {
+        if self.isLive {
+            self.liveIndicator
+        } else {
+            self.playbackTimeline
+        }
+    }
+
+    private var liveIndicator: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 4) {
+                Circle()
+                    .fill(.red)
+                    .frame(width: 5, height: 5)
+
+                Text("LIVE")
+                    .font(.system(size: 11))
+                    .lineLimit(1)
+            }
+            .frame(height: 12)
+
+            Capsule()
+                .fill(self.accent)
+                .frame(height: PlayerBarSliderVisuals.trackThickness)
+                .frame(height: 12, alignment: .top)
+        }
+        .frame(height: 30)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(String(localized: "Live stream"))
+    }
+
+    private var playbackTimeline: some View {
         VStack(spacing: 6) {
             HStack(spacing: 8) {
-                Text(self.isLive ? String(localized: "LIVE") : self.elapsedText)
-                    .foregroundStyle(self.isLive ? .red : .secondary)
+                Text(self.elapsedText)
+                    .foregroundStyle(.secondary)
 
                 Spacer(minLength: 8)
 
-                Text(self.isLive ? "" : self.remainingText)
+                Text(self.remainingText)
                     .foregroundStyle(.secondary)
             }
             .font(.system(size: 11))
@@ -120,7 +151,6 @@ struct PlayerBarProgressLane: View {
                     )
                     .fill(fillColor)
                     .frame(width: fillWidth, height: PlayerBarSliderVisuals.trackThickness)
-                    .opacity(self.isLive ? 0 : 1)
                 } else {
                     self.segmentedTrack(width: width, fillColor: fillColor)
                 }
@@ -142,7 +172,7 @@ struct PlayerBarProgressLane: View {
                                 x: self.markerX(marker, trackWidth: width, isHighlighted: isHighlighted),
                                 y: -3
                             )
-                            .opacity(self.isLive || self.isLoading ? 0 : 1)
+                            .opacity(self.isLoading ? 0 : 1)
                             .accessibilityHidden(true)
                     }
                 }
@@ -156,7 +186,7 @@ struct PlayerBarProgressLane: View {
                     )
                     .opacity(self.canSeek ? 1 : 0)
 
-                if let segment = self.hoveredSegment, self.segments.contains(segment), !self.isLoading, !self.isLive {
+                if let segment = self.hoveredSegment, self.segments.contains(segment), !self.isLoading {
                     self.segmentTooltip(segment, trackWidth: width)
                         .onGeometryChange(for: CGSize.self) { $0.size } action: { self.tooltipSize = $0 }
                         .offset(
@@ -342,7 +372,6 @@ struct PlayerBarProgressLane: View {
                     RoundedRectangle(cornerRadius: 2, style: .continuous)
                         .fill(fillColor)
                         .frame(width: geometry.width * within, height: PlayerBarSliderVisuals.trackThickness)
-                        .opacity(self.isLive ? 0 : 1)
                 }
                 .frame(width: geometry.width, alignment: .leading)
                 .scaleEffect(y: isProminent ? 2.0 : 1, anchor: .center)

--- a/Sources/Kaset/Views/YouTube/YouTubePlayerBar.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubePlayerBar.swift
@@ -3,10 +3,6 @@ import SwiftUI
 // MARK: - YouTubePlayerBar
 
 /// The Liquid Glass player bar for inline and detached YouTube playback.
-///
-/// Transport controls seek 30 seconds within the video. Chapter markers appear
-/// in the progress bar, and video controls manage captions, quality, AirPlay,
-/// picture in picture, and fullscreen.
 struct YouTubePlayerBar: View {
     private static let brandAccent = PackageResourceLookup.brandAccent
     private static let fullVideoDetailsWidth: CGFloat = 294
@@ -102,7 +98,7 @@ struct YouTubePlayerBar: View {
             self.clearSeekHold()
             self.chapterPreviewMarker = nil
         }
-        .onChange(of: self.youtubePlayer.isShowingAd) { _, _ in
+        .onChange(of: self.canSeek) { _, _ in
             self.clearSeekHold()
             self.chapterPreviewMarker = nil
         }
@@ -303,7 +299,7 @@ struct YouTubePlayerBar: View {
                         remainingText: "-\(Self.formatTime(max(0, self.youtubePlayer.duration - self.progressTextValue)))",
                         markers: self.chapterProgressMarkers,
                         segments: self.chapterProgressSegments,
-                        isLive: false,
+                        isLive: self.isLive,
                         canSeek: self.canSeek,
                         isLoading: self.isProgressLoading,
                         onScrub: { fraction in
@@ -328,20 +324,9 @@ struct YouTubePlayerBar: View {
 
     private var youtubeTransportControls: some View {
         HStack(spacing: 6) {
-            PlayerBarIconButton(
-                action: {
-                    HapticService.playback()
-                    self.youtubePlayer.seekBackward()
-                },
-                accessibilityLabel: String(localized: "Back 30 seconds"),
-                icon: {
-                    Image(systemName: "gobackward.30")
-                        .font(.system(size: 16, weight: .regular))
-                        .frame(width: 16, height: 16)
-                        .foregroundStyle(.primary)
-                }
-            )
-            .disabled(!self.canSeek)
+            if !self.isLive {
+                self.youtubeSeekButton(isForward: false)
+            }
 
             PlayerBarIconButton(
                 action: {
@@ -361,20 +346,9 @@ struct YouTubePlayerBar: View {
             .compatGlassID("youtubePlayPause", in: self.playerNamespace)
             .disabled(self.youtubePlayer.currentVideo == nil)
 
-            PlayerBarIconButton(
-                action: {
-                    HapticService.playback()
-                    self.youtubePlayer.seekForward()
-                },
-                accessibilityLabel: String(localized: "Forward 30 seconds"),
-                icon: {
-                    Image(systemName: "goforward.30")
-                        .font(.system(size: 16, weight: .regular))
-                        .frame(width: 16, height: 16)
-                        .foregroundStyle(.primary)
-                }
-            )
-            .disabled(!self.canSeek)
+            if !self.isLive {
+                self.youtubeSeekButton(isForward: true)
+            }
 
             PlayerBarIconButton(
                 action: self.toggleYouTubeVolumeOverlay,
@@ -392,6 +366,27 @@ struct YouTubePlayerBar: View {
                 self.youtubeVolumeOverlay
             }
         }
+    }
+
+    private func youtubeSeekButton(isForward: Bool) -> some View {
+        PlayerBarIconButton(
+            action: {
+                HapticService.playback()
+                if isForward {
+                    self.youtubePlayer.seekForward()
+                } else {
+                    self.youtubePlayer.seekBackward()
+                }
+            },
+            accessibilityLabel: isForward ? String(localized: "Forward 30 seconds") : String(localized: "Back 30 seconds"),
+            icon: {
+                Image(systemName: isForward ? "goforward.30" : "gobackward.30")
+                    .font(.system(size: 16, weight: .regular))
+                    .frame(width: 16, height: 16)
+                    .foregroundStyle(.primary)
+            }
+        )
+        .disabled(!self.canSeek)
     }
 
     private var youtubeOptionsSection: some View {
@@ -614,7 +609,7 @@ struct YouTubePlayerBar: View {
     }
 
     private var chapterProgressMarkers: [PlayerBarProgressMarker] {
-        guard self.youtubePlayer.duration > 0, !self.youtubePlayer.isShowingAd else { return [] }
+        guard self.canSeek else { return [] }
         return self.youtubePlayer.chapters.compactMap { chapter in
             guard chapter.startTime > 0, chapter.startTime < self.youtubePlayer.duration else { return nil }
             return PlayerBarProgressMarker(
@@ -627,7 +622,7 @@ struct YouTubePlayerBar: View {
     }
 
     private var chapterProgressSegments: [PlayerBarProgressSegment] {
-        guard !self.youtubePlayer.isShowingAd else { return [] }
+        guard self.canSeek else { return [] }
         return Self.chapterProgressSegments(
             chapters: self.youtubePlayer.chapters,
             duration: self.youtubePlayer.duration
@@ -690,9 +685,13 @@ struct YouTubePlayerBar: View {
         }
     }
 
-    /// Seeking is unavailable during ads or before a duration is known.
+    private var isLive: Bool {
+        self.youtubePlayer.currentVideo?.isLive == true
+    }
+
+    /// A live stream can report a finite DVR duration, so duration alone does not enable seeking.
     private var canSeek: Bool {
-        self.youtubePlayer.duration > 0 && !self.youtubePlayer.isShowingAd
+        self.youtubePlayer.duration > 0 && !self.youtubePlayer.isShowingAd && !self.isLive
     }
 
     private var isProgressLoading: Bool {


### PR DESCRIPTION
## Description

Live YouTube events could report a finite DVR duration, but the player bar hardcoded their live status to false. That displayed a scrubber and a misleading countdown.

Use the current video's live status to show a red dot, LIVE label, and solid progress line. Hide the 30-second seek buttons and chapter previews during live playback, and expose the live indicator as non-adjustable to accessibility tools.

## Testing

- `swift build`
- `swift test --skip KasetUITests --no-parallel`: all 3,378 tests passed.
- `swiftlint --strict` and `swiftformat --lint .`
- Checked offscreen SwiftUI renders at 1,100-point and 500-point widths for live status from feed metadata and the playback bridge, regular video, and ads during a live stream.
