### PR TITLE
fix(homebrew): replace deprecated postflight syntax

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -469,8 +469,8 @@ jobs:
 
             app "Kaset.app"
 
-            postflight do
-              system_command "/usr/bin/xattr", args: ["-cr", "#{appdir}/Kaset.app"], sudo: false
+            postflight_steps do
+              run "/usr/bin/xattr", args: ["-cr", "{{appdir}}/Kaset.app"], sudo: false
             end
 
             zap trash: [

--- a/Casks/kaset.rb
+++ b/Casks/kaset.rb
@@ -22,8 +22,8 @@ cask "kaset" do
       brew install sozercan/repo/kaset
   EOS
 
-  postflight do
-    system_command "/usr/bin/xattr", args: ["-cr", "#{appdir}/Kaset.app"], sudo: false
+  postflight_steps do
+    run "/usr/bin/xattr", args: ["-cr", "{{appdir}}/Kaset.app"], sudo: false
   end
 
   zap trash: [


### PR DESCRIPTION
## Description

Homebrew warns that `postflight` is deprecated when installing Kaset from the Homebrew tap. Replace the deprecated `postflight` stanza with `postflight_steps` in both the legacy cask and the release workflow that generates the `kaset` cask for `sozercan/homebrew-repo`.

<details>
<summary>Homebrew installation log</summary>

```text
==> Tapping sozercan/repo
Cloning into '/opt/homebrew/Library/Taps/sozercan/homebrew-repo'...
Tapped 4 casks and 1 formula (20 files, 55.9KB).
Warning: Calling `postflight` is deprecated! Use `postflight_steps` instead.
Please report this issue to the sozercan/homebrew-repo tap (not Homebrew/* repositories), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/sozercan/homebrew-repo/Casks/kaset.rb:18

==> Trusted cask sozercan/repo/kaset
Warning: Calling `postflight` is deprecated! Use `postflight_steps` instead.
Please report this issue to the sozercan/homebrew-repo tap (not Homebrew/* repositories), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/sozercan/homebrew-repo/Casks/kaset.rb:18

==> Would install 1 cask:
sozercan/repo/kaset
==> Fetching downloads for: sozercan/repo/kaset
✔︎ Cask kaset (0.14.0)                                                                                                           Downloaded   17.8MB/ 17.8MB
==> Installing Cask kaset
Warning: Calling `postflight` is deprecated! Use `postflight_steps` instead.
Please report this issue to the sozercan/homebrew-repo tap (not Homebrew/* repositories), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/sozercan/homebrew-repo/Casks/kaset.rb:18

==> Moving App 'Kaset.app' to '/Applications/Kaset.app'
🍺  kaset was successfully installed!
Warning: Calling `postflight` is deprecated! Use `postflight_steps` instead.
Please report this issue to the sozercan/homebrew-repo tap (not Homebrew/* repositories), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/sozercan/homebrew-repo/Casks/kaset.rb:18
```

</details>

## Type of Change

- [x] Bug fix
- [x] Build/CI configuration

## Related Issues

Related precedent: #296 updated deprecated Homebrew syntax in the same two files while preserving their existing settings.

## Changes Made

- Replace `postflight` with `postflight_steps` and `system_command` with `run`.
- Use the install-time `{{appdir}}` token in command arguments.
- Preserve the `xattr -cr` command and execution without sudo.

## Testing

- `ruby -c Casks/kaset.rb`: passed.
- Parsed the release workflow YAML and generated its cask in a temporary directory with fixture version/checksum values; generated Ruby syntax passed.
- Loaded both casks through Homebrew's content loader without the `postflight` deprecation warning; checked the serialized command, arguments, sudo setting, and failure behavior.
- `git diff --check`: passed.
- Manual code review against the Homebrew DSL documentation and implementation: no actionable findings.

Swift build, unit tests, SwiftLint, and SwiftFormat were not run for this cask-only change. No application installation or UI tests were performed.

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have run `swiftlint --strict && swiftformat .` - Not run: no Swift changes.
- [ ] I have added tests that prove my fix/feature works - N/A: validated the casks directly; see Testing.
- [ ] New and existing unit tests pass locally - Not run: no Swift changes.
- [ ] I have updated documentation if needed - N/A: no documentation changes needed.
- [x] I have checked for any performance implications
- [x] My changes generate no new warnings - Verified when loading both casks through Homebrew.

## Additional Notes

The published cask in `sozercan/homebrew-repo` is maintained separately. The published cask will receive this fix when a release runs with the updated workflow. An immediate fix there requires a separate change.
