### PR TITLE
fix(home): restore infinite scroll and stop the startup reload

### DIFF
--- a/Sources/Kaset/Services/API/YTMusicClient.swift
+++ b/Sources/Kaset/Services/API/YTMusicClient.swift
@@ -153,6 +153,13 @@ final class YTMusicClient: YTMusicClientProtocol {
 
             self.logger.info("\(type.displayName.capitalized) continuation loaded: \(additionalSections.count) sections, hasMore: \(hasMore)")
             return additionalSections
+        } catch is CancellationError {
+            // A cancelled request says nothing about the server-side page, so
+            // keep the token: the bottom-of-scroll sentinel is torn down (and
+            // its task cancelled) whenever a freshly appended page pushes it
+            // out of the lazy stack, and the next appearance must be able to
+            // retry the same continuation instead of ending pagination.
+            throw CancellationError()
         } catch {
             self.logger.warning("Failed to fetch \(type.displayName) continuation: \(error.localizedDescription)")
             if generation == self.continuationGeneration,

--- a/Sources/Kaset/Views/MainWindow.swift
+++ b/Sources/Kaset/Views/MainWindow.swift
@@ -76,6 +76,11 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
     @State private var contentResetID = UUID()
     @State private var guestRefreshTask: Task<Void, Never>?
     @State private var accountResolutionFailOpenGeneration: UInt64?
+    /// Whether authenticated content has been shown for the current signed-in
+    /// identity. Distinguishes the first account-scope resolution at startup
+    /// (nothing fetched yet) from a real switch away from content that was
+    /// already rendered under the unresolved primary scope.
+    @State private var hasRenderedAuthenticatedContent = false
 
     // MARK: - Cached ViewModels (persist across tab switches)
 
@@ -212,6 +217,7 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
                 } else if self.authService.hasPersonalAccount {
                     if self.canRenderAuthenticatedContent {
                         self.mainContent
+                            .onAppear { self.hasRenderedAuthenticatedContent = true }
                     } else {
                         // Give the initial account fetch a bounded chance to restore
                         // the selected primary or brand account before requests start.
@@ -383,8 +389,8 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
 
     private var accountLifecycleContent: some View {
         self.appLifecycleContent
-            .onChange(of: self.accountService.currentAccountScopeID) { _, newAccountScope in
-                self.handleAccountScopeChange(newAccountScope: newAccountScope)
+            .onChange(of: self.accountService.currentAccountScopeID) { oldAccountScope, newAccountScope in
+                self.handleAccountScopeChange(oldAccountScope: oldAccountScope, newAccountScope: newAccountScope)
             }
             .onChange(of: self.accountService.verifiedIdentitySequence) { _, _ in
                 // Re-point in-flight playback ONLY once the new session identity is
@@ -423,13 +429,25 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
 
     // MARK: - Main Content
 
-    private func handleAccountScopeChange(newAccountScope: String?) {
+    private func handleAccountScopeChange(oldAccountScope: String?, newAccountScope: String?) {
         let currentAccount = self.accountService.currentAccount
         let newAccountId = self.accountService.currentAccount?.id
-        self.client.resetSessionStateForAccountSwitch()
-        self.youtubeClient.resetSessionStateForAccountSwitch()
-        self.likeStatusManager.clearCache()
-        LibraryMutationActions.cancelAllPendingLibraryMutations()
+        // The first resolution after startup/login goes `nil -> scope` before
+        // any authenticated view has rendered, so nothing was fetched under a
+        // wrong scope: wire the scope up below but skip the switch teardown
+        // (cache wipe + refresh of every surface), which otherwise reloads
+        // Home right after its initial page and discards its continuation.
+        // Content rendered under the unresolved scope (fail-open timeout, or a
+        // retried account fetch) is a real switch and still refreshes.
+        let isInitialScopeResolution = oldAccountScope == nil
+            && newAccountScope != nil
+            && !self.hasRenderedAuthenticatedContent
+        if !isInitialScopeResolution {
+            self.client.resetSessionStateForAccountSwitch()
+            self.youtubeClient.resetSessionStateForAccountSwitch()
+            self.likeStatusManager.clearCache()
+            LibraryMutationActions.cancelAllPendingLibraryMutations()
+        }
         self.libraryViewModel?.activateAccountScope(
             newAccountScope,
             isPrimary: currentAccount?.isPrimary == true
@@ -443,6 +461,7 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
         if let newAccountId {
             self.podcastsAvailability.activateAccount(newAccountId)
         }
+        guard !isInitialScopeResolution else { return }
 
         Task { @MainActor in
             APICache.shared.invalidateAll()
@@ -806,6 +825,7 @@ struct MainWindow: View { // swiftlint:disable:this type_body_length
             // Still checking login status, do nothing
             break
         case .loggedOut:
+            self.hasRenderedAuthenticatedContent = false
             let isReauthTransition = self.authService.needsReauth
             let crossedSignOutBoundary = oldState.isLoggedIn && !isReauthTransition
             let shouldRefreshGuestContent = crossedSignOutBoundary || oldState.isInitializing || isReauthTransition

--- a/Tests/KasetTests/HomeRefreshCacheTests.swift
+++ b/Tests/KasetTests/HomeRefreshCacheTests.swift
@@ -143,6 +143,71 @@ struct HomeRefreshCacheTests {
         #expect(HomeRefreshControlledURLProtocol.requestCount == 3)
     }
 
+    @Test("A cancelled YouTube Music continuation keeps its token so pagination can resume")
+    func musicHomeCancelledContinuationKeepsToken() async throws {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [HomeRefreshControlledURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+        HomeRefreshControlledURLProtocol.reset()
+        defer {
+            session.invalidateAndCancel()
+            HomeRefreshControlledURLProtocol.reset()
+        }
+
+        let webKitManager = WebKitManager.makeTestInstance()
+        let authService = AuthService(webKitManager: webKitManager)
+        await authService.checkLoginStatus()
+        let client = YTMusicClient(
+            authService: authService,
+            webKitManager: webKitManager,
+            session: session,
+            apiKeyResolver: .init(session: session, environment: { name in
+                name == YTMusicAPIKeyResolver.environmentVariable ? "mock-token" : nil
+            }),
+            cache: APICache()
+        )
+
+        let seedTask = Task {
+            try await client.getHome(forceRefresh: false)
+        }
+        let seedRequest = await HomeRefreshControlledURLProtocol.nextRequest()
+        try HomeRefreshControlledURLProtocol.respond(
+            seedRequest,
+            data: JSONSerialization.data(
+                withJSONObject: Self.musicHomePayload(title: "Seed", continuation: "page-2")
+            )
+        )
+        _ = try await seedTask.value
+        #expect(client.hasMoreHomeSections)
+
+        // The bottom-of-scroll sentinel's task gets cancelled when a freshly
+        // appended page pushes it out of the lazy stack mid-request.
+        let cancelledTask = Task {
+            try await client.getHomeContinuation()
+        }
+        _ = await HomeRefreshControlledURLProtocol.nextRequest()
+        cancelledTask.cancel()
+        await #expect(throws: CancellationError.self) {
+            try await cancelledTask.value
+        }
+        #expect(client.hasMoreHomeSections)
+
+        let retryTask = Task {
+            try await client.getHomeContinuation()
+        }
+        let retryRequest = await HomeRefreshControlledURLProtocol.nextRequest()
+        let retryBody = try Self.requestBody(from: retryRequest.request)
+        #expect(retryBody["continuation"] as? String == "page-2")
+
+        try HomeRefreshControlledURLProtocol.respond(
+            retryRequest,
+            data: Self.musicHomeContinuationPayload(continuation: "page-3")
+        )
+        let sections = try await retryTask.value
+        #expect(sections != nil)
+        #expect(client.hasMoreHomeSections)
+    }
+
     @Test("A stale YouTube Music continuation cannot replace a forced refresh continuation")
     func musicHomeForceRefreshFencesInFlightContinuation() async throws {
         let configuration = URLSessionConfiguration.ephemeral


### PR DESCRIPTION
Cancelled Home pagination requests could clear their continuation token and stop infinite scroll. Startup also treated the first resolved account scope as a switch, forcing a second Home load about 300 ms after the first completed.

Preserve the continuation token on cancellation so the next pagination attempt can retry it. During initial account resolution, wire the account scopes and initialize shared Liked Music and Library state without restarting Home or duplicating an active tab load. Real account switches, including resolution after authenticated content has already rendered, retain their cache invalidation and refresh behavior.

The controlled-transport regression test checks cancellation and successful retry. Its continuation prerequisites now fail immediately, preventing the test from waiting indefinitely when the token is lost.

## Validation

- `swift build`, `swiftlint --strict`, `swiftformat --lint .`, and `git diff --check` passed.
- 239 focused tests passed across the affected Home, account, like-status, Library, and playlist suites.
- All 3,390 unit tests passed with CI's serial configuration: `swift test --skip-build --skip KasetUITests --disable-xctest --no-parallel`.
- Instrumented packaged startup comparison reproduced the second forced Home load on the base. The updated branch performed one Home load, no forced reload, and one initialization each for Liked Music and Library. Temporary instrumentation was removed.
- Final code review found no actionable issues.
