### PR TITLE
fix(youtube): remove ambient style toolbar picker

### DIFF
--- a/Sources/Kaset/Views/YouTube/AmbientBackdropStyle.swift
+++ b/Sources/Kaset/Views/YouTube/AmbientBackdropStyle.swift
@@ -38,14 +38,4 @@ enum AmbientBackdropStyle: String, CaseIterable, Identifiable {
         case .live: String(localized: "Live (follows video)")
         }
     }
-
-    /// Terse label for the DEBUG developer style picker.
-    var debugLabel: String {
-        switch self {
-        case .off: "Off"
-        case .soft: "Soft"
-        case .glow: "Glow"
-        case .live: "Live (storyboard)"
-        }
-    }
 }

--- a/Sources/Kaset/Views/YouTube/YouTubeWatchView.swift
+++ b/Sources/Kaset/Views/YouTube/YouTubeWatchView.swift
@@ -123,27 +123,22 @@ struct YouTubeWatchView: View {
             )
         }
         .youtubeAskAccessibilityAnnouncements(viewModel: self.viewModel.ask)
-        #if DEBUG
-            .toolbar {
-                self.ambientStylePicker
-            }
-        #endif
-            .task {
-                self.startOrAdoptPlayback()
-            }
-            .task(id: self.askAccountScope) {
-                let accountScope = self.askAccountScope
-                await self.viewModel.load(accountScope: accountScope)
-                YouTubeWatchPlaybackLifecycle.synchronizeLoadedData(
-                    videoId: self.video.videoId,
-                    player: self.youtubePlayer,
-                    data: self.viewModel.data
-                )
-            }
-            .onDisappear {
-                self.viewModel.cancel()
-                self.youtubePlayer.inlineSurfaceWillDisappear(videoId: self.video.videoId)
-            }
+        .task {
+            self.startOrAdoptPlayback()
+        }
+        .task(id: self.askAccountScope) {
+            let accountScope = self.askAccountScope
+            await self.viewModel.load(accountScope: accountScope)
+            YouTubeWatchPlaybackLifecycle.synchronizeLoadedData(
+                videoId: self.video.videoId,
+                player: self.youtubePlayer,
+                data: self.viewModel.data
+            )
+        }
+        .onDisappear {
+            self.viewModel.cancel()
+            self.youtubePlayer.inlineSurfaceWillDisappear(videoId: self.video.videoId)
+        }
     }
 
     private var askPlayerOffsetMilliseconds: Int64 {
@@ -152,32 +147,6 @@ struct YouTubeWatchView: View {
         }
         return YouTubeAskPlayerOffset.milliseconds(for: self.youtubePlayer.progress)
     }
-
-    // MARK: - Ambient Style Picker (PROTOTYPE)
-
-    #if DEBUG
-        /// DEBUG-only toolbar control to switch ambient styles live on-device.
-        /// Binds to the same `SettingsManager` value as the Settings → YouTube
-        /// tab, so there is a single source of truth. The whole property is
-        /// compiled out of release builds (an empty `@ToolbarContentBuilder`
-        /// body would otherwise be invalid).
-        @ToolbarContentBuilder
-        private var ambientStylePicker: some ToolbarContent {
-            ToolbarItem(placement: .automatic) {
-                Menu {
-                    Picker(String(localized: "Ambient"), selection: self.$settings.ambientBackdropStyle) {
-                        ForEach(AmbientBackdropStyle.allCases) { style in
-                            Text(style.debugLabel).tag(style)
-                        }
-                    }
-                    .pickerStyle(.inline)
-                } label: {
-                    Image(systemName: "paintpalette")
-                }
-                .help(String(localized: "Ambient backdrop style (developer)"))
-            }
-        }
-    #endif
 
     // MARK: - Video Surface
 

--- a/Tests/KasetTests/StoryboardSheetTests.swift
+++ b/Tests/KasetTests/StoryboardSheetTests.swift
@@ -157,11 +157,10 @@ struct AmbientBackdropStyleTests {
         #expect(Set(ids).count == ids.count)
     }
 
-    @Test("Display and debug names are non-empty for every case")
-    func namesNonEmpty() {
+    @Test("Display names are non-empty for every case")
+    func displayNamesNonEmpty() {
         for style in AmbientBackdropStyle.allCases {
             #expect(!style.displayName.isEmpty)
-            #expect(!style.debugLabel.isEmpty)
         }
     }
 


### PR DESCRIPTION
## Description

Remove the developer ambient dropdown from the top-right of the YouTube watch page, along with its unused debug labels. Update the existing ambient style test to cover the remaining display names.

## Testing

- `swift build`
- `swiftlint --strict`
- `swiftformat --lint .`
- All 8 `AmbientBackdropStyleTests` passed with `swift test --skip-build --skip KasetUITests --disable-xctest --no-parallel --filter AmbientBackdropStyleTests`. The local runner required `DYLD_FRAMEWORK_PATH` set to the build products directory to load Sparkle.
