### PR TITLE
perf(home): skip re-evaluating unchanged shelf cards while scrolling

### DIFF
--- a/Sources/Kaset/Models/HomeSection.swift
+++ b/Sources/Kaset/Models/HomeSection.swift
@@ -3,7 +3,7 @@ import Foundation
 // MARK: - HomeSection
 
 /// Represents a section on the YouTube Music home page.
-struct HomeSection: Identifiable {
+struct HomeSection: Identifiable, Hashable {
     let id: String
     let title: String
     let items: [HomeSectionItem]
@@ -22,7 +22,7 @@ struct HomeSection: Identifiable {
 // MARK: - HomeSectionItem
 
 /// An item within a home section (can be song, album, playlist, or artist).
-enum HomeSectionItem: Identifiable {
+enum HomeSectionItem: Identifiable, Hashable {
     case song(Song)
     case album(Album)
     case playlist(Playlist)

--- a/Sources/Kaset/Views/ChartsView.swift
+++ b/Sources/Kaset/Views/ChartsView.swift
@@ -109,6 +109,7 @@ struct ChartsView: View {
             ) {
                 self.playItem(item, in: section, at: index)
             }
+            .equatable()
         }
     }
 

--- a/Sources/Kaset/Views/ExploreView.swift
+++ b/Sources/Kaset/Views/ExploreView.swift
@@ -110,6 +110,7 @@ struct ExploreView: View {
             ) {
                 self.playItem(item, in: section, at: index)
             }
+            .equatable()
         }
     }
 

--- a/Sources/Kaset/Views/HomeView.swift
+++ b/Sources/Kaset/Views/HomeView.swift
@@ -140,6 +140,7 @@ struct HomeView: View {
             ) {
                 self.playItem(item, in: section, at: index)
             }
+            .equatable()
             .contextMenu {
                 self.contextMenuItems(for: item, in: section, at: index)
             }

--- a/Sources/Kaset/Views/MoodCategoryDetailView.swift
+++ b/Sources/Kaset/Views/MoodCategoryDetailView.swift
@@ -92,6 +92,7 @@ struct MoodCategoryDetailView: View {
                     await self.playerService.playWithRadio(song: song)
                 }
             }
+            .equatable()
         case let .playlist(playlist):
             // Playlists navigate using NavigationLink
             if let parsed = playlist.resolvedMoodCategoryEndpoint {

--- a/Sources/Kaset/Views/MoodsAndGenresView.swift
+++ b/Sources/Kaset/Views/MoodsAndGenresView.swift
@@ -130,6 +130,7 @@ struct MoodsAndGenresView: View {
             ) {
                 self.playItem(item, in: section, at: index)
             }
+            .equatable()
         }
     }
 

--- a/Sources/Kaset/Views/NewReleasesView.swift
+++ b/Sources/Kaset/Views/NewReleasesView.swift
@@ -109,6 +109,7 @@ struct NewReleasesView: View {
             ) {
                 self.playItem(item, in: section, at: index)
             }
+            .equatable()
         }
     }
 

--- a/Sources/Kaset/Views/SharedViews/CarouselShelf.swift
+++ b/Sources/Kaset/Views/SharedViews/CarouselShelf.swift
@@ -15,7 +15,11 @@ struct CarouselShelf<Content: View>: View {
     private let content: () -> Content
 
     @State private var scrollPosition = ScrollPosition(edge: .leading)
-    @State private var scrollMetrics = CarouselShelfScrollMetrics()
+    /// Raw geometry lives in a plain reference box so per-pixel horizontal
+    /// scroll updates don't invalidate the shelf body; only the derived
+    /// overflow flags below are SwiftUI state, and they change rarely.
+    @State private var metricsStore = CarouselShelfMetricsStore()
+    @State private var overflow = CarouselShelfOverflow()
     @State private var isShelfHovering = false
     @FocusState private var focusedDirection: CarouselShelfDirection?
 
@@ -60,7 +64,11 @@ struct CarouselShelf<Content: View>: View {
         .onScrollGeometryChange(for: CarouselShelfScrollMetrics.self) { geometry in
             CarouselShelfScrollMetrics(geometry: geometry)
         } action: { _, newMetrics in
-            self.scrollMetrics = newMetrics
+            self.metricsStore.metrics = newMetrics
+            let overflow = CarouselShelfOverflow(metrics: newMetrics)
+            if overflow != self.overflow {
+                self.overflow = overflow
+            }
         }
         .overlay(alignment: Alignment(horizontal: .leading, vertical: self.controlVerticalAlignment)) {
             if self.showsLeadingControl {
@@ -89,11 +97,11 @@ struct CarouselShelf<Content: View>: View {
     }
 
     private var hasLeadingOverflow: Bool {
-        self.scrollMetrics.contentOffsetX > 1
+        self.overflow.leading
     }
 
     private var hasTrailingOverflow: Bool {
-        self.scrollMetrics.remainingContentWidth > 1
+        self.overflow.trailing
     }
 
     private var showsLeadingControl: Bool {
@@ -134,14 +142,15 @@ struct CarouselShelf<Content: View>: View {
     }
 
     private func page(in direction: CarouselShelfDirection) {
-        let pageWidth = max(1, self.scrollMetrics.viewportWidth * self.pageFraction)
+        let metrics = self.metricsStore.metrics
+        let pageWidth = max(1, metrics.viewportWidth * self.pageFraction)
         let destination = switch direction {
         case .leading:
-            self.scrollMetrics.contentOffsetX - pageWidth
+            metrics.contentOffsetX - pageWidth
         case .trailing:
-            self.scrollMetrics.contentOffsetX + pageWidth
+            metrics.contentOffsetX + pageWidth
         }
-        let clampedDestination = min(max(destination, 0), self.scrollMetrics.maxContentOffsetX)
+        let clampedDestination = min(max(destination, 0), metrics.maxContentOffsetX)
 
         withAnimation(AppAnimation.smooth) {
             self.scrollPosition.scrollTo(x: clampedDestination)
@@ -283,6 +292,30 @@ private struct CarouselShelfScrollMetrics: Equatable {
 
     var remainingContentWidth: CGFloat {
         max(0, self.maxContentOffsetX - self.contentOffsetX)
+    }
+}
+
+// MARK: - CarouselShelfMetricsStore
+
+/// Holds the latest scroll geometry without participating in SwiftUI
+/// invalidation (deliberately not `@Observable`).
+@MainActor
+private final class CarouselShelfMetricsStore {
+    var metrics = CarouselShelfScrollMetrics()
+}
+
+// MARK: - CarouselShelfOverflow
+
+/// The only geometry-derived facts the shelf body renders from.
+private struct CarouselShelfOverflow: Equatable {
+    var leading = false
+    var trailing = false
+
+    init() {}
+
+    init(metrics: CarouselShelfScrollMetrics) {
+        self.leading = metrics.contentOffsetX > 1
+        self.trailing = metrics.remainingContentWidth > 1
     }
 }
 

--- a/Sources/Kaset/Views/SharedViews/HomeSectionItemCard.swift
+++ b/Sources/Kaset/Views/SharedViews/HomeSectionItemCard.swift
@@ -3,7 +3,7 @@ import SwiftUI
 // MARK: - HomeSectionItemCard
 
 /// Reusable card view for home section items (songs, playlists, albums, artists).
-struct HomeSectionItemCard: View {
+struct HomeSectionItemCard: View, Equatable {
     let item: HomeSectionItem
     let rank: Int?
     let playAction: (() -> Void)?
@@ -31,6 +31,18 @@ struct HomeSectionItemCard: View {
         self.action = action
     }
 
+    /// Lets SwiftUI skip re-evaluating unchanged cards when a shelf or its
+    /// parent re-renders (measured: this is what made Home scrolling hitch).
+    ///
+    /// Contract for callers: `action`/`playAction` must depend only on `item`
+    /// (and `rank`). If two cards compare equal, the old closures are kept, so
+    /// an action that captured section membership or index would go stale.
+    nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.item == rhs.item
+            && lhs.rank == rhs.rank
+            && (lhs.playAction == nil) == (rhs.playAction == nil)
+    }
+
     var body: some View {
         if self.supportsPlaylistPlayAction {
             self.cardContent
@@ -51,6 +63,8 @@ struct HomeSectionItemCard: View {
                     self.regularContent
                 }
             }
+            // Hover scale/shadow are applied once, below, so the button style
+            // only contributes press feedback (and registers no hover responder).
             .buttonStyle(.interactiveCard(showShadow: false, hoverScale: 1))
         }
         .scaleEffect(self.isHovering ? 1.02 : 1)

--- a/Sources/Kaset/Views/SharedViews/HomeSectionItemCard.swift
+++ b/Sources/Kaset/Views/SharedViews/HomeSectionItemCard.swift
@@ -63,18 +63,11 @@ struct HomeSectionItemCard: View, Equatable {
                     self.regularContent
                 }
             }
-            // Hover scale/shadow are applied once, below, so the button style
-            // only contributes press feedback (and registers no hover responder).
+            // Hover feedback lives on the thumbnail (see `thumbnail`), so the
+            // button style only contributes press feedback and registers no
+            // hover responder.
             .buttonStyle(.interactiveCard(showShadow: false, hoverScale: 1))
         }
-        .scaleEffect(self.isHovering ? 1.02 : 1)
-        .shadow(
-            color: self.isHovering ? .black.opacity(0.15) : .clear,
-            radius: self.isHovering ? 12 : 0,
-            x: 0,
-            y: self.isHovering ? 4 : 0
-        )
-        .animation(AppAnimation.spring, value: self.isHovering)
         .onHover { hovering in
             withAnimation(AppAnimation.quick) {
                 self.isHovering = hovering
@@ -140,6 +133,12 @@ struct HomeSectionItemCard: View, Equatable {
         }
         .frame(width: self.thumbnailSize.width, height: self.thumbnailSize.height)
         .clipShape(.rect(cornerRadius: 8))
+        // Hover lift is applied to the thumbnail only, and the shadow node only
+        // exists while hovering. Scaling the whole card re-rasterized its title
+        // and subtitle on every frame of the spring, and a resident `.shadow`
+        // (even clear) kept an effect layer on every card; measured together
+        // at ~5% of the app's scroll-time CPU and ~15% of dropped frames.
+        .modifier(ThumbnailHoverLift(isHovering: self.isHovering))
         .overlay {
             // Play overlay on hover (for songs)
             if case .song = self.item, self.isHovering {
@@ -321,6 +320,27 @@ struct HomeSectionItemCard: View, Equatable {
 
         let subtitle = song.artistsDisplay.lowercased()
         return subtitle.contains("views") || subtitle.contains("video")
+    }
+}
+
+// MARK: - ThumbnailHoverLift
+
+private struct ThumbnailHoverLift: ViewModifier {
+    let isHovering: Bool
+
+    func body(content: Content) -> some View {
+        self.shadowed(content)
+            .scaleEffect(self.isHovering ? 1.02 : 1)
+            .animation(AppAnimation.spring, value: self.isHovering)
+    }
+
+    @ViewBuilder
+    private func shadowed(_ content: Content) -> some View {
+        if self.isHovering {
+            content.shadow(color: .black.opacity(0.15), radius: 12, x: 0, y: 4)
+        } else {
+            content
+        }
     }
 }
 

--- a/Sources/Kaset/Views/SharedViews/InteractiveCardStyle.swift
+++ b/Sources/Kaset/Views/SharedViews/InteractiveCardStyle.swift
@@ -19,8 +19,17 @@ struct InteractiveCardStyle: ButtonStyle {
 
     @State private var isHovering = false
 
+    /// Hover tracking is skipped entirely when hovering has no visual effect.
+    /// Each `.onHover` adds a responder that SwiftUI hit-tests on every pointer
+    /// move — including during scrolling — so cards that layer their own hover
+    /// treatment on top of this style shouldn't pay for a second one.
+    private var tracksHover: Bool {
+        self.showShadow || self.hoverScale != 1
+    }
+
+    @ViewBuilder
     func makeBody(configuration: Configuration) -> some View {
-        configuration.label
+        let label = configuration.label
             .scaleEffect(configuration.isPressed ? self.pressScale : (self.isHovering ? self.hoverScale : 1.0))
             .shadow(
                 color: self.showShadow && self.isHovering ? .black.opacity(0.15) : .clear,
@@ -30,14 +39,19 @@ struct InteractiveCardStyle: ButtonStyle {
             )
             .animation(AppAnimation.spring, value: configuration.isPressed)
             .animation(AppAnimation.spring, value: self.isHovering)
-            .onHover { hovering in
-                self.isHovering = hovering
-            }
             .onChange(of: configuration.isPressed) { _, isPressed in
                 if isPressed, let feedback = hapticFeedback {
                     HapticService.perform(feedback)
                 }
             }
+
+        if self.tracksHover {
+            label.onHover { hovering in
+                self.isHovering = hovering
+            }
+        } else {
+            label
+        }
     }
 }
 


### PR DESCRIPTION
Home and Explore repeatedly re-evaluated visible cards when their shelves updated. Cards now skip updates when their data is unchanged, while song metadata changes still refresh the displayed content and captured actions. Hover lift applies to the thumbnail and preserves the loaded image across hover transitions.

- Make Home sections and items hashable and apply `.equatable()` to shelf cards. Equality includes the song metadata used by rendering, playback, navigation, and library actions, as well as rank and play-action availability.
- Keep play-action availability in an immutable boolean so the nonisolated equality check does not access the action closure.
- Store raw carousel geometry outside observable state and update the rendered overflow flags only when they change.
- Avoid registering a button-style hover responder when its hover effects are disabled.
- Put the conditional hover shadow in the thumbnail background, keeping the stateful image outside the conditional branch.
- Add regression coverage for song metadata, unchanged cards, each item kind, rank changes, and playlist play-action availability.

Local build, non-UI regression tests, SwiftLint, and formatting passed for `575c624`. Code review completed with no remaining actionable findings. GitHub Actions runs the repository's standard checks, including hosted UI tests.

Repeat-pass vertical scrolling still feels choppy during manual trackpad use. Follow-up #494 records the Instruments findings, tracing overhead, and the plan to investigate shelf layout and animation scope with a lighter baseline. This PR does not claim to resolve that remaining behavior.


