### PR TITLE
feat(parser): resolve the audio recording behind music-video album rows

### DIFF
--- a/Sources/Kaset/Models/Song.swift
+++ b/Sources/Kaset/Models/Song.swift
@@ -38,6 +38,20 @@ struct Song: Identifiable, Codable, Hashable {
     /// Only populated when the song was parsed from a playlist's track list.
     var playlistSetVideoId: String?
 
+    /// Video ID of this track's audio recording, when the row itself is a music video.
+    ///
+    /// Album rows are sometimes official music videos (`MUSIC_VIDEO_TYPE_OMV`). YouTube
+    /// Music still advertises the audio recording of the same track in the row's
+    /// credits menu, and this carries that ID. `nil` when the row is already an audio
+    /// recording or when no credits entry was present — use `preferredAudioVideoId`
+    /// to resolve either case.
+    var audioTrackVideoId: String?
+
+    /// The audio recording to prefer for this track, falling back to `videoId`.
+    var preferredAudioVideoId: String {
+        self.audioTrackVideoId ?? self.videoId
+    }
+
     private enum CodingKeys: String, CodingKey {
         case id
         case title
@@ -54,6 +68,7 @@ struct Song: Identifiable, Codable, Hashable {
         case feedbackTokens
         case isExplicit
         case playlistSetVideoId
+        case audioTrackVideoId
     }
 
     /// Memberwise initializer with default values for mutable properties.
@@ -72,7 +87,8 @@ struct Song: Identifiable, Codable, Hashable {
         isInLibrary: Bool? = nil,
         feedbackTokens: FeedbackTokens? = nil,
         isExplicit: Bool? = nil,
-        playlistSetVideoId: String? = nil
+        playlistSetVideoId: String? = nil,
+        audioTrackVideoId: String? = nil
     ) {
         self.id = id
         self.title = title
@@ -89,6 +105,7 @@ struct Song: Identifiable, Codable, Hashable {
         self.feedbackTokens = feedbackTokens
         self.isExplicit = isExplicit
         self.playlistSetVideoId = playlistSetVideoId
+        self.audioTrackVideoId = audioTrackVideoId
     }
 
     init(from decoder: any Decoder) throws {
@@ -108,6 +125,7 @@ struct Song: Identifiable, Codable, Hashable {
         self.feedbackTokens = try container.decodeIfPresent(FeedbackTokens.self, forKey: .feedbackTokens)
         self.isExplicit = try container.decodeIfPresent(Bool.self, forKey: .isExplicit)
         self.playlistSetVideoId = try container.decodeIfPresent(String.self, forKey: .playlistSetVideoId)
+        self.audioTrackVideoId = try container.decodeIfPresent(String.self, forKey: .audioTrackVideoId)
     }
 
     func encode(to encoder: any Encoder) throws {
@@ -127,6 +145,7 @@ struct Song: Identifiable, Codable, Hashable {
         try container.encodeIfPresent(self.feedbackTokens, forKey: .feedbackTokens)
         try container.encodeIfPresent(self.isExplicit, forKey: .isExplicit)
         try container.encodeIfPresent(self.playlistSetVideoId, forKey: .playlistSetVideoId)
+        try container.encodeIfPresent(self.audioTrackVideoId, forKey: .audioTrackVideoId)
     }
 
     func replacingDisplayMetadata(title: String, artists: [Artist], thumbnailURL: URL?) -> Song {
@@ -145,7 +164,8 @@ struct Song: Identifiable, Codable, Hashable {
             isInLibrary: self.isInLibrary,
             feedbackTokens: self.feedbackTokens,
             isExplicit: self.isExplicit,
-            playlistSetVideoId: self.playlistSetVideoId
+            playlistSetVideoId: self.playlistSetVideoId,
+            audioTrackVideoId: self.audioTrackVideoId
         )
     }
 

--- a/Sources/Kaset/Services/API/Parsers/ParsingHelpers+TrackCredits.swift
+++ b/Sources/Kaset/Services/API/Parsers/ParsingHelpers+TrackCredits.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+extension ParsingHelpers {
+    /// Extracts the audio-recording video ID advertised by a track row's
+    /// "View song credits" menu entry.
+    ///
+    /// YouTube Music builds the track-credits browse ID by prefixing `MPTC` to the
+    /// video ID of the song's *audio* recording. On albums whose rows are official
+    /// music videos (`MUSIC_VIDEO_TYPE_OMV`), that suffix is the audio counterpart
+    /// of the same track; on ordinary audio rows it simply repeats the row's own
+    /// video ID.
+    ///
+    /// The credits entry is matched on its `MUSIC_PAGE_TYPE_TRACK_CREDITS` page type
+    /// rather than its label, so this keeps working under any content language.
+    static func extractTrackCreditsVideoId(from data: [String: Any]) -> String? {
+        guard let menu = data["menu"] as? [String: Any],
+              let menuRenderer = menu["menuRenderer"] as? [String: Any],
+              let items = menuRenderer["items"] as? [[String: Any]]
+        else {
+            return nil
+        }
+
+        for item in items {
+            guard let navigationItem = item["menuNavigationItemRenderer"] as? [String: Any],
+                  let endpoint = navigationItem["navigationEndpoint"] as? [String: Any],
+                  let browseEndpoint = endpoint["browseEndpoint"] as? [String: Any],
+                  self.extractPageType(from: browseEndpoint) == self.trackCreditsPageType,
+                  let browseId = browseEndpoint["browseId"] as? String,
+                  browseId.hasPrefix(self.trackCreditsBrowseIdPrefix)
+            else {
+                continue
+            }
+
+            let videoId = String(browseId.dropFirst(self.trackCreditsBrowseIdPrefix.count))
+            return videoId.isEmpty ? nil : videoId
+        }
+
+        return nil
+    }
+
+    /// Page type identifying a track-credits browse destination.
+    private static let trackCreditsPageType = "MUSIC_PAGE_TYPE_TRACK_CREDITS"
+
+    /// Prefix YouTube Music prepends to a video ID to form its credits browse ID.
+    private static let trackCreditsBrowseIdPrefix = "MPTC"
+}

--- a/Sources/Kaset/Services/API/Parsers/PlaylistParser.swift
+++ b/Sources/Kaset/Services/API/Parsers/PlaylistParser.swift
@@ -1102,6 +1102,12 @@ enum PlaylistParser {
         let isPlayable = ParsingHelpers.isPlayableMusicItem(from: responsiveRenderer)
         let isExplicit = ParsingHelpers.extractIsExplicit(from: responsiveRenderer)
         let playlistSetVideoId = ParsingHelpers.extractPlaylistSetVideoId(from: responsiveRenderer)
+        let musicVideoType = ParsingHelpers.extractMusicVideoType(from: responsiveRenderer)
+
+        // Music-video rows advertise their audio recording through the credits menu.
+        // Ignore the credits ID when it just repeats the row (ordinary audio tracks).
+        let creditsVideoId = ParsingHelpers.extractTrackCreditsVideoId(from: responsiveRenderer)
+        let audioTrackVideoId = creditsVideoId == videoId ? nil : creditsVideoId
 
         return Song(
             id: videoId,
@@ -1112,8 +1118,10 @@ enum PlaylistParser {
             thumbnailURL: thumbnailURL,
             videoId: videoId,
             isPlayable: isPlayable,
+            musicVideoType: musicVideoType,
             isExplicit: isExplicit,
-            playlistSetVideoId: playlistSetVideoId
+            playlistSetVideoId: playlistSetVideoId,
+            audioTrackVideoId: audioTrackVideoId
         )
     }
 

--- a/Sources/Kaset/Services/API/YTMusicClient.swift
+++ b/Sources/Kaset/Services/API/YTMusicClient.swift
@@ -1095,7 +1095,8 @@ final class YTMusicClient: YTMusicClientProtocol {
                             musicVideoType: song.musicVideoType,
                             likeStatus: song.likeStatus,
                             isInLibrary: song.isInLibrary,
-                            feedbackTokens: song.feedbackTokens
+                            feedbackTokens: song.feedbackTokens,
+                            audioTrackVideoId: song.audioTrackVideoId
                         )
                     }
                     return song

--- a/Sources/Kaset/Services/Player/PlayerService+Library.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+Library.swift
@@ -436,8 +436,7 @@ extension PlayerService {
         let libraryMutationGeneration = self.libraryMutationGeneration
         let accountSessionGeneration = self.accountSessionGeneration
         let pendingMutationKey = self.pendingLibraryMutationKey(
-            accountID: activeAccountID,
-            videoId: videoId,
+            accountID: activeAccountID, videoId: videoId,
             sessionGeneration: accountSessionGeneration
         )
         let libraryMutationWasPending = self.pendingLibraryMutationCountsByKey[pendingMutationKey, default: 0] > 0
@@ -499,7 +498,8 @@ extension PlayerService {
                     feedbackTokens: libraryMutationIsCurrent
                         ? songData.feedbackTokens
                         : self.currentTrack?.feedbackTokens,
-                    isExplicit: songData.isExplicit ?? self.currentTrack?.isExplicit
+                    isExplicit: songData.isExplicit ?? self.currentTrack?.isExplicit,
+                    audioTrackVideoId: songData.audioTrackVideoId ?? self.currentTrack?.audioTrackVideoId
                 )
 
                 // Update service state and sync with SongLikeStatusManager.

--- a/Sources/Kaset/Services/Player/PlayerService+QueueEnrichment.swift
+++ b/Sources/Kaset/Services/Player/PlayerService+QueueEnrichment.swift
@@ -263,7 +263,8 @@ extension PlayerService {
             feedbackTokens: includesAccountMetadata
                 ? (current.feedbackTokens ?? response.feedbackTokens)
                 : current.feedbackTokens,
-            isExplicit: current.isExplicit ?? response.isExplicit
+            isExplicit: current.isExplicit ?? response.isExplicit,
+            audioTrackVideoId: current.audioTrackVideoId ?? response.audioTrackVideoId
         )
     }
 }

--- a/Sources/Kaset/Services/Player/PlaylistPlaybackActions.swift
+++ b/Sources/Kaset/Services/Player/PlaylistPlaybackActions.swift
@@ -106,11 +106,18 @@ enum PlaylistPlaybackActions {
 
     static func tracksForPlaylistPlayback(browseTracks: [Song], queueTracks: [Song]) -> [Song] {
         var browsePlayabilityByVideoId: [String: Bool] = [:]
+        var browseAudioIDsByVideoId: [String: String] = [:]
         for track in browseTracks {
             browsePlayabilityByVideoId[track.videoId] = track.isPlayable
+            if let audioTrackVideoId = track.audioTrackVideoId {
+                browseAudioIDsByVideoId[track.videoId] = audioTrackVideoId
+            }
         }
 
-        return queueTracks.map { track in
+        return queueTracks.map { queueTrack in
+            // Queue responses may omit the audio ID already discovered in browse rows.
+            var track = queueTrack
+            track.audioTrackVideoId = track.audioTrackVideoId ?? browseAudioIDsByVideoId[track.videoId]
             guard let browseIsPlayable = browsePlayabilityByVideoId[track.videoId],
                   browseIsPlayable != track.isPlayable
             else {

--- a/Sources/Kaset/Services/Player/PlaylistPlaybackActions.swift
+++ b/Sources/Kaset/Services/Player/PlaylistPlaybackActions.swift
@@ -210,7 +210,8 @@ enum PlaylistPlaybackActions {
             isInLibrary: song.isInLibrary,
             feedbackTokens: carried,
             isExplicit: song.isExplicit,
-            playlistSetVideoId: song.playlistSetVideoId
+            playlistSetVideoId: song.playlistSetVideoId,
+            audioTrackVideoId: song.audioTrackVideoId
         )
     }
 

--- a/Sources/Kaset/Services/Player/QueueSongMetadata.swift
+++ b/Sources/Kaset/Services/Player/QueueSongMetadata.swift
@@ -150,7 +150,8 @@ enum QueueSongMetadata {
             likeStatus: song.likeStatus,
             isInLibrary: song.isInLibrary,
             feedbackTokens: carried,
-            isExplicit: song.isExplicit
+            isExplicit: song.isExplicit,
+            audioTrackVideoId: song.audioTrackVideoId
         )
     }
 }

--- a/Sources/Kaset/Services/Player/QueueSongMetadata.swift
+++ b/Sources/Kaset/Services/Player/QueueSongMetadata.swift
@@ -151,6 +151,7 @@ enum QueueSongMetadata {
             isInLibrary: song.isInLibrary,
             feedbackTokens: carried,
             isExplicit: song.isExplicit,
+            playlistSetVideoId: song.playlistSetVideoId,
             audioTrackVideoId: song.audioTrackVideoId
         )
     }

--- a/Sources/Kaset/Services/Scripting/ScriptCommands.swift
+++ b/Sources/Kaset/Services/Scripting/ScriptCommands.swift
@@ -382,6 +382,7 @@ final class GetPlayQueueCommand: NSScriptCommand {
                     "album": track.album?.title ?? "",
                     "duration": track.duration ?? 0,
                     "videoId": track.videoId,
+                    "audioVideoId": track.preferredAudioVideoId,
                     "artworkURL": track.thumbnailURL?.absoluteString ?? "",
                 ]
             }

--- a/Sources/Kaset/ViewModels/PlaylistDetailViewModel.swift
+++ b/Sources/Kaset/ViewModels/PlaylistDetailViewModel.swift
@@ -340,7 +340,10 @@ extension PlaylistDetailViewModel {
         )
         return PlaylistDetail(
             playlist: playlist,
-            tracks: allTracks,
+            tracks: PlaylistPlaybackActions.tracksForPlaylistPlayback(
+                browseTracks: detail.tracks,
+                queueTracks: allTracks
+            ),
             duration: detail.duration,
             libraryTargetId: detail.libraryTargetId ?? self.playlist.libraryTargetId
         )

--- a/Sources/Kaset/Views/PlaylistDetailView.swift
+++ b/Sources/Kaset/Views/PlaylistDetailView.swift
@@ -580,69 +580,10 @@ struct PlaylistDetailView: View {
     func playableTracks(
         _ tracks: [Song], fallbackArtist: String?, fallbackAlbum: Album? = nil
     ) -> [Song] {
-        self.cleanTracks(
+        QueueSongMetadata.songsForQueue(
             tracks.filter(\.isPlayable), fallbackArtist: fallbackArtist,
             fallbackAlbum: fallbackAlbum
         )
-    }
-
-    /// Cleans track artists and applies fallback artist/album when needed.
-    private func cleanTracks(_ tracks: [Song], fallbackArtist: String?, fallbackAlbum: Album? = nil)
-        -> [Song]
-    {
-        tracks.map { song in
-            var cleanedArtists = song.artists.compactMap { artist -> Artist? in
-                if artist.name == "Album" {
-                    return nil
-                }
-                var cleanName = artist.name
-                if cleanName.hasPrefix("Album, ") {
-                    cleanName = String(cleanName.dropFirst(7))
-                }
-                return Artist(
-                    id: artist.id,
-                    name: cleanName,
-                    thumbnailURL: artist.thumbnailURL,
-                    subtitle: artist.subtitle,
-                    profileKind: artist.profileKind
-                )
-            }
-
-            // Use fallback artist if artists are empty (and clean the fallback too)
-            if cleanedArtists.isEmpty, let fallback = fallbackArtist, !fallback.isEmpty {
-                var cleanFallback = fallback
-                if cleanFallback == "Album" {
-                    cleanFallback = "Unknown Artist"
-                } else if cleanFallback.hasPrefix("Album, ") {
-                    cleanFallback = String(cleanFallback.dropFirst(7))
-                }
-                // Also handle case where it's "Album, Artist" but we got it as a combined string
-                if cleanFallback.contains("Album,") {
-                    let parts = cleanFallback.split(separator: ",", maxSplits: 1)
-                    if parts.count > 1 {
-                        cleanFallback = String(parts[1]).trimmingCharacters(in: .whitespaces)
-                    }
-                }
-                cleanedArtists = [Artist(id: "unknown", name: cleanFallback)]
-            }
-
-            // Use fallback album if song doesn't have album info
-            let finalAlbum = song.album ?? fallbackAlbum
-            // Use fallback thumbnail if song doesn't have one
-            let finalThumbnail = song.thumbnailURL ?? fallbackAlbum?.thumbnailURL
-
-            return Song(
-                id: song.id,
-                title: song.title,
-                artists: cleanedArtists,
-                album: finalAlbum,
-                duration: song.duration,
-                thumbnailURL: finalThumbnail,
-                videoId: song.videoId,
-                isPlayable: song.isPlayable,
-                playlistSetVideoId: song.playlistSetVideoId
-            )
-        }
     }
 
     private func refinePlaylist(tracks: [Song], prompt: String) async {

--- a/Tests/KasetTests/PlayerServiceLibraryTests.swift
+++ b/Tests/KasetTests/PlayerServiceLibraryTests.swift
@@ -1096,6 +1096,36 @@ struct PlayerServiceLibraryTests { // swiftlint:disable:this type_body_length
         ))
     }
 
+    @Test("Audio IDs survive metadata refresh and clearing upcoming tracks", arguments: [nil, "fetched-audio"] as [String?])
+    func audioIDsSurviveMetadataRefreshAndQueueClearing(fetchedAudioID: String?) async throws {
+        let suiteName = "AudioIDRefreshTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        self.playerService.queuePersistenceDefaults = defaults
+
+        var song = TestFixtures.makeSong(id: "music-video")
+        song.audioTrackVideoId = "album-audio"
+        var fetchedSong = song
+        fetchedSong.audioTrackVideoId = fetchedAudioID
+        self.mockClient.songResponses[song.videoId] = fetchedSong
+        self.playerService.setQueue([song, TestFixtures.makeSong(id: "next-track")])
+        self.playerService.activePlaybackQueueEntryID = self.playerService.queueEntryIDs.first
+        self.playerService.currentTrack = song
+
+        await self.playerService.fetchSongMetadata(videoId: song.videoId)
+
+        let expectedAudioID = fetchedAudioID ?? "album-audio"
+        #expect(self.playerService.currentTrack?.preferredAudioVideoId == expectedAudioID)
+
+        self.playerService.clearQueue()
+
+        #expect(self.playerService.queue.map(\.videoId) == [song.videoId])
+        #expect(self.playerService.queue.first?.preferredAudioVideoId == expectedAudioID)
+        let savedData = try #require(defaults.data(forKey: "kaset.saved.queue"))
+        let savedQueue = try JSONDecoder().decode([Song].self, from: savedData)
+        #expect(savedQueue.first?.preferredAudioVideoId == expectedAudioID)
+    }
+
     @Test("fetchSongMetadata preserves cached like status when API like status is unknown")
     func fetchSongMetadataPreservesCachedLikeStatusWhenAPILikeStatusIsUnknown() async {
         let song = TestFixtures.makeSong(id: "test-video")

--- a/Tests/KasetTests/PlayerServiceQueueEnrichmentTests.swift
+++ b/Tests/KasetTests/PlayerServiceQueueEnrichmentTests.swift
@@ -313,6 +313,32 @@ struct PlayerServiceQueueEnrichmentTests {
         playerService.clearNativeQueueMaintenance()
     }
 
+    @Test("Queue enrichment keeps the album audio recording ID when next has none")
+    func mergingQueueMetadataPreservesAudioTrackVideoId() {
+        let current = Song(
+            id: "gQlMMD8auMs",
+            title: "Pink Venom",
+            artists: [Artist(id: "artist", name: "BLACKPINK")],
+            videoId: "gQlMMD8auMs",
+            musicVideoType: .omv,
+            audioTrackVideoId: "qCDPprTDkJE"
+        )
+        let response = Song(
+            id: "gQlMMD8auMs",
+            title: "Pink Venom",
+            artists: [Artist(id: "artist", name: "BLACKPINK")],
+            duration: 186,
+            videoId: "gQlMMD8auMs",
+            musicVideoType: .omv
+        )
+
+        let merged = PlayerService.mergingQueueMetadata(current: current, response: response)
+
+        #expect(merged.audioTrackVideoId == "qCDPprTDkJE")
+        #expect(merged.preferredAudioVideoId == "qCDPprTDkJE")
+        #expect(merged.duration == 186)
+    }
+
     private static func incompleteSong(videoId: String) -> Song {
         Song(
             id: videoId,

--- a/Tests/KasetTests/PlaylistDetailViewModelTests.swift
+++ b/Tests/KasetTests/PlaylistDetailViewModelTests.swift
@@ -95,6 +95,40 @@ struct PlaylistDetailViewModelTests {
         #expect(self.viewModel.playlistDetail?.tracks.count == 10)
     }
 
+    @Test("Loading a radio playlist preserves browse audio IDs and playability")
+    func radioLoadPreservesBrowseAudioIDs() async {
+        let playlist = TestFixtures.makePlaylist(id: "RD-audio-id")
+        let browseTrack = Song(
+            id: "music-video",
+            title: "Music Video",
+            artists: [],
+            videoId: "music-video",
+            isPlayable: false,
+            audioTrackVideoId: "browse-audio"
+        )
+        let queueTrack = TestFixtures.makeSong(id: browseTrack.videoId)
+        let queueOnlyTrack = TestFixtures.makeSong(id: "queue-only")
+        self.mockClient.playlistDetails[playlist.id] = PlaylistDetail(
+            playlist: playlist,
+            tracks: [browseTrack],
+            duration: nil
+        )
+        self.mockClient.playlistAllTracks[playlist.id] = [queueTrack, queueOnlyTrack]
+        let viewModel = PlaylistDetailViewModel(
+            playlist: playlist,
+            client: self.mockClient,
+            likeStatusManager: self.likeStatusManager
+        )
+
+        await viewModel.load()
+
+        #expect(viewModel.loadingState == .loaded)
+        #expect(viewModel.playlistDetail?.tracks.map(\.videoId) == [browseTrack.videoId, queueOnlyTrack.videoId])
+        #expect(viewModel.playlistDetail?.tracks.first?.audioTrackVideoId == "browse-audio")
+        #expect(viewModel.playlistDetail?.tracks.first?.isPlayable == false)
+        #expect(viewModel.playlistDetail?.tracks.last == queueOnlyTrack)
+    }
+
     // MARK: - Track Removal Tests
 
     @Test("Optimistic track removal removes the matching track and confirms successfully")

--- a/Tests/KasetTests/PlaylistParserAudioTrackTests.swift
+++ b/Tests/KasetTests/PlaylistParserAudioTrackTests.swift
@@ -117,6 +117,32 @@ struct PlaylistParserAudioTrackTests {
         #expect(audioRow.preferredAudioVideoId == "qCDPprTDkJE")
     }
 
+    @Test("Audio recording ID survives album queue prep")
+    func audioTrackVideoIdSurvivesAlbumQueuePrep() {
+        let data = self.makeAlbumData(rows: [
+            .init(videoId: "gQlMMD8auMs", title: "Pink Venom", creditsBrowseId: "MPTCqCDPprTDkJE"),
+        ])
+        let detail = PlaylistParser.parsePlaylistDetail(data, playlistId: "MPREb_J7wVS5GlYZK")
+        let album = Album(
+            id: "MPREb_J7wVS5GlYZK",
+            title: "BORN PINK",
+            artists: [Artist(id: "artist", name: "BLACKPINK")],
+            thumbnailURL: nil,
+            year: "2022",
+            trackCount: 1
+        )
+
+        let queued = QueueSongMetadata.albumSongs(
+            detail.tracks,
+            album: album,
+            purpose: .playback(trackCount: 1)
+        )
+
+        #expect(queued.map(\.videoId) == ["gQlMMD8auMs"])
+        #expect(queued.map(\.audioTrackVideoId) == ["qCDPprTDkJE"])
+        #expect(queued.map(\.preferredAudioVideoId) == ["qCDPprTDkJE"])
+    }
+
     // MARK: - Fixtures
 
     private struct Row {

--- a/Tests/KasetTests/PlaylistParserAudioTrackTests.swift
+++ b/Tests/KasetTests/PlaylistParserAudioTrackTests.swift
@@ -1,0 +1,234 @@
+import Foundation
+import Testing
+@testable import Kaset
+
+/// Tests for resolving the audio recording behind music-video album rows.
+///
+/// Some albums are returned with every track row typed `MUSIC_VIDEO_TYPE_OMV`.
+/// YouTube Music still advertises each track's audio recording in the row's
+/// credits menu, as `MPTC` + the audio video ID.
+@Suite(.tags(.parser))
+struct PlaylistParserAudioTrackTests {
+    // MARK: - Parser
+
+    @Test("Music-video album rows expose the audio recording from their credits entry")
+    func musicVideoRowResolvesAudioTrackVideoId() {
+        let data = self.makeAlbumData(rows: [
+            .init(videoId: "gQlMMD8auMs", title: "Pink Venom", creditsBrowseId: "MPTCqCDPprTDkJE"),
+            .init(videoId: "POe9SOEKotk", title: "Shut Down", creditsBrowseId: "MPTC950BdJKBhGo"),
+        ])
+
+        let detail = PlaylistParser.parsePlaylistDetail(data, playlistId: "MPREb_J7wVS5GlYZK")
+
+        #expect(detail.tracks.map(\.videoId) == ["gQlMMD8auMs", "POe9SOEKotk"])
+        #expect(detail.tracks.map(\.audioTrackVideoId) == ["qCDPprTDkJE", "950BdJKBhGo"])
+        #expect(detail.tracks.allSatisfy { $0.musicVideoType == .omv })
+    }
+
+    @Test("Audio rows whose credits entry repeats the row ID carry no separate audio ID")
+    func audioRowHasNoSeparateAudioTrackVideoId() {
+        let data = self.makeAlbumData(rows: [
+            .init(
+                videoId: "qCDPprTDkJE",
+                title: "Pink Venom",
+                creditsBrowseId: "MPTCqCDPprTDkJE",
+                musicVideoType: "MUSIC_VIDEO_TYPE_ATV"
+            ),
+        ])
+
+        let detail = PlaylistParser.parsePlaylistDetail(data, playlistId: "MPREb_Wbh7z3ktrMG")
+
+        #expect(detail.tracks.first?.audioTrackVideoId == nil)
+        #expect(detail.tracks.first?.musicVideoType == .atv)
+    }
+
+    @Test("Rows without a credits entry parse without an audio ID")
+    func rowWithoutCreditsMenuParses() {
+        let data = self.makeAlbumData(rows: [
+            .init(videoId: "gQlMMD8auMs", title: "Pink Venom", creditsBrowseId: nil),
+        ])
+
+        let detail = PlaylistParser.parsePlaylistDetail(data, playlistId: "MPREb_J7wVS5GlYZK")
+
+        #expect(detail.tracks.count == 1)
+        #expect(detail.tracks.first?.audioTrackVideoId == nil)
+    }
+
+    // MARK: - Helper
+
+    @Test("Credits entries are matched by page type, not by menu label")
+    func creditsEntryMatchedByPageTypeUnderAnyLanguage() {
+        let renderer = Self.makeRowRenderer(
+            videoId: "gQlMMD8auMs",
+            title: "Pink Venom",
+            creditsBrowseId: "MPTCqCDPprTDkJE",
+            creditsLabel: "Songwriter-Credits anzeigen"
+        )
+
+        #expect(ParsingHelpers.extractTrackCreditsVideoId(from: renderer) == "qCDPprTDkJE")
+    }
+
+    @Test("Browse IDs that are not track credits are ignored")
+    func nonCreditsBrowseIdsAreIgnored() {
+        let renderer: [String: Any] = [
+            "menu": [
+                "menuRenderer": [
+                    "items": [[
+                        "menuNavigationItemRenderer": [
+                            "text": ["runs": [["text": "Go to artist"]]],
+                            "navigationEndpoint": [
+                                "browseEndpoint": [
+                                    "browseId": "UCkbbMCA40i18i7UdjayMPAg",
+                                    "browseEndpointContextSupportedConfigs": [
+                                        "browseEndpointContextMusicConfig": [
+                                            "pageType": "MUSIC_PAGE_TYPE_ARTIST",
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ]],
+                ],
+            ],
+        ]
+
+        #expect(ParsingHelpers.extractTrackCreditsVideoId(from: renderer) == nil)
+    }
+
+    // MARK: - Model
+
+    @Test("Preferred audio video ID falls back to the row's own video ID")
+    func preferredAudioVideoIdFallsBack() {
+        let musicVideoRow = Song(
+            id: "gQlMMD8auMs",
+            title: "Pink Venom",
+            artists: [],
+            videoId: "gQlMMD8auMs",
+            audioTrackVideoId: "qCDPprTDkJE"
+        )
+        let audioRow = Song(
+            id: "qCDPprTDkJE",
+            title: "Pink Venom",
+            artists: [],
+            videoId: "qCDPprTDkJE"
+        )
+
+        #expect(musicVideoRow.preferredAudioVideoId == "qCDPprTDkJE")
+        #expect(audioRow.preferredAudioVideoId == "qCDPprTDkJE")
+    }
+
+    // MARK: - Fixtures
+
+    private struct Row {
+        let videoId: String
+        let title: String
+        let creditsBrowseId: String?
+        var musicVideoType: String = "MUSIC_VIDEO_TYPE_OMV"
+    }
+
+    private func makeAlbumData(rows: [Row]) -> [String: Any] {
+        let contents = rows.map { row in
+            [
+                "musicResponsiveListItemRenderer": Self.makeRowRenderer(
+                    videoId: row.videoId,
+                    title: row.title,
+                    creditsBrowseId: row.creditsBrowseId,
+                    musicVideoType: row.musicVideoType
+                ),
+            ]
+        }
+
+        return [
+            "header": [
+                "musicDetailHeaderRenderer": [
+                    "title": ["runs": [["text": "BORN PINK"]]],
+                ],
+            ],
+            "contents": [
+                "singleColumnBrowseResultsRenderer": [
+                    "tabs": [[
+                        "tabRenderer": [
+                            "content": [
+                                "sectionListRenderer": [
+                                    "contents": [[
+                                        "musicShelfRenderer": [
+                                            "contents": contents,
+                                        ],
+                                    ]],
+                                ],
+                            ],
+                        ],
+                    ]],
+                ],
+            ],
+        ]
+    }
+
+    private static func makeRowRenderer(
+        videoId: String,
+        title: String,
+        creditsBrowseId: String?,
+        musicVideoType: String = "MUSIC_VIDEO_TYPE_OMV",
+        creditsLabel: String = "View song credits"
+    ) -> [String: Any] {
+        // Album rows carry no top-level navigationEndpoint; the play overlay holds
+        // the watch endpoint, matching live `browse` responses for MPRE albums.
+        var renderer: [String: Any] = [
+            "playlistItemData": ["videoId": videoId],
+            "overlay": [
+                "musicItemThumbnailOverlayRenderer": [
+                    "content": [
+                        "musicPlayButtonRenderer": [
+                            "playNavigationEndpoint": [
+                                "watchEndpoint": [
+                                    "videoId": videoId,
+                                    "watchEndpointMusicSupportedConfigs": [
+                                        "watchEndpointMusicConfig": [
+                                            "musicVideoType": musicVideoType,
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            "flexColumns": [
+                [
+                    "musicResponsiveListItemFlexColumnRenderer": [
+                        "text": ["runs": [["text": title]]],
+                    ],
+                ],
+                [
+                    "musicResponsiveListItemFlexColumnRenderer": [
+                        "text": ["runs": [["text": "BLACKPINK"]]],
+                    ],
+                ],
+            ],
+        ]
+
+        if let creditsBrowseId {
+            renderer["menu"] = [
+                "menuRenderer": [
+                    "items": [[
+                        "menuNavigationItemRenderer": [
+                            "text": ["runs": [["text": creditsLabel]]],
+                            "navigationEndpoint": [
+                                "browseEndpoint": [
+                                    "browseId": creditsBrowseId,
+                                    "browseEndpointContextSupportedConfigs": [
+                                        "browseEndpointContextMusicConfig": [
+                                            "pageType": "MUSIC_PAGE_TYPE_TRACK_CREDITS",
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ]],
+                ],
+            ]
+        }
+
+        return renderer
+    }
+}

--- a/Tests/KasetTests/PlaylistPlaybackActionsTests.swift
+++ b/Tests/KasetTests/PlaylistPlaybackActionsTests.swift
@@ -20,7 +20,8 @@ struct PlaylistPlaybackActionsTests {
             thumbnailURL: URL(string: "https://example.com/browse.jpg"),
             videoId: "video-1",
             isPlayable: false,
-            isExplicit: true
+            isExplicit: true,
+            audioTrackVideoId: "audio-1"
         )
         let queueTrack = Song(
             id: "track-1",
@@ -29,7 +30,8 @@ struct PlaylistPlaybackActionsTests {
             thumbnailURL: URL(string: "https://example.com/queue.jpg"),
             videoId: "video-1",
             isPlayable: true,
-            isExplicit: true
+            isExplicit: true,
+            audioTrackVideoId: "audio-1"
         )
 
         let tracks = PlaylistPlaybackActions.tracksForPlaylistPlayback(
@@ -41,6 +43,7 @@ struct PlaylistPlaybackActionsTests {
         #expect(tracks.first?.isPlayable == false)
         #expect(tracks.first?.thumbnailURL == queueTrack.thumbnailURL)
         #expect(tracks.first?.isExplicit == true)
+        #expect(tracks.first?.audioTrackVideoId == "audio-1")
     }
 
     @Test("Playable playlist artwork filters unavailable songs and fills missing thumbnails")
@@ -60,7 +63,8 @@ struct PlaylistPlaybackActionsTests {
             thumbnailURL: nil,
             videoId: "playable",
             isPlayable: true,
-            isExplicit: true
+            isExplicit: true,
+            audioTrackVideoId: "audio-playable"
         )
 
         let songs = PlaylistPlaybackActions.playableSongsWithPlaylistArtwork(
@@ -71,6 +75,7 @@ struct PlaylistPlaybackActionsTests {
         #expect(songs.map(\.videoId) == ["playable"])
         #expect(songs.first?.thumbnailURL == playlist.thumbnailURL)
         #expect(songs.first?.isExplicit == true)
+        #expect(songs.first?.audioTrackVideoId == "audio-playable")
     }
 
     @Test("Remaining playlist tracks tolerate removal from the initially queued prefix")

--- a/Tests/KasetTests/PlaylistPlaybackActionsTests.swift
+++ b/Tests/KasetTests/PlaylistPlaybackActionsTests.swift
@@ -30,8 +30,7 @@ struct PlaylistPlaybackActionsTests {
             thumbnailURL: URL(string: "https://example.com/queue.jpg"),
             videoId: "video-1",
             isPlayable: true,
-            isExplicit: true,
-            audioTrackVideoId: "audio-1"
+            isExplicit: true
         )
 
         let tracks = PlaylistPlaybackActions.tracksForPlaylistPlayback(
@@ -44,6 +43,26 @@ struct PlaylistPlaybackActionsTests {
         #expect(tracks.first?.thumbnailURL == queueTrack.thumbnailURL)
         #expect(tracks.first?.isExplicit == true)
         #expect(tracks.first?.audioTrackVideoId == "audio-1")
+    }
+
+    @Test("Radio playlist tracks retain known audio IDs when playability agrees", arguments: [nil, "queue-audio"] as [String?])
+    func radioPlaylistTracksRetainAudioIDs(queueAudioID: String?) {
+        var browseTrack = TestFixtures.makeSong(id: "music-video")
+        browseTrack.audioTrackVideoId = "browse-audio"
+        let duplicateWithoutAudioID = TestFixtures.makeSong(id: browseTrack.videoId)
+        var queueTrack = TestFixtures.makeSong(id: browseTrack.videoId, title: "Queue title")
+        queueTrack.audioTrackVideoId = queueAudioID
+        let queueOnlyTrack = TestFixtures.makeSong(id: "queue-only")
+
+        let tracks = PlaylistPlaybackActions.tracksForPlaylistPlayback(
+            browseTracks: [browseTrack, duplicateWithoutAudioID],
+            queueTracks: [queueTrack, queueOnlyTrack]
+        )
+
+        #expect(tracks.map(\.videoId) == [queueTrack.videoId, queueOnlyTrack.videoId])
+        #expect(tracks.first?.title == queueTrack.title)
+        #expect(tracks.first?.audioTrackVideoId == queueAudioID ?? "browse-audio")
+        #expect(tracks.last == queueOnlyTrack)
     }
 
     @Test("Playable playlist artwork filters unavailable songs and fills missing thumbnails")

--- a/Tests/KasetTests/QueueSongMetadataTests.swift
+++ b/Tests/KasetTests/QueueSongMetadataTests.swift
@@ -42,6 +42,7 @@ struct QueueSongMetadataTests {
             likeStatus: .like,
             isInLibrary: true,
             isExplicit: true,
+            playlistSetVideoId: "playlist-occurrence-1",
             audioTrackVideoId: "audio-1"
         )
 
@@ -60,6 +61,7 @@ struct QueueSongMetadataTests {
         #expect(preparedSong?.likeStatus == .like)
         #expect(preparedSong?.isInLibrary == true)
         #expect(preparedSong?.isExplicit == true)
+        #expect(preparedSong?.playlistSetVideoId == "playlist-occurrence-1")
         #expect(preparedSong?.audioTrackVideoId == "audio-1")
     }
 

--- a/Tests/KasetTests/QueueSongMetadataTests.swift
+++ b/Tests/KasetTests/QueueSongMetadataTests.swift
@@ -41,7 +41,8 @@ struct QueueSongMetadataTests {
             musicVideoType: .omv,
             likeStatus: .like,
             isInLibrary: true,
-            isExplicit: true
+            isExplicit: true,
+            audioTrackVideoId: "audio-1"
         )
 
         let preparedSong = QueueSongMetadata.songsForQueue(
@@ -59,6 +60,7 @@ struct QueueSongMetadataTests {
         #expect(preparedSong?.likeStatus == .like)
         #expect(preparedSong?.isInLibrary == true)
         #expect(preparedSong?.isExplicit == true)
+        #expect(preparedSong?.audioTrackVideoId == "audio-1")
     }
 
     @Test("Album playback songs preserve album year and use loaded track count")

--- a/Tests/KasetTests/ScriptCommandsTests.swift
+++ b/Tests/KasetTests/ScriptCommandsTests.swift
@@ -492,6 +492,7 @@ struct ScriptCommandsTests {
             #expect(tracks[0]["album"] as? String == "Album 1")
             #expect(tracks[0]["duration"] as? Double == 120)
             #expect(tracks[0]["videoId"] as? String == "vid-1")
+            #expect(tracks[0]["audioVideoId"] as? String == "vid-1")
             #expect(tracks[0]["artworkURL"] as? String == "https://example.com/song1.jpg")
 
             #expect(tracks[1]["name"] as? String == "Song 2")
@@ -499,6 +500,7 @@ struct ScriptCommandsTests {
             #expect((tracks[1]["album"] as? String)?.isEmpty == true)
             #expect(tracks[1]["duration"] as? Double == 180)
             #expect(tracks[1]["videoId"] as? String == "vid-2")
+            #expect(tracks[1]["audioVideoId"] as? String == "vid-2")
             #expect((tracks[1]["artworkURL"] as? String)?.isEmpty == true)
         } else {
             Issue.record("Failed to parse JSON response")
@@ -525,6 +527,45 @@ struct ScriptCommandsTests {
 
         #expect(json?["currentIndex"] as? Int == 0)
         #expect((json?["tracks"] as? [[String: Any]])?.count == 2)
+    }
+
+    @Test("GetPlayQueue emits the audio recording ID for music-video album rows")
+    func getPlayQueueEmitsPreferredAudioVideoId() async {
+        let album = Album(
+            id: "MPREb_J7wVS5GlYZK",
+            title: "BORN PINK",
+            artists: [Artist(id: "artist", name: "BLACKPINK")],
+            thumbnailURL: nil,
+            year: "2022",
+            trackCount: 1
+        )
+        let musicVideoRow = Song(
+            id: "gQlMMD8auMs",
+            title: "Pink Venom",
+            artists: [Artist(id: "artist", name: "BLACKPINK")],
+            videoId: "gQlMMD8auMs",
+            musicVideoType: .omv,
+            audioTrackVideoId: "qCDPprTDkJE"
+        )
+        let queued = QueueSongMetadata.albumSongs(
+            [musicVideoRow],
+            album: album,
+            purpose: .playback(trackCount: 1)
+        )
+        let playerService = PlayerService()
+        await playerService.playQueue(queued, startingAt: 0)
+        PlayerService.shared = playerService
+        defer { PlayerService.shared = nil }
+
+        let result = GetPlayQueueCommand().performDefaultImplementation() as? String
+        let json = result?.data(using: .utf8).flatMap {
+            try? JSONSerialization.jsonObject(with: $0) as? [String: Any]
+        }
+        let tracks = json?["tracks"] as? [[String: Any]]
+
+        #expect(tracks?.count == 1)
+        #expect(tracks?.first?["videoId"] as? String == "gQlMMD8auMs")
+        #expect(tracks?.first?["audioVideoId"] as? String == "qCDPprTDkJE")
     }
 
     // MARK: - PlayTrackAtIndexCommand Tests

--- a/Tests/KasetTests/ScriptCommandsTests.swift
+++ b/Tests/KasetTests/ScriptCommandsTests.swift
@@ -529,8 +529,8 @@ struct ScriptCommandsTests {
         #expect((json?["tracks"] as? [[String: Any]])?.count == 2)
     }
 
-    @Test("GetPlayQueue emits the audio recording ID for music-video album rows")
-    func getPlayQueueEmitsPreferredAudioVideoId() async {
+    @Test("GetPlayQueue emits the audio recording ID through album playback paths", arguments: [false, true])
+    func getPlayQueueEmitsPreferredAudioVideoId(usesDetailView: Bool) async {
         let album = Album(
             id: "MPREb_J7wVS5GlYZK",
             title: "BORN PINK",
@@ -547,11 +547,20 @@ struct ScriptCommandsTests {
             musicVideoType: .omv,
             audioTrackVideoId: "qCDPprTDkJE"
         )
-        let queued = QueueSongMetadata.albumSongs(
-            [musicVideoRow],
-            album: album,
-            purpose: .playback(trackCount: 1)
-        )
+        let queued: [Song]
+        if usesDetailView {
+            guard #available(macOS 26.0, *) else { return }
+            let playlist = TestFixtures.makePlaylist(id: album.id, title: album.title)
+            let viewModel = PlaylistDetailViewModel(playlist: playlist, client: MockYTMusicClient())
+            let view = PlaylistDetailView(playlist: playlist, viewModel: viewModel)
+            queued = view.playableTracks([musicVideoRow], fallbackArtist: nil, fallbackAlbum: album)
+        } else {
+            queued = QueueSongMetadata.albumSongs(
+                [musicVideoRow],
+                album: album,
+                purpose: .playback(trackCount: 1)
+            )
+        }
         let playerService = PlayerService()
         await playerService.playQueue(queued, startingAt: 0)
         PlayerService.shared = playerService
@@ -566,6 +575,7 @@ struct ScriptCommandsTests {
         #expect(tracks?.count == 1)
         #expect(tracks?.first?["videoId"] as? String == "gQlMMD8auMs")
         #expect(tracks?.first?["audioVideoId"] as? String == "qCDPprTDkJE")
+        #expect(playerService.queue.first?.musicVideoType == .omv)
     }
 
     // MARK: - PlayTrackAtIndexCommand Tests


### PR DESCRIPTION
## Description

Some YouTube Music albums come back with every track row typed `MUSIC_VIDEO_TYPE_OMV` — official music videos rather than audio recordings. `PlaylistParser.parseTrackItem` previously discarded the row's menu, so Kaset never saw that the same track's audio recording is already named in the `browse` response.

This PR extracts that ID and surfaces it on `get play queue` as `audioVideoId`. No extra network request: the mapping is already in the album payload. Existing scripts that read `videoId` are unchanged. Playback still uses the album row's original `videoId`, so album queue identity is not swapped.

I use `get play queue` to send tracks to a player that accepts YouTube Music audio IDs and rejects music-video IDs. Without this key those album rows are unusable there.

## AI Prompt (Optional)

<details>
<summary>🤖 AI Prompt Used</summary>

```
Is there a setting in Kaset to exclude music videos from album track lists?
```

```
Run the api-explorer probe and tell me whether `next` exposes an audio/video
counterpart ID, or whether upstream's "not implemented" note still holds.
```

```
Implement the parser change only, following AGENTS.md and the existing
ParsingHelpers patterns. Match the credits entry by page type rather than label.
Add unit tests with fixtures shaped like real album responses.
```

```
Carry audioTrackVideoId through the Song rebuilds on the queue path and add
audioVideoId to get play queue. Do not swap the row videoId used for playback.
```

The work was investigative rather than a single prompt. The session started from the album-MV question, confirmed it in the parser, then used this repo's `api-explorer` (`--guest`) to see whether an audio counterpart was reachable.

The `next` probe reproduced `docs/api-discovery.md`: counterpart fields 0, tabs only Up next / Lyrics / Related. The mapping is in the album `browse` response: each row's credits menu browse ID is `MPTC` plus the audio recording's video ID. That was checked by fetching four credits pages (same title, `MUSIC_VIDEO_TYPE_ATV`, `Song • 2022`) and then counting the rule across seven albums.

A later pass carried the parsed ID through the queue `Song` rebuilds and exposed `preferredAudioVideoId` on `get play queue`.

</details>

**AI Tool:** Claude (Claude Code) and Cursor Grok

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Refactoring (no functional changes)
- [x] 🧪 Test update
- [ ] 🔧 Build/CI configuration

## Related Issues

None opened for this specifically. `docs/api-discovery.md` records the audio/video counterpart switch as not implemented; this PR does not change that doc. Happy to add the `browse` / `MPTC` finding there if you want it recorded.

## Changes Made

- Parse `MUSIC_PAGE_TYPE_TRACK_CREDITS` menu browse IDs (`MPTC` + audio video ID) in `ParsingHelpers+TrackCredits.swift`. Match on page type, not the English label, so it survives the content-language setting.
- Add `Song.audioTrackVideoId` and `preferredAudioVideoId` (falls back to `videoId`). Leave `audioTrackVideoId` nil when the credits ID merely repeats the row ID, or when the menu entry is missing.
- Carry the field through the queue `Song` rebuilds in `QueueSongMetadata`, `PlaylistPlaybackActions`, `PlayerService.mergingQueueMetadata`, and artist-song duration enrichment.
- Emit additive `audioVideoId` from `get play queue`. No `.sdef` change; the command already returns JSON.
- Also populate `musicVideoType` on playlist/album rows (previously always nil). See notes below.

## Testing

- [x] Focused unit tests pass (`swift test --skip KasetUITests --filter 'PlaylistParserAudioTrackTests|QueueSongMetadataTests|PlaylistPlaybackActionsTests|PlayerServiceQueueEnrichmentTests|ScriptCommandsTests'` — 63/63)
- [x] `swift build`
- [x] `swiftlint --strict` and `swiftformat` on changed files
- [ ] Manual testing performed
- [ ] UI tested on macOS 26+

Parser fixtures are shaped like live album `browse` rows (watch endpoint under the play overlay; album rows have no top-level `navigationEndpoint`). One test uses a German credits label to lock page-type matching.

Four tests (`PlayerServiceQueuePersistenceSyncTests` and three in `PlayerServiceEndedIdentityCoordinatorTests`) fail on this branch and on an untouched checkout of `main`. The issue count varies run to run on unchanged code, so they look like local `UserDefaults` / timing flakes rather than this change.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `swiftlint --strict` and `swiftformat` on the changed files
- [x] I have added tests that prove my fix/feature works
- [x] Focused unit tests pass locally
- [ ] I have updated documentation if needed (left `docs/api-discovery.md` unchanged on purpose)
- [x] I have checked for any performance implications (no extra network requests)
- [x] My changes generate no new warnings

## Additional Notes

### How the mapping works

```
album row   'Pink Venom'   videoId=gQlMMD8auMs   MUSIC_VIDEO_TYPE_OMV
menu entry  MUSIC_PAGE_TYPE_TRACK_CREDITS        browseId=MPTCqCDPprTDkJE
                                                          ^^^^^^^^^^^ audio recording
```

Seven guest-mode `WEB_REMIX` album `browse` responses:

| album | rows | OMV rows | rows w/ credits | credits ID == row ID |
| --- | --- | --- | --- | --- |
| `MPREb_J7wVS5GlYZK` | 8 | 8 | 8 | 0 |
| `MPREb_ODbk3DwVCqR` | 8 | 8 | 8 | 0 |
| `MPREb_ZK7RXf2soA7` | 5 | 5 | 5 | 0 |
| `MPREb_wnnx9WI1QIP` | 5 | 5 | 5 | 0 |
| `MPREb_5akfGIsrUrJ` | 8 | 3 | 8 | 5 |
| `MPREb_a8dPYoKfrQ4` | 5 | 2 | 5 | 3 |
| `MPREb_Wbh7z3ktrMG` | 14 | 0 | 0 | 0 |

The mixed albums are the useful check: 8 rows / 3 OMV → exactly 5 matches; 5 rows / 2 OMV → exactly 3. The credits ID differs from the row ID on precisely the music-video rows. `MPREb_Wbh7z3ktrMG` has no credits entry on any row, so a missing menu is treated as "no separate audio recording."

### Behavior change

`parseTrackItem` now populates `musicVideoType`. `PlayerBar` gates the Video button on `musicVideoType?.hasVideoContent`, so that button enables immediately on album MV rows instead of after `fetchSongMetadata`. I believe that is a fix — those rows really are OMV — but it is a visible change.

### Out of scope

A setting to prefer audio recordings on album playback. Substituting the row's `videoId` is risky: album playback context (`playlistId`, `playlistSetVideoId`, `index`) refers to the music-video rows, so swapping IDs under the queue could desync playback.

The helper is a new `ParsingHelpers+TrackCredits.swift` file because adding it inline pushed `ParsingHelpers.swift` past the 900-line `file_length` limit. That follows `ParsingHelpers+Metadata.swift`. `ParsingHelpers.swift` itself is unchanged.
